### PR TITLE
chore(rewards): rename Perps competition CTA to "Trade now" (RWDS-1335) cp-7.79.0

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.test.tsx
@@ -55,7 +55,7 @@ jest.mock('./CampaignOptInSheet', () => {
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {
     const map: Record<string, string> = {
-      'rewards.perps_trading_campaign.open_position_cta': 'Open Position',
+      'rewards.perps_trading_campaign.open_position_cta': 'Trade now',
       'rewards.campaign_details.join_campaign': 'Join Campaign',
       'rewards.campaign.geo_locked_cta': 'Geo locked',
       'rewards.campaign.geo_locked_toast_title': 'Not available',
@@ -150,7 +150,7 @@ describe('PerpsTradingCampaignCTA', () => {
     expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
   });
 
-  it('when opted in, shows Open Position and calls handleDeeplink with perps market-list URL', () => {
+  it('when opted in, shows Trade now and calls handleDeeplink with perps market-list URL', () => {
     const { getByTestId, getByText } = render(
       <PerpsTradingCampaignCTA
         campaign={buildCampaign()}
@@ -158,7 +158,7 @@ describe('PerpsTradingCampaignCTA', () => {
       />,
     );
 
-    expect(getByText('Open Position')).toBeOnTheScreen();
+    expect(getByText('Trade now')).toBeOnTheScreen();
     fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
 
     expect(mockHandleDeeplink).toHaveBeenCalledWith({

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.tsx
@@ -69,7 +69,7 @@ const PerpsTradingCampaignCTA: React.FC<PerpsTradingCampaignCTAProps> = ({
     return null;
   }
 
-  // Opted in — show "Open Position"
+  // Opted in — show "Trade now"
   if (isOptedIn) {
     return (
       <Box twClassName="p-4 mb-2">

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9014,7 +9014,7 @@
       "label_notional_volume": "Notional volume",
       "pending": "Pending",
       "qualified": "Qualified",
-      "open_position_cta": "Open Position",
+      "open_position_cta": "Trade now",
       "leaderboard_title": "Leaderboard",
       "leaderboard_total_participants": "{{count}} participants",
       "last_updated": "Last updated: {{time}}",


### PR DESCRIPTION
## **Description**

Replaces the **"Open Position"** copy on the Perps Trading Competition opted-in CTA with **"Trade now"**, per [RWDS-1335](https://consensyssoftware.atlassian.net/browse/RWDS-1335).

Scope is intentionally copy-only:
- `locales/languages/en.json` — `rewards.perps_trading_campaign.open_position_cta` value.
- `app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.tsx` — comment updated to match.
- `app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.test.tsx` — mock value, test name, and rendered-text assertion.

No behavior, navigation, or analytics changes — the CTA still deep-links to `link.metamask.io/perps?screen=market-list`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [RWDS-1335](https://consensyssoftware.atlassian.net/browse/RWDS-1335)

## **Manual testing steps**

```gherkin
Feature: Perps Trading Competition CTA copy

  Scenario: Opted-in user sees the renamed CTA
    Given I am opted in to the Perps Trading Competition campaign
    And the campaign is active
    When I open the Rewards campaigns view
    Then the campaign CTA reads "Trade now"
    And tapping it deep-links to the Perps market list
```

## **Screenshots/Recordings**

### **Before**

CTA: "Open Position"

### **After**

CTA: "Trade now"

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

[RWDS-1335]: https://consensyssoftware.atlassian.net/browse/RWDS-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RWDS-1335]: https://consensyssoftware.atlassian.net/browse/RWDS-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to an existing i18n string and tests; navigation and campaign logic are unchanged.
> 
> **Overview**
> Renames the opted-in **Perps Trading Competition** primary CTA label from **"Open Position"** to **"Trade now"** via `rewards.perps_trading_campaign.open_position_cta` in English (`en.json`). The component still uses the same i18n key and `handleOpenPosition` still deep-links to `link.metamask.io/perps?screen=market-list`; only the displayed string and an inline comment change. Unit tests update the i18n mock, test description, and on-screen text assertion to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c865b9b98367fc9c204d2c270a2ffab5c57a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->