### PR TITLE
fix: non-evm assets not being added

### DIFF
--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
@@ -754,7 +754,7 @@ describe('SearchTokenAutocomplete', () => {
       );
     });
 
-    it('does not call AssetsController.addCustomAsset for non-EVM chains', async () => {
+    it('calls AssetsController.addCustomAsset for non-EVM chains when assetsUnify is enabled', async () => {
       mockSelectInternalAccountByScope.mockReturnValue({
         id: 'non-evm-account-id',
         address: 'non-evm-address',
@@ -767,7 +767,50 @@ describe('SearchTokenAutocomplete', () => {
       const [, params] = mockNavigation.navigate.mock.calls[0];
       await params.addTokenList();
 
+      expect(
+        Engine.context.MultichainAssetsController.addAssets,
+      ).toHaveBeenCalled();
+      expect(mockAddCustomAsset).toHaveBeenCalledWith(
+        'non-evm-account-id',
+        mockNonEvmToken.address,
+      );
+    });
+
+    it('does not call AssetsController.addCustomAsset for non-EVM chains when assetsUnify is disabled', async () => {
+      mockSelectInternalAccountByScope.mockReturnValue({
+        id: 'non-evm-account-id',
+        address: 'non-evm-address',
+      });
+      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(false);
+
+      const utils = renderComponent({ selectedChainId: solanaChainId });
+      selectTokenAndPressNext(utils);
+
+      const [, params] = mockNavigation.navigate.mock.calls[0];
+      await params.addTokenList();
+
+      expect(
+        Engine.context.MultichainAssetsController.addAssets,
+      ).toHaveBeenCalled();
       expect(mockAddCustomAsset).not.toHaveBeenCalled();
+    });
+
+    it('logs error but still tracks analytics when addCustomAsset throws for non-EVM', async () => {
+      mockSelectInternalAccountByScope.mockReturnValue({
+        id: 'non-evm-account-id',
+        address: 'non-evm-address',
+      });
+      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
+      mockAddCustomAsset.mockRejectedValue(new Error('snap error'));
+
+      const utils = renderComponent({ selectedChainId: solanaChainId });
+      selectTokenAndPressNext(utils);
+
+      const [, params] = mockNavigation.navigate.mock.calls[0];
+      await params.addTokenList();
+
+      expect(mockAddCustomAsset).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -280,6 +280,21 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
         addresses as CaipAssetType[],
         selectedNonEvmAccount.id,
       );
+
+      if (isAssetsUnifyStateEnabled) {
+        try {
+          await Promise.all(
+            (addresses as CaipAssetType[]).map((assetId) =>
+              handleAddCustomAsset(assetId, selectedNonEvmAccount.id),
+            ),
+          );
+        } catch (error) {
+          Logger.error(
+            error as Error,
+            'SearchTokenAutoComplete: addCustomAsset failed for non-EVM asset',
+          );
+        }
+      }
     } else {
       const caipChainId = formatChainIdToCaip(
         selectedChainId as SupportedCaipChainId,

--- a/app/selectors/assets/assets-migration.test.ts
+++ b/app/selectors/assets/assets-migration.test.ts
@@ -1542,7 +1542,9 @@ describe('getMultiChainBalancesControllerBalances', () => {
                   [solanaTokenAssetId]: { amount: '250.5' },
                 },
               },
+              customAssets: {},
             },
+            MultichainAssetsController: { assetsMetadata: {} },
             AccountsController: {
               internalAccounts: {
                 accounts: {
@@ -1568,6 +1570,172 @@ describe('getMultiChainBalancesControllerBalances', () => {
           [solanaTokenAssetId]: { amount: '250.5', unit: 'USDC' },
         },
       });
+    });
+  });
+
+  describe('edge cases when enabled', () => {
+    it('adds zero-balance placeholder for custom non-EVM asset not yet in assetsBalance', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainBalancesController: { balances: {} },
+            AssetsController: {
+              assetsInfo: {
+                [solanaTokenAssetId]: {
+                  type: 'token',
+                  decimals: 6,
+                  symbol: 'USDC',
+                },
+              },
+              assetsBalance: {},
+              customAssets: {
+                [mockAccountId2]: [solanaTokenAssetId as CaipAssetType],
+              },
+            },
+            MultichainAssetsController: { assetsMetadata: {} },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId2]: {
+                    id: mockAccountId2,
+                    type: 'solana:data-account',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getMultiChainBalancesControllerBalances(state);
+
+      expect(result).toStrictEqual({
+        [mockAccountId2]: {
+          [solanaTokenAssetId]: { amount: '0', unit: 'USDC' },
+        },
+      });
+    });
+
+    it('falls back to MultichainAssetsController metadata symbol when assetsInfo has no entry', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainBalancesController: { balances: {} },
+            AssetsController: {
+              assetsInfo: {},
+              assetsBalance: {},
+              customAssets: {
+                [mockAccountId2]: [solanaTokenAssetId as CaipAssetType],
+              },
+            },
+            MultichainAssetsController: {
+              assetsMetadata: {
+                [solanaTokenAssetId as CaipAssetType]: {
+                  fungible: true as const,
+                  symbol: 'USDC',
+                  name: 'USD Coin',
+                  units: [{ decimals: 6, symbol: 'USDC', name: 'USD Coin' }],
+                },
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId2]: {
+                    id: mockAccountId2,
+                    type: 'solana:data-account',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getMultiChainBalancesControllerBalances(state);
+
+      expect(result[mockAccountId2][solanaTokenAssetId]).toStrictEqual({
+        amount: '0',
+        unit: 'USDC',
+      });
+    });
+
+    it('does not overwrite a real balance with the zero placeholder', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainBalancesController: { balances: {} },
+            AssetsController: {
+              assetsInfo: {
+                [solanaTokenAssetId]: {
+                  type: 'token',
+                  decimals: 6,
+                  symbol: 'USDC',
+                },
+              },
+              assetsBalance: {
+                [mockAccountId2]: {
+                  [solanaTokenAssetId]: { amount: '100' },
+                },
+              },
+              customAssets: {
+                [mockAccountId2]: [solanaTokenAssetId as CaipAssetType],
+              },
+            },
+            MultichainAssetsController: { assetsMetadata: {} },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId2]: {
+                    id: mockAccountId2,
+                    type: 'solana:data-account',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getMultiChainBalancesControllerBalances(state);
+
+      expect(result[mockAccountId2][solanaTokenAssetId]).toStrictEqual({
+        amount: '100',
+        unit: 'USDC',
+      });
+    });
+
+    it('skips EVM custom assets from the non-EVM placeholder logic', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainBalancesController: { balances: {} },
+            AssetsController: {
+              assetsInfo: {},
+              assetsBalance: {},
+              customAssets: {
+                [mockAccountId]: [erc20AssetId as CaipAssetType],
+              },
+            },
+            MultichainAssetsController: { assetsMetadata: {} },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId]: {
+                    id: mockAccountId,
+                    address: mockAccountAddressLowercase,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getMultiChainBalancesControllerBalances(state);
+
+      expect(result).toStrictEqual({});
     });
   });
 });

--- a/app/selectors/assets/assets-migration.ts
+++ b/app/selectors/assets/assets-migration.ts
@@ -541,6 +541,11 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
     (state) =>
       state.engine?.backgroundState?.AssetsController?.assetsInfo ?? {},
     (state) =>
+      state.engine?.backgroundState?.AssetsController?.customAssets ?? {},
+    (state) =>
+      state.engine?.backgroundState?.MultichainAssetsController
+        ?.assetsMetadata ?? {},
+    (state) =>
       state.engine?.backgroundState?.AccountsController?.internalAccounts
         ?.accounts ?? {},
   ],
@@ -549,6 +554,8 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
     balances: MultichainBalancesControllerState['balances'],
     assetsBalance: AssetsControllerState['assetsBalance'],
     assetsInfo: AssetsControllerState['assetsInfo'],
+    customAssets: AssetsControllerState['customAssets'],
+    multichainAssetsMetadata: MultichainAssetsControllerState['assetsMetadata'],
     internalAccountsById: AccountsControllerState['internalAccounts']['accounts'],
   ): MultichainBalancesControllerState['balances'] => {
     if (!isAssetsUnifyStateEnabled) {
@@ -580,6 +587,38 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
           amount: balance.amount,
           unit: metadata.symbol,
         };
+      }
+    }
+
+    // Add zero-balance placeholder entries for custom non-EVM assets that have
+    // no balance entry yet (e.g. freshly imported tokens awaiting first snap
+    // poll). Without this, selectAllMultichainAssets skips them entirely and
+    // they never appear in the token list.
+    for (const [accountId, assetIds] of Object.entries(customAssets)) {
+      const internalAccount = internalAccountsById[accountId];
+      if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+        continue;
+      }
+
+      const accountBalances = assetsBalance[accountId] ?? {};
+
+      for (const assetId of assetIds) {
+        if (accountBalances[assetId]) {
+          continue; // real balance already handled above
+        }
+
+        const assetType = parseCaipAssetType(assetId);
+        if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+          continue;
+        }
+
+        // Prefer symbol from assetsInfo; fall back to MultichainAssetsController metadata
+        const unifyMetadata = assetsInfo[assetId];
+        const multichainMetadata = multichainAssetsMetadata[assetId];
+        const unit = unifyMetadata?.symbol ?? multichainMetadata?.symbol ?? '';
+
+        result[accountId] ??= {};
+        result[accountId][assetId] = { amount: '0', unit };
       }
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fix non-evm assets not being added

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix non-evm assets not being added

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3268

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the token-import path and balance migration selectors that drive what appears in the wallet; failures are mostly logged, but incorrect placeholders could affect token list display.
> 
> **Overview**
> Fixes **non-EVM token import** when **assets unify** is on by mirroring the EVM path: after `MultichainAssetsController.addAssets`, `SearchTokenAutocomplete` now also registers each asset via `handleAddCustomAsset` (gated on the feature flag), with errors logged but analytics still fired.
> 
> **`getMultiChainBalancesControllerBalances`** now synthesizes **zero-balance** rows for custom non-EVM assets that lack `assetsBalance` yet (symbol from `assetsInfo` or multichain metadata), so freshly imported tokens are not dropped from multichain asset selectors before the first balance poll.
> 
> Tests cover the new import behavior and placeholder edge cases (no overwrite of real balances, EVM custom assets skipped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89ff619a99a8331ec90f0817930f7a03abd4a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->