### PR TITLE
fix(money): update How it works description (MUSD-843)

### DIFF
--- a/app/components/UI/Money/components/MoneyHowItWorks/MoneyHowItWorks.test.tsx
+++ b/app/components/UI/Money/components/MoneyHowItWorks/MoneyHowItWorks.test.tsx
@@ -15,11 +15,9 @@ describe('MoneyHowItWorks', () => {
     const { getByTestId } = render(<MoneyHowItWorks apy={4} />);
 
     const description = getByTestId(MoneyHowItWorksTestIds.DESCRIPTION);
+    expect(description).toHaveTextContent(/Add mUSD and earn up to/);
     expect(description).toHaveTextContent(
-      /Deposit mUSD into your Money account and earn up to/,
-    );
-    expect(description).toHaveTextContent(
-      /Your balance is dollar-backed and ready to spend, trade, or send anytime\./,
+      /\(variable\)\. Your balance is dollar-backed and ready to spend, trade, or send anytime\./,
     );
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6798,8 +6798,8 @@
     },
     "how_it_works": {
       "title": "How it works",
-      "description_prefix": "Deposit mUSD into your Money account and earn up to",
-      "description_suffix": ". Your balance is dollar-backed and ready to spend, trade, or send anytime."
+      "description_prefix": "Add mUSD and earn up to",
+      "description_suffix": " (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "Add"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Update the home-screen "How it works" description to match the latest Figma copy ([Figma node 8027-14650](https://www.figma.com/design/XKZ8hRqSn2iTiuzmlQLuYQ/Money-account?node-id=8027-14650&m=dev)).

- Before: "Deposit mUSD into your Money account and earn up to 4% APY. Your balance is dollar-backed and ready to spend, trade, or send anytime."
- After:  "Add mUSD and earn up to 4% APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."

The existing component already splits this into i18n `description_prefix` · highlighted APY · `description_suffix`, so only the two locale strings in `locales/languages/en.json` change. Non-English locales come from the localization pipeline.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Money home "How it works" description copy.

## **Related issues**

Fixes: [MUSD-843](https://consensyssoftware.atlassian.net/browse/MUSD-843)

## **Manual testing steps**

```gherkin
Feature: Money home — "How it works" copy

  Scenario: User views the updated description on the Money home screen
    Given the user has a Money account

    When user opens the Money home screen
    Then the "How it works" section reads "Add mUSD and earn up to 4% APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."
    And the "4% APY" segment is highlighted in the success color
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-843]: https://consensyssoftware.atlassian.net/browse/MUSD-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in English locale strings and tests; no business logic or security impact.
> 
> **Overview**
> Updates the Money home **How it works** copy in English to match Figma: the prefix shifts from depositing into the Money account to **Add mUSD and earn up to**, and the suffix now includes **(variable)** before the dollar-backed balance sentence.
> 
> `MoneyHowItWorks` still composes prefix, highlighted APY, and suffix from i18n—no UI logic changes. Unit tests in `MoneyHowItWorks.test.tsx` were aligned with the new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f635b783af85a5a6f588ca71a8660d2408af17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->