### PR TITLE
feat: enhance Braze URL handling for in-app messages [GE-251]

### DIFF
--- a/ios/MetaMask/AppDelegate.m
+++ b/ios/MetaMask/AppDelegate.m
@@ -120,7 +120,8 @@ static Braze *_braze = nil;
 //
 // Universal links (Branch domains) are forwarded to Branch for proper routing.
 // All other URLs are suppressed here; they are handled exclusively through
-// the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE.
+// the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE. In-app message
+// URLs are allowed through Braze so custom HTML CTA deeplinks can open the app.
 - (BOOL)braze:(Braze *)braze shouldOpenURL:(BRZURLContext *)context {
   NSString *host = context.url.host;
   if (host &&
@@ -130,6 +131,9 @@ static Braze *_braze = nil;
        [host containsString:@"link-test.metamask.io"])) {
     [[Branch getInstance] handleDeepLink:context.url];
     return NO;
+  }
+  if (context.channel == BRZChannelInAppMessage) {
+    return YES;
   }
   return NO;
 }

--- a/ios/MetaMask/AppDelegate.m
+++ b/ios/MetaMask/AppDelegate.m
@@ -119,9 +119,9 @@ static Braze *_braze = nil;
 // the Braze RN bridge JS event and once from the system URL handler).
 //
 // Universal links (Branch domains) are forwarded to Branch for proper routing.
-// All other URLs are suppressed here; they are handled exclusively through
-// the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE. In-app message
-// URLs are allowed through Braze so custom HTML CTA deeplinks can open the app.
+// Notification URLs are suppressed here; they are handled exclusively through
+// the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE. Other Braze UI
+// surfaces are allowed through Braze so their CTAs can open app links.
 - (BOOL)braze:(Braze *)braze shouldOpenURL:(BRZURLContext *)context {
   NSString *host = context.url.host;
   if (host &&
@@ -132,10 +132,16 @@ static Braze *_braze = nil;
     [[Branch getInstance] handleDeepLink:context.url];
     return NO;
   }
-  if (context.channel == BRZChannelInAppMessage) {
-    return YES;
+
+  switch (context.channel) {
+    case BRZChannelInAppMessage:
+    case BRZChannelContentCard:
+    case BRZChannelBanner:
+      return YES;
+    case BRZChannelNotification:
+    default:
+      return NO;
   }
-  return NO;
 }
 
 @end

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -152,9 +152,9 @@ extension AppDelegate: BrazeDelegate {
   // the Braze RN bridge JS event and once from the system URL handler).
   //
   // Universal links (Branch domains) are forwarded to Branch for proper routing.
-  // All other URLs are suppressed here; they are handled exclusively through
-  // the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE. In-app message
-  // URLs are allowed through Braze so custom HTML CTA deeplinks can open the app.
+  // Notification URLs are suppressed here; they are handled exclusively through
+  // the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE. Other Braze UI
+  // surfaces are allowed through Braze so their CTAs can open app links.
   func braze(_ braze: Braze, shouldOpenURL context: Braze.URLContext) -> Bool {
     if let host = context.url.host,
        host.contains("app.link") ||
@@ -164,9 +164,14 @@ extension AppDelegate: BrazeDelegate {
       Branch.getInstance().handleDeepLink(context.url)
       return false
     }
-    if context.channel == .inAppMessage {
+
+    switch context.channel {
+    case .inAppMessage, .contentCard, .banner:
       return true
+    case .notification:
+      return false
+    @unknown default:
+      return false
     }
-    return false
   }
 }

--- a/ios/MetaMask/AppDelegate.swift
+++ b/ios/MetaMask/AppDelegate.swift
@@ -153,7 +153,8 @@ extension AppDelegate: BrazeDelegate {
   //
   // Universal links (Branch domains) are forwarded to Branch for proper routing.
   // All other URLs are suppressed here; they are handled exclusively through
-  // the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE.
+  // the JS PUSH_NOTIFICATION_EVENT, tagged with ORIGIN_BRAZE. In-app message
+  // URLs are allowed through Braze so custom HTML CTA deeplinks can open the app.
   func braze(_ braze: Braze, shouldOpenURL context: Braze.URLContext) -> Bool {
     if let host = context.url.host,
        host.contains("app.link") ||
@@ -162,6 +163,9 @@ extension AppDelegate: BrazeDelegate {
        host.contains("link-test.metamask.io") {
       Branch.getInstance().handleDeepLink(context.url)
       return false
+    }
+    if context.channel == .inAppMessage {
+      return true
     }
     return false
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This update allows deeplinks starting by `metamask://` to be opened from Braze full-screen modals, enabling custom HTML CTA deeplinks to launch the app. The changes include modifications to the `braze:shouldOpenURL` method, ensuring that URLs from in-app messages are permitted while maintaining existing behavior for other URLs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native deeplink gating for Braze surfaces; notification suppression is preserved but new allow paths could affect how untrusted Braze CTA URLs reach the app.
> 
> **Overview**
> **iOS Braze deep-link routing** is narrowed so only **push notification** taps stay blocked at the native layer (still routed through JS with `ORIGIN_BRAZE`), while **in-app messages, content cards, and banners** can let Braze open their CTA URLs—including custom schemes like `metamask://` from full-screen HTML modals.
> 
> Branch universal-link hosts are unchanged: those URLs still go to **Branch** and return **false** to Braze. The same `braze:shouldOpenURL` / channel `switch` logic is applied in both **`AppDelegate.m`** and **`AppDelegate.swift`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e012fca568df2ed2b9e5807db3ab6f147db0c8b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->