### PR TITLE
feat: enhance address poisoning detection with error logging

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useAddressPoisoningDetection.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAddressPoisoningDetection.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useAddressPoisoningDetection } from './useAddressPoisoningDetection';
 import Engine from '../../../../../core/Engine';
+import Logger from '../../../../../util/Logger';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -8,6 +9,10 @@ jest.mock('../../../../../core/Engine', () => ({
       checkAddressPoisoning: jest.fn(),
     },
   },
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  error: jest.fn(),
 }));
 
 const mockCheckAddressPoisoning = Engine.context.PhishingController
@@ -67,5 +72,24 @@ describe('useAddressPoisoningDetection', () => {
     renderHook(() => useAddressPoisoningDetection('0xcandidate'));
 
     expect(mockCheckAddressPoisoning).toHaveBeenCalledWith('0xcandidate');
+  });
+
+  it('returns no suspect and logs when checkAddressPoisoning throws', () => {
+    const error = new Error('controller failure');
+    mockCheckAddressPoisoning.mockImplementation(() => {
+      throw error;
+    });
+
+    const { result } = renderHook(() =>
+      useAddressPoisoningDetection('0xcandidate'),
+    );
+
+    expect(result.current.isPoisoningSuspect).toBe(false);
+    expect(result.current.bestMatch).toBeNull();
+    expect(result.current.matches).toHaveLength(0);
+    expect(Logger.error).toHaveBeenCalledWith(
+      error,
+      'useAddressPoisoningDetection',
+    );
   });
 });

--- a/app/components/Views/confirmations/hooks/send/useAddressPoisoningDetection.ts
+++ b/app/components/Views/confirmations/hooks/send/useAddressPoisoningDetection.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { SimilarAddressMatch } from '@metamask/phishing-controller';
 import Engine from '../../../../../core/Engine';
+import Logger from '../../../../../util/Logger';
 
 interface AddressPoisoningDetectionResult {
   isPoisoningSuspect: boolean;
@@ -16,13 +17,18 @@ export function useAddressPoisoningDetection(
       return { isPoisoningSuspect: false, bestMatch: null, matches: [] };
     }
 
-    const matches =
-      Engine.context.PhishingController.checkAddressPoisoning(toAddress);
+    try {
+      const matches =
+        Engine.context.PhishingController.checkAddressPoisoning(toAddress);
 
-    return {
-      isPoisoningSuspect: matches.length > 0,
-      bestMatch: matches[0] ?? null,
-      matches,
-    };
+      return {
+        isPoisoningSuspect: matches.length > 0,
+        bestMatch: matches[0] ?? null,
+        matches,
+      };
+    } catch (error) {
+      Logger.error(error as Error, 'useAddressPoisoningDetection');
+      return { isPoisoningSuspect: false, bestMatch: null, matches: [] };
+    }
   }, [toAddress]);
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -130,7 +130,7 @@
     },
     "address_poisoning": {
       "title": "Address poisoning detected",
-      "message": "This address closely resembles one you've used before. It may have been designed to trick you into sending funds to the wrong recipient.",
+      "message": "This address closely resembles one you've interacted with before. It may have been designed to trick you into sending funds to the wrong recipient.",
       "badge": "Poisoned"
     },
     "burn_address": {


### PR DESCRIPTION
## **Description**

Follow-up to #27294 addressing two review comments from @imblue-dabadee that were missed before merge:

1. **Defensive error handling in `useAddressPoisoningDetection`** — `PhishingController.checkAddressPoisoning` is called on every recipient change. If it throws (e.g. on a malformed address or an uninitialized controller), the exception bubbles out of `useMemo` and crashes the send flow. This PR wraps the call in a `try/catch`, logs via `Logger.error`, and returns a safe default (`isPoisoningSuspect: false`, empty matches). Failing open is acceptable here because the check is an advisory UI warning, not a security gate.

2. **Copy refinement in `en.json`** — the alert message now says `you've interacted with before` instead of `you've used before`. Address poisoning matches against *any* prior interaction (incoming or outgoing), so "interacted with" is more accurate than "used".

A unit test was added covering the error path of the hook.

## **Changelog**

CHANGELOG entry: Improved reliability of address poisoning detection in the send flow and refined the warning copy.

## **Related issues**

Follow-up to: #27294

## **Manual testing steps**

```gherkin
Feature: Address poisoning detection in send flow

  Scenario: User is warned when sending to a poisoning-suspect address
    Given the user has previously interacted with address A
    And address A' is a visually similar poisoning candidate
    When the user enters address A' as the recipient in the send flow
    Then the "Address poisoning detected" alert is shown
    And the message reads "This address closely resembles one you've interacted with before..."

  Scenario: PhishingController failure does not crash the send flow
    Given PhishingController.checkAddressPoisoning throws an error
    When the user enters any recipient address in the send flow
    Then the send flow continues without a crash
    And no poisoning alert is shown
    And the error is logged via Logger.error
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> On PhishingController failure the hook fails open (no poisoning warning), which could briefly hide a real poisoning alert until the check works again.
>
> **Overview**
> **Address poisoning detection** in send/confirm flows now **wraps** \`PhishingController.checkAddressPoisoning\` in a **try/catch**. If the controller throws, the hook **logs** via \`Logger.error\` and returns a **safe default** (no suspect, empty matches) instead of crashing the UI.
>
> A **unit test** covers the error path. The **address poisoning** alert copy in \`en.json\` now says **"interacted with"** instead of **"used"** for the similar-address warning.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76286a68e098c76928e38adf14a095e18b2ec9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->