### PR TITLE
feat: add haptic feedback to What's Happening Trade CTA

### DIFF
--- a/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.test.tsx
@@ -10,6 +10,12 @@ import type { PerpsPriceEntry } from '../hooks/useWhatsHappeningAssetPrices';
 
 const mockNavigate = jest.fn();
 const mockTrackEvent = jest.fn();
+const mockPlayImpact = jest.fn();
+
+jest.mock('../../../../util/haptics', () => ({
+  playImpact: (moment: string) => mockPlayImpact(moment),
+  ImpactMoment: { PrimaryCTA: 'primaryCta' },
+}));
 const mockCreateEventBuilder = jest.fn((eventName: string) => ({
   addProperties: jest.fn((properties: Record<string, unknown>) => ({
     build: jest.fn(() => ({ category: eventName, properties })),
@@ -178,6 +184,37 @@ describe('PerpsRow', () => {
         }),
       }),
     );
+  });
+
+  it('plays primary CTA haptic feedback on Trade press', () => {
+    renderWithProvider(
+      <PerpsRow
+        asset={perpsOnlyAsset}
+        item={mockItem}
+        cardIndex={0}
+        source="homepage"
+        perpsPriceBySymbol={emptyPriceMap}
+      />,
+    );
+    fireEvent.press(screen.getByText('Trade'));
+    expect(mockPlayImpact).toHaveBeenCalledWith('primaryCta');
+  });
+
+  it('does not play haptic feedback when perps market is missing', () => {
+    const assetNoPerps: RelatedAsset = {
+      ...perpsOnlyAsset,
+      hlPerpsMarket: [],
+    };
+    renderWithProvider(
+      <PerpsRow
+        asset={assetNoPerps}
+        item={mockItem}
+        cardIndex={0}
+        source="homepage"
+        perpsPriceBySymbol={emptyPriceMap}
+      />,
+    );
+    expect(mockPlayImpact).not.toHaveBeenCalled();
   });
 
   it('displays price and 24h change from perpsPriceBySymbol', () => {

--- a/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.tsx
@@ -13,6 +13,7 @@ import { formatAssetPrice } from '../utils/formatAssetPrice';
 import type { PerpsPriceEntry } from '../hooks/useWhatsHappeningAssetPrices';
 import AssetRow from './AssetRow';
 import useTradeNavigation from '../hooks/useTradeNavigation';
+import { playImpact, ImpactMoment } from '../../../../util/haptics';
 
 interface PerpsRowProps {
   asset: RelatedAsset;
@@ -53,6 +54,7 @@ const PerpsRow: React.FC<PerpsRowProps> = ({
     if (!perpsMarket) {
       return;
     }
+    playImpact(ImpactMoment.PrimaryCTA);
     trackEvent(
       createEventBuilder(MetaMetricsEvents.WHATS_HAPPENING_INTERACTED)
         .addProperties({


### PR DESCRIPTION
## **Description**

Adds a Primary CTA haptic impact when the user presses the **Trade** button on a related-asset row in the What's Happening expanded card.

- The Trade button is a primary commit action that opens the Perps market detail flow. Per the haptics catalog, `ImpactMoment.PrimaryCTA` is the moment reserved for primary surface commits (Buy/Trade/Save) and is the correct mapping here.
- The haptic fires only when there is a valid `hlPerpsMarket` symbol (i.e., the same guard that gates navigation and analytics). If the press is a no-op, no haptic plays.
- Implemented via the project's `util/haptics` facade (`playImpact` + `ImpactMoment`), not by importing `expo-haptics` directly — consistent with the existing eslint rule and the catalog-driven haptics architecture used elsewhere (e.g. `PerpsSlider`).

## **Changelog**

CHANGELOG entry: Added haptic feedback to the Trade button in the What's Happening detail card.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Haptic feedback on What's Happening Trade CTA

  Scenario: User taps Trade on a related perps asset
    Given the user has opened a What's Happening card with at least one related perps asset
    And the device has system haptics enabled
    When the user taps the "Trade" button next to a related asset
    Then a medium "Primary CTA" haptic impact is felt
    And the app navigates to the Perps market details screen

  Scenario: Row without a perps market does not render Trade
    Given a related asset has no hlPerpsMarket symbol
    When the user views the row
    Then no Trade button is shown
    And no haptic fires
```

## **Screenshots/Recordings**

### **Before**

No haptic on Trade press.

### **After**

Primary CTA haptic fires on Trade press (see attached screenshot of the affected screen in the PR description).

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX addition behind existing trade guards; no auth, data, or navigation logic changes beyond calling the shared haptics helper.
> 
> **Overview**
> Adds **Primary CTA** haptic feedback when users tap **Trade** on a related perps asset row in the What's Happening detail card, using `playImpact(ImpactMoment.PrimaryCTA)` from `util/haptics`.
> 
> The impact runs only inside the existing trade handler after a valid `hlPerpsMarket` symbol is confirmed—the same guard as navigation and analytics—so no-op rows never trigger haptics. **Unit tests** mock the haptics facade and cover both successful Trade press and missing-market cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f94739828c970d26f5f1f76996e21036b908de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->