### PR TITLE
refactor(Predict): remove temporary BTC up/down row flag and update imports cp-7.80.0 

### DIFF
--- a/app/components/UI/Predict/constants/btcUpDown5mSeries.ts
+++ b/app/components/UI/Predict/constants/btcUpDown5mSeries.ts
@@ -1,12 +1,5 @@
 import type { PredictSeries } from '../types';
 
-/**
- * Temporary kill switch while the shared BTC up/down data hook lives on
- * `predict/crypto-updown-feed-card`. Remove this flag when that branch is
- * merged and the BTC row is ready to render from the shared hook.
- */
-export const SHOW_BTC_UP_DOWN_5M_ROW = false;
-
 /** Polymarket Gamma `series_id` for the BTC 5-minute up/down series. */
 export const BTC_UP_DOWN_5M_SERIES_ID = '10684';
 

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -153,6 +153,21 @@ jest.mock('../../../../UI/Predict/hooks/useLiveCryptoPrices', () => ({
   })),
 }));
 
+jest.mock(
+  '../../../../UI/Predict/hooks/useCurrentCryptoUpDownMarketData',
+  () => ({
+    useCurrentCryptoUpDownMarketData: jest.fn(() => ({
+      marketId: undefined,
+      market: undefined,
+      currentPrice: undefined,
+      priceToBeat: undefined,
+      countdown: '--:--',
+      isLoading: false,
+      isFetching: false,
+    })),
+  }),
+);
+
 jest.mock('../../../../UI/Predict/hooks/usePredictClaim', () => ({
   usePredictClaim: () => ({ claim: mockClaim }),
 }));

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -9,13 +9,16 @@ import SectionHeader from '../../../../../../../component-library/components-tem
 import { WalletViewSelectorsIDs } from '../../../../../Wallet/WalletView.testIds';
 import { PredictEntryPointProvider } from '../../../../../../UI/Predict/contexts';
 import { PredictEventValues } from '../../../../../../UI/Predict/constants/eventNames';
-import { SHOW_BTC_UP_DOWN_5M_ROW } from '../../../../../../UI/Predict/constants/btcUpDown5mSeries';
+import { BTC_UP_OR_DOWN_5M_SERIES } from '../../../../../../UI/Predict/constants/btcUpDown5mSeries';
 import {
   PREDICT_EMPTY_STATE_CTA_NAMES,
   type PredictEmptyStateCtaName,
 } from '../../../../abTestConfig';
 import { PREDICT_WORLD_CUP_TAB_KEYS } from '../../../../../../UI/Predict/constants/worldCupTabs';
+import { useCurrentCryptoUpDownMarketData } from '../../../../../../UI/Predict/hooks/useCurrentCryptoUpDownMarketData';
+import { usePredictNavigation } from '../../../../../../UI/Predict/hooks/usePredictNavigation';
 import {
+  selectPredictEnabledFlag,
   selectPredictHomepageDiscoveryNbaChampionEnabledFlag,
   selectPredictWorldCupScreenEnabledFlag,
 } from '../../../../../../UI/Predict/selectors/featureFlags';
@@ -60,12 +63,24 @@ const HomepagePredictWorldCupDiscovery: React.FC<
   onTreatmentCtaClick,
 }) => {
   const navigation = useNavigation();
+  const { navigateToMarketDetails } = usePredictNavigation();
   const worldCupScreenEnabled = useSelector(
     selectPredictWorldCupScreenEnabledFlag,
   );
+  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const showNbaChampionDiscoveryRow = useSelector(
     selectPredictHomepageDiscoveryNbaChampionEnabledFlag,
   );
+  const {
+    marketId: btcMarketId,
+    market: btcWindowMarket,
+    currentPrice: btcSpotUsd,
+    priceToBeat,
+    countdown: btcCountdown,
+  } = useCurrentCryptoUpDownMarketData({
+    series: BTC_UP_OR_DOWN_5M_SERIES,
+    enabled: isPredictEnabled,
+  });
   const championshipRowKind = showNbaChampionDiscoveryRow
     ? 'nba'
     : 'world_cup_winner';
@@ -73,35 +88,6 @@ const HomepagePredictWorldCupDiscovery: React.FC<
     championshipRowKind === 'world_cup_winner'
       ? WORLD_CUP_CTA_CATEGORY_NAME
       : 'nba';
-
-  /*
-   * TODO: When `predict/crypto-updown-feed-card` is merged, remove
-   * SHOW_BTC_UP_DOWN_5M_ROW and uncomment the shared hook wiring below.
-   *
-   * import { BTC_UP_OR_DOWN_5M_SERIES } from '../../../../../../UI/Predict/constants/btcUpDown5mSeries';
-   * import { useCurrentCryptoUpDownMarketData } from '../../../../../../UI/Predict/hooks/useCurrentCryptoUpDownMarketData';
-   * import { usePredictNavigation } from '../../../../../../UI/Predict/hooks/usePredictNavigation';
-   * import {
-   *   selectPredictEnabledFlag,
-   *   selectPredictWorldCupScreenEnabledFlag,
-   * } from '../../../../../../UI/Predict/selectors/featureFlags';
-   *
-   * const { navigateToMarketDetails } = usePredictNavigation();
-   * const isPredictEnabled = useSelector(selectPredictEnabledFlag);
-   * const {
-   *   marketId: btcMarketId,
-   *   market: btcWindowMarket,
-   *   currentPrice: btcSpotUsd,
-   *   priceToBeat,
-   *   countdown: btcCountdown,
-   * } = useCurrentCryptoUpDownMarketData({
-   *   series: BTC_UP_OR_DOWN_5M_SERIES,
-   *   enabled: isPredictEnabled,
-   * });
-   */
-  const btcSpotUsd = undefined;
-  const priceToBeat = undefined;
-  const btcCountdown = '--:--';
 
   const { marketData, isFetching, hasMore } = worldCup;
   const { marketData: nbaMarketData, isFetching: isNbaFetching } = nbaChampion;
@@ -159,24 +145,18 @@ const HomepagePredictWorldCupDiscovery: React.FC<
       PREDICT_EMPTY_STATE_CTA_NAMES.BROWSE_CATEGORY,
       'crypto',
     );
-    /*
-     * TODO: When `predict/crypto-updown-feed-card` is merged, uncomment this
-     * branch with the shared hook data above so the BTC row opens the live
-     * market directly.
-     *
-     * if (btcMarketId) {
-     *   navigateToMarketDetails(
-     *     {
-     *       marketId: btcMarketId,
-     *       entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
-     *       title: btcWindowMarket?.title ?? BTC_UP_OR_DOWN_5M_SERIES.title,
-     *       image: btcWindowMarket?.image,
-     *     },
-     *     { throughRoot: true },
-     *   );
-     *   return;
-     * }
-     */
+    if (btcMarketId) {
+      navigateToMarketDetails(
+        {
+          marketId: btcMarketId,
+          entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+          title: btcWindowMarket?.title ?? BTC_UP_OR_DOWN_5M_SERIES.title,
+          image: btcWindowMarket?.image,
+        },
+        { throughRoot: true },
+      );
+      return;
+    }
     navigation.navigate(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
       params: {
@@ -185,7 +165,15 @@ const HomepagePredictWorldCupDiscovery: React.FC<
         ...(transactionActiveAbTests?.length && { transactionActiveAbTests }),
       },
     });
-  }, [navigation, onTreatmentCtaClick, transactionActiveAbTests]);
+  }, [
+    btcMarketId,
+    btcWindowMarket?.image,
+    btcWindowMarket?.title,
+    navigateToMarketDetails,
+    navigation,
+    onTreatmentCtaClick,
+    transactionActiveAbTests,
+  ]);
 
   const goToWorldCup = useCallback(
     (initialTab: string) => {
@@ -254,14 +242,12 @@ const HomepagePredictWorldCupDiscovery: React.FC<
         entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
       >
         <Box twClassName="px-4 mt-3">
-          {SHOW_BTC_UP_DOWN_5M_ROW ? (
-            <BtcLiveRow
-              onPress={handleBtcRow}
-              btcSpotUsd={btcSpotUsd}
-              priceToBeat={priceToBeat}
-              countdown={btcCountdown}
-            />
-          ) : null}
+          <BtcLiveRow
+            onPress={handleBtcRow}
+            btcSpotUsd={btcSpotUsd}
+            priceToBeat={priceToBeat}
+            countdown={btcCountdown}
+          />
           <ChampionshipRow
             state={championshipRow}
             onPress={handleChampionshipRowPress}

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -152,6 +152,9 @@ const HomepagePredictWorldCupDiscovery: React.FC<
           entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
           title: btcWindowMarket?.title ?? BTC_UP_OR_DOWN_5M_SERIES.title,
           image: btcWindowMarket?.image,
+          ...(transactionActiveAbTests?.length && {
+            transactionActiveAbTests,
+          }),
         },
         { throughRoot: true },
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Enables the live BTC 5-minute up/down row in the Predict homepage discovery section (HomepagePredictWorldCupDiscovery).

The row was previously gated behind a temporary SHOW_BTC_UP_DOWN_5M_ROW kill switch while waiting on the shared useCurrentCryptoUpDownMarketData hook. That hook is now wired up, so the row shows live BTC spot price, price-to-beat, and a countdown. Tapping the row opens the active BTC market details when available; otherwise it falls back to the crypto category market list.

**Why:** Surface live crypto up/down markets on the homepage discovery treatment and remove dead placeholder/TODO wiring.

**Changes:**

- Remove SHOW_BTC_UP_DOWN_5M_ROW from btcUpDown5mSeries.ts
- Wire useCurrentCryptoUpDownMarketData + usePredictNavigation in HomepagePredictWorldCupDiscovery
- Always render BtcLiveRow (no longer conditional on kill switch)
- Navigate to live market on row tap when btcMarketId is available


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a live BTC up/down row to the Predict homepage discovery section with real-time price, price-to-beat, and countdown.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict homepage discovery BTC live row

  Scenario: BTC row displays live data when Predict is enabled
    Given Predict is enabled
    And the user is in the homepage discovery treatment (world cup discovery layout)
    When the user views the Predict section on the homepage
    Then the BTC live row is visible
    And it shows BTC spot price, price-to-beat, and a live countdown

  Scenario: Tapping BTC row opens the active market
    Given Predict is enabled
    And a live BTC 5-minute up/down market is available
    When the user taps the BTC live row
    Then the app navigates to that market's details screen
    And the entry point is HOME_SECTION

  Scenario: Tapping BTC row falls back when no live market
    Given Predict is enabled
    And no live BTC market is available
    When the user taps the BTC live row
    Then the app navigates to the Predict crypto category market list
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="403" height="234" alt="Screenshot 2026-05-28 at 13 26 58" src="https://github.com/user-attachments/assets/d71ebb53-84bb-4c6c-943f-a3adbcab1b0e" />

<!-- [screenshots/recordings] -->

### **After**
<img width="410" height="867" alt="Screenshot 2026-05-28 at 17 41 35" src="https://github.com/user-attachments/assets/9c35e1a5-8ed6-4a24-8c47-8c09e2ebc419" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible homepage Predict navigation and live market data depend on external feeds; misconfiguration could send users to the wrong market or show stale prices, but scope is limited to discovery UI.
> 
> **Overview**
> Removes the temporary **`SHOW_BTC_UP_DOWN_5M_ROW`** kill switch and turns on the **BTC 5-minute up/down** discovery row on the Predict homepage.
> 
> **`HomepagePredictWorldCupDiscovery`** now loads live window data via **`useCurrentCryptoUpDownMarketData`** (series **`BTC_UP_OR_DOWN_5M_SERIES`**, gated by **`selectPredictEnabledFlag`**) and always renders **`BtcLiveRow`** with spot price, price-to-beat, and countdown. Tapping the row opens the active market through **`navigateToMarketDetails`** when **`btcMarketId`** exists (including **`transactionActiveAbTests`** when present); otherwise it still navigates to the crypto market list. Placeholder constants and commented TODO wiring are deleted.
> 
> **`PredictionsSection.test.tsx`** mocks **`useCurrentCryptoUpDownMarketData`** so tests stay stable without live market data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e187e45e0132c9e9aac198fcaf38ffef2f66115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->