### PR TITLE
fix: remove Save button from trader notifications bottom sheet

### DIFF
--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -446,6 +446,68 @@ describe('useNotificationPreferences', () => {
       );
     });
 
+    it('keeps the optimistic overlay while a PUT is in flight even if the query data momentarily reports the pre-PUT value (no snap-back)', async () => {
+      // Simulate a stale refetch landing between the optimistic cache write
+      // and the PUT resolving: the second render of the hook receives query
+      // data that no longer matches the optimistic overlay.
+      const remoteWithMute = buildRemote({
+        socialAI: {
+          ...DEFAULT_SOCIAL_AI_PREFERENCES,
+          mutedTraderProfileIds: ['trader-x'],
+        },
+      });
+      const remoteWithoutMute = buildRemote();
+
+      mockUseQuery.mockReturnValue(
+        makeQueryResult({ data: remoteWithoutMute }),
+      );
+
+      let resolvePut: () => void = () => undefined;
+      const putPromise = new Promise<void>((resolve) => {
+        resolvePut = resolve;
+      });
+      mockCall.mockImplementation(async (action: string) => {
+        if (action === GET_ACTION) return remoteWithoutMute;
+        if (action === PUT_ACTION) return putPromise;
+        return undefined;
+      });
+
+      const { result, rerender } = renderHook(() =>
+        useNotificationPreferences(),
+      );
+
+      act(() => {
+        result.current.toggleTraderNotification('trader-x');
+      });
+
+      expect(result.current.isTraderNotificationEnabled('trader-x')).toBe(
+        false,
+      );
+
+      mockUseQuery.mockReturnValue(
+        makeQueryResult({ data: remoteWithoutMute }),
+      );
+      rerender({});
+
+      expect(result.current.isTraderNotificationEnabled('trader-x')).toBe(
+        false,
+      );
+
+      await act(async () => {
+        resolvePut();
+        await putPromise;
+      });
+
+      mockUseQuery.mockReturnValue(makeQueryResult({ data: remoteWithMute }));
+      rerender({});
+
+      await waitFor(() => {
+        expect(result.current.isTraderNotificationEnabled('trader-x')).toBe(
+          false,
+        );
+      });
+    });
+
     it('rolls back from the optimistic cache update when the PUT fails', async () => {
       mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
       mockCall.mockImplementation(async (action: string) => {

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
@@ -90,6 +90,11 @@ export const useNotificationPreferences =
     const [overlay, setOverlay] = useState<SocialAIPreference | undefined>(
       undefined,
     );
+    // Number of in-flight PUTs. The overlay is only allowed to drop once this
+    // is 0, so a refetch landing mid-flight cannot snap the UI back to the
+    // pre-PUT value via the react-query cache. Bumped synchronously in
+    // applyChange (before await) and decremented when the PUT settles.
+    const [pendingWrites, setPendingWrites] = useState(0);
     const [persistError, setPersistError] = useState<string | null>(null);
 
     const remoteSocialAI: SocialAIPreference =
@@ -144,6 +149,7 @@ export const useNotificationPreferences =
         const nextSocialAI = updater(currentSocialAIRef.current);
         currentSocialAIRef.current = nextSocialAI;
         setOverlay(nextSocialAI);
+        setPendingWrites((count) => count + 1);
         setPersistError(null);
 
         try {
@@ -160,16 +166,22 @@ export const useNotificationPreferences =
             setPersistError(toErrorMessage(err));
           }
           return;
+        } finally {
+          setPendingWrites((count) => Math.max(0, count - 1));
         }
       },
       [enqueuePersist, hasNotificationPreferences],
     );
 
     useEffect(() => {
-      if (overlay && hasRemoteCaughtUp(overlay, remoteSocialAI)) {
+      if (
+        overlay &&
+        pendingWrites === 0 &&
+        hasRemoteCaughtUp(overlay, remoteSocialAI)
+      ) {
         setOverlay(undefined);
       }
-    }, [overlay, remoteSocialAI]);
+    }, [overlay, pendingWrites, remoteSocialAI]);
 
     const setPushNotificationsEnabled = useCallback(
       (value: boolean) =>

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useEffect } from 'react';
-import { Platform } from 'react-native';
+import React, { useRef, useEffect, useState } from 'react';
+import { Platform, Pressable } from 'react-native';
 import { screen, fireEvent } from '@testing-library/react-native';
 import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller/notification-services';
 import {
@@ -275,22 +275,62 @@ describe('TraderNotificationsBottomSheet', () => {
       expect(mockToggleTraderNotification).toHaveBeenCalledWith('trader-1');
     });
 
-    it('reflects the new value locally and does not snap back if the hook still reports the old value', () => {
-      renderOpenedSheet({
-        traderId: 'trader-1',
-        isTraderNotificationEnabled: () => true,
-      });
+    it('mirrors the hook value on every render so the optimistic overlay (or rollback) drives the Switch directly', () => {
+      const Controllable: React.FC = () => {
+        const ref = useRef<TraderNotificationsBottomSheetRef>(null);
+        const [hookEnabled, setHookEnabled] = useState(true);
+        mockIsTraderNotificationEnabled.mockImplementation(() => hookEnabled);
+        useEffect(() => {
+          ref.current?.onOpenBottomSheet();
+        }, []);
+        return (
+          <>
+            <TraderNotificationsBottomSheet
+              ref={ref}
+              traderId="trader-1"
+              traderName="dutchiono"
+            />
+            <Pressable
+              testID="reopen"
+              onPress={() => ref.current?.onOpenBottomSheet()}
+            />
+            <Pressable
+              testID="hook-flip-off"
+              onPress={() => setHookEnabled(false)}
+            />
+            <Pressable
+              testID="hook-flip-on"
+              onPress={() => setHookEnabled(true)}
+            />
+          </>
+        );
+      };
 
-      fireEvent(
-        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
-        'valueChange',
-        false,
-      );
+      renderWithProvider(<Controllable />);
 
       expect(
         screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE)
           .props.value,
+      ).toBe(true);
+
+      fireEvent.press(screen.getByTestId('hook-flip-off'));
+      expect(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE)
+          .props.value,
       ).toBe(false);
+
+      fireEvent.press(
+        screen.getByTestId(
+          TraderNotificationsBottomSheetSelectorsIDs.CLOSE_BUTTON,
+        ),
+      );
+      fireEvent.press(screen.getByTestId('hook-flip-on'));
+      fireEvent.press(screen.getByTestId('reopen'));
+
+      expect(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE)
+          .props.value,
+      ).toBe(true);
     });
 
     it('disables the toggle when push notifications are off', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
@@ -1,10 +1,9 @@
 import React, { useRef, useEffect } from 'react';
 import { Platform } from 'react-native';
-import { screen, fireEvent, act } from '@testing-library/react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
 import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller/notification-services';
 import {
   ImpactFeedbackStyle,
-  ImpactMoment,
   playImpact,
 } from '../../../../../../util/haptics';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
@@ -231,16 +230,6 @@ describe('TraderNotificationsBottomSheet', () => {
         ),
       ).toBeOnTheScreen();
     });
-
-    it('renders the save button', () => {
-      renderOpenedSheet();
-
-      expect(
-        screen.getByTestId(
-          TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-        ),
-      ).toBeOnTheScreen();
-    });
   });
 
   describe('toggle', () => {
@@ -270,7 +259,7 @@ describe('TraderNotificationsBottomSheet', () => {
       expect(toggle.props.value).toBe(false);
     });
 
-    it('flips the toggle value locally but does NOT call toggleTraderNotification immediately', () => {
+    it('calls toggleTraderNotification immediately when the toggle is changed', () => {
       renderOpenedSheet({
         traderId: 'trader-1',
         isTraderNotificationEnabled: () => true,
@@ -282,7 +271,22 @@ describe('TraderNotificationsBottomSheet', () => {
         false,
       );
 
-      expect(mockToggleTraderNotification).not.toHaveBeenCalled();
+      expect(mockToggleTraderNotification).toHaveBeenCalledTimes(1);
+      expect(mockToggleTraderNotification).toHaveBeenCalledWith('trader-1');
+    });
+
+    it('reflects the new value locally and does not snap back if the hook still reports the old value', () => {
+      renderOpenedSheet({
+        traderId: 'trader-1',
+        isTraderNotificationEnabled: () => true,
+      });
+
+      fireEvent(
+        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
+        'valueChange',
+        false,
+      );
+
       expect(
         screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE)
           .props.value,
@@ -356,145 +360,11 @@ describe('TraderNotificationsBottomSheet', () => {
     });
   });
 
-  describe('save button', () => {
-    it('calls toggleTraderNotification when the toggle was changed before saving', () => {
-      renderOpenedSheet({
-        traderId: 'trader-1',
-        isTraderNotificationEnabled: () => true,
-      });
-
-      fireEvent(
-        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
-        'valueChange',
-        false,
-      );
-
-      act(() => {
-        fireEvent.press(
-          screen.getByTestId(
-            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          ),
-        );
-      });
-
-      expect(mockToggleTraderNotification).toHaveBeenCalledWith('trader-1');
-    });
-
-    it('does not call toggleTraderNotification when the toggle was not changed before saving', () => {
-      renderOpenedSheet({
-        traderId: 'trader-1',
-        isTraderNotificationEnabled: () => true,
-      });
-
-      act(() => {
-        fireEvent.press(
-          screen.getByTestId(
-            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          ),
-        );
-      });
-
-      expect(mockToggleTraderNotification).not.toHaveBeenCalled();
-    });
-
-    it('does not call toggleTraderNotification when the toggle was changed and then reverted before saving', () => {
-      renderOpenedSheet({
-        traderId: 'trader-1',
-        isTraderNotificationEnabled: () => true,
-      });
-
-      fireEvent(
-        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
-        'valueChange',
-        false,
-      );
-      fireEvent(
-        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
-        'valueChange',
-        true,
-      );
-
-      act(() => {
-        fireEvent.press(
-          screen.getByTestId(
-            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          ),
-        );
-      });
-
-      expect(mockToggleTraderNotification).not.toHaveBeenCalled();
-    });
-
-    it('closes the sheet and calls onDismiss when save is pressed', () => {
-      const mockOnDismiss = jest.fn();
-
-      renderOpenedSheet({ onDismiss: mockOnDismiss });
-
-      act(() => {
-        fireEvent.press(
-          screen.getByTestId(
-            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          ),
-        );
-      });
-
-      expect(mockOnDismiss).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).not.toHaveBeenCalled();
-    });
-  });
-
   describe('haptic feedback', () => {
     const originalPlatform = Platform.OS;
 
     afterEach(() => {
       Platform.OS = originalPlatform;
-    });
-
-    it('fires a medium impact when pressing save', () => {
-      Platform.OS = 'ios';
-      renderOpenedSheet({
-        traderId: 'trader-1',
-        isTraderNotificationEnabled: () => true,
-      });
-
-      fireEvent(
-        screen.getByTestId(TraderNotificationsBottomSheetSelectorsIDs.TOGGLE),
-        'valueChange',
-        false,
-      );
-      mockImpactAsync.mockClear();
-      mockPlayImpact.mockClear();
-
-      act(() => {
-        fireEvent.press(
-          screen.getByTestId(
-            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          ),
-        );
-      });
-
-      expect(mockPlayImpact).toHaveBeenCalledTimes(1);
-      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
-    });
-
-    it('fires a medium impact when pressing save even if the value did not change', () => {
-      Platform.OS = 'ios';
-      renderOpenedSheet({
-        traderId: 'trader-1',
-        isTraderNotificationEnabled: () => true,
-      });
-
-      act(() => {
-        fireEvent.press(
-          screen.getByTestId(
-            TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          ),
-        );
-      });
-
-      expect(mockPlayImpact).toHaveBeenCalledTimes(1);
-      expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
-      expect(mockToggleTraderNotification).not.toHaveBeenCalled();
     });
 
     it('fires a light impact when toggling the local switch on Android', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.testIds.ts
@@ -3,5 +3,4 @@ export const TraderNotificationsBottomSheetSelectorsIDs = {
   CLOSE_BUTTON: 'trader-notifications-bottom-sheet-close-button',
   TOGGLE: 'trader-notifications-bottom-sheet-toggle',
   MANAGE_TRADERS_ROW: 'trader-notifications-bottom-sheet-manage-traders-row',
-  SAVE_BUTTON: 'trader-notifications-bottom-sheet-save-button',
 };

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useCallback, useEffect, useState } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -17,16 +23,12 @@ import {
   IconColor,
 } from '@metamask/design-system-react-native';
 import BottomSheet from '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet';
-import BottomSheetFooter from '../../../../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter';
 import HeaderCompactStandard from '../../../../../../component-library/components-temp/HeaderCompactStandard';
-import { ButtonVariants } from '../../../../../../component-library/components/Buttons/Button/Button.types';
 import { strings } from '../../../../../../../locales/i18n';
 import Routes from '../../../../../../constants/navigation/Routes';
 import {
   fireSwitchHaptic,
   ImpactFeedbackStyle,
-  playImpact,
-  ImpactMoment,
 } from '../../../../../../util/haptics';
 import { useNotificationPreferences } from '../../../NotificationPreferences/hooks';
 import AllowPushNotificationsRow from '../../../NotificationPreferences/components/AllowPushNotificationsRow';
@@ -54,9 +56,6 @@ const TraderNotificationsBottomSheet = forwardRef<
     isTraderNotificationEnabled,
     toggleTraderNotification,
   } = useNotificationPreferences();
-  const [localEnabled, setLocalEnabled] = useState(() =>
-    isTraderNotificationEnabled(traderId),
-  );
   const tw = useTailwind();
   const navigation = useNavigation();
 
@@ -66,10 +65,19 @@ const TraderNotificationsBottomSheet = forwardRef<
   const pushNotificationsOff =
     !hasNotificationPreferences || !preferences.pushNotificationsEnabled;
 
-  // Snapshot the remote value each time the sheet opens so the toggle
-  // always starts from the authoritative server state.
+  // Local optimistic value shown in the Switch. Seeded from the hook on the
+  // first open and then driven purely by user taps. This shields the UI from
+  // transient remote churn (stale refetches overwriting the optimistic cache)
+  // which would otherwise snap the Switch back even though the PUT succeeded,
+  // or show the old value on reopen. Once the user has touched the toggle,
+  // local state stays authoritative for the rest of the bottom sheet's mount.
+  const [localEnabled, setLocalEnabled] = useState(() =>
+    isTraderNotificationEnabled(traderId),
+  );
+  const userTouchedRef = useRef(false);
+
   useEffect(() => {
-    if (isVisible) {
+    if (isVisible && !userTouchedRef.current) {
       setLocalEnabled(isTraderNotificationEnabled(traderId));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -97,23 +105,20 @@ const TraderNotificationsBottomSheet = forwardRef<
     });
   }, [hasNotificationPreferences, navigation, sheetRef]);
 
-  // Only persist when the user explicitly confirms with Save.
-  // If the local draft differs from the remote value, issue one toggle call.
-  // Save is a deliberate primary-action commit, so always fire the haptic
-  // — including when the value didn't change — to acknowledge the press.
-  const handleSave = useCallback(() => {
-    playImpact(ImpactMoment.PrimaryCTA);
-    if (localEnabled !== isTraderNotificationEnabled(traderId)) {
+  const handleToggle = useCallback(
+    (next: boolean) => {
+      if (pushNotificationsOff) {
+        return;
+      }
+      // Subordinate switch: rely on iOS UISwitch's native tick on iOS,
+      // fire a Light impact only on Android where there is none.
+      fireSwitchHaptic(ImpactFeedbackStyle.Light);
+      userTouchedRef.current = true;
+      setLocalEnabled(next);
       toggleTraderNotification(traderId);
-    }
-    closeSheet();
-  }, [
-    closeSheet,
-    isTraderNotificationEnabled,
-    localEnabled,
-    toggleTraderNotification,
-    traderId,
-  ]);
+    },
+    [pushNotificationsOff, toggleTraderNotification, traderId],
+  );
 
   if (!isVisible) {
     return null;
@@ -150,15 +155,7 @@ const TraderNotificationsBottomSheet = forwardRef<
           { traderName },
         )}
         value={localEnabled}
-        onValueChange={(next: boolean) => {
-          if (pushNotificationsOff) {
-            return;
-          }
-          // Subordinate switch: rely on iOS UISwitch's native tick on iOS,
-          // fire a Light impact only on Android where there is none.
-          fireSwitchHaptic(ImpactFeedbackStyle.Light);
-          setLocalEnabled(next);
-        }}
+        onValueChange={handleToggle}
         disabled={pushNotificationsOff}
         toggleTestID={TraderNotificationsBottomSheetSelectorsIDs.TOGGLE}
       />
@@ -175,7 +172,7 @@ const TraderNotificationsBottomSheet = forwardRef<
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Between}
-          twClassName="px-4 py-4"
+          twClassName="px-4 py-4 mb-4"
         >
           <Box
             flexDirection={BoxFlexDirection.Row}
@@ -200,18 +197,6 @@ const TraderNotificationsBottomSheet = forwardRef<
           />
         </Box>
       </TouchableOpacity>
-
-      <BottomSheetFooter
-        buttonPropsArray={[
-          {
-            variant: ButtonVariants.Primary,
-            label: strings('social_leaderboard.trader_notifications.save'),
-            onPress: handleSave,
-            testID: TraderNotificationsBottomSheetSelectorsIDs.SAVE_BUTTON,
-          },
-        ]}
-        style={tw.style('px-4 mb-4')}
-      />
     </BottomSheet>
   );
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.tsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -65,23 +59,11 @@ const TraderNotificationsBottomSheet = forwardRef<
   const pushNotificationsOff =
     !hasNotificationPreferences || !preferences.pushNotificationsEnabled;
 
-  // Local optimistic value shown in the Switch. Seeded from the hook on the
-  // first open and then driven purely by user taps. This shields the UI from
-  // transient remote churn (stale refetches overwriting the optimistic cache)
-  // which would otherwise snap the Switch back even though the PUT succeeded,
-  // or show the old value on reopen. Once the user has touched the toggle,
-  // local state stays authoritative for the rest of the bottom sheet's mount.
-  const [localEnabled, setLocalEnabled] = useState(() =>
-    isTraderNotificationEnabled(traderId),
-  );
-  const userTouchedRef = useRef(false);
-
-  useEffect(() => {
-    if (isVisible && !userTouchedRef.current) {
-      setLocalEnabled(isTraderNotificationEnabled(traderId));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isVisible]);
+  // The hook is the single source of truth: it serves an optimistic overlay
+  // that flips instantly on tap, drops only once the remote catches up, and
+  // rolls back on failed PUTs. Reading it directly avoids stale local state
+  // surviving across open/close cycles.
+  const enabled = isTraderNotificationEnabled(traderId);
 
   const handleManageTradersPress = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet(() => {
@@ -105,20 +87,15 @@ const TraderNotificationsBottomSheet = forwardRef<
     });
   }, [hasNotificationPreferences, navigation, sheetRef]);
 
-  const handleToggle = useCallback(
-    (next: boolean) => {
-      if (pushNotificationsOff) {
-        return;
-      }
-      // Subordinate switch: rely on iOS UISwitch's native tick on iOS,
-      // fire a Light impact only on Android where there is none.
-      fireSwitchHaptic(ImpactFeedbackStyle.Light);
-      userTouchedRef.current = true;
-      setLocalEnabled(next);
-      toggleTraderNotification(traderId);
-    },
-    [pushNotificationsOff, toggleTraderNotification, traderId],
-  );
+  const handleToggle = useCallback(() => {
+    if (pushNotificationsOff) {
+      return;
+    }
+    // Subordinate switch: rely on iOS UISwitch's native tick on iOS,
+    // fire a Light impact only on Android where there is none.
+    fireSwitchHaptic(ImpactFeedbackStyle.Light);
+    toggleTraderNotification(traderId);
+  }, [pushNotificationsOff, toggleTraderNotification, traderId]);
 
   if (!isVisible) {
     return null;
@@ -154,7 +131,7 @@ const TraderNotificationsBottomSheet = forwardRef<
           'social_leaderboard.trader_notifications.allow_push_notifications_desc',
           { traderName },
         )}
-        value={localEnabled}
+        value={enabled}
         onValueChange={handleToggle}
         disabled={pushNotificationsOff}
         toggleTestID={TraderNotificationsBottomSheetSelectorsIDs.TOGGLE}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1047,8 +1047,7 @@
       "title": "Notifications from {{traderName}}",
       "allow_push_notifications": "Allow push notifications",
       "allow_push_notifications_desc": "Get notified on {{traderName}}'s trading activity",
-      "manage_traders": "Manage traders you follow",
-      "save": "Save"
+      "manage_traders": "Manage traders you follow"
     },
     "trader_notifications_setup": {
       "description": "Get real-time alerts on trades from the traders you follow",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -1045,8 +1045,7 @@
       "title": "Notifications de {{traderName}}",
       "allow_push_notifications": "Autoriser les notifications push",
       "allow_push_notifications_desc": "Recevez des notifications concernant l’activité de trading de {{traderName}}",
-      "manage_traders": "Gérer les traders que vous suivez",
-      "save": "Sauvegarder"
+      "manage_traders": "Gérer les traders que vous suivez"
     },
     "trader_notifications_setup": {
       "description": "Recevez des alertes en temps réel sur les transactions des traders que vous suivez",


### PR DESCRIPTION
## **Description**

The per-trader notifications bottom sheet had two related problems:

1. The **Save** button was inconsistent with every other notification setting in the app, which auto-save on toggle. It also added a confirmation step nobody asked for.
2. Removing the Save button surfaced an existing **snap-back bug** in `useNotificationPreferences`: the optimistic overlay was being dropped too eagerly, so a background refetch landing during the in-flight PUT would briefly flip the Switch back to the pre-PUT value.

**Root cause of the snap-back.** `updatePreferencesSection` writes the new value to the react-query cache synchronously via `setQueryData(...)`. That makes `remoteSocialAI === overlay` on the very next render, the drop effect fires, and the overlay is gone before the PUT has reached the server. Any subsequent background refetch (focus, interval, invalidation) returning stale data then overwrites the cache and snaps the Switch back.

**Fix.** Gate the overlay drop on a `pendingWrites` counter inside `useNotificationPreferences`. The overlay can only clear once **both** conditions hold: the PUT has actually settled, AND the remote matches. This lets the bottom sheet bind the Switch directly to `isTraderNotificationEnabled(traderId)` — no local state, no `userTouchedRef`, no open/close gymnastics.

**Bottom sheet cleanup.** With the hook fixed, `TraderNotificationsBottomSheet` reads straight from the hook. The Save button, its translation key, and its test id are removed. Each tap calls `toggleTraderNotification` immediately and the Switch reflects the optimistic value (or the rolled-back value on PUT failure) without flicker.

## **Changelog**

CHANGELOG entry: Fixed an issue where the per-trader notifications toggle could briefly snap back to its previous value while saving, and removed the redundant Save button in favor of immediate save.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: per-trader notifications bottom sheet

  Scenario: user toggles a trader notification off
    Given the user is on a trader profile
    And the per-trader notifications bottom sheet is open
    And the toggle is currently on
    When the user taps the toggle
    Then the toggle flips to off immediately
    And the toggle does not snap back during the network round-trip
    And closing and reopening the sheet still shows the toggle as off

  Scenario: PUT fails mid-flight
    Given the user has just toggled the per-trader notification
    When the backend rejects the PUT
    Then the toggle rolls back to its previous value
    And reopening the sheet still shows the rolled-back value

  Scenario: push notifications are disabled globally
    Given push notifications are off
    When the user opens the bottom sheet
    Then the per-trader toggle is disabled
    And tapping it does not fire a PUT
```

## **Screenshots/Recordings**

### **Before**

<img width="416" height="866" alt="image" src="https://github.com/user-attachments/assets/0711a210-b7a8-493b-80f6-86d5bf388cc8" />


### **After**

<img width="416" height="866" alt="image" src="https://github.com/user-attachments/assets/eb1c7006-a7fc-4b18-ade9-b71751e4630c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and preference-sync changes in Social Leaderboard notifications; no auth or payment paths, with regression tests added.
>
> **Overview**
> Removes the **Save** step from the per-trader notifications bottom sheet so toggles **persist immediately** via `toggleTraderNotification`, matching other notification settings.
>
> The sheet no longer keeps local draft state: the switch reads **`isTraderNotificationEnabled`** from `useNotificationPreferences` and calls **`toggleTraderNotification`** on change (with existing push-off guard and switch haptics).
>
> **`useNotificationPreferences`** adds a **`pendingWrites`** counter so the optimistic overlay is cleared only when no PUT is in flight **and** remote data has caught up—preventing the toggle from snapping back if React Query briefly shows stale data mid-request.
>
> Tests cover in-flight overlay stability and updated bottom-sheet behavior; **`SAVE_BUTTON`** test id and **`social_leaderboard.trader_notifications.save`** copy are removed.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336d32e69594fbb16ad4c4ce7e79c2085248e441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
