### PR TITLE
chore: 7702 support money account keyring

### DIFF
--- a/app/constants/keyringTypes.ts
+++ b/app/constants/keyringTypes.ts
@@ -3,6 +3,7 @@ enum ExtendedKeyringTypes {
   hd = 'HD Key Tree',
   qr = 'QR Hardware Wallet Device',
   ledger = 'Ledger Hardware',
+  money = 'Money Keyring',
 }
 
 export default ExtendedKeyringTypes;

--- a/app/util/transactions/account-supports-7702.test.ts
+++ b/app/util/transactions/account-supports-7702.test.ts
@@ -51,6 +51,15 @@ describe('accountSupports7702', () => {
     );
   });
 
+  it('returns true for Money keyring', async () => {
+    const controller = createMockKeyringController({
+      type: ExtendedKeyringTypes.money,
+    });
+    await expect(accountSupports7702(SAMPLE_ADDRESS, controller)).resolves.toBe(
+      true,
+    );
+  });
+
   it('returns false for Ledger hardware keyring', async () => {
     const controller = createMockKeyringController({
       type: ExtendedKeyringTypes.ledger,

--- a/app/util/transactions/account-supports-7702.ts
+++ b/app/util/transactions/account-supports-7702.ts
@@ -12,6 +12,7 @@ interface KeyringControllerLike {
 const KEYRING_TYPES_SUPPORTING_7702: string[] = [
   ExtendedKeyringTypes.hd,
   ExtendedKeyringTypes.simple,
+  ExtendedKeyringTypes.money,
 ];
 
 /**


### PR DESCRIPTION

## **Description**

Enables money account keyring to be 7702 upgradeable. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Already enabled in core: https://github.com/MetaMask/core/pull/8687

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist and enum addition with a unit test; no auth, payment, or broad transaction-path changes.
> 
> **Overview**
> Treats **Money Keyring** accounts as EIP-7702–capable in mobile, matching core support for money-account smart-account upgrades.
> 
> Adds `ExtendedKeyringTypes.money` and includes it in `KEYRING_TYPES_SUPPORTING_7702` so `accountSupports7702` returns true for money accounts (same as HD and simple keyrings). A unit test locks in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6124cb18512df1915d7bb2f0dd8b08eec002ee03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->