### PR TITLE
ci: improve E2E shard caching and add cache/timing summaries

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -1,6 +1,14 @@
 name: 'Setup E2E Test Environment'
 description: 'Sets up the environment for running E2E tests'
 
+outputs:
+  cocoapods-deps-cache-hit:
+    description: 'Whether CocoaPods dependencies cache hit (iOS, non-Namespace)'
+    value: ${{ steps.cocoapods-deps-cache.outputs.cache-hit }}
+  cocoapods-install-ran:
+    description: 'Whether bundle exec pod install executed in this run'
+    value: ${{ steps.cocoapods-install-ran.outputs.value || steps.cocoapods-install-skipped.outputs.value }}
+
 inputs:
   platform:
     description: 'Platform (ios or android)'
@@ -422,8 +430,22 @@ runs:
           ${{ runner.os }}-cocoapods-specs-
       continue-on-error: true
 
+    - name: Restore CocoaPods dependencies cache
+      if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
+      id: cocoapods-deps-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ios/Pods
+          ~/Library/Caches/CocoaPods
+        key: ${{ inputs.cache-prefix }}-pods-v1-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+        restore-keys: |
+          ${{ inputs.cache-prefix }}-pods-v1-${{ runner.os }}-
+      continue-on-error: true
+
     - name: Install CocoaPods via bundler
-      if: ${{ inputs.platform == 'ios'}}
+      if: ${{ inputs.platform == 'ios' && (inputs.runner_provider == 'namespace' || steps.cocoapods-deps-cache.outputs.cache-hit != 'true') }}
+      id: install-cocoapods
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
       with:
         timeout_minutes: ${{ fromJSON(inputs.pod-install-timeout-minutes) }}
@@ -435,6 +457,23 @@ runs:
         command: cd ios && bundle exec pod install --repo-update
       env:
         COCOAPODS_DISABLE_STATS: 'true'
+
+    - name: Mark CocoaPods install ran
+      if: ${{ inputs.platform == 'ios' && (inputs.runner_provider == 'namespace' || steps.cocoapods-deps-cache.outputs.cache-hit != 'true') }}
+      id: cocoapods-install-ran
+      run: echo "value=true" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Skip CocoaPods install on dependency cache hit
+      if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' && steps.cocoapods-deps-cache.outputs.cache-hit == 'true' }}
+      run: echo "CocoaPods dependency cache hit - skipping pod install."
+      shell: bash
+
+    - name: Mark CocoaPods install skipped
+      if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' && steps.cocoapods-deps-cache.outputs.cache-hit == 'true' }}
+      id: cocoapods-install-skipped
+      run: echo "value=false" >> "$GITHUB_OUTPUT"
+      shell: bash
 
     - name: Install applesimutils
       if: ${{ inputs.platform == 'ios' }}

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -49,6 +49,13 @@ on:
         required: false
         type: string
         default: ''
+      source_fingerprint:
+        description: >-
+          Canonical @expo/fingerprint hash used for cross-run Android APK cache
+          restore in test shards. Empty disables APK cache restore.
+        required: false
+        type: string
+        default: ''
       artifact_name_prefix:
         description: 'Optional prefix added to uploaded test artifacts'
         required: false
@@ -64,6 +71,9 @@ jobs:
   test-e2e-mobile:
     name: ${{ inputs.test-suite-name }}
     runs-on: ${{ inputs.runner_provider == 'namespace' && (inputs.platform == 'ios' && 'namespace-profile-metamask-ios-e2e' || 'namespace-profile-metamask-android-build') || (startsWith(github.base_ref, 'release/') && fromJSON(format('["{0}"]', inputs.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:tahoe' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg')) || fromJSON(format('["{0}", "low-priority"]', inputs.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:tahoe' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'))) }}
+    permissions:
+      contents: read
+      actions: read
     outputs:
       apk-target-path: ${{ steps.determine-target-paths.outputs.apk-target-path }}
       test-apk-target-path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
@@ -98,6 +108,8 @@ jobs:
       MM_SOLANA_E2E_TEST_SRP: ${{ secrets.MM_SOLANA_E2E_TEST_SRP }}
       MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
       YARN_ENABLE_GLOBAL_CACHE: 'true' # Enable Yarn global cache for faster installs
+      CACHE_GENERATION: v1 # Increment to bust Android artifact cache keys.
+      ANDROID_ARTIFACT_CACHE_KEY_SUFFIX: ${{ inputs.source_fingerprint != '' && inputs.source_fingerprint || github.sha }}
 
     steps:
       - name: Checkout (Namespace)
@@ -137,6 +149,7 @@ jobs:
             ~/Library/Detox
 
       - name: Restore .metamask folder
+        id: restore-metamask
         if: ${{ inputs.runner_provider != 'namespace' }}
         uses: actions/cache@v4
         with:
@@ -144,6 +157,7 @@ jobs:
           key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
 
       - name: Set up E2E environment
+        id: setup-e2e-env
         # Namespace iOS smoke runs many matrix jobs in parallel; CocoaPods + yarn need more
         # headroom than the composite default (see INFRA-3596 / run 25755790077 timeouts).
         timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && 45 || 25 }}
@@ -193,13 +207,35 @@ jobs:
           mkdir -p ${{ steps.determine-target-paths.outputs.apk-target-path }}
           mkdir -p ${{ steps.determine-target-paths.outputs.test-apk-target-path }}
 
+      - name: Restore Android build artifacts from branch cache
+        if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' }}
+        id: android-artifacts-cache
+        uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        with:
+          path: |
+            ${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk
+            ${{ steps.determine-target-paths.outputs.test-apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}-androidTest.apk
+          key: android-apk-${{ github.ref_name }}-${{ inputs.build_type }}-${{ env.CACHE_GENERATION }}-${{ env.ANDROID_ARTIFACT_CACHE_KEY_SUFFIX }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Report Android artifact cache status
+        if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' }}
+        env:
+          BRANCH_ARTIFACT_CACHE_HIT: ${{ steps.android-artifacts-cache.outputs.cache-hit }}
+        run: |
+          if [[ "$BRANCH_ARTIFACT_CACHE_HIT" == "true" ]]; then
+            echo "Android artifact cache hit - skipping artifact download."
+          else
+            echo "Android artifact cache miss - will download artifacts from build job."
+          fi
+
       - name: Download Android build artifacts (Namespace)
         if: ${{ inputs.platform == 'android' && inputs.runner_provider == 'namespace' }}
         uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
         with:
           path: artifacts/
       - name: Download Android build artifacts (current)
-        if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' }}
+        id: download-android-build-artifacts-current
+        if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' && steps.android-artifacts-cache.outputs.cache-hit != 'true' }}
         uses: actions/download-artifact@v4
         with:
           path: artifacts/
@@ -305,6 +341,7 @@ jobs:
           find ./previous-test-results -type f -name "*.xml" | head -1 | xargs head -50 || echo "No XML files found"
 
       - name: 🧪 Run E2E tests
+        id: run-e2e-tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: |
           echo "Running ${{ inputs.test-suite-name }} tests on ${{ inputs.platform }}"
@@ -376,3 +413,193 @@ jobs:
           name: test-e2e-${{ inputs.artifact_name_prefix }}${{ inputs.test-suite-name }}-screenshots
           path: tests/artifacts/
           retention-days: 7
+
+      - name: Write E2E cache and timing summary
+        if: always()
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SUITE_NAME: ${{ inputs.test-suite-name }}
+          PLATFORM: ${{ inputs.platform }}
+          RUNNER_PROVIDER: ${{ inputs.runner_provider }}
+          ANDROID_ARTIFACT_CACHE_HIT: ${{ steps.android-artifacts-cache.outputs.cache-hit }}
+          IOS_PODS_CACHE_HIT: ${{ steps.setup-e2e-env.outputs.cocoapods-deps-cache-hit }}
+          IOS_PODS_INSTALL_RAN: ${{ steps.setup-e2e-env.outputs.cocoapods-install-ran }}
+          METAMASK_CACHE_HIT: ${{ steps.restore-metamask.outputs.cache-hit }}
+        run: |
+          node <<'EOF'
+          const fs = require('node:fs');
+
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const {
+            GITHUB_TOKEN,
+            REPOSITORY,
+            RUN_ID,
+            RUN_ATTEMPT,
+            SUITE_NAME,
+            PLATFORM,
+            RUNNER_PROVIDER,
+            ANDROID_ARTIFACT_CACHE_HIT,
+            IOS_PODS_CACHE_HIT,
+            IOS_PODS_INSTALL_RAN,
+            METAMASK_CACHE_HIT,
+          } = process.env;
+
+          (async () => {
+          const toState = (value) => {
+            if (value === 'true') return 'hit';
+            if (value === 'false') return 'miss';
+            return 'n/a';
+          };
+
+          const cacheRows = [];
+          if (PLATFORM === 'android' && RUNNER_PROVIDER !== 'namespace') {
+            cacheRows.push(['Android build artifacts', toState(ANDROID_ARTIFACT_CACHE_HIT)]);
+          }
+          if (PLATFORM === 'ios' && RUNNER_PROVIDER !== 'namespace') {
+            cacheRows.push(['CocoaPods dependencies', toState(IOS_PODS_CACHE_HIT)]);
+            cacheRows.push([
+              'CocoaPods install execution',
+              IOS_PODS_INSTALL_RAN === 'true'
+                ? 'ran'
+                : IOS_PODS_INSTALL_RAN === 'false'
+                  ? 'skipped'
+                  : 'n/a',
+            ]);
+          }
+          if (RUNNER_PROVIDER !== 'namespace') {
+            cacheRows.push(['.metamask cache', toState(METAMASK_CACHE_HIT)]);
+          }
+
+          const cacheHits = cacheRows.filter(([, state]) => state === 'hit').length;
+          const cacheMisses = cacheRows.filter(([, state]) => state === 'miss').length;
+
+          const baselineByStep = PLATFORM === 'ios'
+            ? {
+                'Set up E2E environment': 7.9,
+              }
+            : {
+                'Set up E2E environment': 3.7,
+                'Download Android build artifacts (current)': 4.0,
+              };
+
+          const trackedStepNames = [
+            'Set up E2E environment',
+            'Download Android build artifacts (current)',
+            '🧪 Run E2E tests',
+          ];
+
+          let timingRows = [];
+          let timingError = null;
+
+          try {
+            const jobsResponse = await fetch(
+              `https://api.github.com/repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100`,
+              {
+                headers: {
+                  Authorization: `Bearer ${GITHUB_TOKEN}`,
+                  Accept: 'application/vnd.github+json',
+                  'X-GitHub-Api-Version': '2022-11-28',
+                },
+              },
+            );
+
+            if (!jobsResponse.ok) {
+              throw new Error(`GitHub API returned ${jobsResponse.status}`);
+            }
+
+            const jobsPayload = await jobsResponse.json();
+            const jobs = jobsPayload.jobs || [];
+            const job = jobs.find((candidate) => {
+              const name = candidate.name || '';
+              return (
+                name === SUITE_NAME ||
+                name.endsWith(` / ${SUITE_NAME}`) ||
+                name.endsWith(SUITE_NAME)
+              );
+            });
+
+            if (!job) {
+              throw new Error(`Could not find current job for suite "${SUITE_NAME}"`);
+            }
+
+            const stepsByName = new Map((job.steps || []).map((step) => [step.name, step]));
+
+            for (const stepName of trackedStepNames) {
+              if (PLATFORM === 'ios' && stepName === 'Download Android build artifacts (current)') {
+                continue;
+              }
+
+              const step = stepsByName.get(stepName);
+              if (!step || !step.started_at || !step.completed_at) {
+                timingRows.push([stepName, 'n/a', 'n/a', 'n/a']);
+                continue;
+              }
+
+              const durationMin =
+                (Date.parse(step.completed_at) - Date.parse(step.started_at)) / 60000;
+              const baseline = baselineByStep[stepName];
+              const delta =
+                typeof baseline === 'number' ? `${(durationMin - baseline).toFixed(2)}m` : 'n/a';
+
+              timingRows.push([
+                stepName,
+                `${durationMin.toFixed(2)}m`,
+                typeof baseline === 'number' ? `${baseline.toFixed(2)}m` : 'n/a',
+                delta,
+              ]);
+            }
+          } catch (error) {
+            timingError = error instanceof Error ? error.message : String(error);
+            timingRows = trackedStepNames
+              .filter((stepName) => !(PLATFORM === 'ios' && stepName === 'Download Android build artifacts (current)'))
+              .map((stepName) => [stepName, 'n/a', 'n/a', 'n/a']);
+          }
+
+          let summary = '';
+          summary += `### E2E Cache and Timing Summary (${SUITE_NAME})\n\n`;
+          summary += `- Platform: \`${PLATFORM}\`\n`;
+          summary += `- Runner provider: \`${RUNNER_PROVIDER}\`\n`;
+          summary += `- Cache hits: \`${cacheHits}\`\n`;
+          summary += `- Cache misses: \`${cacheMisses}\`\n\n`;
+
+          if (cacheRows.length > 0) {
+            summary += '| Cache Item | Status |\n';
+            summary += '| --- | --- |\n';
+            for (const [name, state] of cacheRows) {
+              summary += `| ${name} | ${state} |\n`;
+            }
+            summary += '\n';
+          }
+
+          summary += '| Step | Duration | Baseline | Delta |\n';
+          summary += '| --- | --- | --- | --- |\n';
+          for (const [name, duration, baseline, delta] of timingRows) {
+            summary += `| ${name} | ${duration} | ${baseline} | ${delta} |\n`;
+          }
+          summary += '\n';
+
+          if (timingError) {
+            summary += `> Timing delta note: ${timingError}\n`;
+          } else {
+            summary += '> Timing deltas are measured as (current duration - baseline) for the steps with defined baselines.\n';
+          }
+
+          fs.appendFileSync(summaryPath, summary);
+          })().catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            const fallback = [
+              `### E2E Cache and Timing Summary (${SUITE_NAME})`,
+              '',
+              `- Platform: \`${PLATFORM}\``,
+              `- Runner provider: \`${RUNNER_PROVIDER}\``,
+              '',
+              `> Summary generation failed: ${message}`,
+              '',
+            ].join('\n');
+            fs.appendFileSync(summaryPath, fallback);
+          });
+          EOF

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -241,7 +241,7 @@ jobs:
           path: artifacts/
 
       - name: Move Android artifacts to expected locations
-        if: ${{ inputs.platform == 'android' }}
+        if: ${{ inputs.platform == 'android' && (inputs.runner_provider == 'namespace' || steps.android-artifacts-cache.outputs.cache-hit != 'true') }}
         run: |
           # Copy from artifacts to expected locations
           # Each artifact is uploaded as a folder so we need to cp from inside the folder

--- a/tests/smoke/identity/account-syncing/multi-srp.spec.ts
+++ b/tests/smoke/identity/account-syncing/multi-srp.spec.ts
@@ -25,6 +25,8 @@ import EditAccountName from '../../../page-objects/MultichainAccounts/EditAccoun
 describe.skip(SmokeIdentity('Account syncing - Mutiple SRPs'), () => {
   let sharedUserStorageController: UserStorageMockttpController;
 
+  // FORCE E2E
+
   beforeAll(async () => {
     await TestHelpers.reverseServerPort();
     sharedUserStorageController = createUserStorageController();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## Summary
- Improve iOS E2E setup caching by restoring CocoaPods dependencies (`ios/Pods` and CocoaPods cache) and skipping `pod install` on cache hits for non-Namespace runners.
- Improve Android E2E shard startup by restoring cached APK/test APK artifacts before downloading build artifacts, and skip artifact download on cache hit.
- Add per-shard E2E step summary output that reports cache hit/miss states and key step duration deltas to make cache effectiveness measurable.

## Test plan
- [x] Run `actionlint -config-file .github/actionlint.yaml .github/workflows/run-e2e-workflow.yml`
- [x] Validate modified YAML parses locally (`ruby -e "require 'yaml'; YAML.load_file(...)"`)
- [ ] Trigger CI and verify E2E shard summaries include cache status and timing.
- [ ] Confirm Android shards skip `Download Android build artifacts (current)` when cache hits.
- [ ] Confirm iOS shards skip `Install CocoaPods via bundler` when CocoaPods dependency cache hits.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only changes, but stale CocoaPods or APK caches could cause confusing E2E failures until keys are busted; the stray test comment should be dropped before merge.
> 
> **Overview**
> Speeds up **E2E test shards** on non-Namespace runners by caching heavy setup work and reporting whether caches helped.
> 
> **iOS:** `setup-e2e-env` now restores a CocoaPods dependency cache (`ios/Pods` + CocoaPods download cache keyed on `Podfile.lock`), skips `pod install` on hit, and exposes outputs for cache hit and whether install ran. Namespace runners still always run install.
> 
> **Android:** `run-e2e-workflow` restores branch-scoped APK/androidTest APK paths via `cirruslabs/cache` before downloading build artifacts; download and copy steps run only on miss. A new optional `source_fingerprint` input (Expo fingerprint) can align cache keys across shards; otherwise the key suffix falls back to `github.sha`. Job `actions: read` was added for timing API access.
> 
> **Observability:** Each shard appends a **E2E Cache and Timing Summary** to `GITHUB_STEP_SUMMARY` (cache hit/miss table plus step durations vs fixed baselines via the Actions jobs API).
> 
> **Unrelated:** `multi-srp.spec.ts` adds a `// FORCE E2E` comment only (suite remains `describe.skip`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26506b7fd84bc05bfc23797d470247e453de875e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->