### PR TITLE
fix(predict): preserve game market outcomes in staleness filtering cp-7.79.0

### DIFF
--- a/app/components/UI/Predict/utils/marketStaleness.test.ts
+++ b/app/components/UI/Predict/utils/marketStaleness.test.ts
@@ -263,6 +263,20 @@ describe('marketStaleness', () => {
 
       expect(getVisiblePredictMarket(market, { now: NOW })).toEqual(market);
     });
+
+    it('keeps game markets without filtering stale-priced outcomes', () => {
+      const market = createMarket({
+        id: 'game-market',
+        game: createGame('scheduled'),
+        outcomes: [
+          createOutcome({ id: 'favorite', price: 0.97 }),
+          createOutcome({ id: 'draw', price: 0.04 }),
+          createOutcome({ id: 'underdog', price: 0.03 }),
+        ],
+      });
+
+      expect(getVisiblePredictMarket(market, { now: NOW })).toEqual(market);
+    });
   });
 
   describe('penalties and ranking', () => {
@@ -333,6 +347,22 @@ describe('marketStaleness', () => {
           (market) => market.id,
         ),
       ).toEqual(['highlighted', 'live', 'stale']);
+    });
+
+    it('does not apply staleness ranking penalties to game markets', () => {
+      const stalePricedGame = createMarket({
+        id: 'stale-priced-game',
+        game: createGame('scheduled'),
+        outcomes: [createOutcome({ id: 'heavy-favorite', price: 0.99 })],
+      });
+      const liveOne = createMarket({ id: 'live-one' });
+      const liveTwo = createMarket({ id: 'live-two' });
+
+      expect(
+        getVisiblePredictMarkets([stalePricedGame, liveOne, liveTwo], {
+          now: NOW,
+        }).map((market) => market.id),
+      ).toEqual(['stale-priced-game', 'live-one', 'live-two']);
     });
 
     it('preserves original order when ranking scores tie', () => {

--- a/app/components/UI/Predict/utils/marketStaleness.ts
+++ b/app/components/UI/Predict/utils/marketStaleness.ts
@@ -187,7 +187,7 @@ const getPredictMarketStalenessPenalty = (
   market: PredictMarket,
   options?: PredictMarketStalenessOptions,
 ): number => {
-  if (market.isHighlighted) {
+  if (market.isHighlighted || isGameMarket(market)) {
     return 1;
   }
 
@@ -211,6 +211,10 @@ export const getVisiblePredictMarket = (
 
   if (isPredictMarketExpiredByTime(market, options)) {
     return null;
+  }
+
+  if (isGameMarket(market)) {
+    return market;
   }
 
   return filterVisibleMarketOutcomes(market);


### PR DESCRIPTION
## **Description**

Fixes World Cup/sports game cards that could show only two outcomes for draw-capable moneyline games when one outcome had very low odds.

The shared market staleness filter removes outcomes priced at or below 5% or at or above 95%. That behavior is useful for multi-outcome non-game cards, but it breaks game cards that need the complete moneyline set. For example, Germany vs. Curacao has Germany, Draw, and Curacao outcomes, but Curacao can be priced below 5%. Once that outcome is filtered out, the card falls back to a binary path and the away-team button can open the `No` token for the favorite instead of the underdog moneyline.

This change skips stale-price outcome filtering and stale-price ranking penalties for game markets. Closed markets and ended games are still filtered out as before.

## **Changelog**

CHANGELOG entry: Fixed a bug where sports game cards could hide low-probability outcomes and open the wrong prediction.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-934?atlOrigin=eyJpIjoiZjVmNDJkY2I3NzBjNGQ4MjgwZWY5MjQ5ZjcyOTlkYWMiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: World Cup game card outcomes

  Scenario: user opens a draw-capable World Cup game card with a low-probability away team
    Given the World Cup feed includes a game with home, draw, and away moneyline outcomes
    And one of the moneyline outcomes is priced at or below 5%

    When user views the game card
    Then the card shows all available moneyline outcomes

    When user taps the away-team prediction button
    Then the buy sheet opens for the away-team outcome, not the favorite team's No token
```

## **Screenshots/Recordings**

### **Before**

<img width="420" height="861" alt="Screenshot 2026-05-27 at 14 27 35" src="https://github.com/user-attachments/assets/6ec940a0-5db6-4323-a7aa-58cb422c00a8" />


### **After**

<img width="420" height="875" alt="Screenshot 2026-05-27 at 14 27 49" src="https://github.com/user-attachments/assets/6f277b93-5d88-4353-87e0-68588e88f944" />

## **Testing**

- `node .yarn/releases/yarn-4.14.1.cjs jest app/components/UI/Predict/utils/marketStaleness.test.ts`

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Predict visibility/ranking utilities; closed and ended games remain hidden; non-game staleness behavior unchanged.
> 
> **Overview**
> **Game markets** with a `game` attachment are now exempt from Predict’s stale-price outcome filtering (≤5% / ≥95%) and from staleness-based feed ranking penalties, matching the existing **highlighted** market behavior.
> 
> `getVisiblePredictMarket` returns the full market for open game markets after the usual closed/expired checks, so moneyline sets (e.g. home / draw / away) stay intact when an underdog is priced very low. Non-game cards still drop “dead” outcomes and can be deprioritized in the list.
> 
> Tests cover full outcome preservation on game cards and unchanged ordering when a game market would otherwise be penalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ead89aa9e865f0293c50b5a90efc1f389bffa0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->