### PR TITLE
fix: add explore entrypoint attribution in predict

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -72,8 +72,8 @@ import {
   resolvePredictSeriesMarket,
   type PredictMarketWithSeries,
 } from '../../utils/series';
-import { usePredictEntryPoint, usePredictPreviewSheet } from '../../contexts';
-import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
+import { usePredictPreviewSheet } from '../../contexts';
+import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import { PredictCryptoUpDownMarketCardSelectorsIDs } from '../../Predict.testIds';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import type { LivelinePoint } from '../../../Charts/LivelineChart/LivelineChart.types';
@@ -1067,15 +1067,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { navigateToMarketDetails } = usePredictNavigation();
   const { openBuySheet } = usePredictPreviewSheet();
-  const contextEntryPoint = usePredictEntryPoint();
-  const baseEntryPoint =
-    contextEntryPoint ??
-    propEntryPoint ??
-    PredictEventValues.ENTRY_POINT.PREDICT_FEED;
-  const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
-    .isFromTrending
-    ? PredictEventValues.ENTRY_POINT.TRENDING
-    : baseEntryPoint;
+  const resolvedEntryPoint = useResolvedPredictEntryPoint(propEntryPoint);
   const { executeGuardedAction } = usePredictActionGuard({ navigation });
   const durationMs = getSeriesDurationMs(market.series.recurrence);
   const windowMs = useSharedSeriesWindowMs(durationMs);

--- a/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
+++ b/app/components/UI/Predict/components/PredictMarket/PredictMarket.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { PredictMarket as PredictMarketType } from '../../types';
 import { PredictEntryPoint } from '../../types/navigation';
-import { PredictEventValues } from '../../constants/eventNames';
-import { usePredictEntryPoint } from '../../contexts';
+import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import PredictMarketSingle from '../PredictMarketSingle';
 import PredictMarketMultiple from '../PredictMarketMultiple';
@@ -31,11 +30,7 @@ const PredictMarket: React.FC<PredictMarketProps> = ({
   onBuyButtonPress,
   transactionActiveAbTests,
 }) => {
-  const contextEntryPoint = usePredictEntryPoint();
-  const entryPoint =
-    contextEntryPoint ??
-    propEntryPoint ??
-    PredictEventValues.ENTRY_POINT.PREDICT_FEED;
+  const entryPoint = useResolvedPredictEntryPoint(propEntryPoint);
   if (market.game) {
     return (
       <PredictMarketSportCard

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -41,9 +41,9 @@ import {
 } from '../../types/navigation';
 import { formatPercentage, formatVolume } from '../../utils/format';
 import styleSheet from './PredictMarketMultiple.styles';
-import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
 import { PredictEventValues } from '../../constants/eventNames';
-import { usePredictEntryPoint, usePredictPreviewSheet } from '../../contexts';
+import { usePredictPreviewSheet } from '../../contexts';
+import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 
 interface PredictMarketMultipleProps {
@@ -67,16 +67,7 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   onBuyButtonPress,
   transactionActiveAbTests,
 }) => {
-  const contextEntryPoint = usePredictEntryPoint();
-  const baseEntryPoint =
-    contextEntryPoint ??
-    propEntryPoint ??
-    PredictEventValues.ENTRY_POINT.PREDICT_FEED;
-
-  const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
-    .isFromTrending
-    ? PredictEventValues.ENTRY_POINT.TRENDING
-    : baseEntryPoint;
+  const resolvedEntryPoint = useResolvedPredictEntryPoint(propEntryPoint);
 
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -31,8 +31,8 @@ import {
 import { formatVolume } from '../../utils/format';
 import styleSheet from './PredictMarketSingle.styles';
 import { PredictEventValues } from '../../constants/eventNames';
-import { usePredictEntryPoint, usePredictPreviewSheet } from '../../contexts';
-import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
+import { usePredictPreviewSheet } from '../../contexts';
+import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 
 interface SemiCircleYesPercentageProps {
@@ -145,16 +145,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   onBuyButtonPress,
   transactionActiveAbTests,
 }) => {
-  const contextEntryPoint = usePredictEntryPoint();
-  const baseEntryPoint =
-    contextEntryPoint ??
-    propEntryPoint ??
-    PredictEventValues.ENTRY_POINT.PREDICT_FEED;
-
-  const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
-    .isFromTrending
-    ? PredictEventValues.ENTRY_POINT.TRENDING
-    : baseEntryPoint;
+  const resolvedEntryPoint = useResolvedPredictEntryPoint(propEntryPoint);
 
   const outcome = market.outcomes[0];
   const navigation =

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -254,15 +254,11 @@ describe('PredictMarketSportCard', () => {
     });
   });
 
-  it('uses trending entry point when opened from trending feed', () => {
+  it('uses trending entry point when no explicit entry point and session is active', () => {
     mockIsFromTrending.mockReturnValue(true);
 
     const { getByTestId } = renderWithProvider(
-      <PredictMarketSportCard
-        market={mockMarket}
-        testID="sport-market-card"
-        entryPoint={PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS}
-      />,
+      <PredictMarketSportCard market={mockMarket} testID="sport-market-card" />,
       { state: initialState },
     );
 
@@ -273,6 +269,30 @@ describe('PredictMarketSportCard', () => {
       expect.objectContaining({
         params: expect.objectContaining({
           entryPoint: PredictEventValues.ENTRY_POINT.TRENDING,
+        }),
+      }),
+    );
+  });
+
+  it('explicit entry point takes priority over trending session', () => {
+    mockIsFromTrending.mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(
+      <PredictMarketSportCard
+        market={mockMarket}
+        testID="sport-market-card"
+        entryPoint={PredictEventValues.ENTRY_POINT.EXPLORE}
+      />,
+      { state: initialState },
+    );
+
+    fireEvent.press(getByTestId('sport-market-card'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.PREDICT.ROOT,
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
         }),
       }),
     );

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -30,7 +30,8 @@ import { PredictEventValues } from '../../constants/eventNames';
 import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { useLiveGameUpdates } from '../../hooks/useLiveGameUpdates';
-import { usePredictEntryPoint, usePredictPreviewSheet } from '../../contexts';
+import { usePredictPreviewSheet } from '../../contexts';
+import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import {
   PredictMarket as PredictMarketType,
   PredictMarketGame,
@@ -45,7 +46,6 @@ import {
 } from '../../types/navigation';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import { parseScore } from '../../utils/gameParser';
-import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
 import PredictSportTeamLogo from '../PredictSportTeamLogo/PredictSportTeamLogo';
 import PulsingLiveDot from '../PulsingLiveDot/PulsingLiveDot';
 
@@ -230,21 +230,11 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
 }) => {
   const tw = useTailwind();
   const { colors } = useTheme();
-  const contextEntryPoint = usePredictEntryPoint();
+  const resolvedEntryPoint = useResolvedPredictEntryPoint(propEntryPoint);
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { openBuySheet } = usePredictPreviewSheet();
   const { executeGuardedAction } = usePredictActionGuard({ navigation });
-
-  const baseEntryPoint =
-    contextEntryPoint ??
-    propEntryPoint ??
-    PredictEventValues.ENTRY_POINT.PREDICT_FEED;
-
-  const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
-    .isFromTrending
-    ? PredictEventValues.ENTRY_POINT.TRENDING
-    : baseEntryPoint;
 
   const game = market.game as PredictMarketGame | undefined;
   const config = game ? getLeagueConfig(game.league) : undefined;

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -547,7 +547,24 @@ describe('PredictSportCardFooter', () => {
       });
     });
 
-    it('uses trending entry point when from trending feed', async () => {
+    it('uses trending entry point when no explicit entry point and session is active', async () => {
+      mockIsFromTrending.mockReturnValue(true);
+      const market = createMockMarket();
+      setupPositionsMock();
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+      fireEvent.press(screen.getByTestId('footer-action-buttons-bet-yes'));
+
+      await waitFor(() => {
+        expect(mockOpenBuySheet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            entryPoint: PredictEventValues.ENTRY_POINT.TRENDING,
+          }),
+        );
+      });
+    });
+
+    it('explicit entry point takes priority over trending session', async () => {
       mockIsFromTrending.mockReturnValue(true);
       const market = createMockMarket();
       setupPositionsMock();
@@ -555,7 +572,7 @@ describe('PredictSportCardFooter', () => {
       render(
         <PredictSportCardFooter
           market={market}
-          entryPoint={PredictEventValues.ENTRY_POINT.PREDICT_FEED}
+          entryPoint={PredictEventValues.ENTRY_POINT.EXPLORE}
           testID="footer"
         />,
       );
@@ -564,7 +581,7 @@ describe('PredictSportCardFooter', () => {
       await waitFor(() => {
         expect(mockOpenBuySheet).toHaveBeenCalledWith(
           expect.objectContaining({
-            entryPoint: PredictEventValues.ENTRY_POINT.TRENDING,
+            entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
           }),
         );
       });

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -12,8 +12,8 @@ import {
   PredictEntryPoint,
 } from '../../types/navigation';
 import { PredictEventValues } from '../../constants/eventNames';
-import { usePredictEntryPoint, usePredictPreviewSheet } from '../../contexts';
-import TrendingFeedSessionManager from '../../../Trending/services/TrendingFeedSessionManager';
+import { usePredictPreviewSheet } from '../../contexts';
+import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { PredictActionButtons } from '../PredictActionButtons';
 import { PredictPicksForCard } from '../PredictPicks';
@@ -42,16 +42,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
-  const contextEntryPoint = usePredictEntryPoint();
-  const baseEntryPoint =
-    contextEntryPoint ??
-    propEntryPoint ??
-    PredictEventValues.ENTRY_POINT.PREDICT_FEED;
-
-  const resolvedEntryPoint = TrendingFeedSessionManager.getInstance()
-    .isFromTrending
-    ? PredictEventValues.ENTRY_POINT.TRENDING
-    : baseEntryPoint;
+  const resolvedEntryPoint = useResolvedPredictEntryPoint(propEntryPoint);
 
   const { data: positions = [], isLoading } = usePredictPositions({
     marketId: market.id,

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -110,6 +110,7 @@ export const PredictEventValues = {
     TRENDING: 'trending',
     BUY_PREVIEW: 'buy_preview',
     HOME_SECTION: 'home_section',
+    EXPLORE: 'explore',
   },
   TRANSACTION_TYPE: {
     MM_PREDICT_BUY: 'mm_predict_buy',

--- a/app/components/UI/Predict/hooks/useResolvedPredictEntryPoint.test.ts
+++ b/app/components/UI/Predict/hooks/useResolvedPredictEntryPoint.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useResolvedPredictEntryPoint } from './useResolvedPredictEntryPoint';
+import { PredictEventValues } from '../constants/eventNames';
+
+const mockUsePredictEntryPoint = jest.fn();
+jest.mock('../contexts', () => ({
+  usePredictEntryPoint: () => mockUsePredictEntryPoint(),
+}));
+
+const mockIsFromTrending = jest.fn();
+jest.mock('../../Trending/services/TrendingFeedSessionManager', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      get isFromTrending() {
+        return mockIsFromTrending();
+      },
+    }),
+  },
+}));
+
+describe('useResolvedPredictEntryPoint', () => {
+  beforeEach(() => {
+    mockUsePredictEntryPoint.mockReturnValue(undefined);
+    mockIsFromTrending.mockReturnValue(false);
+  });
+
+  it('returns context entry point when set', () => {
+    mockUsePredictEntryPoint.mockReturnValue(
+      PredictEventValues.ENTRY_POINT.CAROUSEL,
+    );
+    mockIsFromTrending.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useResolvedPredictEntryPoint(PredictEventValues.ENTRY_POINT.EXPLORE),
+    );
+
+    expect(result.current).toBe(PredictEventValues.ENTRY_POINT.CAROUSEL);
+  });
+
+  it('returns prop entry point when no context', () => {
+    mockIsFromTrending.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useResolvedPredictEntryPoint(PredictEventValues.ENTRY_POINT.EXPLORE),
+    );
+
+    expect(result.current).toBe(PredictEventValues.ENTRY_POINT.EXPLORE);
+  });
+
+  it('returns TRENDING when session is active and no prop or context', () => {
+    mockIsFromTrending.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useResolvedPredictEntryPoint(undefined),
+    );
+
+    expect(result.current).toBe(PredictEventValues.ENTRY_POINT.TRENDING);
+  });
+
+  it('returns PREDICT_FEED as default', () => {
+    mockIsFromTrending.mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useResolvedPredictEntryPoint(undefined),
+    );
+
+    expect(result.current).toBe(PredictEventValues.ENTRY_POINT.PREDICT_FEED);
+  });
+});

--- a/app/components/UI/Predict/hooks/useResolvedPredictEntryPoint.ts
+++ b/app/components/UI/Predict/hooks/useResolvedPredictEntryPoint.ts
@@ -1,0 +1,17 @@
+import { PredictEntryPoint } from '../types/navigation';
+import { PredictEventValues } from '../constants/eventNames';
+import { usePredictEntryPoint } from '../contexts';
+import TrendingFeedSessionManager from '../../Trending/services/TrendingFeedSessionManager';
+
+export function useResolvedPredictEntryPoint(
+  propEntryPoint: PredictEntryPoint | undefined,
+): PredictEntryPoint {
+  const contextEntryPoint = usePredictEntryPoint();
+
+  if (contextEntryPoint) return contextEntryPoint;
+  if (propEntryPoint) return propEntryPoint;
+  if (TrendingFeedSessionManager.getInstance().isFromTrending) {
+    return PredictEventValues.ENTRY_POINT.TRENDING;
+  }
+  return PredictEventValues.ENTRY_POINT.PREDICT_FEED;
+}

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -30,7 +30,8 @@ export type PredictEntryPoint =
   | typeof PredictEventValues.ENTRY_POINT.BACKGROUND
   | typeof PredictEventValues.ENTRY_POINT.TRENDING_SEARCH
   | typeof PredictEventValues.ENTRY_POINT.TRENDING
-  | typeof PredictEventValues.ENTRY_POINT.HOME_SECTION;
+  | typeof PredictEventValues.ENTRY_POINT.HOME_SECTION
+  | typeof PredictEventValues.ENTRY_POINT.EXPLORE;
 
 /** Predict market list parameters */
 export interface PredictMarketListParams {

--- a/app/components/Views/TrendingView/feeds/predictions/PredictionRowItem.tsx
+++ b/app/components/Views/TrendingView/feeds/predictions/PredictionRowItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PredictMarket from '../../../../UI/Predict/components/PredictMarket';
 import PredictMarketRowItem from '../../../../UI/Predict/components/PredictMarketRowItem';
 import type { PredictMarket as PredictMarketType } from '../../../../UI/Predict/types';
+import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 
 interface PredictionCarouselRowItemProps {
   market: PredictMarketType;
@@ -19,6 +20,7 @@ export const PredictionCarouselRowItem: React.FC<
   <PredictMarket
     market={market}
     isCarousel
+    entryPoint={PredictEventValues.ENTRY_POINT.EXPLORE}
     testID={testIdPrefix ? `${testIdPrefix}-${market.id}` : undefined}
     onCardPress={onCardPress}
     onBuyButtonPress={onBuyButtonPress}
@@ -32,4 +34,9 @@ interface PredictionSearchRowItemProps {
 /** Compact list row used inside the omni-search results. */
 export const PredictionSearchRowItem: React.FC<
   PredictionSearchRowItemProps
-> = ({ market }) => <PredictMarketRowItem market={market} />;
+> = ({ market }) => (
+  <PredictMarketRowItem
+    market={market}
+    entryPoint={PredictEventValues.ENTRY_POINT.EXPLORE}
+  />
+);

--- a/app/components/Views/TrendingView/tabs/SportsTab.tsx
+++ b/app/components/Views/TrendingView/tabs/SportsTab.tsx
@@ -40,6 +40,7 @@ import {
   trackExploreInteracted,
   type ExploreSectionName,
 } from '../search/analytics';
+import { PredictEventValues } from '../../../UI/Predict/constants/eventNames';
 
 const SPORT_KEY_TO_SECTION: Record<string, ExploreSectionName> = {
   soccer: 'predictions_football',
@@ -172,6 +173,7 @@ const SportsTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
       return (
         <PredictMarket
           market={item}
+          entryPoint={PredictEventValues.ENTRY_POINT.EXPLORE}
           onCardPress={() =>
             trackExploreInteracted({
               interaction_type: 'section_item_tapped',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

`Predict Market Details Opened` and `Predict Trade Transaction` had no way to attribute conversions originating from the Explore page — `EXPLORE` was simply missing from `ENTRY_POINT`, and the Explore→Predict navigation never passed one.

- Adds `ENTRY_POINT.EXPLORE = 'explore'` to `PredictEventValues` and the `PredictEntryPoint` union (mirrors `SOURCE.EXPLORE` in Perps)
- `PredictionCarouselRowItem` and `PredictionSearchRowItem` hardcode `ENTRY_POINT.EXPLORE` — same pattern as `PerpsRowItem`
- `SportsTab` sets it on the one direct `PredictMarket` usage
- Extracts `useResolvedPredictEntryPoint` hook to centralise the context > prop > trending session > default priority that was duplicated across 5 card components; fixes a pre-existing bug where the session manager could override an explicit prop

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add explore entrypoint attribution in predict

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-929?issueKey=PRED-929&subProduct=jira-software & https://consensyssoftware.atlassian.net/browse/ASSETS-3271

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and UI wiring only; no auth, payments, or data-handling changes. Behavior change is clearer entry-point attribution and a small priority bugfix.
> 
> **Overview**
> Adds **`ENTRY_POINT.EXPLORE`** (`explore`) to Predict analytics types and passes it from **Explore** surfaces: prediction carousel/search rows and **Sports** tab market cards—so market opens and trades can attribute to Explore.
> 
> Introduces **`useResolvedPredictEntryPoint`** to replace duplicated logic across Predict market cards. Resolution order is **context → prop → trending session → `predict_feed` default**. This also fixes a bug where an active trending session could override an **explicit** `entryPoint` prop.
> 
> Card components and related tests are updated to use the hook and to assert that **explicit entry points win over trending**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c32f7f8341b9b09292f4f3c39466bf2723e4d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->