### PR TITLE
feat(onboarding): TMCU-792 interest questionnaire 2-column grid

### DIFF
--- a/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.test.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.test.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, screen } from '@testing-library/react-native';
 import { InterestSelectionIndicator } from './InterestSelectionIndicator';
+import { InterestSelectionIndicatorTestIds } from './InterestSelectionIndicator.testIds';
 
 describe('InterestSelectionIndicator', () => {
   it('renders when selected', () => {
-    const { toJSON } = render(<InterestSelectionIndicator isSelected />);
+    render(<InterestSelectionIndicator isSelected />);
 
-    expect(toJSON()).toBeTruthy();
+    expect(
+      screen.getByTestId(InterestSelectionIndicatorTestIds.CONTAINER),
+    ).toBeOnTheScreen();
   });
 
   it('renders when not selected', () => {
-    const { toJSON } = render(
-      <InterestSelectionIndicator isSelected={false} />,
-    );
+    render(<InterestSelectionIndicator isSelected={false} />);
 
-    expect(toJSON()).toBeTruthy();
+    expect(
+      screen.getByTestId(InterestSelectionIndicatorTestIds.CONTAINER),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.test.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { InterestSelectionIndicator } from './InterestSelectionIndicator';
+
+describe('InterestSelectionIndicator', () => {
+  it('renders when selected', () => {
+    const { toJSON } = render(<InterestSelectionIndicator isSelected />);
+
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders when not selected', () => {
+    const { toJSON } = render(
+      <InterestSelectionIndicator isSelected={false} />,
+    );
+
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.testIds.ts
+++ b/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.testIds.ts
@@ -1,0 +1,3 @@
+export enum InterestSelectionIndicatorTestIds {
+  CONTAINER = 'onboarding-interest-selection-indicator',
+}

--- a/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { InterestSelectionIndicatorTestIds } from './InterestSelectionIndicator.testIds';
 
 interface InterestSelectionIndicatorProps {
   isSelected: boolean;
@@ -13,6 +14,7 @@ export const InterestSelectionIndicator = ({
 
   return (
     <View
+      testID={InterestSelectionIndicatorTestIds.CONTAINER}
       style={tw.style(
         'h-4 w-4 rounded-full',
         isSelected ? 'bg-icon-default' : 'border border-muted bg-transparent',

--- a/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/InterestSelectionIndicator.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+interface InterestSelectionIndicatorProps {
+  isSelected: boolean;
+}
+
+export const InterestSelectionIndicator = ({
+  isSelected,
+}: InterestSelectionIndicatorProps) => {
+  const tw = useTailwind();
+
+  return (
+    <View
+      style={tw.style(
+        'h-4 w-4 rounded-full',
+        isSelected ? 'bg-icon-default' : 'border border-muted bg-transparent',
+      )}
+    />
+  );
+};

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.test.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.test.tsx
@@ -97,7 +97,24 @@ describe('OnboardingInterestQuestionnaire', () => {
       ).toBeOnTheScreen();
     });
 
-    it('renders all six option rows', () => {
+    it('renders updated option labels from i18n', () => {
+      renderComponent();
+
+      expect(
+        screen.getByText(
+          strings(
+            'onboarding_interest_questionnaire.option_buy_and_sell_crypto',
+          ),
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText(
+          strings('onboarding_interest_questionnaire.option_advanced_trades'),
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders all six option cards in the grid', () => {
       renderComponent();
 
       const optionIds = [
@@ -340,6 +357,20 @@ describe('OnboardingInterestQuestionnaire', () => {
       await waitFor(() => {
         expect(mockOnComplete).toHaveBeenCalledTimes(1);
       });
+    });
+
+    it('does not navigate to another screen on Continue', async () => {
+      renderComponent();
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(
+            OnboardingInterestQuestionnaireTestIds.CONTINUE_BUTTON,
+          ),
+        );
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.tsx
@@ -21,8 +21,9 @@ import {
   TextColor,
   FontWeight,
   BoxFlexDirection,
-  BoxAlignItems,
+  BoxFlexWrap,
 } from '@metamask/design-system-react-native';
+import { InterestSelectionIndicator } from './InterestSelectionIndicator';
 import { strings } from '../../../../locales/i18n';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -85,6 +86,9 @@ const INTEREST_OPTION_IMAGES: Record<InterestOptionId, ImageSourcePropType> = {
   crypto_as_money: cryptoAsMoneyImage,
   connect_apps_sites: connectAppsSitesImage,
 };
+
+/** 8px gutters between 2-column grid cells (4px padding per column side). */
+const GRID_GUTTER_PX = 4;
 
 const OnboardingInterestQuestionnaire = () => {
   const tw = useTailwind();
@@ -195,49 +199,60 @@ const OnboardingInterestQuestionnaire = () => {
         contentContainerStyle={tw.style('px-4 pb-4')}
         showsVerticalScrollIndicator={false}
       >
-        {INTEREST_OPTIONS.map((option) => {
-          const isSelected = selectedIds.has(option.id);
-          return (
-            <Pressable
-              key={option.id}
-              onPress={() => toggleOption(option.id)}
-              style={({ pressed }) =>
-                tw.style(
-                  'rounded-xl px-3 py-3 mt-2 bg-background-muted',
-                  isSelected
-                    ? 'border border-border-default'
-                    : 'border border-transparent',
-                  pressed && 'opacity-70',
-                )
-              }
-              testID={`${OnboardingInterestQuestionnaireTestIds.OPTION_PREFIX}${option.id}`}
-              accessibilityRole="checkbox"
-              accessibilityState={{ checked: isSelected }}
-            >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          flexWrap={BoxFlexWrap.Wrap}
+          style={tw.style('py-2', { marginHorizontal: -GRID_GUTTER_PX })}
+        >
+          {INTEREST_OPTIONS.map((option) => {
+            const isSelected = selectedIds.has(option.id);
+            return (
               <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                gap={3}
+                key={option.id}
+                style={tw.style({
+                  width: '50%',
+                  paddingHorizontal: GRID_GUTTER_PX,
+                  marginBottom: GRID_GUTTER_PX * 2,
+                })}
               >
-                <Image
-                  source={INTEREST_OPTION_IMAGES[option.id]}
-                  style={tw.style('h-10 w-10')}
-                  resizeMode="contain"
-                  accessibilityElementsHidden
-                  importantForAccessibility="no-hide-descendants"
-                />
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={TextColor.TextDefault}
-                  twClassName="shrink flex-1"
+                <Pressable
+                  onPress={() => toggleOption(option.id)}
+                  style={({ pressed }) =>
+                    tw.style(
+                      'relative h-[120px] w-full rounded-xl bg-background-muted',
+                      isSelected
+                        ? 'border border-border-default bg-background-muted-hover'
+                        : 'border border-muted',
+                      pressed && 'opacity-70',
+                    )
+                  }
+                  testID={`${OnboardingInterestQuestionnaireTestIds.OPTION_PREFIX}${option.id}`}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ checked: isSelected }}
                 >
-                  {strings(option.labelKey)}
-                </Text>
+                  <Box style={tw.style('absolute top-3 right-3')}>
+                    <InterestSelectionIndicator isSelected={isSelected} />
+                  </Box>
+                  <Image
+                    source={INTEREST_OPTION_IMAGES[option.id]}
+                    style={tw.style('absolute top-3 left-3 h-10 w-10')}
+                    resizeMode="contain"
+                    accessibilityElementsHidden
+                    importantForAccessibility="no-hide-descendants"
+                  />
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                    color={TextColor.TextDefault}
+                    style={tw.style('absolute bottom-3 left-3 right-3')}
+                  >
+                    {strings(option.labelKey)}
+                  </Text>
+                </Pressable>
               </Box>
-            </Pressable>
-          );
-        })}
+            );
+          })}
+        </Box>
       </ScrollView>
 
       <Box twClassName="px-4 py-2">

--- a/app/components/Views/OnboardingInterestQuestionnaire/useOnboardingInterestQuestionnaireEligibility.ts
+++ b/app/components/Views/OnboardingInterestQuestionnaire/useOnboardingInterestQuestionnaireEligibility.ts
@@ -2,8 +2,7 @@ import { useCallback } from 'react';
 import { generateDeterministicRandomNumber } from '@metamask/remote-feature-flag-controller';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 
-// TODO: remove __DEV__ override before experiment ships at 25% rollout
-const TREATMENT_ROLLOUT_THRESHOLD = __DEV__ ? 1 : 0.25;
+const TREATMENT_ROLLOUT_THRESHOLD = 0.25;
 
 /**
  * Returns a function that resolves whether the onboarding interest questionnaire

--- a/app/components/Views/OnboardingInterestQuestionnaire/useOnboardingInterestQuestionnaireEligibility.ts
+++ b/app/components/Views/OnboardingInterestQuestionnaire/useOnboardingInterestQuestionnaireEligibility.ts
@@ -2,7 +2,8 @@ import { useCallback } from 'react';
 import { generateDeterministicRandomNumber } from '@metamask/remote-feature-flag-controller';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 
-const TREATMENT_ROLLOUT_THRESHOLD = 0.25;
+// TODO: remove __DEV__ override before experiment ships at 25% rollout
+const TREATMENT_ROLLOUT_THRESHOLD = __DEV__ ? 1 : 0.25;
 
 /**
  * Returns a function that resolves whether the onboarding interest questionnaire

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3027,9 +3027,9 @@
   "onboarding_interest_questionnaire": {
     "title": "What do you want to do with MetaMask?",
     "description": "Select all that apply.",
-    "option_buy_and_sell_crypto": "Buy and sell crypto",
+    "option_buy_and_sell_crypto": "Buy and sell crypto tokens",
     "option_consolidate_wallets": "Consolidate your wallets",
-    "option_advanced_trades": "Make advanced trades",
+    "option_advanced_trades": "Trade perpetuals",
     "option_predict_sports_events": "Predict sports and events",
     "option_crypto_as_money": "Use crypto as money",
     "option_connect_apps_sites": "Connect to apps or sites",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Updates the onboarding interest questionnaire (“What do you want to do with MetaMask?”) to match the TMCU-792 design refresh:

- Options are shown in a **two-column grid** with consistent 8px gutters (50% column wrappers + padding).
- Each card uses a **top-right selection indicator** and keeps the **existing option illustrations** in `app/images/`.
- Copy updates in `en.json`: “Buy and sell crypto tokens” and “Trade perpetuals” (`advanced_trades` id unchanged for analytics).
- **Continue** still calls `onComplete()` directly (crypto experience screen is **TMCU-833**, separate PR).

## **Changelog**

CHANGELOG entry: Updated the onboarding interest questionnaire layout to a two-column grid with refreshed option labels.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-792

## **Manual testing steps**

```gherkin
Feature: Onboarding interest questionnaire grid (TMCU-792)

  Scenario: user completes interest questionnaire after opting in to metrics
    Given the user is on the OptinMetrics screen during onboarding
    And the interest questionnaire eligibility check returns true

    When the user opts in to basic usage data and taps Continue
    Then the interest questionnaire is shown with six options in a two-column grid
    And the user can select multiple options
    And tapping Continue submits analytics and proceeds with onboarding (onComplete)

  Scenario: user can skip selecting interests
    Given the user is on the interest questionnaire screen

    When the user taps Continue without selecting any option
    Then onboarding continues with skipped interest analytics
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


| Light Mode | Dark Mode |
|------------|-----------|
| <img width="300" alt="questionnaire_light" src="https://github.com/user-attachments/assets/dafd9077-f68d-4ca8-9bed-5362947608ad" /> | <img width="300" alt="questionnaire_dark" src="https://github.com/user-attachments/assets/16629619-d53d-4fec-a277-b128429a044b" /> |

### **After**


| Light Mode | Dark Mode |
|------------|-----------|
| <img width="300" alt="questionnaire_light" src="https://github.com/user-attachments/assets/34981465-f9d9-4651-bf89-0adbdc5880c0" /> | <img width="300" alt="questionnaire_dark" src="https://github.com/user-attachments/assets/e43e09bb-3813-49a3-9582-cc7ea2b68d68" /> |


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and copy only; selection analytics and Continue flow are unchanged aside from layout.
> 
> **Overview**
> Refreshes the onboarding **interest questionnaire** to a **two-column card grid** (8px gutters) instead of full-width list rows. Each option is a fixed-height card with the illustration and label repositioned and a new **top-right selection indicator** (`InterestSelectionIndicator`).
> 
> English copy updates two labels: *Buy and sell crypto tokens* and *Trade perpetuals* (option ids unchanged for analytics). **Continue** still only invokes `onComplete()`—tests now assert it does not call navigation.
> 
> Adds unit tests for the indicator and extends questionnaire tests for the grid layout, i18n strings, and continue behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf523e9807914342cd612e1b7365a57aa2ed6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->