### PR TITLE
feat: enhance payment method and provider selection error handling wi…

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.test.tsx
@@ -122,4 +122,36 @@ describe('PaymentMethodListItem', () => {
 
     expect(getByText('Debit or Credit')).toBeOnTheScreen();
   });
+
+  it('renders the error subtitle and does not call onPress when quoteError is true', () => {
+    const mockOnPress = jest.fn();
+    const { getByText, queryByText } = renderWithTheme(
+      <PaymentMethodListItem
+        paymentMethod={mockPaymentMethod}
+        onPress={mockOnPress}
+        {...defaultQuoteProps}
+        quoteError
+        quoteErrorMessage="Amount below minimum 25 USD"
+      />,
+    );
+
+    expect(getByText('Amount below minimum 25 USD')).toBeOnTheScreen();
+    // Error subtitle replaces the delay text.
+    expect(queryByText('5 - 10 mins')).toBeNull();
+
+    fireEvent.press(getByText('Debit or Credit'));
+    expect(mockOnPress).not.toHaveBeenCalled();
+  });
+
+  it('falls back to delay text when quoteError is true but no message is provided', () => {
+    const { getByText } = renderWithTheme(
+      <PaymentMethodListItem
+        paymentMethod={mockPaymentMethod}
+        {...defaultQuoteProps}
+        quoteError
+      />,
+    );
+
+    expect(getByText('5 - 10 mins')).toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
@@ -44,6 +44,7 @@ interface PaymentMethodListItemProps {
   quote: Quote | null;
   quoteLoading: boolean;
   quoteError: boolean;
+  quoteErrorMessage?: string;
   currency: string;
   tokenSymbol: string;
 }
@@ -56,6 +57,7 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
   quote,
   quoteLoading,
   quoteError,
+  quoteErrorMessage,
   currency,
   tokenSymbol,
 }) => {
@@ -83,7 +85,8 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
   return (
     <ListItemSelect
       isSelected={isSelected}
-      onPress={onPress}
+      isDisabled={quoteError}
+      onPress={quoteError ? undefined : onPress}
       accessibilityRole="button"
       accessible
     >
@@ -102,7 +105,11 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
         <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
           {paymentMethod.name}
         </Text>
-        {delayText ? (
+        {quoteError && quoteErrorMessage ? (
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {quoteErrorMessage}
+          </Text>
+        ) : delayText ? (
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {delayText}
           </Text>

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentMethodListItem.tsx
@@ -70,6 +70,9 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
       ? formatDelayFromArray(paymentMethod.delay)
       : null;
 
+  const subtitleText =
+    quoteError && quoteErrorMessage ? quoteErrorMessage : delayText;
+
   const cryptoAmount =
     quote?.quote?.amountOut != null && tokenSymbol
       ? formatToken(Number(quote.quote.amountOut), tokenSymbol, {
@@ -105,13 +108,9 @@ const PaymentMethodListItem: React.FC<PaymentMethodListItemProps> = ({
         <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
           {paymentMethod.name}
         </Text>
-        {quoteError && quoteErrorMessage ? (
+        {subtitleText ? (
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {quoteErrorMessage}
-          </Text>
-        ) : delayText ? (
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {delayText}
+            {subtitleText}
           </Text>
         ) : null}
       </ListItemColumn>

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.test.tsx
@@ -360,7 +360,7 @@ describe('PaymentSelectionModal', () => {
     });
   });
 
-  it('keeps payment method visible when only custom-action quote matches', () => {
+  it('keeps payment method visible when only custom-action quote matches and greys out the rest', () => {
     const customActionQuote = {
       provider: '/providers/transak',
       quote: {
@@ -382,10 +382,103 @@ describe('PaymentSelectionModal', () => {
     const { queryAllByText, queryByText } = renderWithProvider(
       PaymentSelectionModal,
     );
-    // debit-credit-card-1 matches the custom-action quote → visible.
-    // debit-credit-card-2 has no matching quote → filtered out.
-    expect(queryAllByText('Debit or Credit').length).toBe(1);
+    // Both methods render. debit-credit-card-1 matches the custom-action quote,
+    // debit-credit-card-2 has no matching quote → disabled with fallback subtitle.
+    expect(queryAllByText('Debit or Credit').length).toBe(2);
     expect(queryByText('fiat_on_ramp.no_payment_methods_available')).toBeNull();
+    expect(queryAllByText('fiat_on_ramp.quote_unavailable').length).toBe(1);
+  });
+
+  it('disables payment methods without a success quote and shows the provider error message', () => {
+    mockUseRampsQuotes.mockImplementation(() => ({
+      ...defaultQuotesReturn,
+      data: {
+        success: [],
+        error: [
+          {
+            provider: '/providers/transak',
+            error: 'Amount below minimum 25 USD',
+          },
+        ],
+        sorted: [],
+        customActions: [],
+      },
+      loading: false,
+    }));
+
+    const { queryAllByText, queryByText } = renderWithProvider(
+      PaymentSelectionModal,
+    );
+
+    expect(queryAllByText('Debit or Credit').length).toBe(2);
+    expect(queryAllByText('Amount below minimum 25 USD').length).toBe(2);
+    expect(queryByText('fiat_on_ramp.no_payment_methods_available')).toBeNull();
+  });
+
+  it('ignores errors from other providers when sourcing the disabled subtitle', () => {
+    mockUseRampsQuotes.mockImplementation(() => ({
+      ...defaultQuotesReturn,
+      data: {
+        success: [],
+        error: [
+          {
+            provider: '/providers/moonpay',
+            error: 'Should not be shown',
+          },
+        ],
+        sorted: [],
+        customActions: [],
+      },
+      loading: false,
+    }));
+
+    const { queryByText, queryAllByText } = renderWithProvider(
+      PaymentSelectionModal,
+    );
+
+    expect(queryByText('Should not be shown')).toBeNull();
+    expect(queryAllByText('fiat_on_ramp.quote_unavailable').length).toBe(2);
+  });
+
+  it('does not disable payment methods while quotes are loading', () => {
+    mockUseRampsQuotes.mockImplementation(() => ({
+      ...defaultQuotesReturn,
+      data: null,
+      loading: true,
+    }));
+
+    const { queryAllByText, queryByText } = renderWithProvider(
+      PaymentSelectionModal,
+    );
+
+    expect(queryAllByText('Debit or Credit').length).toBe(2);
+    expect(queryByText('fiat_on_ramp.quote_unavailable')).toBeNull();
+  });
+
+  it('does not invoke onPaymentMethodSelect when a disabled row is pressed', async () => {
+    const onPaymentMethodSelect = jest.fn();
+    mockUseParams.mockReturnValue({ onPaymentMethodSelect });
+    mockUseRampsQuotes.mockImplementation(() => ({
+      ...defaultQuotesReturn,
+      data: {
+        success: [],
+        error: [
+          { provider: '/providers/transak', error: 'Amount below minimum' },
+        ],
+        sorted: [],
+        customActions: [],
+      },
+      loading: false,
+    }));
+
+    const { getAllByText } = renderWithProvider(PaymentSelectionModal);
+
+    fireEvent.press(getAllByText('Debit or Credit')[0]);
+
+    await waitFor(() => {
+      expect(onPaymentMethodSelect).not.toHaveBeenCalled();
+      expect(mockSetSelectedPaymentMethod).not.toHaveBeenCalled();
+    });
   });
 
   it('does not use custom-action quote amount for price preview', () => {

--- a/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/PaymentSelectionModal/PaymentSelectionModal.tsx
@@ -167,10 +167,19 @@ function PaymentSelectionModal() {
             quote.quote?.paymentMethod === paymentMethod.id &&
             !isCustomAction(quote),
         ) ?? null;
+      const hasSuccessQuoteForMethod = (quotes?.success ?? []).some(
+        (q) => q.quote?.paymentMethod === paymentMethod.id,
+      );
       const hasQuoteError =
-        !matchedQuote &&
-        (quotes?.error?.length ?? 0) > 0 &&
-        (quotes?.success?.length ?? 0) === 0;
+        !quotesLoading && quotes !== null && !hasSuccessQuoteForMethod;
+      const providerErrorMessage = selectedProvider
+        ? quotes?.error?.find(
+            (e) => e.provider === selectedProvider.id && e.error,
+          )?.error
+        : undefined;
+      const quoteErrorMessage = hasQuoteError
+        ? (providerErrorMessage ?? strings('fiat_on_ramp.quote_unavailable'))
+        : undefined;
 
       return (
         <PaymentMethodListItem
@@ -181,6 +190,7 @@ function PaymentSelectionModal() {
           quote={matchedQuote}
           quoteLoading={quotesLoading}
           quoteError={hasQuoteError}
+          quoteErrorMessage={quoteErrorMessage}
           currency={currency}
           tokenSymbol={tokenSymbol}
         />
@@ -189,6 +199,7 @@ function PaymentSelectionModal() {
     [
       handlePaymentMethodPress,
       selectedPaymentMethod,
+      selectedProvider,
       amount,
       quotes,
       quotesLoading,
@@ -219,18 +230,7 @@ function PaymentSelectionModal() {
         </ScrollView>
       );
     }
-    // Filter out payment methods that have no available quote once quotes
-    // have loaded. This avoids showing dead-end options to the user.
-    // Custom-action quotes (e.g. PayPal) count as available since they have
-    // their own checkout flow even without a standard priced quote.
-    const visiblePaymentMethods =
-      !quotesLoading && quotes
-        ? paymentMethods.filter((pm) =>
-            quotes.success?.some((q) => q.quote?.paymentMethod === pm.id),
-          )
-        : paymentMethods;
-
-    if (visiblePaymentMethods.length === 0) {
+    if (paymentMethods.length === 0) {
       return (
         <ScrollView
           style={styles.list}
@@ -246,7 +246,7 @@ function PaymentSelectionModal() {
     return (
       <FlatList
         style={styles.list}
-        data={visiblePaymentMethods}
+        data={paymentMethods}
         renderItem={renderPaymentMethod}
         keyExtractor={(item) => item.id}
         keyboardDismissMode="none"

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.test.tsx
@@ -482,4 +482,125 @@ describe('ProviderSelection', () => {
       expect(getByText('Previously used')).toBeOnTheScreen();
     });
   });
+
+  it('shows provider error subtitle and prevents selection when provider has no matched quote', async () => {
+    const onProviderSelect = jest.fn();
+    jest.mocked(useRampsController).mockReturnValue({
+      ...defaultMockController,
+      userRegion: mockUserRegion,
+      selectedToken: mockSelectedToken,
+      providers: [transakProvider, moonpayProvider],
+      selectedProvider: null,
+    });
+
+    const { getByText } = renderScreen(
+      () => (
+        <ProviderSelection
+          quotes={{
+            success: [createMockQuote('/providers/transak', 'Transak')],
+            sorted: [],
+            error: [
+              {
+                provider: '/providers/moonpay',
+                error: 'Amount below minimum 25 USD',
+              },
+            ],
+            customActions: [],
+          }}
+          quotesLoading={false}
+          quotesError={null}
+          onProviderSelect={onProviderSelect}
+          onBack={mockOnBack}
+        />
+      ),
+      { name: 'ProviderSelection' },
+      { state: { engine: { backgroundState } } },
+    );
+
+    await waitFor(() => {
+      expect(getByText('Amount below minimum 25 USD')).toBeOnTheScreen();
+    });
+
+    fireEvent.press(getByText('MoonPay'));
+    expect(onProviderSelect).not.toHaveBeenCalled();
+  });
+
+  it('hides the provider tag when the provider is unavailable', async () => {
+    jest.mocked(useRampsController).mockReturnValue({
+      ...defaultMockController,
+      userRegion: mockUserRegion,
+      selectedToken: mockSelectedToken,
+      providers: [transakProvider, moonpayProvider],
+      selectedProvider: null,
+    });
+
+    const { queryByText } = renderScreen(
+      () => (
+        <ProviderSelection
+          quotes={{
+            success: [createMockQuote('/providers/transak', 'Transak')],
+            sorted: [],
+            error: [
+              {
+                provider: '/providers/moonpay',
+                error: 'Amount below minimum',
+              },
+            ],
+            customActions: [],
+          }}
+          quotesLoading={false}
+          quotesError={null}
+          ordersProviders={['/providers/moonpay']}
+          onProviderSelect={jest.fn()}
+          onBack={mockOnBack}
+        />
+      ),
+      { name: 'ProviderSelection' },
+      { state: { engine: { backgroundState } } },
+    );
+
+    expect(queryByText('Previously used')).toBeNull();
+    expect(queryByText('Amount below minimum')).toBeOnTheScreen();
+  });
+
+  it('keeps provider selectable when it has a matched quote even if an error entry exists', async () => {
+    const onProviderSelect = jest.fn();
+    jest.mocked(useRampsController).mockReturnValue({
+      ...defaultMockController,
+      userRegion: mockUserRegion,
+      selectedToken: mockSelectedToken,
+      providers: [transakProvider],
+      selectedProvider: null,
+    });
+
+    const { getByText, queryByText } = renderScreen(
+      () => (
+        <ProviderSelection
+          quotes={{
+            success: [createMockQuote('/providers/transak', 'Transak')],
+            sorted: [],
+            error: [
+              {
+                provider: '/providers/transak',
+                error: 'Stale error from a previous payment method',
+              },
+            ],
+            customActions: [],
+          }}
+          quotesLoading={false}
+          quotesError={null}
+          onProviderSelect={onProviderSelect}
+          onBack={mockOnBack}
+        />
+      ),
+      { name: 'ProviderSelection' },
+      { state: { engine: { backgroundState } } },
+    );
+
+    expect(
+      queryByText('Stale error from a previous payment method'),
+    ).toBeNull();
+    fireEvent.press(getByText('Transak'));
+    expect(onProviderSelect).toHaveBeenCalledWith(transakProvider);
+  });
 });

--- a/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx
+++ b/app/components/UI/Ramp/Views/Modals/ProviderSelectionModal/ProviderSelection.tsx
@@ -270,6 +270,10 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
           (q) => q.provider === provider.id && !isCustomActionQuote(q),
         ) ??
         null;
+      const providerError = showQuotes
+        ? quotes?.error?.find((e) => e.provider === provider.id)?.error
+        : undefined;
+      const isUnavailable = Boolean(providerError && !matchedQuote);
       const amountOut = matchedQuote?.quote?.amountOut;
       const cryptoAmount =
         amountOut != null && symbol
@@ -283,14 +287,21 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
           ? formatCurrency(Number(matchedQuote.quote.amountOutInFiat), currency)
           : null;
       const isSelected = selectedProvider?.id === provider.id;
-      const tag = displayQuotes
-        ? getProviderTag(provider.id, matchedQuote, ordersProviders)
-        : null;
+      const tag =
+        !isUnavailable && displayQuotes
+          ? getProviderTag(provider.id, matchedQuote, ordersProviders)
+          : null;
+      const subtitle = isUnavailable ? providerError : tag;
 
       return (
         <ListItemSelect
           isSelected={isSelected}
-          onPress={() => handleProviderSelect(provider, matchedQuote)}
+          isDisabled={isUnavailable}
+          onPress={
+            isUnavailable
+              ? undefined
+              : () => handleProviderSelect(provider, matchedQuote)
+          }
           accessibilityRole="button"
           accessible
         >
@@ -298,12 +309,12 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
             <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {provider.name}
             </Text>
-            {tag ? (
+            {subtitle ? (
               <Text
                 variant={TextVariant.BodySm}
                 color={TextColor.TextAlternative}
               >
-                {tag}
+                {subtitle}
               </Text>
             ) : null}
           </ListItemColumn>
@@ -325,6 +336,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
       selectedProvider,
       selectedPaymentMethod,
       displayQuotes,
+      showQuotes,
       ordersProviders,
       handleProviderSelect,
       formatToken,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

In Unified Buy v2, when a user entered an amount that fell outside one provider's supported range (e.g. below MoonPay's minimum), the payment method picker showed a blanket "No payment methods available" alert and the provider picker silently dropped the affected provider. This was misleading: other providers / payment methods were often still viable, and the user had no way to learn _why_ a given option was unavailable.

This PR keeps every payment method and provider visible regardless of quote state, and instead:

- **Greys out** rows that have no successful quote (sets `isDisabled` on `ListItemSelect`, suppresses `onPress`).
- **Shows the provider's error message** (e.g. "Amount below minimum 25 USD") as the row subtitle, scoped to the row's provider — never bleeding errors across providers.
- Falls back to a generic `Quote unavailable.` subtitle when the API does not return an error string.
- Suppresses the "Previously used" / "Best rate" / "Most reliable" tag on unavailable provider rows so the failure reason is the dominant signal.
- Drops the previous list-level `visiblePaymentMethods` filter, since the disabled-row UX makes silent filtering unnecessary.

## **Changelog**

CHANGELOG entry: Fixed a misleading "No payment methods available" error in Buy when entering an amount outside a provider's limits. Unavailable payment methods and providers are now shown greyed out with the specific reason (e.g. "Amount below minimum 25 USD") instead of being hidden.

## **Related issues**

Fixes: [TRAM-3556](https://consensyssoftware.atlassian.net/browse/TRAM-3556)

## **Manual testing steps**

```gherkin
Feature: Buy payment-method and provider selection error states

  Scenario: User enters an amount below the selected provider's minimum
    Given the user is on the Buy amount entry screen
    And the selected provider is MoonPay
    When the user enters an amount below MoonPay's minimum (e.g. 1 USD)
    And the user opens the "Pay with" payment selection modal
    Then every payment method is still listed
    And each payment method row is greyed out
    And each row's subtitle shows the provider's error message
      (e.g. "Amount below minimum 25 USD") or "Quote unavailable." as a fallback
    And tapping a greyed-out row does nothing

  Scenario: User enters an amount supported by only some providers
    Given the user is on the Buy amount entry screen
    And the entered amount is supported by Transak but not by MoonPay
    When the user opens the provider selection modal
    Then Transak is listed with its quote and tag (e.g. "Best rate")
    And MoonPay is listed but greyed out
    And MoonPay's row subtitle shows its error message
    And MoonPay's tag (e.g. "Previously used") is hidden
    And tapping MoonPay does not advance the flow

  Scenario: User enters a valid amount
    Given the user is on the Buy amount entry screen
    And the entered amount is supported by every provider/payment method
    When the user opens either selection modal
    Then all rows are enabled
    And each row shows its expected quote and tags
    And tapping a row selects it and closes the modal as before
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/9b3294a6-a3df-4503-a8af-599d6b758eeb




<!-- Payment selection modal showing "No payment methods are available" banner for an amount below MoonPay's minimum, despite other providers being viable. -->

### **After**


https://github.com/user-attachments/assets/d6da5ee3-1648-45df-b968-6f1395318b98



<!-- Payment selection modal listing all payment methods greyed out with the provider error message ("Amount below minimum 25 USD") as subtitle; provider selection modal listing MoonPay greyed out with its error subtitle while Transak remains selectable. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TRAM-3556]: https://consensyssoftware.atlassian.net/browse/TRAM-3556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in fiat on-ramp selection modals with expanded unit tests; no auth, payments execution, or backend contract changes.
> 
> **Overview**
> Fixes misleading **Buy** UX when quotes fail for some options: payment methods and providers stay visible instead of being hidden or replaced by a blanket “no payment methods” state.
> 
> **Payment selection** stops filtering the list to methods with successful quotes. Rows without a success quote (after quotes finish loading) are **disabled**, show the **selected provider’s** API error or `fiat_on_ramp.quote_unavailable`, and ignore taps. `PaymentMethodListItem` accepts `quoteErrorMessage`, swaps subtitle for that message when present, and uses `ListItemSelect` `isDisabled` / no `onPress` on quote error.
> 
> **Provider selection** treats providers with an error and no matched (non–custom-action) quote as **unavailable**: disabled row, provider-specific error as subtitle (tags like “Previously used” hidden), selection blocked. Providers with a valid matched quote stay selectable even if a stale error exists for that provider.
> 
> Tests cover disabled rows, error scoping, loading behavior, and custom-action quote edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30025b4cdc80fd0e518c23ecd562b6aea0c4b1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->