### PR TITLE
chore: bump `@metamask/assets-controllers` to `^108.2.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
     "@metamask/assets-controller": "^8.0.1",
-    "@metamask/assets-controllers": "^108.1.0",
+    "@metamask/assets-controllers": "^108.2.0",
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7942,9 +7942,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^108.0.0, @metamask/assets-controllers@npm:^108.1.0":
-  version: 108.1.0
-  resolution: "@metamask/assets-controllers@npm:108.1.0"
+"@metamask/assets-controllers@npm:^108.0.0, @metamask/assets-controllers@npm:^108.1.0, @metamask/assets-controllers@npm:^108.2.0":
+  version: 108.2.0
+  resolution: "@metamask/assets-controllers@npm:108.2.0"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -7959,7 +7959,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/core-backend": "npm:^6.2.2"
+    "@metamask/core-backend": "npm:^6.3.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/keyring-controller": "npm:^25.5.0"
@@ -7967,10 +7967,10 @@ __metadata:
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/multichain-account-service": "npm:^10.0.0"
     "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/network-enablement-controller": "npm:^5.1.1"
+    "@metamask/network-enablement-controller": "npm:^5.2.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/phishing-controller": "npm:^17.1.2"
-    "@metamask/polling-controller": "npm:^16.0.5"
+    "@metamask/phishing-controller": "npm:^17.2.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
     "@metamask/preferences-controller": "npm:^23.1.0"
     "@metamask/profile-sync-controller": "npm:^28.1.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
@@ -7978,7 +7978,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
     "@metamask/storage-service": "npm:^1.0.1"
-    "@metamask/transaction-controller": "npm:^65.3.0"
+    "@metamask/transaction-controller": "npm:^66.0.0"
     "@metamask/utils": "npm:^11.9.0"
     "@tanstack/query-core": "npm:^5.62.16"
     "@types/bn.js": "npm:^5.1.5"
@@ -7995,7 +7995,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/b30574058978f594505b6585dff7501b05a1b36591dfe97ea58c915b85f4e534374d8d3fc72420d58f0a44df9d29aa62c526ec5e903482a64ed9384ff4f09f44
+  checksum: 10/732e4cdab79a6dc31c7094149a1d684555cfc7b9a434f435e79873b00f860c8ad540425ed80d700a22a07c73eefb9cd69c2bcd8985a266d622fd82012b7904d4
   languageName: node
   linkType: hard
 
@@ -35520,7 +35520,7 @@ __metadata:
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
     "@metamask/assets-controller": "npm:^8.0.1"
-    "@metamask/assets-controllers": "npm:^108.1.0"
+    "@metamask/assets-controllers": "npm:^108.2.0"
     "@metamask/authenticated-user-storage": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/assets-controllers` from `^108.0.1` to `^108.2.0`.

The relevant change in this release is the Forma native token price fix shipped in [core#8873](https://github.com/MetaMask/core/pull/8873) (part of [core Release/1002.0.0](https://github.com/MetaMask/core/pull/8911)):

> Fixed Forma (chain `984122`) native token price resolution by requesting TIA as the zero-address native asset (`erc20:0x0000000000000000000000000000000000000000`) instead of a non-canonical SLIP-44 reference.

Without this bump, the mobile app does not display the TIA price on Forma. The price-API side of the fix is already live in production, so once this lands users will see TIA prices end-to-end.

Companion extension PR: MetaMask/metamask-extension#42981

See the [108.2.0 changelog](https://github.com/MetaMask/core/blob/main/packages/assets-controllers/CHANGELOG.md) for the full set of changes in this release.

## **Changelog**

CHANGELOG entry: Fixed missing native token price for Forma network (TIA)

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: TIA native token price on Forma

  Scenario: user views the native TIA asset on Forma
    Given the mobile app is built from this branch
    And the user has added the Forma network (chainId 984122)

    When the user opens the native TIA asset page on Forma
    Then a USD price is displayed (not "$0.00" or empty)
```

## **Screenshots/Recordings**

### **Before**

TIA price missing on Forma — token page shows no price.

### **After**

TIA price shown on Forma — populated from CoinGecko via the assets-controller spot prices path.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no local code edits; behavior change is limited to native token price resolution for Forma via the upstream package.
> 
> **Overview**
> Bumps **`@metamask/assets-controllers`** from **`^108.1.0`** to **`^108.2.0`** in `package.json`, with the matching **`yarn.lock`** resolution and checksum updates. There are **no application source changes** in this PR.
> 
> The mobile app picks up the **Forma (chain `984122`) native TIA price fix** from core: spot pricing now uses the zero-address native asset (`erc20:0x0000…0000`) instead of a non-canonical SLIP-44 reference, so the native TIA asset page can show a USD price once this version is shipped (the price API side is already live per the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7badc7d366d33a25e9dab6b06d5ec27c5cf6536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->