### PR TITLE
refactor(predictions): introduce useHomepagePredictWorldCupMarkets hook and update related components

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -107,11 +107,20 @@ jest.mock('../../UI/Perps', () => ({
 }));
 
 jest.mock('../../UI/Perps/providers/PerpsConnectionProvider', () => {
-  const actual = jest.requireActual(
-    '../../UI/Perps/providers/PerpsConnectionProvider',
-  );
+  const ReactLib = jest.requireActual<typeof import('react')>('react');
+  const PerpsConnectionContext = ReactLib.createContext({
+    isConnected: true,
+    isConnecting: false,
+    isInitialized: true,
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    resetError: jest.fn(),
+    reconnectWithNewContext: jest.fn().mockResolvedValue(undefined),
+  });
+
   return {
-    ...actual,
+    PerpsConnectionContext,
     PerpsConnectionProvider: ({ children }: { children: React.ReactNode }) =>
       children,
   };
@@ -190,6 +199,46 @@ jest.mock('../../UI/NftGrid/NftGridItemBottomSheet', () => () => null);
 
 jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
   selectPredictEnabledFlag: jest.fn(() => true),
+  selectPredictWorldCupConfig: jest.fn(() => ({
+    enabled: false,
+    minimumVersion: '',
+    showMainFeedBanner: false,
+    showMainFeedTab: false,
+    showWorldCupScreen: false,
+    seriesId: '10218',
+    tagSlug: 'fifa-world-cup',
+    gamesTagId: '100639',
+    stages: [],
+  })),
+  selectPredictWorldCupScreenEnabledFlag: jest.fn(() => false),
+  selectPredictHomepageDiscoveryNbaChampionEnabledFlag: jest.fn(() => false),
+}));
+
+jest.mock('../../UI/Predict/hooks/usePredictWorldCup', () => ({
+  usePredictWorldCupMarkets: () => ({
+    marketData: [],
+    isFetching: false,
+    isFetchingMore: false,
+    error: null,
+    hasMore: false,
+    refetch: jest.fn().mockResolvedValue(undefined),
+    fetchMore: jest.fn().mockResolvedValue(undefined),
+  }),
+  usePredictWorldCupAvailability: () => ({
+    availability: { live: false, props: false, stages: {} },
+    isFetching: false,
+    isLoading: false,
+    errors: [],
+    refetch: jest.fn(),
+  }),
+  usePredictWorldCupAvailableTabs: () => ({
+    availability: { live: false, props: false, stages: {} },
+    tabs: [],
+    isFetching: false,
+    isLoading: false,
+    errors: [],
+    refetch: jest.fn(),
+  }),
 }));
 
 jest.mock('@tanstack/react-query', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -184,12 +184,8 @@ jest.mock('@tanstack/react-query', () => {
 jest.mock('./hooks', () => {
   const actual = jest.requireActual('./hooks') as Record<string, unknown>;
   const tagQueries = actual.HOMEPAGE_PREDICT_TAG_QUERIES as {
-    worldCup: string;
     nbaChampion: string;
   };
-  // Two distinct jest mocks under the hood so tests can target each feed
-  // independently (`.mockReturnValue(...)` on either still works); the
-  // consolidated `useHomepagePredictTaggedMarkets` dispatches by tag query.
   const worldCupMock = jest.fn(() =>
     worldCupMarketsWithDiscoveryChampionship(),
   );
@@ -210,11 +206,12 @@ jest.mock('./hooks', () => {
       error: null,
       refetch: jest.fn(),
     })),
+    useHomepagePredictWorldCupMarkets: worldCupMock,
     useHomepagePredictTaggedMarkets: jest.fn(
       ({ customQueryParams }: { customQueryParams: string }) =>
         customQueryParams === tagQueries.nbaChampion
           ? nbaMock()
-          : worldCupMock(),
+          : worldCupHomepageMarketsMock([]),
     ),
     __mockUsePredictWorldCupHomepageMarkets: worldCupMock,
     __mockUsePredictNbaChampionHomepageMarkets: nbaMock,

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -25,6 +25,7 @@ import {
   usePredictMarketsForHomepage,
   usePredictPositionsForHomepage,
   useHomepagePredictTaggedMarkets,
+  useHomepagePredictWorldCupMarkets,
   HOMEPAGE_PREDICT_TAG_QUERIES,
   usePredictHomepageDiscoveryExperiment,
 } from './hooks';
@@ -52,10 +53,7 @@ import type { TransactionActiveAbTestEntry } from '../../../../../util/transacti
 
 /** Loads both feeds the World Cup discovery rail needs (World Cup tag + NBA Champion event). */
 const useWorldCupDiscoveryFeeds = (enabled: boolean) => ({
-  worldCup: useHomepagePredictTaggedMarkets({
-    enabled,
-    customQueryParams: HOMEPAGE_PREDICT_TAG_QUERIES.worldCup,
-  }),
+  worldCup: useHomepagePredictWorldCupMarkets({ enabled }),
   nbaChampion: useHomepagePredictTaggedMarkets({
     enabled,
     customQueryParams: HOMEPAGE_PREDICT_TAG_QUERIES.nbaChampion,

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingMarkets.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingMarkets.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
 import type { TransactionActiveAbTestEntry } from '../../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+import type { UseHomepagePredictWorldCupMarketsResult } from '../hooks/useHomepagePredictWorldCupMarkets';
 import type { UseHomepagePredictTaggedMarketsResult } from '../hooks/useHomepagePredictTaggedMarkets';
 import type { PredictionsTrendingHeaderTestId } from '../predictionsSectionTypes';
 import type { PredictEmptyStateCtaName } from '../../../abTestConfig';
@@ -18,7 +19,7 @@ export interface HomepagePredictTrendingMarketsProps {
   markets: PredictMarket[];
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   /** Required when `discoveryLayout` is `list` (World Cup discovery rail). */
-  worldCupHomepage?: UseHomepagePredictTaggedMarketsResult;
+  worldCupHomepage?: UseHomepagePredictWorldCupMarketsResult;
   /** Required when `discoveryLayout` is `list` (NBA champion event, separate from World Cup tag). */
   nbaChampionHomepage?: UseHomepagePredictTaggedMarketsResult;
   emptyStateTransactionActiveAbTests?: TransactionActiveAbTestEntry[];

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -23,6 +23,7 @@ import {
   pickWorldCupWinnerMarket,
   resolveNbaChampionHomepageMarket,
 } from '../../utils/marketResolvers';
+import type { UseHomepagePredictWorldCupMarketsResult } from '../../hooks/useHomepagePredictWorldCupMarkets';
 import type { UseHomepagePredictTaggedMarketsResult } from '../../hooks/useHomepagePredictTaggedMarkets';
 import type { PredictionsTrendingHeaderTestId } from '../../predictionsSectionTypes';
 import type { TransactionActiveAbTestEntry } from '../../../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
@@ -39,7 +40,7 @@ export interface HomepagePredictWorldCupDiscoveryProps {
     transactionActiveAbTests?: TransactionActiveAbTestEntry[],
   ) => void;
   headerTestIdKey: PredictionsTrendingHeaderTestId;
-  worldCup: UseHomepagePredictTaggedMarketsResult;
+  worldCup: UseHomepagePredictWorldCupMarketsResult;
   nbaChampion: UseHomepagePredictTaggedMarketsResult;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   onTreatmentCtaClick?: (

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/index.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/index.ts
@@ -2,6 +2,7 @@ export * from './usePredictMarketsForHomepage';
 export * from './usePredictPositionsForHomepage';
 export * from './usePredictHomepageDiscoveryExperiment';
 export * from './useHomepagePredictTaggedMarkets';
+export * from './useHomepagePredictWorldCupMarkets';
 export * from './usePredictionsSectionNavigation';
 export * from './usePredictionsDefaultSectionModel';
 export * from './useTreatmentDiscoveryFeedsLoading';

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictTaggedMarkets.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictTaggedMarkets.ts
@@ -4,12 +4,8 @@ import {
 } from '../../../../../UI/Predict/hooks/usePredictMarketData';
 import { PREDICT_HOME_NBA_CHAMPION_EVENT_QUERY } from '../constants/homepageNbaChampionDiscovery';
 
-/** Polymarket tag for 2026 FIFA World Cup (homepage discovery feed). */
-export const PREDICT_HOME_WORLD_CUP_TAG_QUERY = 'tag_id=102350';
-
 /** Predefined query parameter slugs the homepage rail loads. */
 export const HOMEPAGE_PREDICT_TAG_QUERIES = {
-  worldCup: PREDICT_HOME_WORLD_CUP_TAG_QUERY,
   nbaChampion: PREDICT_HOME_NBA_CHAMPION_EVENT_QUERY,
 } as const;
 

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux';
+import { usePredictWorldCupMarkets } from '../../../../../UI/Predict/hooks/usePredictWorldCup';
+import type { UsePredictMarketDataResult } from '../../../../../UI/Predict/hooks/usePredictMarketData';
+import { PREDICT_WORLD_CUP_TAB_KEYS } from '../../../../../UI/Predict/constants/worldCupTabs';
+import { selectPredictWorldCupConfig } from '../../../../../UI/Predict/selectors/featureFlags';
+
+interface UseHomepagePredictWorldCupMarketsArgs {
+  enabled: boolean;
+}
+
+/**
+ * Homepage discovery: loads World Cup markets using the same ALL-tab query path
+ * as the dedicated World Cup screen (`buildPredictWorldCupAllQuery` → keyset API).
+ */
+export function useHomepagePredictWorldCupMarkets({
+  enabled,
+}: UseHomepagePredictWorldCupMarketsArgs): UsePredictMarketDataResult {
+  const config = useSelector(selectPredictWorldCupConfig);
+
+  return usePredictWorldCupMarkets({
+    tabKey: PREDICT_WORLD_CUP_TAB_KEYS.ALL,
+    config,
+    enabled,
+  });
+}
+
+export type UseHomepagePredictWorldCupMarketsResult =
+  UsePredictMarketDataResult;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Homepage Predict empty-state World Cup discovery was loading markets through a separate path (useHomepagePredictTaggedMarkets → category: 'sports' + hardcoded tag_id=102350), while the dedicated World Cup screen uses usePredictWorldCupMarkets with the ALL tab (buildPredictWorldCupAllQuery → events/keyset?tag_slug=...).

This PR aligns the homepage feed with the World Cup screen by introducing useHomepagePredictWorldCupMarkets, which wraps usePredictWorldCupMarkets with PREDICT_WORLD_CUP_TAB_KEYS.ALL and selectPredictWorldCupConfig. The NBA champion discovery feed is unchanged and still uses useHomepagePredictTaggedMarkets.

Why: Avoid divergent Polymarket query logic between homepage discovery and the World Cup screen.

How: Thin homepage hook + swap the World Cup feed in PredictionsSection; remove the obsolete PREDICT_HOME_WORLD_CUP_TAG_QUERY constant; update types and test mocks.
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix bug that was causing wrong events number in world cup (predict) section

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Homepage Predict empty state World Cup discovery

  Scenario: World Cup discovery loads when user has no positions
    Given Predict is enabled
    And the user is in the Predict positions empty state AB treatment
    And the user has no open Predict positions

    When the user opens the Homepage Predict section
    Then the World Cup discovery rail renders (event count, bracket pills, championship row)
    And World Cup markets are fetched via the World Cup ALL-tab keyset query (tag_slug from feature flag config)

  Scenario: World Cup discovery navigation still works
    Given the World Cup discovery rail is visible on Homepage

    When the user taps the men's World Cup row or a bracket pill
    Then navigation opens the World Cup screen (or Predict market list fallback) with the expected initial tab

  Scenario: NBA champion row is unaffected
    Given NBA champion homepage discovery is enabled

    When the user opens the Homepage Predict empty state
    Then the NBA champion row still loads via the existing tagged-markets hook
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="403" height="234" alt="Screenshot 2026-05-28 at 13 26 58" src="https://github.com/user-attachments/assets/e26cb906-3a85-4ffc-a961-3ee7c1a29652" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Polymarket fetch logic for a user-visible homepage discovery rail (fixes wrong event counts) but is scoped to Predict UI with tests updated; NBA feed unchanged.
> 
> **Overview**
> Homepage Predict **empty-state World Cup discovery** no longer loads markets through `useHomepagePredictTaggedMarkets` with a hardcoded sports `tag_id=102350`. It now uses a new **`useHomepagePredictWorldCupMarkets`** hook that wraps **`usePredictWorldCupMarkets`** on the World Cup **ALL** tab with **`selectPredictWorldCupConfig`**, matching the dedicated World Cup screen’s keyset/`tag_slug` query path.
> 
> **`PredictionsSection`** and the World Cup discovery UI types were switched to that hook; the obsolete World Cup tag constant was removed from **`HOMEPAGE_PREDICT_TAG_QUERIES`**. **NBA champion** discovery still uses tagged markets. Tests and Homepage mocks were updated for the new hook and World Cup feature-flag/hook stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c053706c35da986f11e50509fdc1c05c7f3a4120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->