### PR TITLE
chore: track explore conversions in predict cp-7.80.0

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -2185,6 +2185,33 @@ describe('PredictBuyPreview', () => {
       ).toBeOnTheScreen();
     });
 
+    it('tracks initiated trade transaction with explore entry point', () => {
+      mockUseRoute.mockReturnValue({
+        ...mockRoute,
+        params: {
+          ...mockRoute.params,
+          entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+        },
+      });
+      mockBalance = 1000;
+      mockBalanceLoading = false;
+
+      renderWithProvider(<PredictBuyPreview />, { state: initialState });
+
+      const trackPredictOrderEvent =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../../../../../core/Engine').context.PredictController
+          .trackPredictOrderEvent;
+
+      expect(trackPredictOrderEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          analyticsProperties: expect.objectContaining({
+            entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+          }),
+        }),
+      );
+    });
+
     it('handles undefined entryPoint with fallback', () => {
       const routeWithoutEntryPoint = {
         ...mockRoute,

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -133,7 +133,7 @@ jest.mock('../../components/PredictMarket', () => {
   return {
     __esModule: true,
     default: jest.fn(({ testID, entryPoint }) => (
-      <View testID={testID} accessibilityLabel={entryPoint}>
+      <View testID={testID}>
         <Text>Market Card</Text>
       </View>
     )),
@@ -144,6 +144,9 @@ import PredictMarket from '../../components/PredictMarket';
 import { PredictEventValues } from '../../constants/eventNames';
 
 const mockPredictMarket = PredictMarket as jest.Mock;
+
+const getPredictMarketEntryPoints = () =>
+  mockPredictMarket.mock.calls.map(([props]) => props.entryPoint);
 
 jest.mock('../../components/PredictMarketSkeleton', () => {
   const { View } = jest.requireActual('react-native');
@@ -800,7 +803,7 @@ describe('PredictFeed', () => {
       );
     });
 
-    it('starts session with predict_feed when entry point is not provided', () => {
+    it('preserves an unattributed session when entry point is not provided', () => {
       mockUseRoute.mockReturnValue({
         params: {},
       });
@@ -808,12 +811,26 @@ describe('PredictFeed', () => {
       render(<PredictFeed />);
 
       expect(mockSessionManager.startSession).toHaveBeenCalledWith(
-        PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+        undefined,
         'trending',
       );
-      expect(mockPredictMarket.mock.calls[0][0].entryPoint).toBe(
-        PredictEventValues.ENTRY_POINT.PREDICT_FEED,
-      );
+    });
+
+    it('defaults market list items to predict_feed when entry point is not provided', () => {
+      mockUseRoute.mockReturnValue({
+        params: {},
+      });
+
+      render(<PredictFeed />);
+
+      const entryPoints = getPredictMarketEntryPoints();
+      expect(entryPoints.length).toBeGreaterThan(0);
+      expect(
+        entryPoints.every(
+          (entryPoint) =>
+            entryPoint === PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+        ),
+      ).toBe(true);
     });
 
     it('passes explore entryPoint to market list items from route params', () => {
@@ -829,9 +846,40 @@ describe('PredictFeed', () => {
         PredictEventValues.ENTRY_POINT.EXPLORE,
         'trending',
       );
-      expect(mockPredictMarket.mock.calls[0][0].entryPoint).toBe(
-        PredictEventValues.ENTRY_POINT.EXPLORE,
+      const entryPoints = getPredictMarketEntryPoints();
+      expect(entryPoints.length).toBeGreaterThan(0);
+      expect(
+        entryPoints.every(
+          (entryPoint) => entryPoint === PredictEventValues.ENTRY_POINT.EXPLORE,
+        ),
+      ).toBe(true);
+    });
+
+    it('uses prop entryPoint for embedded feed list items and session attribution', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+        },
+      });
+
+      render(
+        <PredictFeed
+          entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
+        />,
       );
+
+      expect(mockSessionManager.startSession).toHaveBeenCalledWith(
+        PredictEventValues.ENTRY_POINT.HOME_SECTION,
+        'trending',
+      );
+      const entryPoints = getPredictMarketEntryPoints();
+      expect(entryPoints.length).toBeGreaterThan(0);
+      expect(
+        entryPoints.every(
+          (entryPoint) =>
+            entryPoint === PredictEventValues.ENTRY_POINT.HOME_SECTION,
+        ),
+      ).toBe(true);
     });
   });
 

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -132,13 +132,18 @@ jest.mock('../../components/PredictMarket', () => {
   const { View, Text } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: jest.fn(({ testID }) => (
-      <View testID={testID}>
+    default: jest.fn(({ testID, entryPoint }) => (
+      <View testID={testID} accessibilityLabel={entryPoint}>
         <Text>Market Card</Text>
       </View>
     )),
   };
 });
+
+import PredictMarket from '../../components/PredictMarket';
+import { PredictEventValues } from '../../constants/eventNames';
+
+const mockPredictMarket = PredictMarket as jest.Mock;
 
 jest.mock('../../components/PredictMarketSkeleton', () => {
   const { View } = jest.requireActual('react-native');
@@ -795,7 +800,7 @@ describe('PredictFeed', () => {
       );
     });
 
-    it('starts session with undefined entry point when not provided', () => {
+    it('starts session with predict_feed when entry point is not provided', () => {
       mockUseRoute.mockReturnValue({
         params: {},
       });
@@ -803,8 +808,29 @@ describe('PredictFeed', () => {
       render(<PredictFeed />);
 
       expect(mockSessionManager.startSession).toHaveBeenCalledWith(
-        undefined,
+        PredictEventValues.ENTRY_POINT.PREDICT_FEED,
         'trending',
+      );
+      expect(mockPredictMarket.mock.calls[0][0].entryPoint).toBe(
+        PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+      );
+    });
+
+    it('passes explore entryPoint to market list items from route params', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+        },
+      });
+
+      render(<PredictFeed />);
+
+      expect(mockSessionManager.startSession).toHaveBeenCalledWith(
+        PredictEventValues.ENTRY_POINT.EXPLORE,
+        'trending',
+      );
+      expect(mockPredictMarket.mock.calls[0][0].entryPoint).toBe(
+        PredictEventValues.ENTRY_POINT.EXPLORE,
       );
     });
   });

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -252,6 +252,7 @@ const PredictMarketListItem: React.FC<PredictMarketListItemProps> = ({
 interface PredictTabContentProps {
   category: PredictCategory;
   isActive: boolean;
+  listEntryPoint: PredictEntryPoint;
   scrollHandler: ReturnType<typeof useAnimatedScrollHandler>;
   headerHeight: number;
   tabBarHeight: number;
@@ -263,6 +264,7 @@ interface PredictTabContentProps {
 const PredictTabContent: React.FC<PredictTabContentProps> = ({
   category,
   isActive,
+  listEntryPoint,
   scrollHandler,
   headerHeight,
   tabBarHeight,
@@ -272,10 +274,6 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
 }) => {
   const tw = useTailwind();
   const listRef = useRef<PredictFlashListRef>(null);
-  const route =
-    useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
-  const listEntryPoint =
-    route.params?.entryPoint ?? PredictEventValues.ENTRY_POINT.PREDICT_FEED;
 
   const [hasEverBeenActive, setHasEverBeenActive] = useState(isActive);
   useEffect(() => {
@@ -452,6 +450,7 @@ interface PredictFeedTabsProps {
   tabs: FeedTab[];
   activeIndex: number;
   onPageChange: (index: number) => void;
+  listEntryPoint: PredictEntryPoint;
   scrollHandler: ReturnType<typeof useAnimatedScrollHandler>;
   headerHeight: number;
   tabBarHeight: number;
@@ -464,6 +463,7 @@ const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
   tabs,
   activeIndex,
   onPageChange,
+  listEntryPoint,
   scrollHandler,
   headerHeight,
   tabBarHeight,
@@ -503,6 +503,7 @@ const PredictFeedTabs: React.FC<PredictFeedTabsProps> = ({
           <PredictTabContent
             category={tab.key}
             isActive={index === activeIndex}
+            listEntryPoint={listEntryPoint}
             scrollHandler={scrollHandler}
             headerHeight={headerHeight}
             tabBarHeight={tabBarHeight}
@@ -648,6 +649,7 @@ const PredictSearchOverlay: React.FC<PredictSearchOverlayProps> = ({
 
 interface PredictFeedProps {
   hideHeader?: boolean;
+  entryPoint?: PredictEntryPoint;
   onHeaderHiddenChange?: (hidden: boolean) => void;
   walletHeaderTranslateY?: SharedValue<number>;
   walletHeaderHeight?: number;
@@ -655,6 +657,7 @@ interface PredictFeedProps {
 
 const PredictFeed: React.FC<PredictFeedProps> = ({
   hideHeader = false,
+  entryPoint: propEntryPoint,
   onHeaderHiddenChange,
   walletHeaderTranslateY,
   walletHeaderHeight,
@@ -667,6 +670,9 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
   const route =
     useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
   const transactionActiveAbTests = route.params?.transactionActiveAbTests;
+  const feedEntryPoint = propEntryPoint ?? route.params?.entryPoint;
+  const listEntryPoint =
+    feedEntryPoint ?? PredictEventValues.ENTRY_POINT.PREDICT_FEED;
 
   const headerRef = useRef<View>(null);
   const tabBarRef = useRef<View>(null);
@@ -695,23 +701,20 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
     traceName: TraceName.PredictFeedView,
     conditions: [!isSearchVisible],
     debugContext: {
-      entryPoint: route.params?.entryPoint,
+      entryPoint: feedEntryPoint,
       isSearchVisible,
     },
   });
 
   useEffect(() => {
     sessionManager.enableAppStateListener();
-    sessionManager.startSession(
-      route.params?.entryPoint ?? PredictEventValues.ENTRY_POINT.PREDICT_FEED,
-      initialTabKey,
-    );
+    sessionManager.startSession(feedEntryPoint, initialTabKey);
 
     return () => {
       sessionManager.endSession();
       sessionManager.disableAppStateListener();
     };
-  }, [route.params?.entryPoint, sessionManager, initialTabKey]);
+  }, [feedEntryPoint, sessionManager, initialTabKey]);
 
   useFocusEffect(
     useCallback(() => {
@@ -815,6 +818,7 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
               tabs={tabs}
               activeIndex={activeIndex}
               onPageChange={handlePageChange}
+              listEntryPoint={listEntryPoint}
               scrollHandler={scrollHandler}
               headerHeight={headerHeight}
               tabBarHeight={tabBarHeight + 6}

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -272,6 +272,10 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
 }) => {
   const tw = useTailwind();
   const listRef = useRef<PredictFlashListRef>(null);
+  const route =
+    useRoute<RouteProp<PredictNavigationParamList, 'PredictMarketList'>>();
+  const listEntryPoint =
+    route.params?.entryPoint ?? PredictEventValues.ENTRY_POINT.PREDICT_FEED;
 
   const [hasEverBeenActive, setHasEverBeenActive] = useState(isActive);
   useEffect(() => {
@@ -317,7 +321,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
     (info: { item: PredictMarketType; index: number }) => (
       <PredictMarketListItem
         market={info.item}
-        entryPoint={PredictEventValues.ENTRY_POINT.PREDICT_FEED}
+        entryPoint={listEntryPoint}
         testID={getPredictMarketListSelector.marketCardByCategory(
           category,
           info.index + 1, // E2E tests use 1-based indexing
@@ -325,7 +329,7 @@ const PredictTabContent: React.FC<PredictTabContentProps> = ({
         transactionActiveAbTests={transactionActiveAbTests}
       />
     ),
-    [category, transactionActiveAbTests],
+    [category, listEntryPoint, transactionActiveAbTests],
   );
 
   const keyExtractor = useCallback((item: PredictMarketType) => item.id, []);
@@ -698,7 +702,10 @@ const PredictFeed: React.FC<PredictFeedProps> = ({
 
   useEffect(() => {
     sessionManager.enableAppStateListener();
-    sessionManager.startSession(route.params?.entryPoint, initialTabKey);
+    sessionManager.startSession(
+      route.params?.entryPoint ?? PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+      initialTabKey,
+    );
 
     return () => {
       sessionManager.endSession();

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -798,6 +798,31 @@ describe('PredictMarketDetails', () => {
       expect(screen.getByText(mockMarket.title)).toBeOnTheScreen();
     });
 
+    it('tracks market details opened with explore entry point from route params', async () => {
+      setupPredictMarketDetailsTest(
+        {},
+        {
+          params: {
+            marketId: 'market-1',
+            entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+          },
+        },
+      );
+
+      const trackMarketDetailsOpened =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require('../../../../../core/Engine').context.PredictController
+          .trackMarketDetailsOpened;
+
+      await waitFor(() => {
+        expect(trackMarketDetailsOpened).toHaveBeenCalledWith(
+          expect.objectContaining({
+            entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+          }),
+        );
+      });
+    });
+
     it('displays loading state when market is fetching', () => {
       setupPredictMarketDetailsTest(
         {},

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -3,6 +3,7 @@ import { InteractionManager, Text } from 'react-native';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import type { SectionRefreshHandle } from '../../types';
 import HomepageDiscoveryTabs from './HomepageDiscoveryTabs';
+import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import { HomeTabNames } from '../../hooks/useTabViewedEvent';
 
 const mockTrackTabViewed = jest.fn();
@@ -209,6 +210,18 @@ describe('HomepageDiscoveryTabs', () => {
       render(<HomepageDiscoveryTabs ref={ref} />);
       await act(async () => {
         await ref.current?.refresh();
+      });
+    });
+  });
+
+  describe('Predictions tab', () => {
+    it('passes Predict feed entry point explicitly to embedded PredictFeed', async () => {
+      renderComponent();
+
+      await pressTab('Predictions');
+
+      expect(mockPredictFeedProps.current).toMatchObject({
+        entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
       });
     });
   });

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -25,6 +25,7 @@ import { TabsIconListRef } from '../../../../../component-library/components-tem
 import Homepage from '../../Homepage';
 import PerpsHomeView from '../../../../UI/Perps/Views/PerpsHomeView/PerpsHomeView';
 import PredictFeed from '../../../../UI/Predict/views/PredictFeed';
+import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import { PerpsConnectionProvider } from '../../../../UI/Perps/providers/PerpsConnectionProvider';
 import {
   PerpsStreamProvider,
@@ -388,6 +389,7 @@ const HomepageDiscoveryTabs = forwardRef<
                   <PredictPreviewSheetProvider disableBottomSheet>
                     <PredictFeed
                       hideHeader
+                      entryPoint={PredictEventValues.ENTRY_POINT.PREDICT_FEED}
                       walletHeaderTranslateY={walletHeaderTranslateY}
                       walletHeaderHeight={walletHeaderHeight}
                       onHeaderHiddenChange={animateIcons}

--- a/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.test.ts
+++ b/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.test.ts
@@ -1,14 +1,21 @@
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
-import { navigateToPredictionsList } from './predictionsNavigation';
+import {
+  navigateToExplorePredictionsList,
+  navigateToPredictionsList,
+} from './predictionsNavigation';
 
 describe('navigateToPredictionsList', () => {
-  it('navigates with explore entryPoint and no tab for trending variant', () => {
+  it('navigates with an explicit entryPoint and no tab for trending variant', () => {
     const navigate = jest.fn();
     const navigation = { navigate } as unknown as AppNavigationProp;
 
-    navigateToPredictionsList(navigation, 'trending');
+    navigateToPredictionsList(
+      navigation,
+      'trending',
+      PredictEventValues.ENTRY_POINT.EXPLORE,
+    );
 
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
@@ -20,7 +27,11 @@ describe('navigateToPredictionsList', () => {
     const navigate = jest.fn();
     const navigation = { navigate } as unknown as AppNavigationProp;
 
-    navigateToPredictionsList(navigation, 'sports');
+    navigateToPredictionsList(
+      navigation,
+      'sports',
+      PredictEventValues.ENTRY_POINT.EXPLORE,
+    );
 
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
@@ -35,7 +46,11 @@ describe('navigateToPredictionsList', () => {
     const navigate = jest.fn();
     const navigation = { navigate } as unknown as AppNavigationProp;
 
-    navigateToPredictionsList(navigation, 'crypto');
+    navigateToPredictionsList(
+      navigation,
+      'crypto',
+      PredictEventValues.ENTRY_POINT.EXPLORE,
+    );
 
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
@@ -59,6 +74,18 @@ describe('navigateToPredictionsList', () => {
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
       params: { entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED },
+    });
+  });
+
+  it('navigates from Explore with explore entryPoint', () => {
+    const navigate = jest.fn();
+    const navigation = { navigate } as unknown as AppNavigationProp;
+
+    navigateToExplorePredictionsList(navigation, 'trending');
+
+    expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+      params: { entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE },
     });
   });
 });

--- a/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.test.ts
+++ b/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.test.ts
@@ -1,9 +1,10 @@
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
+import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import { navigateToPredictionsList } from './predictionsNavigation';
 
 describe('navigateToPredictionsList', () => {
-  it('navigates without tab params for trending variant', () => {
+  it('navigates with explore entryPoint and no tab for trending variant', () => {
     const navigate = jest.fn();
     const navigation = { navigate } as unknown as AppNavigationProp;
 
@@ -11,11 +12,11 @@ describe('navigateToPredictionsList', () => {
 
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
-      params: undefined,
+      params: { entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE },
     });
   });
 
-  it('includes tab param for sports variant', () => {
+  it('includes tab and explore entryPoint for sports variant', () => {
     const navigate = jest.fn();
     const navigation = { navigate } as unknown as AppNavigationProp;
 
@@ -23,11 +24,14 @@ describe('navigateToPredictionsList', () => {
 
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
-      params: { tab: 'sports' },
+      params: {
+        entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+        tab: 'sports',
+      },
     });
   });
 
-  it('includes tab param for crypto variant', () => {
+  it('includes tab and explore entryPoint for crypto variant', () => {
     const navigate = jest.fn();
     const navigation = { navigate } as unknown as AppNavigationProp;
 
@@ -35,7 +39,26 @@ describe('navigateToPredictionsList', () => {
 
     expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
-      params: { tab: 'crypto' },
+      params: {
+        entryPoint: PredictEventValues.ENTRY_POINT.EXPLORE,
+        tab: 'crypto',
+      },
+    });
+  });
+
+  it('passes a custom entryPoint when provided', () => {
+    const navigate = jest.fn();
+    const navigation = { navigate } as unknown as AppNavigationProp;
+
+    navigateToPredictionsList(
+      navigation,
+      'trending',
+      PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+    );
+
+    expect(navigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+      params: { entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED },
     });
   });
 });

--- a/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.ts
+++ b/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.ts
@@ -1,5 +1,7 @@
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
+import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
+import type { PredictEntryPoint } from '../../../../UI/Predict/types/navigation';
 import type { PredictionsVariant } from './usePredictionsFeed';
 
 const VARIANT_TO_TAB: Record<PredictionsVariant, string | undefined> = {
@@ -13,10 +15,14 @@ const VARIANT_TO_TAB: Record<PredictionsVariant, string | undefined> = {
 export const navigateToPredictionsList = (
   navigation: AppNavigationProp,
   variant: PredictionsVariant,
+  entryPoint: PredictEntryPoint = PredictEventValues.ENTRY_POINT.EXPLORE,
 ): void => {
   const tab = VARIANT_TO_TAB[variant];
   navigation.navigate(Routes.PREDICT.ROOT, {
     screen: Routes.PREDICT.MARKET_LIST,
-    params: tab ? { tab } : undefined,
+    params: {
+      entryPoint,
+      ...(tab && { tab }),
+    },
   });
 };

--- a/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.ts
+++ b/app/components/Views/TrendingView/feeds/predictions/predictionsNavigation.ts
@@ -26,3 +26,15 @@ export const navigateToPredictionsList = (
     },
   });
 };
+
+/** Navigate from Explore prediction sections to the Predict market list. */
+export const navigateToExplorePredictionsList = (
+  navigation: AppNavigationProp,
+  variant: PredictionsVariant,
+): void => {
+  navigateToPredictionsList(
+    navigation,
+    variant,
+    PredictEventValues.ENTRY_POINT.EXPLORE,
+  );
+};

--- a/app/components/Views/TrendingView/tabs/CryptoTab.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.tsx
@@ -23,7 +23,7 @@ import PerpsMarketTileCardSkeleton from '../../Homepage/Sections/Perpetuals/comp
 import { navigateToPerpsMarketList } from '../feeds/perps/perpsNavigation';
 import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
 import PredictionsCarouselSection from '../feeds/predictions/PredictionsCarouselSection';
-import { navigateToPredictionsList } from '../feeds/predictions/predictionsNavigation';
+import { navigateToExplorePredictionsList } from '../feeds/predictions/predictionsNavigation';
 import CardList from '../components/CardList';
 import ExploreScroll from '../components/ExploreScroll';
 import SectionHeader from '../components/SectionHeader';
@@ -164,7 +164,7 @@ const CryptoTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
         title={strings('trending.predictions')}
         testIdPrefix="predict-crypto-market-row-item"
         idPrefix="crypto_predictions"
-        onViewAll={() => navigateToPredictionsList(navigation, 'crypto')}
+        onViewAll={() => navigateToExplorePredictionsList(navigation, 'crypto')}
       />
     </ExploreScroll>
   );

--- a/app/components/Views/TrendingView/tabs/MacroTab.tsx
+++ b/app/components/Views/TrendingView/tabs/MacroTab.tsx
@@ -13,7 +13,7 @@ import PerpsToggleBlock from '../feeds/perps/PerpsToggleBlock';
 import { navigateToPerpsMarketList } from '../feeds/perps/perpsNavigation';
 import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
 import PredictionsCarouselSection from '../feeds/predictions/PredictionsCarouselSection';
-import { navigateToPredictionsList } from '../feeds/predictions/predictionsNavigation';
+import { navigateToExplorePredictionsList } from '../feeds/predictions/predictionsNavigation';
 import ExploreScroll from '../components/ExploreScroll';
 import type { PillToggleCardListTab } from '../components/PillToggleCardList';
 import type { TabProps } from '../hooks/useExploreRefresh';
@@ -87,7 +87,9 @@ const MacroTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
         title={strings('trending.predictions')}
         testIdPrefix="predict-rwa-politics-market-row-item"
         idPrefix="politics_predictions"
-        onViewAll={() => navigateToPredictionsList(appNavigation, 'politics')}
+        onViewAll={() =>
+          navigateToExplorePredictionsList(appNavigation, 'politics')
+        }
         isEnabled={isPredictEnabled}
       />
 

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -23,7 +23,7 @@ import PerpsPillItem from '../feeds/perps/PerpsPillItem';
 import { navigateToPerpsMarketList } from '../feeds/perps/perpsNavigation';
 import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
 import PredictionsCarouselSection from '../feeds/predictions/PredictionsCarouselSection';
-import { navigateToPredictionsList } from '../feeds/predictions/predictionsNavigation';
+import { navigateToExplorePredictionsList } from '../feeds/predictions/predictionsNavigation';
 import { useStocksFeed } from '../feeds/stocks/useStocksFeed';
 import { getCaipChainIdFromAssetId } from '../../../UI/Trending/components/TrendingTokenRowItem/utils';
 import CardList from '../components/CardList';
@@ -166,7 +166,7 @@ const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
       title={strings('wallet.predict')}
       testIdPrefix="predict-market-row-item"
       idPrefix="predictions"
-      onViewAll={() => navigateToPredictionsList(navigation, 'trending')}
+      onViewAll={() => navigateToExplorePredictionsList(navigation, 'trending')}
       isEnabled={isPredictEnabled}
     />
   );

--- a/app/components/Views/TrendingView/tabs/RwasTab.tsx
+++ b/app/components/Views/TrendingView/tabs/RwasTab.tsx
@@ -22,7 +22,7 @@ import PerpsToggleBlock from '../feeds/perps/PerpsToggleBlock';
 import { navigateToPerpsMarketList } from '../feeds/perps/perpsNavigation';
 import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
 import PredictionsCarouselSection from '../feeds/predictions/PredictionsCarouselSection';
-import { navigateToPredictionsList } from '../feeds/predictions/predictionsNavigation';
+import { navigateToExplorePredictionsList } from '../feeds/predictions/predictionsNavigation';
 import CardList from '../components/CardList';
 import ExploreScroll from '../components/ExploreScroll';
 import type { PillToggleCardListTab } from '../components/PillToggleCardList';
@@ -130,7 +130,9 @@ const RwasTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
         title={strings('trending.predictions')}
         testIdPrefix="predict-rwa-politics-market-row-item"
         idPrefix="politics_predictions"
-        onViewAll={() => navigateToPredictionsList(appNavigation, 'politics')}
+        onViewAll={() =>
+          navigateToExplorePredictionsList(appNavigation, 'politics')
+        }
         isEnabled={isPredictEnabled}
       />
 

--- a/app/components/Views/TrendingView/tabs/SportsTab.tsx
+++ b/app/components/Views/TrendingView/tabs/SportsTab.tsx
@@ -31,7 +31,7 @@ import {
 } from '../feeds/predictions/useSportsMarketsFeed';
 import PredictionsCarouselSection from '../feeds/predictions/PredictionsCarouselSection';
 import PredictionsSkeleton from '../feeds/predictions/PredictionsSkeleton';
-import { navigateToPredictionsList } from '../feeds/predictions/predictionsNavigation';
+import { navigateToExplorePredictionsList } from '../feeds/predictions/predictionsNavigation';
 import PillRow from '../components/PillRow';
 import SectionHeader from '../components/SectionHeader';
 import type { TabProps } from '../hooks/useExploreRefresh';
@@ -77,7 +77,7 @@ const SportsListHeader: React.FC<SportsListHeaderProps> = ({
       title={strings('trending.predictions')}
       testIdPrefix="predict-sports-market-row-item"
       idPrefix="sports_predictions"
-      onViewAll={() => navigateToPredictionsList(navigation, 'sports')}
+      onViewAll={() => navigateToExplorePredictionsList(navigation, 'sports')}
       isEnabled={showSportsPredictions}
     />
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Track explore conversions in predict


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: track explore conversions in predict


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3271

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics attribution and navigation params only; no changes to trading, auth, or payment logic.
> 
> **Overview**
> This PR wires **Predict analytics `entryPoint`** through navigation and the feed so Explore-driven journeys can be measured as conversions.
> 
> **`PredictFeed`** now accepts an optional `entryPoint` prop (overriding route params), uses that value for session attribution and performance traces, and passes a resolved `listEntryPoint` into market cards—defaulting to `predict_feed` when nothing is set. Search results still use the search entry point.
> 
> **Explore → Predict list:** `navigateToPredictionsList` always sends `entryPoint` in route params (default **explore**); a new `navigateToExplorePredictionsList` helper is used from Explore tabs (Now, Crypto, Sports, Macro, RWAs). **Homepage** embedded feed explicitly passes `predict_feed`.
> 
> Tests assert explore entry points on buy preview order events, market details, feed market cards, and homepage discovery tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c59bfcc8f5286d8d866b2e5906066c5e4d45c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->