### PR TITLE
feat(onboarding): preselect swap tokens on wallet home trade step (TMCU-681)

### DIFF
--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { ActionLocation } from '../../../util/analytics/actionButtonTracking';
+import { useWalletHomeOnboardingChecklistTradePress } from './useWalletHomeOnboardingChecklistTradePress';
+import type { BridgeToken } from '../Bridge/types';
+import type { WalletHomeOnboardingTradeSwapPair } from './walletHomeOnboardingTradeSwapBalances';
+
+const mockUseWalletHomeOnboardingTradeSwapPair = jest.fn();
+jest.mock('./useWalletHomeOnboardingTradeSwapPair', () => ({
+  useWalletHomeOnboardingTradeSwapPair: () =>
+    mockUseWalletHomeOnboardingTradeSwapPair(),
+}));
+
+describe('useWalletHomeOnboardingChecklistTradePress', () => {
+  const goToSwaps = jest.fn();
+
+  const sourceToken = {
+    address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+    symbol: 'mUSD',
+    name: 'MetaMask USD',
+    decimals: 6,
+    chainId: '0x1',
+  } as BridgeToken;
+
+  const destToken = {
+    address: '0x0000000000000000000000000000000000000000',
+    symbol: 'ETH',
+    name: 'Ether',
+    decimals: 18,
+    chainId: '0x1',
+  } as BridgeToken;
+
+  const swapPair = {
+    sourceToken,
+    destToken,
+  } as WalletHomeOnboardingTradeSwapPair;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseWalletHomeOnboardingTradeSwapPair.mockReturnValue(undefined);
+  });
+
+  it('calls goToSwaps with swap pair when resolved', () => {
+    mockUseWalletHomeOnboardingTradeSwapPair.mockReturnValue(swapPair);
+
+    const { result } = renderHook(() =>
+      useWalletHomeOnboardingChecklistTradePress(goToSwaps),
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    expect(goToSwaps).toHaveBeenCalledWith(
+      sourceToken,
+      destToken,
+      undefined,
+      undefined,
+      ActionLocation.ONBOARDING_CHECKLIST,
+    );
+  });
+
+  it('falls back to default goToSwaps when no swap pair', () => {
+    const { result } = renderHook(() =>
+      useWalletHomeOnboardingChecklistTradePress(goToSwaps),
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    expect(goToSwaps).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ActionLocation.ONBOARDING_CHECKLIST,
+    );
+  });
+});

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { ActionLocation } from '../../../util/analytics/actionButtonTracking';
+import { useWalletHomeOnboardingTradeSwapPair } from './useWalletHomeOnboardingTradeSwapPair';
+
+type GoToSwapsFromSwapBridgeNavigation = ReturnType<
+  typeof import('../Bridge/hooks/useSwapBridgeNavigation').useSwapBridgeNavigation
+>['goToSwaps'];
+
+/**
+ * Opens unified swaps from the wallet home onboarding trade step (TMCU-681) with
+ * source/dest defaults based on mainnet mUSD or ETH balance.
+ */
+export function useWalletHomeOnboardingChecklistTradePress(
+  goToSwaps: GoToSwapsFromSwapBridgeNavigation,
+): () => void {
+  const swapPair = useWalletHomeOnboardingTradeSwapPair();
+
+  return useCallback(() => {
+    if (swapPair) {
+      goToSwaps(
+        swapPair.sourceToken,
+        swapPair.destToken,
+        undefined,
+        undefined,
+        ActionLocation.ONBOARDING_CHECKLIST,
+      );
+      return;
+    }
+
+    goToSwaps(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ActionLocation.ONBOARDING_CHECKLIST,
+    );
+  }, [goToSwaps, swapPair]);
+}

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { ActionLocation } from '../../../util/analytics/actionButtonTracking';
 import { useWalletHomeOnboardingTradeSwapPair } from './useWalletHomeOnboardingTradeSwapPair';
 
@@ -14,12 +14,16 @@ export function useWalletHomeOnboardingChecklistTradePress(
   goToSwaps: GoToSwapsFromSwapBridgeNavigation,
 ): () => void {
   const swapPair = useWalletHomeOnboardingTradeSwapPair();
+  const swapPairRef = useRef(swapPair);
+  swapPairRef.current = swapPair;
 
   return useCallback(() => {
-    if (swapPair) {
+    const pair = swapPairRef.current;
+
+    if (pair) {
       goToSwaps(
-        swapPair.sourceToken,
-        swapPair.destToken,
+        pair.sourceToken,
+        pair.destToken,
         undefined,
         undefined,
         ActionLocation.ONBOARDING_CHECKLIST,
@@ -34,5 +38,5 @@ export function useWalletHomeOnboardingChecklistTradePress(
       undefined,
       ActionLocation.ONBOARDING_CHECKLIST,
     );
-  }, [goToSwaps, swapPair]);
+  }, [goToSwaps]);
 }

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
+import type { RootState } from '../../../reducers';
+import { selectSelectedInternalAccountAddress } from '../../../selectors/accountsController';
+import { useWalletHomeOnboardingTradeSwapPair } from './useWalletHomeOnboardingTradeSwapPair';
+import type { WalletHomeOnboardingTradeSwapPair } from './walletHomeOnboardingTradeSwapBalances';
+
+const mockResolveWalletHomeOnboardingTradeSwapPair = jest.fn();
+jest.mock('./walletHomeOnboardingTradeSwapBalances', () => ({
+  resolveWalletHomeOnboardingTradeSwapPair: (...args: unknown[]) =>
+    mockResolveWalletHomeOnboardingTradeSwapPair(...args),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+
+describe('useWalletHomeOnboardingTradeSwapPair', () => {
+  const mockState = { engine: {} } as RootState;
+  const accountAddress = '0xAccount1' as Hex;
+  const swapPair = {
+    sourceToken: { symbol: 'mUSD' },
+    destToken: { symbol: 'ETH' },
+  } as WalletHomeOnboardingTradeSwapPair;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveWalletHomeOnboardingTradeSwapPair.mockReturnValue(swapPair);
+  });
+
+  it('returns undefined when selected account address is missing', () => {
+    mockUseSelector
+      .mockReturnValueOnce(undefined)
+      .mockReturnValueOnce(undefined);
+
+    const { result } = renderHook(() => useWalletHomeOnboardingTradeSwapPair());
+
+    expect(result.current).toBeUndefined();
+    expect(mockResolveWalletHomeOnboardingTradeSwapPair).not.toHaveBeenCalled();
+  });
+
+  it('resolves pair from state and selected account via selector', () => {
+    let pairSelector: ((state: RootState) => unknown) | undefined;
+
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectSelectedInternalAccountAddress) {
+        return accountAddress;
+      }
+
+      pairSelector = selector as (state: RootState) => unknown;
+      return (selector as (state: RootState) => unknown)(mockState);
+    });
+
+    const { result } = renderHook(() => useWalletHomeOnboardingTradeSwapPair());
+
+    expect(pairSelector).toBeDefined();
+    expect(pairSelector?.(mockState)).toBe(swapPair);
+    expect(mockResolveWalletHomeOnboardingTradeSwapPair).toHaveBeenCalledWith(
+      mockState,
+      accountAddress,
+    );
+    expect(result.current).toBe(swapPair);
+  });
+});

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.test.ts
@@ -1,16 +1,10 @@
 import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import { Hex } from '@metamask/utils';
-import type { RootState } from '../../../reducers';
-import { selectSelectedInternalAccountAddress } from '../../../selectors/accountsController';
 import { useWalletHomeOnboardingTradeSwapPair } from './useWalletHomeOnboardingTradeSwapPair';
-import type { WalletHomeOnboardingTradeSwapPair } from './walletHomeOnboardingTradeSwapBalances';
-
-const mockResolveWalletHomeOnboardingTradeSwapPair = jest.fn();
-jest.mock('./walletHomeOnboardingTradeSwapBalances', () => ({
-  resolveWalletHomeOnboardingTradeSwapPair: (...args: unknown[]) =>
-    mockResolveWalletHomeOnboardingTradeSwapPair(...args),
-}));
+import {
+  selectWalletHomeOnboardingTradeSwapPair,
+  type WalletHomeOnboardingTradeSwapPair,
+} from './walletHomeOnboardingTradeSwapBalances';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -19,8 +13,6 @@ jest.mock('react-redux', () => ({
 const mockUseSelector = jest.mocked(useSelector);
 
 describe('useWalletHomeOnboardingTradeSwapPair', () => {
-  const mockState = { engine: {} } as RootState;
-  const accountAddress = '0xAccount1' as Hex;
   const swapPair = {
     sourceToken: { symbol: 'mUSD' },
     destToken: { symbol: 'ETH' },
@@ -28,39 +20,15 @@ describe('useWalletHomeOnboardingTradeSwapPair', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockResolveWalletHomeOnboardingTradeSwapPair.mockReturnValue(swapPair);
   });
 
-  it('returns undefined when selected account address is missing', () => {
-    mockUseSelector
-      .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(undefined);
+  it('subscribes to the memoized trade swap pair selector', () => {
+    mockUseSelector.mockReturnValue(swapPair);
 
     const { result } = renderHook(() => useWalletHomeOnboardingTradeSwapPair());
 
-    expect(result.current).toBeUndefined();
-    expect(mockResolveWalletHomeOnboardingTradeSwapPair).not.toHaveBeenCalled();
-  });
-
-  it('resolves pair from state and selected account via selector', () => {
-    let pairSelector: ((state: RootState) => unknown) | undefined;
-
-    mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectSelectedInternalAccountAddress) {
-        return accountAddress;
-      }
-
-      pairSelector = selector as (state: RootState) => unknown;
-      return (selector as (state: RootState) => unknown)(mockState);
-    });
-
-    const { result } = renderHook(() => useWalletHomeOnboardingTradeSwapPair());
-
-    expect(pairSelector).toBeDefined();
-    expect(pairSelector?.(mockState)).toBe(swapPair);
-    expect(mockResolveWalletHomeOnboardingTradeSwapPair).toHaveBeenCalledWith(
-      mockState,
-      accountAddress,
+    expect(mockUseSelector).toHaveBeenCalledWith(
+      selectWalletHomeOnboardingTradeSwapPair,
     );
     expect(result.current).toBe(swapPair);
   });

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.ts
@@ -1,9 +1,6 @@
 import { useSelector } from 'react-redux';
-import { Hex } from '@metamask/utils';
-import type { RootState } from '../../../reducers';
-import { selectSelectedInternalAccountAddress } from '../../../selectors/accountsController';
 import {
-  resolveWalletHomeOnboardingTradeSwapPair,
+  selectWalletHomeOnboardingTradeSwapPair,
   type WalletHomeOnboardingTradeSwapPair,
 } from './walletHomeOnboardingTradeSwapBalances';
 
@@ -13,16 +10,5 @@ import {
 export function useWalletHomeOnboardingTradeSwapPair():
   | WalletHomeOnboardingTradeSwapPair
   | undefined {
-  const accountAddress = useSelector(selectSelectedInternalAccountAddress);
-
-  return useSelector((state: RootState) => {
-    if (!accountAddress) {
-      return undefined;
-    }
-
-    return resolveWalletHomeOnboardingTradeSwapPair(
-      state,
-      accountAddress as Hex,
-    );
-  });
+  return useSelector(selectWalletHomeOnboardingTradeSwapPair);
 }

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingTradeSwapPair.ts
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
+import type { RootState } from '../../../reducers';
+import { selectSelectedInternalAccountAddress } from '../../../selectors/accountsController';
+import {
+  resolveWalletHomeOnboardingTradeSwapPair,
+  type WalletHomeOnboardingTradeSwapPair,
+} from './walletHomeOnboardingTradeSwapBalances';
+
+/**
+ * Subscribes to mainnet balances and resolves trade-step swap defaults (TMCU-681).
+ */
+export function useWalletHomeOnboardingTradeSwapPair():
+  | WalletHomeOnboardingTradeSwapPair
+  | undefined {
+  const accountAddress = useSelector(selectSelectedInternalAccountAddress);
+
+  return useSelector((state: RootState) => {
+    if (!accountAddress) {
+      return undefined;
+    }
+
+    return resolveWalletHomeOnboardingTradeSwapPair(
+      state,
+      accountAddress as Hex,
+    );
+  });
+}

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.test.ts
@@ -1,0 +1,30 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  getMainnetBtcBridgeToken,
+  getMainnetEthBridgeToken,
+  getMainnetMusdBridgeToken,
+  MAINNET_MUSD_TOKEN_ADDRESS,
+} from './walletHomeOnboardingTradeSwapAssets';
+
+describe('walletHomeOnboardingTradeSwapAssets', () => {
+  it('exposes mainnet mUSD bridge token with expected address', () => {
+    const token = getMainnetMusdBridgeToken();
+
+    expect(token.address).toBe(MAINNET_MUSD_TOKEN_ADDRESS);
+    expect(token.chainId).toBe(CHAIN_IDS.MAINNET);
+    expect(token.symbol).toBe('mUSD');
+  });
+
+  it('exposes mainnet ETH native bridge token', () => {
+    const token = getMainnetEthBridgeToken();
+
+    expect(token.symbol).toBe('ETH');
+    expect(token.chainId).toBe(CHAIN_IDS.MAINNET);
+  });
+
+  it('exposes mainnet BTC bridge token from default pairs', () => {
+    const token = getMainnetBtcBridgeToken();
+
+    expect(token.symbol).toBe('BTC');
+  });
+});

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.ts
@@ -1,6 +1,7 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { EthScope } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
+import { toChecksumAddress } from '../../../util/address';
 import { Bip44TokensForDefaultPairs } from '../Bridge/constants/default-swap-dest-tokens';
 import { getNativeSourceToken } from '../Bridge/utils/tokenUtils';
 import type { BridgeToken } from '../Bridge/types';
@@ -12,6 +13,11 @@ export const MAINNET_NATIVE_ETH_TOKEN_ADDRESS: Hex =
 /** Mainnet mUSD contract address (TMCU-681 trade-step swap defaults). */
 export const MAINNET_MUSD_TOKEN_ADDRESS: Hex =
   '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+/** TokenBalancesController keys are checksummed (see assets-migration). */
+export const MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS = toChecksumAddress(
+  MAINNET_MUSD_TOKEN_ADDRESS,
+) as Hex;
 
 const MAINNET_BTC_CAIP_ASSET_ID =
   'bip122:000000000019d6689c085ae165831e93/slip44:0' as const;

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.ts
@@ -1,0 +1,39 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { EthScope } from '@metamask/keyring-api';
+import { Hex } from '@metamask/utils';
+import { Bip44TokensForDefaultPairs } from '../Bridge/constants/default-swap-dest-tokens';
+import { getNativeSourceToken } from '../Bridge/utils/tokenUtils';
+import type { BridgeToken } from '../Bridge/types';
+
+/** Native ETH placeholder address used in token balance lookups on EVM chains. */
+export const MAINNET_NATIVE_ETH_TOKEN_ADDRESS: Hex =
+  '0x0000000000000000000000000000000000000000';
+
+/** Mainnet mUSD contract address (TMCU-681 trade-step swap defaults). */
+export const MAINNET_MUSD_TOKEN_ADDRESS: Hex =
+  '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+const MAINNET_BTC_CAIP_ASSET_ID =
+  'bip122:000000000019d6689c085ae165831e93/slip44:0' as const;
+
+const MAINNET_MUSD_BRIDGE_TOKEN: BridgeToken = {
+  address: MAINNET_MUSD_TOKEN_ADDRESS,
+  chainId: CHAIN_IDS.MAINNET,
+  symbol: 'mUSD',
+  name: 'MetaMask USD',
+  decimals: 6,
+  image:
+    'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xaca92e438df0b2401ff60da7e4337b687a2435da.png',
+};
+
+export function getMainnetMusdBridgeToken(): BridgeToken {
+  return MAINNET_MUSD_BRIDGE_TOKEN;
+}
+
+export function getMainnetEthBridgeToken(): BridgeToken {
+  return getNativeSourceToken(EthScope.Mainnet);
+}
+
+export function getMainnetBtcBridgeToken(): BridgeToken {
+  return Bip44TokensForDefaultPairs[MAINNET_BTC_CAIP_ASSET_ID];
+}

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapAssets.ts
@@ -30,8 +30,12 @@ export function getMainnetMusdBridgeToken(): BridgeToken {
   return MAINNET_MUSD_BRIDGE_TOKEN;
 }
 
+const MAINNET_ETH_BRIDGE_TOKEN: BridgeToken = getNativeSourceToken(
+  EthScope.Mainnet,
+);
+
 export function getMainnetEthBridgeToken(): BridgeToken {
-  return getNativeSourceToken(EthScope.Mainnet);
+  return MAINNET_ETH_BRIDGE_TOKEN;
 }
 
 export function getMainnetBtcBridgeToken(): BridgeToken {

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.test.ts
@@ -2,23 +2,20 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import type { RootState } from '../../../reducers';
 import {
-  hasMainnetEthBalance,
-  hasMainnetMusdBalance,
-  hasPositiveHexTokenBalance,
   MAINNET_ETH_TO_BTC_SWAP_PAIR,
   MAINNET_MUSD_TO_ETH_SWAP_PAIR,
-  resolveWalletHomeOnboardingTradeSwapPair,
+  selectWalletHomeOnboardingTradeSwapPair,
 } from './walletHomeOnboardingTradeSwapBalances';
 import {
   MAINNET_MUSD_TOKEN_ADDRESS,
+  MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS,
   MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
 } from './walletHomeOnboardingTradeSwapAssets';
 
 const ACCOUNT = '0xAccount1' as Hex;
 
-function buildStateWithTokenBalance(
-  tokenAddress: Hex,
-  balanceHex: string,
+function buildStateWithMainnetBalances(
+  mainnetBalances: Record<string, string>,
 ): RootState {
   return {
     engine: {
@@ -26,8 +23,17 @@ function buildStateWithTokenBalance(
         TokenBalancesController: {
           tokenBalances: {
             [ACCOUNT]: {
-              [CHAIN_IDS.MAINNET]: {
-                [tokenAddress]: balanceHex,
+              [CHAIN_IDS.MAINNET]: mainnetBalances,
+            },
+          },
+        },
+        AccountsController: {
+          internalAccounts: {
+            selectedAccount: 'account1',
+            accounts: {
+              account1: {
+                id: 'account1',
+                address: ACCOUNT,
               },
             },
           },
@@ -37,97 +43,83 @@ function buildStateWithTokenBalance(
   } as unknown as RootState;
 }
 
-describe('walletHomeOnboardingTradeSwapBalances', () => {
-  describe('hasPositiveHexTokenBalance', () => {
-    it('returns false for missing or zero balance', () => {
-      expect(hasPositiveHexTokenBalance(undefined)).toBe(false);
-      expect(hasPositiveHexTokenBalance('0x0')).toBe(false);
+describe('selectWalletHomeOnboardingTradeSwapPair', () => {
+  it('returns stable pair references for repeated selection', () => {
+    const state = buildStateWithMainnetBalances({
+      [MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS]: '0x1',
     });
 
-    it('returns true for positive balance', () => {
-      expect(hasPositiveHexTokenBalance('0x1')).toBe(true);
-      expect(hasPositiveHexTokenBalance('0x100')).toBe(true);
-    });
+    const first = selectWalletHomeOnboardingTradeSwapPair(state);
+    const second = selectWalletHomeOnboardingTradeSwapPair(state);
+
+    expect(first).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
+    expect(second).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
+    expect(first).toBe(second);
   });
 
-  describe('hasMainnetMusdBalance', () => {
-    it('detects positive mUSD balance on mainnet', () => {
-      const state = buildStateWithTokenBalance(
-        MAINNET_MUSD_TOKEN_ADDRESS,
-        '0x1',
-      );
-      expect(hasMainnetMusdBalance(state, ACCOUNT)).toBe(true);
+  it('prefers mUSD → ETH when checksummed mUSD balance is positive', () => {
+    const state = buildStateWithMainnetBalances({
+      [MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS]: '0x1',
+      [MAINNET_NATIVE_ETH_TOKEN_ADDRESS]: '0x64',
     });
+
+    expect(selectWalletHomeOnboardingTradeSwapPair(state)).toBe(
+      MAINNET_MUSD_TO_ETH_SWAP_PAIR,
+    );
   });
 
-  describe('hasMainnetEthBalance', () => {
-    it('detects positive native ETH balance on mainnet', () => {
-      const state = buildStateWithTokenBalance(
-        MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
-        '0x64',
-      );
-      expect(hasMainnetEthBalance(state, ACCOUNT)).toBe(true);
+  it('does not match mUSD balance stored under lowercase address key', () => {
+    const state = buildStateWithMainnetBalances({
+      [MAINNET_MUSD_TOKEN_ADDRESS]: '0x1',
+      [MAINNET_NATIVE_ETH_TOKEN_ADDRESS]: '0x64',
     });
+
+    expect(selectWalletHomeOnboardingTradeSwapPair(state)).toBe(
+      MAINNET_ETH_TO_BTC_SWAP_PAIR,
+    );
   });
 
-  describe('resolveWalletHomeOnboardingTradeSwapPair', () => {
-    it('returns stable pair object references for repeated resolution', () => {
-      const state = buildStateWithTokenBalance(
-        MAINNET_MUSD_TOKEN_ADDRESS,
-        '0x1',
-      );
-
-      const first = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
-      const second = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
-
-      expect(first).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
-      expect(second).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
-      expect(first).toBe(second);
+  it('uses ETH → BTC when only mainnet ETH balance is positive', () => {
+    const state = buildStateWithMainnetBalances({
+      [MAINNET_NATIVE_ETH_TOKEN_ADDRESS]: '0x64',
     });
 
-    it('prefers mUSD → ETH when mUSD balance is positive', () => {
-      const state = {
-        engine: {
-          backgroundState: {
-            TokenBalancesController: {
-              tokenBalances: {
-                [ACCOUNT]: {
-                  [CHAIN_IDS.MAINNET]: {
-                    [MAINNET_MUSD_TOKEN_ADDRESS]: '0x1',
-                    [MAINNET_NATIVE_ETH_TOKEN_ADDRESS]: '0x64',
-                  },
+    expect(selectWalletHomeOnboardingTradeSwapPair(state)).toBe(
+      MAINNET_ETH_TO_BTC_SWAP_PAIR,
+    );
+  });
+
+  it('returns undefined when neither mUSD nor ETH balance is positive', () => {
+    const state = buildStateWithMainnetBalances({
+      [MAINNET_NATIVE_ETH_TOKEN_ADDRESS]: '0x0',
+    });
+
+    expect(selectWalletHomeOnboardingTradeSwapPair(state)).toBeUndefined();
+  });
+
+  it('returns undefined when selected account is missing', () => {
+    const state = {
+      engine: {
+        backgroundState: {
+          TokenBalancesController: {
+            tokenBalances: {
+              [ACCOUNT]: {
+                [CHAIN_IDS.MAINNET]: {
+                  [MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS]: '0x1',
                 },
               },
             },
           },
+          AccountsController: {
+            internalAccounts: {
+              selectedAccount: 'missing',
+              accounts: {},
+            },
+          },
         },
-      } as unknown as RootState;
+      },
+    } as unknown as RootState;
 
-      const pair = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
-
-      expect(pair).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
-    });
-
-    it('uses ETH → BTC when only ETH balance is positive', () => {
-      const state = buildStateWithTokenBalance(
-        MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
-        '0x64',
-      );
-
-      const pair = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
-
-      expect(pair).toBe(MAINNET_ETH_TO_BTC_SWAP_PAIR);
-    });
-
-    it('returns undefined when neither mUSD nor ETH balance is positive', () => {
-      const state = buildStateWithTokenBalance(
-        MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
-        '0x0',
-      );
-
-      expect(
-        resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT),
-      ).toBeUndefined();
-    });
+    expect(selectWalletHomeOnboardingTradeSwapPair(state)).toBeUndefined();
   });
 });

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.test.ts
@@ -1,0 +1,119 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import type { RootState } from '../../../reducers';
+import {
+  hasMainnetEthBalance,
+  hasMainnetMusdBalance,
+  hasPositiveHexTokenBalance,
+  resolveWalletHomeOnboardingTradeSwapPair,
+} from './walletHomeOnboardingTradeSwapBalances';
+import {
+  MAINNET_MUSD_TOKEN_ADDRESS,
+  MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
+} from './walletHomeOnboardingTradeSwapAssets';
+
+const ACCOUNT = '0xAccount1' as Hex;
+
+function buildStateWithTokenBalance(
+  tokenAddress: Hex,
+  balanceHex: string,
+): RootState {
+  return {
+    engine: {
+      backgroundState: {
+        TokenBalancesController: {
+          tokenBalances: {
+            [ACCOUNT]: {
+              [CHAIN_IDS.MAINNET]: {
+                [tokenAddress]: balanceHex,
+              },
+            },
+          },
+        },
+      },
+    },
+  } as unknown as RootState;
+}
+
+describe('walletHomeOnboardingTradeSwapBalances', () => {
+  describe('hasPositiveHexTokenBalance', () => {
+    it('returns false for missing or zero balance', () => {
+      expect(hasPositiveHexTokenBalance(undefined)).toBe(false);
+      expect(hasPositiveHexTokenBalance('0x0')).toBe(false);
+    });
+
+    it('returns true for positive balance', () => {
+      expect(hasPositiveHexTokenBalance('0x1')).toBe(true);
+      expect(hasPositiveHexTokenBalance('0x100')).toBe(true);
+    });
+  });
+
+  describe('hasMainnetMusdBalance', () => {
+    it('detects positive mUSD balance on mainnet', () => {
+      const state = buildStateWithTokenBalance(
+        MAINNET_MUSD_TOKEN_ADDRESS,
+        '0x1',
+      );
+      expect(hasMainnetMusdBalance(state, ACCOUNT)).toBe(true);
+    });
+  });
+
+  describe('hasMainnetEthBalance', () => {
+    it('detects positive native ETH balance on mainnet', () => {
+      const state = buildStateWithTokenBalance(
+        MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
+        '0x64',
+      );
+      expect(hasMainnetEthBalance(state, ACCOUNT)).toBe(true);
+    });
+  });
+
+  describe('resolveWalletHomeOnboardingTradeSwapPair', () => {
+    it('prefers mUSD → ETH when mUSD balance is positive', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            TokenBalancesController: {
+              tokenBalances: {
+                [ACCOUNT]: {
+                  [CHAIN_IDS.MAINNET]: {
+                    [MAINNET_MUSD_TOKEN_ADDRESS]: '0x1',
+                    [MAINNET_NATIVE_ETH_TOKEN_ADDRESS]: '0x64',
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as unknown as RootState;
+
+      const pair = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
+
+      expect(pair?.sourceToken.symbol).toBe('mUSD');
+      expect(pair?.destToken.symbol).toBe('ETH');
+    });
+
+    it('uses ETH → BTC when only ETH balance is positive', () => {
+      const state = buildStateWithTokenBalance(
+        MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
+        '0x64',
+      );
+
+      const pair = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
+
+      expect(pair?.sourceToken.symbol).toBe('ETH');
+      expect(pair?.destToken.symbol).toBe('BTC');
+    });
+
+    it('returns undefined when neither mUSD nor ETH balance is positive', () => {
+      const state = buildStateWithTokenBalance(
+        MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
+        '0x0',
+      );
+
+      expect(
+        resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.test.ts
@@ -5,6 +5,8 @@ import {
   hasMainnetEthBalance,
   hasMainnetMusdBalance,
   hasPositiveHexTokenBalance,
+  MAINNET_ETH_TO_BTC_SWAP_PAIR,
+  MAINNET_MUSD_TO_ETH_SWAP_PAIR,
   resolveWalletHomeOnboardingTradeSwapPair,
 } from './walletHomeOnboardingTradeSwapBalances';
 import {
@@ -69,6 +71,20 @@ describe('walletHomeOnboardingTradeSwapBalances', () => {
   });
 
   describe('resolveWalletHomeOnboardingTradeSwapPair', () => {
+    it('returns stable pair object references for repeated resolution', () => {
+      const state = buildStateWithTokenBalance(
+        MAINNET_MUSD_TOKEN_ADDRESS,
+        '0x1',
+      );
+
+      const first = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
+      const second = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
+
+      expect(first).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
+      expect(second).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
+      expect(first).toBe(second);
+    });
+
     it('prefers mUSD → ETH when mUSD balance is positive', () => {
       const state = {
         engine: {
@@ -89,8 +105,7 @@ describe('walletHomeOnboardingTradeSwapBalances', () => {
 
       const pair = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
 
-      expect(pair?.sourceToken.symbol).toBe('mUSD');
-      expect(pair?.destToken.symbol).toBe('ETH');
+      expect(pair).toBe(MAINNET_MUSD_TO_ETH_SWAP_PAIR);
     });
 
     it('uses ETH → BTC when only ETH balance is positive', () => {
@@ -101,8 +116,7 @@ describe('walletHomeOnboardingTradeSwapBalances', () => {
 
       const pair = resolveWalletHomeOnboardingTradeSwapPair(state, ACCOUNT);
 
-      expect(pair?.sourceToken.symbol).toBe('ETH');
-      expect(pair?.destToken.symbol).toBe('BTC');
+      expect(pair).toBe(MAINNET_ETH_TO_BTC_SWAP_PAIR);
     });
 
     it('returns undefined when neither mUSD nor ETH balance is positive', () => {

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
@@ -41,7 +41,7 @@ const selectSelectedAccountMainnetMusdBalanceHex = createSelector(
       return undefined;
     }
 
-    return tokenBalances?.[accountAddress]?.[CHAIN_IDS.MAINNET]?.[
+    return tokenBalances?.[accountAddress as Hex]?.[CHAIN_IDS.MAINNET]?.[
       MAINNET_MUSD_TOKEN_ADDRESS
     ];
   },
@@ -54,7 +54,7 @@ const selectSelectedAccountMainnetEthBalanceHex = createSelector(
       return undefined;
     }
 
-    return tokenBalances?.[accountAddress]?.[CHAIN_IDS.MAINNET]?.[
+    return tokenBalances?.[accountAddress as Hex]?.[CHAIN_IDS.MAINNET]?.[
       MAINNET_NATIVE_ETH_TOKEN_ADDRESS
     ];
   },

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
@@ -2,18 +2,14 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { BigNumber } from 'ethers';
 import { Hex } from '@metamask/utils';
 import { createSelector } from 'reselect';
-import type { RootState } from '../../../reducers';
 import { selectSelectedInternalAccountAddress } from '../../../selectors/accountsController';
-import {
-  selectSingleTokenBalance,
-  selectTokensBalances,
-} from '../../../selectors/tokenBalancesController';
+import { selectTokensBalances } from '../../../selectors/tokenBalancesController';
 import type { BridgeToken } from '../Bridge/types';
 import {
   getMainnetBtcBridgeToken,
   getMainnetEthBridgeToken,
   getMainnetMusdBridgeToken,
-  MAINNET_MUSD_TOKEN_ADDRESS,
+  MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS,
   MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
 } from './walletHomeOnboardingTradeSwapAssets';
 
@@ -34,6 +30,18 @@ export const MAINNET_ETH_TO_BTC_SWAP_PAIR: WalletHomeOnboardingTradeSwapPair = {
   destToken: getMainnetBtcBridgeToken(),
 };
 
+function hasPositiveHexTokenBalance(balanceHex: string | undefined): boolean {
+  if (!balanceHex) {
+    return false;
+  }
+
+  try {
+    return BigNumber.from(balanceHex).gt(0);
+  } catch {
+    return false;
+  }
+}
+
 const selectSelectedAccountMainnetMusdBalanceHex = createSelector(
   [selectSelectedInternalAccountAddress, selectTokensBalances],
   (accountAddress, tokenBalances) => {
@@ -42,7 +50,7 @@ const selectSelectedAccountMainnetMusdBalanceHex = createSelector(
     }
 
     return tokenBalances?.[accountAddress as Hex]?.[CHAIN_IDS.MAINNET]?.[
-      MAINNET_MUSD_TOKEN_ADDRESS
+      MAINNET_MUSD_TOKEN_BALANCE_LOOKUP_ADDRESS
     ];
   },
 );
@@ -85,76 +93,3 @@ export const selectWalletHomeOnboardingTradeSwapPair = createSelector(
     return undefined;
   },
 );
-
-function readTokenBalanceHex(
-  state: RootState,
-  accountAddress: Hex,
-  chainId: Hex,
-  tokenAddress: Hex,
-): string | undefined {
-  const balances = selectSingleTokenBalance(
-    state,
-    accountAddress,
-    chainId,
-    tokenAddress,
-  );
-  return balances[tokenAddress];
-}
-
-export function hasPositiveHexTokenBalance(
-  balanceHex: string | undefined,
-): boolean {
-  if (!balanceHex) {
-    return false;
-  }
-
-  try {
-    return BigNumber.from(balanceHex).gt(0);
-  } catch {
-    return false;
-  }
-}
-
-export function hasMainnetMusdBalance(
-  state: RootState,
-  accountAddress: Hex,
-): boolean {
-  const balanceHex = readTokenBalanceHex(
-    state,
-    accountAddress,
-    CHAIN_IDS.MAINNET,
-    MAINNET_MUSD_TOKEN_ADDRESS,
-  );
-  return hasPositiveHexTokenBalance(balanceHex);
-}
-
-export function hasMainnetEthBalance(
-  state: RootState,
-  accountAddress: Hex,
-): boolean {
-  const balanceHex = readTokenBalanceHex(
-    state,
-    accountAddress,
-    CHAIN_IDS.MAINNET,
-    MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
-  );
-  return hasPositiveHexTokenBalance(balanceHex);
-}
-
-/**
- * Resolves onboarding trade-step swap tokens: mUSD → ETH, else ETH → BTC.
- */
-export function resolveWalletHomeOnboardingTradeSwapPair(
-  state: RootState,
-  accountAddress: Hex,
-): WalletHomeOnboardingTradeSwapPair | undefined {
-  if (hasMainnetMusdBalance(state, accountAddress)) {
-    return MAINNET_MUSD_TO_ETH_SWAP_PAIR;
-  }
-
-  if (hasMainnetEthBalance(state, accountAddress)) {
-    return MAINNET_ETH_TO_BTC_SWAP_PAIR;
-  }
-
-  return undefined;
-}

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
@@ -1,0 +1,97 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { BigNumber } from 'ethers';
+import { Hex } from '@metamask/utils';
+import type { RootState } from '../../../reducers';
+import { selectSingleTokenBalance } from '../../../selectors/tokenBalancesController';
+import type { BridgeToken } from '../Bridge/types';
+import {
+  getMainnetBtcBridgeToken,
+  getMainnetEthBridgeToken,
+  getMainnetMusdBridgeToken,
+  MAINNET_MUSD_TOKEN_ADDRESS,
+  MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
+} from './walletHomeOnboardingTradeSwapAssets';
+
+export interface WalletHomeOnboardingTradeSwapPair {
+  sourceToken: BridgeToken;
+  destToken: BridgeToken;
+}
+
+function readTokenBalanceHex(
+  state: RootState,
+  accountAddress: Hex,
+  chainId: Hex,
+  tokenAddress: Hex,
+): string | undefined {
+  const balances = selectSingleTokenBalance(
+    state,
+    accountAddress,
+    chainId,
+    tokenAddress,
+  );
+  return balances[tokenAddress];
+}
+
+export function hasPositiveHexTokenBalance(
+  balanceHex: string | undefined,
+): boolean {
+  if (!balanceHex) {
+    return false;
+  }
+
+  try {
+    return BigNumber.from(balanceHex).gt(0);
+  } catch {
+    return false;
+  }
+}
+
+export function hasMainnetMusdBalance(
+  state: RootState,
+  accountAddress: Hex,
+): boolean {
+  const balanceHex = readTokenBalanceHex(
+    state,
+    accountAddress,
+    CHAIN_IDS.MAINNET,
+    MAINNET_MUSD_TOKEN_ADDRESS,
+  );
+  return hasPositiveHexTokenBalance(balanceHex);
+}
+
+export function hasMainnetEthBalance(
+  state: RootState,
+  accountAddress: Hex,
+): boolean {
+  const balanceHex = readTokenBalanceHex(
+    state,
+    accountAddress,
+    CHAIN_IDS.MAINNET,
+    MAINNET_NATIVE_ETH_TOKEN_ADDRESS,
+  );
+  return hasPositiveHexTokenBalance(balanceHex);
+}
+
+/**
+ * Resolves onboarding trade-step swap tokens: mUSD → ETH, else ETH → BTC.
+ */
+export function resolveWalletHomeOnboardingTradeSwapPair(
+  state: RootState,
+  accountAddress: Hex,
+): WalletHomeOnboardingTradeSwapPair | undefined {
+  if (hasMainnetMusdBalance(state, accountAddress)) {
+    return {
+      sourceToken: getMainnetMusdBridgeToken(),
+      destToken: getMainnetEthBridgeToken(),
+    };
+  }
+
+  if (hasMainnetEthBalance(state, accountAddress)) {
+    return {
+      sourceToken: getMainnetEthBridgeToken(),
+      destToken: getMainnetBtcBridgeToken(),
+    };
+  }
+
+  return undefined;
+}

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingTradeSwapBalances.ts
@@ -1,8 +1,13 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { BigNumber } from 'ethers';
 import { Hex } from '@metamask/utils';
+import { createSelector } from 'reselect';
 import type { RootState } from '../../../reducers';
-import { selectSingleTokenBalance } from '../../../selectors/tokenBalancesController';
+import { selectSelectedInternalAccountAddress } from '../../../selectors/accountsController';
+import {
+  selectSingleTokenBalance,
+  selectTokensBalances,
+} from '../../../selectors/tokenBalancesController';
 import type { BridgeToken } from '../Bridge/types';
 import {
   getMainnetBtcBridgeToken,
@@ -16,6 +21,70 @@ export interface WalletHomeOnboardingTradeSwapPair {
   sourceToken: BridgeToken;
   destToken: BridgeToken;
 }
+
+/** Stable references so selectors and press handlers avoid per-render allocations. */
+export const MAINNET_MUSD_TO_ETH_SWAP_PAIR: WalletHomeOnboardingTradeSwapPair =
+  {
+    sourceToken: getMainnetMusdBridgeToken(),
+    destToken: getMainnetEthBridgeToken(),
+  };
+
+export const MAINNET_ETH_TO_BTC_SWAP_PAIR: WalletHomeOnboardingTradeSwapPair = {
+  sourceToken: getMainnetEthBridgeToken(),
+  destToken: getMainnetBtcBridgeToken(),
+};
+
+const selectSelectedAccountMainnetMusdBalanceHex = createSelector(
+  [selectSelectedInternalAccountAddress, selectTokensBalances],
+  (accountAddress, tokenBalances) => {
+    if (!accountAddress) {
+      return undefined;
+    }
+
+    return tokenBalances?.[accountAddress]?.[CHAIN_IDS.MAINNET]?.[
+      MAINNET_MUSD_TOKEN_ADDRESS
+    ];
+  },
+);
+
+const selectSelectedAccountMainnetEthBalanceHex = createSelector(
+  [selectSelectedInternalAccountAddress, selectTokensBalances],
+  (accountAddress, tokenBalances) => {
+    if (!accountAddress) {
+      return undefined;
+    }
+
+    return tokenBalances?.[accountAddress]?.[CHAIN_IDS.MAINNET]?.[
+      MAINNET_NATIVE_ETH_TOKEN_ADDRESS
+    ];
+  },
+);
+
+/**
+ * Memoized swap pair for the selected account; output is one of the stable pair constants.
+ */
+export const selectWalletHomeOnboardingTradeSwapPair = createSelector(
+  [
+    selectSelectedInternalAccountAddress,
+    selectSelectedAccountMainnetMusdBalanceHex,
+    selectSelectedAccountMainnetEthBalanceHex,
+  ],
+  (accountAddress, musdBalanceHex, ethBalanceHex) => {
+    if (!accountAddress) {
+      return undefined;
+    }
+
+    if (hasPositiveHexTokenBalance(musdBalanceHex)) {
+      return MAINNET_MUSD_TO_ETH_SWAP_PAIR;
+    }
+
+    if (hasPositiveHexTokenBalance(ethBalanceHex)) {
+      return MAINNET_ETH_TO_BTC_SWAP_PAIR;
+    }
+
+    return undefined;
+  },
+);
 
 function readTokenBalanceHex(
   state: RootState,
@@ -80,17 +149,11 @@ export function resolveWalletHomeOnboardingTradeSwapPair(
   accountAddress: Hex,
 ): WalletHomeOnboardingTradeSwapPair | undefined {
   if (hasMainnetMusdBalance(state, accountAddress)) {
-    return {
-      sourceToken: getMainnetMusdBridgeToken(),
-      destToken: getMainnetEthBridgeToken(),
-    };
+    return MAINNET_MUSD_TO_ETH_SWAP_PAIR;
   }
 
   if (hasMainnetEthBalance(state, accountAddress)) {
-    return {
-      sourceToken: getMainnetEthBridgeToken(),
-      destToken: getMainnetBtcBridgeToken(),
-    };
+    return MAINNET_ETH_TO_BTC_SWAP_PAIR;
   }
 
   return undefined;

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -176,6 +176,7 @@ import { useSendNonEvmAsset } from '../../hooks/useSendNonEvmAsset';
 ///: END:ONLY_INCLUDE_IF
 import { suppressWalletHomeOnboardingSteps } from '../../../actions/onboarding';
 import { WALLET_HOME_POST_ONBOARDING_REVEAL_MS } from '../../UI/WalletHomeOnboardingSteps';
+import { useWalletHomeOnboardingChecklistTradePress } from '../../UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress';
 import {
   IconColor,
   IconName,
@@ -747,16 +748,8 @@ const Wallet = ({
     sourcePage: 'MainView',
   });
 
-  /** Trade checklist primary — Segment location per TMCU-680. */
-  const goToSwapsFromOnboardingChecklist = useCallback(() => {
-    goToSwaps(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      ActionLocation.ONBOARDING_CHECKLIST,
-    );
-  }, [goToSwaps]);
+  const onTradePrimaryPress =
+    useWalletHomeOnboardingChecklistTradePress(goToSwaps);
   const handleWalletHomeOnboardingNotificationsPrimary = useCallback(() => {
     navigation.navigate(Routes.SETTINGS_VIEW, {
       screen: Routes.SETTINGS.NOTIFICATIONS,
@@ -1367,7 +1360,7 @@ const Wallet = ({
   const walletHomeAccountGroupBalanceProps = {
     onCoordinatedFlowExit: runWalletHomePostOnboardingComplete,
     suspendRiveForCurtain: postOnboardingExitAnimating,
-    onTradePrimaryPress: goToSwapsFromOnboardingChecklist,
+    onTradePrimaryPress,
     onNotificationsPrimaryPress: handleWalletHomeOnboardingNotificationsPrimary,
   };
 


### PR DESCRIPTION
## **Description**

Implements the **Trade** portion of [TMCU-681](https://consensyssoftware.atlassian.net/browse/TMCU-681): when the user taps **Trade** on the wallet home onboarding checklist, the app opens unified swaps with source/destination defaults based on mainnet balances at press time.

**Priority:**
1. Mainnet **mUSD** balance &gt; 0 → swap **mUSD → ETH**
2. Else mainnet **ETH** balance &gt; 0 → swap **ETH → BTC**
3. Else → existing `goToSwaps(undefined, undefined)` fallback

**Implementation:**
- `walletHomeOnboardingTradeSwapAssets.ts` — mainnet mUSD / ETH / BTC `BridgeToken` helpers (local constants; no Ramp edits).
- `walletHomeOnboardingTradeSwapBalances.ts` — balance checks via `selectSingleTokenBalance` + `resolveWalletHomeOnboardingTradeSwapPair`.
- `useWalletHomeOnboardingTradeSwapPair` — subscribes via `useSelector` and resolves the pair reactively.
- `useWalletHomeOnboardingChecklistTradePress` — passes resolved tokens to `goToSwaps` with `ActionLocation.ONBOARDING_CHECKLIST` (TMCU-680 analytics location unchanged).

Complements the **Add funds** work in https://github.com/MetaMask/metamask-mobile/pull/30692 (separate PR; can merge independently).

## **Changelog**

CHANGELOG entry: Improved the wallet home onboarding **Trade** step to open swaps with sensible default tokens (mUSD→ETH or ETH→BTC) when the user has matching mainnet balances.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-681

## **Manual testing steps**

```gherkin
Feature: Wallet home onboarding trade step swap preselection

  Scenario: Trade opens swaps with mUSD source and ETH destination when mainnet mUSD balance is positive
    Given wallet home onboarding checklist is visible on the trade step
    And the selected account has a positive mainnet mUSD balance

    When user taps Trade
    Then unified swaps opens with mUSD as source and ETH as destination

  Scenario: Trade opens swaps with ETH source and BTC destination when only mainnet ETH balance is positive
    Given wallet home onboarding checklist is visible on the trade step
    And the selected account has no mainnet mUSD balance but has positive mainnet ETH balance

    When user taps Trade
    Then unified swaps opens with ETH as source and BTC as destination

  Scenario: Trade opens default swaps when neither mUSD nor ETH mainnet balance is positive
    Given wallet home onboarding checklist is visible on the trade step
    And the selected account has no positive mainnet mUSD or ETH balance

    When user taps Trade
    Then unified swaps opens with default token selection (no overrides)
```

## **Screenshots/Recordings**

### **Before**

Trade opened unified swaps with default token selection (no source/dest overrides).

### **After**

Trade opens with mUSD→ETH or ETH→BTC when the user has the corresponding mainnet balance.

<!-- Add screenshots/recordings during manual QA if needed -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-681]: https://consensyssoftware.atlassian.net/browse/TMCU-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only navigation change with balance-driven token defaults and tests; no auth, payments, or core swap execution logic modified.
> 
> **Overview**
> **Wallet home onboarding Trade** now opens unified swaps with **preselected source/destination tokens** from the user’s mainnet balances instead of always using empty overrides.
> 
> On **Trade** press, a memoized selector reads **TokenBalancesController** for the selected account: positive **mUSD** (checksummed address key) → **mUSD → ETH**; else positive **ETH** → **ETH → BTC**; otherwise behavior matches the previous **`goToSwaps(undefined, undefined)`** fallback. **`ActionLocation.ONBOARDING_CHECKLIST`** is unchanged.
> 
> **Wallet** wires the checklist through **`useWalletHomeOnboardingChecklistTradePress`**, which reads the latest pair via a ref at tap time. New modules cover mainnet **BridgeToken** helpers, stable swap-pair constants, hooks, and unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f718e84019fc6500d2d380dfb6932ebc428bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->