### PR TITLE
fix: explore search shows count on loading state cp-7.79.0

### DIFF
--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -95,46 +95,52 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
   );
 
   const renderSectionHeader = useCallback(
-    (item: ListItemHeader, section: SearchFeedSection) => (
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Between}
-        twClassName="py-2 bg-default"
-      >
-        <Text
-          variant={TextVariant.HeadingSm}
-          fontWeight={FontWeight.Medium}
-          twClassName="text-alternative"
+    (item: ListItemHeader, section: SearchFeedSection) => {
+      const viewMoreLabel = getViewMoreLabel(
+        section.feedId,
+        section.isLoading ? 0 : section.items.length,
+        searchQuery,
+        section.isLoading ? undefined : section.total,
+      );
+      return (
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+          twClassName="py-2 bg-default"
         >
-          {item.title}
-        </Text>
-        <Pressable
-          onPress={() => handleViewMore(section)}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={`${getViewMoreLabel(section.feedId, section.isLoading ? 0 : section.items.length, searchQuery, section.isLoading ? undefined : section.total)} ${item.title}`}
-          style={({ pressed }) => [
-            pressedStyle.pressable,
-            pressed && { opacity: 0.5 },
-          ]}
-        >
-          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-            {getViewMoreLabel(
-              section.feedId,
-              section.isLoading ? 0 : section.items.length,
-              searchQuery,
-              section.isLoading ? undefined : section.total,
-            )}
+          <Text
+            variant={TextVariant.HeadingSm}
+            fontWeight={FontWeight.Medium}
+            twClassName="text-alternative"
+          >
+            {item.title}
           </Text>
-          <Icon
-            name={IconName.ArrowRight}
-            size={IconSize.Sm}
-            color={IconColor.IconAlternative}
-          />
-        </Pressable>
-      </Box>
-    ),
+          <Pressable
+            onPress={() => handleViewMore(section)}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={`${viewMoreLabel} ${item.title}`}
+            style={({ pressed }) => [
+              pressedStyle.pressable,
+              pressed && { opacity: 0.5 },
+            ]}
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              {viewMoreLabel}
+            </Text>
+            <Icon
+              name={IconName.ArrowRight}
+              size={IconSize.Sm}
+              color={IconColor.IconAlternative}
+            />
+          </Pressable>
+        </Box>
+      );
+    },
     [handleViewMore, searchQuery],
   );
 

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -113,7 +113,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
           onPress={() => handleViewMore(section)}
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel={`${getViewMoreLabel(section.feedId, section.items.length, searchQuery, section.total)} ${item.title}`}
+          accessibilityLabel={`${getViewMoreLabel(section.feedId, section.isLoading ? 0 : section.items.length, searchQuery, section.isLoading ? undefined : section.total)} ${item.title}`}
           style={({ pressed }) => [
             pressedStyle.pressable,
             pressed && { opacity: 0.5 },
@@ -122,9 +122,9 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {getViewMoreLabel(
               section.feedId,
-              section.items.length,
+              section.isLoading ? 0 : section.items.length,
               searchQuery,
-              section.total,
+              section.isLoading ? undefined : section.total,
             )}
           </Text>
           <Icon

--- a/app/components/Views/TrendingView/search/viewMoreLabel.test.ts
+++ b/app/components/Views/TrendingView/search/viewMoreLabel.test.ts
@@ -62,6 +62,20 @@ describe('getViewMoreLabel', () => {
     });
   });
 
+  describe('loading state — component passes 0 items and no serverTotal', () => {
+    // When a section is loading, ExploreSearchResultsV2 passes visibleCount=0 and
+    // serverTotal=undefined so that stale data from the previous query does not
+    // produce a "View X more" count while skeletons are shown.
+    it.each(['perps', 'stocks', 'sites', 'tokens', 'predictions'] as const)(
+      '%s: returns "view_all" during loading (0 items, no serverTotal)',
+      (feedId) => {
+        expect(getViewMoreLabel(feedId, 0, 'eth', undefined)).toBe(
+          'trending.view_all',
+        );
+      },
+    );
+  });
+
   describe('server total provided (tokens and predictions with API count)', () => {
     it('returns "view_x_more" using total when there are remaining results', () => {
       // total: 2101, visible: 3 → extra = 2101 - 3 = 2098


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Fix explore search shows count on loading state
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix explore search shows count on loading state

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3266

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label logic in explore search with unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes explore search section headers showing a **“View X more”** count while results are still loading.
> 
> `ExploreSearchResultsV2` now computes the view-more label with **zero visible items** and **no server total** when `section.isLoading` is true, so counts from the previous query are not reused alongside skeleton rows. The label and accessibility text share one computed `viewMoreLabel`. Tests lock in that all feed types get **`trending.view_all`** for that loading input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 353964ddc4f1158b3c680bdb26f32b4f67bf8e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->