### PR TITLE
fix: handle RWA source token routing in Token Details swaps

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
@@ -718,6 +718,10 @@ describe('useTokenAtomicActions - useHandleOnReceive', () => {
 // Source priority is documented under `computeBuySourceToken`.
 describe('useTokenAtomicActions - useHandleOnSwap', () => {
   const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+  const ETH_MAINNET_USDC_ADDRESS =
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+  const BNB_MAINNET_USDT_ADDRESS =
+    '0x55d398326f99059ff775485246999027b3197955';
 
   const arrangeToken = (balance: string): TokenI =>
     ({ ...defaultToken, balance }) as TokenI;
@@ -762,6 +766,49 @@ describe('useTokenAtomicActions - useHandleOnSwap', () => {
     expect(() => result.current()).not.toThrow();
     expect(mockGoToSwaps).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      chainId: '0x1' as Hex,
+      sourceAddress: ETH_MAINNET_USDC_ADDRESS,
+      sourceSymbol: 'USDC',
+    },
+    {
+      chainId: '0x38' as Hex,
+      sourceAddress: BNB_MAINNET_USDT_ADDRESS,
+      sourceSymbol: 'USDT',
+    },
+  ])(
+    'routes $sourceSymbol as source and the RWA token as destination on chain $chainId',
+    ({ chainId, sourceAddress, sourceSymbol }) => {
+      const rwaToken = {
+        ...defaultToken,
+        chainId,
+        balance: '1',
+        rwaData: { instrumentType: 'stock' } as TokenI['rwaData'],
+      } as TokenI;
+
+      const { result } = renderHook(() => useHandleOnSwap({ token: rwaToken }));
+
+      result.current();
+
+      expect(mockSelectAssetsBySelectedAccountGroup).not.toHaveBeenCalled();
+      expect(mockGoToSwaps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: sourceAddress,
+          symbol: sourceSymbol,
+          chainId,
+        }),
+        expect.objectContaining({
+          address: defaultToken.address,
+          chainId,
+          rwaData: { instrumentType: 'stock' },
+        }),
+        undefined,
+        true,
+      );
+    },
+  );
 
   // Cases where the current token has balance, so is indicated as a source token (swap out of the current token)
   const swapOutOfCurrentTokenRoutingCases = [
@@ -972,7 +1019,7 @@ describe('useTokenAtomicActions - useHandleOnSwap securityData adaptation', () =
     );
   });
 
-  it('forwards rwaData so selectIsRwaSwap can detect the convert flow', () => {
+  it('keeps rwaData on the destination token in the RWA convert flow', () => {
     const rwaToken = {
       ...defaultToken,
       balance: '1',
@@ -985,10 +1032,13 @@ describe('useTokenAtomicActions - useHandleOnSwap securityData adaptation', () =
 
     expect(mockGoToSwaps).toHaveBeenCalledWith(
       expect.objectContaining({
+        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        symbol: 'USDC',
+      }),
+      expect.objectContaining({
         address: defaultToken.address,
         rwaData: { instrumentType: 'stock' },
       }),
-      undefined,
       undefined,
       true,
     );

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
@@ -167,6 +167,52 @@ const toCurrentTokenAsBridgeToken = (token: TokenI): BridgeToken => ({
   rwaData: token.rwaData,
 });
 
+const RWA_SWAP_SOURCE_TOKEN_BY_CHAIN_ID: Partial<Record<Hex, BridgeToken>> = {
+  '0x1': {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+    chainId: '0x1',
+    image:
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+  },
+  '0x38': {
+    address: '0x55d398326f99059ff775485246999027b3197955',
+    symbol: 'USDT',
+    name: 'Tether USD',
+    decimals: 18,
+    chainId: '0x38',
+    image:
+      'https://static.cx.metamask.io/api/v1/tokenIcons/56/0x55d398326f99059ff775485246999027b3197955.png',
+  },
+};
+
+const getRwaSwapSourceToken = (
+  chainId: TokenI['chainId'],
+): BridgeToken | undefined => {
+  if (!chainId) {
+    return undefined;
+  }
+
+  if (chainId.startsWith('0x')) {
+    return RWA_SWAP_SOURCE_TOKEN_BY_CHAIN_ID[chainId as Hex];
+  }
+
+  if (!chainId.startsWith('eip155:')) {
+    return undefined;
+  }
+
+  const decimalChainId = Number.parseInt(chainId.slice('eip155:'.length), 10);
+  if (Number.isNaN(decimalChainId)) {
+    return undefined;
+  }
+
+  return RWA_SWAP_SOURCE_TOKEN_BY_CHAIN_ID[
+    `0x${decimalChainId.toString(16)}` as Hex
+  ];
+};
+
 const hasPositiveBalance = (balance: string | number | undefined): boolean => {
   if (typeof balance === 'number') {
     return balance > 0;
@@ -324,6 +370,12 @@ export const useHandleOnSwap = ({
     if (!goToSwaps) return;
 
     const currentTokenAsBridgeToken = toCurrentTokenAsBridgeToken(token);
+    if (token.rwaData) {
+      const rwaSwapSourceToken = getRwaSwapSourceToken(token.chainId);
+      goToSwaps(rwaSwapSourceToken, currentTokenAsBridgeToken, undefined, true);
+      return;
+    }
+
     const balanceForCheck = currentTokenBalance ?? token.balance;
 
     if (hasPositiveBalance(balanceForCheck)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

- Adds an early RWA route in `useHandleOnSwap` so RWA token details open swap as a convert flow.
- Sets destination token to the selected RWA token and source token to chain-specific stablecoins:
  - Ethereum (`0x1`) -> USDC
  - BNB Chain (`0x38`) -> USDT
- Keeps existing non-RWA swap routing behavior unchanged.

## **Changelog**

CHANGELOG entry: Fixed RWA token swap routing from Token Details to prefill stablecoin source and RWA destination.

## **Related issues**

Fixes: N/A (requested via assets team Slack thread)

## **Manual testing steps**

```gherkin
Feature: RWA swap routing from token details

  Scenario: User opens swap from an RWA token details page
    Given a user is on Token Details for a supported RWA token on Ethereum or BNB Chain

    When user taps Swap
    Then Swap opens with source token as USDC on Ethereum or USDT on BNB Chain
    And destination token is the selected RWA token
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A -->

### **After**

<!-- N/A -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C07NF2K42LE/p1779961195654139?thread_ts=1779961195.654139&cid=C07NF2K42LE)

<div><a href="https://cursor.com/agents/bc-33640cb8-30ce-533f-9643-b946419c7e16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33640cb8-30ce-533f-9643-b946419c7e16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

