### PR TITLE
fix: explore search v2 issues cp-7.79.0

### DIFF
--- a/app/components/Views/TrendingView/TrendingView.view.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.view.test.tsx
@@ -185,8 +185,7 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
   });
 
   it('user can search for a trending token from the explore feed', async () => {
-    const { findByPlaceholderText, findByTestId, getByTestId } =
-      renderTrendingViewWithRoutes();
+    const { findByTestId, getByTestId } = renderTrendingViewWithRoutes();
 
     await waitFor(() => {
       expect(
@@ -199,8 +198,8 @@ describeForPlatforms('ExploreFeed - Component Tests', () => {
     );
     await actButtonPress(searchButton);
 
-    const searchInput = await findByPlaceholderText(
-      strings('trending.search_placeholder'),
+    const searchInput = await findByTestId(
+      TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT,
     );
     expect(searchInput).toBeOnTheScreen();
 
@@ -301,7 +300,7 @@ describeForPlatforms('TrendingTokensFullView - Component Tests', () => {
   });
 
   it('user can search on trending tokens full view', async () => {
-    const { findByPlaceholderText, getByTestId, queryByTestId } =
+    const { findByPlaceholderText, findByTestId, getByTestId, queryByTestId } =
       renderTrendingViewWithRoutes();
 
     await waitFor(() => {

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.testIds.ts
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.testIds.ts
@@ -12,7 +12,7 @@ export const ExploreSearchScreenSelectorsIDs = {
   PILL_ROW: 'explore-search-pills',
   /** "All" pill */
   PILL_ALL: 'explore-search-pill-all',
-  /** Cryptos / tokens feed pill */
+  /** Crypto / tokens feed pill */
   PILL_CRYPTOS: 'explore-search-pill-tokens',
   /** Perps feed pill */
   PILL_PERPS: 'explore-search-pill-perps',

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
@@ -83,7 +83,7 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
       ).toBeOnTheScreen();
     });
 
-    // Tap the Cryptos pill to switch to the single-feed view
+    // Tap the Crypto pill to switch to the single-feed view
     await actButtonPress(cryptosPill);
 
     // The aggregated results list disappears (replaced by the single-feed FlashList)
@@ -104,7 +104,7 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     });
   });
 
-  it('Cryptos section header shows "View all" label (remote search — no exact count)', async () => {
+  it('Crypto section header shows "View all" label (remote search — no exact count)', async () => {
     const { findByTestId, getByTestId, getAllByText } =
       renderExploreSearchScreenWithRoutes();
 
@@ -116,7 +116,7 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     // Wait for the aggregated results list to appear
     await findByTestId(ExploreSearchScreenSelectorsIDs.SEARCH_RESULTS_LIST);
 
-    // The Cryptos section header button label should be "View all" because
+    // The Crypto section header button label should be "View all" because
     // tokens use remote pagination and we never have a precise count of
     // remaining items.
     await waitFor(() => {
@@ -125,7 +125,7 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     });
 
     // The Pressable wrapping that label has accessibilityLabel = "{label} {title}".
-    // Verify the Cryptos section specifically by checking the accessibility label.
+    // Verify the Crypto section specifically by checking the accessibility label.
     const viewAllCryptosLabel = `${strings('trending.view_all')} ${strings('trending.search_tabs.crypto')}`;
     await waitFor(() => {
       const resultsListEl = getByTestId(
@@ -146,13 +146,13 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     );
     await userEvent.type(searchInput, 'btc');
 
-    // Tap Cryptos pill to activate it
+    // Tap Crypto pill to activate it
     const cryptosPill = await findByTestId(
       ExploreSearchScreenSelectorsIDs.PILL_CRYPTOS,
     );
     await actButtonPress(cryptosPill);
 
-    // Cryptos pill should now be selected (active): accessibilityState.selected === true
+    // Crypto pill should now be selected (active): accessibilityState.selected === true
     await waitFor(() => {
       expect(cryptosPill.props.accessibilityState?.selected).toBe(true);
     });
@@ -161,7 +161,7 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     const clearButton = getByTestId('explore-search-clear-button');
     await actButtonPress(clearButton);
 
-    // After clearing, the Cryptos pill should remain selected — clearing the
+    // After clearing, the Crypto pill should remain selected — clearing the
     // query must not auto-navigate back to "All".
     await waitFor(() => {
       expect(cryptosPill.props.accessibilityState?.selected).toBe(true);

--- a/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
+++ b/app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.view.test.tsx
@@ -104,8 +104,10 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     });
   });
 
-  it('Crypto section header shows "View all" label (remote search — no exact count)', async () => {
-    const { findByTestId, getByTestId, getAllByText } =
+  it('Crypto section header hides "View all" when results fit within the cap', async () => {
+    // The mock returns 3 tokens (= MAX_ITEMS_PER_SECTION), so getViewMoreLabel
+    // returns null and the "View all" button should not be rendered.
+    const { findByTestId, getByTestId, queryByText } =
       renderExploreSearchScreenWithRoutes();
 
     const searchInput = getByTestId(
@@ -116,25 +118,18 @@ describeForPlatforms('ExploreSearchScreen V2 - Component Tests', () => {
     // Wait for the aggregated results list to appear
     await findByTestId(ExploreSearchScreenSelectorsIDs.SEARCH_RESULTS_LIST);
 
-    // The Crypto section header button label should be "View all" because
-    // tokens use remote pagination and we never have a precise count of
-    // remaining items.
+    // With only 3 results (≤ MAX_ITEMS_PER_SECTION) the "View all" button must
+    // not be rendered — there is nothing more to reveal.
     await waitFor(() => {
-      const viewAllLabels = getAllByText(strings('trending.view_all'));
-      expect(viewAllLabels.length).toBeGreaterThanOrEqual(1);
-    });
-
-    // The Pressable wrapping that label has accessibilityLabel = "{label} {title}".
-    // Verify the Crypto section specifically by checking the accessibility label.
-    const viewAllCryptosLabel = `${strings('trending.view_all')} ${strings('trending.search_tabs.crypto')}`;
-    await waitFor(() => {
+      const viewAllCryptosLabel = `${strings('trending.view_all')} ${strings('trending.search_tabs.crypto')}`;
       const resultsListEl = getByTestId(
         ExploreSearchScreenSelectorsIDs.SEARCH_RESULTS_LIST,
       );
       const pressables = resultsListEl.findAll(
         (node) => node.props.accessibilityLabel === viewAllCryptosLabel,
       );
-      expect(pressables.length).toBeGreaterThan(0);
+      expect(pressables.length).toBe(0);
+      expect(queryByText(strings('trending.view_all'))).toBeNull();
     });
   });
 

--- a/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.test.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import ExploreSearchBar from './ExploreSearchBar';
 import { useSelector } from 'react-redux';
 import { selectBasicFunctionalityEnabled } from '../../../../../selectors/settings';
-import { strings } from '../../../../../../locales/i18n';
+import { TrendingViewSelectorsIDs } from '../../TrendingView.testIds';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -82,7 +82,7 @@ describe('ExploreSearchBar', () => {
       const mockOnSearchChange = jest.fn();
       const mockOnCancel = jest.fn();
 
-      const { getByPlaceholderText } = render(
+      const { getByTestId } = render(
         <ExploreSearchBar
           type="interactive"
           searchQuery=""
@@ -91,8 +91,8 @@ describe('ExploreSearchBar', () => {
         />,
       );
 
-      const input = getByPlaceholderText(
-        strings('trending.search_placeholder'),
+      const input = getByTestId(
+        TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT,
       );
 
       fireEvent.changeText(input, 'ethereum');
@@ -193,7 +193,7 @@ describe('ExploreSearchBar', () => {
       const mockOnSearchChange = jest.fn();
       const mockOnCancel = jest.fn();
 
-      const { getByPlaceholderText } = render(
+      const { getByTestId } = render(
         <ExploreSearchBar
           type="interactive"
           searchQuery=""
@@ -202,8 +202,8 @@ describe('ExploreSearchBar', () => {
         />,
       );
 
-      const input = getByPlaceholderText(
-        strings('trending.search_placeholder'),
+      const input = getByTestId(
+        TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT,
       );
 
       expect(input.props.autoFocus).toBe(true);

--- a/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
+++ b/app/components/Views/TrendingView/components/ExploreSearchBar/ExploreSearchBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import {
   Box,
   BoxFlexDirection,
@@ -18,6 +18,11 @@ import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import { selectBasicFunctionalityEnabled } from '../../../../../selectors/settings';
 import { TrendingViewSelectorsIDs } from '../../TrendingView.testIds';
+
+// px-4 (16) + icon Md (20) + gap-3 (12) = 48 — aligns overlay text with the input cursor
+const styles = StyleSheet.create({
+  placeholderOverlay: { paddingLeft: 48 },
+});
 
 interface ExploreSearchBarButtonProps {
   type: 'button';
@@ -61,7 +66,12 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
         size={IconSize.Md}
         color={IconColor.IconAlternative}
       />
-      <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+      <Text
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextAlternative}
+        numberOfLines={1}
+        twClassName="flex-1"
+      >
         {placeholder}
       </Text>
     </Box>
@@ -91,7 +101,7 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
             <TextFieldSearch
               value={props.searchQuery}
               onChangeText={props.onSearchChange}
-              placeholder={placeholder}
+              placeholder=""
               autoFocus={props.type === 'interactive'}
               onPressClearButton={() => {
                 props.onSearchChange('');
@@ -102,6 +112,23 @@ const ExploreSearchBar: React.FC<ExploreSearchBarProps> = (props) => {
                 testID: TrendingViewSelectorsIDs.EXPLORE_VIEW_SEARCH_TEXT_INPUT,
               }}
             />
+            {!props.searchQuery && (
+              <View
+                style={[
+                  tw.style('absolute inset-0 justify-center pr-4'),
+                  styles.placeholderOverlay,
+                ]}
+                pointerEvents="none"
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
+                  numberOfLines={1}
+                >
+                  {placeholder}
+                </Text>
+              </View>
+            )}
           </Box>
           <TouchableOpacity
             onPress={() => {

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.test.ts
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.test.ts
@@ -2,7 +2,8 @@
  * ExploreSearchResultsV2 — unit tests for getViewMoreLabel and LOCAL_SEARCH_FEEDS
  *
  * Tests the pure label-derivation logic that determines what text the
- * "View all / View X more" button shows for each feed section.
+ * "View X more" button shows for each feed section, or null when the button
+ * should not be shown.
  */
 
 import { getViewMoreLabel, LOCAL_SEARCH_FEEDS } from './viewMoreLabel';
@@ -30,17 +31,39 @@ describe('LOCAL_SEARCH_FEEDS', () => {
 });
 
 describe('getViewMoreLabel', () => {
-  describe('tokens — falls back to "View all" without a server total', () => {
-    it('returns "View all" even with many results and an active query', () => {
-      expect(getViewMoreLabel('tokens', 10, 'eth')).toBe('View all');
-    });
-
-    it('returns "View all" with no query', () => {
-      expect(getViewMoreLabel('tokens', 10, '')).toBe('View all');
-    });
+  describe('no active query — always "View all" regardless of item count', () => {
+    it.each([
+      ['perps', 10, ''],
+      ['stocks', 10, '   '],
+      ['sites', 10, ''],
+      ['predictions', 10, ''],
+      ['tokens', 10, ''],
+      ['tokens', 1, ''],
+    ] as [SearchFeedId, number, string][])(
+      '%s: %d items, query "%s" → "View all"',
+      (feedId, totalItems, query) => {
+        expect(getViewMoreLabel(feedId, totalItems, query)).toBe('View all');
+      },
+    );
   });
 
-  describe('local search feeds with active query and extra items', () => {
+  describe('active query — returns null when results fit within the cap (≤ 3)', () => {
+    it.each([
+      ['perps', 0, 'eth'],
+      ['perps', 1, 'eth'],
+      ['perps', 3, 'eth'],
+      ['stocks', 2, 'bit'],
+      ['sites', 1, 'meta'],
+      ['tokens', 3, 'eth'],
+    ] as [SearchFeedId, number, string][])(
+      '%s: %d items → null',
+      (feedId, totalItems, query) => {
+        expect(getViewMoreLabel(feedId, totalItems, query)).toBeNull();
+      },
+    );
+  });
+
+  describe('active query — local feeds return "View X more" when items exceed cap', () => {
     it.each([
       ['perps', 5, 'eth', 'View 2 more'],
       ['stocks', 7, 'bit', 'View 4 more'],
@@ -53,52 +76,28 @@ describe('getViewMoreLabel', () => {
     );
   });
 
-  describe('local search feeds with active query but no extra items', () => {
-    it.each([
-      ['perps', 3, 'eth'],
-      ['stocks', 2, 'bit'],
-      ['sites', 1, 'meta'],
-      ['perps', 0, 'eth'],
-    ] as [SearchFeedId, number, string][])(
-      '%s: %d items → "View all" (no hidden items)',
-      (feedId, totalItems, query) => {
-        expect(getViewMoreLabel(feedId, totalItems, query)).toBe('View all');
-      },
-    );
+  describe('active query — non-local feeds (tokens) without server total fall back to "View all"', () => {
+    it('returns "View all" for tokens with many results but no server total', () => {
+      expect(getViewMoreLabel('tokens', 10, 'eth')).toBe('View all');
+    });
   });
 
-  describe('server total provided (tokens and predictions)', () => {
-    it('returns "View X more" for predictions when server total exceeds visible', () => {
+  describe('active query — server total provided (tokens and predictions)', () => {
+    it('returns null when server total fits within the cap (≤ 3)', () => {
+      expect(getViewMoreLabel('predictions', 3, 'eth', 3)).toBeNull();
+      expect(getViewMoreLabel('tokens', 3, 'eth', 2)).toBeNull();
+    });
+
+    it('returns "View X more" when server total exceeds the cap', () => {
       expect(getViewMoreLabel('predictions', 3, 'eth', 50)).toBe(
         'View 47 more',
       );
-    });
-
-    it('returns "View X more" for tokens when server total exceeds visible', () => {
       expect(getViewMoreLabel('tokens', 3, 'eth', 2101)).toBe('View 2098 more');
     });
 
-    it('returns "View all" when server total equals visible items', () => {
-      expect(getViewMoreLabel('predictions', 3, 'nba', 3)).toBe('View all');
+    it('returns "View all" when server total exceeds cap but all are already shown', () => {
+      expect(getViewMoreLabel('predictions', 3, 'nba', 4)).toBe('View 1 more');
+      expect(getViewMoreLabel('tokens', 3, 'eth', 4)).toBe('View 1 more');
     });
-
-    it('returns "View all" when server total is less than visible items', () => {
-      expect(getViewMoreLabel('tokens', 3, 'eth', 2)).toBe('View all');
-    });
-  });
-
-  describe('no active query — always "View all" regardless of item count', () => {
-    it.each([
-      ['perps', 10, ''],
-      ['stocks', 10, '   '],
-      ['sites', 10, ''],
-      ['predictions', 10, ''],
-      ['tokens', 10, ''],
-    ] as [SearchFeedId, number, string][])(
-      '%s: %d items, query "%s" → "View all"',
-      (feedId, totalItems, query) => {
-        expect(getViewMoreLabel(feedId, totalItems, query)).toBe('View all');
-      },
-    );
   });
 });

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.test.ts
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.test.ts
@@ -95,7 +95,7 @@ describe('getViewMoreLabel', () => {
       expect(getViewMoreLabel('tokens', 3, 'eth', 2101)).toBe('View 2098 more');
     });
 
-    it('returns "View all" when server total exceeds cap but all are already shown', () => {
+    it('returns "View X more" when server total only slightly exceeds cap', () => {
       expect(getViewMoreLabel('predictions', 3, 'nba', 4)).toBe('View 1 more');
       expect(getViewMoreLabel('tokens', 3, 'eth', 4)).toBe('View 1 more');
     });

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -223,6 +223,11 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
     return `${item.feedId}-${getItemId(item.feedId, item.data)}`;
   }, []);
 
+  const otherResultsCount = useMemo(
+    () => sections.reduce((sum, s) => sum + (s.total ?? s.items.length), 0),
+    [sections],
+  );
+
   const listHeader = useMemo(() => {
     if (!emptyFeedTitle) return null;
     return (
@@ -240,14 +245,17 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
             }}
           />
         </Box>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {strings('trending.showing_all_results_for', {
-            query: searchQuery,
-          })}
-        </Text>
+        {flatData.length > 0 && (
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {strings('trending.showing_all_results_for', {
+              count: otherResultsCount,
+              query: searchQuery,
+            })}
+          </Text>
+        )}
       </Box>
     );
-  }, [emptyFeedTitle, searchQuery]);
+  }, [emptyFeedTitle, searchQuery, flatData.length, otherResultsCount]);
 
   return (
     <Box twClassName="flex-1 bg-default">

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -253,8 +253,9 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
       searchQuery.trim().length > 0 && !isLoading && flatData.length === 0;
 
     if (!emptyFeedTitle && !allSectionsEmpty) return null;
+    const showOtherResults = flatData.length > 0 && !isLoading;
     return (
-      <Box twClassName="mb-4">
+      <Box twClassName={showOtherResults ? 'mb-4' : ''}>
         <Box twClassName="rounded-xl bg-secondary py-6 px-4 items-center mb-4">
           <TabEmptyState
             description={
@@ -290,7 +291,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
             ))}
           </Box>
         </Box>
-        {flatData.length > 0 && !isLoading && (
+        {showOtherResults && (
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('trending.showing_all_results_for', {
               count: otherResultsCount,

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -33,6 +33,25 @@ import { type SearchFeedId, type SearchFeedSection } from './useExploreSearch';
 import SearchFeedRow, { SearchFeedSkeleton, getItemId } from './SearchFeedRow';
 import { MAX_ITEMS_PER_SECTION, getViewMoreLabel } from './viewMoreLabel';
 import type { FlatListItem, ListItemHeader } from './searchTypes';
+import CryptoMoversPillItem from '../feeds/tokens/CryptoMoversPillItem';
+
+const POPULAR_ASSETS: TrendingAsset[] = [
+  {
+    assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+    symbol: 'BTC',
+    name: 'Bitcoin',
+  },
+  {
+    assetId: 'eip155:1/slip44:60',
+    symbol: 'ETH',
+    name: 'Ethereum',
+  },
+  {
+    assetId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+    symbol: 'SOL',
+    name: 'Solana',
+  },
+] as TrendingAsset[];
 
 const pressedStyle = StyleSheet.create({
   pressable: {
@@ -228,22 +247,49 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
     [sections],
   );
 
+  const allSectionsEmpty =
+    searchQuery.trim().length > 0 &&
+    !sections.some((s) => s.isLoading) &&
+    flatData.length === 0;
+
   const listHeader = useMemo(() => {
-    if (!emptyFeedTitle) return null;
+    if (!emptyFeedTitle && !allSectionsEmpty) return null;
     return (
       <Box twClassName="mb-4">
         <Box twClassName="rounded-xl bg-secondary py-6 px-4 items-center mb-4">
           <TabEmptyState
-            description={strings('trending.no_results_for_feed', {
-              feedName: emptyFeedTitle,
-              query: searchQuery,
-            })}
+            description={
+              emptyFeedTitle
+                ? strings('trending.no_results_for_feed', {
+                    feedName: emptyFeedTitle,
+                    query: searchQuery,
+                  })
+                : strings('trending.no_results_for_query', {
+                    query: searchQuery,
+                  })
+            }
             descriptionProps={{
               variant: TextVariant.HeadingSm,
               fontWeight: FontWeight.Bold,
               color: TextColor.TextDefault,
             }}
           />
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {strings('trending.no_results_check_popular')}
+          </Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="gap-2 mt-4"
+          >
+            {POPULAR_ASSETS.map((token, index) => (
+              <CryptoMoversPillItem
+                key={token.assetId}
+                token={token}
+                index={index}
+              />
+            ))}
+          </Box>
         </Box>
         {flatData.length > 0 && !sections.some((s) => s.isLoading) && (
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
@@ -257,6 +303,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
     );
   }, [
     emptyFeedTitle,
+    allSectionsEmpty,
     searchQuery,
     flatData.length,
     otherResultsCount,

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -247,12 +247,11 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
     [sections],
   );
 
-  const allSectionsEmpty =
-    searchQuery.trim().length > 0 &&
-    !sections.some((s) => s.isLoading) &&
-    flatData.length === 0;
-
   const listHeader = useMemo(() => {
+    const isLoading = sections.some((s) => s.isLoading);
+    const allSectionsEmpty =
+      searchQuery.trim().length > 0 && !isLoading && flatData.length === 0;
+
     if (!emptyFeedTitle && !allSectionsEmpty) return null;
     return (
       <Box twClassName="mb-4">
@@ -291,7 +290,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
             ))}
           </Box>
         </Box>
-        {flatData.length > 0 && !sections.some((s) => s.isLoading) && (
+        {flatData.length > 0 && !isLoading && (
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('trending.showing_all_results_for', {
               count: otherResultsCount,
@@ -303,7 +302,6 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
     );
   }, [
     emptyFeedTitle,
-    allSectionsEmpty,
     searchQuery,
     flatData.length,
     otherResultsCount,

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -96,12 +96,14 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
 
   const renderSectionHeader = useCallback(
     (item: ListItemHeader, section: SearchFeedSection) => {
-      const viewMoreLabel = getViewMoreLabel(
-        section.feedId,
-        section.isLoading ? 0 : section.items.length,
-        searchQuery,
-        section.isLoading ? undefined : section.total,
-      );
+      const viewMoreLabel = section.isLoading
+        ? null
+        : getViewMoreLabel(
+            section.feedId,
+            section.items.length,
+            searchQuery,
+            section.total,
+          );
       return (
         <Box
           flexDirection={BoxFlexDirection.Row}
@@ -116,7 +118,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
           >
             {item.title}
           </Text>
-          {!section.isLoading && (
+          {viewMoreLabel !== null && (
             <Pressable
               onPress={() => handleViewMore(section)}
               hitSlop={8}

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -116,28 +116,30 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
           >
             {item.title}
           </Text>
-          <Pressable
-            onPress={() => handleViewMore(section)}
-            hitSlop={8}
-            accessibilityRole="button"
-            accessibilityLabel={`${viewMoreLabel} ${item.title}`}
-            style={({ pressed }) => [
-              pressedStyle.pressable,
-              pressed && { opacity: 0.5 },
-            ]}
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
+          {!section.isLoading && (
+            <Pressable
+              onPress={() => handleViewMore(section)}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={`${viewMoreLabel} ${item.title}`}
+              style={({ pressed }) => [
+                pressedStyle.pressable,
+                pressed && { opacity: 0.5 },
+              ]}
             >
-              {viewMoreLabel}
-            </Text>
-            <Icon
-              name={IconName.ArrowRight}
-              size={IconSize.Sm}
-              color={IconColor.IconAlternative}
-            />
-          </Pressable>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {viewMoreLabel}
+              </Text>
+              <Icon
+                name={IconName.ArrowRight}
+                size={IconSize.Sm}
+                color={IconColor.IconAlternative}
+              />
+            </Pressable>
+          )}
         </Box>
       );
     },

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -242,11 +242,6 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
     return `${item.feedId}-${getItemId(item.feedId, item.data)}`;
   }, []);
 
-  const otherResultsCount = useMemo(
-    () => sections.reduce((sum, s) => sum + (s.total ?? s.items.length), 0),
-    [sections],
-  );
-
   const listHeader = useMemo(() => {
     const isLoading = sections.some((s) => s.isLoading);
     const allSectionsEmpty =
@@ -254,6 +249,10 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
 
     if (!emptyFeedTitle && !allSectionsEmpty) return null;
     const showOtherResults = flatData.length > 0 && !isLoading;
+    const otherResultsCount = sections.reduce(
+      (sum, s) => sum + (s.total ?? s.items.length),
+      0,
+    );
     return (
       <Box twClassName={showOtherResults ? 'mb-4' : ''}>
         <Box twClassName="rounded-xl bg-secondary py-6 px-4 items-center mb-4">
@@ -301,13 +300,7 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
         )}
       </Box>
     );
-  }, [
-    emptyFeedTitle,
-    searchQuery,
-    flatData.length,
-    otherResultsCount,
-    sections,
-  ]);
+  }, [emptyFeedTitle, searchQuery, flatData.length, sections]);
 
   return (
     <Box twClassName="flex-1 bg-default">

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -239,13 +239,13 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
               query: searchQuery,
             })}
             descriptionProps={{
-              variant: TextVariant.BodyMd,
+              variant: TextVariant.HeadingSm,
               fontWeight: FontWeight.Bold,
               color: TextColor.TextDefault,
             }}
           />
         </Box>
-        {flatData.length > 0 && (
+        {flatData.length > 0 && !sections.some((s) => s.isLoading) && (
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('trending.showing_all_results_for', {
               count: otherResultsCount,
@@ -255,7 +255,13 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
         )}
       </Box>
     );
-  }, [emptyFeedTitle, searchQuery, flatData.length, otherResultsCount]);
+  }, [
+    emptyFeedTitle,
+    searchQuery,
+    flatData.length,
+    otherResultsCount,
+    sections,
+  ]);
 
   return (
     <Box twClassName="flex-1 bg-default">

--- a/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
+++ b/app/components/Views/TrendingView/search/ExploreSearchResultsV2.tsx
@@ -273,22 +273,29 @@ const ExploreSearchResultsV2: React.FC<ExploreSearchResultsV2Props> = ({
               color: TextColor.TextDefault,
             }}
           />
-          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-            {strings('trending.no_results_check_popular')}
-          </Text>
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="gap-2 mt-4"
-          >
-            {POPULAR_ASSETS.map((token, index) => (
-              <CryptoMoversPillItem
-                key={token.assetId}
-                token={token}
-                index={index}
-              />
-            ))}
-          </Box>
+          {!isLoading && !showOtherResults && (
+            <>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {strings('trending.no_results_check_popular')}
+              </Text>
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                twClassName="gap-2 mt-2"
+              >
+                {POPULAR_ASSETS.map((token, index) => (
+                  <CryptoMoversPillItem
+                    key={token.assetId}
+                    token={token}
+                    index={index}
+                  />
+                ))}
+              </Box>
+            </>
+          )}
         </Box>
         {showOtherResults && (
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>

--- a/app/components/Views/TrendingView/search/viewMoreLabel.test.ts
+++ b/app/components/Views/TrendingView/search/viewMoreLabel.test.ts
@@ -24,16 +24,16 @@ describe('getViewMoreLabel', () => {
       );
     });
 
-    it('returns "view_all" when items equal MAX_ITEMS_PER_SECTION', () => {
-      expect(getViewMoreLabel('perps', MAX_ITEMS_PER_SECTION, 'eth')).toBe(
-        'trending.view_all',
-      );
+    it('returns null when items equal MAX_ITEMS_PER_SECTION (nothing hidden)', () => {
+      expect(
+        getViewMoreLabel('perps', MAX_ITEMS_PER_SECTION, 'eth'),
+      ).toBeNull();
     });
 
-    it('returns "view_all" when items are fewer than MAX_ITEMS_PER_SECTION', () => {
-      expect(getViewMoreLabel('sites', MAX_ITEMS_PER_SECTION - 1, 'eth')).toBe(
-        'trending.view_all',
-      );
+    it('returns null when items are fewer than MAX_ITEMS_PER_SECTION', () => {
+      expect(
+        getViewMoreLabel('sites', MAX_ITEMS_PER_SECTION - 1, 'eth'),
+      ).toBeNull();
     });
   });
 
@@ -44,7 +44,7 @@ describe('getViewMoreLabel', () => {
       );
     });
 
-    it('returns "view_all" when total equals visible items', () => {
+    it('returns null when total equals MAX_ITEMS_PER_SECTION (nothing hidden)', () => {
       expect(
         getViewMoreLabel(
           'predictions',
@@ -52,26 +52,24 @@ describe('getViewMoreLabel', () => {
           'eth',
           MAX_ITEMS_PER_SECTION,
         ),
-      ).toBe('trending.view_all');
+      ).toBeNull();
     });
 
-    it('falls back to "view_all" when no total is provided (should not normally occur)', () => {
+    it('falls back to "view_all" when no total is provided and items exceed cap', () => {
       expect(
         getViewMoreLabel('predictions', MAX_ITEMS_PER_SECTION + 2, 'eth'),
       ).toBe('trending.view_all');
     });
   });
 
-  describe('loading state — component passes 0 items and no serverTotal', () => {
-    // When a section is loading, ExploreSearchResultsV2 passes visibleCount=0 and
-    // serverTotal=undefined so that stale data from the previous query does not
-    // produce a "View X more" count while skeletons are shown.
+  describe('loading state — component skips getViewMoreLabel entirely (section.isLoading guard)', () => {
+    // ExploreSearchResultsV2 now returns null directly when section.isLoading is true
+    // without calling getViewMoreLabel. These tests verify that if it were called with
+    // 0 items and no serverTotal, it would correctly return null (nothing to show).
     it.each(['perps', 'stocks', 'sites', 'tokens', 'predictions'] as const)(
-      '%s: returns "view_all" during loading (0 items, no serverTotal)',
+      '%s: returns null with 0 items and no serverTotal',
       (feedId) => {
-        expect(getViewMoreLabel(feedId, 0, 'eth', undefined)).toBe(
-          'trending.view_all',
-        );
+        expect(getViewMoreLabel(feedId, 0, 'eth', undefined)).toBeNull();
       },
     );
   });
@@ -91,7 +89,7 @@ describe('getViewMoreLabel', () => {
       );
     });
 
-    it('returns "view_all" when total equals MAX_ITEMS_PER_SECTION', () => {
+    it('returns null when total equals MAX_ITEMS_PER_SECTION (nothing hidden)', () => {
       expect(
         getViewMoreLabel(
           'tokens',
@@ -99,11 +97,11 @@ describe('getViewMoreLabel', () => {
           'eth',
           MAX_ITEMS_PER_SECTION,
         ),
-      ).toBe('trending.view_all');
+      ).toBeNull();
     });
 
-    it('returns "view_all" when total is not greater than visible items', () => {
-      expect(getViewMoreLabel('tokens', 3, 'eth', 2)).toBe('trending.view_all');
+    it('returns null when total is less than or equal to MAX_ITEMS_PER_SECTION', () => {
+      expect(getViewMoreLabel('tokens', 3, 'eth', 2)).toBeNull();
     });
 
     it('returns "view_all" when query is empty regardless of total', () => {

--- a/app/components/Views/TrendingView/search/viewMoreLabel.ts
+++ b/app/components/Views/TrendingView/search/viewMoreLabel.ts
@@ -11,9 +11,14 @@ export const LOCAL_SEARCH_FEEDS: ReadonlySet<SearchFeedId> = new Set([
 ]);
 
 /**
- * Label for the section header "View all / View X more" button.
+ * Label for the section header "View X more" button, or `null` when the
+ * button should not be shown.
+ *
+ * Returns `null` when there is an active query but all results fit within the
+ * section cap — there is nothing more to reveal.
  *
  * @param visibleCount - items loaded in the section (may exceed MAX_ITEMS_PER_SECTION)
+ * @param searchQuery  - current search input
  * @param serverTotal  - server-reported total for feeds that expose it (tokens, predictions)
  */
 export function getViewMoreLabel(
@@ -21,23 +26,24 @@ export function getViewMoreLabel(
   visibleCount: number,
   searchQuery: string,
   serverTotal?: number,
-): string {
+): string | null {
   if (!searchQuery.trim()) {
     return strings('trending.view_all');
   }
 
   if (serverTotal !== undefined) {
+    if (serverTotal <= MAX_ITEMS_PER_SECTION) return null;
     const hidden = serverTotal - Math.min(visibleCount, MAX_ITEMS_PER_SECTION);
     return hidden > 0
       ? strings('trending.view_x_more', { count: hidden })
       : strings('trending.view_all');
   }
 
+  const hidden = visibleCount - MAX_ITEMS_PER_SECTION;
+  if (hidden <= 0) return null;
+
   if (LOCAL_SEARCH_FEEDS.has(feedId)) {
-    const hidden = visibleCount - MAX_ITEMS_PER_SECTION;
-    if (hidden > 0) {
-      return strings('trending.view_x_more', { count: hidden });
-    }
+    return strings('trending.view_x_more', { count: hidden });
   }
 
   return strings('trending.view_all');

--- a/app/components/Views/TrendingView/search/viewMoreLabel.ts
+++ b/app/components/Views/TrendingView/search/viewMoreLabel.ts
@@ -34,9 +34,7 @@ export function getViewMoreLabel(
   if (serverTotal !== undefined) {
     if (serverTotal <= MAX_ITEMS_PER_SECTION) return null;
     const hidden = serverTotal - Math.min(visibleCount, MAX_ITEMS_PER_SECTION);
-    return hidden > 0
-      ? strings('trending.view_x_more', { count: hidden })
-      : strings('trending.view_all');
+    return strings('trending.view_x_more', { count: hidden });
   }
 
   const hidden = visibleCount - MAX_ITEMS_PER_SECTION;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9219,7 +9219,7 @@
     "high_to_low": "High to low",
     "low_to_high": "Low to high",
     "apply": "Apply",
-    "search_placeholder": "Search tokens, markets and URLs and Juan",
+    "search_placeholder": "Search tokens, markets and URLs",
     "cancel": "Cancel",
     "perps": "Perps",
     "rwa_perps_section": "Perps",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9233,6 +9233,8 @@
     "predictions": "Predictions",
     "no_results": "No results found",
     "no_results_for_feed": "No {{feedName}} results for \"{{query}}\"",
+    "no_results_for_query": "No results found for \"{{query}}\"",
+    "no_results_check_popular": "Check out other popular assets",
     "showing_all_results_for": "We found {{count}} other results for \"{{query}}\"",
     "popular": "Popular",
     "sites": "Sites",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9233,7 +9233,7 @@
     "predictions": "Predictions",
     "no_results": "No results found",
     "no_results_for_feed": "No {{feedName}} results for \"{{query}}\"",
-    "showing_all_results_for": "We found these results for \"{{query}}\"",
+    "showing_all_results_for": "We found {{count}} other results for \"{{query}}\"",
     "popular": "Popular",
     "sites": "Sites",
     "popular_sites": "Popular sites",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9263,7 +9263,7 @@
     },
     "search_tabs": {
       "all": "All",
-      "crypto": "Cryptos",
+      "crypto": "Crypto",
       "perps": "Perps",
       "stocks": "Stocks",
       "predictions": "Predictions",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9219,7 +9219,7 @@
     "high_to_low": "High to low",
     "low_to_high": "Low to high",
     "apply": "Apply",
-    "search_placeholder": "Search tokens, markets and URLs",
+    "search_placeholder": "Search tokens, markets and URLs and Juan",
     "cancel": "Cancel",
     "perps": "Perps",
     "rwa_perps_section": "Perps",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

- Fix explore search v2 issues:
- Cryptos -> Crypto
- "View all" wont show in the loading state
- "View all" stays on the no_query state
- When there is a query:
  - "View X more" will be shown only if there are more than 3 items
  - Every section with less than 3 items does not show "View all"
- When there are no results we should show the correct empty state with the pills
- If there are no results for all sections we do not show "We found these results for "Btcx""

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix explore search v2 issues

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3272


## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and label logic in Explore search with broad test updates; no auth, payments, or security-sensitive paths.
> 
> **Overview**
> Explore Search v2 UX fixes: **Crypto** tab copy (was “Cryptos”), smarter **View all / View more** behavior, richer **empty states**, and a **custom search placeholder** overlay.
> 
> **Section actions:** `getViewMoreLabel` now returns `null` when there’s nothing beyond the 3-item cap (with an active query), so headers hide the control instead of showing misleading “View all”. Loading sections skip the button entirely. With **no** query, labels still use **View all**. With a query, **View X more** appears only when counts justify it; tokens without a server total can still fall back to **View all**.
> 
> **Empty results:** When every section is empty, the list shows a global “no results” message, optional **BTC/ETH/SOL** quick pills, and only shows the “other results” line when some sections still have hits (with a `count` in copy). Per-feed empty states keep the feed-specific message.
> 
> **Search bar:** Interactive mode uses an empty native placeholder plus a non-interactive overlay for alignment; tests target `EXPLORE_VIEW_SEARCH_TEXT_INPUT` instead of placeholder text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906285a14c456057f554ffeb6460b45b75ef3974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->