### PR TITLE
feat(swaps): add input currency mode metrics

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -119,6 +119,7 @@ import {
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button/Button.types.ts';
 import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable/index.ts';
+import { BridgeInputCurrencyModeProvider } from '../../hooks/useBridgeInputCurrencyMode';
 
 const SCROLL_NEAR_BOTTOM_PX = 160;
 
@@ -248,6 +249,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
 
   const updateQuoteParams = useBridgeQuoteRequest({
     latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
+    inputCurrencyMode: sourceAmountInput.inputCurrencyMode,
   });
 
   const {
@@ -330,6 +332,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
     isNetworkFeeUnavailable,
     isSubmitDisabled,
     isPriceImpactWarningVisible: shouldShowPriceImpactWarning,
+    inputCurrencyMode: sourceAmountInput.inputCurrencyMode,
   });
 
   const isZeroState = !sourceAmount || !(Number(sourceAmount) > 0);
@@ -370,7 +373,7 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
     headerTitle = `${strings('swaps.title')}/${strings('bridge.title')}`;
   }
 
-  useTrackSwapPageViewed();
+  useTrackSwapPageViewed(sourceAmountInput.inputCurrencyMode);
 
   const handleSourceMaxPress = () => {
     if (latestSourceBalance?.displayBalance) {
@@ -712,36 +715,40 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
             </Box>
           </ScrollView>
 
-          <BridgeViewFooter
-            location={location}
-            latestSourceBalance={latestSourceBalance}
-            transactionActiveAbTests={transactionActiveAbTests}
-          />
-
-          <SwapsKeypad
-            ref={keypadRef}
-            value={sourceAmountInput.keypadValue}
-            onChange={sourceAmountInput.handleKeypadChange}
-            currency={sourceAmountInput.keypadCurrency}
-            decimals={sourceAmountInput.keypadDecimals}
+          <BridgeInputCurrencyModeProvider
+            value={sourceAmountInput.inputCurrencyMode}
           >
-            {sourceAmount && sourceAmount !== '0' ? (
-              <SwapsConfirmButton
-                location={location}
-                latestSourceBalance={latestSourceBalance}
-                transactionActiveAbTests={transactionActiveAbTests}
-                testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD}
-              />
-            ) : (
-              <GaslessQuickPickOptions
-                token={sourceToken}
-                tokenBalance={latestSourceBalance?.displayBalance}
-                onMaxPress={handleSourceMaxPress}
-                isQuoteSponsored={isQuoteSponsored}
-                onAmountSelect={handleSourcePresetAmountSelect}
-              />
-            )}
-          </SwapsKeypad>
+            <BridgeViewFooter
+              location={location}
+              latestSourceBalance={latestSourceBalance}
+              transactionActiveAbTests={transactionActiveAbTests}
+            />
+
+            <SwapsKeypad
+              ref={keypadRef}
+              value={sourceAmountInput.keypadValue}
+              onChange={sourceAmountInput.handleKeypadChange}
+              currency={sourceAmountInput.keypadCurrency}
+              decimals={sourceAmountInput.keypadDecimals}
+            >
+              {sourceAmount && sourceAmount !== '0' ? (
+                <SwapsConfirmButton
+                  location={location}
+                  latestSourceBalance={latestSourceBalance}
+                  transactionActiveAbTests={transactionActiveAbTests}
+                  testID={BridgeViewSelectorsIDs.CONFIRM_BUTTON_KEYPAD}
+                />
+              ) : (
+                <GaslessQuickPickOptions
+                  token={sourceToken}
+                  tokenBalance={latestSourceBalance?.displayBalance}
+                  onMaxPress={handleSourceMaxPress}
+                  isQuoteSponsored={isQuoteSponsored}
+                  onAmountSelect={handleSourcePresetAmountSelect}
+                />
+              )}
+            </SwapsKeypad>
+          </BridgeInputCurrencyModeProvider>
         </Box>
       </ScreenView>
     </SafeAreaView>

--- a/app/components/UI/Bridge/components/GaslessQuickPickOptions/index.tsx
+++ b/app/components/UI/Bridge/components/GaslessQuickPickOptions/index.tsx
@@ -14,6 +14,7 @@ import {
   NUMPAD_QUICK_ACTIONS_VARIANTS,
   NumpadQuickActionsVariant,
 } from './abTestConfig';
+import { useBridgeInputCurrencyMode } from '../../hooks/useBridgeInputCurrencyMode';
 
 interface GaslessQuickPickOptionsProps {
   token?: BridgeToken;
@@ -30,6 +31,7 @@ export const GaslessQuickPickOptions = ({
   tokenBalance,
   isQuoteSponsored,
 }: GaslessQuickPickOptionsProps) => {
+  const inputCurrencyMode = useBridgeInputCurrencyMode();
   const { variantName, isActive } = useABTest(
     NUMPAD_QUICK_ACTIONS_AB_KEY,
     NUMPAD_QUICK_ACTIONS_VARIANTS,
@@ -45,6 +47,7 @@ export const GaslessQuickPickOptions = ({
         {
           input: 'token_amount_source',
           input_value: inputValue,
+          input_currency_mode: inputCurrencyMode,
           ...(preset && { input_amount_preset: preset }),
           // This Bridge-specific event bypasses the shared analytics wrappers,
           // so its A/B context still needs to be attached manually here.
@@ -59,7 +62,7 @@ export const GaslessQuickPickOptions = ({
         },
       );
     },
-    [isActive, variantName],
+    [inputCurrencyMode, isActive, variantName],
   );
 
   const onQuickOptionPress = useCallback(

--- a/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
+++ b/app/components/UI/Bridge/components/MissingPriceModal/index.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import type {
+  InputCurrencyMode,
+  MetaMetricsSwapsEventSource,
+} from '@metamask/bridge-controller';
 import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { useLatestBalance } from '../../hooks/useLatestBalance';
@@ -28,6 +31,7 @@ import {
 
 export interface MissingPriceModalParams {
   location: MetaMetricsSwapsEventSource;
+  inputCurrencyMode?: InputCurrencyMode;
 }
 
 export const MissingPriceModal = () => {
@@ -35,7 +39,7 @@ export const MissingPriceModal = () => {
     useNavigation<StackNavigationProp<Record<string, object | undefined>>>();
   const sheetRef = useRef<BottomSheetRef>(null);
   const [loading, setLoading] = useState(false);
-  const { location } = useParams<MissingPriceModalParams>();
+  const { location, inputCurrencyMode } = useParams<MissingPriceModalParams>();
 
   const sourceToken = useSelector(selectSourceToken);
   const tokenBalance = useLatestBalance({
@@ -50,6 +54,7 @@ export const MissingPriceModal = () => {
   const confirmBridge = useBridgeConfirm({
     activeQuote,
     location,
+    inputCurrencyMode,
   });
 
   const handleClose = useCallback(() => {

--- a/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
+++ b/app/components/UI/Bridge/components/PriceImpactModal/index.tsx
@@ -24,7 +24,8 @@ export const PriceImpactModal = () => {
   const { goBack } = useNavigation();
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const [loading, setLoading] = useState(false);
-  const { type, token, location } = useParams<PriceImpactModalRouterParams>();
+  const { type, token, location, inputCurrencyMode } =
+    useParams<PriceImpactModalRouterParams>();
   const sheetRef = useRef<BottomSheetRef>(null);
   const tokenBalance = useLatestBalance({
     address: token?.address,
@@ -38,6 +39,7 @@ export const PriceImpactModal = () => {
   const confirmBridge = useBridgeConfirm({
     activeQuote,
     location,
+    inputCurrencyMode,
   });
   const priceImpactViewData = usePriceImpactViewData(
     activeQuote?.quote.priceData?.priceImpact,

--- a/app/components/UI/Bridge/components/PriceImpactModal/types.ts
+++ b/app/components/UI/Bridge/components/PriceImpactModal/types.ts
@@ -1,4 +1,7 @@
-import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import type {
+  InputCurrencyMode,
+  MetaMetricsSwapsEventSource,
+} from '@metamask/bridge-controller';
 import { BridgeToken } from '../../types';
 import { PriceImpactModalType } from './constants';
 
@@ -6,4 +9,5 @@ export interface PriceImpactModalRouterParams {
   type: PriceImpactModalType;
   token: BridgeToken;
   location: MetaMetricsSwapsEventSource;
+  inputCurrencyMode?: InputCurrencyMode;
 }

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -23,6 +23,7 @@ import Engine from '../../../../../core/Engine';
 import { setSourceAmount } from '../../../../../core/redux/slices/bridge';
 import {
   ChainId,
+  InputCurrencyMode,
   MetaMetricsSwapsEventSource,
 } from '@metamask/bridge-controller';
 import { PriceImpactModalType } from '../PriceImpactModal/constants';
@@ -1118,6 +1119,8 @@ describe('SwapsConfirmButton', () => {
           expect(mockSubmitBridgeTx).toHaveBeenCalledWith({
             quoteResponse: mockActiveQuote,
             location: 'Main View',
+            transactionActiveAbTests: undefined,
+            inputCurrencyMode: InputCurrencyMode.CRYPTO,
           });
           expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
         });
@@ -1177,6 +1180,8 @@ describe('SwapsConfirmButton', () => {
           expect(mockSubmitBridgeTx).toHaveBeenCalledWith({
             quoteResponse: solanaActiveQuote,
             location: 'Main View',
+            transactionActiveAbTests: undefined,
+            inputCurrencyMode: InputCurrencyMode.CRYPTO,
           });
           expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
         });
@@ -1324,6 +1329,7 @@ describe('SwapsConfirmButton', () => {
           features: mockWarningFeatures,
           mode: TokenWarningModalMode.Execution,
           location: MetaMetricsSwapsEventSource.MainView,
+          inputCurrencyMode: InputCurrencyMode.CRYPTO,
         },
       });
     });
@@ -1536,6 +1542,7 @@ describe('SwapsConfirmButton', () => {
         screen: Routes.BRIDGE.MODALS.MISSING_PRICE_MODAL,
         params: {
           location: MetaMetricsSwapsEventSource.MainView,
+          inputCurrencyMode: InputCurrencyMode.CRYPTO,
         },
       });
     });
@@ -1607,6 +1614,7 @@ describe('SwapsConfirmButton', () => {
           type: PriceImpactModalType.Execution,
           token: mockState.bridge?.sourceToken,
           location: MetaMetricsSwapsEventSource.MainView,
+          inputCurrencyMode: InputCurrencyMode.CRYPTO,
         },
       });
     });
@@ -1681,6 +1689,7 @@ describe('SwapsConfirmButton', () => {
           type: PriceImpactModalType.Execution,
           token: mockState.bridge?.sourceToken,
           location: MetaMetricsSwapsEventSource.MainView,
+          inputCurrencyMode: InputCurrencyMode.CRYPTO,
         },
       });
       expect(mockSubmitBridgeTx).not.toHaveBeenCalled();
@@ -1756,6 +1765,7 @@ describe('SwapsConfirmButton', () => {
         screen: Routes.BRIDGE.MODALS.MISSING_PRICE_MODAL,
         params: {
           location: MetaMetricsSwapsEventSource.MainView,
+          inputCurrencyMode: InputCurrencyMode.CRYPTO,
         },
       });
       expect(mockSubmitBridgeTx).not.toHaveBeenCalled();
@@ -1880,6 +1890,7 @@ describe('SwapsConfirmButton', () => {
           type: PriceImpactModalType.Execution,
           token: mockState.bridge?.sourceToken,
           location: MetaMetricsSwapsEventSource.MainView,
+          inputCurrencyMode: InputCurrencyMode.CRYPTO,
         },
       });
       expect(mockSubmitBridgeTx).not.toHaveBeenCalled();

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -41,6 +41,7 @@ import { TokenWarningModalMode } from '../TokenWarningModal/constants';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
 import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable';
+import { useBridgeInputCurrencyMode } from '../../hooks/useBridgeInputCurrencyMode';
 
 interface Props {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
@@ -57,6 +58,7 @@ export const SwapsConfirmButton = ({
   transactionActiveAbTests,
 }: Props) => {
   const navigation = useNavigation();
+  const inputCurrencyMode = useBridgeInputCurrencyMode();
 
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const destToken = useSelector(selectDestToken);
@@ -185,6 +187,7 @@ export const SwapsConfirmButton = ({
         features: securityData.metadata?.features ?? [],
         mode: TokenWarningModalMode.Execution,
         location,
+        inputCurrencyMode,
       };
       navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
         screen: Routes.BRIDGE.MODALS.TOKEN_WARNING_MODAL,
@@ -198,6 +201,7 @@ export const SwapsConfirmButton = ({
         screen: Routes.BRIDGE.MODALS.MISSING_PRICE_MODAL,
         params: {
           location,
+          inputCurrencyMode,
         },
       });
       return;
@@ -223,6 +227,7 @@ export const SwapsConfirmButton = ({
           type: PriceImpactModalType.Execution,
           token: sourceToken,
           location,
+          inputCurrencyMode,
         },
       });
       return;

--- a/app/components/UI/Bridge/components/TokenWarningModal/index.tsx
+++ b/app/components/UI/Bridge/components/TokenWarningModal/index.tsx
@@ -4,7 +4,10 @@ import { useSelector } from 'react-redux';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import type {
+  InputCurrencyMode,
+  MetaMetricsSwapsEventSource,
+} from '@metamask/bridge-controller';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -56,6 +59,7 @@ export interface TokenWarningModalParams {
   features: SecurityFeature[];
   mode: TokenWarningModalMode;
   location: MetaMetricsSwapsEventSource;
+  inputCurrencyMode?: InputCurrencyMode;
 }
 
 export const getTokenWarningContent = (
@@ -100,6 +104,7 @@ export const TokenWarningModal = () => {
     features = [],
     mode,
     location,
+    inputCurrencyMode,
   } = useParams<TokenWarningModalParams>();
 
   const sourceToken = useSelector(selectSourceToken);
@@ -118,6 +123,7 @@ export const TokenWarningModal = () => {
   const confirmBridge = useBridgeConfirm({
     activeQuote,
     location,
+    inputCurrencyMode,
   });
 
   const handleClose = useCallback(() => {
@@ -128,6 +134,7 @@ export const TokenWarningModal = () => {
     if (hasMissingPriceData(activeQuote)) {
       navigation.replace(Routes.BRIDGE.MODALS.MISSING_PRICE_MODAL, {
         location,
+        inputCurrencyMode,
       });
       return;
     }
@@ -146,6 +153,7 @@ export const TokenWarningModal = () => {
         type: PriceImpactModalType.Execution,
         token: sourceToken,
         location,
+        inputCurrencyMode,
       });
       return;
     }
@@ -159,6 +167,7 @@ export const TokenWarningModal = () => {
     navigation,
     sourceToken,
     location,
+    inputCurrencyMode,
   ]);
 
   const {

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
@@ -5,24 +5,33 @@ import { setIsSubmittingTx } from '../../../../../core/redux/slices/bridge';
 import Routes from '../../../../../constants/navigation/Routes';
 import useSubmitBridgeTx from '../../../../../util/bridge/hooks/useSubmitBridgeTx';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
-import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import type {
+  InputCurrencyMode,
+  MetaMetricsSwapsEventSource,
+} from '@metamask/bridge-controller';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+import { useBridgeInputCurrencyMode } from '../useBridgeInputCurrencyMode';
 
 interface Params {
   activeQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] | null;
   location: MetaMetricsSwapsEventSource;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
+  inputCurrencyMode?: InputCurrencyMode;
 }
 
 export const useBridgeConfirm = ({
   activeQuote,
   location,
   transactionActiveAbTests,
+  inputCurrencyMode,
 }: Params) => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const { submitBridgeTx } = useSubmitBridgeTx();
   const walletAddress = useSelector(selectSourceWalletAddress);
+  const contextInputCurrencyMode = useBridgeInputCurrencyMode();
+  const resolvedInputCurrencyMode =
+    inputCurrencyMode ?? contextInputCurrencyMode;
 
   const handleConfirm = async () => {
     try {
@@ -33,6 +42,7 @@ export const useBridgeConfirm = ({
           quoteResponse: activeQuote,
           location,
           transactionActiveAbTests,
+          inputCurrencyMode: resolvedInputCurrencyMode,
         });
       }
     } catch (error) {

--- a/app/components/UI/Bridge/hooks/useBridgeInputCurrencyMode/index.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeInputCurrencyMode/index.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext, type ReactNode } from 'react';
+import { InputCurrencyMode } from '@metamask/bridge-controller';
+
+const BridgeInputCurrencyModeContext = createContext<InputCurrencyMode>(
+  InputCurrencyMode.CRYPTO,
+);
+
+export const BridgeInputCurrencyModeProvider = ({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: InputCurrencyMode;
+}) => (
+  <BridgeInputCurrencyModeContext.Provider value={value}>
+    {children}
+  </BridgeInputCurrencyModeContext.Provider>
+);
+
+export const useBridgeInputCurrencyMode = () =>
+  useContext(BridgeInputCurrencyModeContext);

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from 'react';
 import Engine from '../../../../../core/Engine';
 import {
   getQuotesReceivedProperties,
+  InputCurrencyMode,
   QuoteWarning,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
@@ -26,6 +27,7 @@ export const useBridgeQuoteEvents = ({
   hasTxAlert,
   isSubmitDisabled,
   isPriceImpactWarningVisible,
+  inputCurrencyMode = InputCurrencyMode.CRYPTO,
 }: {
   hasInsufficientBalance: boolean;
   hasInsufficientNativeReserveError: boolean;
@@ -35,6 +37,7 @@ export const useBridgeQuoteEvents = ({
   hasTxAlert: boolean;
   isSubmitDisabled: boolean;
   isPriceImpactWarningVisible: boolean;
+  inputCurrencyMode?: InputCurrencyMode;
 }) => {
   const { quoteFetchError, quotesRefreshCount } = useSelector(
     selectBridgeControllerState,
@@ -77,13 +80,16 @@ export const useBridgeQuoteEvents = ({
     if (!isLoading && quotesRefreshCount > 0 && !quoteFetchError) {
       Engine.context.BridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.QuotesReceived,
-        getQuotesReceivedProperties(
-          activeQuote,
-          warnings,
-          !isSubmitDisabled,
-          recommendedQuote,
-          fromTokenBalanceInUsd,
-        ),
+        {
+          ...getQuotesReceivedProperties(
+            activeQuote,
+            warnings,
+            !isSubmitDisabled,
+            recommendedQuote,
+            fromTokenBalanceInUsd,
+          ),
+          input_currency_mode: inputCurrencyMode,
+        },
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -3,7 +3,10 @@ import { useBridgeQuoteEvents } from '.';
 import Engine from '../../../../../core/Engine';
 import { createBridgeTestState } from '../../testUtils';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import { RequestStatus } from '@metamask/bridge-controller';
+import {
+  InputCurrencyMode,
+  RequestStatus,
+} from '@metamask/bridge-controller';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -110,6 +113,7 @@ describe('useBridgeQuoteEvents', () => {
         can_submit: true,
         gas_included: false,
         gas_included_7702: false,
+        input_currency_mode: InputCurrencyMode.CRYPTO,
         price_impact: -0.001991570073761955,
         provider: 'lifi_jupiter',
         quoted_time_minutes: 0.08333333333333333,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -3,10 +3,7 @@ import { useBridgeQuoteEvents } from '.';
 import Engine from '../../../../../core/Engine';
 import { createBridgeTestState } from '../../testUtils';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
-import {
-  InputCurrencyMode,
-  RequestStatus,
-} from '@metamask/bridge-controller';
+import { InputCurrencyMode, RequestStatus } from '@metamask/bridge-controller';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import Engine from '../../../../../core/Engine';
 import {
   formatAddressToCaipReference,
   type GenericQuoteRequest,
+  type InputCurrencyMode,
 } from '@metamask/bridge-controller';
 import { useSelector } from 'react-redux';
 import {
@@ -25,11 +26,13 @@ import useIsInsufficientBalance from '../useInsufficientBalance';
 import { useLatestBalance } from '../useLatestBalance';
 import { BigNumber } from 'ethers';
 import { useInsufficientNativeReserveError } from '../useInsufficientNativeReserveError';
+import { useBridgeInputCurrencyMode } from '../useBridgeInputCurrencyMode';
 
 export const DEBOUNCE_WAIT = 300;
 
 interface UseBridgeQuoteRequestOptions {
   latestSourceAtomicBalance?: BigNumber;
+  inputCurrencyMode?: InputCurrencyMode;
 }
 
 /**
@@ -47,7 +50,13 @@ export const useBridgeQuoteRequest = (
   const walletAddress = useSelector(selectSourceWalletAddress);
   const destAddress = useSelector(selectDestAddress);
   const context = useUnifiedSwapBridgeContext();
-  const { latestSourceAtomicBalance } = options;
+  const contextInputCurrencyMode = useBridgeInputCurrencyMode();
+  const {
+    latestSourceAtomicBalance,
+    inputCurrencyMode = contextInputCurrencyMode,
+  } = options;
+  const inputCurrencyModeRef = useRef(inputCurrencyMode);
+  inputCurrencyModeRef.current = inputCurrencyMode;
   const hasLatestSourceBalanceOverride = 'latestSourceAtomicBalance' in options;
 
   const latestSourceBalance = useLatestBalance(
@@ -128,7 +137,10 @@ export const useBridgeQuoteRequest = (
 
     await Engine.context.BridgeController.updateBridgeQuoteRequestParams(
       params,
-      context,
+      {
+        ...context,
+        input_currency_mode: inputCurrencyModeRef.current,
+      },
       0,
       1,
     );

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -1,7 +1,10 @@
 import { BigNumber } from 'ethers';
 import { act } from '@testing-library/react-native';
 
-import { isSolanaChainId } from '@metamask/bridge-controller';
+import {
+  InputCurrencyMode,
+  isSolanaChainId,
+} from '@metamask/bridge-controller';
 
 import '../../_mocks_/initialState';
 import { DEBOUNCE_WAIT, useBridgeQuoteRequest } from './';
@@ -84,6 +87,11 @@ const spyUpdateBridgeQuoteRequestParams = jest.spyOn(
   Engine.context.BridgeController,
   'updateBridgeQuoteRequestParams',
 );
+
+const defaultQuoteRequestContext = () =>
+  expect.objectContaining({
+    input_currency_mode: InputCurrencyMode.CRYPTO,
+  });
 
 const mockSelectSourceWalletAddress =
   selectSourceWalletAddress as jest.MockedFunction<
@@ -252,7 +260,7 @@ describe('useBridgeQuoteRequest', () => {
       expect.objectContaining({
         srcTokenAmount: '1500000000000000000', // 1.5 ETH in wei
       }),
-      undefined,
+      defaultQuoteRequestContext(),
       0,
       1,
     );
@@ -278,7 +286,7 @@ describe('useBridgeQuoteRequest', () => {
       expect.objectContaining({
         srcTokenAmount: '0',
       }),
-      undefined,
+      defaultQuoteRequestContext(),
       0,
       1,
     );
@@ -315,7 +323,7 @@ describe('useBridgeQuoteRequest', () => {
       expect.objectContaining({
         srcTokenAmount: '1000500000', // 1000.5 with 6 decimals
       }),
-      undefined,
+      defaultQuoteRequestContext(),
       0,
       1,
     );
@@ -391,7 +399,7 @@ describe('useBridgeQuoteRequest', () => {
       expect.objectContaining({
         destWalletAddress: destSolanaAddress,
       }),
-      undefined,
+      defaultQuoteRequestContext(),
       0,
       1,
     );
@@ -421,7 +429,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           gasIncluded: true,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -447,7 +455,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           gasIncluded: false,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -486,7 +494,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           gasIncluded7702: true,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -508,7 +516,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           gasIncluded7702: false,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -554,7 +562,7 @@ describe('useBridgeQuoteRequest', () => {
           gasIncluded: false,
           gasIncluded7702: false,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -583,7 +591,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           insufficientBal: false,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -615,7 +623,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           insufficientBal: true,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );
@@ -647,7 +655,7 @@ describe('useBridgeQuoteRequest', () => {
         expect.objectContaining({
           insufficientBal: true,
         }),
-        undefined,
+        defaultQuoteRequestContext(),
         0,
         1,
       );

--- a/app/components/UI/Bridge/hooks/useSourceAmountInput/index.ts
+++ b/app/components/UI/Bridge/hooks/useSourceAmountInput/index.ts
@@ -13,6 +13,11 @@ import {
 import { formatCurrency, getCurrencySymbol } from '../../utils/currencyUtils';
 import { useSourceAmountCursor } from '../useSourceAmountCursor';
 import { useTokenFiatRate } from '../useTokenFiatRate';
+import Engine from '../../../../../core/Engine';
+import {
+  InputCurrencyMode,
+  UnifiedSwapBridgeEventName,
+} from '@metamask/bridge-controller';
 
 const FIAT_KEYPAD_CURRENCY = 'SWAPS_FIAT_INPUT';
 
@@ -34,6 +39,9 @@ export const useSourceAmountInput = ({
   const canToggle = Boolean(isFiatToggleEnabled && fiatRate && fiatRate > 0);
   const amount = isFiatMode ? fiatAmount : sourceAmount;
   const isFiatInputChangeRef = useRef(false);
+  const inputCurrencyMode = isFiatMode
+    ? InputCurrencyMode.FIAT
+    : InputCurrencyMode.CRYPTO;
 
   const handleAmountChange = useCallback(
     (value: string | undefined) => {
@@ -143,6 +151,19 @@ export const useSourceAmountInput = ({
       return;
     }
 
+    const nextInputCurrencyMode = isFiatMode
+      ? InputCurrencyMode.CRYPTO
+      : InputCurrencyMode.FIAT;
+
+    Engine.context.BridgeController.trackUnifiedSwapBridgeEvent(
+      UnifiedSwapBridgeEventName.InputChanged,
+      {
+        input: 'input_currency_mode',
+        input_value: nextInputCurrencyMode,
+        input_currency_mode: nextInputCurrencyMode,
+      },
+    );
+
     if (isFiatMode) {
       setSourceAmountCursorPositionToEnd(sourceAmount);
       setIsFiatMode(false);
@@ -215,6 +236,7 @@ export const useSourceAmountInput = ({
     handleKeypadChange,
     handleSelectionChange,
     handleToggle,
+    inputCurrencyMode,
     inputPrefix,
     isFiatMode,
     keypadCurrency: isFiatMode

--- a/app/components/UI/Bridge/hooks/useTrackSwapPageViewed/index.ts
+++ b/app/components/UI/Bridge/hooks/useTrackSwapPageViewed/index.ts
@@ -7,8 +7,11 @@ import {
   selectDestToken,
   selectSourceToken,
 } from '../../../../../core/redux/slices/bridge';
+import { InputCurrencyMode } from '@metamask/bridge-controller';
 
-export const useTrackSwapPageViewed = () => {
+export const useTrackSwapPageViewed = (
+  inputCurrencyMode = InputCurrencyMode.CRYPTO,
+) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
@@ -27,6 +30,7 @@ export const useTrackSwapPageViewed = () => {
         token_symbol_destination: destToken?.symbol,
         token_address_source: sourceToken.address,
         token_address_destination: destToken?.address,
+        input_currency_mode: inputCurrencyMode,
       };
       trackEvent(
         createEventBuilder(MetaMetricsEvents.SWAP_PAGE_VIEWED)
@@ -34,5 +38,11 @@ export const useTrackSwapPageViewed = () => {
           .build(),
       );
     }
-  }, [sourceToken, destToken, trackEvent, createEventBuilder]);
+  }, [
+    sourceToken,
+    destToken,
+    inputCurrencyMode,
+    trackEvent,
+    createEventBuilder,
+  ]);
 };

--- a/app/util/bridge/hooks/useSubmitBridgeTx.test.tsx
+++ b/app/util/bridge/hooks/useSubmitBridgeTx.test.tsx
@@ -8,7 +8,11 @@ import {
   DummyQuotesNoApproval,
   DummyQuotesWithApproval,
 } from '../../../../tests/api-mocking/mock-responses/bridge-api-quotes';
-import { QuoteMetadata, QuoteResponse } from '@metamask/bridge-controller';
+import {
+  InputCurrencyMode,
+  QuoteMetadata,
+  QuoteResponse,
+} from '@metamask/bridge-controller';
 import { backgroundState } from '../../test/initial-root-state';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { selectSourceWalletAddress } from '../../../selectors/bridge';
@@ -29,6 +33,11 @@ let mockSubmitIntent: jest.Mock<
   Promise<TransactionMeta>,
   [{ quoteResponse: BridgeQuoteResponse; accountAddress: string }]
 >;
+
+const defaultQuotesReceivedContext = () =>
+  expect.objectContaining({
+    input_currency_mode: InputCurrencyMode.CRYPTO,
+  });
 
 jest.mock('../../../core/Engine', () => {
   mockSubmitTx = jest.fn<
@@ -216,7 +225,7 @@ describe('useSubmitBridgeTx', () => {
         approval: undefined,
       },
       true,
-      undefined,
+      defaultQuotesReceivedContext(),
       undefined,
       undefined,
       undefined,
@@ -267,7 +276,7 @@ describe('useSubmitBridgeTx', () => {
         approval: undefined,
       },
       true,
-      undefined,
+      defaultQuotesReceivedContext(),
       undefined,
       undefined,
       [
@@ -313,7 +322,7 @@ describe('useSubmitBridgeTx', () => {
         approval: mockQuoteResponse.approval ?? undefined,
       },
       true,
-      undefined,
+      defaultQuotesReceivedContext(),
       undefined,
       undefined,
       undefined,
@@ -520,6 +529,7 @@ describe('useSubmitBridgeTx', () => {
       abTests: undefined,
       activeAbTests: undefined,
       tokenSecurityTypeDestination: null,
+      inputCurrencyMode: InputCurrencyMode.CRYPTO,
     });
 
     // Re-render with an active assignment to verify submitIntent forwards activeAbTests.
@@ -553,6 +563,7 @@ describe('useSubmitBridgeTx', () => {
         }),
       ],
       tokenSecurityTypeDestination: null,
+      inputCurrencyMode: InputCurrencyMode.CRYPTO,
     });
     expect(mockSubmitTx).not.toHaveBeenCalled();
     expect(txResult).toEqual(mockIntentResult);
@@ -597,7 +608,7 @@ describe('useSubmitBridgeTx', () => {
         approval: undefined,
       },
       true,
-      undefined,
+      defaultQuotesReceivedContext(),
       undefined,
       undefined,
       [
@@ -650,7 +661,7 @@ describe('useSubmitBridgeTx', () => {
       '0x1234567890123456789012345678901234567890',
       expect.any(Object),
       expect.any(Boolean),
-      undefined,
+      defaultQuotesReceivedContext(),
       undefined,
       undefined,
       undefined,

--- a/app/util/bridge/hooks/useSubmitBridgeTx.ts
+++ b/app/util/bridge/hooks/useSubmitBridgeTx.ts
@@ -1,7 +1,11 @@
-import type {
-  MetaMetricsSwapsEventSource,
-  QuoteMetadata,
-  QuoteResponse,
+import {
+  getQuotesReceivedProperties,
+  InputCurrencyMode,
+  UnifiedSwapBridgeEventName,
+  type MetaMetricsSwapsEventSource,
+  type QuoteMetadata,
+  type QuoteResponse,
+  type RequiredEventContextFromClient,
 } from '@metamask/bridge-controller';
 import Engine from '../../../core/Engine';
 import { useSelector } from 'react-redux';
@@ -36,6 +40,9 @@ import {
   createActiveABTestAssignment,
   normalizeActiveABTestAssignments,
 } from '../../analytics/activeABTestAssignments';
+
+type QuotesReceivedContext =
+  RequiredEventContextFromClient[UnifiedSwapBridgeEventName.QuotesReceived];
 
 function mergeTransactionActiveAbTests(
   ...groups: (TransactionActiveAbTestEntry[] | undefined)[]
@@ -137,12 +144,14 @@ export default function useSubmitBridgeTx() {
     quoteResponse,
     location,
     transactionActiveAbTests: transactionActiveAbTestsFromRoute,
+    inputCurrencyMode = InputCurrencyMode.CRYPTO,
   }: {
     quoteResponse: QuoteResponse & QuoteMetadata;
     /** The entry point from which the user initiated the swap or bridge */
     location?: MetaMetricsSwapsEventSource;
     /** Route-carried tests (e.g. homepage trending sections) merged at submit time */
     transactionActiveAbTests?: TransactionActiveAbTestEntry[];
+    inputCurrencyMode?: InputCurrencyMode;
   }) => {
     if (!walletAddress) {
       throw new Error('Wallet address is not set');
@@ -165,8 +174,14 @@ export default function useSubmitBridgeTx() {
             abTests,
             activeAbTests: mergedActiveAbTests,
             tokenSecurityTypeDestination,
+            inputCurrencyMode,
           });
         }
+        const quotesReceivedContext: QuotesReceivedContext = {
+          ...getQuotesReceivedProperties(quoteResponse),
+          input_currency_mode: inputCurrencyMode,
+        };
+
         return await Engine.context.BridgeStatusController.submitTx(
           walletAddress,
           {
@@ -174,7 +189,7 @@ export default function useSubmitBridgeTx() {
             approval: quoteResponse.approval ?? undefined,
           },
           stxEnabled,
-          undefined, // quotesReceivedContext
+          quotesReceivedContext,
           location,
           abTests,
           mergedActiveAbTests,


### PR DESCRIPTION
## **Description**

Adds `input_currency_mode` to Unified SwapBridge analytics so the fiat/crypto entry mode can segment the full swap bridge funnel.

This mobile wiring:

- Derives the mode from the existing fiat/crypto source amount input state.
- Emits the existing `Unified SwapBridge Input Changed` event when the user taps the fiat/crypto toggle.
- Stamps `input_currency_mode` onto mobile-controlled page viewed, quote request, quote received, input changed, submit, and completion analytics contexts.
- Uses lightweight bridge input mode context for confirm and modal flows instead of adding Redux state or new controller submit parameters.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Unified SwapBridge input currency mode metrics

  Scenario: user changes fiat/crypto input mode and completes the swap bridge flow
    Given the Unified SwapBridge screen is open
    And a source token and destination token are selected
    When user taps the fiat/crypto input toggle
    And user requests quotes
    And user submits the selected quote
    Then Unified SwapBridge analytics include input_currency_mode matching the selected input mode
```

Additional validation:

- Verified the bridge flow in the simulator.
- Ran focused Jest checks for the touched bridge hooks/components with `--collectCoverage=false`.
- Ran `yarn lint:tsc`; remaining failures were unrelated Rewards test typing errors from the controller preview state.

## **Screenshots/Recordings**

N/A, analytics-only change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and context wiring only; swap/bridge execution logic is unchanged aside from passing mode into existing tracking and submit context parameters.
> 
> **Overview**
> This PR wires **`input_currency_mode`** (fiat vs crypto) through the Unified Swap/Bridge mobile funnel for analytics, derived from the existing fiat/crypto source amount input state—no new Redux or controller submit API surface beyond passing context through existing calls.
> 
> A new **`BridgeInputCurrencyModeProvider`** wraps the footer, keypad, and confirm flow so modals and **`useBridgeConfirm`** can read the current mode (route params override context when opened from **`SwapsConfirmButton`**). Toggling fiat/crypto now emits **`Unified SwapBridge Input Changed`** with `input: 'input_currency_mode'`.
> 
> **`input_currency_mode`** is attached to page viewed, quote request context, **Quotes Received**, quick-pick **Input Changed**, and submit paths (**`submitTx`** / **`submitIntent`** via **`quotesReceivedContext`**). Tests are updated to assert the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1aff82945af07cd9ce3434d3ea83342e4620e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->