### PR TITLE
fix: dismiss AddWallet sheet before entering HW flow to fix post-connect navigation

### DIFF
--- a/app/components/Views/AddWallet/AddWallet.test.tsx
+++ b/app/components/Views/AddWallet/AddWallet.test.tsx
@@ -96,6 +96,7 @@ describe('AddWallet', () => {
     fireEvent.press(screen.getByTestId(AddWalletTestIds.IMPORT_WALLET_BUTTON));
 
     expect(mockedNavigate).toHaveBeenCalledWith(Routes.MULTI_SRP.IMPORT);
+    expect(mockedGoBack).not.toHaveBeenCalled();
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.IMPORT_SECRET_RECOVERY_PHRASE_CLICKED,
     );
@@ -112,6 +113,7 @@ describe('AddWallet', () => {
     fireEvent.press(screen.getByTestId(AddWalletTestIds.IMPORT_ACCOUNT_BUTTON));
 
     expect(mockedNavigate).toHaveBeenCalledWith(Routes.IMPORT_PRIVATE_KEY_VIEW);
+    expect(mockedGoBack).not.toHaveBeenCalled();
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.ACCOUNTS_IMPORTED_NEW_ACCOUNT,
     );
@@ -120,7 +122,7 @@ describe('AddWallet', () => {
     );
   });
 
-  it('opens the hardware wallet flow', () => {
+  it('opens the hardware wallet flow and dismisses AddWallet', () => {
     renderScreen(() => <AddWallet />, {
       name: 'AddWallet',
     });
@@ -130,6 +132,9 @@ describe('AddWallet', () => {
     );
 
     expect(mockedNavigate).toHaveBeenCalledWith(Routes.HW.CONNECT);
+    // AddWallet must be dismissed so that pop(2) in the HW screens lands on
+    // AccountSelector rather than back on this screen.
+    expect(mockedGoBack).toHaveBeenCalledTimes(1);
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.ADD_HARDWARE_WALLET,
     );

--- a/app/components/Views/AddWallet/AddWallet.tsx
+++ b/app/components/Views/AddWallet/AddWallet.tsx
@@ -79,6 +79,11 @@ const AddWallet = () => {
   const handleActionPress = useCallback(
     (config: ActionConfig) => {
       navigation.navigate(config.routeName as never);
+      // Dismiss AddWallet so that hardware wallet completion (pop(2) in HW
+      // screens) lands on AccountSelector rather than back here.
+      if (config.routeName === Routes.HW.CONNECT) {
+        navigation.goBack();
+      }
       trackEvent(createEventBuilder(config.analyticsEvent).build());
     },
     [createEventBuilder, navigation, trackEvent],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: dismiss AddWallet sheet before entering HW flow to fix post-connect navigation

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/29240

## **Manual testing steps**

```gherkin
Feature: view accounts list after adding HW

  Scenario: user adds HW
    Given the user has a HW connected

    When user finishes HW account selection and taps confirm
    Then they are taken back to the accounts list screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, route-specific navigation change with targeted unit tests; no auth, data, or import-flow behavior changes.
> 
> **Overview**
> When users start **Connect hardware** from `AddWallet`, the screen now calls **`navigation.goBack()`** right after navigating to the HW flow so the add-wallet sheet is removed from the stack. Hardware completion still uses **`pop(2)`** in the HW screens; without this dismiss, one of those pops returned to AddWallet instead of the accounts list (**AccountSelector**).
> 
> Import wallet and import private key behavior is unchanged; tests now assert **`goBack` is not** invoked for those actions and **is** invoked once for hardware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c80e604a359c0ca448744e739fc481f2e96ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->