### PR TITLE
fix: avoid layout shift in confirmation loading skeleton

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -315,7 +315,6 @@ describe('Confirm', () => {
     });
 
     expect(mockSetOptions).toHaveBeenCalledWith({
-      headerShown: false,
       gestureEnabled: false,
     });
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 
 import { ConfirmationUIType } from '../../ConfirmationView.testIds';
 import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -122,16 +123,13 @@ export const Confirm = ({
   });
 
   useEffect(() => {
-    const options = {
-      headerShown: false,
-      // If there is an approvalRequest, we need to allow the user to swipe to reject the confirmation.
+    const options: NativeStackNavigationOptions = {
       // If not, keep the loading state in place until there is a request that can be rejected.
       gestureEnabled: Boolean(approvalRequest),
     };
 
-    if (approvalRequest && isFullScreenConfirmation) {
-      // If the confirmation is full screen, we need to show the header
-      options.headerShown = true;
+    if (approvalRequest) {
+      options.headerShown = Boolean(isFullScreenConfirmation);
     }
 
     navigation.setOptions(options);


### PR DESCRIPTION
## **Description**

Fixes a layout shift in the confirmation loading skeleton caused by `navigation.setOptions({ headerShown: false })` being called unconditionally on mount.

### Problem

PR #30474 moved `navigation.setOptions` outside the `if (approvalRequest)` guard to fix gesture/back-button dismissal during loading. However, this caused `headerShown` to be set to `false` immediately on mount, then flipped to `true` once the approval request arrived for full-screen confirmations — producing a visible layout shift as the header bar appeared and pushed content down.

### Fix

Only set `headerShown` when `approvalRequest` exists (restoring the original behavior), while keeping `gestureEnabled: Boolean(approvalRequest)` unconditional so the swipe/back-button fix is preserved.

## **Manual testing steps**

1. Open any confirmation that uses the loading skeleton (e.g. a full-screen confirmation)
2. Verify the skeleton renders without any visible layout jump
3. Verify swiping back is disabled during loading state
4. Verify Android back button is blocked during loading state
5. Once the approval request loads, verify swiping to dismiss works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-options change in the confirmation screen with no auth, data, or payment impact.
> 
> **Overview**
> Fixes a **layout jump** on the confirmation loading skeleton by no longer calling `navigation.setOptions` with `headerShown: false` before an approval request exists.
> 
> While waiting for the request, only **`gestureEnabled: false`** is applied (plus the existing Android back-handler block), so users still cannot dismiss the loading state. Once `approvalRequest` is present, **`headerShown`** is set from **`isFullScreenConfirmation`** as before, without toggling the header on and off during load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406d0c4aed246b9d1a91770d91a28a78ab3d06f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->