### PR TITLE
feat: enable pay-with bottom sheet by default and remove env variable

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.test.tsx
@@ -142,13 +142,13 @@ describe('PerpsPayRow', () => {
     ).toHaveTextContent('USDC');
   });
 
-  it('navigates to pay with modal when row is pressed and not hardware account', () => {
+  it('navigates to pay with bottom sheet when row is pressed and not hardware account', () => {
     const { getByTestId } = renderWithProvider(<PerpsPayRow />);
 
     fireEvent.press(getByTestId(ConfirmationRowComponentIDs.PAY_WITH));
 
     expect(navigateMock).toHaveBeenCalledWith(
-      Routes.CONFIRMATION_PAY_WITH_MODAL,
+      Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
     );
     expect(setConfirmationMetricMock).toHaveBeenCalledWith({
       properties: { mm_pay_token_list_opened: true },

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -46,7 +46,6 @@ import { useIsPerpsBalanceSelected } from '../../hooks/useIsPerpsBalanceSelected
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { Hex } from '@metamask/utils';
 import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.events';
-import { isPayWithBottomSheetEnabled } from '../../../../Views/confirmations/utils/transaction-pay';
 
 const tokenIconStyles = StyleSheet.create({
   iconSmall: {
@@ -123,11 +122,7 @@ export const PerpsPayRow = ({
       [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
         PERPS_EVENT_VALUE.INTERACTION_TYPE.PAYMENT_TOKEN_SELECTOR,
     });
-    if (isPayWithBottomSheetEnabled()) {
-      navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET);
-      return;
-    }
-    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_MODAL);
+    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET);
   }, [canEdit, navigation, setConfirmationMetric, track]);
 
   // Display data: use local state (defaults to Perps balance) so UI always shows "Perps balance" by default

--- a/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { TransactionType } from '@metamask/transaction-controller';
 import { usePerpsBalanceTokenFilter } from './usePerpsBalanceTokenFilter';
@@ -7,34 +7,13 @@ import { useIsPerpsBalanceSelected } from './useIsPerpsBalanceSelected';
 import {
   type AssetType,
   type TokenListItem,
-  isHighlightedItemOutsideAssetList,
 } from '../../../Views/confirmations/types/token';
-import { usePerpsTrading } from './usePerpsTrading';
-import { usePerpsPaymentToken } from './usePerpsPaymentToken';
-import Routes from '../../../../constants/navigation/Routes';
-import { useNavigation } from '@react-navigation/native';
-import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
-import { selectPerpsAccountState } from '../selectors/perpsController';
 import { selectPerpsPayWithAnyTokenAllowlistAssets } from '../selectors/featureFlags';
-import { isPayWithBottomSheetEnabled } from '../../../Views/confirmations/utils/transaction-pay';
-
-jest.mock('../../../../../locales/i18n', () => ({
-  strings: jest.fn((key: string) => key),
-}));
 
 jest.mock(
   '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest',
 );
 jest.mock('./useIsPerpsBalanceSelected');
-jest.mock('./usePerpsTrading');
-jest.mock('../../../Views/confirmations/hooks/useApprovalRequest', () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: jest.fn(),
-}));
-jest.mock('./usePerpsPaymentToken');
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
@@ -42,17 +21,6 @@ jest.mock('react-redux', () => ({
 jest.mock('images/perps-pay-token-icon.png', () => ({
   uri: 'perps-pay-token-icon-uri',
 }));
-
-jest.mock('../../../Views/confirmations/utils/transaction-pay', () => ({
-  ...jest.requireActual('../../../Views/confirmations/utils/transaction-pay'),
-  isPayWithBottomSheetEnabled: jest.fn(() => false),
-}));
-jest.mock('../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter', () =>
-  jest.fn(
-    () => (value: { toNumber: () => number }) =>
-      `$${value.toNumber().toFixed(2)}`,
-  ),
-);
 
 const mockUseTransactionMetadataRequest =
   useTransactionMetadataRequest as jest.MockedFunction<
@@ -63,58 +31,22 @@ const mockUseIsPerpsBalanceSelected =
     typeof useIsPerpsBalanceSelected
   >;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockUsePerpsTrading = usePerpsTrading as jest.MockedFunction<
-  typeof usePerpsTrading
->;
-const mockUsePerpsPaymentToken = usePerpsPaymentToken as jest.MockedFunction<
-  typeof usePerpsPaymentToken
->;
-const mockUseNavigation = useNavigation as jest.MockedFunction<
-  typeof useNavigation
->;
-const mockUseApprovalRequest = useApprovalRequest as jest.MockedFunction<
-  typeof useApprovalRequest
->;
-const mockIsPayWithBottomSheetEnabled =
-  isPayWithBottomSheetEnabled as jest.MockedFunction<
-    typeof isPayWithBottomSheetEnabled
-  >;
 
 describe('usePerpsBalanceTokenFilter', () => {
   const chainId = '0xa4b1';
-  const mockDepositWithConfirmation = jest.fn().mockResolvedValue(undefined);
-  const mockNavigate = jest.fn();
-  const mockOnReject = jest.fn();
-  const mockOnPerpsPaymentTokenChange = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsPayWithBottomSheetEnabled.mockReturnValue(false);
     mockUseTransactionMetadataRequest.mockReturnValue(undefined);
     mockUseIsPerpsBalanceSelected.mockReturnValue(false);
     mockUseSelector.mockImplementation(
       (selector: (state: unknown) => unknown) => {
-        if (selector === selectPerpsAccountState) {
-          return { spendableBalance: '1500.00' };
-        }
         if (selector === selectPerpsPayWithAnyTokenAllowlistAssets) {
           return [];
         }
         return undefined;
       },
     );
-    mockUsePerpsTrading.mockReturnValue({
-      depositWithConfirmation: mockDepositWithConfirmation,
-    } as unknown as ReturnType<typeof usePerpsTrading>);
-    mockUseNavigation.mockReturnValue({
-      navigate: mockNavigate,
-    } as unknown as ReturnType<typeof useNavigation>);
-    mockUseApprovalRequest.mockReturnValue({
-      onReject: mockOnReject,
-    } as unknown as ReturnType<typeof useApprovalRequest>);
-    mockUsePerpsPaymentToken.mockReturnValue({
-      onPaymentTokenChange: mockOnPerpsPaymentTokenChange,
-    } as unknown as ReturnType<typeof usePerpsPaymentToken>);
   });
 
   describe('when transaction is not perpsDepositAndOrder', () => {
@@ -161,12 +93,7 @@ describe('usePerpsBalanceTokenFilter', () => {
       } as ReturnType<typeof useTransactionMetadataRequest>);
     });
 
-    it('prepends highlighted row with perps balance and Add funds button', () => {
-      mockUseSelector.mockReturnValue({
-        spendableBalance: '2000.50',
-        withdrawableBalance: '2000.50',
-      });
-      mockUseIsPerpsBalanceSelected.mockReturnValue(true);
+    it('returns mapped tokens without synthetic highlighted row', () => {
       const inputTokens: AssetType[] = [
         {
           address: '0xusdc',
@@ -181,92 +108,13 @@ describe('usePerpsBalanceTokenFilter', () => {
       const { result } = renderHook(() => usePerpsBalanceTokenFilter());
       const output = result.current(inputTokens);
 
-      expect(output).toHaveLength(2);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(true);
-      const highlightedAction = output[0];
-      if (isHighlightedItemOutsideAssetList(highlightedAction)) {
-        expect(highlightedAction.position).toBe('outside_of_asset_list');
-        expect(highlightedAction.name).toBe(
-          'perps.adjust_margin.perps_balance',
-        );
-        expect(highlightedAction.name_description).toBe('$2000.50');
-        expect(highlightedAction.fiat).toBe('$2000.50');
-        expect(highlightedAction.fiat_description).toBe('$2000.50');
-        expect(highlightedAction.isSelected).toBe(true);
-        expect(highlightedAction.actions).toHaveLength(1);
-        expect(highlightedAction.actions?.[0]?.buttonLabel).toBe(
-          'perps.add_funds',
-        );
-      }
-      expect((output[1] as AssetType).address).toBe('0xusdc');
-    });
-
-    it('uses spendableBalance from perps account in highlighted row', () => {
-      mockUseSelector.mockReturnValue({
-        spendableBalance: '999.99',
-        withdrawableBalance: '999.99',
-      });
-      const inputTokens: AssetType[] = [];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
       expect(output).toHaveLength(1);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(true);
-      if (isHighlightedItemOutsideAssetList(output[0])) {
-        expect(output[0].name_description).toBe('$999.99');
-        expect(output[0].fiat).toBe('$999.99');
-      }
-    });
-
-    it('uses spendableBalance for Unified Account users', () => {
-      // Unified Account / Portfolio Margin: collateral lives in spot. The
-      // provider folds free spot USDC into spendableBalance via
-      // addSpotBalanceToAccountState, so the Pay-with sheet's synthetic
-      // Perps row sees the unified total without branching on mode.
-      mockUseSelector.mockReturnValue({
-        spendableBalance: '2500.00',
-        withdrawableBalance: '2500.00',
-      });
-      const inputTokens: AssetType[] = [];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
-      expect(output).toHaveLength(1);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(true);
-      if (isHighlightedItemOutsideAssetList(output[0])) {
-        expect(output[0].name_description).toBe('$2500.00');
-        expect(output[0].fiat).toBe('$2500.00');
-      }
-    });
-
-    it('uses zero balance when perps account is null', () => {
-      mockUseSelector.mockImplementation(
-        (selector: (state: unknown) => unknown) => {
-          if (selector === selectPerpsAccountState) return null;
-          if (selector === selectPerpsPayWithAnyTokenAllowlistAssets) return [];
-          return undefined;
-        },
-      );
-      const inputTokens: AssetType[] = [];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
-      expect(output).toHaveLength(1);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(true);
-      if (isHighlightedItemOutsideAssetList(output[0])) {
-        expect(output[0].name_description).toBe('$0.00');
-        expect(output[0].fiat).toBe('$0.00');
-      }
+      expect((output[0] as AssetType).address).toBe('0xusdc');
     });
 
     it('clears isSelected on other tokens when perps balance is selected', () => {
       mockUseSelector.mockImplementation(
         (selector: (state: unknown) => unknown) => {
-          if (selector === selectPerpsAccountState)
-            return { spendableBalance: '1500.00' };
           if (selector === selectPerpsPayWithAnyTokenAllowlistAssets) return [];
           return undefined;
         },
@@ -290,15 +138,14 @@ describe('usePerpsBalanceTokenFilter', () => {
       const { result } = renderHook(() => usePerpsBalanceTokenFilter());
       const output = result.current(inputTokens);
 
+      expect(output).toHaveLength(2);
+      expect((output[0] as AssetType).isSelected).toBe(false);
       expect((output[1] as AssetType).isSelected).toBe(false);
-      expect((output[2] as AssetType).isSelected).toBe(false);
     });
 
     it('keeps token isSelected when perps balance is not selected', () => {
       mockUseSelector.mockImplementation(
         (selector: (state: unknown) => unknown) => {
-          if (selector === selectPerpsAccountState)
-            return { spendableBalance: '1500.00' };
           if (selector === selectPerpsPayWithAnyTokenAllowlistAssets) return [];
           return undefined;
         },
@@ -316,129 +163,14 @@ describe('usePerpsBalanceTokenFilter', () => {
       const { result } = renderHook(() => usePerpsBalanceTokenFilter());
       const output = result.current(inputTokens);
 
-      expect((output[1] as AssetType).isSelected).toBe(true);
+      expect(output).toHaveLength(1);
+      expect((output[0] as AssetType).isSelected).toBe(true);
     });
 
     it('filters to only allowlisted tokens when allowlist is set', () => {
       const allowlistKey = `${chainId}.0xusdc`.toLowerCase();
       mockUseSelector.mockImplementation(
         (selector: (state: unknown) => unknown) => {
-          if (selector === selectPerpsAccountState)
-            return { spendableBalance: '100.00' };
-          if (selector === selectPerpsPayWithAnyTokenAllowlistAssets)
-            return [allowlistKey];
-          return [];
-        },
-      );
-      const inputTokens: AssetType[] = [
-        {
-          address: '0xusdc',
-          chainId,
-          symbol: 'USDC',
-          name: 'USD Coin',
-          balance: '500',
-        } as AssetType,
-        {
-          address: '0xother',
-          chainId,
-          symbol: 'OTHER',
-          name: 'Other',
-          balance: '100',
-        } as AssetType,
-      ];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
-      expect(output).toHaveLength(2);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(true);
-      expect((output[1] as AssetType).address).toBe('0xusdc');
-      expect((output[1] as AssetType).symbol).toBe('USDC');
-    });
-
-    it('calls onReject, depositWithConfirmation and navigation.navigate when Add funds is pressed', async () => {
-      mockUseSelector.mockReturnValue({
-        spendableBalance: '500.00',
-        withdrawableBalance: '500.00',
-      });
-      const inputTokens: AssetType[] = [
-        {
-          address: '0xusdc',
-          chainId,
-          symbol: 'USDC',
-          name: 'USD Coin',
-          balance: '100',
-        } as AssetType,
-      ];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
-      expect(output).toHaveLength(2);
-      const highlightedAction = output[0];
-      expect(isHighlightedItemOutsideAssetList(highlightedAction)).toBe(true);
-      if (isHighlightedItemOutsideAssetList(highlightedAction)) {
-        highlightedAction.actions?.[0]?.onPress();
-        await waitFor(
-          () => {
-            expect(mockOnReject).toHaveBeenCalledTimes(1);
-            expect(mockDepositWithConfirmation).toHaveBeenCalledTimes(1);
-            expect(mockNavigate).toHaveBeenCalledWith(
-              Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
-              { showPerpsHeader: true },
-            );
-          },
-          { timeout: 2000 },
-        );
-      }
-    });
-
-    it('calls onPerpsPaymentTokenChange with null when row action is invoked', () => {
-      mockUseSelector.mockReturnValue({
-        spendableBalance: '100.00',
-        withdrawableBalance: '100.00',
-      });
-      const inputTokens: AssetType[] = [];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
-      expect(output).toHaveLength(1);
-      const highlightedAction = output[0];
-      expect(isHighlightedItemOutsideAssetList(highlightedAction)).toBe(true);
-      if (isHighlightedItemOutsideAssetList(highlightedAction)) {
-        highlightedAction.action();
-        expect(mockOnPerpsPaymentTokenChange).toHaveBeenCalledWith(null);
-      }
-    });
-
-    it('omits the synthetic perps balance row when the new Pay With bottom sheet is enabled', () => {
-      mockIsPayWithBottomSheetEnabled.mockReturnValue(true);
-      const inputTokens: AssetType[] = [
-        {
-          address: '0xabc',
-          chainId,
-          symbol: 'USDC',
-          name: 'USD Coin',
-          balance: '100',
-        } as AssetType,
-      ];
-
-      const { result } = renderHook(() => usePerpsBalanceTokenFilter());
-      const output = result.current(inputTokens);
-
-      expect(output).toHaveLength(1);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(false);
-      expect((output[0] as AssetType).address).toBe('0xabc');
-    });
-
-    it('still applies the allowlist filter when the new Pay With bottom sheet is enabled', () => {
-      mockIsPayWithBottomSheetEnabled.mockReturnValue(true);
-      const allowlistKey = `${chainId}.0xusdc`.toLowerCase();
-      mockUseSelector.mockImplementation(
-        (selector: (state: unknown) => unknown) => {
-          if (selector === selectPerpsAccountState)
-            return { spendableBalance: '100.00' };
           if (selector === selectPerpsPayWithAnyTokenAllowlistAssets)
             return [allowlistKey];
           return [];
@@ -465,8 +197,8 @@ describe('usePerpsBalanceTokenFilter', () => {
       const output = result.current(inputTokens);
 
       expect(output).toHaveLength(1);
-      expect(isHighlightedItemOutsideAssetList(output[0])).toBe(false);
       expect((output[0] as AssetType).address).toBe('0xusdc');
+      expect((output[0] as AssetType).symbol).toBe('USDC');
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.ts
+++ b/app/components/UI/Perps/hooks/usePerpsBalanceTokenFilter.ts
@@ -1,35 +1,24 @@
 import { TransactionType } from '@metamask/transaction-controller';
-import { BigNumber } from 'bignumber.js';
 import perpsPayTokenIcon from 'images/perps-pay-token-icon.png';
 import { useCallback } from 'react';
 import { Image } from 'react-native';
 import { useSelector } from 'react-redux';
-import { strings } from '../../../../../locales/i18n';
-import useFiatFormatter from '../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { useTransactionMetadataRequest } from '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
 import {
   AssetType,
-  HighlightedItem,
   type TokenListItem,
 } from '../../../Views/confirmations/types/token';
-import { isPayWithBottomSheetEnabled } from '../../../Views/confirmations/utils/transaction-pay';
 import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
 import { selectPerpsPayWithAnyTokenAllowlistAssets } from '../selectors/featureFlags';
-import { selectPerpsAccountState } from '../selectors/perpsController';
 import { useIsPerpsBalanceSelected } from './useIsPerpsBalanceSelected';
-import { usePerpsPaymentToken } from './usePerpsPaymentToken';
-import Routes from '../../../../constants/navigation/Routes';
-import { usePerpsTrading } from './usePerpsTrading';
-import { useNavigation } from '@react-navigation/native';
-import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
+
 /** URI for the perps balance token icon, shared with PerpsPayRow and pay-with modal. */
 const resolvedPerpsIcon = Image.resolveAssetSource(perpsPayTokenIcon);
 export const PERPS_BALANCE_ICON_URI = resolvedPerpsIcon?.uri ?? '';
 
 /**
- * Returns a filter that prepends a synthetic "Perps balance" token to the list
- * when the transaction type is perpsDepositAndOrder. The token shows the perps
- * account balance, USDC icon, and label "Perps balance".
+ * Returns a filter that applies allowlist filtering and deselects other tokens
+ * when the Perps balance is selected for perpsDepositAndOrder transactions.
  *
  * Uses PerpsController state (Redux) so it works in any screen, including
  * PayWithModal and confirmations where PerpsStreamProvider is not mounted.
@@ -39,40 +28,9 @@ export function usePerpsBalanceTokenFilter(): (
 ) => TokenListItem[] {
   const transactionMeta = useTransactionMetadataRequest();
   const isPerpsBalanceSelected = useIsPerpsBalanceSelected();
-  const perpsAccount = useSelector(selectPerpsAccountState);
   const allowListAssets = useSelector(
     selectPerpsPayWithAnyTokenAllowlistAssets,
   );
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
-
-  const { depositWithConfirmation } = usePerpsTrading();
-
-  const isPerpsDepositAndOrder = hasTransactionType(transactionMeta, [
-    TransactionType.perpsDepositAndOrder,
-  ]);
-
-  const { onReject: handleReject } = useApprovalRequest();
-
-  const navigation = useNavigation();
-
-  const handlePerpsDepositPress = useCallback(() => {
-    handleReject();
-    depositWithConfirmation()
-      .then(() => {
-        navigation.navigate(
-          Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
-          {
-            showPerpsHeader: true,
-          },
-        );
-      })
-      .catch(() => {
-        // Deposit flow handles errors (e.g. user rejection or missing network).
-      });
-  }, [navigation, depositWithConfirmation, handleReject]);
-
-  const { onPaymentTokenChange: onPerpsPaymentTokenChange } =
-    usePerpsPaymentToken();
 
   const filterAllowedTokens = useCallback(
     (tokens: AssetType[]): TokenListItem[] => {
@@ -83,13 +41,6 @@ export function usePerpsBalanceTokenFilter(): (
       ) {
         return tokens;
       }
-
-      const spendableBalance = perpsAccount?.spendableBalance || '0';
-      const balanceInSelectedCurrency = formatFiat(
-        new BigNumber(spendableBalance),
-      );
-
-      const perpsBalanceName = strings('perps.adjust_margin.perps_balance');
 
       let mappedTokens = tokens.map((token) => ({
         ...token,
@@ -105,43 +56,9 @@ export function usePerpsBalanceTokenFilter(): (
         });
       }
 
-      if (!isPerpsDepositAndOrder) {
-        return mappedTokens;
-      }
-
-      if (isPayWithBottomSheetEnabled()) {
-        return mappedTokens;
-      }
-
-      const highlightedAction: HighlightedItem = {
-        position: 'outside_of_asset_list',
-        icon: PERPS_BALANCE_ICON_URI,
-        name: perpsBalanceName,
-        name_description: balanceInSelectedCurrency,
-        fiat: balanceInSelectedCurrency,
-        fiat_description: balanceInSelectedCurrency,
-        isSelected: isPerpsBalanceSelected,
-        action: () => onPerpsPaymentTokenChange(null),
-        actions: [
-          {
-            buttonLabel: strings('perps.add_funds'),
-            onPress: handlePerpsDepositPress,
-          },
-        ],
-      };
-
-      return [highlightedAction, ...mappedTokens];
+      return mappedTokens;
     },
-    [
-      handlePerpsDepositPress,
-      isPerpsDepositAndOrder,
-      allowListAssets,
-      formatFiat,
-      onPerpsPaymentTokenChange,
-      isPerpsBalanceSelected,
-      perpsAccount?.spendableBalance,
-      transactionMeta,
-    ],
+    [allowListAssets, isPerpsBalanceSelected, transactionMeta],
   );
 
   return filterAllowedTokens;

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.test.ts
@@ -1,37 +1,9 @@
 import { renderHook } from '@testing-library/react-native';
-import { useSelector } from 'react-redux';
-import {
-  AssetType,
-  HighlightedItem,
-  isHighlightedItemInAssetList,
-} from '../../../Views/confirmations/types/token';
+import { AssetType } from '../../../Views/confirmations/types/token';
 import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
-import { isPayWithBottomSheetEnabled } from '../../../Views/confirmations/utils/transaction-pay';
 import { usePredictBalanceTokenFilter } from './usePredictBalanceTokenFilter';
-import { dismissActivePreviewSheet } from '../contexts';
-import Routes from '../../../../constants/navigation/Routes';
 
-const mockNavigate = jest.fn();
-
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate }),
-}));
-
-let mockIsPredictBalanceSelected = false;
-let mockPredictBalance = 100;
 let mockTransactionMeta: { type?: string } | null = null;
-
-jest.mock('./usePredictPaymentToken', () => ({
-  usePredictPaymentToken: () => ({
-    isPredictBalanceSelected: mockIsPredictBalanceSelected,
-  }),
-}));
-
-jest.mock('./usePredictBalance', () => ({
-  usePredictBalance: () => ({
-    data: mockPredictBalance,
-  }),
-}));
 
 jest.mock(
   '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest',
@@ -40,43 +12,13 @@ jest.mock(
   }),
 );
 
-jest.mock('../../SimulationDetails/FiatDisplay/useFiatFormatter', () => ({
-  __esModule: true,
-  default: () => (value: { toString: () => string }) =>
-    `$${Number(value.toString()).toFixed(2)}`,
-}));
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
-
 jest.mock('../../../Views/confirmations/utils/transaction', () => ({
   hasTransactionType: jest.fn(),
-}));
-
-jest.mock('../../../Views/confirmations/utils/transaction-pay', () => ({
-  ...jest.requireActual('../../../Views/confirmations/utils/transaction-pay'),
-  isPayWithBottomSheetEnabled: jest.fn(() => false),
-}));
-
-const mockOnReject = jest.fn();
-jest.mock('../../../Views/confirmations/hooks/useApprovalRequest', () => ({
-  __esModule: true,
-  default: () => ({ onReject: mockOnReject, approvalRequest: { id: 'test' } }),
-}));
-
-jest.mock('../contexts', () => ({
-  dismissActivePreviewSheet: jest.fn(),
 }));
 
 const mockHasTransactionType = hasTransactionType as jest.MockedFunction<
   typeof hasTransactionType
 >;
-const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockIsPayWithBottomSheetEnabled =
-  isPayWithBottomSheetEnabled as jest.MockedFunction<
-    typeof isPayWithBottomSheetEnabled
-  >;
 
 const createMockToken = (overrides?: Partial<AssetType>): AssetType => ({
   address: '0xtoken1',
@@ -98,14 +40,8 @@ const createMockToken = (overrides?: Partial<AssetType>): AssetType => ({
 describe('usePredictBalanceTokenFilter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsPredictBalanceSelected = false;
-    mockPredictBalance = 100;
     mockTransactionMeta = null;
     mockHasTransactionType.mockReturnValue(false);
-    mockUseSelector.mockReturnValue({ image: 'pusd-token-image' });
-    mockNavigate.mockReset();
-    mockIsPayWithBottomSheetEnabled.mockReturnValue(false);
-    mockOnReject.mockReset();
   });
 
   it('returns original tokens when transaction type does not match and forceEnabled is false', () => {
@@ -118,149 +54,25 @@ describe('usePredictBalanceTokenFilter', () => {
     expect(filteredTokens).toEqual(tokens);
   });
 
-  it('prepends Predict balance HighlightedItem when transaction type matches', () => {
+  it('returns tokens unchanged when transaction type matches', () => {
     const tokens = [createMockToken()];
     mockHasTransactionType.mockReturnValue(true);
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect(filteredTokens).toHaveLength(2);
-    expect(isHighlightedItemInAssetList(filteredTokens[0])).toBe(true);
-  });
-
-  it('suppresses the Predict balance HighlightedItem when isPayWithBottomSheetEnabled returns true', () => {
-    const tokens = [createMockToken()];
-    mockHasTransactionType.mockReturnValue(true);
-    mockIsPayWithBottomSheetEnabled.mockReturnValue(true);
 
     const { result } = renderHook(() => usePredictBalanceTokenFilter());
     const filteredTokens = result.current(tokens);
 
     expect(filteredTokens).toEqual(tokens);
+    expect(filteredTokens).toHaveLength(1);
   });
 
-  it('prepends Predict balance HighlightedItem when forceEnabled is true', () => {
+  it('returns tokens unchanged when forceEnabled is true', () => {
     const tokens = [createMockToken()];
     mockHasTransactionType.mockReturnValue(false);
 
     const { result } = renderHook(() => usePredictBalanceTokenFilter(true));
     const filteredTokens = result.current(tokens);
 
-    expect(filteredTokens).toHaveLength(2);
-    expect(isHighlightedItemInAssetList(filteredTokens[0])).toBe(true);
-  });
-
-  it('sets the Predict balance row as selected when isPredictBalanceSelected is true', () => {
-    mockIsPredictBalanceSelected = true;
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect((filteredTokens[0] as HighlightedItem).isSelected).toBe(true);
-  });
-
-  it('deselects existing tokens when Predict balance is selected', () => {
-    mockIsPredictBalanceSelected = true;
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken({ isSelected: true })];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect((filteredTokens[1] as AssetType).isSelected).toBe(false);
-  });
-
-  it('preserves existing token isSelected when Predict balance is not selected', () => {
-    mockIsPredictBalanceSelected = false;
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken({ isSelected: true })];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect((filteredTokens[1] as AssetType).isSelected).toBe(true);
-  });
-
-  it('formats the Predict balance as a fiat string in the HighlightedItem', () => {
-    mockPredictBalance = 42.5;
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect((filteredTokens[0] as HighlightedItem).fiat).toBe('$42.50');
-  });
-
-  it('shows name_description as pUSD on the Predict balance row', () => {
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect((filteredTokens[0] as HighlightedItem).name_description).toBe(
-      'pUSD',
-    );
-  });
-
-  it('uses empty string for icon when pusdToken is null', () => {
-    mockHasTransactionType.mockReturnValue(true);
-    mockUseSelector.mockReturnValue(null);
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    expect((filteredTokens[0] as HighlightedItem).icon).toBe('');
-  });
-
-  it('always includes an Add action button on the Predict balance row', () => {
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    const item = filteredTokens[0] as HighlightedItem;
-    expect(item.actions).toHaveLength(1);
-    expect(item.actions?.[0].buttonLabel).toBeTruthy();
-  });
-
-  it('rejects the current approval and navigates to ADD_FUNDS_SHEET when the Add action is pressed', () => {
-    mockHasTransactionType.mockReturnValue(true);
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() => usePredictBalanceTokenFilter());
-    const filteredTokens = result.current(tokens);
-
-    const item = filteredTokens[0] as HighlightedItem;
-    item.actions?.[0].onPress();
-
-    expect(dismissActivePreviewSheet).toHaveBeenCalledTimes(1);
-    expect(mockOnReject).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      params: { autoDeposit: true },
-    });
-  });
-
-  it('calls onSelect when the row action is triggered', () => {
-    mockHasTransactionType.mockReturnValue(true);
-    const mockOnSelect = jest.fn();
-    const tokens = [createMockToken()];
-
-    const { result } = renderHook(() =>
-      usePredictBalanceTokenFilter(true, mockOnSelect),
-    );
-    const filteredTokens = result.current(tokens);
-
-    const item = filteredTokens[0] as HighlightedItem;
-    item.action();
-
-    expect(mockOnSelect).toHaveBeenCalledTimes(1);
+    expect(filteredTokens).toEqual(tokens);
+    expect(filteredTokens).toHaveLength(1);
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
+++ b/app/components/UI/Predict/hooks/usePredictBalanceTokenFilter.ts
@@ -1,54 +1,17 @@
 import { TransactionType } from '@metamask/transaction-controller';
-import { BigNumber } from 'bignumber.js';
 import { useCallback } from 'react';
-import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
-import { strings } from '../../../../../locales/i18n';
-import Routes from '../../../../constants/navigation/Routes';
-import { RootState } from '../../../../reducers';
-import { selectSingleTokenByAddressAndChainId } from '../../../../selectors/tokensController';
-import useFiatFormatter from '../../SimulationDetails/FiatDisplay/useFiatFormatter';
-import { POLYGON_PUSD } from '../../../Views/confirmations/constants/predict';
-import { isPayWithBottomSheetEnabled } from '../../../Views/confirmations/utils/transaction-pay';
 import { useTransactionMetadataRequest } from '../../../Views/confirmations/hooks/transactions/useTransactionMetadataRequest';
 import {
   AssetType,
-  HighlightedItem,
   TokenListItem,
 } from '../../../Views/confirmations/types/token';
 import { hasTransactionType } from '../../../Views/confirmations/utils/transaction';
-import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
-import { PREDICT_BALANCE_CHAIN_ID } from '../constants/transactions';
-import { usePredictBalance } from './usePredictBalance';
-import { usePredictPaymentToken } from './usePredictPaymentToken';
-import { dismissActivePreviewSheet } from '../contexts';
 
 export function usePredictBalanceTokenFilter(
   forceEnabled = false,
-  onSelect?: () => void,
+  _onSelect?: () => void,
 ): (tokens: AssetType[]) => TokenListItem[] {
-  const navigation = useNavigation();
   const transactionMeta = useTransactionMetadataRequest();
-  const { isPredictBalanceSelected } = usePredictPaymentToken();
-  const { onReject } = useApprovalRequest();
-  const { data: predictBalance = 0 } = usePredictBalance();
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
-  const pusdToken = useSelector((state: RootState) =>
-    selectSingleTokenByAddressAndChainId(
-      state,
-      POLYGON_PUSD.address,
-      PREDICT_BALANCE_CHAIN_ID,
-    ),
-  );
-
-  const handleAddFunds = useCallback(() => {
-    onReject();
-    dismissActivePreviewSheet();
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      params: { autoDeposit: true },
-    });
-  }, [navigation, onReject]);
 
   return useCallback(
     (tokens: AssetType[]): TokenListItem[] => {
@@ -61,48 +24,8 @@ export function usePredictBalanceTokenFilter(
         return tokens;
       }
 
-      if (isPayWithBottomSheetEnabled()) {
-        return tokens;
-      }
-
-      const balanceStr = String(predictBalance);
-      const balanceFormatted = formatFiat(new BigNumber(balanceStr));
-
-      const predictBalanceHighlightedItem: HighlightedItem = {
-        position: 'in_asset_list',
-        icon: pusdToken?.image ?? '',
-        name: strings('predict.payment.predict_balance'),
-        name_description: POLYGON_PUSD.symbol,
-        fiat: balanceFormatted,
-        isSelected: isPredictBalanceSelected,
-        action: onSelect ?? (() => undefined),
-        actions: [
-          {
-            buttonLabel: strings('predict.payment.add'),
-            onPress: handleAddFunds,
-          },
-        ],
-      };
-
-      const mappedTokens = tokens.map((token) => ({
-        ...token,
-        isSelected:
-          token.isSelected && isPredictBalanceSelected
-            ? false
-            : token.isSelected,
-      }));
-
-      return [predictBalanceHighlightedItem, ...mappedTokens];
+      return tokens;
     },
-    [
-      forceEnabled,
-      transactionMeta,
-      isPredictBalanceSelected,
-      predictBalance,
-      formatFiat,
-      pusdToken,
-      handleAddFunds,
-      onSelect,
-    ],
+    [forceEnabled, transactionMeta],
   );
 }

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -81,14 +81,6 @@ jest.mock('../../utils/format', () => ({
   formatPrice: jest.fn((value: number) => `$${value.toFixed(2)}`),
 }));
 
-let mockIsPayWithBottomSheetEnabled = false;
-jest.mock('../../../../Views/confirmations/utils/transaction-pay', () => ({
-  ...jest.requireActual(
-    '../../../../Views/confirmations/utils/transaction-pay',
-  ),
-  isPayWithBottomSheetEnabled: () => mockIsPayWithBottomSheetEnabled,
-}));
-
 jest.mock('../../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: () => ({
     isPlacingOrder: mockIsPlacingOrder,
@@ -232,9 +224,7 @@ jest.mock('./components/PredictBuyAmountSection', () => {
   }) {
     return (
       <Text testID="predict-buy-amount-section">
-        {`Amount Section ${availableBalanceDisplay} placing-${String(
-          isPlacingOrder,
-        )}`}
+        {`Amount Section ${availableBalanceDisplay} placing-${String(isPlacingOrder)}`}
       </Text>
     );
   };
@@ -449,7 +439,6 @@ describe('PredictBuyWithAnyToken', () => {
     mockIsCurrentTokenInsufficient = false;
     mockHasAlternativeBalance = false;
     mockIsPaymentSelectorNavigationLocked = false;
-    mockIsPayWithBottomSheetEnabled = false;
     mockUseSelector.mockImplementation((selector) => {
       if (typeof selector === 'function') {
         return selector({
@@ -805,24 +794,9 @@ describe('PredictBuyWithAnyToken', () => {
       );
     });
 
-    it('navigates to PayWithModal when Change Payment Method is pressed (Case 1)', () => {
+    it('navigates to PayWithBottomSheet when Change Payment Method is pressed (Case 1)', () => {
       mockIsCurrentTokenInsufficient = true;
       mockHasAlternativeBalance = true;
-
-      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
-      fireEvent.press(screen.getByTestId('predict-buy-action-button'));
-
-      expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.CONFIRMATION_PAY_WITH_MODAL,
-      );
-      expect(mockLockPaymentSelectorNavigation).toHaveBeenCalledTimes(1);
-      expect(mockHandleConfirm).not.toHaveBeenCalled();
-    });
-
-    it('navigates to PayWithBottomSheet when Change Payment Method is pressed and isPayWithBottomSheetEnabled returns true', () => {
-      mockIsCurrentTokenInsufficient = true;
-      mockHasAlternativeBalance = true;
-      mockIsPayWithBottomSheetEnabled = true;
 
       renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
       fireEvent.press(screen.getByTestId('predict-buy-action-button'));
@@ -830,8 +804,19 @@ describe('PredictBuyWithAnyToken', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
       );
-      expect(mockNavigate).not.toHaveBeenCalledWith(
-        Routes.CONFIRMATION_PAY_WITH_MODAL,
+      expect(mockLockPaymentSelectorNavigation).toHaveBeenCalledTimes(1);
+      expect(mockHandleConfirm).not.toHaveBeenCalled();
+    });
+
+    it('navigates to PayWithBottomSheet when Change Payment Method is pressed', () => {
+      mockIsCurrentTokenInsufficient = true;
+      mockHasAlternativeBalance = true;
+
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+      fireEvent.press(screen.getByTestId('predict-buy-action-button'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
       );
       expect(mockLockPaymentSelectorNavigation).toHaveBeenCalledTimes(1);
     });
@@ -906,7 +891,7 @@ describe('PredictBuyWithAnyToken', () => {
 
       expect(mockHandleRetryWithBestPrice).toHaveBeenCalledTimes(1);
       expect(mockNavigate).not.toHaveBeenCalledWith(
-        Routes.CONFIRMATION_PAY_WITH_MODAL,
+        Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
       );
     });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -58,7 +58,6 @@ import {
   PredictNavigationParamList,
 } from '../../types/navigation';
 import Routes from '../../../../../constants/navigation/Routes';
-import { isPayWithBottomSheetEnabled } from '../../../../Views/confirmations/utils/transaction-pay';
 import { parseAnalyticsProperties } from '../../utils/analytics';
 import { formatPrice } from '../../utils/format';
 import { usePredictBuyError } from './hooks/usePredictBuyError';
@@ -275,10 +274,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
 
   const handleChangePaymentMethod = useCallback(() => {
     lockPaymentSelectorNavigation();
-    const navigateTo = isPayWithBottomSheetEnabled()
-      ? Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET
-      : Routes.CONFIRMATION_PAY_WITH_MODAL;
-    navigation.navigate(navigateTo);
+    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET);
   }, [lockPaymentSelectorNavigation, navigation]);
 
   const handleAddFunds = useCallback(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.test.tsx
@@ -69,17 +69,6 @@ jest.mock('../../../../../../Views/confirmations/utils/transaction', () => ({
   },
 }));
 
-let mockIsPayWithBottomSheetEnabled = false;
-jest.mock(
-  '../../../../../../Views/confirmations/utils/transaction-pay',
-  () => ({
-    ...jest.requireActual(
-      '../../../../../../Views/confirmations/utils/transaction-pay',
-    ),
-    isPayWithBottomSheetEnabled: () => mockIsPayWithBottomSheetEnabled,
-  }),
-);
-
 jest.mock('../../../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     if (key === 'confirm.label.pay_with') return 'Pay with';
@@ -120,7 +109,6 @@ describe('PredictPayWithRow', () => {
     mockSelectedPaymentToken = null;
     mockIsHardwareAccount.mockReturnValue(false);
     mockHasTransactionType = true;
-    mockIsPayWithBottomSheetEnabled = false;
   });
 
   it('renders label with payToken symbol', () => {
@@ -167,28 +155,13 @@ describe('PredictPayWithRow', () => {
     expect(screen.queryByTestId(/token-icon/)).toBeNull();
   });
 
-  it('navigates to pay-with modal on press', () => {
-    renderWithProvider(<PredictPayWithRow />);
-
-    fireEvent.press(screen.getByText('Pay with USDC'));
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.CONFIRMATION_PAY_WITH_MODAL,
-    );
-  });
-
-  it('navigates to pay-with bottom sheet when isPayWithBottomSheetEnabled returns true', () => {
-    mockIsPayWithBottomSheetEnabled = true;
-
+  it('navigates to pay-with bottom sheet on press', () => {
     renderWithProvider(<PredictPayWithRow />);
 
     fireEvent.press(screen.getByText('Pay with USDC'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
-    );
-    expect(mockNavigate).not.toHaveBeenCalledWith(
-      Routes.CONFIRMATION_PAY_WITH_MODAL,
     );
   });
 
@@ -205,7 +178,7 @@ describe('PredictPayWithRow', () => {
 
     expect(onPaymentSelectorOpen).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(
-      Routes.CONFIRMATION_PAY_WITH_MODAL,
+      Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
     );
     expect(callOrder).toStrictEqual(['lock', 'navigate']);
   });
@@ -409,13 +382,13 @@ describe('PredictPayWithRow', () => {
       expect(screen.getByText(/USDC/)).toBeOnTheScreen();
     });
 
-    it('navigates to pay-with modal on press', () => {
+    it('navigates to pay-with bottom sheet on press', () => {
       renderWithProvider(<PredictPayWithRow variant="row" />);
 
       fireEvent.press(screen.getByText('Pay with'));
 
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.CONFIRMATION_PAY_WITH_MODAL,
+        Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
       );
     });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictPayWithRow/PredictPayWithRow.tsx
@@ -28,7 +28,6 @@ import {
 } from '../../../../../../Views/confirmations/components/token-icon';
 import { isHardwareAccount } from '../../../../../../../util/address';
 import { POLYGON_PUSD } from '../../../../../../Views/confirmations/constants/predict';
-import { isPayWithBottomSheetEnabled } from '../../../../../../Views/confirmations/utils/transaction-pay';
 import { usePredictPaymentToken } from '../../../../hooks/usePredictPaymentToken';
 import { PREDICT_BALANCE_CHAIN_ID } from '../../../../constants/transactions';
 import { usePredictDefaultPaymentToken } from '../../hooks/usePredictDefaultPaymentToken';
@@ -70,10 +69,7 @@ export function PredictPayWithRow({
   const handlePress = useCallback(() => {
     if (!canEdit) return;
     onPaymentSelectorOpen?.();
-    const navigateTo = isPayWithBottomSheetEnabled()
-      ? Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET
-      : Routes.CONFIRMATION_PAY_WITH_MODAL;
-    navigation.navigate(navigateTo);
+    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET);
   }, [canEdit, navigation, onPaymentSelectorOpen]);
 
   const label = strings('confirm.label.pay_with');

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -24,16 +24,12 @@ import {
   useTransactionPayFiatPayment,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useFiatPaymentHighlightedActions } from '../../../hooks/pay/useFiatPaymentHighlightedActions';
+import { getAvailableTokens } from '../../../utils/transaction-pay';
+import { useWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
 import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { EMPTY_ADDRESS } from '../../../../../../constants/transaction';
-import {
-  getAvailableTokens,
-  isPayWithBottomSheetEnabled,
-} from '../../../utils/transaction-pay';
-import { useWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
 import { usePerpsPaymentToken } from '../../../../../UI/Perps/hooks/usePerpsPaymentToken';
 import { usePerpsBalanceTokenFilter } from '../../../../../UI/Perps/hooks/usePerpsBalanceTokenFilter';
 import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredictPaymentToken';
@@ -59,13 +55,11 @@ jest.mock('../../../../../../core/Engine', () => ({
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPayWithdraw');
-jest.mock('../../../hooks/pay/useFiatPaymentHighlightedActions');
 jest.mock('../../../hooks/pay/useWithdrawTokenFilter');
 jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../utils/transaction-pay', () => ({
   ...jest.requireActual('../../../utils/transaction-pay'),
   getAvailableTokens: jest.fn(),
-  isPayWithBottomSheetEnabled: jest.fn(),
 }));
 jest.mock('../../../../../UI/Perps/hooks/usePerpsPaymentToken');
 jest.mock('../../../../../UI/Perps/hooks/usePerpsBalanceTokenFilter');
@@ -217,9 +211,6 @@ describe('PayWithModal', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useTransactionPayWithdrawMock = jest.mocked(useTransactionPayWithdraw);
   const getAvailableTokensMock = jest.mocked(getAvailableTokens);
-  const isPayWithBottomSheetEnabledMock = jest.mocked(
-    isPayWithBottomSheetEnabled,
-  );
   const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
@@ -246,9 +237,7 @@ describe('PayWithModal', () => {
     });
 
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
-    jest.mocked(useFiatPaymentHighlightedActions).mockReturnValue([]);
 
-    isPayWithBottomSheetEnabledMock.mockReturnValue(false);
     getAvailableTokensMock.mockReturnValue(TOKENS_MOCK);
     useWithdrawTokenFilterMock.mockReturnValue(
       jest.fn((tokens: AssetType[]) => tokens),
@@ -538,47 +527,6 @@ describe('PayWithModal', () => {
       expect(getAvailableTokensMock).toHaveBeenCalledWith(
         expect.objectContaining({ fiatPayment: fiatPaymentMock }),
       );
-    });
-
-    it('prepends fiat highlighted actions to token list', () => {
-      const fiatAction = {
-        position: 'outside_of_asset_list' as const,
-        icon: 'card-icon',
-        paymentType: 'debit-credit-card',
-        name: 'Credit Card',
-        name_description: '5-10 min',
-        action: jest.fn(),
-        isSelected: false,
-      };
-
-      jest
-        .mocked(useFiatPaymentHighlightedActions)
-        .mockReturnValue([fiatAction]);
-
-      const { getByText } = render();
-
-      expect(getByText('Credit Card')).toBeDefined();
-    });
-
-    it('suppresses fiat highlighted actions when the new Pay With bottom sheet is enabled', () => {
-      const fiatAction = {
-        position: 'outside_of_asset_list' as const,
-        icon: 'card-icon',
-        paymentType: 'debit-credit-card',
-        name: 'Credit Card',
-        name_description: '5-10 min',
-        action: jest.fn(),
-        isSelected: false,
-      };
-
-      jest
-        .mocked(useFiatPaymentHighlightedActions)
-        .mockReturnValue([fiatAction]);
-      isPayWithBottomSheetEnabledMock.mockReturnValue(true);
-
-      const { queryByText } = render();
-
-      expect(queryByText('Credit Card')).toBeNull();
     });
   });
 });

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Hex } from '@metamask/utils';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import Engine from '../../../../../../core/Engine';
@@ -22,11 +22,7 @@ import {
   useTransactionPayFiatPayment,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
-import { useFiatPaymentHighlightedActions } from '../../../hooks/pay/useFiatPaymentHighlightedActions';
-import {
-  getAvailableTokens,
-  isPayWithBottomSheetEnabled,
-} from '../../../utils/transaction-pay';
+import { getAvailableTokens } from '../../../utils/transaction-pay';
 import { useTransactionPayBlockedTokens } from '../../../hooks/pay/useTransactionPayBlockedTokens';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { TransactionType } from '@metamask/transaction-controller';
@@ -67,11 +63,6 @@ export function PayWithModal() {
   const { isWithdraw } = useTransactionPayWithdraw();
   const requiredTokens = useTransactionPayRequiredTokens();
   const fiatPayment = useTransactionPayFiatPayment();
-  const fiatHighlightedActions = useFiatPaymentHighlightedActions();
-  const effectiveFiatHighlightedActions = useMemo(
-    () => (isPayWithBottomSheetEnabled() ? [] : fiatHighlightedActions),
-    [fiatHighlightedActions],
-  );
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const { filterAllowedTokens: musdTokenFilter } = useMusdConversionTokens();
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
@@ -236,16 +227,10 @@ export function PayWithModal() {
         filteredTokens = predictBalanceTokenFilter(availableTokens);
       }
 
-      const wrappedTokens = wrapHighlightedItemCallbacks(filteredTokens);
-      const wrappedFiatActions = wrapHighlightedItemCallbacks(
-        effectiveFiatHighlightedActions,
-      );
-
-      return [...wrappedFiatActions, ...wrappedTokens];
+      return wrapHighlightedItemCallbacks(filteredTokens);
     },
     [
       blockedTokens,
-      effectiveFiatHighlightedActions,
       fiatPayment,
       withdrawTokenFilter,
       musdTokenFilter,

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -64,9 +64,7 @@ jest.mock('../../token-icon/', () => ({
   TokenIcon: (props: TokenIconProps) => (
     <>
       <MockText>{`${props.address} ${props.chainId}`}</MockText>
-      <MockText testID="token-icon-symbol">
-        {`icon-symbol:${props.symbol ?? ''}`}
-      </MockText>
+      <MockText testID="token-icon-symbol">{`icon-symbol:${props.symbol ?? ''}`}</MockText>
     </>
   ),
   TokenIconVariant: { Default: 'default', Row: 'row', Hero: 'hero' },
@@ -157,7 +155,8 @@ describe('PayWithRow', () => {
     });
 
     expect(navigateMock).toHaveBeenCalledWith(
-      Routes.CONFIRMATION_PAY_WITH_MODAL,
+      Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
+      expect.any(Object),
     );
   });
 
@@ -279,7 +278,7 @@ describe('PayWithRow', () => {
       expect(getByText('Credit Card')).toBeDefined();
     });
 
-    it('navigates to modal when fiat payment method row is pressed', async () => {
+    it('navigates to bottom sheet when fiat payment method row is pressed', async () => {
       jest
         .mocked(useTransactionPaySelectedFiatPaymentMethod)
         .mockReturnValue(FIAT_PAYMENT_METHOD_MOCK);
@@ -291,7 +290,8 @@ describe('PayWithRow', () => {
       });
 
       expect(navigateMock).toHaveBeenCalledWith(
-        Routes.CONFIRMATION_PAY_WITH_MODAL,
+        Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET,
+        expect.any(Object),
       );
     });
   });

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -49,7 +49,6 @@ import { SetPayTokenRequest } from '../../../hooks/pay/useAutomaticTransactionPa
 import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
 import { useConfirmationContext } from '../../../context/confirmation-context';
 import { useTheme } from '../../../../../../util/theme';
-import { isPayWithBottomSheetEnabled } from '../../../utils/transaction-pay';
 
 interface PayWithRouteParams {
   preferredPaymentToken?: SetPayTokenRequest;
@@ -96,14 +95,9 @@ function PayWithRowInteractive() {
         mm_pay_token_list_opened: true,
       },
     });
-    if (isPayWithBottomSheetEnabled()) {
-      navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET, {
-        preferredPaymentToken,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_MODAL);
+    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET, {
+      preferredPaymentToken,
+    });
   }, [isDisabled, navigation, preferredPaymentToken, setConfirmationMetric]);
 
   const label = isWithdraw
@@ -278,13 +272,9 @@ function PayWithRowMoneyAccount() {
     setConfirmationMetric({
       properties: { mm_pay_token_list_opened: true },
     });
-    if (isPayWithBottomSheetEnabled()) {
-      navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET, {
-        preferredPaymentToken,
-      });
-      return;
-    }
-    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_MODAL);
+    navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET, {
+      preferredPaymentToken,
+    });
   }, [navigation, preferredPaymentToken, setConfirmationMetric]);
 
   if (!payToken) {

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -344,11 +344,3 @@ export function resolvePreferredPayToken({
 
   return undefined;
 }
-
-/**
- * Temporary build-time feature gate for the new Pay With bottom sheet UI.
- * Remove this helper and its callers once the bottom sheet ships behind the
- * remote `confirmations_pay_fiat` flag.
- */
-export const isPayWithBottomSheetEnabled = (): boolean =>
-  process.env.MM_DEV_PAY_WITH_BOTTOM_SHEET === 'true';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

The pay-with bottom sheet was gated behind the `MM_DEV_PAY_WITH_BOTTOM_SHEET` env variable via the `isPayWithBottomSheetEnabled()` helper. 

This PR removes the feature flag entirely and enables the pay-with bottom sheet unconditionally:

1. **Removes `isPayWithBottomSheetEnabled()`** from `transaction-pay.ts`
2. **Simplifies navigation** in 4 files (`PayWithRow`, `PerpsPayRow`, `PredictPayWithRow`, `PredictBuyWithAnyToken`) - always navigate to `CONFIRMATION_PAY_WITH_BOTTOM_SHEET` instead of conditionally choosing between the bottom sheet and the old modal
3. **Removes dead code** from `usePredictBalanceTokenFilter` and `usePerpsBalanceTokenFilter` - the synthetic `HighlightedItem` rows (Predict balance / Perps balance) that were only shown in the old modal path are removed along with their unused hooks and imports
4. **Simplifies `PayWithModal`** - removes fiat highlighted actions suppression logic since the bottom sheet handles fiat actions
5. **Updates 7 test files** - removes mocks for the flag, updates navigation assertions, removes tests for old-path behavior

> **Note:** `PayWithModal` and its route (`CONFIRMATION_PAY_WITH_MODAL`) are intentionally kept - they are still used as the "Other assets" token picker launched from within the bottom sheet via `usePayWithCryptoSection`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Pay-with bottom sheet

  Scenario: user opens pay-with token picker from confirmation
    Given user has a pending transaction confirmation with pay-with row

    When user taps the pay-with row
    Then the pay-with bottom sheet opens (not the old full-screen modal)

  Scenario: user opens pay-with from Perps order view
    Given user is on the Perps order view with a pay-with row

    When user taps the pay-with row
    Then the pay-with bottom sheet opens

  Scenario: user opens pay-with from Predict buy flow
    Given user is in the Predict buy-with-any-token flow

    When user taps Change Payment Method
    Then the pay-with bottom sheet opens
```

## **Screenshots/Recordings**

### **Before**

### **After**

### MUSD Conversion

https://github.com/user-attachments/assets/fefa8b80-cc81-4876-8221-29d9aed79c86

### Perps

https://github.com/user-attachments/assets/b48cd1bf-4497-464b-94f3-07daea47716b

### Predict

https://github.com/user-attachments/assets/362ad188-7724-4e6d-9844-2c80899147a6

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment selection navigation across confirmations, Perps, and Predict; behavior change is broad but localized to pay-with UX, not auth or funds signing.
> 
> **Overview**
> Removes the **`MM_DEV_PAY_WITH_BOTTOM_SHEET`** gate (`isPayWithBottomSheetEnabled`) and makes the **pay-with bottom sheet** the only entry path from confirmations, Perps, and Predict (always **`CONFIRMATION_PAY_WITH_BOTTOM_SHEET`**).
> 
> **Perps** and **Predict** balance token filters no longer prepend synthetic **Perps balance** / **Predict balance** highlighted rows or wire **Add funds** from those lists—that UI lived on the old modal path. Perps still applies allowlist filtering and clears other tokens’ selection when perps balance is selected.
> 
> **`PayWithModal`** stops prepending fiat highlighted actions and the flag-based suppression; token lists come from filters only. The modal route remains for flows such as **Other assets** from the bottom sheet.
> 
> Tests drop flag mocks and assert bottom-sheet navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8b7e4ca93c64ad79b37b8123ffe3645a28cd14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->