### PR TITLE
feat(predict): add shared portfolio model hook

### DIFF
--- a/app/components/UI/Predict/hooks/index.ts
+++ b/app/components/UI/Predict/hooks/index.ts
@@ -35,6 +35,7 @@ export {
 } from './usePredictSearch';
 
 export { usePredictCashOut } from './usePredictCashOut';
+export { usePredictPortfolio } from './usePredictPortfolio';
 
 export {
   usePredictWorldCupMarkets,

--- a/app/components/UI/Predict/hooks/usePredictBalance.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalance.test.ts
@@ -5,23 +5,18 @@ import { usePredictBalance } from './usePredictBalance';
 import { predictQueries } from '../queries';
 
 const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
+const SECOND_MOCK_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 
 const mockGetBalance = jest.fn();
+const mockGetAccountsFromSelectedAccountGroup = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
       getBalance: (...args: unknown[]) => mockGetBalance(...args),
     },
     AccountTreeController: {
-      getAccountsFromSelectedAccountGroup: jest.fn(() => [
-        {
-          id: 'test-account-id',
-          address: '0x1234567890123456789012345678901234567890',
-          type: 'eip155:eoa',
-          name: 'Test Account',
-          metadata: { lastSelected: 0 },
-        },
-      ]),
+      getAccountsFromSelectedAccountGroup: () =>
+        mockGetAccountsFromSelectedAccountGroup(),
     },
   },
 }));
@@ -62,6 +57,15 @@ describe('usePredictBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetBalance.mockResolvedValue(100);
+    mockGetAccountsFromSelectedAccountGroup.mockReturnValue([
+      {
+        id: 'test-account-id',
+        address: MOCK_ADDRESS,
+        type: 'eip155:eoa',
+        name: 'Test Account',
+        metadata: { lastSelected: 0 },
+      },
+    ]);
     mockEnsurePolygonNetworkExists.mockResolvedValue(undefined);
   });
 
@@ -86,6 +90,42 @@ describe('usePredictBalance', () => {
       expect(result.current.error).toBeNull();
       expect(mockGetBalance).toHaveBeenCalledWith({
         address: MOCK_ADDRESS,
+      });
+    });
+
+    it('fetches against the new address after the selected account changes', async () => {
+      const { Wrapper } = createWrapper();
+      mockGetBalance.mockImplementation(({ address }) =>
+        Promise.resolve(address === SECOND_MOCK_ADDRESS ? 200 : 100),
+      );
+
+      const { result, rerender } = renderHook(() => usePredictBalance(), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.data).toBe(100);
+      });
+
+      mockGetAccountsFromSelectedAccountGroup.mockReturnValue([
+        {
+          id: 'second-account-id',
+          address: SECOND_MOCK_ADDRESS,
+          type: 'eip155:eoa',
+          name: 'Second Account',
+          metadata: { lastSelected: 1 },
+        },
+      ]);
+
+      rerender({});
+
+      await waitFor(() => {
+        expect(result.current.data).toBe(200);
+      });
+
+      expect(mockGetBalance).toHaveBeenCalledWith({ address: MOCK_ADDRESS });
+      expect(mockGetBalance).toHaveBeenCalledWith({
+        address: SECOND_MOCK_ADDRESS,
       });
     });
   });

--- a/app/components/UI/Predict/hooks/usePredictPortfolio.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPortfolio.test.ts
@@ -263,7 +263,7 @@ describe('usePredictPortfolio', () => {
       ({ claimable }: { claimable?: boolean }) =>
         createQuery<PredictPosition[]>({
           data: claimable ? [] : undefined,
-          isLoading: claimable ? false : true,
+          isLoading: !claimable,
         }),
     );
 

--- a/app/components/UI/Predict/hooks/usePredictPortfolio.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPortfolio.test.ts
@@ -1,0 +1,324 @@
+import { renderHook } from '@testing-library/react-native';
+import { PredictPosition, PredictPositionStatus } from '../types';
+import { usePredictPortfolio } from './usePredictPortfolio';
+
+const mockUsePredictBalance = jest.fn();
+const mockUsePredictPositions = jest.fn();
+const mockUsePredictClaim = jest.fn();
+const mockUsePredictDeposit = jest.fn();
+const mockUsePredictWithdraw = jest.fn();
+const mockUsePredictAccountState = jest.fn();
+
+jest.mock('./usePredictBalance', () => ({
+  usePredictBalance: () => mockUsePredictBalance(),
+}));
+
+jest.mock('./usePredictPositions', () => ({
+  usePredictPositions: (options: unknown) => mockUsePredictPositions(options),
+}));
+
+jest.mock('./usePredictClaim', () => ({
+  usePredictClaim: () => mockUsePredictClaim(),
+}));
+
+jest.mock('./usePredictDeposit', () => ({
+  usePredictDeposit: () => mockUsePredictDeposit(),
+}));
+
+jest.mock('./usePredictWithdraw', () => ({
+  usePredictWithdraw: () => mockUsePredictWithdraw(),
+}));
+
+jest.mock('./usePredictAccountState', () => ({
+  usePredictAccountState: (options: unknown) =>
+    mockUsePredictAccountState(options),
+}));
+
+const createPosition = (
+  id: string,
+  overrides: Partial<PredictPosition> = {},
+): PredictPosition => ({
+  amount: 10,
+  avgPrice: 1,
+  cashPnl: 0,
+  claimable: false,
+  currentValue: 100,
+  endDate: '2026-01-01T00:00:00Z',
+  icon: 'icon',
+  id,
+  initialValue: 100,
+  marketId: `market-${id}`,
+  outcome: 'Yes',
+  outcomeId: `outcome-${id}`,
+  outcomeIndex: 0,
+  outcomeTokenId: `token-${id}`,
+  percentPnl: 0,
+  price: 1,
+  providerId: 'provider',
+  size: 10,
+  status: PredictPositionStatus.OPEN,
+  title: `Market ${id}`,
+  ...overrides,
+});
+
+const createQuery = <T>(overrides: Partial<Record<string, unknown>> = {}) => ({
+  data: undefined as T | undefined,
+  error: null,
+  isLoading: false,
+  isRefetching: false,
+  refetch: jest.fn(),
+  ...overrides,
+});
+
+describe('usePredictPortfolio', () => {
+  const mockClaim = jest.fn();
+  const mockDeposit = jest.fn();
+  const mockWithdraw = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUsePredictBalance.mockReturnValue(createQuery<number>({ data: 0 }));
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable ? [] : [],
+        }),
+    );
+    mockUsePredictClaim.mockReturnValue({
+      claim: mockClaim,
+      isClaimPending: false,
+    });
+    mockUsePredictDeposit.mockReturnValue({
+      deposit: mockDeposit,
+      isDepositPending: false,
+    });
+    mockUsePredictWithdraw.mockReturnValue({
+      withdraw: mockWithdraw,
+      withdrawTransaction: undefined,
+    });
+    mockUsePredictAccountState.mockReturnValue(
+      createQuery({
+        data: undefined,
+      }),
+    );
+  });
+
+  it('returns the first-time zero portfolio state', () => {
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.portfolioValue).toBe(0);
+    expect(result.current.availableBalance).toBe(0);
+    expect(result.current.showPnlLine).toBe(false);
+    expect(result.current.showUnrealizedPnl).toBe(false);
+    expect(result.current.totalUnrealizedPnlPercent).toBeUndefined();
+    expect(result.current.openPositionCount).toBe(0);
+    expect(result.current.claimablePositionCount).toBe(0);
+    expect(result.current.positionsBadgeCount).toBe(0);
+    expect(result.current.hasClaimableWinnings).toBe(false);
+  });
+
+  it('returns a usable balance-only portfolio state', () => {
+    mockUsePredictBalance.mockReturnValue(createQuery<number>({ data: 250 }));
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.portfolioValue).toBe(250);
+    expect(result.current.availableBalance).toBe(250);
+    expect(result.current.openPositionCount).toBe(0);
+    expect(result.current.claimablePositionCount).toBe(0);
+    expect(result.current.positionsBadgeCount).toBe(0);
+    expect(result.current.totalUnrealizedPnlAmount).toBe(0);
+    expect(result.current.totalUnrealizedPnlPercent).toBeUndefined();
+    expect(result.current.showUnrealizedPnl).toBe(false);
+  });
+
+  it('combines available balance, open position value, and position-derived P&L for returning users', () => {
+    const openPosition = createPosition('open', {
+      cashPnl: 999,
+      currentValue: 980,
+      initialValue: 1000,
+    });
+    mockUsePredictBalance.mockReturnValue(createQuery<number>({ data: 250 }));
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable ? [] : [openPosition],
+        }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.portfolioValue).toBe(1230);
+    expect(result.current.totalUnrealizedPnlAmount).toBe(-20);
+    expect(result.current.totalUnrealizedPnlPercent).toBe(-2);
+    expect(result.current.showPnlLine).toBe(true);
+    expect(result.current.showUnrealizedPnl).toBe(true);
+    expect(result.current.openPositionCount).toBe(1);
+    expect(result.current.claimablePositionCount).toBe(0);
+    expect(result.current.positionsBadgeCount).toBe(1);
+  });
+
+  it('counts only actionable won claimable positions in value, claim amount, and badge', () => {
+    const openPosition = createPosition('open', { currentValue: 100 });
+    const wonClaimablePosition = createPosition('won', {
+      claimable: true,
+      currentValue: 46.35,
+      status: PredictPositionStatus.WON,
+    });
+    const lostClaimablePosition = createPosition('lost', {
+      claimable: true,
+      currentValue: 10,
+      status: PredictPositionStatus.LOST,
+    });
+
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable
+            ? [wonClaimablePosition, lostClaimablePosition]
+            : [openPosition],
+        }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.claimableAmount).toBe(46.35);
+    expect(result.current.hasClaimableWinnings).toBe(true);
+    expect(result.current.portfolioValue).toBe(146.35);
+    expect(result.current.openPositionCount).toBe(1);
+    expect(result.current.claimablePositionCount).toBe(1);
+    expect(result.current.positionsBadgeCount).toBe(2);
+  });
+
+  it('hides the secondary P&L line below the one-cent threshold', () => {
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable
+            ? []
+            : [
+                createPosition('open', {
+                  cashPnl: 999,
+                  currentValue: 100.009,
+                  initialValue: 100,
+                }),
+              ],
+        }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.totalUnrealizedPnlAmount).toBeCloseTo(0.009);
+    expect(result.current.showPnlLine).toBe(false);
+    expect(result.current.showUnrealizedPnl).toBe(false);
+  });
+
+  it('derives gains from current value minus initial value', () => {
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable
+            ? []
+            : [
+                createPosition('open', {
+                  cashPnl: 999,
+                  currentValue: 125,
+                  initialValue: 100,
+                }),
+              ],
+        }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.totalUnrealizedPnlAmount).toBe(25);
+    expect(result.current.totalUnrealizedPnlPercent).toBe(25);
+  });
+
+  it('omits unrealized P&L percent when open positions have no initial value', () => {
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable
+            ? []
+            : [
+                createPosition('open', {
+                  currentValue: 10,
+                  initialValue: 0,
+                }),
+              ],
+        }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.totalUnrealizedPnlAmount).toBe(10);
+    expect(result.current.totalUnrealizedPnlPercent).toBeUndefined();
+    expect(result.current.showUnrealizedPnl).toBe(true);
+  });
+
+  it('treats position loading as portfolio loading', () => {
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: claimable ? [] : undefined,
+          isLoading: claimable ? false : true,
+        }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('aggregates loading, error, and refetch state', async () => {
+    const balanceRefetch = jest.fn();
+    const activeRefetch = jest.fn();
+    const claimableRefetch = jest.fn();
+    const accountStateRefetch = jest.fn();
+    const balanceError = new Error('balance failed');
+    const activePositionsError = new Error('active positions failed');
+    const claimablePositionsError = new Error('claimable positions failed');
+    const accountStateError = new Error('account state failed');
+
+    mockUsePredictBalance.mockReturnValue(
+      createQuery<number>({
+        error: balanceError,
+        isLoading: true,
+        isRefetching: true,
+        refetch: balanceRefetch,
+      }),
+    );
+    mockUsePredictPositions.mockImplementation(
+      ({ claimable }: { claimable?: boolean }) =>
+        createQuery<PredictPosition[]>({
+          data: [],
+          error: claimable ? claimablePositionsError : activePositionsError,
+          refetch: claimable ? claimableRefetch : activeRefetch,
+        }),
+    );
+    mockUsePredictAccountState.mockReturnValue(
+      createQuery({ error: accountStateError, refetch: accountStateRefetch }),
+    );
+
+    const { result } = renderHook(() => usePredictPortfolio());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isRefreshing).toBe(true);
+    expect(result.current.error).toBe(balanceError);
+    expect(result.current.balanceError).toBe(balanceError);
+    expect(result.current.openPositionsError).toBe(activePositionsError);
+    expect(result.current.claimablePositionsError).toBe(
+      claimablePositionsError,
+    );
+    expect(result.current.accountStateError).toBe(accountStateError);
+
+    await result.current.refetch();
+
+    expect(balanceRefetch).toHaveBeenCalled();
+    expect(activeRefetch).toHaveBeenCalled();
+    expect(claimableRefetch).toHaveBeenCalled();
+    expect(accountStateRefetch).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictPortfolio.ts
+++ b/app/components/UI/Predict/hooks/usePredictPortfolio.ts
@@ -1,6 +1,9 @@
 import { useCallback, useMemo } from 'react';
-import type { AccountState, PredictPosition } from '../types';
-import { PredictPositionStatus } from '../types';
+import {
+  PredictPositionStatus,
+  type AccountState,
+  type PredictPosition,
+} from '../types';
 import { usePredictAccountState } from './usePredictAccountState';
 import { usePredictBalance } from './usePredictBalance';
 import { usePredictClaim } from './usePredictClaim';
@@ -9,6 +12,7 @@ import { usePredictPositions } from './usePredictPositions';
 import { usePredictWithdraw } from './usePredictWithdraw';
 
 const PNL_DISPLAY_THRESHOLD = 0.01;
+const EMPTY_POSITIONS: PredictPosition[] = [];
 
 const sumCurrentValue = (positions: PredictPosition[]) =>
   positions.reduce((sum, position) => sum + position.currentValue, 0);
@@ -85,8 +89,10 @@ export function usePredictPortfolio(): PredictPortfolioModel {
   });
   const claimablePositionsQuery = usePredictPositions({ claimable: true });
 
-  const activePositions = activePositionsQuery.data ?? [];
-  const claimablePositions = claimablePositionsQuery.data ?? [];
+  const activePositions = activePositionsQuery.data ?? EMPTY_POSITIONS;
+  const claimablePositions = claimablePositionsQuery.data ?? EMPTY_POSITIONS;
+  const refetchActivePositions = activePositionsQuery.refetch;
+  const refetchClaimablePositions = claimablePositionsQuery.refetch;
   const openPositions = useMemo(
     () =>
       activePositions.filter(
@@ -112,6 +118,7 @@ export function usePredictPortfolio(): PredictPortfolioModel {
   const accountStateQuery = usePredictAccountState({
     enabled: availableBalance > 0,
   });
+  const refetchAccountState = accountStateQuery.refetch;
 
   const openPositionsValue = useMemo(
     () => sumCurrentValue(openPositions),
@@ -145,15 +152,15 @@ export function usePredictPortfolio(): PredictPortfolioModel {
   const refetch = useCallback(async () => {
     await Promise.all([
       refetchBalance(),
-      activePositionsQuery.refetch(),
-      claimablePositionsQuery.refetch(),
-      accountStateQuery.refetch(),
+      refetchActivePositions(),
+      refetchClaimablePositions(),
+      refetchAccountState(),
     ]);
   }, [
-    accountStateQuery,
-    activePositionsQuery,
-    claimablePositionsQuery,
     refetchBalance,
+    refetchActivePositions,
+    refetchClaimablePositions,
+    refetchAccountState,
   ]);
 
   return {

--- a/app/components/UI/Predict/hooks/usePredictPortfolio.ts
+++ b/app/components/UI/Predict/hooks/usePredictPortfolio.ts
@@ -1,0 +1,203 @@
+import { useCallback, useMemo } from 'react';
+import type { AccountState, PredictPosition } from '../types';
+import { PredictPositionStatus } from '../types';
+import { usePredictAccountState } from './usePredictAccountState';
+import { usePredictBalance } from './usePredictBalance';
+import { usePredictClaim } from './usePredictClaim';
+import { usePredictDeposit } from './usePredictDeposit';
+import { usePredictPositions } from './usePredictPositions';
+import { usePredictWithdraw } from './usePredictWithdraw';
+
+const PNL_DISPLAY_THRESHOLD = 0.01;
+
+const sumCurrentValue = (positions: PredictPosition[]) =>
+  positions.reduce((sum, position) => sum + position.currentValue, 0);
+
+export interface PredictPortfolioModel {
+  activePositions: PredictPosition[];
+  actionableClaimablePositions: PredictPosition[];
+  accountStateError: Error | null;
+  availableBalance: number;
+  balanceError: Error | null;
+  claim: ReturnType<typeof usePredictClaim>['claim'];
+  claimableAmount: number;
+  claimablePositionCount: number;
+  claimablePositions: PredictPosition[];
+  claimablePositionsError: Error | null;
+  deposit: ReturnType<typeof usePredictDeposit>['deposit'];
+  error: Error | null;
+  hasClaimableWinnings: boolean;
+  isBalanceLoading: boolean;
+  isClaimPending: boolean;
+  isDepositPending: boolean;
+  isLoading: boolean;
+  isPositionsLoading: boolean;
+  isRefreshing: boolean;
+  openPositionCount: number;
+  openPositions: PredictPosition[];
+  openPositionsError: Error | null;
+  openPositionsValue: number;
+  portfolioValue: number;
+  positionsBadgeCount: number;
+  refetch: () => Promise<void>;
+  showPnlLine: boolean;
+  showUnrealizedPnl: boolean;
+  totalUnrealizedPnlAmount: number;
+  totalUnrealizedPnlPercent?: number;
+  walletType?: AccountState['walletType'];
+  withdraw: ReturnType<typeof usePredictWithdraw>['withdraw'];
+  withdrawTransaction: ReturnType<
+    typeof usePredictWithdraw
+  >['withdrawTransaction'];
+}
+
+const getPositionsPnl = (positions: PredictPosition[]) => {
+  const totals = positions.reduce(
+    (acc, position) => ({
+      currentValue: acc.currentValue + position.currentValue,
+      initialValue: acc.initialValue + position.initialValue,
+    }),
+    { currentValue: 0, initialValue: 0 },
+  );
+  const amount = totals.currentValue - totals.initialValue;
+
+  return {
+    amount,
+    percent:
+      totals.initialValue > 0
+        ? (amount / totals.initialValue) * 100
+        : undefined,
+  };
+};
+
+export function usePredictPortfolio(): PredictPortfolioModel {
+  const {
+    data: availableBalance = 0,
+    isLoading: isBalanceLoading,
+    isRefetching: isBalanceRefetching,
+    error: balanceError,
+    refetch: refetchBalance,
+  } = usePredictBalance();
+
+  const activePositionsQuery = usePredictPositions({
+    claimable: false,
+    livePriceUpdates: true,
+  });
+  const claimablePositionsQuery = usePredictPositions({ claimable: true });
+
+  const activePositions = activePositionsQuery.data ?? [];
+  const claimablePositions = claimablePositionsQuery.data ?? [];
+  const openPositions = useMemo(
+    () =>
+      activePositions.filter(
+        (position) => position.status === PredictPositionStatus.OPEN,
+      ),
+    [activePositions],
+  );
+  const actionableClaimablePositions = useMemo(
+    () =>
+      claimablePositions.filter(
+        (position) =>
+          position.status === PredictPositionStatus.WON &&
+          position.currentValue > 0,
+      ),
+    [claimablePositions],
+  );
+
+  const hasOpenPositions = openPositions.length > 0;
+  const { claim, isClaimPending } = usePredictClaim();
+  const { deposit, isDepositPending } = usePredictDeposit();
+  const { withdraw, withdrawTransaction } = usePredictWithdraw();
+
+  const accountStateQuery = usePredictAccountState({
+    enabled: availableBalance > 0,
+  });
+
+  const openPositionsValue = useMemo(
+    () => sumCurrentValue(openPositions),
+    [openPositions],
+  );
+  const claimableAmount = useMemo(
+    () => sumCurrentValue(actionableClaimablePositions),
+    [actionableClaimablePositions],
+  );
+  const totalUnrealizedPnl = useMemo(
+    () => getPositionsPnl(openPositions),
+    [openPositions],
+  );
+
+  const totalUnrealizedPnlAmount = hasOpenPositions
+    ? totalUnrealizedPnl.amount
+    : 0;
+  const totalUnrealizedPnlPercent = hasOpenPositions
+    ? totalUnrealizedPnl.percent
+    : undefined;
+  const portfolioValue =
+    availableBalance + openPositionsValue + claimableAmount;
+  const openPositionCount = openPositions.length;
+  const claimablePositionCount = actionableClaimablePositions.length;
+  const positionsBadgeCount = openPositionCount + claimablePositionCount;
+  const isPositionsLoading =
+    activePositionsQuery.isLoading || claimablePositionsQuery.isLoading;
+  const showUnrealizedPnl =
+    Math.abs(totalUnrealizedPnlAmount) >= PNL_DISPLAY_THRESHOLD;
+
+  const refetch = useCallback(async () => {
+    await Promise.all([
+      refetchBalance(),
+      activePositionsQuery.refetch(),
+      claimablePositionsQuery.refetch(),
+      accountStateQuery.refetch(),
+    ]);
+  }, [
+    accountStateQuery,
+    activePositionsQuery,
+    claimablePositionsQuery,
+    refetchBalance,
+  ]);
+
+  return {
+    activePositions,
+    actionableClaimablePositions,
+    accountStateError: accountStateQuery.error ?? null,
+    availableBalance,
+    balanceError,
+    claim,
+    claimableAmount,
+    claimablePositionCount,
+    claimablePositions,
+    claimablePositionsError: claimablePositionsQuery.error ?? null,
+    deposit,
+    error:
+      balanceError ??
+      activePositionsQuery.error ??
+      claimablePositionsQuery.error ??
+      accountStateQuery.error ??
+      null,
+    hasClaimableWinnings: claimableAmount > 0,
+    isBalanceLoading,
+    isClaimPending,
+    isDepositPending,
+    isLoading: isBalanceLoading || isPositionsLoading,
+    isPositionsLoading,
+    isRefreshing:
+      isBalanceRefetching ||
+      activePositionsQuery.isRefetching ||
+      claimablePositionsQuery.isRefetching ||
+      accountStateQuery.isRefetching,
+    openPositionCount,
+    openPositions,
+    openPositionsError: activePositionsQuery.error ?? null,
+    openPositionsValue,
+    portfolioValue,
+    positionsBadgeCount,
+    refetch,
+    showPnlLine: showUnrealizedPnl,
+    showUnrealizedPnl,
+    totalUnrealizedPnlAmount,
+    totalUnrealizedPnlPercent,
+    walletType: accountStateQuery.data?.walletType,
+    withdraw,
+    withdrawTransaction,
+  };
+}

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -5,6 +5,7 @@ import { type PredictPosition, PredictPositionStatus } from '../types';
 import { usePredictPositions } from './usePredictPositions';
 
 const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
+const SECOND_MOCK_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 
 const mockEnsurePolygonNetworkExists = jest.fn<Promise<void>, []>();
 jest.mock('./usePredictNetworkManagement', () => ({
@@ -103,6 +104,10 @@ describe('usePredictPositions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockEnsurePolygonNetworkExists.mockResolvedValue(undefined);
+    mockGetEvmAccountFromSelectedAccountGroup.mockReturnValue({
+      address: MOCK_ADDRESS,
+      type: 'eip155:eoa',
+    });
     mockGetPositions.mockResolvedValue([]);
     mockUsePredictLivePositions.mockImplementation(() => undefined);
   });
@@ -120,6 +125,43 @@ describe('usePredictPositions', () => {
 
     expect(result.current.data).toEqual([]);
     expect(result.current.error).toBeNull();
+  });
+
+  it('fetches against the new address after the selected account changes', async () => {
+    const { Wrapper } = createWrapper();
+    const firstAccountPosition = createPosition('first-account-position');
+    const secondAccountPosition = createPosition('second-account-position');
+    mockGetPositions.mockImplementation(({ address }) =>
+      Promise.resolve(
+        address === SECOND_MOCK_ADDRESS
+          ? [secondAccountPosition]
+          : [firstAccountPosition],
+      ),
+    );
+
+    const { result, rerender } = renderHook(() => usePredictPositions(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([firstAccountPosition]);
+    });
+
+    mockGetEvmAccountFromSelectedAccountGroup.mockReturnValue({
+      address: SECOND_MOCK_ADDRESS,
+      type: 'eip155:eoa',
+    });
+
+    rerender({});
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([secondAccountPosition]);
+    });
+
+    expect(mockGetPositions).toHaveBeenCalledWith({ address: MOCK_ADDRESS });
+    expect(mockGetPositions).toHaveBeenCalledWith({
+      address: SECOND_MOCK_ADDRESS,
+    });
   });
 
   it('returns active and claimable positions when claimable is undefined', async () => {


### PR DESCRIPTION
## **Description**

Adds the shared Predict portfolio data/model hook for PRED-902.

This introduces `usePredictPortfolio`, a reusable portfolio-domain hook that centralizes the Predict balance, open positions, claimable positions, claim/deposit/withdraw handlers, loading/error state, and derived portfolio summary values for the homepage portfolio module and future Positions screen.

The hook derives:

- available Predict balance
- active/open positions and actionable claimable positions
- portfolio value
- open, claimable, and badge counts
- claimable amount
- total unrealized P&L amount and optional percent
- P&L visibility using the one-cent threshold
- aggregate and granular loading/error/refetch state

Unrealized P&L is calculated from open positions only using summed current value minus summed initial value. Resolved won/lost positions are excluded from unrealized P&L, and the P&L percent is omitted when total initial value is zero.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-902

## **Manual testing steps**

```gherkin
Feature: Predict portfolio shared data model

  Scenario: portfolio model derives reusable values for Predict surfaces
    Given the Predict portfolio hook is rendered with balance, open positions, and claimable positions

    When the underlying balance or positions query data changes
    Then the hook returns updated portfolio value, P&L, counts, claimable amount, and loading/error state
```

Manual app QA: N/A. This PR adds a shared data/model hook and unit coverage only; no UI integration is included.

## **Screenshots/Recordings**

N/A. No user-facing UI changes are included in this PR.

### **Before**

N/A

### **After**

N/A

## **Testing**

- `NODE_OPTIONS=--max-old-space-size=8192 node .yarn/releases/yarn-4.14.1.cjs jest app/components/UI/Predict/hooks/usePredictPortfolio.test.ts app/components/UI/Predict/hooks/usePredictBalance.test.ts app/components/UI/Predict/hooks/usePredictPositions.test.ts --runInBand --watchman=false --forceExit --silent --coverage=false`
- `node .yarn/releases/yarn-4.14.1.cjs lint:tsc`

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-layer hook and unit tests only; no UI or payment/auth changes, though derived portfolio/P&amp;L logic will need careful review when integrated.
> 
> **Overview**
> Introduces **`usePredictPortfolio`**, a shared Predict data hook that composes balance, active/claimable positions (with live updates on open positions), account state, and claim/deposit/withdraw actions into one **`PredictPortfolioModel`**.
> 
> It **derives** portfolio value (balance + open position value + actionable won claimables), open/claimable/badge counts, claimable amount, unrealized P&amp;L from open positions only (current vs initial value, percent omitted when initial value is zero), and P&amp;L visibility behind a **$0.01** threshold. Won claimables with positive value count toward value and badges; lost claimables do not. Loading, refresh, aggregated/per-source errors, and a combined **`refetch`** are exposed.
> 
> **Exports** the hook from the Predict hooks barrel. **Adds** unit coverage for the portfolio hook and **new tests** that balance and positions refetch when the selected account address changes (with more flexible account mocks).
> 
> No UI wiring in this PR—hook and tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8588a0932ae53f83dc32e5451e89480d1e1de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->