### PR TITLE
fix(Rewards): Ondo campaign UX cp-7.79.0

### DIFF
--- a/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignDetailsView.test.tsx
@@ -460,7 +460,7 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.campaigns_view.error_description': 'Please try again.',
       'rewards.campaigns_view.retry_button': 'Retry',
       'rewards.campaign_details.join_campaign': 'Join Campaign',
-      'rewards.campaign_details.open_position': 'Open Position',
+      'rewards.campaign_details.open_position': 'Trade now',
       'rewards.campaign_details.swap_ondo_assets': 'Swap Ondo Assets',
       'rewards.campaign_details.ondo.entries_closed_title': 'Entries closed',
       'rewards.campaign_details.ondo.entries_closed_description':
@@ -803,7 +803,7 @@ describe('OndoCampaignDetailsView', () => {
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeDefined();
     });
 
-    it('renders "Open Position" CTA when participant is opted in with no positions', () => {
+    it('renders "Trade now" CTA when participant is opted in with no positions', () => {
       mockUseRewardCampaigns.mockReturnValue({
         ...hookDefaults,
         campaigns: [createTestCampaign()],
@@ -816,7 +816,7 @@ describe('OndoCampaignDetailsView', () => {
       });
       const { getByTestId, getByText } = render(<OndoCampaignDetailsView />);
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeDefined();
-      expect(getByText('Open Position')).toBeDefined();
+      expect(getByText('Trade now')).toBeDefined();
     });
 
     it('renders "Swap Ondo Assets" CTA when participant is opted in with positions', () => {

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -674,6 +674,20 @@ describe('OndoCampaignRwaSelectorView', () => {
       expect(queryByTestId('after-hours-sheet')).toBeNull();
     });
 
+    it('uses USDT as the source token for BNB Chain assets when after hours confirm is pressed', () => {
+      const token = buildToken('AAPL', 'eip155:56/erc20:0xaapl');
+      mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });
+      const { getByTestId } = render(<OndoCampaignRwaSelectorView />);
+      fireEvent.press(getByTestId('token-row-AAPL'));
+      fireEvent.press(getByTestId('after-hours-confirm'));
+
+      expect(mockGoToSwaps).toHaveBeenCalledTimes(1);
+      const [srcArg, destArg] = mockGoToSwaps.mock.calls[0];
+      expect(srcArg?.symbol).toBe('USDT');
+      expect(srcArg?.chainId).toBe('0x38');
+      expect(destArg?.chainId).toBe('eip155:56');
+    });
+
     it('tracks button_clicked event when after hours confirm is pressed', () => {
       const token = buildToken('AAPL');
       mockUseRwaTokens.mockReturnValue({ data: [token], isLoading: false });

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import OndoCampaignRwaSelectorView from './OndoCampaignRwaSelectorView';
+import OndoCampaignRwaSelectorView, {
+  getOndoOpenPositionSourceToken,
+} from './OndoCampaignRwaSelectorView';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import {
@@ -723,5 +725,26 @@ describe('OndoCampaignRwaSelectorView', () => {
       fireEvent.press(getByTestId('ondo-rwa-selector-header-search-close'));
       expect(getByTestId('filter-bar')).toBeDefined();
     });
+  });
+});
+
+describe('getOndoOpenPositionSourceToken', () => {
+  it('returns USDT for BNB Chain when the chain ID is hex', () => {
+    expect(getOndoOpenPositionSourceToken('0x38')).toEqual(
+      expect.objectContaining({
+        symbol: 'USDT',
+        chainId: '0x38',
+      }),
+    );
+  });
+
+  it('returns undefined when no chain ID is provided', () => {
+    expect(getOndoOpenPositionSourceToken(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for unsupported non-EVM chain IDs', () => {
+    expect(
+      getOndoOpenPositionSourceToken('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'),
+    ).toBeUndefined();
   });
 });

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -68,10 +68,10 @@ const USDY_CAIP19 =
   'eip155:1/erc20:0x96f6ef951840721adbf46ac996b59e0235cb985c' as const;
 const USDY_DECIMALS = 18;
 
-const ONDO_OPEN_POSITION_SOURCE_TOKENS: Partial<
-  Record<CaipChainId, BridgeToken>
+const ONDO_OPEN_POSITION_SOURCE_TOKENS_BY_CHAIN_ID: Partial<
+  Record<Hex, BridgeToken>
 > = {
-  'eip155:1': {
+  '0x1': {
     address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     symbol: 'USDC',
     name: 'USD Coin',
@@ -80,7 +80,7 @@ const ONDO_OPEN_POSITION_SOURCE_TOKENS: Partial<
     image:
       'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
   },
-  'eip155:56': {
+  '0x38': {
     address: '0x55d398326f99059ff775485246999027b3197955',
     symbol: 'USDT',
     name: 'Tether USD',
@@ -89,6 +89,22 @@ const ONDO_OPEN_POSITION_SOURCE_TOKENS: Partial<
     image:
       'https://static.cx.metamask.io/api/v1/tokenIcons/56/0x55d398326f99059ff775485246999027b3197955.png',
   },
+};
+
+const getOndoOpenPositionSourceToken = (
+  chainId: BridgeToken['chainId'] | undefined,
+): BridgeToken | undefined => {
+  if (!chainId) return undefined;
+
+  if (chainId.startsWith('0x')) {
+    return ONDO_OPEN_POSITION_SOURCE_TOKENS_BY_CHAIN_ID[chainId as Hex];
+  }
+
+  if (!chainId.startsWith('eip155:')) return undefined;
+
+  return ONDO_OPEN_POSITION_SOURCE_TOKENS_BY_CHAIN_ID[
+    caipChainIdToHex(chainId as CaipChainId)
+  ];
 };
 
 // ParamListBase requires an index signature, which interfaces don't support
@@ -306,7 +322,7 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
       };
       const openPositionSourceToken =
         mode === 'open_position'
-          ? (ondoUsdSrcToken ?? ONDO_OPEN_POSITION_SOURCE_TOKENS[destChainId])
+          ? (ondoUsdSrcToken ?? getOndoOpenPositionSourceToken(destChainId))
           : undefined;
 
       if (!isTokenTradingOpen(destToken)) {
@@ -482,9 +498,9 @@ const OndoCampaignRwaSelectorView: React.FC = () => {
                 const openPositionSourceToken =
                   mode === 'open_position'
                     ? (ondoUsdSrcToken ??
-                      ONDO_OPEN_POSITION_SOURCE_TOKENS[
-                        afterHoursPendingToken.chainId as CaipChainId
-                      ])
+                      getOndoOpenPositionSourceToken(
+                        afterHoursPendingToken.chainId,
+                      ))
                     : undefined;
                 trackEvent(
                   createEventBuilder(

--- a/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
+++ b/app/components/UI/Rewards/Views/OndoCampaignRwaSelectorView.tsx
@@ -91,7 +91,7 @@ const ONDO_OPEN_POSITION_SOURCE_TOKENS_BY_CHAIN_ID: Partial<
   },
 };
 
-const getOndoOpenPositionSourceToken = (
+export const getOndoOpenPositionSourceToken = (
   chainId: BridgeToken['chainId'] | undefined,
 ): BridgeToken | undefined => {
   if (!chainId) return undefined;

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.test.tsx
@@ -110,7 +110,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
       'rewards.campaign_details.join_campaign': 'Join Campaign',
-      'rewards.campaign_details.open_position': 'Open Position',
+      'rewards.campaign_details.open_position': 'Trade now',
       'rewards.campaign_details.swap_ondo_assets': 'Swap Ondo Assets',
       'rewards.campaign_details.ondo.entries_closed_title': 'Entries closed',
       'rewards.campaign_details.ondo.entries_closed_description':
@@ -222,7 +222,7 @@ describe('OndoCampaignCTA', () => {
   });
 
   describe('opted in, no portfolio positions', () => {
-    it('renders the "Open Position" button', () => {
+    it('renders the "Trade now" button', () => {
       const { getByTestId, getByText } = render(
         <OndoCampaignCTA
           campaign={buildCampaign()}
@@ -233,7 +233,7 @@ describe('OndoCampaignCTA', () => {
       );
 
       expect(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeOnTheScreen();
-      expect(getByText('Open Position')).toBeOnTheScreen();
+      expect(getByText('Trade now')).toBeOnTheScreen();
     });
 
     it('navigates to RWA asset selector in open_position mode when pressed', () => {

--- a/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/OndoCampaignCTA.tsx
@@ -35,7 +35,7 @@ interface OndoCampaignCTAProps {
  * Renders one of four states depending on campaign/participant status:
  * - Delegates to CampaignOptInCta for the opt-in flow (active, not opted in, within deposit window). Passes ONDO_RESTRICTED_COUNTRIES so that CampaignOptInCta shows the geo-locked "Check eligibility" CTA for restricted users.
  * - "Entries closed" button (with Lock icon + toast) when cutoff has passed and user is not opted in
- * - "Open Position" button when the user has opted in but has no portfolio positions
+ * - "Trade now" button when the user has opted in but has no portfolio positions
  * - "Swap Ondo Assets" button when the user has opted in and has portfolio positions
  */
 const OndoCampaignCTA: React.FC<OndoCampaignCTAProps> = ({

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8892,7 +8892,7 @@
       "checking_opt_in_status": "Checking opt in status",
       "swap": "Swap",
       "swap_ondo_assets": "Swap Ondo Assets",
-      "open_position": "Open Position",
+      "open_position": "Trade now",
       "how_it_works": "How it works",
       "ondo": {
         "entries_closed_title": "Entries closed",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This attempts to fix what was intended to be fixed in PR #30419 but for some reason that PR did not work - to ensure that a source token is used when opening an Ondo swap from Rewards. It also updates the button text to say "Trade now" instead of "Open Position." 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: n/a

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and Rewards swap prefill logic only; changes are localized with new unit tests and no auth or payment impact.
> 
> **Overview**
> Renames the opted-in, no-positions Ondo campaign CTA from **Open Position** to **Trade now** via `rewards.campaign_details.open_position` in `en.json`, with matching test and comment updates.
> 
> Fixes **open position** swaps from Rewards by resolving default source tokens through a new `getOndoOpenPositionSourceToken` helper: chain defaults are keyed by hex (`0x1` → USDC, `0x38` → USDT) instead of CAIP-only map lookups, and the helper accepts hex or `eip155:` chain IDs (including after-hours confirm). USDY balance preference is unchanged; tests cover BNB/USDT and the helper edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be88b881266f146b370bb4f7520f5164b1ff0af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->