### PR TITLE
chore: Add mobile memory leak profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To learn how to contribute to the MetaMask codebase, visit our [Contributor Docs
 - [Development Process](./docs/readme/development-process.md)
 - [Performance](./docs/readme/performance.md)
 - [Release Build Profiling](./docs/readme/release-build-profiler.md)
+- [Mobile Memory Leak Profiling](./docs/readme/mobile-memory-leak-profiler.md)
 - [Storybook](./docs/readme/storybook.md)
 - [Miscellaneous](./docs/readme/miscellaneous.md)
 - [Reassure Performance Testing (pilot)](./docs/readme/reassure.md)

--- a/app/components/UI/ProfilerManager/ProfilerManager.test.tsx
+++ b/app/components/UI/ProfilerManager/ProfilerManager.test.tsx
@@ -5,6 +5,7 @@ import RNFS from 'react-native-fs';
 import { startProfiling, stopProfiling } from 'react-native-release-profiler';
 import ShakeDetector from './ShakeDetector';
 import ProfilerManager from './ProfilerManager';
+import { testConfig } from '../../../util/test/utils';
 
 jest.mock('react-native-device-info', () => ({
   getBundleId: jest.fn(),
@@ -25,9 +26,12 @@ jest.mock('react-native-fs', () => ({
   copyFile: jest.fn(),
 }));
 
+const profilerTestConfig = testConfig as { enableProfiler?: string };
+
 describe('ProfilerManager', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    delete profilerTestConfig.enableProfiler;
   });
 
   describe('environment-based enabling', () => {
@@ -46,6 +50,14 @@ describe('ProfilerManager', () => {
       const { toJSON } = render(<ProfilerManager />);
       expect(toJSON()).toBeNull();
       expect(ShakeDetector).not.toHaveBeenCalled();
+    });
+
+    it('enables profiler when requested through launch args', () => {
+      profilerTestConfig.enableProfiler = 'true';
+
+      render(<ProfilerManager />);
+
+      expect(ShakeDetector).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/ProfilerManager/ProfilerManager.tsx
+++ b/app/components/UI/ProfilerManager/ProfilerManager.tsx
@@ -11,8 +11,21 @@ import {
   IconName,
   IconColor,
 } from '../../../component-library/components/Icons/Icon';
+import { testConfig } from '../../../util/test/utils';
 
-const shouldEnableProfiler = (() => {
+interface ProfilerTestConfig {
+  enableProfiler?: unknown;
+}
+
+const isProfilerLaunchArgEnabled = (value: unknown) =>
+  value === true || value === 'true' || value === '1';
+
+const shouldEnableProfiler = () => {
+  const profilerConfig = testConfig as ProfilerTestConfig;
+  if (isProfilerLaunchArgEnabled(profilerConfig.enableProfiler)) {
+    return true;
+  }
+
   switch (process.env.METAMASK_ENVIRONMENT) {
     case 'rc':
       return true;
@@ -21,13 +34,13 @@ const shouldEnableProfiler = (() => {
     default:
       return false;
   }
-})();
+};
 
 interface ProfilerManagerProps {
   enabled?: boolean;
 }
 const ProfilerManager: React.FC<ProfilerManagerProps> = ({
-  enabled = shouldEnableProfiler,
+  enabled = shouldEnableProfiler(),
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
@@ -141,6 +154,7 @@ const ProfilerManager: React.FC<ProfilerManagerProps> = ({
             </Box>
             <Box twClassName="flex-row gap-2 mb-3">
               <Pressable
+                testID="toggle-profiler-button"
                 style={tw.style(
                   'flex-1 p-2 rounded-md items-center justify-center',
                   isRecording ? 'bg-error-default' : 'bg-primary-default',

--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -25,12 +25,42 @@ interface MockAccountTrackerState {
     Record<string, { balance?: string; stakedBalance?: string }>
   >;
 }
+interface MockAssetsControllerState {
+  assetsBalance: Record<string, Record<string, { amount: string }>>;
+  assetsInfo: Record<
+    string,
+    {
+      type: string;
+      name: string;
+      symbol: string;
+      decimals: number;
+    }
+  >;
+}
+interface MockTokenBalancesControllerState {
+  tokenBalances: Record<string, Record<string, Record<string, string>>>;
+}
 const mockAccountTrackerState: MockAccountTrackerState = {
   accountsByChainId: {},
+};
+const mockAssetsControllerState: MockAssetsControllerState = {
+  assetsBalance: {},
+  assetsInfo: {},
+};
+const mockTokenBalancesControllerState: MockTokenBalancesControllerState = {
+  tokenBalances: {},
 };
 const mockAccountTrackerUpdate = jest.fn(
   (updater: (state: MockAccountTrackerState) => void) =>
     updater(mockAccountTrackerState),
+);
+const mockAssetsControllerUpdate = jest.fn(
+  (updater: (state: MockAssetsControllerState) => void) =>
+    updater(mockAssetsControllerState),
+);
+const mockTokenBalancesControllerUpdate = jest.fn(
+  (updater: (state: MockTokenBalancesControllerState) => void) =>
+    updater(mockTokenBalancesControllerState),
 );
 const mockSetUseTransactionSimulations = jest.fn();
 
@@ -82,6 +112,14 @@ jest.mock('../Engine', () => ({
     AccountTrackerController: {
       update: (updater: (state: MockAccountTrackerState) => void) =>
         mockAccountTrackerUpdate(updater),
+    },
+    AssetsController: {
+      update: (updater: (state: MockAssetsControllerState) => void) =>
+        mockAssetsControllerUpdate(updater),
+    },
+    TokenBalancesController: {
+      update: (updater: (state: MockTokenBalancesControllerState) => void) =>
+        mockTokenBalancesControllerUpdate(updater),
     },
     PreferencesController: {
       setUseTransactionSimulations: (...args: unknown[]) =>
@@ -694,6 +732,11 @@ describe('AgenticService.install', () => {
       mockEnableNetwork.mockClear();
       mockAccountTrackerUpdate.mockClear();
       mockAccountTrackerState.accountsByChainId = {};
+      mockAssetsControllerUpdate.mockClear();
+      mockAssetsControllerState.assetsBalance = {};
+      mockAssetsControllerState.assetsInfo = {};
+      mockTokenBalancesControllerUpdate.mockClear();
+      mockTokenBalancesControllerState.tokenBalances = {};
       mockSetUseTransactionSimulations.mockClear();
       (
         MockEngine.context.AccountsController.getSelectedAccount as jest.Mock
@@ -1002,6 +1045,27 @@ describe('AgenticService.install', () => {
             balance: '0x123',
             stakedBalance: '0x0',
           },
+          '0x0000000000000000000000000000000000000aBc': {
+            balance: '0x123',
+            stakedBalance: '0x0',
+          },
+        },
+      });
+      expect(mockTokenBalancesControllerState.tokenBalances).toStrictEqual({
+        '0x0000000000000000000000000000000000000abc': {
+          '0x1': {
+            '0x0000000000000000000000000000000000000000': '0x123',
+          },
+        },
+        '0x0000000000000000000000000000000000000aBc': {
+          '0x1': {
+            '0x0000000000000000000000000000000000000000': '0x123',
+          },
+        },
+      });
+      expect(mockAssetsControllerState.assetsBalance).toStrictEqual({
+        'acc-1': {
+          'eip155:1/slip44:60': { amount: '0.000000000000000291' },
         },
       });
     });
@@ -1036,6 +1100,71 @@ describe('AgenticService.install', () => {
             balance: '0x456',
             stakedBalance: '0x0',
           },
+          '0x0000000000000000000000000000000000000aBc': {
+            balance: '0x456',
+            stakedBalance: '0x0',
+          },
+        },
+      });
+      expect(mockAssetsControllerState.assetsInfo).toStrictEqual({
+        'eip155:1/slip44:60': {
+          type: 'native',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      });
+      expect(mockAssetsControllerState.assetsBalance).toStrictEqual({
+        'acc-1': {
+          'eip155:1/slip44:60': { amount: '0.00000000000000111' },
+        },
+      });
+    });
+
+    it('seeds Ethereum send state for checksummed and lowercase account keys', () => {
+      const account = {
+        id: 'acc-1',
+        address: '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
+        metadata: { name: 'Account 1' },
+      };
+      mockAccountTrackerState.accountsByChainId = {
+        '0x1': {
+          '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3': {
+            balance: '0x0',
+            stakedBalance: '0x0',
+          },
+        },
+      };
+      (
+        MockEngine.context.AccountsController.getSelectedAccount as jest.Mock
+      ).mockReturnValue(account);
+      (
+        MockEngine.context.AccountsController.listAccounts as jest.Mock
+      ).mockReturnValue([account]);
+
+      const result = bridge().seedEthereumSendState({
+        balanceWei: '0x8ac7230489e80000',
+      });
+
+      expect(result).toStrictEqual({
+        ok: true,
+        accountAddress: '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3',
+      });
+      expect(mockAccountTrackerState.accountsByChainId).toStrictEqual({
+        '0x1': {
+          '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3': {
+            balance: '0x8ac7230489e80000',
+            stakedBalance: '0x0',
+          },
+          '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3': {
+            balance: '0x8ac7230489e80000',
+            stakedBalance: '0x0',
+          },
+        },
+      });
+      expect(mockAssetsControllerState.assetsBalance).toStrictEqual({
+        'acc-1': {
+          'eip155:1/slip44:60': { amount: '10' },
         },
       });
     });

--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -16,6 +16,23 @@ import type {
 
 const mockCreateWallet = jest.fn().mockResolvedValue(undefined);
 const mockImportAccount = jest.fn().mockResolvedValue(undefined);
+const mockSubmitPassword = jest.fn().mockResolvedValue(undefined);
+const mockIsUnlocked = jest.fn(() => false);
+const mockEnableNetwork = jest.fn();
+interface MockAccountTrackerState {
+  accountsByChainId: Record<
+    string,
+    Record<string, { balance?: string; stakedBalance?: string }>
+  >;
+}
+const mockAccountTrackerState: MockAccountTrackerState = {
+  accountsByChainId: {},
+};
+const mockAccountTrackerUpdate = jest.fn(
+  (updater: (state: MockAccountTrackerState) => void) =>
+    updater(mockAccountTrackerState),
+);
+const mockSetUseTransactionSimulations = jest.fn();
 
 jest.mock('../Engine', () => ({
   context: {
@@ -44,11 +61,31 @@ jest.mock('../Engine', () => ({
       init: jest.fn().mockResolvedValue(undefined),
     },
     KeyringController: {
+      state: {
+        vault: undefined,
+        keyrings: [],
+        isUnlocked: false,
+        encryptionKey: undefined,
+        encryptionSalt: undefined,
+      },
+      isUnlocked: () => mockIsUnlocked(),
+      submitPassword: (password: string) => mockSubmitPassword(password),
       importAccountWithStrategy: (...args: unknown[]) =>
         mockImportAccount(...args),
     },
     PerpsController: {
       markTutorialCompleted: jest.fn(),
+    },
+    NetworkEnablementController: {
+      enableNetwork: (...args: unknown[]) => mockEnableNetwork(...args),
+    },
+    AccountTrackerController: {
+      update: (updater: (state: MockAccountTrackerState) => void) =>
+        mockAccountTrackerUpdate(updater),
+    },
+    PreferencesController: {
+      setUseTransactionSimulations: (...args: unknown[]) =>
+        mockSetUseTransactionSimulations(...args),
     },
   },
   setSelectedAddress: jest.fn(),
@@ -126,6 +163,19 @@ jest.mock('../SDKConnect/utils/DevLogger', () => ({
 const MockEngine = jest.mocked(Engine);
 
 // ─── Test helpers ───────────────────────────────────────────────────────────
+
+function setMockKeyringState(
+  state: Partial<typeof MockEngine.context.KeyringController.state>,
+) {
+  MockEngine.context.KeyringController.state = {
+    vault: undefined,
+    keyrings: [],
+    isUnlocked: false,
+    encryptionKey: undefined,
+    encryptionSalt: undefined,
+    ...state,
+  } as typeof MockEngine.context.KeyringController.state;
+}
 
 function makeFiber(
   overrides: Partial<FiberNode> & {
@@ -638,6 +688,24 @@ describe('AgenticService.install', () => {
     beforeEach(() => {
       mockCreateWallet.mockClear();
       mockImportAccount.mockClear();
+      mockSubmitPassword.mockClear();
+      mockIsUnlocked.mockClear();
+      mockIsUnlocked.mockReturnValue(false);
+      mockEnableNetwork.mockClear();
+      mockAccountTrackerUpdate.mockClear();
+      mockAccountTrackerState.accountsByChainId = {};
+      mockSetUseTransactionSimulations.mockClear();
+      (
+        MockEngine.context.AccountsController.getSelectedAccount as jest.Mock
+      ).mockReturnValue({
+        id: 'acc-1',
+        address: '0xabc',
+        metadata: { name: 'Account 1' },
+      });
+      (
+        MockEngine.context.AccountsController.listAccounts as jest.Mock
+      ).mockReturnValue([]);
+      setMockKeyringState({});
       mockDispatch.mockClear();
     });
 
@@ -665,6 +733,32 @@ describe('AgenticService.install', () => {
         expect.objectContaining({ type: 'create', password: 'test123' }),
       );
       expect(mockImportAccount).toHaveBeenCalled();
+    });
+
+    it('unlocks an existing fixture vault instead of creating a wallet', async () => {
+      setMockKeyringState({ vault: 'encrypted' });
+
+      const result = await bridge().setupWallet({
+        password: 'test123',
+        accounts: [{ type: 'mnemonic', value: 'word1 word2 word3' }],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockCreateWallet).not.toHaveBeenCalled();
+      expect(mockSubmitPassword).toHaveBeenCalledWith('test123');
+    });
+
+    it('does not resubmit the password when an existing vault is unlocked', async () => {
+      setMockKeyringState({ vault: 'encrypted' });
+      mockIsUnlocked.mockReturnValue(true);
+
+      const result = await bridge().setupWallet({
+        password: 'test123',
+        accounts: [],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockSubmitPassword).not.toHaveBeenCalled();
     });
 
     it('imports private key accounts', async () => {
@@ -857,6 +951,16 @@ describe('AgenticService.install', () => {
       );
     });
 
+    it('disables transaction simulations when requested', async () => {
+      await bridge().setupWallet({
+        password: 'test123',
+        accounts: [],
+        settings: { disableTransactionSimulations: true },
+      });
+
+      expect(mockSetUseTransactionSimulations).toHaveBeenCalledWith(false);
+    });
+
     it('always dispatches setMultichainAccountsIntroModalSeen', async () => {
       mockDispatch.mockClear();
       await bridge().setupWallet({
@@ -869,6 +973,71 @@ describe('AgenticService.install', () => {
           payload: { seen: true },
         }),
       );
+    });
+
+    it('seeds Ethereum send state when requested', async () => {
+      const account = {
+        id: 'acc-1',
+        address: '0x0000000000000000000000000000000000000abc',
+        metadata: { name: 'Account 1' },
+      };
+      (
+        MockEngine.context.AccountsController.getSelectedAccount as jest.Mock
+      ).mockReturnValue(account);
+      (
+        MockEngine.context.AccountsController.listAccounts as jest.Mock
+      ).mockReturnValue([account]);
+
+      await bridge().setupWallet({
+        password: 'test123',
+        accounts: [],
+        settings: { seedEthereumBalanceWei: '0x123' },
+      });
+
+      expect(mockEnableNetwork).toHaveBeenCalledWith('eip155:1');
+      expect(mockAccountTrackerUpdate).toHaveBeenCalledTimes(1);
+      expect(mockAccountTrackerState.accountsByChainId).toStrictEqual({
+        '0x1': {
+          '0x0000000000000000000000000000000000000abc': {
+            balance: '0x123',
+            stakedBalance: '0x0',
+          },
+        },
+      });
+    });
+
+    it('seeds Ethereum send state without rerunning wallet setup', () => {
+      const account = {
+        id: 'acc-1',
+        address: '0x0000000000000000000000000000000000000abc',
+        metadata: { name: 'Account 1' },
+      };
+      (
+        MockEngine.context.AccountsController.getSelectedAccount as jest.Mock
+      ).mockReturnValue(account);
+      (
+        MockEngine.context.AccountsController.listAccounts as jest.Mock
+      ).mockReturnValue([account]);
+
+      const result = bridge().seedEthereumSendState({
+        balanceWei: '0x456',
+      });
+
+      expect(result).toStrictEqual({
+        ok: true,
+        accountAddress: '0x0000000000000000000000000000000000000abc',
+      });
+      expect(mockCreateWallet).not.toHaveBeenCalled();
+      expect(mockEnableNetwork).toHaveBeenCalledWith('eip155:1');
+      expect(mockAccountTrackerUpdate).toHaveBeenCalledTimes(1);
+      expect(mockAccountTrackerState.accountsByChainId).toStrictEqual({
+        '0x1': {
+          '0x0000000000000000000000000000000000000abc': {
+            balance: '0x456',
+            stakedBalance: '0x0',
+          },
+        },
+      });
     });
   });
 });

--- a/app/core/AgenticService/AgenticService.ts
+++ b/app/core/AgenticService/AgenticService.ts
@@ -27,6 +27,7 @@ import { setCompletedOnboarding } from '../../actions/onboarding';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree';
 import { AccountImportStrategy } from '@metamask/keyring-controller';
 import type { CaipChainId, Hex } from '@metamask/utils';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 import StorageWrapper from '../../store/storage-wrapper';
 import {
   OPTIN_META_METRICS_UI_SEEN,
@@ -86,8 +87,26 @@ interface AgenticAccountTrackerState {
   >;
 }
 
-interface AgenticAccountTrackerController {
-  update(updater: (state: AgenticAccountTrackerState) => void): void;
+interface AgenticAssetsControllerState {
+  assetsBalance: Record<string, Record<string, { amount: string }>>;
+  assetsInfo: Record<
+    string,
+    {
+      type: 'native' | string;
+      name: string;
+      symbol: string;
+      decimals: number;
+      image?: string;
+    }
+  >;
+}
+
+interface AgenticTokenBalancesControllerState {
+  tokenBalances: Record<Hex, Record<Hex, Record<Hex, Hex>>>;
+}
+
+interface AgenticMutableController<State> {
+  update(updater: (state: State) => void): void;
 }
 
 /** Shape of the __DEV__-only agentic bridge on globalThis. */
@@ -254,6 +273,10 @@ function walkFiberRoots(visitor: (rootFiber: FiberNode) => boolean): boolean {
 
 const ETH_MAINNET_CHAIN_ID = '0x1' as Hex;
 const ETH_MAINNET_CAIP_CHAIN_ID = 'eip155:1' as CaipChainId;
+const ETH_MAINNET_ASSET_ID = 'eip155:1/slip44:60';
+const ETH_NATIVE_TOKEN_ADDRESS =
+  '0x0000000000000000000000000000000000000000' as Hex;
+const WEI_PER_ETH = 10n ** 18n;
 
 /** Map an internal account to the slim shape exposed by the bridge. */
 function toAccountSummary(a: {
@@ -279,6 +302,23 @@ function getEvmAccountAddress(
   return accounts.find((account) => isEvmAddress(account.address))?.address;
 }
 
+function hexWeiToEthAmount(balanceWei: string): string {
+  const wei = BigInt(balanceWei);
+  const wholeEth = wei / WEI_PER_ETH;
+  const fractionalWei = wei % WEI_PER_ETH;
+
+  if (fractionalWei === 0n) {
+    return wholeEth.toString();
+  }
+
+  const fractionalEth = fractionalWei
+    .toString()
+    .padStart(18, '0')
+    .replace(/0+$/u, '');
+
+  return `${wholeEth}.${fractionalEth}`;
+}
+
 function seedEthereumSendState(balanceWei?: string): {
   ok: boolean;
   accountAddress?: string;
@@ -291,10 +331,13 @@ function seedEthereumSendState(balanceWei?: string): {
   const {
     AccountsController,
     AccountTrackerController,
+    AssetsController,
     NetworkEnablementController,
+    TokenBalancesController,
   } = Engine.context;
+  const selectedAccount = AccountsController.getSelectedAccount();
   const accountAddress = getEvmAccountAddress(
-    AccountsController.getSelectedAccount(),
+    selectedAccount,
     AccountsController.listAccounts(),
   );
 
@@ -307,19 +350,63 @@ function seedEthereumSendState(balanceWei?: string): {
 
   NetworkEnablementController.enableNetwork(ETH_MAINNET_CAIP_CHAIN_ID);
   const accountTrackerController =
-    AccountTrackerController as unknown as AgenticAccountTrackerController;
+    AccountTrackerController as unknown as AgenticMutableController<AgenticAccountTrackerState>;
+  const assetsController =
+    AssetsController as unknown as AgenticMutableController<AgenticAssetsControllerState>;
+  const tokenBalancesController =
+    TokenBalancesController as unknown as AgenticMutableController<AgenticTokenBalancesControllerState>;
+  const accountAddressHex = accountAddress as Hex;
+  const lowerAddress = accountAddress.toLowerCase() as Hex;
+  const checksummedAddress = toChecksumHexAddress(accountAddress) as Hex;
+  const accountAddresses = [
+    ...new Set([accountAddressHex, lowerAddress, checksummedAddress]),
+  ];
 
   accountTrackerController.update((state) => {
-    const lowerAddress = accountAddress.toLowerCase() as Hex;
     state.accountsByChainId = state.accountsByChainId ?? {};
     state.accountsByChainId[ETH_MAINNET_CHAIN_ID] =
       state.accountsByChainId[ETH_MAINNET_CHAIN_ID] ?? {};
-    state.accountsByChainId[ETH_MAINNET_CHAIN_ID][lowerAddress] = {
-      ...state.accountsByChainId[ETH_MAINNET_CHAIN_ID][lowerAddress],
+    const mainnetAccounts = state.accountsByChainId[ETH_MAINNET_CHAIN_ID];
+    const existingAccount = accountAddresses
+      .map((address) => mainnetAccounts[address])
+      .find(Boolean);
+    const seededAccount = {
+      ...existingAccount,
       balance: balanceWei as Hex,
-      stakedBalance:
-        state.accountsByChainId[ETH_MAINNET_CHAIN_ID][lowerAddress]
-          ?.stakedBalance ?? ('0x0' as Hex),
+      stakedBalance: existingAccount?.stakedBalance ?? ('0x0' as Hex),
+    };
+    accountAddresses.forEach((address) => {
+      mainnetAccounts[address] = seededAccount;
+    });
+  });
+
+  tokenBalancesController.update((state) => {
+    state.tokenBalances = state.tokenBalances ?? {};
+    accountAddresses.forEach((address) => {
+      state.tokenBalances[address] = state.tokenBalances[address] ?? {};
+      state.tokenBalances[address][ETH_MAINNET_CHAIN_ID] =
+        state.tokenBalances[address][ETH_MAINNET_CHAIN_ID] ?? {};
+      state.tokenBalances[address][ETH_MAINNET_CHAIN_ID][
+        ETH_NATIVE_TOKEN_ADDRESS
+      ] = balanceWei as Hex;
+    });
+  });
+
+  assetsController.update((state) => {
+    state.assetsInfo = state.assetsInfo ?? {};
+    state.assetsBalance = state.assetsBalance ?? {};
+    state.assetsInfo[ETH_MAINNET_ASSET_ID] = {
+      ...state.assetsInfo[ETH_MAINNET_ASSET_ID],
+      type: 'native',
+      name: 'Ethereum',
+      symbol: 'ETH',
+      decimals: 18,
+    };
+    state.assetsBalance[selectedAccount.id] =
+      state.assetsBalance[selectedAccount.id] ?? {};
+    state.assetsBalance[selectedAccount.id][ETH_MAINNET_ASSET_ID] = {
+      ...state.assetsBalance[selectedAccount.id][ETH_MAINNET_ASSET_ID],
+      amount: hexWeiToEthAmount(balanceWei),
     };
   });
 

--- a/app/core/AgenticService/AgenticService.ts
+++ b/app/core/AgenticService/AgenticService.ts
@@ -26,6 +26,7 @@ import {
 import { setCompletedOnboarding } from '../../actions/onboarding';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree';
 import { AccountImportStrategy } from '@metamask/keyring-controller';
+import type { CaipChainId, Hex } from '@metamask/utils';
 import StorageWrapper from '../../store/storage-wrapper';
 import {
   OPTIN_META_METRICS_UI_SEEN,
@@ -76,6 +77,17 @@ interface FiberRoot {
 interface ReactDevToolsHook {
   renderers: Map<number, unknown>;
   getFiberRoots?: (id: number) => Set<FiberRoot>;
+}
+
+interface AgenticAccountTrackerState {
+  accountsByChainId: Record<
+    Hex,
+    Record<Hex, { balance: Hex; stakedBalance?: Hex }>
+  >;
+}
+
+interface AgenticAccountTrackerController {
+  update(updater: (state: AgenticAccountTrackerState) => void): void;
 }
 
 /** Shape of the __DEV__-only agentic bridge on globalThis. */
@@ -153,12 +165,19 @@ interface AgenticBridge {
       skipPerpsTutorial?: boolean;
       autoLockNever?: boolean;
       deviceAuthEnabled?: boolean;
+      disableTransactionSimulations?: boolean;
+      seedEthereumBalanceWei?: string;
     };
   }) => Promise<{
     ok: boolean;
     error?: string;
     accounts?: { address: string; name: string }[];
   }>;
+  seedEthereumSendState: (settings?: { balanceWei?: string }) => {
+    ok: boolean;
+    accountAddress?: string;
+    error?: string;
+  };
   showStep: (step: { id: string; description: string }) => void;
   hideStep: () => void;
   findFiberByTestId: (testId: string) => boolean;
@@ -233,6 +252,9 @@ function walkFiberRoots(visitor: (rootFiber: FiberNode) => boolean): boolean {
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────
 
+const ETH_MAINNET_CHAIN_ID = '0x1' as Hex;
+const ETH_MAINNET_CAIP_CHAIN_ID = 'eip155:1' as CaipChainId;
+
 /** Map an internal account to the slim shape exposed by the bridge. */
 function toAccountSummary(a: {
   id: string;
@@ -240,6 +262,68 @@ function toAccountSummary(a: {
   metadata: { name: string };
 }): { id: string; address: string; name: string } {
   return { id: a.id, address: a.address, name: a.metadata.name };
+}
+
+function isEvmAddress(address: string): boolean {
+  return /^0x[a-fA-F0-9]{40}$/u.test(address);
+}
+
+function getEvmAccountAddress(
+  selectedAccount: { address: string },
+  accounts: { address: string }[],
+): string | undefined {
+  if (isEvmAddress(selectedAccount.address)) {
+    return selectedAccount.address;
+  }
+
+  return accounts.find((account) => isEvmAddress(account.address))?.address;
+}
+
+function seedEthereumSendState(balanceWei?: string): {
+  ok: boolean;
+  accountAddress?: string;
+  error?: string;
+} {
+  if (!balanceWei) {
+    return { ok: true };
+  }
+
+  const {
+    AccountsController,
+    AccountTrackerController,
+    NetworkEnablementController,
+  } = Engine.context;
+  const accountAddress = getEvmAccountAddress(
+    AccountsController.getSelectedAccount(),
+    AccountsController.listAccounts(),
+  );
+
+  if (!accountAddress) {
+    return {
+      ok: false,
+      error: 'No EVM account available for Ethereum send state seed.',
+    };
+  }
+
+  NetworkEnablementController.enableNetwork(ETH_MAINNET_CAIP_CHAIN_ID);
+  const accountTrackerController =
+    AccountTrackerController as unknown as AgenticAccountTrackerController;
+
+  accountTrackerController.update((state) => {
+    const lowerAddress = accountAddress.toLowerCase() as Hex;
+    state.accountsByChainId = state.accountsByChainId ?? {};
+    state.accountsByChainId[ETH_MAINNET_CHAIN_ID] =
+      state.accountsByChainId[ETH_MAINNET_CHAIN_ID] ?? {};
+    state.accountsByChainId[ETH_MAINNET_CHAIN_ID][lowerAddress] = {
+      ...state.accountsByChainId[ETH_MAINNET_CHAIN_ID][lowerAddress],
+      balance: balanceWei as Hex,
+      stakedBalance:
+        state.accountsByChainId[ETH_MAINNET_CHAIN_ID][lowerAddress]
+          ?.stakedBalance ?? ('0x0' as Hex),
+    };
+  });
+
+  return { ok: true, accountAddress };
 }
 
 /**
@@ -659,6 +743,17 @@ const AgenticService = {
         });
         return found;
       },
+      seedEthereumSendState: (settings = {}) => {
+        try {
+          const result = seedEthereumSendState(settings.balanceWei);
+          if (!result.ok) {
+            Logger.log(`[AgenticService] ${result.error}`);
+          }
+          return result;
+        } catch (e) {
+          return { ok: false, error: String((e as Error).message || e) };
+        }
+      },
       setupWallet: async (fixture) => {
         try {
           const {
@@ -668,28 +763,42 @@ const AgenticService = {
           } = Engine.context;
           const store = ReduxService.store;
           const settings = fixture.settings ?? {};
+          const existingVault = KeyringController.state?.vault;
 
-          // 1. Create wallet from the first mnemonic (same path as onboarding UI)
-          const mnemonicAccount = fixture.accounts.find(
-            (a) => a.type === 'mnemonic',
-          );
-          if (mnemonicAccount) {
-            const mnemonic = mnemonicPhraseToBytes(mnemonicAccount.value);
-            await MultichainAccountService.createMultichainAccountWallet({
-              type: 'restore',
-              password: fixture.password,
-              mnemonic,
-            });
+          if (settings.disableTransactionSimulations === true) {
+            Engine.context.PreferencesController.setUseTransactionSimulations(
+              false,
+            );
+          }
+
+          // 1. Unlock an injected fixture vault, or create wallet from the first mnemonic.
+          if (existingVault) {
+            if (!KeyringController.isUnlocked()) {
+              await KeyringController.submitPassword(fixture.password);
+            }
           } else {
-            await MultichainAccountService.createMultichainAccountWallet({
-              type: 'create',
-              password: fixture.password,
-            });
+            const mnemonicAccount = fixture.accounts.find(
+              (a) => a.type === 'mnemonic',
+            );
+            if (mnemonicAccount) {
+              const mnemonic = mnemonicPhraseToBytes(mnemonicAccount.value);
+              await MultichainAccountService.createMultichainAccountWallet({
+                type: 'restore',
+                password: fixture.password,
+                mnemonic,
+              });
+            } else {
+              await MultichainAccountService.createMultichainAccountWallet({
+                type: 'create',
+                password: fixture.password,
+              });
+            }
           }
 
           // 2. Initialize services (same as Authentication.dispatchLogin)
           await AccountTreeInitService.initializeAccountTree();
           await MultichainAccountService.init();
+          seedEthereumSendState(settings.seedEthereumBalanceWei);
 
           // 3. Import private key accounts
           for (const account of fixture.accounts) {

--- a/docs/readme/mobile-memory-leak-profiler.md
+++ b/docs/readme/mobile-memory-leak-profiler.md
@@ -70,6 +70,20 @@ Convert a local iOS-exported `.cpuprofile` into the artifact directory:
 yarn llm:mobile:memory -- --platform ios --hermes-profile /path/to/profile.cpuprofile
 ```
 
+Capture Hermes heap snapshots before and after a flow, then include a shallow
+heap-growth comparison in the memory report:
+
+```bash
+yarn llm:mobile:memory -- --platform ios --device booted --flow wallet-send-eth-cancel --fixture default --expo-dev-url "http://localhost:8092?disableOnboarding=1" --headless-wallet-setup --capture-heap-snapshots
+```
+
+Heap snapshots are written to `<artifact-dir>/heap-snapshots` by default. Use
+`--heap-snapshot-dir` to choose a different directory, and
+`--heap-snapshot-top-count` to control how many growing node groups are included
+in the diff. The comparison groups nodes by heap snapshot `type:name` and ranks
+them by shallow `self_size` growth; it is useful for finding retained object
+classes or large strings, but it is not a dominator or retained-size analysis.
+
 ## Profiler Overlay
 
 The in-app `react-native-release-profiler` overlay is enabled for `rc` and

--- a/docs/readme/mobile-memory-leak-profiler.md
+++ b/docs/readme/mobile-memory-leak-profiler.md
@@ -47,6 +47,7 @@ launch arg, loads the Metro URL, and uses the app's local AgenticService CDP
 bridge to prepare the fixture wallet before sampling:
 
 ```bash
+METAMASK_ENVIRONMENT=e2e IS_TEST=true METAMASK_BUILD_TYPE=main EXPO_NO_TYPESCRIPT_SETUP=1 yarn expo start --port 8092
 yarn llm:mobile:memory -- --platform ios --device booted --flow wallet-send-eth-cancel --fixture default --expo-dev-url "http://localhost:8092?disableOnboarding=1" --headless-wallet-setup
 ```
 
@@ -116,10 +117,13 @@ The default send amount is `25%`, which uses the send screen percentage button
 and avoids depending on the current fiat/native amount mode. You can also pass
 `--send-amount 0.001`, `50%`, `75%`, `100%`, or `max`.
 
-For local iOS dev-client builds, pass `--expo-dev-url` to load the Metro bundle
-headlessly through Appium before baseline sampling. Pair it with
-`--headless-wallet-setup` when the fixture loads a locked vault or the app lands
-on onboarding before the wallet screen.
+For local iOS dev-client builds, run Metro with `METAMASK_ENVIRONMENT=e2e` and
+`IS_TEST=true`, then pass `--expo-dev-url` to load the Metro bundle headlessly
+through Appium before baseline sampling. Pair it with `--headless-wallet-setup`
+when the fixture loads a locked vault or the app lands on onboarding before the
+wallet screen. In that mode the CLI skips waiting for the app to fetch
+`/state.json`; the fixture wallet is injected through AgenticService over CDP,
+and the fixture server stays available for mocked JSON-RPC.
 
 `wallet-send-eth-cancel` opens the confirmation screen and taps the confirmation
 footer Cancel button, so it is the safer repeatable leak loop. The submit flow

--- a/docs/readme/mobile-memory-leak-profiler.md
+++ b/docs/readme/mobile-memory-leak-profiler.md
@@ -34,6 +34,19 @@ Idle sampling against an already-running app:
 yarn llm:mobile:memory -- --platform android --no-launch --flow idle --iterations 50 --interval 1000
 ```
 
+Create an ETH send confirmation from the wallet and cancel it on each
+iteration:
+
+```bash
+yarn llm:mobile:memory -- --platform android --flow wallet-send-eth-cancel --iterations 10
+```
+
+Submit an ETH send transaction from the wallet on each iteration:
+
+```bash
+yarn llm:mobile:memory -- --platform android --flow wallet-send-eth-submit --send-amount 0.001 --recipient-address 0x0000000000000000000000000000000000000001 --allow-transaction-submit
+```
+
 Pull the latest Android `.cpuprofile` from Downloads and convert it with
 `react-native-release-profiler` after memory sampling:
 
@@ -58,6 +71,23 @@ yarn llm:mobile:memory -- --enable-in-app-profiler
 
 That passes `enableProfiler=true` through mobile launch arguments when the CLI
 starts the app.
+
+## Wallet Confirmation Flows
+
+The `wallet-send-eth-cancel` and `wallet-send-eth-submit` flows drive the
+installed app through Appium. They assume the wallet is already onboarded,
+unlocked, and on or navigable back to the Wallet screen. The CLI starts a local
+Appium server on `http://127.0.0.1:4723/` by default; use `--reuse-appium` when
+connecting to a server you started yourself, and `--appium-url` to point at a
+custom WebDriver endpoint.
+
+The default send amount is `25%`, which uses the send screen percentage button
+and avoids depending on the current fiat/native amount mode. You can also pass
+`--send-amount 0.001`, `50%`, `75%`, `100%`, or `max`.
+
+`wallet-send-eth-cancel` opens the confirmation screen and taps the confirmation
+footer Cancel button, so it is the safer repeatable leak loop. The submit flow
+can broadcast a real transaction and requires `--allow-transaction-submit`.
 
 ## Notes
 

--- a/docs/readme/mobile-memory-leak-profiler.md
+++ b/docs/readme/mobile-memory-leak-profiler.md
@@ -1,0 +1,69 @@
+# Mobile Memory Leak Profiler
+
+`yarn llm:mobile:memory` is a repeatable memory profiling entrypoint for
+MetaMask Mobile. It adapts the extension memory-profiler report shape to mobile
+process telemetry:
+
+- Android: samples `adb shell dumpsys meminfo <package>` and records RSS, PSS,
+  Java heap PSS, native heap PSS, graphics, code, stack, system, and swap PSS.
+- iOS simulator: samples `xcrun simctl spawn <device> ps` and records RSS and
+  virtual size for the app process.
+- Hermes CPU profiles: optionally invokes the existing
+  `react-native-release-profiler` CLI to pull or convert `.cpuprofile` files
+  into the same artifact directory.
+
+Reports are written to `test-artifacts/mobile-memory` by default.
+
+## Examples
+
+Android relaunch leak check:
+
+```bash
+yarn llm:mobile:memory -- --platform android --iterations 25 --max-pss-growth 40MiB
+```
+
+iOS simulator relaunch leak check:
+
+```bash
+yarn llm:mobile:memory -- --platform ios --device booted --iterations 25 --max-rss-growth 80MiB
+```
+
+Idle sampling against an already-running app:
+
+```bash
+yarn llm:mobile:memory -- --platform android --no-launch --flow idle --iterations 50 --interval 1000
+```
+
+Pull the latest Android `.cpuprofile` from Downloads and convert it with
+`react-native-release-profiler` after memory sampling:
+
+```bash
+yarn llm:mobile:memory -- --platform android --pull-hermes-profile --sourcemap-path ./sourcemaps
+```
+
+Convert a local iOS-exported `.cpuprofile` into the artifact directory:
+
+```bash
+yarn llm:mobile:memory -- --platform ios --hermes-profile /path/to/profile.cpuprofile
+```
+
+## Profiler Overlay
+
+The in-app `react-native-release-profiler` overlay is enabled for `rc` and
+`exp` builds. Profiling automation can also enable it on launch with:
+
+```bash
+yarn llm:mobile:memory -- --enable-in-app-profiler
+```
+
+That passes `enableProfiler=true` through mobile launch arguments when the CLI
+starts the app.
+
+## Notes
+
+- Build and install the app before running this command. The CLI launches or
+  relaunches an already-installed package; it does not build the app.
+- Android defaults to `io.metamask` and `io.metamask.MainActivity`.
+- iOS defaults to bundle id `io.metamask.MetaMask`, device `booted`, and process
+  name `MetaMask`.
+- Use `--help` for the full option list.

--- a/docs/readme/mobile-memory-leak-profiler.md
+++ b/docs/readme/mobile-memory-leak-profiler.md
@@ -38,7 +38,16 @@ Create an ETH send confirmation from the wallet and cancel it on each
 iteration:
 
 ```bash
-yarn llm:mobile:memory -- --platform android --flow wallet-send-eth-cancel --iterations 10
+yarn llm:mobile:memory -- --platform android --flow wallet-send-eth-cancel --fixture default --iterations 10
+```
+
+Load a local Expo dev-client bundle before driving the wallet flow. This runs
+headlessly, starts the default fixture server, passes the fixture port as a
+launch arg, loads the Metro URL, and uses the app's local AgenticService CDP
+bridge to prepare the fixture wallet before sampling:
+
+```bash
+yarn llm:mobile:memory -- --platform ios --device booted --flow wallet-send-eth-cancel --fixture default --expo-dev-url "http://localhost:8092?disableOnboarding=1" --headless-wallet-setup
 ```
 
 Submit an ETH send transaction from the wallet on each iteration:
@@ -75,15 +84,42 @@ starts the app.
 ## Wallet Confirmation Flows
 
 The `wallet-send-eth-cancel` and `wallet-send-eth-submit` flows drive the
-installed app through Appium. They assume the wallet is already onboarded,
-unlocked, and on or navigable back to the Wallet screen. The CLI starts a local
-Appium server on `http://127.0.0.1:4723/` by default; use `--reuse-appium` when
-connecting to a server you started yourself, and `--appium-url` to point at a
-custom WebDriver endpoint.
+installed app through Appium. For repeatable local runs, pass
+`--fixture default`; the CLI starts the E2E fixture server on
+`--fixture-server-port` (`12345` by default), passes that port as a mobile
+launch argument, and waits for the app to request `/state.json`. For fully
+headless dev-client runs, add `--headless-wallet-setup`; the CLI calls the
+local AgenticService CDP bridge on `--cdp-port` (inferred from
+`--expo-dev-url`, otherwise `8081`) to unlock or create the fixture wallet with
+`--wallet-password` (`123123123` by default). For send flows, the default
+fixture is patched locally before serving so Ethereum mainnet is enabled and
+the selected EVM account has a local-only ETH balance; no real funds are
+created or moved by fixture setup. The fixture also points Ethereum mainnet at
+the profiler fixture server's local JSON-RPC endpoint and disables transaction
+simulations/smart transactions, so the confirmation can be created without
+Infura, Sentinel, or Blockaid network access. The headless ETH balance seed is
+also reapplied immediately before each send iteration and again after the asset
+picker opens, so balance polling cannot clear the local seed before Ethereum is
+selected. For the default fixture recipient, the flow first tries to select
+`Account 2` from the wallet recipient list, then falls back to typing the
+default external recipient address and accepting the new-address warning if the
+fixture wallet only has one account. Pass `--recipient-address` to exercise a
+specific typed external-address path instead. Without `--fixture`, the wallet
+must already be onboarded, unlocked, funded, and on or navigable back to the
+Wallet screen.
+
+The CLI starts a local Appium server on `http://127.0.0.1:4723/` by default;
+use `--reuse-appium` when connecting to a server you started yourself, and
+`--appium-url` to point at a custom WebDriver endpoint.
 
 The default send amount is `25%`, which uses the send screen percentage button
 and avoids depending on the current fiat/native amount mode. You can also pass
 `--send-amount 0.001`, `50%`, `75%`, `100%`, or `max`.
+
+For local iOS dev-client builds, pass `--expo-dev-url` to load the Metro bundle
+headlessly through Appium before baseline sampling. Pair it with
+`--headless-wallet-setup` when the fixture loads a locked vault or the app lands
+on onboarding before the wallet screen.
 
 `wallet-send-eth-cancel` opens the confirmation screen and taps the confirmation
 footer Cancel button, so it is the safer repeatable leak loop. The submit flow

--- a/package.json
+++ b/package.json
@@ -132,6 +132,8 @@
     "run-system-tests:android-onboarding-emu": "yarn playwright test --project system-android-onboarding-emu --config tests/playwright.system-emulator.config.ts",
     "run-system-tests:ios-login-sim": "yarn playwright test --project system-ios-login-sim --config tests/playwright.system-emulator.config.ts",
     "run-system-tests:ios-onboarding-sim": "yarn playwright test --project system-ios-onboarding-sim --config tests/playwright.system-emulator.config.ts",
+    "llm:mobile:memory": "tsx scripts/memory-profiler/mobile-memory-profiler.ts",
+    "profile:hermes": "react-native-release-profiler",
     "test:depcheck": "yarn depcheck",
     "test:tgz-check": "./scripts/tgz-check.sh",
     "test:attribution-check": "./scripts/attributions-check.sh",

--- a/scripts/memory-profiler/mobile-memory-profiler.test.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.test.ts
@@ -1,5 +1,7 @@
 import {
+  aggregateHeapSnapshot,
   calculateDeltas,
+  compareHeapSnapshotAggregates,
   createMobileMemoryReport,
   parseAndroidMeminfo,
   parseByteSize,
@@ -9,6 +11,7 @@ import {
   recipientAddressInputSelectors,
   isRetriableCdpBridgeError,
   shouldWaitForFixtureStateRequest,
+  summarizeHeapSnapshotAggregates,
   type MobileMemorySample,
 } from './mobile-memory-profiler';
 
@@ -98,6 +101,11 @@ describe('mobile-memory-profiler', () => {
         '/tmp/profile.cpuprofile',
         '--sourcemap-path',
         '/tmp/sourcemaps',
+        '--capture-heap-snapshots',
+        '--heap-snapshot-dir',
+        '/tmp/heaps',
+        '--heap-snapshot-top-count',
+        '12',
         '--max-rss-growth',
         '25MiB',
         '--output',
@@ -119,6 +127,9 @@ describe('mobile-memory-profiler', () => {
           intervalMs: 50,
           hermesProfilePath: '/tmp/profile.cpuprofile',
           sourcemapPath: '/tmp/sourcemaps',
+          captureHeapSnapshots: true,
+          heapSnapshotDir: '/tmp/heaps',
+          heapSnapshotTopCount: 12,
           maxRssGrowthBytes: 25 * 1024 * 1024,
           outputPath: '/tmp/report.json',
         }),
@@ -472,6 +483,86 @@ describe('mobile-memory-profiler', () => {
         },
       ]);
       expect(report.options).not.toHaveProperty('help');
+    });
+  });
+
+  describe('heap snapshot analysis', () => {
+    function createHeapSnapshot(nodes: number[], strings: string[]) {
+      return {
+        snapshot: {
+          meta: {
+            node_fields: ['type', 'name', 'id', 'self_size', 'edge_count'],
+            node_types: [
+              ['hidden', 'object', 'string', 'code', 'array'],
+              'string',
+              'number',
+              'number',
+              'number',
+            ],
+          },
+        },
+        nodes,
+        strings,
+      };
+    }
+
+    it('aggregates heap nodes by type and name', () => {
+      const aggregates = aggregateHeapSnapshot(
+        createHeapSnapshot(
+          [
+            1, 0, 1, 24, 0,
+            1, 0, 2, 40, 0,
+            2, 1, 3, 10, 0,
+          ],
+          ['Controller', 'status'],
+        ),
+      );
+
+      expect(aggregates.get('object:Controller')).toStrictEqual({
+        type: 'object',
+        name: 'Controller',
+        count: 2,
+        selfSizeBytes: 64,
+      });
+      expect(aggregates.get('string:status')).toStrictEqual({
+        type: 'string',
+        name: 'status',
+        count: 1,
+        selfSizeBytes: 10,
+      });
+      expect(summarizeHeapSnapshotAggregates(aggregates)).toStrictEqual({
+        nodeCount: 3,
+        selfSizeBytes: 74,
+      });
+    });
+
+    it('ranks heap growth by self size delta', () => {
+      const baseline = aggregateHeapSnapshot(
+        createHeapSnapshot([1, 0, 1, 24, 0], ['Controller']),
+      );
+      const final = aggregateHeapSnapshot(
+        createHeapSnapshot(
+          [
+            1, 0, 1, 24, 0,
+            1, 0, 2, 88, 0,
+            4, 1, 3, 16, 0,
+          ],
+          ['Controller', 'Array'],
+        ),
+      );
+
+      expect(compareHeapSnapshotAggregates(baseline, final, 1)).toStrictEqual([
+        {
+          type: 'object',
+          name: 'Controller',
+          countDelta: 1,
+          selfSizeDeltaBytes: 88,
+          baselineCount: 1,
+          finalCount: 2,
+          baselineSelfSizeBytes: 24,
+          finalSelfSizeBytes: 112,
+        },
+      ]);
     });
   });
 });

--- a/scripts/memory-profiler/mobile-memory-profiler.test.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.test.ts
@@ -7,6 +7,8 @@ import {
   parseMobileMemoryProfilerArgs,
   prepareDefaultFixtureForWalletSend,
   recipientAddressInputSelectors,
+  isRetriableCdpBridgeError,
+  shouldWaitForFixtureStateRequest,
   type MobileMemorySample,
 } from './mobile-memory-profiler';
 
@@ -305,6 +307,56 @@ describe('mobile-memory-profiler', () => {
           expect.stringContaining('Enter address to send to'),
         ]),
       );
+    });
+  });
+
+  describe('shouldWaitForFixtureStateRequest', () => {
+    const runtime = {
+      fixtureServer: {
+        waitForNextStateRequest: jest.fn<Promise<void>, []>(),
+        stop: jest.fn<Promise<void>, []>(),
+      },
+    };
+
+    it('waits for fixture state in fixture-backed app launch mode', () => {
+      const options = parseMobileMemoryProfilerArgs(['--fixture', 'default']);
+
+      expect(shouldWaitForFixtureStateRequest(options, runtime)).toBe(true);
+    });
+
+    it('does not wait when headless wallet setup injects fixture state through CDP', () => {
+      const options = parseMobileMemoryProfilerArgs([
+        '--fixture',
+        'default',
+        '--headless-wallet-setup',
+      ]);
+
+      expect(shouldWaitForFixtureStateRequest(options, runtime)).toBe(false);
+    });
+  });
+
+  describe('isRetriableCdpBridgeError', () => {
+    it('retries transient CDP discovery failures', () => {
+      expect(
+        isRetriableCdpBridgeError(
+          new Error(
+            'ERROR: No debug targets found at http://localhost:8092/json/list',
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        isRetriableCdpBridgeError(
+          new Error('ERROR: Cannot reach Metro at http://localhost:8092'),
+        ),
+      ).toBe(true);
+    });
+
+    it('does not retry app-level bridge failures', () => {
+      expect(
+        isRetriableCdpBridgeError(
+          new Error('Headless wallet setup returned invalid CDP output'),
+        ),
+      ).toBe(false);
     });
   });
 

--- a/scripts/memory-profiler/mobile-memory-profiler.test.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.test.ts
@@ -1,0 +1,258 @@
+import {
+  calculateDeltas,
+  createMobileMemoryReport,
+  parseAndroidMeminfo,
+  parseByteSize,
+  parseIosPsOutput,
+  parseMobileMemoryProfilerArgs,
+  type MobileMemorySample,
+} from './mobile-memory-profiler';
+
+const baselineSample: MobileMemorySample = {
+  label: 'baseline',
+  timestamp: '2026-05-27T00:00:00.000Z',
+  platform: 'android',
+  appId: 'io.metamask',
+  deviceId: 'emulator-5554',
+  processId: 111,
+  memory: {
+    rssBytes: 200,
+    pssBytes: 100,
+    nativeHeapBytes: 50,
+    javaHeapBytes: 25,
+    graphicsBytes: null,
+    codeBytes: null,
+    stackBytes: null,
+    privateOtherBytes: null,
+    systemBytes: null,
+    swapPssBytes: null,
+    virtualSizeBytes: null,
+  },
+};
+
+const finalSample: MobileMemorySample = {
+  label: 'iteration-1',
+  timestamp: '2026-05-27T00:01:00.000Z',
+  platform: 'android',
+  appId: 'io.metamask',
+  deviceId: 'emulator-5554',
+  processId: 112,
+  memory: {
+    rssBytes: 260,
+    pssBytes: 140,
+    nativeHeapBytes: 65,
+    javaHeapBytes: 30,
+    graphicsBytes: null,
+    codeBytes: null,
+    stackBytes: null,
+    privateOtherBytes: null,
+    systemBytes: null,
+    swapPssBytes: null,
+    virtualSizeBytes: null,
+  },
+};
+
+describe('mobile-memory-profiler', () => {
+  describe('parseMobileMemoryProfilerArgs', () => {
+    it('uses useful Android defaults', () => {
+      const options = parseMobileMemoryProfilerArgs([]);
+
+      expect(options.platform).toBe('android');
+      expect(options.appId).toBe('io.metamask');
+      expect(options.androidActivity).toBe('io.metamask.MainActivity');
+      expect(options.iterations).toBe(5);
+      expect(options.flow).toBe('relaunch');
+      expect(options.sampleMode).toBe('each');
+      expect(options.outputPath).toMatch(
+        /test-artifacts\/mobile-memory\/mobile-android-memory-profile-\d+\.json/u,
+      );
+    });
+
+    it('parses explicit profiling options', () => {
+      const options = parseMobileMemoryProfilerArgs([
+        '--platform',
+        'ios',
+        '--app-id',
+        'io.metamask.MetaMask.flask',
+        '--device',
+        'booted',
+        '--ios-process-name',
+        'MetaMaskFlask',
+        '--iterations',
+        '25',
+        '--flow',
+        'idle',
+        '--sample',
+        'final',
+        '--no-launch',
+        '--enable-in-app-profiler',
+        '--wait-after-flow',
+        '250',
+        '--interval',
+        '50',
+        '--hermes-profile',
+        '/tmp/profile.cpuprofile',
+        '--sourcemap-path',
+        '/tmp/sourcemaps',
+        '--max-rss-growth',
+        '25MiB',
+        '--output',
+        '/tmp/report.json',
+      ]);
+
+      expect(options).toStrictEqual(
+        expect.objectContaining({
+          platform: 'ios',
+          appId: 'io.metamask.MetaMask.flask',
+          deviceId: 'booted',
+          iosProcessName: 'MetaMaskFlask',
+          iterations: 25,
+          flow: 'idle',
+          sampleMode: 'final',
+          launch: false,
+          enableInAppProfiler: true,
+          waitAfterFlowMs: 250,
+          intervalMs: 50,
+          hermesProfilePath: '/tmp/profile.cpuprofile',
+          sourcemapPath: '/tmp/sourcemaps',
+          maxRssGrowthBytes: 25 * 1024 * 1024,
+          outputPath: '/tmp/report.json',
+        }),
+      );
+    });
+
+    it('rejects invalid choices and unknown options', () => {
+      expect(() =>
+        parseMobileMemoryProfilerArgs(['--platform', 'web']),
+      ).toThrow('--platform must be one of: android, ios');
+
+      expect(() => parseMobileMemoryProfilerArgs(['--wat'])).toThrow(
+        'Unknown option: --wat',
+      );
+    });
+  });
+
+  describe('parseByteSize', () => {
+    it('parses byte units', () => {
+      expect(parseByteSize('1024')).toBe(1024);
+      expect(parseByteSize('1kb')).toBe(1000);
+      expect(parseByteSize('1KiB')).toBe(1024);
+      expect(parseByteSize('1.5MiB')).toBe(1572864);
+    });
+  });
+
+  describe('parseAndroidMeminfo', () => {
+    it('extracts Android dumpsys meminfo app summary values', () => {
+      const metrics = parseAndroidMeminfo(`
+        App Summary
+                       Pss(KB)                        Rss(KB)
+                        ------                         ------
+        Java Heap:       14,728                         20,648
+        Native Heap:     41,580                         51,784
+        Code:            44,836                         72,936
+        Stack:              188                            188
+        Graphics:        49,216                         49,216
+        Private Other:    8,392
+        System:          47,203
+        TOTAL PSS:      206,143            TOTAL RSS:      398,460       TOTAL SWAP PSS: 12
+      `);
+
+      expect(metrics.pssBytes).toBe(206143 * 1024);
+      expect(metrics.rssBytes).toBe(398460 * 1024);
+      expect(metrics.javaHeapBytes).toBe(14728 * 1024);
+      expect(metrics.nativeHeapBytes).toBe(41580 * 1024);
+      expect(metrics.graphicsBytes).toBe(49216 * 1024);
+      expect(metrics.swapPssBytes).toBe(12 * 1024);
+    });
+  });
+
+  describe('parseIosPsOutput', () => {
+    it('extracts RSS and VSZ for an iOS simulator process', () => {
+      const parsed = parseIosPsOutput(
+        `
+          100 10 20 launchd
+          321 123456 654321 /Users/me/MetaMask.app/MetaMask
+        `,
+        'MetaMask',
+      );
+
+      expect(parsed).toStrictEqual({
+        pid: 321,
+        memory: expect.objectContaining({
+          rssBytes: 123456 * 1024,
+          virtualSizeBytes: 654321 * 1024,
+        }),
+      });
+    });
+  });
+
+  describe('calculateDeltas', () => {
+    it('calculates memory deltas', () => {
+      expect(calculateDeltas(baselineSample, finalSample)).toStrictEqual({
+        rssBytes: 60,
+        pssBytes: 40,
+        nativeHeapBytes: 15,
+        javaHeapBytes: 5,
+        virtualSizeBytes: null,
+      });
+    });
+  });
+
+  describe('createMobileMemoryReport', () => {
+    it('summarizes samples and threshold results', () => {
+      const options = parseMobileMemoryProfilerArgs([
+        '--output',
+        '/tmp/report.json',
+        '--max-rss-growth',
+        '70b',
+        '--max-pss-growth',
+        '30b',
+        '--max-native-heap-growth',
+        '15b',
+        '--max-java-heap-growth',
+        '3b',
+      ]);
+
+      const report = createMobileMemoryReport({
+        createdAt: '2026-05-27T00:00:00.000Z',
+        options,
+        samples: [baselineSample, finalSample],
+        hermesProfileCliResult: null,
+      });
+
+      expect(report.summary.deltas.rssBytes).toBe(60);
+      expect(report.summary.deltas.pssBytes).toBe(40);
+      expect(report.summary.thresholds).toStrictEqual([
+        {
+          name: 'rssBytes',
+          limit: 70,
+          actual: 60,
+          unit: 'bytes',
+          passed: true,
+        },
+        {
+          name: 'pssBytes',
+          limit: 30,
+          actual: 40,
+          unit: 'bytes',
+          passed: false,
+        },
+        {
+          name: 'nativeHeapBytes',
+          limit: 15,
+          actual: 15,
+          unit: 'bytes',
+          passed: true,
+        },
+        {
+          name: 'javaHeapBytes',
+          limit: 3,
+          actual: 5,
+          unit: 'bytes',
+          passed: false,
+        },
+      ]);
+      expect(report.options).not.toHaveProperty('help');
+    });
+  });
+});

--- a/scripts/memory-profiler/mobile-memory-profiler.test.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.test.ts
@@ -5,6 +5,8 @@ import {
   parseByteSize,
   parseIosPsOutput,
   parseMobileMemoryProfilerArgs,
+  prepareDefaultFixtureForWalletSend,
+  recipientAddressInputSelectors,
   type MobileMemorySample,
 } from './mobile-memory-profiler';
 
@@ -129,6 +131,17 @@ describe('mobile-memory-profiler', () => {
         '0x000000000000000000000000000000000000dEaD',
         '--send-amount',
         '0.001',
+        '--fixture',
+        'default',
+        '--fixture-server-port',
+        '12345',
+        '--wallet-password',
+        'secret-password',
+        '--wallet-mnemonic',
+        'test test test test test test test test test test test junk',
+        '--headless-wallet-setup',
+        '--cdp-port',
+        '8092',
         '--appium-url',
         'http://127.0.0.1:4723/wd/hub',
         '--reuse-appium',
@@ -136,6 +149,8 @@ describe('mobile-memory-profiler', () => {
         '15000',
         '--appium-element-timeout',
         '5000',
+        '--expo-dev-url',
+        'http://localhost:8092?disableOnboarding=1',
         '--allow-transaction-submit',
       ]);
 
@@ -144,13 +159,30 @@ describe('mobile-memory-profiler', () => {
           flow: 'wallet-send-eth-submit',
           recipientAddress: '0x000000000000000000000000000000000000dEaD',
           sendAmount: '0.001',
+          fixture: 'default',
+          fixtureServerPort: 12345,
+          walletPassword: 'secret-password',
+          walletMnemonic:
+            'test test test test test test test test test test test junk',
+          headlessWalletSetup: true,
+          cdpPort: 8092,
           appiumUrl: 'http://127.0.0.1:4723/wd/hub',
           reuseAppium: true,
           appiumStartupTimeoutMs: 15000,
           appiumElementTimeoutMs: 5000,
+          expoDevUrl: 'http://localhost:8092?disableOnboarding=1',
           allowTransactionSubmit: true,
         }),
       );
+    });
+
+    it('infers the CDP port from the Expo dev URL', () => {
+      const options = parseMobileMemoryProfilerArgs([
+        '--expo-dev-url',
+        'http://localhost:8092?disableOnboarding=1',
+      ]);
+
+      expect(options.cdpPort).toBe(8092);
     });
 
     it('rejects invalid choices and unknown options', () => {
@@ -170,6 +202,109 @@ describe('mobile-memory-profiler', () => {
       expect(parseByteSize('1kb')).toBe(1000);
       expect(parseByteSize('1KiB')).toBe(1024);
       expect(parseByteSize('1.5MiB')).toBe(1572864);
+    });
+  });
+
+  describe('prepareDefaultFixtureForWalletSend', () => {
+    it('enables Ethereum mainnet and seeds the selected EVM account balance', () => {
+      const fixture: Record<string, unknown> = {
+        state: {
+          engine: {
+            backgroundState: {
+              AccountsController: {
+                internalAccounts: {
+                  selectedAccount: 'account-1',
+                  accounts: {
+                    'account-1': {
+                      address: '0x0000000000000000000000000000000000000abc',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      prepareDefaultFixtureForWalletSend(fixture, {
+        ethereumRpcUrl: 'http://localhost:12345/rpc',
+      });
+
+      const state = fixture.state as Record<string, unknown>;
+      const engine = state.engine as Record<string, unknown>;
+      const backgroundState = engine.backgroundState as Record<string, unknown>;
+      const accountTrackerController =
+        backgroundState.AccountTrackerController as Record<string, unknown>;
+      const accountsByChainId =
+        accountTrackerController.accountsByChainId as Record<string, unknown>;
+      const mainnetAccounts = accountsByChainId['0x1'] as Record<
+        string,
+        unknown
+      >;
+      const accountBalance = mainnetAccounts[
+        '0x0000000000000000000000000000000000000abc'
+      ] as Record<string, unknown>;
+      const networkEnablementController =
+        backgroundState.NetworkEnablementController as Record<string, unknown>;
+      const enabledNetworkMap =
+        networkEnablementController.enabledNetworkMap as Record<
+          string,
+          unknown
+        >;
+      const enabledEvmNetworks = enabledNetworkMap.eip155 as Record<
+        string,
+        unknown
+      >;
+      const preferencesController =
+        backgroundState.PreferencesController as Record<string, unknown>;
+      const networkController =
+        backgroundState.NetworkController as Record<string, unknown>;
+      const networkConfigurations =
+        networkController.networkConfigurationsByChainId as Record<
+          string,
+          unknown
+        >;
+      const mainnetNetwork = networkConfigurations['0x1'] as Record<
+        string,
+        unknown
+      >;
+      const rpcEndpoints = mainnetNetwork.rpcEndpoints as Record<
+        string,
+        unknown
+      >[];
+
+      expect(enabledEvmNetworks['0x1']).toBe(true);
+      expect(accountBalance.balance).toMatch(/^0x/u);
+      expect(preferencesController.useTransactionSimulations).toBe(false);
+      expect(preferencesController.smartTransactionsOptInStatus).toBe(false);
+      expect(mainnetNetwork.defaultRpcEndpointIndex).toBe(1);
+      expect(networkController.selectedNetworkClientId).toBe(
+        'memory-profiler-mainnet',
+      );
+      expect(rpcEndpoints).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            networkClientId: 'mainnet',
+            type: 'infura',
+          }),
+          expect.objectContaining({
+            networkClientId: 'memory-profiler-mainnet',
+            type: 'custom',
+            url: 'http://localhost:12345/rpc',
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('recipientAddressInputSelectors', () => {
+    it('falls back to the iOS placeholder when the recipient input testID is not exposed', () => {
+      expect(recipientAddressInputSelectors('ios')).toEqual(
+        expect.arrayContaining([
+          '~recipient-address-input',
+          expect.stringContaining('Enter address to send to'),
+        ]),
+      );
     });
   });
 

--- a/scripts/memory-profiler/mobile-memory-profiler.test.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.test.ts
@@ -121,6 +121,38 @@ describe('mobile-memory-profiler', () => {
       );
     });
 
+    it('parses wallet send confirmation flow options', () => {
+      const options = parseMobileMemoryProfilerArgs([
+        '--flow',
+        'wallet-send-eth-submit',
+        '--recipient-address',
+        '0x000000000000000000000000000000000000dEaD',
+        '--send-amount',
+        '0.001',
+        '--appium-url',
+        'http://127.0.0.1:4723/wd/hub',
+        '--reuse-appium',
+        '--appium-startup-timeout',
+        '15000',
+        '--appium-element-timeout',
+        '5000',
+        '--allow-transaction-submit',
+      ]);
+
+      expect(options).toStrictEqual(
+        expect.objectContaining({
+          flow: 'wallet-send-eth-submit',
+          recipientAddress: '0x000000000000000000000000000000000000dEaD',
+          sendAmount: '0.001',
+          appiumUrl: 'http://127.0.0.1:4723/wd/hub',
+          reuseAppium: true,
+          appiumStartupTimeoutMs: 15000,
+          appiumElementTimeoutMs: 5000,
+          allowTransactionSubmit: true,
+        }),
+      );
+    });
+
     it('rejects invalid choices and unknown options', () => {
       expect(() =>
         parseMobileMemoryProfilerArgs(['--platform', 'web']),

--- a/scripts/memory-profiler/mobile-memory-profiler.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.ts
@@ -31,6 +31,8 @@ const EXPO_DEV_CLIENT_BUNDLE_TIMEOUT_MS = 120_000;
 const FIXTURE_STATE_REQUEST_TIMEOUT_MS = 180_000;
 const CDP_BRIDGE_RETRY_COUNT = 6;
 const CDP_BRIDGE_RETRY_INTERVAL_MS = 2_000;
+const DEFAULT_HEAP_SNAPSHOT_TOP_COUNT = 20;
+const HEAP_SNAPSHOT_NAME_MAX_LENGTH = 240;
 const COMMAND_MAX_BUFFER = 50 * 1024 * 1024;
 
 export type MobileMemoryPlatform = 'android' | 'ios';
@@ -74,6 +76,9 @@ export interface MobileMemoryProfilerOptions {
   pullHermesProfile: boolean;
   hermesProfilePath?: string;
   sourcemapPath?: string;
+  captureHeapSnapshots: boolean;
+  heapSnapshotDir?: string;
+  heapSnapshotTopCount: number;
   maxRssGrowthBytes?: number;
   maxPssGrowthBytes?: number;
   maxNativeHeapGrowthBytes?: number;
@@ -128,6 +133,39 @@ export interface HermesProfileCliResult {
   stderr: string;
 }
 
+export interface MobileHeapSnapshotArtifact {
+  label: string;
+  path: string;
+  sizeBytes: number;
+  chunksCount: number;
+  collectedGarbage: boolean;
+}
+
+export interface HeapSnapshotGrowthEntry {
+  type: string;
+  name: string;
+  countDelta: number;
+  selfSizeDeltaBytes: number;
+  baselineCount: number;
+  finalCount: number;
+  baselineSelfSizeBytes: number;
+  finalSelfSizeBytes: number;
+}
+
+export interface HeapSnapshotComparison {
+  baselineLabel: string;
+  baselinePath: string;
+  baselineNodeCount: number;
+  baselineSelfSizeBytes: number;
+  finalLabel: string;
+  finalPath: string;
+  finalNodeCount: number;
+  finalSelfSizeBytes: number;
+  nodeCountDelta: number;
+  totalSelfSizeDeltaBytes: number;
+  topGrowth: HeapSnapshotGrowthEntry[];
+}
+
 export interface MobileMemoryReport {
   schemaVersion: 1;
   createdAt: string;
@@ -139,6 +177,8 @@ export interface MobileMemoryReport {
   };
   samples: MobileMemorySample[];
   hermesProfileCliResult: HermesProfileCliResult | null;
+  heapSnapshots: MobileHeapSnapshotArtifact[];
+  heapSnapshotComparison: HeapSnapshotComparison | null;
   summary: {
     baseline: MobileMemorySample | null;
     final: MobileMemorySample | null;
@@ -274,6 +314,8 @@ export function parseMobileMemoryProfilerArgs(
     appiumElementTimeoutMs: DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS,
     allowTransactionSubmit: false,
     pullHermesProfile: false,
+    captureHeapSnapshots: false,
+    heapSnapshotTopCount: DEFAULT_HEAP_SNAPSHOT_TOP_COUNT,
     help: false,
   };
 
@@ -438,6 +480,20 @@ export function parseMobileMemoryProfilerArgs(
           readArgValue(argv, (index += 1), arg),
         );
         break;
+      case '--capture-heap-snapshots':
+        mutableOptions.captureHeapSnapshots = true;
+        break;
+      case '--heap-snapshot-dir':
+        mutableOptions.heapSnapshotDir = resolveOutputPath(
+          readArgValue(argv, (index += 1), arg),
+        );
+        break;
+      case '--heap-snapshot-top-count':
+        mutableOptions.heapSnapshotTopCount = parsePositiveInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
       case '--max-rss-growth':
         mutableOptions.maxRssGrowthBytes = parseByteSize(
           readArgValue(argv, (index += 1), arg),
@@ -521,6 +577,10 @@ export function parseMobileMemoryProfilerArgs(
     pullHermesProfile: mutableOptions.pullHermesProfile ?? false,
     hermesProfilePath: mutableOptions.hermesProfilePath,
     sourcemapPath: mutableOptions.sourcemapPath,
+    captureHeapSnapshots: mutableOptions.captureHeapSnapshots ?? false,
+    heapSnapshotDir: mutableOptions.heapSnapshotDir,
+    heapSnapshotTopCount:
+      mutableOptions.heapSnapshotTopCount ?? DEFAULT_HEAP_SNAPSHOT_TOP_COUNT,
     maxRssGrowthBytes: mutableOptions.maxRssGrowthBytes,
     maxPssGrowthBytes: mutableOptions.maxPssGrowthBytes,
     maxNativeHeapGrowthBytes: mutableOptions.maxNativeHeapGrowthBytes,
@@ -754,11 +814,15 @@ export function createMobileMemoryReport({
   options,
   samples,
   hermesProfileCliResult,
+  heapSnapshots = [],
+  heapSnapshotComparison = null,
 }: {
   createdAt: string;
   options: MobileMemoryProfilerOptions;
   samples: MobileMemorySample[];
   hermesProfileCliResult: HermesProfileCliResult | null;
+  heapSnapshots?: MobileHeapSnapshotArtifact[];
+  heapSnapshotComparison?: HeapSnapshotComparison | null;
 }): MobileMemoryReport {
   const baseline = samples[0] ?? null;
   const final = samples[samples.length - 1] ?? null;
@@ -776,6 +840,8 @@ export function createMobileMemoryReport({
     },
     samples,
     hermesProfileCliResult,
+    heapSnapshots,
+    heapSnapshotComparison,
     summary: {
       baseline,
       final,
@@ -796,11 +862,163 @@ export function shouldWaitForFixtureStateRequest(
   );
 }
 
+export interface RawHeapSnapshot {
+  snapshot?: {
+    meta?: {
+      node_fields?: string[];
+      node_types?: unknown[];
+    };
+  };
+  nodes?: number[];
+  strings?: string[];
+}
+
+export interface HeapSnapshotAggregate {
+  type: string;
+  name: string;
+  count: number;
+  selfSizeBytes: number;
+}
+
+export interface HeapSnapshotAggregateSummary {
+  nodeCount: number;
+  selfSizeBytes: number;
+}
+
+export function aggregateHeapSnapshot(
+  snapshot: RawHeapSnapshot,
+): Map<string, HeapSnapshotAggregate> {
+  const nodeFields = snapshot.snapshot?.meta?.node_fields;
+  const nodeTypes = snapshot.snapshot?.meta?.node_types;
+  const nodes = snapshot.nodes;
+  const strings = snapshot.strings;
+
+  if (
+    !Array.isArray(nodeFields) ||
+    !Array.isArray(nodeTypes) ||
+    !Array.isArray(nodes) ||
+    !Array.isArray(strings)
+  ) {
+    throw new Error('Invalid heap snapshot: missing node metadata.');
+  }
+
+  const typeIndex = nodeFields.indexOf('type');
+  const nameIndex = nodeFields.indexOf('name');
+  const selfSizeIndex = nodeFields.indexOf('self_size');
+  const typeNames = nodeTypes[typeIndex];
+
+  if (
+    typeIndex === -1 ||
+    nameIndex === -1 ||
+    selfSizeIndex === -1 ||
+    !Array.isArray(typeNames)
+  ) {
+    throw new Error('Invalid heap snapshot: unsupported node field layout.');
+  }
+
+  const aggregates = new Map<string, HeapSnapshotAggregate>();
+  const stride = nodeFields.length;
+
+  for (let index = 0; index < nodes.length; index += stride) {
+    const type = String(typeNames[nodes[index + typeIndex]] ?? 'unknown');
+    const name = strings[nodes[index + nameIndex]] ?? '';
+    const selfSizeBytes = nodes[index + selfSizeIndex] ?? 0;
+    const key = `${type}:${name}`;
+    const aggregate = aggregates.get(key) ?? {
+      type,
+      name,
+      count: 0,
+      selfSizeBytes: 0,
+    };
+
+    aggregate.count += 1;
+    aggregate.selfSizeBytes += selfSizeBytes;
+    aggregates.set(key, aggregate);
+  }
+
+  return aggregates;
+}
+
+export function compareHeapSnapshotAggregates(
+  baseline: Map<string, HeapSnapshotAggregate>,
+  final: Map<string, HeapSnapshotAggregate>,
+  topCount = DEFAULT_HEAP_SNAPSHOT_TOP_COUNT,
+): HeapSnapshotGrowthEntry[] {
+  const keys = new Set([...baseline.keys(), ...final.keys()]);
+  const growth: HeapSnapshotGrowthEntry[] = [];
+
+  for (const key of keys) {
+    const baselineAggregate = baseline.get(key);
+    const finalAggregate = final.get(key);
+    const countDelta =
+      (finalAggregate?.count ?? 0) - (baselineAggregate?.count ?? 0);
+    const selfSizeDeltaBytes =
+      (finalAggregate?.selfSizeBytes ?? 0) -
+      (baselineAggregate?.selfSizeBytes ?? 0);
+
+    if (countDelta <= 0 && selfSizeDeltaBytes <= 0) {
+      continue;
+    }
+
+    growth.push({
+      type: finalAggregate?.type ?? baselineAggregate?.type ?? 'unknown',
+      name: formatHeapSnapshotNodeName(
+        finalAggregate?.name ?? baselineAggregate?.name ?? '',
+      ),
+      countDelta,
+      selfSizeDeltaBytes,
+      baselineCount: baselineAggregate?.count ?? 0,
+      finalCount: finalAggregate?.count ?? 0,
+      baselineSelfSizeBytes: baselineAggregate?.selfSizeBytes ?? 0,
+      finalSelfSizeBytes: finalAggregate?.selfSizeBytes ?? 0,
+    });
+  }
+
+  return growth
+    .sort(
+      (a, b) =>
+        b.selfSizeDeltaBytes - a.selfSizeDeltaBytes ||
+        b.countDelta - a.countDelta,
+    )
+    .slice(0, topCount);
+}
+
+export function summarizeHeapSnapshotAggregates(
+  aggregates: Map<string, HeapSnapshotAggregate>,
+): HeapSnapshotAggregateSummary {
+  let nodeCount = 0;
+  let selfSizeBytes = 0;
+
+  for (const aggregate of aggregates.values()) {
+    nodeCount += aggregate.count;
+    selfSizeBytes += aggregate.selfSizeBytes;
+  }
+
+  return { nodeCount, selfSizeBytes };
+}
+
+function formatHeapSnapshotNodeName(name: string): string {
+  if (name.length <= HEAP_SNAPSHOT_NAME_MAX_LENGTH) {
+    return name;
+  }
+
+  const suffix = `...<${name.length} chars>`;
+  return `${name.slice(0, HEAP_SNAPSHOT_NAME_MAX_LENGTH - suffix.length)}${suffix}`;
+}
+
+async function aggregateHeapSnapshotFile(
+  snapshotPath: string,
+): Promise<Map<string, HeapSnapshotAggregate>> {
+  const raw = await fs.readFile(snapshotPath, 'utf8');
+  return aggregateHeapSnapshot(JSON.parse(raw) as RawHeapSnapshot);
+}
+
 export async function runMobileMemoryProfiler(
   options: MobileMemoryProfilerOptions,
   runner: CommandRunner = runCommand,
 ): Promise<MobileMemoryReport> {
   const samples: MobileMemorySample[] = [];
+  const heapSnapshots: MobileHeapSnapshotArtifact[] = [];
   const runtime: AppiumRuntime = {};
 
   try {
@@ -837,6 +1055,7 @@ export async function runMobileMemoryProfiler(
     }
 
     samples.push(await collectMemorySample(options, 'baseline', runner));
+    await maybeCaptureHeapSnapshot(options, 'baseline', runner, heapSnapshots);
 
     for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
       await runFlowIteration(options, runner, runtime);
@@ -844,6 +1063,12 @@ export async function runMobileMemoryProfiler(
       if (options.sampleMode === 'each') {
         samples.push(
           await collectMemorySample(options, `iteration-${iteration}`, runner),
+        );
+        await maybeCaptureHeapSnapshot(
+          options,
+          `iteration-${iteration}`,
+          runner,
+          heapSnapshots,
         );
       }
 
@@ -854,17 +1079,24 @@ export async function runMobileMemoryProfiler(
 
     if (options.sampleMode === 'final') {
       samples.push(await collectMemorySample(options, 'final', runner));
+      await maybeCaptureHeapSnapshot(options, 'final', runner, heapSnapshots);
     }
 
     const hermesProfileCliResult = await maybeRunHermesProfileCli(
       options,
       runner,
     );
+    const heapSnapshotComparison = await maybeCompareHeapSnapshots(
+      options,
+      heapSnapshots,
+    );
     const report = createMobileMemoryReport({
       createdAt: new Date().toISOString(),
       options,
       samples,
       hermesProfileCliResult,
+      heapSnapshots,
+      heapSnapshotComparison,
     });
 
     await fs.mkdir(path.dirname(options.outputPath), { recursive: true });
@@ -937,6 +1169,12 @@ Options:
                                 after the memory run. Android only.
   --hermes-profile <path>       Convert a local .cpuprofile with react-native-release-profiler
   --sourcemap-path <path>       Sourcemap path passed to react-native-release-profiler
+  --capture-heap-snapshots      Capture Hermes heap snapshots through CDP after
+                                baseline and sampled iterations.
+  --heap-snapshot-dir <path>    Directory for .heapsnapshot files. Defaults to
+                                <artifact-dir>/heap-snapshots
+  --heap-snapshot-top-count <n> Number of growing heap node groups in the diff.
+                                Default: ${DEFAULT_HEAP_SNAPSHOT_TOP_COUNT}
   --max-rss-growth <size>       Fail if RSS grows above size
   --max-pss-growth <size>       Fail if Android PSS grows above size
   --max-native-heap-growth <size>
@@ -979,6 +1217,26 @@ async function main(): Promise<void> {
       report.summary.deltas.virtualSizeBytes,
     )}`,
   );
+
+  if (report.heapSnapshotComparison) {
+    console.log(
+      `Heap snapshot diff: ${report.heapSnapshotComparison.baselineLabel} -> ${report.heapSnapshotComparison.finalLabel}`,
+    );
+    console.log(
+      `Heap snapshot shallow size delta: ${formatBytes(
+        report.heapSnapshotComparison.totalSelfSizeDeltaBytes,
+      )} (${report.heapSnapshotComparison.nodeCountDelta >= 0 ? '+' : ''}${
+        report.heapSnapshotComparison.nodeCountDelta
+      } nodes)`,
+    );
+    for (const entry of report.heapSnapshotComparison.topGrowth.slice(0, 10)) {
+      console.log(
+        `  ${entry.type}:${entry.name || '<anonymous>'} ${formatBytes(
+          entry.selfSizeDeltaBytes,
+        )} (${entry.countDelta >= 0 ? '+' : ''}${entry.countDelta} nodes)`,
+      );
+    }
+  }
 
   if (report.hermesProfileCliResult) {
     console.log(
@@ -1805,6 +2063,95 @@ async function runCdpBridgeCommand(
   }
 
   throw lastError ?? new Error('Unknown CDP bridge failure.');
+}
+
+async function maybeCaptureHeapSnapshot(
+  options: MobileMemoryProfilerOptions,
+  label: string,
+  runner: CommandRunner,
+  heapSnapshots: MobileHeapSnapshotArtifact[],
+): Promise<void> {
+  if (!options.captureHeapSnapshots) {
+    return;
+  }
+
+  const snapshotDir =
+    options.heapSnapshotDir ??
+    path.join(options.artifactDir, 'heap-snapshots');
+  const snapshotPath = path.join(
+    snapshotDir,
+    `${sanitizeArtifactLabel(label)}.heapsnapshot`,
+  );
+  const result = await runCdpBridgeCommand(options, runner, [
+    'heap-snapshot',
+    '--label',
+    label,
+    '--out',
+    snapshotPath,
+  ]);
+  const payload = JSON.parse(result.stdout) as {
+    ok?: boolean;
+    path?: string;
+    sizeBytes?: number;
+    chunksCount?: number;
+    collectedGarbage?: boolean;
+    error?: string;
+  };
+
+  if (payload.ok !== true || !payload.path) {
+    throw new Error(
+      `Heap snapshot capture failed: ${payload.error ?? result.stdout}`,
+    );
+  }
+
+  heapSnapshots.push({
+    label,
+    path: payload.path,
+    sizeBytes: payload.sizeBytes ?? 0,
+    chunksCount: payload.chunksCount ?? 0,
+    collectedGarbage: payload.collectedGarbage ?? true,
+  });
+}
+
+async function maybeCompareHeapSnapshots(
+  options: MobileMemoryProfilerOptions,
+  heapSnapshots: MobileHeapSnapshotArtifact[],
+): Promise<HeapSnapshotComparison | null> {
+  if (!options.captureHeapSnapshots || heapSnapshots.length < 2) {
+    return null;
+  }
+
+  const baseline = heapSnapshots[0];
+  const final = heapSnapshots[heapSnapshots.length - 1];
+  const [baselineAggregate, finalAggregate] = await Promise.all([
+    aggregateHeapSnapshotFile(baseline.path),
+    aggregateHeapSnapshotFile(final.path),
+  ]);
+  const baselineSummary = summarizeHeapSnapshotAggregates(baselineAggregate);
+  const finalSummary = summarizeHeapSnapshotAggregates(finalAggregate);
+
+  return {
+    baselineLabel: baseline.label,
+    baselinePath: baseline.path,
+    baselineNodeCount: baselineSummary.nodeCount,
+    baselineSelfSizeBytes: baselineSummary.selfSizeBytes,
+    finalLabel: final.label,
+    finalPath: final.path,
+    finalNodeCount: finalSummary.nodeCount,
+    finalSelfSizeBytes: finalSummary.selfSizeBytes,
+    nodeCountDelta: finalSummary.nodeCount - baselineSummary.nodeCount,
+    totalSelfSizeDeltaBytes:
+      finalSummary.selfSizeBytes - baselineSummary.selfSizeBytes,
+    topGrowth: compareHeapSnapshotAggregates(
+      baselineAggregate,
+      finalAggregate,
+      options.heapSnapshotTopCount,
+    ),
+  };
+}
+
+function sanitizeArtifactLabel(label: string): string {
+  return label.replace(/[^a-z0-9._-]+/giu, '-');
 }
 
 async function setupHeadlessWallet(

--- a/scripts/memory-profiler/mobile-memory-profiler.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.ts
@@ -29,6 +29,8 @@ const DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS = 20_000;
 const DEFAULT_CDP_PORT = 8081;
 const EXPO_DEV_CLIENT_BUNDLE_TIMEOUT_MS = 120_000;
 const FIXTURE_STATE_REQUEST_TIMEOUT_MS = 180_000;
+const CDP_BRIDGE_RETRY_COUNT = 6;
+const CDP_BRIDGE_RETRY_INTERVAL_MS = 2_000;
 const COMMAND_MAX_BUFFER = 50 * 1024 * 1024;
 
 export type MobileMemoryPlatform = 'android' | 'ios';
@@ -783,6 +785,17 @@ export function createMobileMemoryReport({
   };
 }
 
+export function shouldWaitForFixtureStateRequest(
+  options: MobileMemoryProfilerOptions,
+  runtime: AppiumRuntime,
+): boolean {
+  return Boolean(
+    runtime.fixtureServer &&
+      (options.launch || options.expoDevUrl) &&
+      !options.headlessWalletSetup,
+  );
+}
+
 export async function runMobileMemoryProfiler(
   options: MobileMemoryProfilerOptions,
   runner: CommandRunner = runCommand,
@@ -795,7 +808,8 @@ export async function runMobileMemoryProfiler(
 
     runtime.fixtureServer = await startFixtureServer(options);
     const fixtureStateRequest =
-      runtime.fixtureServer && (options.launch || options.expoDevUrl)
+      shouldWaitForFixtureStateRequest(options, runtime) &&
+      runtime.fixtureServer
         ? runtime.fixtureServer.waitForNextStateRequest(
             FIXTURE_STATE_REQUEST_TIMEOUT_MS,
           )
@@ -1096,7 +1110,7 @@ async function runWalletSendEthFlow(
 
   await unlockWalletIfNeeded(appiumDriver, options);
   if (options.headlessWalletSetup) {
-    await setupHeadlessWallet(options, runner);
+    await seedHeadlessEthereumSendState(options, runner);
     await sleep(500);
   }
   await navigateToWalletHome(appiumDriver, options);
@@ -1262,6 +1276,7 @@ export function prepareDefaultFixtureForWalletSend(
   const accountAddress =
     getSelectedEvmAccountAddress(backgroundState) ??
     '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3';
+  const lowerAccountAddress = accountAddress.toLowerCase();
 
   const currencyRateController = getOrCreateRecord(
     backgroundState,
@@ -1284,6 +1299,9 @@ export function prepareDefaultFixtureForWalletSend(
   );
   const legacyAccounts = getOrCreateRecord(accountTrackerController, 'accounts');
   legacyAccounts[accountAddress] = { balance: DEFAULT_SEND_ETH_BALANCE_WEI };
+  legacyAccounts[lowerAccountAddress] = {
+    balance: DEFAULT_SEND_ETH_BALANCE_WEI,
+  };
   const accountsByChainId = getOrCreateRecord(
     accountTrackerController,
     'accountsByChainId',
@@ -1293,6 +1311,9 @@ export function prepareDefaultFixtureForWalletSend(
     ETH_MAINNET_CHAIN_ID,
   );
   mainnetAccounts[accountAddress] = { balance: DEFAULT_SEND_ETH_BALANCE_WEI };
+  mainnetAccounts[lowerAccountAddress] = {
+    balance: DEFAULT_SEND_ETH_BALANCE_WEI,
+  };
 
   const tokenBalancesController = getOrCreateRecord(
     backgroundState,
@@ -1308,6 +1329,16 @@ export function prepareDefaultFixtureForWalletSend(
     ETH_MAINNET_CHAIN_ID,
   );
   mainnetTokenBalances[ETH_NATIVE_TOKEN_ADDRESS] =
+    DEFAULT_SEND_ETH_BALANCE_WEI;
+  const lowerAccountTokenBalances = getOrCreateRecord(
+    tokenBalances,
+    lowerAccountAddress,
+  );
+  const lowerMainnetTokenBalances = getOrCreateRecord(
+    lowerAccountTokenBalances,
+    ETH_MAINNET_CHAIN_ID,
+  );
+  lowerMainnetTokenBalances[ETH_NATIVE_TOKEN_ADDRESS] =
     DEFAULT_SEND_ETH_BALANCE_WEI;
 
   const networkEnablementController = getOrCreateRecord(
@@ -1728,6 +1759,54 @@ function isEvmAddress(address: string): boolean {
   return /^0x[a-fA-F0-9]{40}$/u.test(address);
 }
 
+export function isRetriableCdpBridgeError(error: Error): boolean {
+  return [
+    'Cannot reach Metro',
+    'No debug targets found',
+    'No suitable debug target found',
+    'WebSocket connection closed',
+    'ECONNREFUSED',
+  ].some((message) => error.message.includes(message));
+}
+
+async function runCdpBridgeCommand(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+  args: string[],
+): Promise<CommandResult> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= CDP_BRIDGE_RETRY_COUNT; attempt++) {
+    try {
+      return await runner(
+        'node',
+        ['scripts/perps/agentic/cdp-bridge.js', ...args],
+        {
+          env: {
+            ...process.env,
+            WATCHER_PORT: String(options.cdpPort),
+            CDP_TIMEOUT: String(
+              Math.max(options.appiumStartupTimeoutMs, 30_000),
+            ),
+          },
+        },
+      );
+    } catch (error) {
+      lastError = error as Error;
+      if (
+        attempt === CDP_BRIDGE_RETRY_COUNT ||
+        !isRetriableCdpBridgeError(lastError)
+      ) {
+        throw lastError;
+      }
+
+      await sleep(CDP_BRIDGE_RETRY_INTERVAL_MS);
+    }
+  }
+
+  throw lastError ?? new Error('Unknown CDP bridge failure.');
+}
+
 async function setupHeadlessWallet(
   options: MobileMemoryProfilerOptions,
   runner: CommandRunner,
@@ -1756,17 +1835,10 @@ async function setupHeadlessWallet(
 
   let result: CommandResult;
   try {
-    result = await runner(
-      'node',
-      ['scripts/perps/agentic/cdp-bridge.js', 'eval-async', expression],
-      {
-        env: {
-          ...process.env,
-          WATCHER_PORT: String(options.cdpPort),
-          CDP_TIMEOUT: String(Math.max(options.appiumStartupTimeoutMs, 30_000)),
-        },
-      },
-    );
+    result = await runCdpBridgeCommand(options, runner, [
+      'eval-async',
+      expression,
+    ]);
   } catch (error) {
     throw new Error(
       `Headless wallet setup failed through Metro CDP on port ${
@@ -1805,17 +1877,7 @@ async function seedHeadlessEthereumSendState(
 
   let result: CommandResult;
   try {
-    result = await runner(
-      'node',
-      ['scripts/perps/agentic/cdp-bridge.js', 'eval', expression],
-      {
-        env: {
-          ...process.env,
-          WATCHER_PORT: String(options.cdpPort),
-          CDP_TIMEOUT: String(Math.max(options.appiumStartupTimeoutMs, 30_000)),
-        },
-      },
-    );
+    result = await runCdpBridgeCommand(options, runner, ['eval', expression]);
   } catch (error) {
     throw new Error(
       `Headless Ethereum send state seed failed through Metro CDP on port ${
@@ -1961,13 +2023,37 @@ async function unlockWalletIfNeeded(
     return;
   }
 
-  await setElementValueById(
-    appiumDriver,
-    options,
-    LOGIN_PASSWORD_INPUT_ID,
-    options.walletPassword,
-    'Login password input',
-  );
+  try {
+    await setElementValueById(
+      appiumDriver,
+      options,
+      LOGIN_PASSWORD_INPUT_ID,
+      options.walletPassword,
+      'Login password input',
+    );
+  } catch (error) {
+    const didUnlock =
+      (await isElementVisibleById(
+        appiumDriver,
+        options,
+        WALLET_SEND_BUTTON_ID,
+        'Wallet Send',
+        1500,
+      )) ||
+      !(await isElementVisibleById(
+        appiumDriver,
+        options,
+        LOGIN_PASSWORD_INPUT_ID,
+        'Login password input',
+        500,
+      ));
+
+    if (didUnlock) {
+      return;
+    }
+
+    throw error;
+  }
 
   if (
     await isElementVisibleById(

--- a/scripts/memory-profiler/mobile-memory-profiler.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.ts
@@ -2,6 +2,7 @@
 /* eslint-disable import-x/no-nodejs-modules */
 
 import { execFile, type ChildProcess } from 'child_process';
+import { createServer, type Server } from 'http';
 import path from 'path';
 import { promises as fs } from 'fs';
 
@@ -15,9 +16,19 @@ const DEFAULT_WAIT_AFTER_FLOW_MS = 1000;
 const DEFAULT_SEND_RECIPIENT_ADDRESS =
   '0x0000000000000000000000000000000000000001';
 const DEFAULT_SEND_AMOUNT = '25%';
+const DEFAULT_SEND_ETH_BALANCE_WEI = `0x${(10n * 10n ** 18n).toString(16)}`;
+const RECIPIENT_ADDRESS_PLACEHOLDER = 'Enter address to send to';
+const DEFAULT_FIXTURE = 'none';
+const DEFAULT_FIXTURE_SERVER_PORT = 12345;
+const DEFAULT_WALLET_PASSWORD = '123123123';
+const DEFAULT_WALLET_MNEMONIC =
+  'drive manage close raven tape average sausage pledge riot furnace august tip';
 const DEFAULT_APPIUM_URL = 'http://127.0.0.1:4723/';
 const DEFAULT_APPIUM_STARTUP_TIMEOUT_MS = 60_000;
 const DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS = 20_000;
+const DEFAULT_CDP_PORT = 8081;
+const EXPO_DEV_CLIENT_BUNDLE_TIMEOUT_MS = 120_000;
+const FIXTURE_STATE_REQUEST_TIMEOUT_MS = 180_000;
 const COMMAND_MAX_BUFFER = 50 * 1024 * 1024;
 
 export type MobileMemoryPlatform = 'android' | 'ios';
@@ -27,6 +38,7 @@ export type MobileMemoryFlow =
   | 'wallet-send-eth-cancel'
   | 'wallet-send-eth-submit';
 export type MobileMemorySampleMode = 'each' | 'final';
+export type MobileMemoryFixture = 'none' | 'default';
 
 export interface MobileMemoryProfilerOptions {
   platform: MobileMemoryPlatform;
@@ -45,10 +57,17 @@ export interface MobileMemoryProfilerOptions {
   intervalMs: number;
   recipientAddress: string;
   sendAmount: string;
+  fixture: MobileMemoryFixture;
+  fixtureServerPort: number;
+  walletPassword: string;
+  walletMnemonic: string;
+  headlessWalletSetup: boolean;
+  cdpPort: number;
   appiumUrl: string;
   reuseAppium: boolean;
   appiumStartupTimeoutMs: number;
   appiumElementTimeoutMs: number;
+  expoDevUrl?: string;
   allowTransactionSubmit: boolean;
   pullHermesProfile: boolean;
   hermesProfilePath?: string;
@@ -134,7 +153,7 @@ export interface CommandResult {
 export type CommandRunner = (
   command: string,
   args: string[],
-  options?: { cwd?: string },
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
 ) => Promise<CommandResult>;
 
 interface AppiumDriver {
@@ -155,6 +174,7 @@ interface AppiumElement {
 interface AppiumRuntime {
   driver?: AppiumDriver;
   serverProcess?: ChildProcess;
+  fixtureServer?: FixtureServerRuntime;
 }
 
 interface AppiumEndpoint {
@@ -162,6 +182,11 @@ interface AppiumEndpoint {
   hostname: string;
   port: number;
   path: string;
+}
+
+interface FixtureServerRuntime {
+  stop(): Promise<void>;
+  waitForNextStateRequest(timeoutMs?: number): Promise<void>;
 }
 
 const VALID_PLATFORMS: MobileMemoryPlatform[] = ['android', 'ios'];
@@ -172,12 +197,37 @@ const VALID_FLOWS: MobileMemoryFlow[] = [
   'wallet-send-eth-submit',
 ];
 const VALID_SAMPLE_MODES: MobileMemorySampleMode[] = ['each', 'final'];
+const VALID_FIXTURES: MobileMemoryFixture[] = ['none', 'default'];
 const PERCENTAGE_AMOUNTS = new Set(['25', '50', '75', '100']);
 const WALLET_SEND_BUTTON_ID = 'wallet-send-button';
+const LOGIN_PASSWORD_INPUT_ID = 'login-password-input';
+const LOGIN_BUTTON_ID = 'log-in-button';
 const RECIPIENT_ADDRESS_INPUT_ID = 'recipient-address-input';
 const REVIEW_BUTTON_ID = 'review-button';
 const CONFIRM_BUTTON_ID = 'confirm-button';
 const CANCEL_BUTTON_ID = 'cancel-button';
+const ETH_MAINNET_CHAIN_ID = '0x1';
+const ETH_MAINNET_CAIP_CHAIN_ID = 'eip155:1';
+const ETH_NATIVE_ASSET_ID = `${ETH_MAINNET_CAIP_CHAIN_ID}/slip44:60`;
+const ETH_NATIVE_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ETH_MAINNET_RPC_PATH = '/rpc';
+const MEMORY_PROFILER_MAINNET_NETWORK_CLIENT_ID = 'memory-profiler-mainnet';
+const FAKE_TRANSACTION_HASH = `0x${'1'.repeat(64)}`;
+
+type JsonRpcId = string | number | null;
+
+interface JsonRpcPayload {
+  id?: JsonRpcId;
+  jsonrpc?: string;
+  method?: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  id: JsonRpcId;
+  jsonrpc: '2.0';
+  result: unknown;
+}
 
 const emptyMemoryMetrics = (): MobileMemoryMetrics => ({
   rssBytes: null,
@@ -211,6 +261,11 @@ export function parseMobileMemoryProfilerArgs(
     intervalMs: 0,
     recipientAddress: DEFAULT_SEND_RECIPIENT_ADDRESS,
     sendAmount: DEFAULT_SEND_AMOUNT,
+    fixture: DEFAULT_FIXTURE,
+    fixtureServerPort: DEFAULT_FIXTURE_SERVER_PORT,
+    walletPassword: DEFAULT_WALLET_PASSWORD,
+    walletMnemonic: DEFAULT_WALLET_MNEMONIC,
+    headlessWalletSetup: false,
     appiumUrl: DEFAULT_APPIUM_URL,
     reuseAppium: false,
     appiumStartupTimeoutMs: DEFAULT_APPIUM_STARTUP_TIMEOUT_MS,
@@ -315,6 +370,34 @@ export function parseMobileMemoryProfilerArgs(
       case '--send-amount':
         mutableOptions.sendAmount = readArgValue(argv, (index += 1), arg);
         break;
+      case '--fixture':
+        mutableOptions.fixture = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_FIXTURES,
+          arg,
+        );
+        break;
+      case '--fixture-server-port':
+        mutableOptions.fixtureServerPort = parsePositiveInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--wallet-password':
+        mutableOptions.walletPassword = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--wallet-mnemonic':
+        mutableOptions.walletMnemonic = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--headless-wallet-setup':
+        mutableOptions.headlessWalletSetup = true;
+        break;
+      case '--cdp-port':
+        mutableOptions.cdpPort = parsePositiveInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
       case '--appium-url':
         mutableOptions.appiumUrl = readArgValue(argv, (index += 1), arg);
         break;
@@ -332,6 +415,10 @@ export function parseMobileMemoryProfilerArgs(
           readArgValue(argv, (index += 1), arg),
           arg,
         );
+        break;
+      case '--expo-dev-url':
+      case '--metro-url':
+        mutableOptions.expoDevUrl = readArgValue(argv, (index += 1), arg);
         break;
       case '--allow-transaction-submit':
         mutableOptions.allowTransactionSubmit = true;
@@ -409,6 +496,16 @@ export function parseMobileMemoryProfilerArgs(
     recipientAddress:
       mutableOptions.recipientAddress ?? DEFAULT_SEND_RECIPIENT_ADDRESS,
     sendAmount: mutableOptions.sendAmount ?? DEFAULT_SEND_AMOUNT,
+    fixture: mutableOptions.fixture ?? DEFAULT_FIXTURE,
+    fixtureServerPort:
+      mutableOptions.fixtureServerPort ?? DEFAULT_FIXTURE_SERVER_PORT,
+    walletPassword: mutableOptions.walletPassword ?? DEFAULT_WALLET_PASSWORD,
+    walletMnemonic: mutableOptions.walletMnemonic ?? DEFAULT_WALLET_MNEMONIC,
+    headlessWalletSetup: mutableOptions.headlessWalletSetup ?? false,
+    cdpPort:
+      mutableOptions.cdpPort ??
+      inferPortFromUrl(mutableOptions.expoDevUrl) ??
+      DEFAULT_CDP_PORT,
     appiumUrl: mutableOptions.appiumUrl ?? DEFAULT_APPIUM_URL,
     reuseAppium: mutableOptions.reuseAppium ?? false,
     appiumStartupTimeoutMs:
@@ -417,6 +514,7 @@ export function parseMobileMemoryProfilerArgs(
     appiumElementTimeoutMs:
       mutableOptions.appiumElementTimeoutMs ??
       DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS,
+    expoDevUrl: mutableOptions.expoDevUrl,
     allowTransactionSubmit: mutableOptions.allowTransactionSubmit ?? false,
     pullHermesProfile: mutableOptions.pullHermesProfile ?? false,
     hermesProfilePath: mutableOptions.hermesProfilePath,
@@ -427,6 +525,19 @@ export function parseMobileMemoryProfilerArgs(
     maxJavaHeapGrowthBytes: mutableOptions.maxJavaHeapGrowthBytes,
     help: mutableOptions.help ?? false,
   };
+}
+
+function inferPortFromUrl(url: string | undefined): number | undefined {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.port ? Number(parsedUrl.port) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function parseByteSize(value: string, optionName = 'value'): number {
@@ -682,9 +793,33 @@ export async function runMobileMemoryProfiler(
   try {
     await fs.mkdir(options.artifactDir, { recursive: true });
 
+    runtime.fixtureServer = await startFixtureServer(options);
+    const fixtureStateRequest =
+      runtime.fixtureServer && (options.launch || options.expoDevUrl)
+        ? runtime.fixtureServer.waitForNextStateRequest(
+            FIXTURE_STATE_REQUEST_TIMEOUT_MS,
+          )
+        : undefined;
+
     if (options.launch) {
+      if (shouldTerminateBeforeInitialLaunch(options)) {
+        await terminateApp(options, runner).catch(() => undefined);
+      }
+
       await launchApp(options, runner);
       await sleep(options.waitAfterFlowMs);
+    }
+
+    if (options.expoDevUrl) {
+      await loadExpoDevClientUrl(options, runtime);
+    }
+
+    if (fixtureStateRequest) {
+      await fixtureStateRequest;
+    }
+
+    if (options.headlessWalletSetup) {
+      await setupHeadlessWallet(options, runner);
     }
 
     samples.push(await collectMemorySample(options, 'baseline', runner));
@@ -727,6 +862,7 @@ export async function runMobileMemoryProfiler(
     return report;
   } finally {
     await cleanupAppiumRuntime(runtime);
+    await cleanupFixtureServer(runtime);
   }
 }
 
@@ -765,11 +901,23 @@ Options:
   --send-amount <value>         Amount for wallet-send-eth-* flows.
                                 Supports keypad values like 0.001 or percentages
                                 25%, 50%, 75%, 100%, max. Default: ${DEFAULT_SEND_AMOUNT}
+  --fixture <name>              Start a local E2E fixture server: none, default.
+                                Default: ${DEFAULT_FIXTURE}
+  --fixture-server-port <port>  Local fixture server port. Default: ${DEFAULT_FIXTURE_SERVER_PORT}
+  --wallet-password <value>     Password used to unlock fixture wallet flows.
+                                Default: ${DEFAULT_WALLET_PASSWORD}
+  --wallet-mnemonic <value>     Mnemonic used by headless wallet setup.
+  --headless-wallet-setup       Prepare the wallet through the app's local
+                                AgenticService CDP bridge before sampling.
+  --cdp-port <port>             Metro/CDP port for --headless-wallet-setup.
+                                Defaults to --expo-dev-url port or ${DEFAULT_CDP_PORT}
   --appium-url <url>            WebDriver endpoint for Appium flows.
                                 Default: ${DEFAULT_APPIUM_URL}
   --reuse-appium                Connect to an already-running Appium server
   --appium-startup-timeout <ms> Appium startup timeout. Default: ${DEFAULT_APPIUM_STARTUP_TIMEOUT_MS}
   --appium-element-timeout <ms> Appium element wait timeout. Default: ${DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS}
+  --expo-dev-url <url>          Load an Expo dev-client Metro URL before
+                                sampling, through Appium. Alias: --metro-url
   --allow-transaction-submit    Required with --flow wallet-send-eth-submit
   --pull-hermes-profile         Run yarn react-native-release-profiler --fromDownload
                                 after the memory run. Android only.
@@ -786,7 +934,7 @@ Examples:
   yarn llm:mobile:memory -- --platform android --iterations 25 --max-pss-growth 40MiB
   yarn llm:mobile:memory -- --platform ios --flow relaunch --sample final --device booted
   yarn llm:mobile:memory -- --platform android --pull-hermes-profile --sourcemap-path ./sourcemaps
-  yarn llm:mobile:memory -- --flow wallet-send-eth-cancel --iterations 10
+  yarn llm:mobile:memory -- --flow wallet-send-eth-cancel --fixture default --headless-wallet-setup --iterations 10
 `;
 }
 
@@ -877,14 +1025,21 @@ async function collectIosMemorySample(
   runner: CommandRunner,
 ): Promise<{ pid: number | null; memory: MobileMemoryMetrics }> {
   const simulatorDevice = options.deviceId ?? 'booted';
-  const result = await runner('xcrun', [
-    'simctl',
-    'spawn',
-    simulatorDevice,
-    'ps',
-    '-axo',
-    'pid=,rss=,vsz=,comm=',
-  ]);
+  let result: CommandResult;
+
+  try {
+    result = await runner('xcrun', [
+      'simctl',
+      'spawn',
+      simulatorDevice,
+      'ps',
+      '-axo',
+      'pid=,rss=,vsz=,comm=',
+    ]);
+  } catch {
+    result = await runner('ps', ['-axo', 'pid=,rss=,vsz=,comm=']);
+  }
+
   const parsed = parseIosPsOutput(result.stdout, options.iosProcessName);
 
   if (!parsed) {
@@ -911,12 +1066,12 @@ async function runFlowIteration(
       await sleep(options.waitAfterFlowMs);
       break;
     case 'wallet-send-eth-cancel':
-      await runWalletSendEthFlow(options, runtime, {
+      await runWalletSendEthFlow(options, runner, runtime, {
         submitTransaction: false,
       });
       break;
     case 'wallet-send-eth-submit':
-      await runWalletSendEthFlow(options, runtime, {
+      await runWalletSendEthFlow(options, runner, runtime, {
         submitTransaction: true,
       });
       break;
@@ -927,6 +1082,7 @@ async function runFlowIteration(
 
 async function runWalletSendEthFlow(
   options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
   runtime: AppiumRuntime,
   { submitTransaction }: { submitTransaction: boolean },
 ): Promise<void> {
@@ -938,6 +1094,11 @@ async function runWalletSendEthFlow(
 
   const appiumDriver = await getAppiumDriver(options, runtime);
 
+  await unlockWalletIfNeeded(appiumDriver, options);
+  if (options.headlessWalletSetup) {
+    await setupHeadlessWallet(options, runner);
+    await sleep(500);
+  }
   await navigateToWalletHome(appiumDriver, options);
   await tapElementById(
     appiumDriver,
@@ -945,6 +1106,10 @@ async function runWalletSendEthFlow(
     WALLET_SEND_BUTTON_ID,
     'Wallet Send',
   );
+  if (options.headlessWalletSetup) {
+    await seedHeadlessEthereumSendState(options, runner);
+    await sleep(250);
+  }
   await tapElementByText(appiumDriver, options, 'Ethereum', 'Ethereum asset');
   await selectSendAmount(appiumDriver, options);
   await tapElementByText(
@@ -953,14 +1118,7 @@ async function runWalletSendEthFlow(
     'Continue',
     'Send amount Continue',
   );
-  await setElementValueById(
-    appiumDriver,
-    options,
-    RECIPIENT_ADDRESS_INPUT_ID,
-    options.recipientAddress,
-    'Recipient address input',
-  );
-  await tapElementById(appiumDriver, options, REVIEW_BUTTON_ID, 'Review');
+  await selectSendRecipient(appiumDriver, options);
   await waitForElementById(
     appiumDriver,
     options,
@@ -974,6 +1132,7 @@ async function runWalletSendEthFlow(
       options,
       CONFIRM_BUTTON_ID,
       'Confirm transaction',
+      { requireEnabled: true },
     );
   } else {
     await tapElementById(
@@ -983,6 +1142,885 @@ async function runWalletSendEthFlow(
       'Cancel transaction',
     );
     await navigateToWalletHome(appiumDriver, options);
+  }
+
+  await sleep(options.waitAfterFlowMs);
+}
+
+async function selectSendRecipient(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+): Promise<void> {
+  if (shouldUseHeadlessFixtureRecipient(options)) {
+    const fixtureRecipient = await findElement(
+      appiumDriver,
+      textSelectors(options.platform, 'Account 2'),
+      'Fixture recipient account',
+      Math.min(options.appiumElementTimeoutMs, 3000),
+    ).catch(() => undefined);
+
+    if (fixtureRecipient) {
+      await fixtureRecipient
+        .waitForEnabled({ timeout: 5000 })
+        .catch(() => undefined);
+      await fixtureRecipient.click();
+      await sleep(250);
+      return;
+    }
+  }
+
+  await setElementValue(
+    appiumDriver,
+    recipientAddressInputSelectors(options.platform),
+    options.recipientAddress,
+    'Recipient address input',
+    options.appiumElementTimeoutMs,
+  );
+  await tapElementById(appiumDriver, options, REVIEW_BUTTON_ID, 'Review', {
+    enabledTimeoutMs: Math.max(options.appiumElementTimeoutMs, 20_000),
+    requireEnabled: true,
+  });
+  await dismissNewAddressWarningIfPresent(appiumDriver, options);
+}
+
+function shouldUseHeadlessFixtureRecipient(
+  options: MobileMemoryProfilerOptions,
+): boolean {
+  return (
+    options.headlessWalletSetup &&
+    options.fixture === 'default' &&
+    options.recipientAddress === DEFAULT_SEND_RECIPIENT_ADDRESS
+  );
+}
+
+async function dismissNewAddressWarningIfPresent(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+): Promise<void> {
+  const continueButton = await findElement(
+    appiumDriver,
+    textSelectors(options.platform, 'Continue'),
+    'New address warning Continue',
+    3000,
+  ).catch(() => undefined);
+
+  if (!continueButton) {
+    return;
+  }
+
+  await continueButton.waitForEnabled({ timeout: 5000 }).catch(() => undefined);
+  await continueButton.click();
+  await sleep(250);
+}
+
+async function startFixtureServer(
+  options: MobileMemoryProfilerOptions,
+): Promise<FixtureServerRuntime | undefined> {
+  if (options.fixture === 'none') {
+    return undefined;
+  }
+
+  const fixture = await loadDefaultFixture(options);
+  const fixtureServer = createFixtureServer(
+    options.fixtureServerPort,
+    fixture,
+  );
+  await fixtureServer.start();
+
+  return fixtureServer;
+}
+
+async function loadDefaultFixture(
+  options: MobileMemoryProfilerOptions,
+): Promise<unknown> {
+  const fixturePath = path.resolve(
+    process.cwd(),
+    'tests/framework/fixtures/json/default-fixture.json',
+  );
+  const rawFixture = await fs.readFile(fixturePath, 'utf8');
+  const fixture = JSON.parse(rawFixture) as Record<string, unknown>;
+  prepareDefaultFixtureForWalletSend(fixture, {
+    ethereumRpcUrl: `${getFixtureServerBaseUrl(options)}${ETH_MAINNET_RPC_PATH}`,
+  });
+  const state = getMutableRecord(fixture.state);
+  const legalNotices = getMutableRecord(state.legalNotices);
+
+  if (legalNotices) {
+    legalNotices.newPrivacyPolicyToastShownDate = Date.now();
+  }
+
+  return fixture;
+}
+
+export function prepareDefaultFixtureForWalletSend(
+  fixture: Record<string, unknown>,
+  options: { ethereumRpcUrl?: string } = {},
+): void {
+  const state = getOrCreateRecord(fixture, 'state');
+  const engineState = getOrCreateRecord(state, 'engine');
+  const backgroundState = getOrCreateRecord(engineState, 'backgroundState');
+  const accountAddress =
+    getSelectedEvmAccountAddress(backgroundState) ??
+    '0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3';
+
+  const currencyRateController = getOrCreateRecord(
+    backgroundState,
+    'CurrencyRateController',
+  );
+  currencyRateController.currentCurrency = 'usd';
+  const currencyRates = getOrCreateRecord(
+    currencyRateController,
+    'currencyRates',
+  );
+  currencyRates.ETH = {
+    conversionDate: Date.now() / 1000,
+    conversionRate: 3000,
+    usdConversionRate: 3000,
+  };
+
+  const accountTrackerController = getOrCreateRecord(
+    backgroundState,
+    'AccountTrackerController',
+  );
+  const legacyAccounts = getOrCreateRecord(accountTrackerController, 'accounts');
+  legacyAccounts[accountAddress] = { balance: DEFAULT_SEND_ETH_BALANCE_WEI };
+  const accountsByChainId = getOrCreateRecord(
+    accountTrackerController,
+    'accountsByChainId',
+  );
+  const mainnetAccounts = getOrCreateRecord(
+    accountsByChainId,
+    ETH_MAINNET_CHAIN_ID,
+  );
+  mainnetAccounts[accountAddress] = { balance: DEFAULT_SEND_ETH_BALANCE_WEI };
+
+  const tokenBalancesController = getOrCreateRecord(
+    backgroundState,
+    'TokenBalancesController',
+  );
+  const tokenBalances = getOrCreateRecord(
+    tokenBalancesController,
+    'tokenBalances',
+  );
+  const accountTokenBalances = getOrCreateRecord(tokenBalances, accountAddress);
+  const mainnetTokenBalances = getOrCreateRecord(
+    accountTokenBalances,
+    ETH_MAINNET_CHAIN_ID,
+  );
+  mainnetTokenBalances[ETH_NATIVE_TOKEN_ADDRESS] =
+    DEFAULT_SEND_ETH_BALANCE_WEI;
+
+  const networkEnablementController = getOrCreateRecord(
+    backgroundState,
+    'NetworkEnablementController',
+  );
+  const enabledNetworkMap = getOrCreateRecord(
+    networkEnablementController,
+    'enabledNetworkMap',
+  );
+  const enabledEvmNetworks = getOrCreateRecord(enabledNetworkMap, 'eip155');
+  enabledEvmNetworks[ETH_MAINNET_CHAIN_ID] = true;
+  const nativeAssetIdentifiers = getOrCreateRecord(
+    networkEnablementController,
+    'nativeAssetIdentifiers',
+  );
+  nativeAssetIdentifiers[ETH_MAINNET_CAIP_CHAIN_ID] = ETH_NATIVE_ASSET_ID;
+
+  const preferencesController = getOrCreateRecord(
+    backgroundState,
+    'PreferencesController',
+  );
+  preferencesController.useTransactionSimulations = false;
+  preferencesController.smartTransactionsOptInStatus = false;
+  preferencesController.securityAlertsEnabled = false;
+
+  if (options.ethereumRpcUrl) {
+    const networkController = getOrCreateRecord(
+      backgroundState,
+      'NetworkController',
+    );
+    const networkConfigurationsByChainId = getOrCreateRecord(
+      networkController,
+      'networkConfigurationsByChainId',
+    );
+    const mainnetConfiguration = getOrCreateRecord(
+      networkConfigurationsByChainId,
+      ETH_MAINNET_CHAIN_ID,
+    );
+    mainnetConfiguration.chainId = ETH_MAINNET_CHAIN_ID;
+    mainnetConfiguration.name = 'Ethereum Main Network';
+    mainnetConfiguration.nativeCurrency = 'ETH';
+    const existingRpcEndpoints = Array.isArray(
+      mainnetConfiguration.rpcEndpoints,
+    )
+      ? (mainnetConfiguration.rpcEndpoints as Record<string, unknown>[])
+      : [];
+    const mainnetInfuraEndpoint = existingRpcEndpoints.find(
+      (endpoint) => endpoint.networkClientId === 'mainnet',
+    ) ?? {
+      failoverUrls: [],
+      networkClientId: 'mainnet',
+      type: 'infura',
+      url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+    };
+    const otherRpcEndpoints = existingRpcEndpoints.filter(
+      (endpoint) =>
+        endpoint.networkClientId !== 'mainnet' &&
+        endpoint.networkClientId !== MEMORY_PROFILER_MAINNET_NETWORK_CLIENT_ID,
+    );
+    mainnetConfiguration.rpcEndpoints = [
+      mainnetInfuraEndpoint,
+      ...otherRpcEndpoints,
+      {
+        failoverUrls: [],
+        name: 'Memory profiler mainnet RPC',
+        networkClientId: MEMORY_PROFILER_MAINNET_NETWORK_CLIENT_ID,
+        type: 'custom',
+        url: options.ethereumRpcUrl,
+      },
+    ];
+    mainnetConfiguration.defaultRpcEndpointIndex =
+      (mainnetConfiguration.rpcEndpoints as unknown[]).length - 1;
+    networkController.selectedNetworkClientId =
+      MEMORY_PROFILER_MAINNET_NETWORK_CLIENT_ID;
+
+    const networksMetadata = getOrCreateRecord(
+      networkController,
+      'networksMetadata',
+    );
+    networksMetadata[MEMORY_PROFILER_MAINNET_NETWORK_CLIENT_ID] = {
+      EIPS: { '1559': true },
+      status: 'available',
+    };
+    networksMetadata.mainnet = networksMetadata.mainnet ?? {
+      EIPS: { '1559': true },
+      status: 'available',
+    };
+  }
+}
+
+function getFixtureServerBaseUrl(options: MobileMemoryProfilerOptions): string {
+  const host = options.platform === 'android' ? '10.0.2.2' : 'localhost';
+  return `http://${host}:${options.fixtureServerPort}`;
+}
+
+function createFixtureServer(
+  port: number,
+  fixture: unknown,
+): FixtureServerRuntime & { start(): Promise<void> } {
+  let stateRequestCount = 0;
+  const waiters = new Set<{
+    requestCountAtStart: number;
+    timeout?: ReturnType<typeof setTimeout>;
+    resolve: () => void;
+    reject: (error: Error) => void;
+  }>();
+
+  const resolveWaiters = () => {
+    for (const waiter of waiters) {
+      if (stateRequestCount <= waiter.requestCountAtStart) {
+        continue;
+      }
+
+      if (waiter.timeout) {
+        clearTimeout(waiter.timeout);
+      }
+
+      waiters.delete(waiter);
+      waiter.resolve();
+    }
+  };
+
+  const rejectWaiters = (error: Error) => {
+    for (const waiter of waiters) {
+      if (waiter.timeout) {
+        clearTimeout(waiter.timeout);
+      }
+
+      waiters.delete(waiter);
+      waiter.reject(error);
+    }
+  };
+
+  const server = createServer((request, response) => {
+    response.setHeader('Access-Control-Allow-Origin', '*');
+    response.setHeader(
+      'Access-Control-Allow-Methods',
+      'GET, POST, PUT, DELETE',
+    );
+    response.setHeader(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept',
+    );
+
+    if (request.method === 'OPTIONS') {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    if (request.method === 'GET' && request.url === '/state.json') {
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify(fixture));
+      response.once('finish', () => {
+        stateRequestCount += 1;
+        resolveWaiters();
+      });
+      return;
+    }
+
+    if (request.method === 'POST' && request.url === ETH_MAINNET_RPC_PATH) {
+      readRequestBody(request)
+        .then((body) => {
+          response.setHeader('Content-Type', 'application/json');
+          response.end(JSON.stringify(createFixtureRpcResponse(body)));
+        })
+        .catch((error: Error) => {
+          response.statusCode = 500;
+          response.end(error.message);
+        });
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end();
+  });
+
+  return {
+    async start() {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.once('listening', () => {
+          server.removeListener('error', reject);
+          resolve();
+        });
+        server.listen({ host: 'localhost', port, exclusive: true });
+      });
+    },
+    async stop() {
+      rejectWaiters(
+        new Error(
+          'Fixture server stopped before the app requested fixture state from /state.json.',
+        ),
+      );
+      await closeServer(server);
+    },
+    waitForNextStateRequest(timeoutMs = FIXTURE_STATE_REQUEST_TIMEOUT_MS) {
+      const requestCountAtStart = stateRequestCount;
+
+      return new Promise<void>((resolve, reject) => {
+        const waiter: {
+          requestCountAtStart: number;
+          timeout?: ReturnType<typeof setTimeout>;
+          resolve: () => void;
+          reject: (error: Error) => void;
+        } = {
+          requestCountAtStart,
+          resolve,
+          reject,
+        };
+        waiter.timeout = setTimeout(() => {
+          waiters.delete(waiter);
+          reject(
+            new Error(
+              `Timed out waiting ${timeoutMs}ms for the app to request fixture state from /state.json.`,
+            ),
+          );
+        }, timeoutMs);
+
+        waiters.add(waiter);
+        resolveWaiters();
+      });
+    },
+  };
+}
+
+function readRequestBody(request: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    request.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    request.on('error', reject);
+  });
+}
+
+function createFixtureRpcResponse(
+  bodyText: string,
+): JsonRpcResponse | JsonRpcResponse[] {
+  const parsedBody = parseJsonRpcBody(bodyText);
+
+  if (Array.isArray(parsedBody)) {
+    return parsedBody.map(createFixtureRpcSingleResponse);
+  }
+
+  return createFixtureRpcSingleResponse(parsedBody);
+}
+
+function parseJsonRpcBody(bodyText: string): JsonRpcPayload | JsonRpcPayload[] {
+  try {
+    const parsed = JSON.parse(bodyText) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.map((payload) =>
+        isJsonRpcPayload(payload) ? payload : {},
+      );
+    }
+
+    return isJsonRpcPayload(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function isJsonRpcPayload(value: unknown): value is JsonRpcPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+  const id = payload.id;
+  return (
+    (id === undefined ||
+      id === null ||
+      typeof id === 'string' ||
+      typeof id === 'number') &&
+    (payload.method === undefined || typeof payload.method === 'string')
+  );
+}
+
+function createFixtureRpcSingleResponse(
+  payload: JsonRpcPayload,
+): JsonRpcResponse {
+  return {
+    id: payload.id ?? 1,
+    jsonrpc: '2.0',
+    result: getFixtureRpcResult(payload.method),
+  };
+}
+
+function getFixtureRpcResult(method?: string): unknown {
+  switch (method) {
+    case 'eth_accounts':
+      return [];
+    case 'eth_blockNumber':
+      return '0x1234567';
+    case 'eth_call':
+      return '0x';
+    case 'eth_chainId':
+      return ETH_MAINNET_CHAIN_ID;
+    case 'eth_createAccessList':
+      return { accessList: [], gasUsed: '0x5208' };
+    case 'eth_estimateGas':
+      return '0x5208';
+    case 'eth_feeHistory':
+      return {
+        baseFeePerGas: ['0x3B9ACA00', '0x3B9ACA00'],
+        gasUsedRatio: [0.5],
+        oldestBlock: '0x1234566',
+        reward: [['0x3B9ACA00']],
+      };
+    case 'eth_gasPrice':
+    case 'eth_maxPriorityFeePerGas':
+      return '0x3B9ACA00';
+    case 'eth_getBalance':
+      return DEFAULT_SEND_ETH_BALANCE_WEI;
+    case 'eth_getBlockByNumber':
+      return {
+        baseFeePerGas: '0x3B9ACA00',
+        gasLimit: '0x1c9c380',
+        gasUsed: '0x5208',
+        hash: '0xabc123',
+        number: '0x1234567',
+        timestamp: `0x${Math.floor(Date.now() / 1000).toString(16)}`,
+        transactions: [],
+      };
+    case 'eth_getCode':
+      return '0x';
+    case 'eth_getLogs':
+      return [];
+    case 'eth_getTransactionByHash':
+    case 'eth_getTransactionReceipt':
+      return null;
+    case 'eth_getTransactionCount':
+      return '0x0';
+    case 'eth_sendRawTransaction':
+      return FAKE_TRANSACTION_HASH;
+    case 'eth_syncing':
+      return false;
+    case 'net_version':
+      return '1';
+    case 'web3_clientVersion':
+      return 'mobile-memory-profiler/1.0.0';
+    default:
+      return '0x';
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.once('close', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+    server.close();
+  });
+}
+
+function getMutableRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function getOrCreateRecord(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const value = parent[key];
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  const record: Record<string, unknown> = {};
+  parent[key] = record;
+  return record;
+}
+
+function getSelectedEvmAccountAddress(
+  backgroundState: Record<string, unknown>,
+): string | undefined {
+  const accountsController = getMutableRecord(
+    backgroundState.AccountsController,
+  );
+  const internalAccounts = getMutableRecord(
+    accountsController.internalAccounts,
+  );
+  const accounts = getMutableRecord(internalAccounts.accounts);
+  const selectedAccountId = internalAccounts.selectedAccount;
+
+  if (typeof selectedAccountId === 'string') {
+    const selectedAccount = getMutableRecord(accounts[selectedAccountId]);
+    const selectedAddress = selectedAccount.address;
+
+    if (typeof selectedAddress === 'string' && isEvmAddress(selectedAddress)) {
+      return selectedAddress;
+    }
+  }
+
+  return Object.values(accounts)
+    .map((account) => getMutableRecord(account).address)
+    .find(
+      (address): address is string =>
+        typeof address === 'string' && isEvmAddress(address),
+    );
+}
+
+function isEvmAddress(address: string): boolean {
+  return /^0x[a-fA-F0-9]{40}$/u.test(address);
+}
+
+async function setupHeadlessWallet(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<void> {
+  const walletFixture = {
+    password: options.walletPassword,
+    accounts: [
+      {
+        type: 'mnemonic',
+        value: options.walletMnemonic,
+      },
+    ],
+    settings: {
+      metametrics: false,
+      skipGtmModals: true,
+      skipPerpsTutorial: true,
+      autoLockNever: true,
+      deviceAuthEnabled: false,
+      disableTransactionSimulations: true,
+      seedEthereumBalanceWei: DEFAULT_SEND_ETH_BALANCE_WEI,
+    },
+  };
+  const expression = `globalThis.__AGENTIC__?.setupWallet(${JSON.stringify(
+    walletFixture,
+  )})`;
+
+  let result: CommandResult;
+  try {
+    result = await runner(
+      'node',
+      ['scripts/perps/agentic/cdp-bridge.js', 'eval-async', expression],
+      {
+        env: {
+          ...process.env,
+          WATCHER_PORT: String(options.cdpPort),
+          CDP_TIMEOUT: String(Math.max(options.appiumStartupTimeoutMs, 30_000)),
+        },
+      },
+    );
+  } catch (error) {
+    throw new Error(
+      `Headless wallet setup failed through Metro CDP on port ${
+        options.cdpPort
+      }: ${(error as Error).message}`,
+    );
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(result.stdout) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `Headless wallet setup returned invalid CDP output: ${result.stdout}`,
+    );
+  }
+
+  if (payload.ok !== true) {
+    throw new Error(
+      `Headless wallet setup failed through Metro CDP on port ${
+        options.cdpPort
+      }: ${String(payload.error ?? 'unknown error')}`,
+    );
+  }
+}
+
+async function seedHeadlessEthereumSendState(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<void> {
+  const expression = `globalThis.__AGENTIC__?.seedEthereumSendState(${JSON.stringify(
+    {
+      balanceWei: DEFAULT_SEND_ETH_BALANCE_WEI,
+    },
+  )})`;
+
+  let result: CommandResult;
+  try {
+    result = await runner(
+      'node',
+      ['scripts/perps/agentic/cdp-bridge.js', 'eval', expression],
+      {
+        env: {
+          ...process.env,
+          WATCHER_PORT: String(options.cdpPort),
+          CDP_TIMEOUT: String(Math.max(options.appiumStartupTimeoutMs, 30_000)),
+        },
+      },
+    );
+  } catch (error) {
+    throw new Error(
+      `Headless Ethereum send state seed failed through Metro CDP on port ${
+        options.cdpPort
+      }: ${(error as Error).message}`,
+    );
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(result.stdout) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `Headless Ethereum send state seed returned invalid CDP output: ${result.stdout}`,
+    );
+  }
+
+  if (payload.ok !== true) {
+    throw new Error(
+      `Headless Ethereum send state seed failed through Metro CDP on port ${
+        options.cdpPort
+      }: ${String(payload.error ?? 'unknown error')}`,
+    );
+  }
+}
+
+async function loadExpoDevClientUrl(
+  options: MobileMemoryProfilerOptions,
+  runtime: AppiumRuntime,
+): Promise<void> {
+  const appiumDriver = await getAppiumDriver(options, runtime);
+
+  if (
+    await isElementVisibleById(
+      appiumDriver,
+      options,
+      WALLET_SEND_BUTTON_ID,
+      'Wallet Send',
+      1000,
+    )
+  ) {
+    return;
+  }
+
+  if (
+    !(await isElementVisible(
+      appiumDriver,
+      expoDevUrlInputSelectors(options.platform),
+      'Expo Dev Launcher URL input',
+      1000,
+    ))
+  ) {
+    if (
+      !(await isElementVisibleByText(
+        appiumDriver,
+        options,
+        'Enter URL manually',
+        1000,
+      ))
+    ) {
+      return;
+    }
+
+    await tapElementByText(
+      appiumDriver,
+      options,
+      'Enter URL manually',
+      'Expo Dev Launcher manual URL control',
+    );
+  }
+
+  const urlInput = await findElement(
+    appiumDriver,
+    expoDevUrlInputSelectors(options.platform),
+    'Expo Dev Launcher URL input',
+    options.appiumElementTimeoutMs,
+  );
+  await urlInput.click();
+  await urlInput.setValue(options.expoDevUrl ?? '');
+
+  await tapElementByText(
+    appiumDriver,
+    options,
+    'Connect',
+    'Expo Dev Launcher Connect',
+  );
+  await waitForExpoDevClientBundle(appiumDriver, options);
+}
+
+async function waitForExpoDevClientBundle(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+): Promise<void> {
+  const deadline = Date.now() + EXPO_DEV_CLIENT_BUNDLE_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const isStillDevLauncher = await isElementVisibleByText(
+      appiumDriver,
+      options,
+      'DEVELOPMENT SERVERS',
+      1000,
+    );
+    const isBundling = await isElementVisibleByText(
+      appiumDriver,
+      options,
+      'Bundling',
+      1000,
+    );
+    const isSplashScreen = await isElementVisibleById(
+      appiumDriver,
+      options,
+      'fox-splash-screen',
+      'MetaMask splash screen',
+      1000,
+    );
+
+    if (!isStillDevLauncher && !isBundling && !isSplashScreen) {
+      await sleep(options.waitAfterFlowMs);
+      return;
+    }
+
+    await sleep(1000);
+  }
+
+  throw new Error(
+    `Expo dev client did not finish loading ${options.expoDevUrl} within ${EXPO_DEV_CLIENT_BUNDLE_TIMEOUT_MS}ms.`,
+  );
+}
+
+async function unlockWalletIfNeeded(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+): Promise<void> {
+  const isLoginVisible = await isElementVisibleById(
+    appiumDriver,
+    options,
+    LOGIN_PASSWORD_INPUT_ID,
+    'Login password input',
+    1500,
+  );
+
+  if (!isLoginVisible) {
+    return;
+  }
+
+  await setElementValueById(
+    appiumDriver,
+    options,
+    LOGIN_PASSWORD_INPUT_ID,
+    options.walletPassword,
+    'Login password input',
+  );
+
+  if (
+    await isElementVisibleById(
+      appiumDriver,
+      options,
+      WALLET_SEND_BUTTON_ID,
+      'Wallet Send',
+      1500,
+    )
+  ) {
+    return;
+  }
+
+  if (
+    !(await isElementVisibleById(
+      appiumDriver,
+      options,
+      LOGIN_PASSWORD_INPUT_ID,
+      'Login password input',
+      500,
+    ))
+  ) {
+    return;
+  }
+
+  if (
+    await isElementVisibleById(
+      appiumDriver,
+      options,
+      LOGIN_BUTTON_ID,
+      'Unlock button',
+      1000,
+    )
+  ) {
+    await tapElementById(appiumDriver, options, LOGIN_BUTTON_ID, 'Unlock');
+  } else {
+    await tapElementByText(appiumDriver, options, 'Unlock', 'Unlock').catch(
+      async (error: Error) => {
+        if (
+          await isElementVisibleById(
+            appiumDriver,
+            options,
+            WALLET_SEND_BUTTON_ID,
+            'Wallet Send',
+            1500,
+          )
+        ) {
+          return;
+        }
+
+        throw error;
+      },
+    );
   }
 
   await sleep(options.waitAfterFlowMs);
@@ -1101,6 +2139,18 @@ async function cleanupAppiumRuntime(runtime: AppiumRuntime): Promise<void> {
   }
 }
 
+async function cleanupFixtureServer(runtime: AppiumRuntime): Promise<void> {
+  if (!runtime.fixtureServer) {
+    return;
+  }
+
+  try {
+    await runtime.fixtureServer.stop();
+  } catch {
+    // Best-effort cleanup; the original profiling error is more useful.
+  }
+}
+
 async function navigateToWalletHome(
   appiumDriver: AppiumDriver,
   options: MobileMemoryProfilerOptions,
@@ -1175,6 +2225,10 @@ async function tapElementById(
   options: MobileMemoryProfilerOptions,
   testId: string,
   description: string,
+  tapOptions: {
+    enabledTimeoutMs?: number;
+    requireEnabled?: boolean;
+  } = {},
 ): Promise<void> {
   const appiumElement = await waitForElementById(
     appiumDriver,
@@ -1182,7 +2236,15 @@ async function tapElementById(
     testId,
     description,
   );
-  await appiumElement.waitForEnabled({ timeout: 5000 }).catch(() => undefined);
+  const enabledTimeoutMs = tapOptions.enabledTimeoutMs ?? 5000;
+  const waitForEnabledPromise = appiumElement.waitForEnabled({
+    timeout: enabledTimeoutMs,
+  });
+  if (tapOptions.requireEnabled) {
+    await waitForEnabledPromise;
+  } else {
+    await waitForEnabledPromise.catch(() => undefined);
+  }
   await appiumElement.click();
   await sleep(250);
 }
@@ -1204,6 +2266,25 @@ async function tapElementByText(
   await sleep(250);
 }
 
+async function setElementValue(
+  appiumDriver: AppiumDriver,
+  selectors: string[],
+  value: string,
+  description: string,
+  timeoutMs: number,
+): Promise<void> {
+  const appiumElement = await findElement(
+    appiumDriver,
+    selectors,
+    description,
+    timeoutMs,
+  );
+  await appiumElement.click();
+  await appiumElement.setValue(value);
+  await appiumDriver.hideKeyboard().catch(() => undefined);
+  await sleep(250);
+}
+
 async function setElementValueById(
   appiumDriver: AppiumDriver,
   options: MobileMemoryProfilerOptions,
@@ -1211,16 +2292,13 @@ async function setElementValueById(
   value: string,
   description: string,
 ): Promise<void> {
-  const appiumElement = await waitForElementById(
+  await setElementValue(
     appiumDriver,
-    options,
-    testId,
+    idSelectors(options.platform, testId),
+    value,
     description,
+    options.appiumElementTimeoutMs,
   );
-  await appiumElement.click();
-  await appiumElement.setValue(value);
-  await appiumDriver.hideKeyboard().catch(() => undefined);
-  await sleep(250);
 }
 
 async function waitForElementById(
@@ -1244,10 +2322,38 @@ async function isElementVisibleById(
   description: string,
   timeoutMs: number,
 ): Promise<boolean> {
+  return isElementVisible(
+    appiumDriver,
+    idSelectors(options.platform, testId),
+    description,
+    timeoutMs,
+  );
+}
+
+async function isElementVisibleByText(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+  text: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  return isElementVisible(
+    appiumDriver,
+    textSelectors(options.platform, text),
+    text,
+    timeoutMs,
+  );
+}
+
+async function isElementVisible(
+  appiumDriver: AppiumDriver,
+  selectors: string[],
+  description: string,
+  timeoutMs: number,
+): Promise<boolean> {
   try {
     const appiumElement = await findElement(
       appiumDriver,
-      idSelectors(options.platform, testId),
+      selectors,
       description,
       timeoutMs,
     );
@@ -1311,6 +2417,19 @@ function idSelectors(
   ];
 }
 
+export function recipientAddressInputSelectors(
+  platform: MobileMemoryPlatform,
+): string[] {
+  return uniqueStrings([
+    ...idSelectors(platform, RECIPIENT_ADDRESS_INPUT_ID),
+    ...textSelectors(platform, RECIPIENT_ADDRESS_PLACEHOLDER),
+  ]);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
 function textSelectors(platform: MobileMemoryPlatform, text: string): string[] {
   if (platform === 'android') {
     return [
@@ -1337,6 +2456,17 @@ function textSelectors(platform: MobileMemoryPlatform, text: string): string[] {
       text,
     )}) or contains(@value, ${xpathLiteral(text)})]`,
   ];
+}
+
+function expoDevUrlInputSelectors(platform: MobileMemoryPlatform): string[] {
+  if (platform === 'android') {
+    return [
+      'android=new UiSelector().className("android.widget.EditText")',
+      '//android.widget.EditText',
+    ];
+  }
+
+  return ['//XCUIElementTypeTextField'];
 }
 
 function parseAppiumEndpoint(appiumUrl: string): AppiumEndpoint {
@@ -1406,6 +2536,8 @@ async function launchApp(
   options: MobileMemoryProfilerOptions,
   runner: CommandRunner,
 ): Promise<void> {
+  const launchArguments = buildLaunchArguments(options);
+
   if (options.platform === 'android') {
     const args = getAdbArgs(options, [
       'shell',
@@ -1415,8 +2547,8 @@ async function launchApp(
       `${options.appId}/${options.androidActivity}`,
     ]);
 
-    if (options.enableInAppProfiler) {
-      args.push('--es', 'enableProfiler', 'true');
+    for (const [key, value] of Object.entries(launchArguments)) {
+      args.push('--es', key, value);
     }
 
     await runner('adb', args);
@@ -1430,11 +2562,37 @@ async function launchApp(
     options.appId,
   ];
 
-  if (options.enableInAppProfiler) {
-    args.push('-enableProfiler', 'true');
+  for (const [key, value] of Object.entries(launchArguments)) {
+    args.push(`-${key}`, value);
   }
 
   await runner('xcrun', args);
+}
+
+function buildLaunchArguments(
+  options: MobileMemoryProfilerOptions,
+): Record<string, string> {
+  const launchArguments: Record<string, string> = {};
+
+  if (options.enableInAppProfiler) {
+    launchArguments.enableProfiler = 'true';
+  }
+
+  if (options.fixture !== 'none') {
+    launchArguments.fixtureServerPort = String(options.fixtureServerPort);
+  }
+
+  return launchArguments;
+}
+
+function shouldTerminateBeforeInitialLaunch(
+  options: MobileMemoryProfilerOptions,
+): boolean {
+  return (
+    options.enableInAppProfiler ||
+    options.fixture !== 'none' ||
+    Boolean(options.expoDevUrl)
+  );
 }
 
 async function terminateApp(
@@ -1507,7 +2665,7 @@ async function maybeRunHermesProfileCli(
 function runCommand(
   command: string,
   args: string[],
-  options: { cwd?: string } = {},
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
     execFile(
@@ -1515,6 +2673,7 @@ function runCommand(
       args,
       {
         cwd: options.cwd,
+        env: options.env,
         encoding: 'utf8',
         maxBuffer: COMMAND_MAX_BUFFER,
       },

--- a/scripts/memory-profiler/mobile-memory-profiler.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.ts
@@ -1,0 +1,1053 @@
+#!/usr/bin/env node
+/* eslint-disable import-x/no-nodejs-modules */
+
+import { execFile } from 'child_process';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const DEFAULT_ARTIFACT_DIR = 'test-artifacts/mobile-memory';
+const DEFAULT_ANDROID_APP_ID = 'io.metamask';
+const DEFAULT_ANDROID_ACTIVITY = 'io.metamask.MainActivity';
+const DEFAULT_IOS_APP_ID = 'io.metamask.MetaMask';
+const DEFAULT_IOS_PROCESS_NAME = 'MetaMask';
+const DEFAULT_ITERATIONS = 5;
+const DEFAULT_WAIT_AFTER_FLOW_MS = 1000;
+const COMMAND_MAX_BUFFER = 50 * 1024 * 1024;
+
+export type MobileMemoryPlatform = 'android' | 'ios';
+export type MobileMemoryFlow = 'idle' | 'relaunch';
+export type MobileMemorySampleMode = 'each' | 'final';
+
+export interface MobileMemoryProfilerOptions {
+  platform: MobileMemoryPlatform;
+  appId: string;
+  androidActivity: string;
+  iosProcessName: string;
+  deviceId?: string;
+  iterations: number;
+  flow: MobileMemoryFlow;
+  artifactDir: string;
+  outputPath: string;
+  sampleMode: MobileMemorySampleMode;
+  launch: boolean;
+  enableInAppProfiler: boolean;
+  waitAfterFlowMs: number;
+  intervalMs: number;
+  pullHermesProfile: boolean;
+  hermesProfilePath?: string;
+  sourcemapPath?: string;
+  maxRssGrowthBytes?: number;
+  maxPssGrowthBytes?: number;
+  maxNativeHeapGrowthBytes?: number;
+  maxJavaHeapGrowthBytes?: number;
+  help: boolean;
+}
+
+export interface MobileMemoryMetrics {
+  rssBytes: number | null;
+  pssBytes: number | null;
+  nativeHeapBytes: number | null;
+  javaHeapBytes: number | null;
+  graphicsBytes: number | null;
+  codeBytes: number | null;
+  stackBytes: number | null;
+  privateOtherBytes: number | null;
+  systemBytes: number | null;
+  swapPssBytes: number | null;
+  virtualSizeBytes: number | null;
+}
+
+export interface MobileMemorySample {
+  label: string;
+  timestamp: string;
+  platform: MobileMemoryPlatform;
+  appId: string;
+  deviceId: string | null;
+  processId: number | null;
+  memory: MobileMemoryMetrics;
+}
+
+export interface MobileMemoryDeltaSummary {
+  rssBytes: number | null;
+  pssBytes: number | null;
+  nativeHeapBytes: number | null;
+  javaHeapBytes: number | null;
+  virtualSizeBytes: number | null;
+}
+
+export interface MobileMemoryThresholdEvaluation {
+  name: 'rssBytes' | 'pssBytes' | 'nativeHeapBytes' | 'javaHeapBytes';
+  limit: number;
+  actual: number | null;
+  unit: 'bytes';
+  passed: boolean;
+}
+
+export interface HermesProfileCliResult {
+  command: string;
+  cwd: string;
+  stdout: string;
+  stderr: string;
+}
+
+export interface MobileMemoryReport {
+  schemaVersion: 1;
+  createdAt: string;
+  options: Omit<MobileMemoryProfilerOptions, 'help'>;
+  target: {
+    platform: MobileMemoryPlatform;
+    appId: string;
+    deviceId: string | null;
+  };
+  samples: MobileMemorySample[];
+  hermesProfileCliResult: HermesProfileCliResult | null;
+  summary: {
+    baseline: MobileMemorySample | null;
+    final: MobileMemorySample | null;
+    deltas: MobileMemoryDeltaSummary;
+    thresholds: MobileMemoryThresholdEvaluation[];
+  };
+}
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string },
+) => Promise<CommandResult>;
+
+const VALID_PLATFORMS: MobileMemoryPlatform[] = ['android', 'ios'];
+const VALID_FLOWS: MobileMemoryFlow[] = ['idle', 'relaunch'];
+const VALID_SAMPLE_MODES: MobileMemorySampleMode[] = ['each', 'final'];
+
+const emptyMemoryMetrics = (): MobileMemoryMetrics => ({
+  rssBytes: null,
+  pssBytes: null,
+  nativeHeapBytes: null,
+  javaHeapBytes: null,
+  graphicsBytes: null,
+  codeBytes: null,
+  stackBytes: null,
+  privateOtherBytes: null,
+  systemBytes: null,
+  swapPssBytes: null,
+  virtualSizeBytes: null,
+});
+
+export function parseMobileMemoryProfilerArgs(
+  argv: string[],
+): MobileMemoryProfilerOptions {
+  const mutableOptions: Partial<MobileMemoryProfilerOptions> = {
+    platform: 'android',
+    androidActivity: DEFAULT_ANDROID_ACTIVITY,
+    iosProcessName: DEFAULT_IOS_PROCESS_NAME,
+    iterations: DEFAULT_ITERATIONS,
+    flow: 'relaunch',
+    artifactDir: DEFAULT_ARTIFACT_DIR,
+    outputPath: '',
+    sampleMode: 'each',
+    launch: true,
+    enableInAppProfiler: false,
+    waitAfterFlowMs: DEFAULT_WAIT_AFTER_FLOW_MS,
+    intervalMs: 0,
+    pullHermesProfile: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '--':
+        break;
+      case '--help':
+      case '-h':
+        mutableOptions.help = true;
+        break;
+      case '--platform':
+        mutableOptions.platform = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_PLATFORMS,
+          arg,
+        );
+        break;
+      case '--app-id':
+        mutableOptions.appId = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--activity':
+      case '--android-activity':
+        mutableOptions.androidActivity = readArgValue(
+          argv,
+          (index += 1),
+          arg,
+        );
+        break;
+      case '--ios-process-name':
+        mutableOptions.iosProcessName = readArgValue(
+          argv,
+          (index += 1),
+          arg,
+        );
+        break;
+      case '--device':
+      case '--device-id':
+      case '--udid':
+        mutableOptions.deviceId = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--iterations':
+        mutableOptions.iterations = parsePositiveInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--flow':
+        mutableOptions.flow = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_FLOWS,
+          arg,
+        );
+        break;
+      case '--artifact-dir':
+        mutableOptions.artifactDir = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--output':
+        mutableOptions.outputPath = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--sample':
+      case '--sample-mode':
+        mutableOptions.sampleMode = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_SAMPLE_MODES,
+          arg,
+        );
+        break;
+      case '--launch':
+        mutableOptions.launch = true;
+        break;
+      case '--no-launch':
+        mutableOptions.launch = false;
+        break;
+      case '--enable-in-app-profiler':
+        mutableOptions.enableInAppProfiler = true;
+        break;
+      case '--wait-after-flow':
+        mutableOptions.waitAfterFlowMs = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--interval':
+        mutableOptions.intervalMs = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--pull-hermes-profile':
+        mutableOptions.pullHermesProfile = true;
+        break;
+      case '--hermes-profile':
+        mutableOptions.hermesProfilePath = path.resolve(
+          readArgValue(argv, (index += 1), arg),
+        );
+        break;
+      case '--sourcemap-path':
+        mutableOptions.sourcemapPath = path.resolve(
+          readArgValue(argv, (index += 1), arg),
+        );
+        break;
+      case '--max-rss-growth':
+        mutableOptions.maxRssGrowthBytes = parseByteSize(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-pss-growth':
+        mutableOptions.maxPssGrowthBytes = parseByteSize(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-native-heap-growth':
+        mutableOptions.maxNativeHeapGrowthBytes = parseByteSize(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-java-heap-growth':
+        mutableOptions.maxJavaHeapGrowthBytes = parseByteSize(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  const platform = mutableOptions.platform ?? 'android';
+  const artifactDir = resolveOutputPath(
+    mutableOptions.artifactDir ?? DEFAULT_ARTIFACT_DIR,
+  );
+  const appId =
+    mutableOptions.appId ??
+    (platform === 'android' ? DEFAULT_ANDROID_APP_ID : DEFAULT_IOS_APP_ID);
+
+  return {
+    platform,
+    appId,
+    androidActivity:
+      mutableOptions.androidActivity ?? DEFAULT_ANDROID_ACTIVITY,
+    iosProcessName:
+      mutableOptions.iosProcessName ?? DEFAULT_IOS_PROCESS_NAME,
+    deviceId: mutableOptions.deviceId,
+    iterations: mutableOptions.iterations ?? DEFAULT_ITERATIONS,
+    flow: mutableOptions.flow ?? 'relaunch',
+    artifactDir,
+    outputPath: mutableOptions.outputPath
+      ? resolveOutputPath(mutableOptions.outputPath)
+      : createDefaultOutputPath(artifactDir, platform),
+    sampleMode: mutableOptions.sampleMode ?? 'each',
+    launch: mutableOptions.launch ?? true,
+    enableInAppProfiler: mutableOptions.enableInAppProfiler ?? false,
+    waitAfterFlowMs:
+      mutableOptions.waitAfterFlowMs ?? DEFAULT_WAIT_AFTER_FLOW_MS,
+    intervalMs: mutableOptions.intervalMs ?? 0,
+    pullHermesProfile: mutableOptions.pullHermesProfile ?? false,
+    hermesProfilePath: mutableOptions.hermesProfilePath,
+    sourcemapPath: mutableOptions.sourcemapPath,
+    maxRssGrowthBytes: mutableOptions.maxRssGrowthBytes,
+    maxPssGrowthBytes: mutableOptions.maxPssGrowthBytes,
+    maxNativeHeapGrowthBytes: mutableOptions.maxNativeHeapGrowthBytes,
+    maxJavaHeapGrowthBytes: mutableOptions.maxJavaHeapGrowthBytes,
+    help: mutableOptions.help ?? false,
+  };
+}
+
+export function parseByteSize(value: string, optionName = 'value'): number {
+  const match = value
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\s*(b|kb|kib|mb|mib|gb|gib)?$/iu);
+
+  if (!match) {
+    throw new Error(
+      `${optionName} must be a byte size such as 5000000, 25mb, or 25MiB`,
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2]?.toLowerCase() ?? 'b';
+  const multiplier =
+    {
+      b: 1,
+      kb: 1000,
+      kib: 1024,
+      mb: 1000 * 1000,
+      mib: 1024 * 1024,
+      gb: 1000 * 1000 * 1000,
+      gib: 1024 * 1024 * 1024,
+    }[unit] ?? 1;
+
+  return Math.round(amount * multiplier);
+}
+
+export function parseAndroidMeminfo(
+  meminfoOutput: string,
+): MobileMemoryMetrics {
+  const metrics = emptyMemoryMetrics();
+  metrics.pssBytes = parseKbMatch(meminfoOutput, /TOTAL\s+PSS:\s+([\d,]+)/iu);
+  metrics.rssBytes = parseKbMatch(meminfoOutput, /TOTAL\s+RSS:\s+([\d,]+)/iu);
+  metrics.swapPssBytes = parseKbMatch(
+    meminfoOutput,
+    /TOTAL\s+SWAP\s+PSS:\s+([\d,]+)/iu,
+  );
+
+  for (const rawLine of meminfoOutput.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    const match = line.match(
+      /^(Java Heap|Native Heap|Code|Stack|Graphics|Private Other|System):\s+([\d,]+)(?:\s+([\d,]+))?/iu,
+    );
+
+    if (!match) {
+      continue;
+    }
+
+    const label = match[1].toLowerCase();
+    const pssBytes = kbStringToBytes(match[2]);
+    const rssBytes = match[3] ? kbStringToBytes(match[3]) : null;
+
+    switch (label) {
+      case 'java heap':
+        metrics.javaHeapBytes = pssBytes;
+        break;
+      case 'native heap':
+        metrics.nativeHeapBytes = pssBytes;
+        break;
+      case 'code':
+        metrics.codeBytes = pssBytes;
+        break;
+      case 'stack':
+        metrics.stackBytes = pssBytes;
+        break;
+      case 'graphics':
+        metrics.graphicsBytes = pssBytes;
+        break;
+      case 'private other':
+        metrics.privateOtherBytes = pssBytes;
+        break;
+      case 'system':
+        metrics.systemBytes = pssBytes;
+        break;
+      default:
+        break;
+    }
+
+    if (label === 'native heap' && metrics.rssBytes === null) {
+      metrics.rssBytes = rssBytes;
+    }
+  }
+
+  return metrics;
+}
+
+export function parseIosPsOutput(
+  psOutput: string,
+  processName: string,
+): { pid: number; memory: MobileMemoryMetrics } | null {
+  const candidates = psOutput
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/u);
+      if (!match) {
+        return null;
+      }
+      return {
+        pid: Number(match[1]),
+        rssBytes: kbStringToBytes(match[2]),
+        virtualSizeBytes: kbStringToBytes(match[3]),
+        command: match[4],
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+    .filter((entry) => {
+      const commandBaseName = path.basename(entry.command);
+      return (
+        commandBaseName === processName ||
+        entry.command.includes(`/${processName}.app/`) ||
+        entry.command.includes(processName)
+      );
+    });
+
+  const selected = candidates[0];
+  if (!selected) {
+    return null;
+  }
+
+  return {
+    pid: selected.pid,
+    memory: {
+      ...emptyMemoryMetrics(),
+      rssBytes: selected.rssBytes,
+      virtualSizeBytes: selected.virtualSizeBytes,
+    },
+  };
+}
+
+export function calculateDeltas(
+  baseline: MobileMemorySample | null,
+  final: MobileMemorySample | null,
+): MobileMemoryDeltaSummary {
+  return {
+    rssBytes: delta(baseline?.memory.rssBytes, final?.memory.rssBytes),
+    pssBytes: delta(baseline?.memory.pssBytes, final?.memory.pssBytes),
+    nativeHeapBytes: delta(
+      baseline?.memory.nativeHeapBytes,
+      final?.memory.nativeHeapBytes,
+    ),
+    javaHeapBytes: delta(
+      baseline?.memory.javaHeapBytes,
+      final?.memory.javaHeapBytes,
+    ),
+    virtualSizeBytes: delta(
+      baseline?.memory.virtualSizeBytes,
+      final?.memory.virtualSizeBytes,
+    ),
+  };
+}
+
+export function evaluateThresholds(
+  options: Pick<
+    MobileMemoryProfilerOptions,
+    | 'maxRssGrowthBytes'
+    | 'maxPssGrowthBytes'
+    | 'maxNativeHeapGrowthBytes'
+    | 'maxJavaHeapGrowthBytes'
+  >,
+  deltas: MobileMemoryDeltaSummary,
+): MobileMemoryThresholdEvaluation[] {
+  const thresholds: MobileMemoryThresholdEvaluation[] = [];
+
+  if (options.maxRssGrowthBytes !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'rssBytes',
+        limit: options.maxRssGrowthBytes,
+        actual: deltas.rssBytes,
+      }),
+    );
+  }
+
+  if (options.maxPssGrowthBytes !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'pssBytes',
+        limit: options.maxPssGrowthBytes,
+        actual: deltas.pssBytes,
+      }),
+    );
+  }
+
+  if (options.maxNativeHeapGrowthBytes !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'nativeHeapBytes',
+        limit: options.maxNativeHeapGrowthBytes,
+        actual: deltas.nativeHeapBytes,
+      }),
+    );
+  }
+
+  if (options.maxJavaHeapGrowthBytes !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'javaHeapBytes',
+        limit: options.maxJavaHeapGrowthBytes,
+        actual: deltas.javaHeapBytes,
+      }),
+    );
+  }
+
+  return thresholds;
+}
+
+export function createMobileMemoryReport({
+  createdAt,
+  options,
+  samples,
+  hermesProfileCliResult,
+}: {
+  createdAt: string;
+  options: MobileMemoryProfilerOptions;
+  samples: MobileMemorySample[];
+  hermesProfileCliResult: HermesProfileCliResult | null;
+}): MobileMemoryReport {
+  const baseline = samples[0] ?? null;
+  const final = samples[samples.length - 1] ?? null;
+  const deltas = calculateDeltas(baseline, final);
+  const { help: _help, ...serializedOptions } = options;
+
+  return {
+    schemaVersion: 1,
+    createdAt,
+    options: serializedOptions,
+    target: {
+      platform: options.platform,
+      appId: options.appId,
+      deviceId: options.deviceId ?? null,
+    },
+    samples,
+    hermesProfileCliResult,
+    summary: {
+      baseline,
+      final,
+      deltas,
+      thresholds: evaluateThresholds(options, deltas),
+    },
+  };
+}
+
+export async function runMobileMemoryProfiler(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner = runCommand,
+): Promise<MobileMemoryReport> {
+  const samples: MobileMemorySample[] = [];
+  await fs.mkdir(options.artifactDir, { recursive: true });
+
+  if (options.launch) {
+    await launchApp(options, runner);
+    await sleep(options.waitAfterFlowMs);
+  }
+
+  samples.push(await collectMemorySample(options, 'baseline', runner));
+
+  for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
+    await runFlowIteration(options, runner);
+
+    if (options.sampleMode === 'each') {
+      samples.push(
+        await collectMemorySample(options, `iteration-${iteration}`, runner),
+      );
+    }
+
+    if (options.intervalMs > 0 && iteration < options.iterations) {
+      await sleep(options.intervalMs);
+    }
+  }
+
+  if (options.sampleMode === 'final') {
+    samples.push(await collectMemorySample(options, 'final', runner));
+  }
+
+  const hermesProfileCliResult = await maybeRunHermesProfileCli(
+    options,
+    runner,
+  );
+  const report = createMobileMemoryReport({
+    createdAt: new Date().toISOString(),
+    options,
+    samples,
+    hermesProfileCliResult,
+  });
+
+  await fs.mkdir(path.dirname(options.outputPath), { recursive: true });
+  await fs.writeFile(options.outputPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  return report;
+}
+
+export function formatBytes(value: number | null): string {
+  if (value === null) {
+    return 'n/a';
+  }
+
+  return `${(value / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+export function getHelpText(): string {
+  return `Usage: yarn llm:mobile:memory -- [options]
+
+Collect native process memory telemetry for MetaMask Mobile leak investigation.
+
+Options:
+  --platform <name>             android, ios. Default: android
+  --app-id <id>                 Android package or iOS bundle id.
+                                Defaults: ${DEFAULT_ANDROID_APP_ID} / ${DEFAULT_IOS_APP_ID}
+  --activity <name>             Android launchable activity. Default: ${DEFAULT_ANDROID_ACTIVITY}
+  --ios-process-name <name>     iOS simulator process name. Default: ${DEFAULT_IOS_PROCESS_NAME}
+  --device <id>                 adb serial or simctl device id. Default: adb default / booted sim
+  --iterations <n>              Number of flow iterations. Default: ${DEFAULT_ITERATIONS}
+  --flow <name>                 idle, relaunch. Default: relaunch
+  --artifact-dir <path>         Artifact directory. Default: ${DEFAULT_ARTIFACT_DIR}
+  --output <path>               JSON report path
+  --sample <mode>               each, final. Default: each
+  --launch / --no-launch        Launch app before baseline. Default: launch
+  --enable-in-app-profiler      Pass enableProfiler=true when launching the app
+  --wait-after-flow <ms>        Delay after app launch/flow step. Default: ${DEFAULT_WAIT_AFTER_FLOW_MS}
+  --interval <ms>               Delay between iterations. Default: 0
+  --pull-hermes-profile         Run yarn react-native-release-profiler --fromDownload
+                                after the memory run. Android only.
+  --hermes-profile <path>       Convert a local .cpuprofile with react-native-release-profiler
+  --sourcemap-path <path>       Sourcemap path passed to react-native-release-profiler
+  --max-rss-growth <size>       Fail if RSS grows above size
+  --max-pss-growth <size>       Fail if Android PSS grows above size
+  --max-native-heap-growth <size>
+                                Fail if Android native heap PSS grows above size
+  --max-java-heap-growth <size> Fail if Android Java heap PSS grows above size
+  --help                        Show this help text
+
+Examples:
+  yarn llm:mobile:memory -- --platform android --iterations 25 --max-pss-growth 40MiB
+  yarn llm:mobile:memory -- --platform ios --flow relaunch --sample final --device booted
+  yarn llm:mobile:memory -- --platform android --pull-hermes-profile --sourcemap-path ./sourcemaps
+`;
+}
+
+async function main(): Promise<void> {
+  const options = parseMobileMemoryProfilerArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(getHelpText());
+    return;
+  }
+
+  const report = await runMobileMemoryProfiler(options);
+  const failedThresholds = report.summary.thresholds.filter(
+    (threshold) => !threshold.passed,
+  );
+
+  console.log(`Mobile memory report: ${options.outputPath}`);
+  console.log(`RSS delta: ${formatBytes(report.summary.deltas.rssBytes)}`);
+  console.log(`PSS delta: ${formatBytes(report.summary.deltas.pssBytes)}`);
+  console.log(
+    `Native heap delta: ${formatBytes(report.summary.deltas.nativeHeapBytes)}`,
+  );
+  console.log(
+    `Java heap delta: ${formatBytes(report.summary.deltas.javaHeapBytes)}`,
+  );
+  console.log(
+    `Virtual size delta: ${formatBytes(
+      report.summary.deltas.virtualSizeBytes,
+    )}`,
+  );
+
+  if (report.hermesProfileCliResult) {
+    console.log(
+      `Hermes profile CLI output directory: ${report.hermesProfileCliResult.cwd}`,
+    );
+  }
+
+  if (failedThresholds.length > 0) {
+    for (const threshold of failedThresholds) {
+      console.error(
+        `Memory threshold failed: ${threshold.name} grew by ${formatBytes(
+          threshold.actual,
+        )}, limit ${formatBytes(threshold.limit)}`,
+      );
+    }
+    process.exitCode = 1;
+  }
+}
+
+async function collectMemorySample(
+  options: MobileMemoryProfilerOptions,
+  label: string,
+  runner: CommandRunner,
+): Promise<MobileMemorySample> {
+  const result =
+    options.platform === 'android'
+      ? await collectAndroidMemorySample(options, runner)
+      : await collectIosMemorySample(options, runner);
+
+  return {
+    label,
+    timestamp: new Date().toISOString(),
+    platform: options.platform,
+    appId: options.appId,
+    deviceId: options.deviceId ?? (options.platform === 'ios' ? 'booted' : null),
+    processId: result.pid,
+    memory: result.memory,
+  };
+}
+
+async function collectAndroidMemorySample(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<{ pid: number | null; memory: MobileMemoryMetrics }> {
+  const [pid, meminfo] = await Promise.all([
+    getAndroidPid(options, runner),
+    runner('adb', getAdbArgs(options, ['shell', 'dumpsys', 'meminfo', options.appId])),
+  ]);
+
+  return {
+    pid,
+    memory: parseAndroidMeminfo(meminfo.stdout),
+  };
+}
+
+async function collectIosMemorySample(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<{ pid: number | null; memory: MobileMemoryMetrics }> {
+  const simulatorDevice = options.deviceId ?? 'booted';
+  const result = await runner('xcrun', [
+    'simctl',
+    'spawn',
+    simulatorDevice,
+    'ps',
+    '-axo',
+    'pid=,rss=,vsz=,comm=',
+  ]);
+  const parsed = parseIosPsOutput(result.stdout, options.iosProcessName);
+
+  if (!parsed) {
+    throw new Error(
+      `Could not find iOS simulator process "${options.iosProcessName}" in ps output`,
+    );
+  }
+
+  return parsed;
+}
+
+async function runFlowIteration(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<void> {
+  switch (options.flow) {
+    case 'idle':
+      await sleep(options.waitAfterFlowMs);
+      break;
+    case 'relaunch':
+      await terminateApp(options, runner);
+      await launchApp(options, runner);
+      await sleep(options.waitAfterFlowMs);
+      break;
+    default:
+      assertUnreachable(options.flow);
+  }
+}
+
+async function launchApp(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<void> {
+  if (options.platform === 'android') {
+    const args = getAdbArgs(options, [
+      'shell',
+      'am',
+      'start',
+      '-n',
+      `${options.appId}/${options.androidActivity}`,
+    ]);
+
+    if (options.enableInAppProfiler) {
+      args.push('--es', 'enableProfiler', 'true');
+    }
+
+    await runner('adb', args);
+    return;
+  }
+
+  const args = [
+    'simctl',
+    'launch',
+    options.deviceId ?? 'booted',
+    options.appId,
+  ];
+
+  if (options.enableInAppProfiler) {
+    args.push('-enableProfiler', 'true');
+  }
+
+  await runner('xcrun', args);
+}
+
+async function terminateApp(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<void> {
+  if (options.platform === 'android') {
+    await runner('adb', getAdbArgs(options, ['shell', 'am', 'force-stop', options.appId]));
+    return;
+  }
+
+  await runner('xcrun', [
+    'simctl',
+    'terminate',
+    options.deviceId ?? 'booted',
+    options.appId,
+  ]);
+}
+
+async function getAndroidPid(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<number | null> {
+  try {
+    const result = await runner(
+      'adb',
+      getAdbArgs(options, ['shell', 'pidof', options.appId]),
+    );
+    const firstPid = result.stdout.trim().split(/\s+/u)[0];
+    return firstPid ? Number(firstPid) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function maybeRunHermesProfileCli(
+  options: MobileMemoryProfilerOptions,
+  runner: CommandRunner,
+): Promise<HermesProfileCliResult | null> {
+  if (!options.pullHermesProfile && !options.hermesProfilePath) {
+    return null;
+  }
+
+  if (options.pullHermesProfile && options.platform !== 'android') {
+    throw new Error('--pull-hermes-profile is supported only for Android');
+  }
+
+  const args = ['react-native-release-profiler'];
+
+  if (options.hermesProfilePath) {
+    args.push('--local', options.hermesProfilePath);
+  } else {
+    args.push('--fromDownload', '--appId', options.appId);
+  }
+
+  if (options.sourcemapPath) {
+    args.push('--sourcemap-path', options.sourcemapPath);
+  }
+
+  const result = await runner('yarn', args, { cwd: options.artifactDir });
+
+  return {
+    command: ['yarn', ...args].join(' '),
+    cwd: options.artifactDir,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd?: string } = {},
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      {
+        cwd: options.cwd,
+        encoding: 'utf8',
+        maxBuffer: COMMAND_MAX_BUFFER,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const stderrText = typeof stderr === 'string' ? stderr : '';
+          const stdoutText = typeof stdout === 'string' ? stdout : '';
+          reject(
+            new Error(
+              `${command} ${args.join(' ')} failed: ${
+                stderrText || stdoutText || error.message
+              }`,
+            ),
+          );
+          return;
+        }
+
+        resolve({
+          stdout: typeof stdout === 'string' ? stdout : '',
+          stderr: typeof stderr === 'string' ? stderr : '',
+        });
+      },
+    );
+  });
+}
+
+function getAdbArgs(
+  options: Pick<MobileMemoryProfilerOptions, 'deviceId'>,
+  args: string[],
+): string[] {
+  return options.deviceId ? ['-s', options.deviceId, ...args] : args;
+}
+
+function createThresholdEvaluation({
+  name,
+  limit,
+  actual,
+}: Pick<
+  MobileMemoryThresholdEvaluation,
+  'name' | 'limit' | 'actual'
+>): MobileMemoryThresholdEvaluation {
+  return {
+    name,
+    limit,
+    actual,
+    unit: 'bytes',
+    passed: actual !== null && actual <= limit,
+  };
+}
+
+function readArgValue(
+  argv: string[],
+  valueIndex: number,
+  optionName: string,
+): string {
+  const value = argv[valueIndex];
+
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+
+  return value;
+}
+
+function parsePositiveInteger(value: string, optionName: string): number {
+  const parsed = parseNonNegativeInteger(value, optionName);
+
+  if (parsed < 1) {
+    throw new Error(`${optionName} must be greater than 0`);
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeInteger(value: string, optionName: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${optionName} must be a non-negative integer`);
+  }
+
+  return parsed;
+}
+
+function parseChoice<Choice extends string>(
+  value: string,
+  validValues: readonly Choice[],
+  optionName: string,
+): Choice {
+  if (!validValues.includes(value as Choice)) {
+    throw new Error(`${optionName} must be one of: ${validValues.join(', ')}`);
+  }
+
+  return value as Choice;
+}
+
+function parseKbMatch(input: string, regex: RegExp): number | null {
+  const match = input.match(regex);
+  return match?.[1] ? kbStringToBytes(match[1]) : null;
+}
+
+function kbStringToBytes(value: string): number {
+  return Number(value.replace(/,/gu, '')) * 1024;
+}
+
+function delta(
+  baselineValue: number | null | undefined,
+  finalValue: number | null | undefined,
+): number | null {
+  if (baselineValue === null || baselineValue === undefined) {
+    return null;
+  }
+
+  if (finalValue === null || finalValue === undefined) {
+    return null;
+  }
+
+  return finalValue - baselineValue;
+}
+
+function resolveOutputPath(outputPath: string): string {
+  return path.isAbsolute(outputPath) ? outputPath : path.resolve(outputPath);
+}
+
+function createDefaultOutputPath(
+  artifactDir: string,
+  platform: MobileMemoryPlatform,
+): string {
+  return path.join(
+    artifactDir,
+    `mobile-${platform}-memory-profile-${Date.now()}.json`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function assertUnreachable(value: never): never {
+  throw new Error(`Unexpected value: ${value}`);
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  main().catch((error: Error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/memory-profiler/mobile-memory-profiler.ts
+++ b/scripts/memory-profiler/mobile-memory-profiler.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable import-x/no-nodejs-modules */
 
-import { execFile } from 'child_process';
+import { execFile, type ChildProcess } from 'child_process';
 import path from 'path';
 import { promises as fs } from 'fs';
 
@@ -12,10 +12,20 @@ const DEFAULT_IOS_APP_ID = 'io.metamask.MetaMask';
 const DEFAULT_IOS_PROCESS_NAME = 'MetaMask';
 const DEFAULT_ITERATIONS = 5;
 const DEFAULT_WAIT_AFTER_FLOW_MS = 1000;
+const DEFAULT_SEND_RECIPIENT_ADDRESS =
+  '0x0000000000000000000000000000000000000001';
+const DEFAULT_SEND_AMOUNT = '25%';
+const DEFAULT_APPIUM_URL = 'http://127.0.0.1:4723/';
+const DEFAULT_APPIUM_STARTUP_TIMEOUT_MS = 60_000;
+const DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS = 20_000;
 const COMMAND_MAX_BUFFER = 50 * 1024 * 1024;
 
 export type MobileMemoryPlatform = 'android' | 'ios';
-export type MobileMemoryFlow = 'idle' | 'relaunch';
+export type MobileMemoryFlow =
+  | 'idle'
+  | 'relaunch'
+  | 'wallet-send-eth-cancel'
+  | 'wallet-send-eth-submit';
 export type MobileMemorySampleMode = 'each' | 'final';
 
 export interface MobileMemoryProfilerOptions {
@@ -33,6 +43,13 @@ export interface MobileMemoryProfilerOptions {
   enableInAppProfiler: boolean;
   waitAfterFlowMs: number;
   intervalMs: number;
+  recipientAddress: string;
+  sendAmount: string;
+  appiumUrl: string;
+  reuseAppium: boolean;
+  appiumStartupTimeoutMs: number;
+  appiumElementTimeoutMs: number;
+  allowTransactionSubmit: boolean;
   pullHermesProfile: boolean;
   hermesProfilePath?: string;
   sourcemapPath?: string;
@@ -120,9 +137,47 @@ export type CommandRunner = (
   options?: { cwd?: string },
 ) => Promise<CommandResult>;
 
+interface AppiumDriver {
+  $(selector: string): AppiumElement;
+  back(): Promise<void>;
+  deleteSession(): Promise<void>;
+  hideKeyboard(): Promise<void>;
+}
+
+interface AppiumElement {
+  click(): Promise<void>;
+  isDisplayed(): Promise<boolean>;
+  setValue(value: string): Promise<void>;
+  waitForDisplayed(options?: { timeout?: number }): Promise<boolean>;
+  waitForEnabled(options?: { timeout?: number }): Promise<boolean>;
+}
+
+interface AppiumRuntime {
+  driver?: AppiumDriver;
+  serverProcess?: ChildProcess;
+}
+
+interface AppiumEndpoint {
+  protocol: 'http' | 'https';
+  hostname: string;
+  port: number;
+  path: string;
+}
+
 const VALID_PLATFORMS: MobileMemoryPlatform[] = ['android', 'ios'];
-const VALID_FLOWS: MobileMemoryFlow[] = ['idle', 'relaunch'];
+const VALID_FLOWS: MobileMemoryFlow[] = [
+  'idle',
+  'relaunch',
+  'wallet-send-eth-cancel',
+  'wallet-send-eth-submit',
+];
 const VALID_SAMPLE_MODES: MobileMemorySampleMode[] = ['each', 'final'];
+const PERCENTAGE_AMOUNTS = new Set(['25', '50', '75', '100']);
+const WALLET_SEND_BUTTON_ID = 'wallet-send-button';
+const RECIPIENT_ADDRESS_INPUT_ID = 'recipient-address-input';
+const REVIEW_BUTTON_ID = 'review-button';
+const CONFIRM_BUTTON_ID = 'confirm-button';
+const CANCEL_BUTTON_ID = 'cancel-button';
 
 const emptyMemoryMetrics = (): MobileMemoryMetrics => ({
   rssBytes: null,
@@ -154,6 +209,13 @@ export function parseMobileMemoryProfilerArgs(
     enableInAppProfiler: false,
     waitAfterFlowMs: DEFAULT_WAIT_AFTER_FLOW_MS,
     intervalMs: 0,
+    recipientAddress: DEFAULT_SEND_RECIPIENT_ADDRESS,
+    sendAmount: DEFAULT_SEND_AMOUNT,
+    appiumUrl: DEFAULT_APPIUM_URL,
+    reuseAppium: false,
+    appiumStartupTimeoutMs: DEFAULT_APPIUM_STARTUP_TIMEOUT_MS,
+    appiumElementTimeoutMs: DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS,
+    allowTransactionSubmit: false,
     pullHermesProfile: false,
     help: false,
   };
@@ -246,6 +308,34 @@ export function parseMobileMemoryProfilerArgs(
           arg,
         );
         break;
+      case '--recipient':
+      case '--recipient-address':
+        mutableOptions.recipientAddress = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--send-amount':
+        mutableOptions.sendAmount = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--appium-url':
+        mutableOptions.appiumUrl = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--reuse-appium':
+        mutableOptions.reuseAppium = true;
+        break;
+      case '--appium-startup-timeout':
+        mutableOptions.appiumStartupTimeoutMs = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--appium-element-timeout':
+        mutableOptions.appiumElementTimeoutMs = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--allow-transaction-submit':
+        mutableOptions.allowTransactionSubmit = true;
+        break;
       case '--pull-hermes-profile':
         mutableOptions.pullHermesProfile = true;
         break;
@@ -316,6 +406,18 @@ export function parseMobileMemoryProfilerArgs(
     waitAfterFlowMs:
       mutableOptions.waitAfterFlowMs ?? DEFAULT_WAIT_AFTER_FLOW_MS,
     intervalMs: mutableOptions.intervalMs ?? 0,
+    recipientAddress:
+      mutableOptions.recipientAddress ?? DEFAULT_SEND_RECIPIENT_ADDRESS,
+    sendAmount: mutableOptions.sendAmount ?? DEFAULT_SEND_AMOUNT,
+    appiumUrl: mutableOptions.appiumUrl ?? DEFAULT_APPIUM_URL,
+    reuseAppium: mutableOptions.reuseAppium ?? false,
+    appiumStartupTimeoutMs:
+      mutableOptions.appiumStartupTimeoutMs ??
+      DEFAULT_APPIUM_STARTUP_TIMEOUT_MS,
+    appiumElementTimeoutMs:
+      mutableOptions.appiumElementTimeoutMs ??
+      DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS,
+    allowTransactionSubmit: mutableOptions.allowTransactionSubmit ?? false,
     pullHermesProfile: mutableOptions.pullHermesProfile ?? false,
     hermesProfilePath: mutableOptions.hermesProfilePath,
     sourcemapPath: mutableOptions.sourcemapPath,
@@ -575,48 +677,57 @@ export async function runMobileMemoryProfiler(
   runner: CommandRunner = runCommand,
 ): Promise<MobileMemoryReport> {
   const samples: MobileMemorySample[] = [];
-  await fs.mkdir(options.artifactDir, { recursive: true });
+  const runtime: AppiumRuntime = {};
 
-  if (options.launch) {
-    await launchApp(options, runner);
-    await sleep(options.waitAfterFlowMs);
-  }
+  try {
+    await fs.mkdir(options.artifactDir, { recursive: true });
 
-  samples.push(await collectMemorySample(options, 'baseline', runner));
-
-  for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
-    await runFlowIteration(options, runner);
-
-    if (options.sampleMode === 'each') {
-      samples.push(
-        await collectMemorySample(options, `iteration-${iteration}`, runner),
-      );
+    if (options.launch) {
+      await launchApp(options, runner);
+      await sleep(options.waitAfterFlowMs);
     }
 
-    if (options.intervalMs > 0 && iteration < options.iterations) {
-      await sleep(options.intervalMs);
+    samples.push(await collectMemorySample(options, 'baseline', runner));
+
+    for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
+      await runFlowIteration(options, runner, runtime);
+
+      if (options.sampleMode === 'each') {
+        samples.push(
+          await collectMemorySample(options, `iteration-${iteration}`, runner),
+        );
+      }
+
+      if (options.intervalMs > 0 && iteration < options.iterations) {
+        await sleep(options.intervalMs);
+      }
     }
+
+    if (options.sampleMode === 'final') {
+      samples.push(await collectMemorySample(options, 'final', runner));
+    }
+
+    const hermesProfileCliResult = await maybeRunHermesProfileCli(
+      options,
+      runner,
+    );
+    const report = createMobileMemoryReport({
+      createdAt: new Date().toISOString(),
+      options,
+      samples,
+      hermesProfileCliResult,
+    });
+
+    await fs.mkdir(path.dirname(options.outputPath), { recursive: true });
+    await fs.writeFile(
+      options.outputPath,
+      `${JSON.stringify(report, null, 2)}\n`,
+    );
+
+    return report;
+  } finally {
+    await cleanupAppiumRuntime(runtime);
   }
-
-  if (options.sampleMode === 'final') {
-    samples.push(await collectMemorySample(options, 'final', runner));
-  }
-
-  const hermesProfileCliResult = await maybeRunHermesProfileCli(
-    options,
-    runner,
-  );
-  const report = createMobileMemoryReport({
-    createdAt: new Date().toISOString(),
-    options,
-    samples,
-    hermesProfileCliResult,
-  });
-
-  await fs.mkdir(path.dirname(options.outputPath), { recursive: true });
-  await fs.writeFile(options.outputPath, `${JSON.stringify(report, null, 2)}\n`);
-
-  return report;
 }
 
 export function formatBytes(value: number | null): string {
@@ -640,7 +751,8 @@ Options:
   --ios-process-name <name>     iOS simulator process name. Default: ${DEFAULT_IOS_PROCESS_NAME}
   --device <id>                 adb serial or simctl device id. Default: adb default / booted sim
   --iterations <n>              Number of flow iterations. Default: ${DEFAULT_ITERATIONS}
-  --flow <name>                 idle, relaunch. Default: relaunch
+  --flow <name>                 idle, relaunch, wallet-send-eth-cancel,
+                                wallet-send-eth-submit. Default: relaunch
   --artifact-dir <path>         Artifact directory. Default: ${DEFAULT_ARTIFACT_DIR}
   --output <path>               JSON report path
   --sample <mode>               each, final. Default: each
@@ -648,6 +760,17 @@ Options:
   --enable-in-app-profiler      Pass enableProfiler=true when launching the app
   --wait-after-flow <ms>        Delay after app launch/flow step. Default: ${DEFAULT_WAIT_AFTER_FLOW_MS}
   --interval <ms>               Delay between iterations. Default: 0
+  --recipient-address <addr>    Recipient for wallet-send-eth-* flows.
+                                Default: ${DEFAULT_SEND_RECIPIENT_ADDRESS}
+  --send-amount <value>         Amount for wallet-send-eth-* flows.
+                                Supports keypad values like 0.001 or percentages
+                                25%, 50%, 75%, 100%, max. Default: ${DEFAULT_SEND_AMOUNT}
+  --appium-url <url>            WebDriver endpoint for Appium flows.
+                                Default: ${DEFAULT_APPIUM_URL}
+  --reuse-appium                Connect to an already-running Appium server
+  --appium-startup-timeout <ms> Appium startup timeout. Default: ${DEFAULT_APPIUM_STARTUP_TIMEOUT_MS}
+  --appium-element-timeout <ms> Appium element wait timeout. Default: ${DEFAULT_APPIUM_ELEMENT_TIMEOUT_MS}
+  --allow-transaction-submit    Required with --flow wallet-send-eth-submit
   --pull-hermes-profile         Run yarn react-native-release-profiler --fromDownload
                                 after the memory run. Android only.
   --hermes-profile <path>       Convert a local .cpuprofile with react-native-release-profiler
@@ -663,6 +786,7 @@ Examples:
   yarn llm:mobile:memory -- --platform android --iterations 25 --max-pss-growth 40MiB
   yarn llm:mobile:memory -- --platform ios --flow relaunch --sample final --device booted
   yarn llm:mobile:memory -- --platform android --pull-hermes-profile --sourcemap-path ./sourcemaps
+  yarn llm:mobile:memory -- --flow wallet-send-eth-cancel --iterations 10
 `;
 }
 
@@ -775,6 +899,7 @@ async function collectIosMemorySample(
 async function runFlowIteration(
   options: MobileMemoryProfilerOptions,
   runner: CommandRunner,
+  runtime: AppiumRuntime,
 ): Promise<void> {
   switch (options.flow) {
     case 'idle':
@@ -785,9 +910,496 @@ async function runFlowIteration(
       await launchApp(options, runner);
       await sleep(options.waitAfterFlowMs);
       break;
+    case 'wallet-send-eth-cancel':
+      await runWalletSendEthFlow(options, runtime, {
+        submitTransaction: false,
+      });
+      break;
+    case 'wallet-send-eth-submit':
+      await runWalletSendEthFlow(options, runtime, {
+        submitTransaction: true,
+      });
+      break;
     default:
       assertUnreachable(options.flow);
   }
+}
+
+async function runWalletSendEthFlow(
+  options: MobileMemoryProfilerOptions,
+  runtime: AppiumRuntime,
+  { submitTransaction }: { submitTransaction: boolean },
+): Promise<void> {
+  if (submitTransaction && !options.allowTransactionSubmit) {
+    throw new Error(
+      '--flow wallet-send-eth-submit can broadcast a real transaction. Re-run with --allow-transaction-submit to acknowledge this.',
+    );
+  }
+
+  const appiumDriver = await getAppiumDriver(options, runtime);
+
+  await navigateToWalletHome(appiumDriver, options);
+  await tapElementById(
+    appiumDriver,
+    options,
+    WALLET_SEND_BUTTON_ID,
+    'Wallet Send',
+  );
+  await tapElementByText(appiumDriver, options, 'Ethereum', 'Ethereum asset');
+  await selectSendAmount(appiumDriver, options);
+  await tapElementByText(
+    appiumDriver,
+    options,
+    'Continue',
+    'Send amount Continue',
+  );
+  await setElementValueById(
+    appiumDriver,
+    options,
+    RECIPIENT_ADDRESS_INPUT_ID,
+    options.recipientAddress,
+    'Recipient address input',
+  );
+  await tapElementById(appiumDriver, options, REVIEW_BUTTON_ID, 'Review');
+  await waitForElementById(
+    appiumDriver,
+    options,
+    CONFIRM_BUTTON_ID,
+    'Confirm transaction button',
+  );
+
+  if (submitTransaction) {
+    await tapElementById(
+      appiumDriver,
+      options,
+      CONFIRM_BUTTON_ID,
+      'Confirm transaction',
+    );
+  } else {
+    await tapElementById(
+      appiumDriver,
+      options,
+      CANCEL_BUTTON_ID,
+      'Cancel transaction',
+    );
+    await navigateToWalletHome(appiumDriver, options);
+  }
+
+  await sleep(options.waitAfterFlowMs);
+}
+
+async function getAppiumDriver(
+  options: MobileMemoryProfilerOptions,
+  runtime: AppiumRuntime,
+): Promise<AppiumDriver> {
+  if (runtime.driver) {
+    return runtime.driver;
+  }
+
+  const endpoint = parseAppiumEndpoint(options.appiumUrl);
+
+  if (!options.reuseAppium) {
+    assertBundledAppiumEndpoint(endpoint);
+    const appiumServerModule = (await import(
+      '../../tests/framework/services/appium'
+    )) as {
+      startAppiumServer(timeoutMs?: number): Promise<ChildProcess>;
+    };
+    runtime.serverProcess = await appiumServerModule.startAppiumServer(
+      options.appiumStartupTimeoutMs,
+    );
+  }
+
+  const webdriverioModule = (await import('webdriverio')) as unknown as {
+    remote(config: AppiumRemoteConfig): Promise<AppiumDriver>;
+  };
+  runtime.driver = await webdriverioModule.remote(
+    createAppiumRemoteConfig(options, endpoint),
+  );
+  return runtime.driver;
+}
+
+type AppiumCapabilityValue = string | number | boolean;
+
+interface AppiumRemoteConfig {
+  protocol: 'http' | 'https';
+  hostname: string;
+  port: number;
+  path: string;
+  capabilities: Record<string, AppiumCapabilityValue>;
+}
+
+function createAppiumRemoteConfig(
+  options: MobileMemoryProfilerOptions,
+  endpoint: AppiumEndpoint,
+): AppiumRemoteConfig {
+  const platformName = options.platform === 'android' ? 'Android' : 'iOS';
+  const rawCapabilities: Record<string, AppiumCapabilityValue | undefined> = {
+    platformName,
+    'appium:deviceName': options.deviceId ?? platformName,
+    'appium:udid': options.deviceId,
+    'appium:automationName':
+      options.platform === 'android' ? 'UiAutomator2' : 'XCUITest',
+    'appium:newCommandTimeout': 300,
+    'appium:autoGrantPermissions': true,
+    'appium:autoAcceptAlerts': true,
+    'appium:fullReset': false,
+    'appium:noReset': true,
+    'appium:settings[snapshotMaxDepth]': 62,
+    'appium:settings[waitForSelectorTimeout]': 1000,
+    'appium:waitForQuiescence': false,
+    'appium:animationCoolOffTimeout': 0,
+    'appium:disableWindowAnimation': true,
+    ...(options.platform === 'android'
+      ? {
+          'appium:appPackage': options.appId,
+          'appium:appActivity': options.androidActivity,
+        }
+      : {
+          'appium:bundleId': options.appId,
+        }),
+  };
+
+  return {
+    ...endpoint,
+    capabilities: compactCapabilities(rawCapabilities),
+  };
+}
+
+function compactCapabilities(
+  capabilities: Record<string, AppiumCapabilityValue | undefined>,
+): Record<string, AppiumCapabilityValue> {
+  return Object.fromEntries(
+    Object.entries(capabilities).filter((entry): entry is [
+      string,
+      AppiumCapabilityValue,
+    ] => entry[1] !== undefined),
+  );
+}
+
+async function cleanupAppiumRuntime(runtime: AppiumRuntime): Promise<void> {
+  if (runtime.driver) {
+    try {
+      await runtime.driver.deleteSession();
+    } catch {
+      // Appium cleanup is best-effort so the original profiling error is not
+      // hidden by a failed session shutdown.
+    }
+  }
+
+  if (runtime.serverProcess) {
+    try {
+      const appiumServerModule = (await import(
+        '../../tests/framework/services/appium'
+      )) as {
+        stopAppiumServer(): Promise<string>;
+      };
+      await appiumServerModule.stopAppiumServer();
+    } catch {
+      // Best-effort for the same reason as the WebDriver session cleanup.
+    }
+  }
+}
+
+async function navigateToWalletHome(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+): Promise<void> {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    if (
+      await isElementVisibleById(
+        appiumDriver,
+        options,
+        WALLET_SEND_BUTTON_ID,
+        'Wallet Send',
+        1200,
+      )
+    ) {
+      return;
+    }
+
+    await appiumDriver.back().catch(() => undefined);
+    await sleep(500);
+  }
+
+  throw new Error(
+    'Could not find the wallet Send button. The wallet-send-eth-* flows require an unlocked wallet on, or navigable back to, the Wallet screen.',
+  );
+}
+
+async function selectSendAmount(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+): Promise<void> {
+  const amount = options.sendAmount.trim().toLowerCase();
+  const percentageAmount =
+    amount === 'max' ? '100' : amount.match(/^(\d+)%$/u)?.[1];
+
+  if (percentageAmount) {
+    if (!PERCENTAGE_AMOUNTS.has(percentageAmount)) {
+      throw new Error(
+        '--send-amount percentage must be one of: 25%, 50%, 75%, 100%, max',
+      );
+    }
+
+    await tapElementById(
+      appiumDriver,
+      options,
+      `percentage-button-${percentageAmount}`,
+      `${percentageAmount}% amount button`,
+    );
+    return;
+  }
+
+  if (!/^\d+(?:\.\d+)?$/u.test(amount)) {
+    throw new Error(
+      '--send-amount must be a decimal amount or one of: 25%, 50%, 75%, 100%, max',
+    );
+  }
+
+  for (const character of amount) {
+    const keyId =
+      character === '.' ? 'keypad-key-dot' : `keypad-key-${character}`;
+    await tapElementById(
+      appiumDriver,
+      options,
+      keyId,
+      `Amount keypad ${character}`,
+    );
+    await sleep(80);
+  }
+}
+
+async function tapElementById(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+  testId: string,
+  description: string,
+): Promise<void> {
+  const appiumElement = await waitForElementById(
+    appiumDriver,
+    options,
+    testId,
+    description,
+  );
+  await appiumElement.waitForEnabled({ timeout: 5000 }).catch(() => undefined);
+  await appiumElement.click();
+  await sleep(250);
+}
+
+async function tapElementByText(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+  text: string,
+  description: string,
+): Promise<void> {
+  const appiumElement = await findElement(
+    appiumDriver,
+    textSelectors(options.platform, text),
+    description,
+    options.appiumElementTimeoutMs,
+  );
+  await appiumElement.waitForEnabled({ timeout: 5000 }).catch(() => undefined);
+  await appiumElement.click();
+  await sleep(250);
+}
+
+async function setElementValueById(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+  testId: string,
+  value: string,
+  description: string,
+): Promise<void> {
+  const appiumElement = await waitForElementById(
+    appiumDriver,
+    options,
+    testId,
+    description,
+  );
+  await appiumElement.click();
+  await appiumElement.setValue(value);
+  await appiumDriver.hideKeyboard().catch(() => undefined);
+  await sleep(250);
+}
+
+async function waitForElementById(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+  testId: string,
+  description: string,
+): Promise<AppiumElement> {
+  return findElement(
+    appiumDriver,
+    idSelectors(options.platform, testId),
+    description,
+    options.appiumElementTimeoutMs,
+  );
+}
+
+async function isElementVisibleById(
+  appiumDriver: AppiumDriver,
+  options: MobileMemoryProfilerOptions,
+  testId: string,
+  description: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    const appiumElement = await findElement(
+      appiumDriver,
+      idSelectors(options.platform, testId),
+      description,
+      timeoutMs,
+    );
+    return appiumElement.isDisplayed();
+  } catch {
+    return false;
+  }
+}
+
+async function findElement(
+  appiumDriver: AppiumDriver,
+  selectors: string[],
+  description: string,
+  timeoutMs: number,
+): Promise<AppiumElement> {
+  const timeoutPerSelector = Math.max(Math.floor(timeoutMs / selectors.length), 500);
+
+  for (const selector of selectors) {
+    const appiumElement = appiumDriver.$(selector);
+    try {
+      await appiumElement.waitForDisplayed({ timeout: timeoutPerSelector });
+      return appiumElement;
+    } catch {
+      // Try the next selector form. React Native exposes testID differently on
+      // Android/iOS and across Appium drivers.
+    }
+  }
+
+  throw new Error(
+    `Could not find ${description}. Tried selectors: ${selectors.join(', ')}`,
+  );
+}
+
+function idSelectors(
+  platform: MobileMemoryPlatform,
+  testId: string,
+): string[] {
+  if (platform === 'android') {
+    return [
+      `android=new UiSelector().resourceId(${jsonString(testId)})`,
+      `android=new UiSelector().resourceIdMatches(${jsonString(
+        `.*${escapeRegExp(testId)}.*`,
+      )})`,
+      `~${testId}`,
+      `//*[@resource-id=${xpathLiteral(testId)} or @content-desc=${xpathLiteral(
+        testId,
+      )}]`,
+    ];
+  }
+
+  return [
+    `~${testId}`,
+    `-ios predicate string:name == ${predicateString(
+      testId,
+    )} OR label == ${predicateString(testId)} OR value == ${predicateString(
+      testId,
+    )}`,
+    `//*[@name=${xpathLiteral(testId)} or @label=${xpathLiteral(
+      testId,
+    )} or @value=${xpathLiteral(testId)}]`,
+  ];
+}
+
+function textSelectors(platform: MobileMemoryPlatform, text: string): string[] {
+  if (platform === 'android') {
+    return [
+      `android=new UiSelector().text(${jsonString(text)})`,
+      `android=new UiSelector().textContains(${jsonString(text)})`,
+      `//*[@text=${xpathLiteral(text)} or contains(@text, ${xpathLiteral(
+        text,
+      )}) or @content-desc=${xpathLiteral(text)}]`,
+    ];
+  }
+
+  return [
+    `-ios predicate string:name == ${predicateString(
+      text,
+    )} OR label == ${predicateString(text)} OR value == ${predicateString(
+      text,
+    )}`,
+    `-ios predicate string:name CONTAINS ${predicateString(
+      text,
+    )} OR label CONTAINS ${predicateString(
+      text,
+    )} OR value CONTAINS ${predicateString(text)}`,
+    `//*[contains(@name, ${xpathLiteral(text)}) or contains(@label, ${xpathLiteral(
+      text,
+    )}) or contains(@value, ${xpathLiteral(text)})]`,
+  ];
+}
+
+function parseAppiumEndpoint(appiumUrl: string): AppiumEndpoint {
+  try {
+    const url = new URL(appiumUrl);
+    const protocol = url.protocol.replace(':', '');
+
+    if (protocol !== 'http' && protocol !== 'https') {
+      throw new Error('unsupported protocol');
+    }
+
+    return {
+      protocol,
+      hostname: url.hostname,
+      port: Number(url.port || (protocol === 'https' ? 443 : 80)),
+      path: url.pathname || '/',
+    };
+  } catch (error) {
+    throw new Error(
+      `--appium-url must be an HTTP(S) URL, received "${appiumUrl}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+function assertBundledAppiumEndpoint(endpoint: AppiumEndpoint): void {
+  const defaultEndpoint = parseAppiumEndpoint(DEFAULT_APPIUM_URL);
+
+  if (
+    endpoint.protocol !== defaultEndpoint.protocol ||
+    endpoint.hostname !== defaultEndpoint.hostname ||
+    endpoint.port !== defaultEndpoint.port ||
+    endpoint.path !== defaultEndpoint.path
+  ) {
+    throw new Error(
+      '--appium-url can only target a custom endpoint when --reuse-appium is set. The bundled Appium starter listens on http://127.0.0.1:4723/.',
+    );
+  }
+}
+
+function jsonString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function predicateString(value: string): string {
+  return `"${value.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"')}"`;
+}
+
+function xpathLiteral(value: string): string {
+  if (!value.includes("'")) {
+    return `'${value}'`;
+  }
+
+  if (!value.includes('"')) {
+    return `"${value}"`;
+  }
+
+  return `concat('${value.split("'").join(`',"'",'`)}')`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 }
 
 async function launchApp(

--- a/scripts/perps/agentic/cdp-bridge.js
+++ b/scripts/perps/agentic/cdp-bridge.js
@@ -606,6 +606,74 @@ const COMMANDS = {
     };
   },
 
+  async 'heap-snapshot'(client, args) {
+    let outPath = '';
+    let label = 'heap';
+    let collectGarbage = true;
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--out' && i + 1 < args.length) {
+        outPath = args[++i];
+      } else if (args[i] === '--label' && i + 1 < args.length) {
+        label = args[++i];
+      } else if (args[i] === '--no-gc') {
+        collectGarbage = false;
+      }
+    }
+
+    if (!outPath) {
+      const heapDir = path.resolve(
+        process.env.APP_ROOT || process.cwd(),
+        'test-artifacts/mobile-memory/heap-snapshots',
+      );
+      fs.mkdirSync(heapDir, { recursive: true });
+      outPath = path.join(heapDir, `${label}.heapsnapshot`);
+    } else {
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    }
+
+    const fd = fs.openSync(outPath, 'w');
+    let sizeBytes = 0;
+    let chunksCount = 0;
+    const onChunk = (params) => {
+      if (typeof params.chunk === 'string') {
+        fs.writeSync(fd, params.chunk);
+        sizeBytes += Buffer.byteLength(params.chunk, 'utf8');
+        chunksCount += 1;
+      }
+    };
+
+    client.on('HeapProfiler.addHeapSnapshotChunk', onChunk);
+    try {
+      if (collectGarbage) {
+        await client.send('HeapProfiler.collectGarbage', {}, 60000);
+      }
+      await client.send(
+        'HeapProfiler.takeHeapSnapshot',
+        { reportProgress: false },
+        300000,
+      );
+    } finally {
+      client.off('HeapProfiler.addHeapSnapshotChunk', onChunk);
+      fs.closeSync(fd);
+    }
+
+    if (chunksCount === 0) {
+      return {
+        ok: false,
+        error: 'HeapProfiler.takeHeapSnapshot produced no chunks',
+      };
+    }
+
+    return {
+      ok: true,
+      path: outPath,
+      label,
+      sizeBytes,
+      chunksCount,
+      collectedGarbage: collectGarbage,
+    };
+  },
+
   async 'issues-arm'(client) {
     // Installs console.warn/error and global error/unhandledrejection hooks
     // that push into globalThis.__AGENTIC_ISSUES__ (capped at 500 entries).

--- a/scripts/perps/agentic/lib/ws-client.js
+++ b/scripts/perps/agentic/lib/ws-client.js
@@ -29,6 +29,7 @@ function createWSClient(wsUrl, timeout) {
     const ws = new WebSocketImpl(wsUrl);
     let msgId = 0;
     const pending = new Map();
+    const listeners = new Map();
 
     const timer = setTimeout(() => {
       ws.close();
@@ -67,6 +68,19 @@ function createWSClient(wsUrl, timeout) {
         close() {
           ws.close();
         },
+        on(method, handler) {
+          const handlers = listeners.get(method) || new Set();
+          handlers.add(handler);
+          listeners.set(method, handlers);
+        },
+        off(method, handler) {
+          const handlers = listeners.get(method);
+          if (!handlers) return;
+          handlers.delete(handler);
+          if (handlers.size === 0) {
+            listeners.delete(method);
+          }
+        },
       });
     };
 
@@ -86,6 +100,10 @@ function createWSClient(wsUrl, timeout) {
           rej(new Error(`CDP error: ${JSON.stringify(msg.error)}`));
         } else {
           res(msg.result);
+        }
+      } else if (msg.method && listeners.has(msg.method)) {
+        for (const handler of listeners.get(msg.method)) {
+          handler(msg.params || {});
         }
       }
     };

--- a/shim.js
+++ b/shim.js
@@ -114,6 +114,7 @@ if (isTest) {
   testConfig.commandQueueServerPort = raw?.commandQueueServerPort
     ? raw.commandQueueServerPort
     : FALLBACK_COMMAND_QUEUE_SERVER_PORT;
+  testConfig.enableProfiler = raw?.enableProfiler;
 }
 
 // Fix for https://github.com/facebook/react-native/issues/5667

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -287,6 +287,8 @@ export interface LaunchArgs {
   /** Appium specific launch args */
   stop: boolean;
   wait: boolean;
+  /** Enables the in-app react-native-release-profiler overlay for profiling runs. */
+  enableProfiler: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a mobile memory leak profiling CLI for Android and iOS simulator process telemetry.
- Add repeatable wallet ETH send confirmation flows, including headless fixture wallet setup for local Expo dev-client runs.
- Add CDP-backed Hermes heap snapshot capture and shallow baseline-vs-final heap growth analysis.
- Document common profiling workflows, heap snapshot flags, and the limits of shallow heap diffs.

## Impact
Developers can run repeatable memory leak profiling on MetaMask Mobile using `yarn llm:mobile:memory`, with JSON reports, optional Hermes profile conversion through the existing `react-native-release-profiler` package, and optional `.heapsnapshot` artifacts for confirmation-flow leak investigations.
