### PR TITLE
chore: track explore conversions in swaps

### DIFF
--- a/app/components/UI/TokenDetails/constants/constants.ts
+++ b/app/components/UI/TokenDetails/constants/constants.ts
@@ -32,6 +32,22 @@ export enum TokenDetailsSource {
   Unknown = 'unknown',
 }
 
+const EXPLORE_TOKEN_DETAILS_SOURCES = new Set<TokenDetailsSource>([
+  TokenDetailsSource.ExploreNowMovers,
+  TokenDetailsSource.ExploreNowStocks,
+  TokenDetailsSource.ExploreCryptoTrending,
+  TokenDetailsSource.ExploreRwasStocks,
+  TokenDetailsSource.Trending,
+]);
+
+/**
+ * Whether Token Details was opened from the Explore tab (or Explore search).
+ * Used to attribute swap/bridge sessions as Trending Explore instead of Token View.
+ */
+export const isExploreTokenDetailsSource = (
+  source?: TokenDetailsSource,
+): boolean => Boolean(source && EXPLORE_TOKEN_DETAILS_SOURCES.has(source));
+
 /**
  * Extended route params for Token Details page
  * Includes source tracking for analytics

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
@@ -875,6 +875,65 @@ describe('useTokenAtomicActions - useHandleOnSwap', () => {
   });
 });
 
+describe('useTokenAtomicActions - useHandleOnSwap explore swap location', () => {
+  it('uses TrendingExplore location when token.source is an Explore tab source', () => {
+    renderHook(() =>
+      useHandleOnSwap({
+        token: {
+          ...defaultToken,
+          balance: '1',
+          source: TokenDetailsSource.ExploreCryptoTrending,
+        },
+      }),
+    );
+
+    expect(mockUseSwapBridgeNavigation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: 'TrendingExplore',
+        skipLocationUpdate: false,
+      }),
+    );
+  });
+
+  it('uses TokenView location when token.source is not from Explore', () => {
+    renderHook(() =>
+      useHandleOnSwap({
+        token: {
+          ...defaultToken,
+          balance: '1',
+          source: TokenDetailsSource.MobileTokenList,
+        },
+      }),
+    );
+
+    expect(mockUseSwapBridgeNavigation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: 'TokenView',
+        skipLocationUpdate: false,
+      }),
+    );
+  });
+
+  it('skips location update when opened from the bridge asset picker', () => {
+    renderHook(() =>
+      useHandleOnSwap({
+        token: {
+          ...defaultToken,
+          balance: '1',
+          source: TokenDetailsSource.Swap,
+        },
+      }),
+    );
+
+    expect(mockUseSwapBridgeNavigation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: 'TokenView',
+        skipLocationUpdate: true,
+      }),
+    );
+  });
+});
+
 describe('useTokenAtomicActions - useHandleOnSwap securityData adaptation', () => {
   const buildTrendingSecurityData = (
     overrides: Partial<TokenSecurityData> = {},

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
@@ -46,7 +46,10 @@ import useRampsUnifiedV1Enabled from '../../Ramp/hooks/useRampsUnifiedV1Enabled'
 import { BridgeToken } from '../../Bridge/types';
 import { adaptTokenSecurityData } from '../../Bridge/utils/tokenSecurityUtils';
 import { selectAssetsBySelectedAccountGroup } from '../../../../selectors/assets/assets-list';
-import { TokenDetailsSource } from '../constants/constants';
+import {
+  isExploreTokenDetailsSource,
+  TokenDetailsSource,
+} from '../constants/constants';
 import type { RootState } from '../../../../reducers';
 import type { TransactionActiveAbTestEntry } from '../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 
@@ -313,8 +316,12 @@ export const useHandleOnSwap = ({
   // location from the session that opened the bridge (e.g. "Main View").
   const isFromBridgeAssetPicker = token.source === TokenDetailsSource.Swap;
 
+  const swapLocation = isExploreTokenDetailsSource(token.source)
+    ? SwapBridgeNavigationLocation.TrendingExplore
+    : SwapBridgeNavigationLocation.TokenView;
+
   const { goToSwaps } = useSwapBridgeNavigation({
-    location: SwapBridgeNavigationLocation.TokenView,
+    location: swapLocation,
     sourcePage,
     transactionActiveAbTests: token.transactionActiveAbTests,
     skipLocationUpdate: isFromBridgeAssetPicker,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Track explore conversions in swaps
Segment: https://github.com/Consensys/segment-schema/pull/586
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: track explore conversions in swaps

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3264

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics location mapping only; swap routing logic is unchanged aside from metadata passed to the bridge navigation hook.
> 
> **Overview**
> Swap/bridge sessions started from **Token Details** now attribute **Trending Explore** instead of **Token View** when the page was opened from Explore (movers, stocks, crypto trending, RWAs, or generic trending).
> 
> A new `isExploreTokenDetailsSource` helper centralizes which `TokenDetailsSource` values count as Explore. `useHandleOnSwap` passes `SwapBridgeNavigationLocation.TrendingExplore` into `useSwapBridgeNavigation` for those sources; all other entry points still use **Token View**. Opening details from the bridge asset picker (`TokenDetailsSource.Swap`) is unchanged: **Token View** with `skipLocationUpdate: true` so the original bridge session location is preserved.
> 
> Unit tests cover Explore vs wallet list vs bridge-picker behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c4537ec9203fe6b76d8807e0c25887b771c682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->