### PR TITLE
fix: sort no longer sorts on bottom sheet open

### DIFF
--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import React, { useCallback, useEffect } from 'react';
+import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -22,17 +22,15 @@ const TokensFullView = () => {
     selectHomepageSectionsV1Enabled,
   );
 
-  useFocusEffect(
-    useCallback(
-      () => () => {
-        if (isHomepageSectionsV1Enabled) {
-          Engine.context.PreferencesController.setTokenSortConfig(
-            DEFAULT_TOKEN_SORT_CONFIG,
-          );
-        }
-      },
-      [isHomepageSectionsV1Enabled],
-    ),
+  useEffect(
+    () => () => {
+      if (isHomepageSectionsV1Enabled) {
+        Engine.context.PreferencesController.setTokenSortConfig(
+          DEFAULT_TOKEN_SORT_CONFIG,
+        );
+      }
+    },
+    [isHomepageSectionsV1Enabled],
   );
 
   const handleBackPress = useCallback(() => {


### PR DESCRIPTION
## **Description**

On the Tokens full view, opening the Sort bottom sheet silently reset the user's sort preference back to "Declining balance" — even when no row was tapped. The reset originated from a `useFocusEffect` cleanup, which fires on **blur** (e.g. when a modal opens on top) rather than only on unmount.

Switched to `useEffect` with an unmount-only cleanup so the reset still fires when the user leaves the full view back to the wallet, but does not fire when the screen merely blurs behind the sort sheet.

## **Changelog**

CHANGELOG entry: Fixed a bug where the Tokens full view sort preference would silently reset to "Declining balance" when opening the Sort bottom sheet.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-813

## **Manual testing steps**

```gherkin
Feature: Token sort preference persists across opening the Sort bottom sheet

  Scenario: User selects Alphabetical, then re-opens the Sort sheet
    Given the user is on the Tokens full view
    And tokens are currently sorted by "Declining balance ($ high-low)"

    When the user taps the sort icon
    And the user taps "Alphabetically (A–Z)"
    Then the sheet dismisses
    And tokens are sorted alphabetically A–Z

    When the user taps the sort icon again
    Then the Sort bottom sheet shows "Alphabetically (A–Z)" as selected
    And tokens behind the sheet remain in alphabetical order

    When the user dismisses the sheet without tapping any row
    Then tokens remain in alphabetical order

  Scenario: Sort resets when leaving the full view
    Given the user is on the Tokens full view with sort set to "Alphabetically"

    When the user taps back (or swipes back) to the wallet
    And re-enters the Tokens full view
    Then the sort is reset to the default "Declining balance"
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/6afc8d00-0626-41bc-9c7a-b3d749e93177

### **Before**

Uploading before-sort.mov…

### **After**

https://github.com/user-attachments/assets/6afc8d00-0626-41bc-9c7a-b3d749e93177

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in one screen; behavior is more correct and limited to token sort preferences when a feature flag is on.
> 
> **Overview**
> Fixes token sort resetting when the Sort bottom sheet opens on **Tokens full view**.
> 
> **`TokensFullView`** previously used **`useFocusEffect`** cleanup to restore **`DEFAULT_TOKEN_SORT_CONFIG`** when homepage sections v1 is enabled. That cleanup runs on **blur** (e.g. modal/sheet on top), so opening the sort sheet wiped the user's choice without a tap.
> 
> The reset now runs only on **unmount** via **`useEffect`** cleanup, so sort persists while the sheet is open and still resets when leaving the full view back to the wallet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2051fd5e5978b7ae06f6d5317df233b78ca2be94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->