### PR TITLE
test: fixes dismissDevScreens for local playwright runs

### DIFF
--- a/tests/docs/PLAYWRIGHT_LOCAL_EMULATOR.md
+++ b/tests/docs/PLAYWRIGHT_LOCAL_EMULATOR.md
@@ -35,6 +35,27 @@ We keep Appium’s reset flags **mild** in [`EmulatorConfigBuilder`](../framewor
 
 For Android, the adb serial is resolved from `use.device.name` (AVD name) or `use.device.udid` — see [`resolveAndroidAdbUdid`](../framework/services/providers/emulator/android/resolveAndroidAdbUdid.ts) and the `EmulatorConfig` JSDoc in [`types.ts`](../framework/types.ts).
 
+## iOS device targeting
+
+For iOS, using the DeviceName as `iPhone 16 Pro` can become problematic if different XCode versions are installed locally so the device UDID can be used along with the device name.
+
+Example:
+
+```
+use: {
+    platform: Platform.IOS,
+    device: {
+        provider: ProviderName.SIMULATOR,
+        osVersion: '26.2',
+        name: 'iPhone 16 Pro',
+        udid: '<DEVICE_UDID>'
+    }
+}
+```
+
+Get available Simulators:
+`$ xcrun simctl list devices available`
+
 ## Related code
 
 - [`reinstallLocalBuildFromPath`](../framework/services/providers/emulator/reinstallLocalBuildFromPath.ts) — `adb` / `simctl` install helpers.

--- a/tests/flows/general.flow.test.ts
+++ b/tests/flows/general.flow.test.ts
@@ -1,0 +1,124 @@
+jest.mock('../framework/logger', () => ({
+  createLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+jest.mock('../framework', () => ({
+  Gestures: {
+    tap: jest.fn(),
+  },
+  PlaywrightAssertions: {
+    expectElementToBeVisible: jest.fn(),
+    expectElementToNotBeVisible: jest.fn(),
+  },
+  PlaywrightGestures: {
+    waitAndTap: jest.fn(),
+  },
+  PlaywrightMatchers: {
+    getElementById: jest.fn(),
+    getElementByText: jest.fn(),
+  },
+}));
+
+jest.mock('../framework/Assertions', () => ({
+  expectElementToBeVisible: jest.fn(),
+}));
+
+jest.mock('../framework/Matchers', () => ({
+  getElementByID: jest.fn(),
+  getElementByText: jest.fn(),
+}));
+
+jest.mock('../framework/Utilities', () => ({
+  __esModule: true,
+  default: {
+    executeWithRetry: jest.fn(),
+  },
+  sleep: jest.fn(),
+}));
+
+jest.mock('../framework/PlatformLocator', () => ({
+  PlatformDetector: {
+    isAndroid: jest.fn(() => false),
+  },
+}));
+
+jest.mock('../page-objects/wallet/LoginView', () => ({
+  container: {},
+}));
+
+import {
+  dismissDeveloperMenuPlaywright,
+  dismissDevelopmentServerPickerPlaywright,
+} from './general.flow';
+import {
+  PlaywrightAssertions,
+  PlaywrightGestures,
+  PlaywrightMatchers,
+} from '../framework';
+
+describe('general.flow Playwright dev screens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dismisses only the development server picker before app bootstrap', async () => {
+    const serverRow = { selector: 'metro-server-row' };
+    (PlaywrightMatchers.getElementByText as jest.Mock).mockResolvedValue(
+      serverRow,
+    );
+
+    await dismissDevelopmentServerPickerPlaywright();
+
+    expect(PlaywrightMatchers.getElementByText).toHaveBeenCalledWith(
+      'http://localhost:8081',
+    );
+    expect(PlaywrightAssertions.expectElementToBeVisible).toHaveBeenCalledWith(
+      serverRow,
+      expect.objectContaining({ timeout: 2000 }),
+    );
+    expect(PlaywrightGestures.waitAndTap).toHaveBeenCalledWith(serverRow);
+    expect(PlaywrightMatchers.getElementById).not.toHaveBeenCalled();
+  });
+
+  it('closes the developer menu directly without toggling Fast refresh', async () => {
+    const closeButton = { selector: 'xmark' };
+    (PlaywrightMatchers.getElementByText as jest.Mock).mockRejectedValue(
+      new Error('Continue not visible'),
+    );
+    (PlaywrightMatchers.getElementById as jest.Mock).mockResolvedValue(
+      closeButton,
+    );
+
+    await dismissDeveloperMenuPlaywright();
+
+    expect(PlaywrightMatchers.getElementByText).toHaveBeenCalledWith(
+      'Continue',
+    );
+    expect(PlaywrightMatchers.getElementById).toHaveBeenCalledWith('xmark', {
+      exact: true,
+    });
+    expect(PlaywrightGestures.waitAndTap).toHaveBeenNthCalledWith(
+      1,
+      closeButton,
+    );
+    expect(
+      PlaywrightAssertions.expectElementToNotBeVisible,
+    ).toHaveBeenCalledWith(
+      closeButton,
+      expect.objectContaining({ timeout: 5000 }),
+    );
+    expect(
+      (PlaywrightAssertions.expectElementToNotBeVisible as jest.Mock).mock
+        .invocationCallOrder[0],
+    ).toBeGreaterThan(
+      (PlaywrightGestures.waitAndTap as jest.Mock).mock.invocationCallOrder[0],
+    );
+    expect(PlaywrightMatchers.getElementById).not.toHaveBeenCalledWith(
+      'fast-refresh',
+      { exact: true },
+    );
+  });
+});

--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -189,16 +189,6 @@ export const dismissDeveloperMenuPlaywright = async (): Promise<void> => {
 };
 
 /**
- * Dismisses development build screens using Playwright.
- * Handles 'Development servers' and 'Developer menu' screens.
- * These screens are expected to appear when running locally.
- */
-export const dismissDevScreensPlaywright = async (): Promise<void> => {
-  await dismissDevelopmentServerPickerPlaywright();
-  await dismissDeveloperMenuPlaywright();
-};
-
-/**
  * Waits for app initialization and rehydration to complete.
  * This ensures the app is in a stable state before proceeding with tests.
  * Handles the case where React Native reload triggers state rehydration that may

--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -9,6 +9,7 @@ import {
 import Matchers from '../framework/Matchers';
 import Utilities, { sleep } from '../framework/Utilities';
 import LoginView from '../page-objects/wallet/LoginView';
+import { PlatformDetector } from '../framework/PlatformLocator';
 
 const logger = createLogger({
   name: 'GeneralFlow',
@@ -66,27 +67,101 @@ export const dismissDevScreens = async (): Promise<void> => {
   }
 };
 
-/**
- * Dismisses development build screens using Playwright.
- * Handles 'Development servers' and 'Developer menu' screens.
- * These screens are expected to appear when running locally.
- */
-export const dismissDevScreensPlaywright = async (): Promise<void> => {
+const getMetroServerUrl = (): string => {
   const port = process.env.METRO_PORT_E2E || process.env.WATCHER_PORT || '8081';
   const host = process.env.METRO_HOST_E2E || 'localhost';
-  const serverUrl = `http://${host}:${port}`;
+  return `http://${host}:${port}`;
+};
+
+/**
+ * Dismisses the React Native development server picker using Playwright.
+ * This screen appears before JS has loaded, so it must run before app bootstrap
+ * waits such as the fixture `/state.json` request.
+ */
+export const dismissDevelopmentServerPickerPlaywright =
+  async (): Promise<void> => {
+    const serverUrl = getMetroServerUrl();
+
+    try {
+      const devServerRow = await PlaywrightMatchers.getElementByText(serverUrl);
+      await PlaywrightAssertions.expectElementToBeVisible(devServerRow, {
+        timeout: 2000,
+        description: 'Dev Server Row should be visible',
+      });
+      await PlaywrightGestures.waitAndTap(devServerRow);
+    } catch (error) {
+      logger.debug(
+        `Playwright development server picker was not dismissed (best effort): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  };
+
+const closeDeveloperMenuPlaywright = async (): Promise<void> => {
+  try {
+    const closeButton = await PlaywrightMatchers.getElementById('xmark', {
+      exact: true,
+    });
+    await PlaywrightAssertions.expectElementToBeVisible(closeButton, {
+      timeout: 2000,
+      description: 'Dev Menu Close Button should be visible',
+    });
+    await PlaywrightGestures.waitAndTap(closeButton);
+    await PlaywrightAssertions.expectElementToNotBeVisible(closeButton, {
+      timeout: 5000,
+      description: 'Dev Menu Close Button should not be visible',
+    });
+    return;
+  } catch (closeByIdError) {
+    logger.debug(
+      `Playwright developer menu xmark button was not tapped: ${
+        closeByIdError instanceof Error
+          ? closeByIdError.message
+          : String(closeByIdError)
+      }`,
+    );
+  }
 
   try {
-    // 1. Check for Development Servers screen
-    // We tap the server row matching the current metro port
-    const devServerRow = await PlaywrightMatchers.getElementByText(serverUrl);
-    await PlaywrightAssertions.expectElementToBeVisible(devServerRow, {
+    const closeButton = await PlaywrightMatchers.getElementByText('Close');
+    await PlaywrightAssertions.expectElementToBeVisible(closeButton, {
       timeout: 2000,
-      description: 'Dev Server Row should be visible',
+      description: 'Dev Menu Close Button should be visible',
     });
-    await PlaywrightGestures.waitAndTap(devServerRow);
+    await PlaywrightGestures.waitAndTap(closeButton);
+    await PlaywrightAssertions.expectElementToNotBeVisible(closeButton, {
+      timeout: 5000,
+      description: 'Dev Menu Close Button should not be visible',
+    });
+    return;
+  } catch (closeByTextError) {
+    logger.debug(
+      `Playwright developer menu Close text was not tapped: ${
+        closeByTextError instanceof Error
+          ? closeByTextError.message
+          : String(closeByTextError)
+      }`,
+    );
+  }
 
-    // 2. Check for Developer Menu onboarding
+  if (!PlatformDetector.isAndroid()) {
+    return;
+  }
+
+  try {
+    await globalThis.driver?.back();
+  } catch (backError) {
+    logger.debug(
+      `Playwright developer menu Android back dismissal failed: ${
+        backError instanceof Error ? backError.message : String(backError)
+      }`,
+    );
+  }
+};
+
+const dismissDeveloperMenuOnboardingPlaywright = async (): Promise<void> => {
+  try {
     const continueButton =
       await PlaywrightMatchers.getElementByText('Continue');
     await PlaywrightAssertions.expectElementToBeVisible(continueButton, {
@@ -94,28 +169,33 @@ export const dismissDevScreensPlaywright = async (): Promise<void> => {
       description: 'Dev Menu Continue Button should be visible',
     });
 
-    // Tap Continue to proceed past the onboarding screen.
     await PlaywrightGestures.waitAndTap(continueButton);
-
-    // 3. Close the Developer Menu
-    // After tapping Continue, the Developer Menu options list appears.
-    // The user provided the ID 'fast-refresh' to tap on.
-    const fastRefreshButton = await PlaywrightMatchers.getElementById(
-      'fast-refresh',
-      { exact: true },
-    );
-    await PlaywrightAssertions.expectElementToBeVisible(fastRefreshButton, {
-      timeout: 5000,
-      description: 'Dev Menu Fast Refresh Button should be visible',
-    });
-    await PlaywrightGestures.waitAndTap(fastRefreshButton);
   } catch (error) {
     logger.debug(
-      `Playwright dev screens were not dismissed (best effort): ${
+      `Playwright developer menu onboarding was not dismissed (best effort): ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
   }
+};
+
+/**
+ * Dismisses the React Native developer menu using Playwright.
+ * This runs after the app has bootstrapped and JS is available.
+ */
+export const dismissDeveloperMenuPlaywright = async (): Promise<void> => {
+  await dismissDeveloperMenuOnboardingPlaywright();
+  await closeDeveloperMenuPlaywright();
+};
+
+/**
+ * Dismisses development build screens using Playwright.
+ * Handles 'Development servers' and 'Developer menu' screens.
+ * These screens are expected to appear when running locally.
+ */
+export const dismissDevScreensPlaywright = async (): Promise<void> => {
+  await dismissDevelopmentServerPickerPlaywright();
+  await dismissDeveloperMenuPlaywright();
 };
 
 /**

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -18,7 +18,8 @@ import {
 import Utilities from '../Utilities';
 import {
   dismissDevScreens,
-  dismissDevScreensPlaywright,
+  dismissDeveloperMenuPlaywright,
+  dismissDevelopmentServerPickerPlaywright,
 } from '../../flows/general.flow';
 import TestHelpers from '../../helpers';
 import MockServerE2E from '../../api-mocking/MockServerE2E';
@@ -566,6 +567,7 @@ export async function withFixtures(
     ResourceType.ACCOUNT_ACTIVITY_WS,
   );
   let testError: Error | null = null;
+  let didAttemptPlaywrightDevelopmentServerPickerDismissal = false;
 
   try {
     // Step 1: Start local nodes (Anvil/Ganache)
@@ -689,6 +691,10 @@ export async function withFixtures(
           await PlaywrightUtilities.launchApp(currentDeviceDetails, {
             launchArgs: testArgs,
           });
+          if (process.env.CI !== 'true') {
+            await dismissDevelopmentServerPickerPlaywright();
+            didAttemptPlaywrightDevelopmentServerPickerDismissal = true;
+          }
           await appStateRequest;
         } catch (error) {
           appStateRequest.catch(() => undefined);
@@ -712,7 +718,10 @@ export async function withFixtures(
       if (FrameworkDetector.isDetox()) {
         await dismissDevScreens();
       } else if (FrameworkDetector.isAppium()) {
-        await dismissDevScreensPlaywright();
+        if (!didAttemptPlaywrightDevelopmentServerPickerDismissal) {
+          await dismissDevelopmentServerPickerPlaywright();
+        }
+        await dismissDeveloperMenuPlaywright();
       }
     }
 

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
           provider: ProviderName.SIMULATOR,
           osVersion: '26.2',
           name: 'iPhone 16 Pro',
+          udid: '',
         },
         app: {
           appId: 'io.metamask.MetaMask',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
This PR addresses two previous comments on the local playwright runs implementation.
1. Updates documentation to explain how a `UDID` can be specified in order to distinguish simulators with the same name
2. Updates the flow for dismissing the dev screens in order to work with playwright 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1881

## **Manual testing steps**
N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local E2E test flows, fixture bootstrap timing, docs, and unit tests with no production app or security impact.
> 
> **Overview**
> **Local Playwright E2E** now dismisses React Native dev UI in two phases instead of one monolithic flow: the **Metro development server picker** runs as early as possible (including right after `launchApp` and before waiting on fixture `/state.json`), and the **developer menu** runs afterward once JS is up.
> 
> The Playwright dismissal logic no longer taps **Fast refresh** to close the menu; it uses **xmark** / **Close**, optional Android **back**, and still handles **Continue** onboarding. **`withFixtures`** wires the split helpers for Appium and avoids double-dismiss of the server picker. Docs add **iOS `device.udid`** guidance; the sample **ios** Playwright project exposes an empty **`udid`** field. **Jest unit tests** cover the new Playwright helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c739fa86080413bfc1ac27866369d5d909e4b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->