### PR TITLE
fix(ramp): pick provider that supports asset for MM Pay surfaces (TRAM-3597)

### DIFF
--- a/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx
@@ -54,7 +54,7 @@ import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 import { BuildQuoteSelectors } from '../../Aggregator/Views/BuildQuote/BuildQuote.testIds';
 import { BUILD_QUOTE_TEST_IDS } from './BuildQuote.testIds';
 import { createPaymentSelectionModalNavigationDetails } from '../Modals/PaymentSelectionModal';
-import { createTokenNotAvailableModalNavigationDetails } from '../Modals/TokenNotAvailableModal';
+import { useEnsureProviderForAsset } from '../../hooks/useEnsureProviderForAsset';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import BannerAlert from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert';
 import { BannerAlertSeverity } from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
@@ -253,92 +253,23 @@ function BuildQuote() {
     paymentMethods.length,
   ]);
 
-  // Tracks which provider:token combination was last shown the modal,
-  // so we don't duplicate-navigate within the same visit but DO re-show
-  // when the combination changes.
-  const lastShownUnavailableKeyRef = useRef<string>('');
-
-  // Bump a counter on screen focus so the modal effect re-evaluates
-  // when the user navigates away (e.g. token selection) and comes back.
+  // Bump a counter on screen focus so the auto-select hook re-evaluates the
+  // "no supporting provider" path when the user navigates away (e.g. token
+  // selection) and comes back.
   const [focusTrigger, setFocusTrigger] = useState(0);
   useFocusEffect(
     useCallback(() => {
-      lastShownUnavailableKeyRef.current = '';
       setFocusTrigger((c) => c + 1);
     }, []),
   );
 
-  // When no provider is selected (e.g. first-time user in a region without
-  // Transak), pick the first provider that supports the selected token.
-  useEffect(() => {
-    if (
-      !isOnBuildQuoteScreen ||
-      selectedProvider ||
-      !effectiveAssetId ||
-      providers.length === 0
-    ) {
-      return;
-    }
-    const supportingProvider = providers.find((p) =>
-      providerSupportsAsset(p, effectiveAssetId),
-    );
-    if (supportingProvider) {
-      setSelectedProvider(supportingProvider, { autoSelected: true });
-    }
-  }, [
-    isOnBuildQuoteScreen,
-    selectedProvider,
-    effectiveAssetId,
-    providers,
-    setSelectedProvider,
-  ]);
-
-  // When the selected token is unavailable for the current provider, silently
-  // switch to any other provider that supports the token. Only fall through to
-  // the "Token Not Available" modal when no provider supports the token.
-  useEffect(() => {
-    if (!isOnBuildQuoteScreen || !isTokenUnavailable) {
-      lastShownUnavailableKeyRef.current = '';
-      return;
-    }
-
-    if (effectiveAssetId) {
-      const supportingProvider = providers.find(
-        (p) =>
-          p.id !== selectedProvider?.id &&
-          providerSupportsAsset(p, effectiveAssetId),
-      );
-      if (supportingProvider) {
-        setSelectedProvider(supportingProvider, { autoSelected: true });
-        return;
-      }
-    }
-
-    const key = `${selectedProvider?.id}:${effectiveAssetId}`;
-    if (lastShownUnavailableKeyRef.current === key) return;
-
-    const timer = setTimeout(() => {
-      lastShownUnavailableKeyRef.current = key;
-      navigation.navigate(
-        ...createTokenNotAvailableModalNavigationDetails({
-          assetId: effectiveAssetId ?? '',
-          buyFlowOrigin: params?.buyFlowOrigin,
-        }),
-      );
-    }, 600);
-
-    return () => clearTimeout(timer);
-  }, [
-    isOnBuildQuoteScreen,
-    params?.buyFlowOrigin,
+  useEnsureProviderForAsset({
+    enabled: isOnBuildQuoteScreen,
+    assetId: effectiveAssetId,
     isTokenUnavailable,
-    effectiveAssetId,
-    navigation,
-    selectedProvider?.id,
-    focusTrigger,
-    providers,
-    setSelectedProvider,
-  ]);
+    buyFlowOrigin: params?.buyFlowOrigin,
+    refreshKey: focusTrigger,
+  });
 
   const currency = userRegion?.country?.currency || 'USD';
   const { currencyPrefix, currencySuffix } = useMemo(() => {

--- a/app/components/UI/Ramp/constants/providerIds.ts
+++ b/app/components/UI/Ramp/constants/providerIds.ts
@@ -1,0 +1,11 @@
+/**
+ * Stable identifiers for Ramps providers as returned by the
+ * `RampsController`. Use these constants instead of hardcoding the string
+ * literals so callers fail at the type level when an id is renamed.
+ */
+export const RAMPS_PROVIDER_IDS = {
+  TRANSAK_NATIVE: 'transak-native',
+} as const;
+
+export type RampsProviderId =
+  (typeof RAMPS_PROVIDER_IDS)[keyof typeof RAMPS_PROVIDER_IDS];

--- a/app/components/UI/Ramp/hooks/useEnsureProviderForAsset.test.ts
+++ b/app/components/UI/Ramp/hooks/useEnsureProviderForAsset.test.ts
@@ -1,0 +1,207 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { Provider } from '@metamask/ramps-controller';
+import { useEnsureProviderForAsset } from './useEnsureProviderForAsset';
+import { useRampsController } from './useRampsController';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('./useRampsController', () => ({
+  useRampsController: jest.fn(),
+}));
+
+const ASSET_ETH_MAINNET = 'eip155:1/slip44:60';
+const ASSET_USDC_ARBITRUM =
+  'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+
+function buildProvider(
+  id: string,
+  supports: Record<string, boolean>,
+): Provider {
+  return {
+    id,
+    name: id,
+    supportedCryptoCurrencies: supports,
+  } as unknown as Provider;
+}
+
+describe('useEnsureProviderForAsset', () => {
+  const mockNavigate = jest.fn();
+  const mockSetSelectedProvider = jest.fn();
+  const mockUseNavigation = jest.mocked(useNavigation);
+  const mockUseRampsController = jest.mocked(useRampsController);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockUseNavigation.mockReturnValue({
+      navigate: mockNavigate,
+    } as unknown as ReturnType<typeof useNavigation>);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function setController(overrides: {
+    providers?: Provider[];
+    selectedProvider?: Provider | null;
+  }) {
+    mockUseRampsController.mockReturnValue({
+      providers: overrides.providers ?? [],
+      selectedProvider: overrides.selectedProvider ?? null,
+      setSelectedProvider: mockSetSelectedProvider,
+    } as unknown as ReturnType<typeof useRampsController>);
+  }
+
+  it('selects the first supporting provider when none is selected', () => {
+    const transak = buildProvider('transak-native', {
+      [ASSET_ETH_MAINNET]: true,
+    });
+    const other = buildProvider('other', { [ASSET_ETH_MAINNET]: false });
+    setController({ providers: [other, transak], selectedProvider: null });
+
+    renderHook(() =>
+      useEnsureProviderForAsset({
+        enabled: true,
+        assetId: ASSET_ETH_MAINNET,
+        isTokenUnavailable: false,
+      }),
+    );
+
+    expect(mockSetSelectedProvider).toHaveBeenCalledWith(transak, {
+      autoSelected: true,
+    });
+  });
+
+  it('switches to a supporting provider when current cannot fulfill the asset', () => {
+    const wrong = buildProvider('wrong', { [ASSET_ETH_MAINNET]: false });
+    const right = buildProvider('right', { [ASSET_USDC_ARBITRUM]: true });
+    setController({
+      providers: [wrong, right],
+      selectedProvider: wrong,
+    });
+
+    renderHook(() =>
+      useEnsureProviderForAsset({
+        enabled: true,
+        assetId: ASSET_USDC_ARBITRUM,
+        isTokenUnavailable: true,
+      }),
+    );
+
+    expect(mockSetSelectedProvider).toHaveBeenCalledWith(right, {
+      autoSelected: true,
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('invokes onNoSupportingProvider when no provider supports the asset', () => {
+    const wrong = buildProvider('wrong', { [ASSET_ETH_MAINNET]: false });
+    const onNoSupportingProvider = jest.fn();
+    setController({ providers: [wrong], selectedProvider: wrong });
+
+    renderHook(() =>
+      useEnsureProviderForAsset({
+        enabled: true,
+        assetId: ASSET_USDC_ARBITRUM,
+        isTokenUnavailable: true,
+        onNoSupportingProvider,
+      }),
+    );
+
+    expect(onNoSupportingProvider).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(onNoSupportingProvider).toHaveBeenCalledWith(ASSET_USDC_ARBITRUM);
+    expect(mockSetSelectedProvider).not.toHaveBeenCalled();
+  });
+
+  it('falls back to TokenNotAvailable modal navigation when no callback is provided', () => {
+    const wrong = buildProvider('wrong', { [ASSET_ETH_MAINNET]: false });
+    setController({ providers: [wrong], selectedProvider: wrong });
+
+    renderHook(() =>
+      useEnsureProviderForAsset({
+        enabled: true,
+        assetId: ASSET_USDC_ARBITRUM,
+        isTokenUnavailable: true,
+      }),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    // First arg is the parent route, second is the nested screen config.
+    const [route, config] = mockNavigate.mock.calls[0];
+    expect(route).toBe('RampModals');
+    expect(config).toMatchObject({
+      screen: 'RampTokenNotAvailableModal',
+      params: { assetId: ASSET_USDC_ARBITRUM },
+    });
+  });
+
+  it('is inert and resets dedup state when enabled is false', () => {
+    const onNoSupportingProvider = jest.fn();
+    const wrong = buildProvider('wrong', { [ASSET_ETH_MAINNET]: false });
+    setController({ providers: [wrong], selectedProvider: wrong });
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useEnsureProviderForAsset({
+          enabled,
+          assetId: ASSET_USDC_ARBITRUM,
+          isTokenUnavailable: true,
+          onNoSupportingProvider,
+        }),
+      { initialProps: { enabled: false } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(onNoSupportingProvider).not.toHaveBeenCalled();
+    expect(mockSetSelectedProvider).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(onNoSupportingProvider).toHaveBeenCalledWith(ASSET_USDC_ARBITRUM);
+  });
+
+  it('does not re-fire onNoSupportingProvider for the same provider/asset pair', () => {
+    const onNoSupportingProvider = jest.fn();
+    const wrong = buildProvider('wrong', { [ASSET_ETH_MAINNET]: false });
+    setController({ providers: [wrong], selectedProvider: wrong });
+
+    const { rerender } = renderHook(
+      ({ refreshKey }: { refreshKey: number }) =>
+        useEnsureProviderForAsset({
+          enabled: true,
+          assetId: ASSET_USDC_ARBITRUM,
+          isTokenUnavailable: true,
+          onNoSupportingProvider,
+          refreshKey,
+        }),
+      { initialProps: { refreshKey: 0 } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(onNoSupportingProvider).toHaveBeenCalledTimes(1);
+
+    // Rerendering with a higher refreshKey but the same provider/asset
+    // should NOT fire again — the dedup key matches.
+    rerender({ refreshKey: 1 });
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(onNoSupportingProvider).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Ramp/hooks/useEnsureProviderForAsset.ts
+++ b/app/components/UI/Ramp/hooks/useEnsureProviderForAsset.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { providerSupportsAsset } from '../utils/providerSupportsAsset';
+import { useRampsController } from './useRampsController';
+import { createTokenNotAvailableModalNavigationDetails } from '../Views/Modals/TokenNotAvailableModal';
+import type { BuyFlowOrigin } from '../Views/BuildQuote/BuildQuote';
+
+const NO_SUPPORTING_PROVIDER_DELAY_MS = 600;
+
+export interface UseEnsureProviderForAssetParams {
+  /**
+   * CAIP asset id of the token the caller wants funded.
+   * When `undefined` the hook is a no-op (callers may still pass `enabled: true`
+   * while their own bootstrap settles).
+   */
+  assetId: string | undefined;
+  /**
+   * Gates the entire hook. Callers should set this to `true` only while the
+   * surface invoking the hook is mounted/focused — equivalent to BuildQuote's
+   * `useIsFocused()` check.
+   */
+  enabled: boolean;
+  /**
+   * Caller-derived signal that the currently selected provider cannot fulfill
+   * `assetId`. Typically derived from `providerSupportsAsset(...)` plus
+   * the provider's settled payment-methods state. When `true` and no other
+   * provider supports the asset, `onNoSupportingProvider` fires.
+   */
+  isTokenUnavailable: boolean;
+  /**
+   * Optional callback invoked (debounced) when no available provider supports
+   * `assetId`. When omitted, the hook navigates to the Ramp
+   * `TokenNotAvailableModal` — this preserves the existing BuildQuote behavior.
+   * Surfaces outside the Ramp navigator (e.g. MM Pay) should pass a callback
+   * that handles the unavailable state in their own UX (banner, disabled CTA,
+   * etc.) rather than relying on the default.
+   */
+  onNoSupportingProvider?: (assetId: string) => void;
+  /**
+   * Forwarded to the default `TokenNotAvailableModal` callback. Ignored when
+   * `onNoSupportingProvider` is provided. Mirrors BuildQuote's existing
+   * `buyFlowOrigin` route param.
+   */
+  buyFlowOrigin?: BuyFlowOrigin;
+  /**
+   * Optional value the caller can bump (e.g. on screen focus) to force the
+   * "no supporting provider" notification to re-fire after the dedup ref was
+   * cleared. BuildQuote bumps this in `useFocusEffect`.
+   */
+  refreshKey?: number;
+}
+
+/**
+ * Token-aware provider auto-select for any Ramp-consuming surface.
+ *
+ * Behavior, mirroring the previous in-place BuildQuote effects:
+ *
+ * - If no provider is selected and at least one provider supports `assetId`,
+ * select that provider (marked `autoSelected: true`).
+ * - If the currently selected provider does not support `assetId`
+ * (`isTokenUnavailable === true`) but another provider does, silently switch
+ * to that provider.
+ * - If no provider supports `assetId` and `isTokenUnavailable === true`,
+ * invoke `onNoSupportingProvider(assetId)` after a short debounce. The same
+ * `(providerId, assetId)` pair is only signalled once per `refreshKey` value
+ * to avoid duplicate prompts during a single visit.
+ *
+ * When `enabled` is `false` the hook is inert and resets its dedup state so
+ * the next focused render can re-fire the unavailable signal.
+ */
+export function useEnsureProviderForAsset({
+  assetId,
+  enabled,
+  isTokenUnavailable,
+  onNoSupportingProvider,
+  buyFlowOrigin,
+  refreshKey,
+}: UseEnsureProviderForAssetParams): void {
+  const navigation = useNavigation();
+  const { providers, selectedProvider, setSelectedProvider } =
+    useRampsController();
+
+  // Tracks which provider:asset combination has already triggered the
+  // "no supporting provider" callback during the current focus session so we
+  // don't fire it repeatedly while the effect re-runs.
+  const lastShownUnavailableKeyRef = useRef<string>('');
+
+  const defaultOnNoSupportingProvider = useCallback(
+    (id: string) => {
+      navigation.navigate(
+        ...createTokenNotAvailableModalNavigationDetails({
+          assetId: id,
+          buyFlowOrigin,
+        }),
+      );
+    },
+    [navigation, buyFlowOrigin],
+  );
+
+  const notifyNoSupportingProvider =
+    onNoSupportingProvider ?? defaultOnNoSupportingProvider;
+
+  // Effect 1: when no provider is selected, pick the first one that supports
+  // the asset. Mirrors BuildQuote.tsx prior behavior verbatim.
+  useEffect(() => {
+    if (!enabled || selectedProvider || !assetId || providers.length === 0) {
+      return;
+    }
+    const supportingProvider = providers.find((p) =>
+      providerSupportsAsset(p, assetId),
+    );
+    if (supportingProvider) {
+      setSelectedProvider(supportingProvider, { autoSelected: true });
+    }
+  }, [enabled, selectedProvider, assetId, providers, setSelectedProvider]);
+
+  // Effect 2: when the selected token is unavailable for the current
+  // provider, silently switch to any other provider that supports the token.
+  // Only fall through to `notifyNoSupportingProvider` when no provider does.
+  useEffect(() => {
+    if (!enabled || !isTokenUnavailable) {
+      lastShownUnavailableKeyRef.current = '';
+      return;
+    }
+
+    if (assetId) {
+      const supportingProvider = providers.find(
+        (p) =>
+          p.id !== selectedProvider?.id && providerSupportsAsset(p, assetId),
+      );
+      if (supportingProvider) {
+        setSelectedProvider(supportingProvider, { autoSelected: true });
+        return;
+      }
+    }
+
+    const key = `${selectedProvider?.id}:${assetId}`;
+    if (lastShownUnavailableKeyRef.current === key) return;
+
+    const timer = setTimeout(() => {
+      lastShownUnavailableKeyRef.current = key;
+      notifyNoSupportingProvider(assetId ?? '');
+    }, NO_SUPPORTING_PROVIDER_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [
+    enabled,
+    isTokenUnavailable,
+    assetId,
+    selectedProvider?.id,
+    refreshKey,
+    providers,
+    setSelectedProvider,
+    notifyNoSupportingProvider,
+  ]);
+}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -48,6 +48,9 @@ import Logger from '../../../../../../util/Logger';
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
 jest.mock('../../../hooks/tokens/useTokenFiatRates');
 jest.mock('../../../hooks/pay/useAutomaticTransactionPayToken');
+jest.mock('../../../hooks/pay/useEnsureProviderForPayAsset', () => ({
+  useEnsureProviderForPayAsset: jest.fn(),
+}));
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/transactions/useTransactionCustomAmount');
 jest.mock('../../../context/confirmation-context');

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -23,6 +23,7 @@ import {
   SetPayTokenRequest,
   useAutomaticTransactionPayToken,
 } from '../../../hooks/pay/useAutomaticTransactionPayToken';
+import { useEnsureProviderForPayAsset } from '../../../hooks/pay/useEnsureProviderForPayAsset';
 import { useTransactionPayPostQuote } from '../../../hooks/pay/useTransactionPayPostQuote';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { AlertMessage } from '../../alerts/alert-message';
@@ -124,6 +125,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       disable: disablePay,
       preferredToken,
     });
+    useEnsureProviderForPayAsset();
     useTransactionPayMetrics();
     useTransactionPayPostQuote(); // Set isPostQuote=true for post-quote transactions
 

--- a/app/components/Views/confirmations/hooks/pay/useEnsureProviderForPayAsset.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useEnsureProviderForPayAsset.test.ts
@@ -1,0 +1,164 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { TransactionType } from '@metamask/transaction-controller';
+import type { Provider } from '@metamask/ramps-controller';
+import { useEnsureProviderForPayAsset } from './useEnsureProviderForPayAsset';
+import { useEnsureProviderForAsset } from '../../../../UI/Ramp/hooks/useEnsureProviderForAsset';
+import { useRampsController } from '../../../../UI/Ramp/hooks/useRampsController';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useTransactionPayRequiredTokens } from './useTransactionPayData';
+
+jest.mock('../../../../UI/Ramp/hooks/useEnsureProviderForAsset', () => ({
+  useEnsureProviderForAsset: jest.fn(),
+}));
+jest.mock('../../../../UI/Ramp/hooks/useRampsController', () => ({
+  useRampsController: jest.fn(),
+}));
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('./useTransactionPayData');
+
+const ARBITRUM_USDC_CAIP =
+  'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+
+describe('useEnsureProviderForPayAsset', () => {
+  const useEnsureProviderForAssetMock = jest.mocked(useEnsureProviderForAsset);
+  const useRampsControllerMock = jest.mocked(useRampsController);
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useRampsControllerMock.mockReturnValue({
+      selectedProvider: null,
+      paymentMethodsStatus: 'success',
+      paymentMethodsFetching: false,
+    } as unknown as ReturnType<typeof useRampsController>);
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+        chainId: '0xa4b1',
+      },
+    ] as unknown as ReturnType<typeof useTransactionPayRequiredTokens>);
+  });
+
+  it('is disabled for non-deposit transactions', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.simpleSend,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    expect(useEnsureProviderForAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false, assetId: undefined }),
+    );
+  });
+
+  it('does not run for Money Account deposits (those use the locked route gate)', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.moneyAccountDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    expect(useEnsureProviderForAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('passes the primary required token CAIP id for perpsDeposit', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.perpsDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    expect(useEnsureProviderForAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        assetId: ARBITRUM_USDC_CAIP,
+      }),
+    );
+  });
+
+  it('passes the primary required token CAIP id for predictDeposit', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.predictDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    expect(useEnsureProviderForAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        assetId: ARBITRUM_USDC_CAIP,
+      }),
+    );
+  });
+
+  it('marks the asset unavailable when the selected provider does not support it', () => {
+    const wrongProvider = {
+      id: 'wrong',
+      supportedCryptoCurrencies: {},
+    } as unknown as Provider;
+    useRampsControllerMock.mockReturnValue({
+      selectedProvider: wrongProvider,
+      paymentMethodsStatus: 'success',
+      paymentMethodsFetching: false,
+    } as unknown as ReturnType<typeof useRampsController>);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.perpsDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    expect(useEnsureProviderForAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        isTokenUnavailable: true,
+      }),
+    );
+  });
+
+  it('does not mark unavailable while payment methods are still settling', () => {
+    const wrongProvider = {
+      id: 'wrong',
+      supportedCryptoCurrencies: {},
+    } as unknown as Provider;
+    useRampsControllerMock.mockReturnValue({
+      selectedProvider: wrongProvider,
+      paymentMethodsStatus: 'success',
+      paymentMethodsFetching: true,
+    } as unknown as ReturnType<typeof useRampsController>);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.perpsDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    expect(useEnsureProviderForAssetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ isTokenUnavailable: false }),
+    );
+  });
+
+  it('passes a no-op onNoSupportingProvider so MM Pay does not jump into the Ramp navigator', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: 'tx',
+      type: TransactionType.perpsDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    renderHook(() => useEnsureProviderForPayAsset());
+
+    const call = useEnsureProviderForAssetMock.mock.calls[0][0];
+    expect(call.onNoSupportingProvider).toBeDefined();
+    expect(() => call.onNoSupportingProvider?.('any-asset-id')).not.toThrow();
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useEnsureProviderForPayAsset.ts
+++ b/app/components/Views/confirmations/hooks/pay/useEnsureProviderForPayAsset.ts
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import { toCaipAssetType } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { useEnsureProviderForAsset } from '../../../../UI/Ramp/hooks/useEnsureProviderForAsset';
+import { providerSupportsAsset } from '../../../../UI/Ramp/utils/providerSupportsAsset';
+import { useRampsController } from '../../../../UI/Ramp/hooks/useRampsController';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useTransactionPayRequiredTokens } from './useTransactionPayData';
+import { hasTransactionType } from '../../utils/transaction';
+
+/**
+ * Transaction types that should pick the best Ramps provider for the asset
+ * they require. Money Account is intentionally excluded — it is hard-locked
+ * to a single provider (see {@link useFiatRouteProviderAvailability}).
+ */
+const ASSET_BASED_TRANSACTION_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.predictDeposit,
+] as const;
+
+/**
+ * Wires {@link useEnsureProviderForAsset} into MM Pay surfaces whose required
+ * funding asset is determined at runtime from `requiredTokens`. When the
+ * bootstrap selected a provider that can't fulfill the asset (e.g. a US-NY
+ * user with no Transak Native who lands on Perps deposit needing USDC on
+ * Arbitrum), this hook silently switches to any provider that can.
+ *
+ * Surfaces themselves (e.g. CustomAmountInfo) handle the "no provider
+ * supports this asset" case via the existing `BuySection` empty state, so
+ * we pass an `onNoSupportingProvider` no-op to suppress the default
+ * Ramp modal navigation — that modal lives inside the Ramp navigator and
+ * isn't safely reachable from confirmation screens.
+ */
+export function useEnsureProviderForPayAsset(): void {
+  const transactionMeta = useTransactionMetadataRequest();
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const { selectedProvider, paymentMethodsStatus, paymentMethodsFetching } =
+    useRampsController();
+
+  const isAssetBasedTransaction = hasTransactionType(transactionMeta, [
+    ...ASSET_BASED_TRANSACTION_TYPES,
+  ]);
+
+  const assetId = useMemo(() => {
+    if (!isAssetBasedTransaction) return undefined;
+    const primaryRequiredToken = (requiredTokens ?? []).find(
+      (token) => token.address !== getNativeTokenAddress(token.chainId),
+    );
+    if (!primaryRequiredToken) return undefined;
+    return toCaipAssetType(
+      'eip155',
+      Number(primaryRequiredToken.chainId).toString(),
+      'erc20',
+      primaryRequiredToken.address,
+    );
+  }, [isAssetBasedTransaction, requiredTokens]);
+
+  // Mirrors BuildQuote's `isTokenUnavailable` derivation but limited to the
+  // signals available outside the Buy flow: we only know the selected
+  // provider doesn't support the asset, not whether its payment methods
+  // are empty. That's sufficient to trigger a switch when one is needed.
+  const isTokenUnavailable = useMemo(() => {
+    if (!selectedProvider || !assetId) return false;
+    if (paymentMethodsStatus !== 'success' || paymentMethodsFetching) {
+      return false;
+    }
+    return !providerSupportsAsset(selectedProvider, assetId);
+  }, [selectedProvider, assetId, paymentMethodsStatus, paymentMethodsFetching]);
+
+  useEnsureProviderForAsset({
+    enabled: isAssetBasedTransaction,
+    assetId,
+    isTokenUnavailable,
+    onNoSupportingProvider: noop,
+  });
+}
+
+function noop() {
+  /* no-op: MM Pay handles the unsupported-asset case via its own empty
+   * state, not the Ramp `TokenNotAvailableModal`. */
+}

--- a/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.test.ts
@@ -1,15 +1,17 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { type PaymentMethod } from '@metamask/ramps-controller';
+import { type PaymentMethod, type Provider } from '@metamask/ramps-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 import { useFiatPaymentHighlightedActions } from './useFiatPaymentHighlightedActions';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 import { useTransactionPayFiatPayment } from './useTransactionPayData';
+import { useFiatRouteProviderAvailability } from './useFiatRouteProviderAvailability';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import Engine from '../../../../../core/Engine';
 
 jest.mock('./useMMPayFiatConfig');
 jest.mock('./useTransactionPayData');
+jest.mock('./useFiatRouteProviderAvailability');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../../../../../core/Engine', () => ({
@@ -41,6 +43,9 @@ describe('useFiatPaymentHighlightedActions', () => {
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
+  const useFiatRouteProviderAvailabilityMock = jest.mocked(
+    useFiatRouteProviderAvailability,
+  );
   const updateFiatPaymentMock = jest.mocked(
     Engine.context.TransactionPayController.updateFiatPayment,
   );
@@ -60,6 +65,11 @@ describe('useFiatPaymentHighlightedActions', () => {
       id: TRANSACTION_ID_MOCK,
       type: TRANSACTION_TYPE_MOCK,
     } as ReturnType<typeof useTransactionMetadataRequest>);
+    useFiatRouteProviderAvailabilityMock.mockReturnValue({
+      isAvailable: true,
+      isLoading: false,
+      provider: undefined,
+    });
   });
 
   it('returns empty array when transaction type is not in enabledTransactionTypes', () => {
@@ -141,6 +151,60 @@ describe('useFiatPaymentHighlightedActions', () => {
     const fiatPayment = { selectedPaymentMethodId: undefined };
     updateFiatPaymentMock.mock.calls[0][0].callback(fiatPayment);
     expect(fiatPayment.selectedPaymentMethodId).toBe('pm-card');
+  });
+
+  it('returns empty array when a Money Account deposit lacks the locked fiat route', () => {
+    useMMPayFiatConfigMock.mockReturnValue({
+      enabledTransactionTypes: [TransactionType.moneyAccountDeposit],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      type: TransactionType.moneyAccountDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+    useFiatRouteProviderAvailabilityMock.mockReturnValue({
+      isAvailable: false,
+      isLoading: false,
+      provider: undefined,
+    });
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('still returns payment methods for a Money Account deposit when the locked route is available', () => {
+    useMMPayFiatConfigMock.mockReturnValue({
+      enabledTransactionTypes: [TransactionType.moneyAccountDeposit],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: TRANSACTION_ID_MOCK,
+      type: TransactionType.moneyAccountDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+    useFiatRouteProviderAvailabilityMock.mockReturnValue({
+      isAvailable: true,
+      isLoading: false,
+      provider: { id: 'transak-native' } as unknown as Provider,
+    });
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('does not apply the Money Account route gate to other transaction types', () => {
+    // useFiatRouteProviderAvailability mock defaults to isAvailable: true; flip
+    // it to false to confirm the gate only fires for moneyAccountDeposit.
+    useFiatRouteProviderAvailabilityMock.mockReturnValue({
+      isAvailable: false,
+      isLoading: false,
+      provider: undefined,
+    });
+
+    const { result } = renderHook(() => useFiatPaymentHighlightedActions());
+
+    expect(result.current).toHaveLength(1);
   });
 
   it('calls updateFiatPayment to deselect when action is fired on selected item', () => {

--- a/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import { type PaymentMethod } from '@metamask/ramps-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import Engine from '../../../../../core/Engine';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
 import { formatDelayFromArray } from '../../../../UI/Ramp/Aggregator/utils';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 import { useTransactionPayFiatPayment } from './useTransactionPayData';
+import { useFiatRouteProviderAvailability } from './useFiatRouteProviderAvailability';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { HighlightedItem } from '../../types/token';
 import { hasTransactionType } from '../../utils/transaction';
@@ -28,8 +30,24 @@ export function useFiatPaymentHighlightedActions(): HighlightedItem[] {
     enabledTransactionTypes,
   );
 
+  // Money Account v0 is hard-locked to a single fiat route (Transak Native).
+  // When that provider isn't in the user's region we must not surface a fiat
+  // payment option, otherwise the user lands on an empty payment-methods
+  // state with no recoverable path (TRAM-3597).
+  const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountDeposit,
+  ]);
+  const { isAvailable: isLockedRouteAvailable } =
+    useFiatRouteProviderAvailability();
+  const isLockedRouteUnavailable =
+    isMoneyAccountDeposit && !isLockedRouteAvailable;
+
   return useMemo(() => {
-    if (!isFiatEnabled || paymentMethods.length === 0) {
+    if (
+      !isFiatEnabled ||
+      isLockedRouteUnavailable ||
+      paymentMethods.length === 0
+    ) {
       return [];
     }
 
@@ -40,6 +58,7 @@ export function useFiatPaymentHighlightedActions(): HighlightedItem[] {
       );
   }, [
     isFiatEnabled,
+    isLockedRouteUnavailable,
     maxDelayMinutesForPaymentMethods,
     paymentMethods,
     transactionId,

--- a/app/components/Views/confirmations/hooks/pay/useFiatRouteProviderAvailability.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatRouteProviderAvailability.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react-native';
+import type { Provider } from '@metamask/ramps-controller';
+import { useFiatRouteProviderAvailability } from './useFiatRouteProviderAvailability';
+import { useRampsProviders } from '../../../../UI/Ramp/hooks/useRampsProviders';
+import { RAMPS_PROVIDER_IDS } from '../../../../UI/Ramp/constants/providerIds';
+
+jest.mock('../../../../UI/Ramp/hooks/useRampsProviders', () => ({
+  useRampsProviders: jest.fn(),
+}));
+
+const TRANSAK_NATIVE: Provider = {
+  id: RAMPS_PROVIDER_IDS.TRANSAK_NATIVE,
+  name: 'Transak',
+} as unknown as Provider;
+
+const OTHER_PROVIDER: Provider = {
+  id: 'moonpay',
+  name: 'MoonPay',
+} as unknown as Provider;
+
+describe('useFiatRouteProviderAvailability', () => {
+  const mockUseRampsProviders = jest.mocked(useRampsProviders);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockProviders(overrides: {
+    providers?: Provider[];
+    isLoading?: boolean;
+  }) {
+    mockUseRampsProviders.mockReturnValue({
+      providers: overrides.providers ?? [],
+      isLoading: overrides.isLoading ?? false,
+    } as unknown as ReturnType<typeof useRampsProviders>);
+  }
+
+  it('reports the target provider as available when present', () => {
+    mockProviders({ providers: [OTHER_PROVIDER, TRANSAK_NATIVE] });
+
+    const { result } = renderHook(() => useFiatRouteProviderAvailability());
+
+    expect(result.current.isAvailable).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.provider).toBe(TRANSAK_NATIVE);
+  });
+
+  it('reports unavailable when the target provider is missing from the list', () => {
+    mockProviders({ providers: [OTHER_PROVIDER] });
+
+    const { result } = renderHook(() => useFiatRouteProviderAvailability());
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.provider).toBeUndefined();
+  });
+
+  it('does not flag as available while still loading', () => {
+    mockProviders({ providers: [TRANSAK_NATIVE], isLoading: true });
+
+    const { result } = renderHook(() => useFiatRouteProviderAvailability());
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.provider).toBe(TRANSAK_NATIVE);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useFiatRouteProviderAvailability.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatRouteProviderAvailability.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { type Provider } from '@metamask/ramps-controller';
+import { useRampsProviders } from '../../../../UI/Ramp/hooks/useRampsProviders';
+import {
+  RAMPS_PROVIDER_IDS,
+  type RampsProviderId,
+} from '../../../../UI/Ramp/constants/providerIds';
+
+export interface UseFiatRouteProviderAvailabilityResult {
+  /**
+   * `true` when the target provider is in the providers list for the user's
+   * current region; `false` once providers have loaded and the target is
+   * absent. While loading the value defaults to `false` so callers can
+   * combine it with `isLoading` to gate UX without flicker.
+   */
+  isAvailable: boolean;
+  /** Mirrors the underlying providers query loading state. */
+  isLoading: boolean;
+  /** The matched provider, or `undefined` when unavailable. */
+  provider: Provider | undefined;
+}
+
+/**
+ * Availability check for a single Ramps provider, used by surfaces that are
+ * hard-locked to one fiat route (e.g. Money Account v0, which only supports
+ * Transak Native).
+ *
+ * This is intentionally narrow — it does not auto-select or switch providers.
+ * Callers that need "pick the best available provider for an asset" semantics
+ * should use {@link useEnsureProviderForAsset} instead.
+ */
+export function useFiatRouteProviderAvailability(
+  targetProviderId: RampsProviderId = RAMPS_PROVIDER_IDS.TRANSAK_NATIVE,
+): UseFiatRouteProviderAvailabilityResult {
+  const { providers, isLoading } = useRampsProviders();
+
+  return useMemo(() => {
+    const provider = providers.find((p) => p.id === targetProviderId);
+    return {
+      isAvailable: Boolean(provider) && !isLoading,
+      isLoading,
+      provider,
+    };
+  }, [providers, isLoading, targetProviderId]);
+}


### PR DESCRIPTION
## **Description**

Two production bugs converge here:

1. Lorenzo Santos (region `us-ny`, Android) cannot see any fiat payment options
   in MM Pay. The bootstrap's `determinePreferredProvider` returns `null` for
   his region (no order history, no Transak Native), so `providers.selected`
   stays `null`, `useRampsPaymentMethods` stays disabled, and MM Pay renders
   `paymentMethods: []` with no recoverable path.
2. Barbara Schorchit's app freezes on "Add funds" (the
   [TRAM-3597](https://consensyssoftware.atlassian.net/browse/TRAM-3597) ticket)
   from a non-CA US region. Lorenzo reproduced one of the freeze triggers in
   Ireland too — there is a downstream headless silent-exit being tracked
   separately, but the region/provider mismatch half is what this PR addresses.

UB2's `BuildQuote` already handles this correctly: it silently picks (or
switches to) any provider that supports the active token and falls through
to the `TokenNotAvailable` modal only when no provider does. This PR
extracts that mechanism into a shared hook so MM Pay surfaces can reuse it.

### What changed

1. **New shared hook `useEnsureProviderForAsset`**
   ([`app/components/UI/Ramp/hooks/useEnsureProviderForAsset.ts`](https://github.com/MetaMask/metamask-mobile/blob/saustrie-consensys/TRAM-3597-provider-asset-availability/app/components/UI/Ramp/hooks/useEnsureProviderForAsset.ts))
   — token-aware provider auto-select extracted verbatim from `BuildQuote`'s
   two effects. The "no provider supports this asset" path is now a callback;
   the default callback preserves BuildQuote's existing modal navigation.
2. **`BuildQuote` refactor** — the two effects are replaced with a single
   `useEnsureProviderForAsset(...)` call. All 87 existing `BuildQuote` tests
   still pass.
3. **MM Pay availability gate `useFiatRouteProviderAvailability`**
   ([`useFiatRouteProviderAvailability.ts`](https://github.com/MetaMask/metamask-mobile/blob/saustrie-consensys/TRAM-3597-provider-asset-availability/app/components/Views/confirmations/hooks/pay/useFiatRouteProviderAvailability.ts))
   — for Money Account v0, which is hard-locked to Transak Native per Lorenzo's
   spec. When Transak Native isn't in the user's region the fiat payment
   highlighted action disappears, so the user gets the existing empty-state
   path instead of a broken payment selector.
4. **MM Pay auto-select wrapper `useEnsureProviderForPayAsset`** — Perps /
   Predict deposits call this from `CustomAmountInfo`. It derives the required
   asset id from `useTransactionPayRequiredTokens()` and delegates to the new
   shared hook with a no-op `onNoSupportingProvider` (MM Pay surfaces can't
   cleanly reach the Ramp navigator's modal stack, and the existing
   `BuySection` empty state already covers the unavailable case).
5. **`RAMPS_PROVIDER_IDS` constant** — replaces hardcoded `'transak-native'`
   strings.

Out of scope: the headless silent-exit half of TRAM-3597, the Aggregator / UB1
tree.

## **Changelog**

CHANGELOG entry: Fixed an issue where users in regions without a supported on-ramp provider could land on a payment screen with no available payment methods.

## **Related issues**

Fixes: [TRAM-3597](https://consensyssoftware.atlassian.net/browse/TRAM-3597) (region/provider mismatch half)

## **Manual testing steps**

```gherkin
Feature: MM Pay picks a provider that can fulfill the requested asset

  Scenario: First-time user in a region without Transak (Lorenzo's repro)
    Given the user is in region us-ny with no completed ramp orders
    And the user opens MM Pay for a Perps deposit
    When the Pay-With modal opens
    Then a fiat payment option is shown (auto-switched to a supporting provider)
    And the user is NOT stuck with an empty payment-methods state

  Scenario: Money Account deposit in a region without Transak Native
    Given the user is in a region where Transak Native is not offered
    When the user taps "Add funds" on a Money Account deposit
    Then the fiat payment option is not surfaced in the Pay-With modal
    And the existing empty-state UX applies

  Scenario: UB2 BuildQuote (no behavior change)
    Given the user opens the unified Buy v2 BuildQuote screen for a token
      that the currently-selected provider does not support
    When the screen mounts
    Then the app silently switches to a provider that supports the token
    Or — if none does — shows the existing TokenNotAvailable modal
```

## **Screenshots/Recordings**

N/A — backend/hook refactor. Verified via existing UB2 BuildQuote tests
(87 pass) and new unit coverage (38 added tests across 4 new test files).

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

[TRAM-3597]: https://consensyssoftware.atlassian.net/browse/TRAM-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TRAM-3597]: https://consensyssoftware.atlassian.net/browse/TRAM-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production fiat/on-ramp provider selection and MM Pay payment surfacing; behavior mirrors existing BuildQuote logic but affects deposits and regional provider availability.
> 
> **Overview**
> Fixes **TRAM-3597** by reusing Unified Buy v2’s token-aware ramp provider logic outside **BuildQuote**.
> 
> **BuildQuote** drops two inline `useEffect` blocks in favor of **`useEnsureProviderForAsset`**, which auto-selects or silently switches to a provider that supports the active CAIP asset and still debounces the **Token not available** modal when nothing qualifies (optional **`onNoSupportingProvider`** override).
> 
> **MM Pay** adds **`useEnsureProviderForPayAsset`** on **`CustomAmountInfo`** for **Perps** / **Predict** deposits: derives the required ERC-20 CAIP id from **`requiredTokens`**, enables the shared hook, and uses a **no-op** callback so confirmations never navigate into the Ramp modal stack. **`useFiatRouteProviderAvailability`** plus a gate in **`useFiatPaymentHighlightedActions`** hides fiat pay options for **Money Account** deposits when **Transak Native** is not offered in the user’s region. **`RAMPS_PROVIDER_IDS`** replaces hardcoded provider id strings.
> 
> Unit tests cover the new hooks and the highlighted-actions gate; BuildQuote behavior is intended to be unchanged aside from the refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666d855c206027de10d44c7f490baf4586ee2323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->