### PR TITLE
cherry-pick: fix(perps): investigate Failed to execute 'dispatchEvent' on 'EventTa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -424,7 +424,6 @@
     "ethereumjs-util": "^7.0.10",
     "ethers": "^5.0.14",
     "ethjs-ens": "2.0.1",
-    "event-target-shim": "^6.0.2",
     "eventemitter2": "^6.4.9",
     "events": "3.0.0",
     "expo": "54.0.33",

--- a/shim.js
+++ b/shim.js
@@ -158,14 +158,23 @@ global.crypto = {
 
 process.browser = false;
 
-// EventTarget polyfills for Hyperliquid SDK WebSocket support
+// EventTarget / Event polyfills for Hyperliquid SDK WebSocket support.
+// React Native's WebSocket extends RN's internal EventTarget, whose
+// dispatchEvent validates `event instanceof RNEvent`. The event-target-shim
+// package provides a *different* Event class that fails this check, causing
+// "parameter 1 is not of type 'Event'" TypeErrors when @nktkas/rews dispatches
+// CloseEvent on the native WebSocket. Use RN's own classes so all instanceof
+// checks pass consistently.
 if (
   typeof global.EventTarget === 'undefined' ||
   typeof global.Event === 'undefined'
 ) {
-  const { Event, EventTarget } = require('event-target-shim');
-  global.EventTarget = EventTarget;
-  global.Event = Event;
+  // eslint-disable-next-line @react-native/no-deep-imports -- RN does not export Event/EventTarget at the top level
+  global.Event =
+    require('react-native/src/private/webapis/dom/events/Event').default;
+  // eslint-disable-next-line @react-native/no-deep-imports -- RN does not export EventTarget at the top level
+  global.EventTarget =
+    require('react-native/src/private/webapis/dom/events/EventTarget').default;
 }
 
 if (typeof global.CustomEvent === 'undefined') {
@@ -178,29 +187,17 @@ if (typeof global.CustomEvent === 'undefined') {
 }
 
 // CloseEvent polyfill for @nktkas/rews v2 (used by Hyperliquid SDK WebSocket transport)
-// React Native/Hermes does not provide CloseEvent as a global constructor
 if (typeof global.CloseEvent === 'undefined') {
-  global.CloseEvent = function (type, params) {
-    params = params || {};
-    const event = new global.Event(type, params);
-    event.code = params.code ?? 0;
-    event.reason = params.reason ?? '';
-    event.wasClean = params.wasClean ?? false;
-    return event;
-  };
+  // eslint-disable-next-line @react-native/no-deep-imports -- RN does not export CloseEvent at the top level
+  global.CloseEvent =
+    require('react-native/src/private/webapis/websockets/events/CloseEvent').default;
 }
 
 // MessageEvent polyfill for @nktkas/rews v2 (used by Hyperliquid SDK WebSocket transport)
-// React Native/Hermes does not provide MessageEvent as a global constructor
 if (typeof global.MessageEvent === 'undefined') {
-  global.MessageEvent = function (type, params) {
-    params = params || {};
-    const event = new global.Event(type, params);
-    event.data = params.data ?? null;
-    event.origin = params.origin ?? '';
-    event.lastEventId = params.lastEventId ?? '';
-    return event;
-  };
+  // eslint-disable-next-line @react-native/no-deep-imports -- RN does not export MessageEvent at the top level
+  global.MessageEvent =
+    require('react-native/src/private/webapis/html/events/MessageEvent').default;
 }
 
 class AbortError extends Error {

--- a/shim.test.js
+++ b/shim.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests for the Event/EventTarget/CloseEvent/MessageEvent polyfills in shim.js.
+ *
+ * The core fix (TAT-3223) ensures polyfilled globals use React Native's own
+ * Event classes for instanceof compatibility with RN's EventTarget.dispatchEvent.
+ * Full dispatch compatibility is validated by the agentic recipe against the
+ * live runtime; these unit tests verify constructor behavior and property access.
+ */
+
+/* eslint-disable @react-native/no-deep-imports, import-x/no-commonjs */
+const RNCloseEvent =
+  require('react-native/src/private/webapis/websockets/events/CloseEvent').default;
+const RNMessageEvent =
+  require('react-native/src/private/webapis/html/events/MessageEvent').default;
+const RNEvent =
+  require('react-native/src/private/webapis/dom/events/Event').default;
+/* eslint-enable @react-native/no-deep-imports, import-x/no-commonjs */
+
+describe('Event polyfill shims (TAT-3223)', () => {
+  describe('CloseEvent', () => {
+    it('preserves code, reason, and wasClean via getters', () => {
+      const ce = new RNCloseEvent('close', {
+        code: 1006,
+        reason: 'abnormal',
+        wasClean: false,
+      });
+
+      expect(ce.type).toBe('close');
+      expect(ce.code).toBe(1006);
+      expect(ce.reason).toBe('abnormal');
+      expect(ce.wasClean).toBe(false);
+    });
+
+    it('defaults code to 0, reason to empty, wasClean to false', () => {
+      const ce = new RNCloseEvent('close');
+
+      expect(ce.code).toBe(0);
+      expect(ce.reason).toBe('');
+      expect(ce.wasClean).toBe(false);
+    });
+
+    it('extends RN Event', () => {
+      const ce = new RNCloseEvent('close', { code: 1000 });
+
+      expect(ce instanceof RNEvent).toBe(true);
+      expect(ce.type).toBe('close');
+    });
+  });
+
+  describe('MessageEvent', () => {
+    it('preserves data and origin via getters', () => {
+      const me = new RNMessageEvent('message', {
+        data: 'payload',
+        origin: 'wss://example.com',
+      });
+
+      expect(me.type).toBe('message');
+      expect(me.data).toBe('payload');
+      expect(me.origin).toBe('wss://example.com');
+    });
+
+    it('defaults data to undefined, origin to empty string', () => {
+      const me = new RNMessageEvent('message');
+
+      expect(me.data).toBeUndefined();
+      expect(me.origin).toBe('');
+    });
+
+    it('extends RN Event', () => {
+      const me = new RNMessageEvent('message', { data: 'test' });
+
+      expect(me instanceof RNEvent).toBe(true);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -28746,13 +28746,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"event-target-shim@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "event-target-shim@npm:6.0.2"
-  checksum: 10/aa69fc4193cad3f1e4dc0c2d3f2689ea2d477f5ff2fbee8b65f866035b15658e1985932b06ba2190c3d2cc9cc6802c26facd6c60487590c1a05f44545ec24f42
-  languageName: node
-  linkType: hard
-
 "eventemitter2@npm:^6.4.9":
   version: 6.4.9
   resolution: "eventemitter2@npm:6.4.9"
@@ -35683,7 +35676,6 @@ __metadata:
     ethereumjs-util: "npm:^7.0.10"
     ethers: "npm:^5.0.14"
     ethjs-ens: "npm:2.0.1"
-    event-target-shim: "npm:^6.0.2"
     eventemitter2: "npm:^6.4.9"
     events: "npm:3.0.0"
     execa: "npm:^8.0.1"


### PR DESCRIPTION
…rget': parameter 1 is not of type 'Event' (#30612)

## **Description**

Fix `TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'` crash caused by the `CloseEvent` polyfill in `shim.js` using `event-target-shim`'s `Event` class instead of React Native's own `Event` class. When `@nktkas/rews` (Hyperliquid SDK WebSocket transport) dispatches a `CloseEvent` on the native WebSocket, RN's `dispatchEvent` validates `event instanceof RNEvent` — which failed because `event-target-shim` provides a different `Event` class.

Replaced `event-target-shim` globals with React Native's own `Event`, `EventTarget`, `CloseEvent`, and `MessageEvent` classes so all `instanceof` checks pass consistently.

## **Changelog**

CHANGELOG entry: Fixed a crash caused by CloseEvent dispatch on WebSocket failing instanceof validation

## **Related issues**

Fixes:
[TAT-3223](https://consensyssoftware.atlassian.net/browse/TAT-3223)

## **Manual testing steps**

```gherkin
Feature: CloseEvent dispatch on native WebSocket

  Scenario: CloseEvent is dispatched on native WebSocket without error
    Given the app is running with Hyperliquid SDK active

    When a WebSocket connection is closed while in CONNECTING state
    Then no TypeError is thrown
    And the CloseEvent is dispatched successfully
```

## **Screenshots/Recordings**

State-only fix: no visual evidence needed. Both ACs proven via CDP eval (CloseEvent dispatch success) and lint:tsc (no TS errors).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "pr": "TAT-3223",
  "title": "CloseEvent dispatchEvent on native WebSocket must not throw TypeError",
  "jira": "TAT-3223",
  "acceptance_criteria": [
    "CloseEvent dispatched on native WebSocket must not throw TypeError",
    "No new TypeScript errors introduced by the fix"
  ],
  "validate": {
    "static": ["yarn lint:tsc"],
    "workflow": {
      "pre_conditions": ["wallet.unlocked"],
      "entry": "ac1-eval-closeevent-dispatch",
      "nodes": {
        "ac1-eval-closeevent-dispatch": {
          "action": "eval_sync",
          "expression": "(function() { try { var ws = new WebSocket('wss://echo.websocket.org'); var ce = new CloseEvent('close', {code: 1006, reason: '', wasClean: false}); ws.dispatchEvent(ce); ws.close(); return JSON.stringify({success: true, error: null}); } catch(e) { return JSON.stringify({success: false, error: e.message}); } })()",
          "assert": { "operator": "eq", "field": "success", "value": true },
          "next": "ac1-eval-closeevent-props"
        },
        "ac1-eval-closeevent-props": {
          "action": "eval_sync",
          "expression": "(function() { var ce = new CloseEvent('close', {code: 1006, reason: 'test', wasClean: true}); return JSON.stringify({type: ce.type, code: ce.code, reason: ce.reason, wasClean: ce.wasClean}); })()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "code", "value": 1006 },
              { "operator": "eq", "field": "reason", "value": "test" },
              { "operator": "eq", "field": "wasClean", "value": true }
            ]
          },
          "next": "ac1-eval-messageevent-dispatch"
        },
        "ac1-eval-messageevent-dispatch": {
          "action": "eval_sync",
          "expression": "(function() { try { var ws = new WebSocket('wss://echo.websocket.org'); var me = new MessageEvent('message', {data: 'hello'}); ws.dispatchEvent(me); ws.close(); return JSON.stringify({success: true, error: null}); } catch(e) { return JSON.stringify({success: false, error: e.message}); } })()",
          "assert": { "operator": "eq", "field": "success", "value": true },
          "next": "setup-done"
        },
        "setup-done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
graph TD
    ac1-eval-closeevent-dispatch["ac1-eval-closeevent-dispatch<br/>eval_sync: CloseEvent dispatch on native WS"]
    ac1-eval-closeevent-props["ac1-eval-closeevent-props<br/>eval_sync: Verify CloseEvent properties"]
    ac1-eval-messageevent-dispatch["ac1-eval-messageevent-dispatch<br/>eval_sync: MessageEvent dispatch on native WS"]
    setup-done["setup-done<br/>end: pass"]

    ac1-eval-closeevent-dispatch --> ac1-eval-closeevent-props
    ac1-eval-closeevent-props --> ac1-eval-messageevent-dispatch
    ac1-eval-messageevent-dispatch --> setup-done
```

</details>


[TAT-3223]:
https://consensyssoftware.atlassian.net/browse/TAT-3223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app bootstrap polyfills used by Hyperliquid WebSockets; low
blast radius but wrong globals could break perps connectivity at runtime.
> 
> **Overview**
> Fixes a **Hyperliquid / perps WebSocket crash** where `dispatchEvent`
rejected `CloseEvent` because polyfilled events did not pass React Native’s `instanceof Event` check.
> 
> **`shim.js`** stops using **`event-target-shim`** and hand-rolled
`CloseEvent` / `MessageEvent` constructors. When globals are missing, it assigns React Native’s own **`Event`**, **`EventTarget`**, **`CloseEvent`**, and **`MessageEvent`** from RN private web API modules so events dispatched by `@nktkas/rews` match what RN’s WebSocket `EventTarget` expects.
> 
> **`event-target-shim`** is removed from **`package.json`** / lockfile.
**`shim.test.js`** adds unit coverage for RN `CloseEvent` and `MessageEvent` properties and inheritance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit
5d5cb890f0580cb94d2af53ac577caa515aa86a5. Bugbot is set up for automated code reviews on this repo. Configure
[here](https://www.cursor.com/dashboard/bugbot).</sup> <!-- /CURSOR_SUMMARY -->

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3223]: https://consensyssoftware.atlassian.net/browse/TAT-3223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAT-3223]: https://consensyssoftware.atlassian.net/browse/TAT-3223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ