### PR TITLE
fix(social-leaderboard): trade markers on trader price chart

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
@@ -41,7 +41,16 @@ interface TooltipProps {
 
 /** Smaller than TRADE_MARKER_RADIUS so the end-dot doesn't look like a trade marker. */
 const END_DOT_DIAMETER = 5;
-const TRADE_MARKER_RADIUS = 7;
+/**
+ * Trade marker geometry — the inner colored disk is 16x16 with a 4px ring
+ * matching the chart background. SVG strokes are centered on the circumference,
+ * so we set r = innerRadius + strokeWidth/2 (8 + 2 = 10) to make the ring
+ * sit fully outside the visible inner disk.
+ */
+const TRADE_MARKER_INNER_RADIUS = 8;
+const TRADE_MARKER_BORDER_WIDTH = 4;
+const TRADE_MARKER_RADIUS =
+  TRADE_MARKER_INNER_RADIUS + TRADE_MARKER_BORDER_WIDTH / 2;
 
 interface TraderPriceChartProps {
   prices: TokenPrice[];
@@ -284,12 +293,10 @@ const TraderPriceChart = ({
           const cy = y(priceList[m.index]);
           if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null;
           const isBuy = m.intent === 'enter';
-          // Buy: white fill + green stroke — clearly distinct from the green
-          //   chart line while still reading as a "buy" action.
-          // Sell: red fill + dark background halo — high contrast, matches the
-          //   red values shown in the trades list.
-          // The background-colored strokeWidth halos both markers so they
-          // visually punch through the chart line.
+          // Inner disk uses the same green/red as the rest of the UI; the
+          // ring matches the chart background so the marker reads as a
+          // punched-through dot on the line. background.default adapts to
+          // light/dark automatically.
           return (
             <Circle
               key={m.transactionHash}
@@ -297,9 +304,9 @@ const TraderPriceChart = ({
               cx={cx}
               cy={cy}
               r={TRADE_MARKER_RADIUS}
-              fill={isBuy ? 'lightgreen' : theme.colors.error.default}
-              stroke={isBuy ? 'black' : theme.colors.background.default}
-              strokeWidth={Math.max(2, apx(2))}
+              fill={isBuy ? chartColor : theme.colors.error.default}
+              stroke={theme.colors.background.default}
+              strokeWidth={TRADE_MARKER_BORDER_WIDTH}
             />
           );
         })}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
@@ -304,7 +304,11 @@ const TraderPriceChart = ({
               cx={cx}
               cy={cy}
               r={TRADE_MARKER_RADIUS}
-              fill={isBuy ? chartColor : theme.colors.error.default}
+              fill={
+                isBuy
+                  ? theme.colors.success.default
+                  : theme.colors.error.default
+              }
               stroke={theme.colors.background.default}
               strokeWidth={TRADE_MARKER_BORDER_WIDTH}
             />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
+import { Box } from '@metamask/design-system-react-native';
+import type { Trade } from '@metamask/social-controllers';
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Dimensions,
@@ -6,24 +8,20 @@ import {
   PanResponder,
   View,
 } from 'react-native';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { Circle, G, Path, Line as SvgLine } from 'react-native-svg';
 import { AreaChart } from 'react-native-svg-charts';
-import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
-import type { Trade } from '@metamask/social-controllers';
-import { Box } from '@metamask/design-system-react-native';
-import type { TokenPrice } from '../../../../hooks/useTokenHistoricalPrices';
 import { useStyles } from '../../../../../component-library/hooks';
-import { useTheme, LIGHT_MODE_SUCCESS_GREEN } from '../../../../../util/theme';
-import { AppThemeKey } from '../../../../../util/theme/models';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import type { TokenPrice } from '../../../../hooks/useTokenHistoricalPrices';
+import NoDataOverlay from '../../../../UI/AssetOverview/NoDataOverlay/NoDataOverlay';
 import {
   CHART_DATA_THRESHOLD,
   TOKEN_OVERVIEW_CHART_HEIGHT,
 } from '../../../../UI/AssetOverview/Price/tokenOverviewChart.constants';
-import styleSheet from '../../../../UI/AssetOverview/PriceChart/PriceChart.styles';
 import PriceChartContext from '../../../../UI/AssetOverview/PriceChart/PriceChart.context';
-import NoDataOverlay from '../../../../UI/AssetOverview/NoDataOverlay/NoDataOverlay';
+import styleSheet from '../../../../UI/AssetOverview/PriceChart/PriceChart.styles';
 import { mapTradesToMarkers } from '../utils/tradeMarkers';
 
 interface LineProps {
@@ -64,7 +62,6 @@ interface TraderPriceChartProps {
 
 const TraderPriceChart = ({
   prices,
-  priceDiff,
   isLoading,
   onChartIndexChange,
   trades,
@@ -77,11 +74,7 @@ const TraderPriceChart = ({
   const [positionX, setPositionX] = useState(-1);
   const [chartRowWidth, setChartRowWidth] = useState(0);
   const { styles, theme } = useStyles(styleSheet, { chartHeight });
-  const { themeAppearance } = useTheme();
-  const chartColor =
-    themeAppearance === AppThemeKey.light
-      ? LIGHT_MODE_SUCCESS_GREEN
-      : theme.colors.success.default;
+  const chartColor = theme.colors.success.default;
 
   useEffect(() => {
     setPositionX(-1);


### PR DESCRIPTION
## **Description**

Polish the buy/sell trade markers overlaid on the trader price chart in the social leaderboard's `TraderPositionView`. The previous dots were small, used non-token colors (`lightgreen`, `black` stroke), and were hard to read on top of the chart line.

This PR:

- Resizes the inner colored disk to 16x16.
- Uses `theme.colors.success.default` for buys and `theme.colors.error.default` for sells, matching the `+$...` / `-$...` amount colors in the trades list below the chart.
- Adds a 4px ring colored `theme.colors.background.default` so the marker visually punches through the chart line. The SVG `r` is set to `innerRadius + strokeWidth / 2` so the ring sits fully outside the inner disk.
- Adapts automatically to light/dark since both fill and stroke come from the theme.

Only `TraderPriceChart.tsx` is touched; no API or behavior change beyond the visual update.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Trader price chart trade markers

  Scenario: trader with recorded buys and sells
    Given I am viewing a trader position with both buy and sell trades in the visible time window
    When the price chart renders
    Then a 16px green dot is shown at each buy index, matching the green of the "+$..." amount in the trades list
    And a 16px red dot is shown at each sell index, matching the red of the "-$..." amount in the trades list
    And each dot is surrounded by a 4px ring matching the chart background

  Scenario: theme adaptation
    Given a trader position view with trade markers rendered
    When I switch between light and dark mode
    Then the ring around each dot continues to blend into the chart background
```

## **Screenshots/Recordings**

### **Before**

<img width="1207" height="788" alt="image" src="https://github.com/user-attachments/assets/5a478fd8-ab80-462e-8e17-541b5aa6da05" />


### **After**

<img width="784" height="789" alt="image" src="https://github.com/user-attachments/assets/6ff57ff5-057b-497f-91a2-2fcbbc64fe2e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (existing `TraderPriceChart.test.tsx` still passes; markers are asserted by testID, not color)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

N/A — purely visual change to SVG props on an existing component, no new operations to trace.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file SVG styling in TraderPriceChart with no API or data-flow changes.
> 
> **Overview**
> Polishes **buy/sell trade markers** on the social leaderboard **trader price chart** so they read clearly on top of the line.
> 
> Markers are **larger** (16px inner disk) with a **4px background-colored ring**; SVG radius is derived so the ring sits outside the fill. **Buy/sell colors** now use `theme.colors.success.default` and `theme.colors.error.default` (aligned with the trades list), with `theme.colors.background.default` for the halo instead of `lightgreen` / `black`. The **chart line** always uses `theme.colors.success.default`, dropping the separate light-mode green path. **`priceDiff`** is no longer read in the component (import order cleanup only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798663de80d6bdf595e4299095113df2101c10db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->