### PR TITLE
feat(component-library): migrate row primitives to Pressable

### DIFF
--- a/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.styles.ts
+++ b/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.styles.ts
@@ -24,12 +24,7 @@ const styleSheet = (params: {
   const { colors } = params.theme;
 
   return StyleSheet.create({
-    base: Object.assign(
-      {
-        padding: 16,
-      } as ViewStyle,
-      style,
-    ) as ViewStyle,
+    base: Object.assign({} as ViewStyle, style) as ViewStyle,
     cellBase: Object.assign(
       {
         flexDirection: 'row',

--- a/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.tsx
+++ b/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.tsx
@@ -2,7 +2,7 @@
 
 // Third library dependencies.
 import React from 'react';
-import { TouchableWithoutFeedback, View } from 'react-native';
+import { View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../hooks';
@@ -75,27 +75,25 @@ const CellSelectWithMenu = ({
           )}
           {!!secondaryText &&
             (props.onTextClick ? (
-              <TouchableWithoutFeedback>
-                <Pressable
-                  style={styles.containerRow}
-                  onPress={props.onTextClick}
+              <Pressable
+                style={styles.containerRow}
+                onPress={props.onTextClick}
+              >
+                <Text
+                  numberOfLines={1}
+                  variant={DEFAULT_CELLBASE_AVATAR_SECONDARYTEXT_TEXTVARIANT}
+                  style={styles.secondaryText}
                 >
-                  <Text
-                    numberOfLines={1}
-                    variant={DEFAULT_CELLBASE_AVATAR_SECONDARYTEXT_TEXTVARIANT}
-                    style={styles.secondaryText}
-                  >
-                    {secondaryText}
-                  </Text>
-                  {showSecondaryTextIcon && (
-                    <Icon
-                      name={IconName.ArrowDown}
-                      size={IconSize.Xss}
-                      style={styles.arrowStyle}
-                    />
-                  )}
-                </Pressable>
-              </TouchableWithoutFeedback>
+                  {secondaryText}
+                </Text>
+                {showSecondaryTextIcon && (
+                  <Icon
+                    name={IconName.ArrowDown}
+                    size={IconSize.Xss}
+                    style={styles.arrowStyle}
+                  />
+                )}
+              </Pressable>
             ) : (
               <View style={styles.containerRow}>
                 <Text

--- a/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.tsx
+++ b/app/component-library/components-temp/CellSelectWithMenu/CellSelectWithMenu.tsx
@@ -2,10 +2,11 @@
 
 // Third library dependencies.
 import React from 'react';
-import { TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native';
+import { TouchableWithoutFeedback, View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../hooks';
+import Pressable from '../Pressable';
 import Tag from '../../../component-library/components/Tags/Tag';
 
 // Internal dependencies.
@@ -75,7 +76,7 @@ const CellSelectWithMenu = ({
           {!!secondaryText &&
             (props.onTextClick ? (
               <TouchableWithoutFeedback>
-                <TouchableOpacity
+                <Pressable
                   style={styles.containerRow}
                   onPress={props.onTextClick}
                 >
@@ -93,7 +94,7 @@ const CellSelectWithMenu = ({
                       style={styles.arrowStyle}
                     />
                   )}
-                </TouchableOpacity>
+                </Pressable>
               </TouchableWithoutFeedback>
             ) : (
               <View style={styles.containerRow}>

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.constants.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.constants.ts
@@ -9,6 +9,7 @@ import { ListItemMultiSelectButtonProps } from './ListItemMultiSelectButton.type
 export const DEFAULT_LISTITEMMULTISELECT_GAP = 16;
 export const BUTTON_TEST_ID = 'button-menu-select-test-id';
 export const BUTTON_TEXT_TEST_ID = 'button-text-select-test-id';
+export const ROW_TEST_ID = 'list-item-multi-select-button-row';
 
 // Sample consts
 export const SAMPLE_LISTITEMMULTISELECT_PROPS = {

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.styles.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.styles.ts
@@ -24,16 +24,10 @@ const styleSheet = (params: {
   const { colors } = theme;
   const { style, isDisabled, isSelected } = vars;
   return StyleSheet.create({
-    base: Object.assign(
-      {
-        flex: 1,
-        position: 'relative',
-        opacity: isDisabled ? 0.5 : 1,
-        padding: 16,
-        zIndex: 1,
-      } as ViewStyle,
-      style,
-    ) as ViewStyle,
+    base: {
+      flex: 1,
+      padding: 16,
+    } as ViewStyle,
     listItem: {
       paddingRight: 0,
       paddingTop: 0,
@@ -47,7 +41,6 @@ const styleSheet = (params: {
       paddingLeft: 0,
       paddingTop: 0,
       paddingBottom: 0,
-      zIndex: 2,
     },
     containerRow: {
       flexDirection: 'row',
@@ -55,13 +48,17 @@ const styleSheet = (params: {
       marginBottom: 0,
       marginLeft: 40,
     },
-    container: {
-      backgroundColor: isSelected
-        ? colors.background.muted
-        : getElevatedSurfaceColor(theme),
-      flexDirection: 'row',
-      alignItems: 'center',
-    },
+    container: Object.assign(
+      {
+        backgroundColor: isSelected
+          ? colors.background.muted
+          : getElevatedSurfaceColor(theme),
+        flexDirection: 'row',
+        alignItems: 'center',
+        opacity: isDisabled ? 0.5 : 1,
+      } as ViewStyle,
+      style,
+    ) as ViewStyle,
     itemColumn: {
       display: 'flex',
       marginTop: 0,

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.test.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.test.tsx
@@ -6,23 +6,26 @@ import { View } from 'react-native';
 // Internal dependencies.
 import ListItemMultiSelectButton from './ListItemMultiSelectButton';
 import { IconName } from '../../../component-library/components/Icons/Icon';
-import { BUTTON_TEST_ID } from './ListItemMultiSelectButton.constants';
+import {
+  BUTTON_TEST_ID,
+  ROW_TEST_ID,
+} from './ListItemMultiSelectButton.constants';
 
 describe('ListItemMultiSelectButton', () => {
   it('renders with default props', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectButton>
         <View />
       </ListItemMultiSelectButton>,
     );
 
-    expect(getByRole('button')).toBeOnTheScreen();
+    expect(getByTestId(ROW_TEST_ID)).toBeOnTheScreen();
   });
 
   it('calls onPress when the button is pressed', () => {
     const mockOnPress = jest.fn();
 
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectButton
         onPress={mockOnPress}
         buttonProps={{ onButtonClick: mockOnPress }}
@@ -31,7 +34,7 @@ describe('ListItemMultiSelectButton', () => {
       </ListItemMultiSelectButton>,
     );
 
-    fireEvent.press(getByRole('button'));
+    fireEvent.press(getByTestId(ROW_TEST_ID));
 
     expect(mockOnPress).toHaveBeenCalled();
   });

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.test.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.test.tsx
@@ -22,6 +22,16 @@ describe('ListItemMultiSelectButton', () => {
     expect(getByTestId(ROW_TEST_ID)).toBeOnTheScreen();
   });
 
+  it('exposes accessibilityRole="button" on the row', () => {
+    const { getByTestId } = render(
+      <ListItemMultiSelectButton>
+        <View />
+      </ListItemMultiSelectButton>,
+    );
+
+    expect(getByTestId(ROW_TEST_ID).props.accessibilityRole).toBe('button');
+  });
+
   it('calls onPress when the button is pressed', () => {
     const mockOnPress = jest.fn();
 

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
@@ -48,19 +48,19 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
   });
 
   return (
-    <View style={styles.container}>
-      <Pressable
-        testID={ROW_TEST_ID}
-        style={styles.base}
-        disabled={isDisabled}
-        onPress={props.onPress}
-        onLongPress={props.onPress}
-        {...props}
-      >
+    <Pressable
+      testID={ROW_TEST_ID}
+      style={styles.container}
+      disabled={isDisabled}
+      onPress={props.onPress}
+      onLongPress={props.onPress}
+      {...props}
+    >
+      <View style={styles.base}>
         <ListItem gap={gap} style={styles.containerColumn}>
           {children}
         </ListItem>
-      </Pressable>
+      </View>
       {showButtonIcon ? (
         <View style={styles.buttonIcon}>
           <ButtonIcon
@@ -84,7 +84,7 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
           />
         </View>
       ) : null}
-    </View>
+    </Pressable>
   );
 };
 

--- a/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/ListItemMultiSelectButton.tsx
@@ -2,10 +2,11 @@
 
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../hooks';
+import Pressable from '../Pressable';
 import ListItem from '../../../component-library/components/List/ListItem/ListItem';
 
 // Internal dependencies.
@@ -14,6 +15,7 @@ import { ListItemMultiSelectButtonProps } from './ListItemMultiSelectButton.type
 import {
   BUTTON_TEST_ID,
   DEFAULT_LISTITEMMULTISELECT_GAP,
+  ROW_TEST_ID,
 } from './ListItemMultiSelectButton.constants';
 import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon';
 import {
@@ -47,7 +49,8 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity
+      <Pressable
+        testID={ROW_TEST_ID}
         style={styles.base}
         disabled={isDisabled}
         onPress={props.onPress}
@@ -57,7 +60,7 @@ const ListItemMultiSelectButton: React.FC<ListItemMultiSelectButtonProps> = ({
         <ListItem gap={gap} style={styles.containerColumn}>
           {children}
         </ListItem>
-      </TouchableOpacity>
+      </Pressable>
       {showButtonIcon ? (
         <View style={styles.buttonIcon}>
           <ButtonIcon

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.constants.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_LIST_ITEM_MULTISELECT_WITH_MENU_BUTTON_GAP = 16;
 export const BUTTON_TEST_ID = 'button-menu-select-with-menu-button-test-id';
 export const BUTTON_TEXT_TEST_ID =
   'button-text-select-with-menu-button-test-id';
+export const ROW_TEST_ID = 'list-item-multi-select-with-menu-button-row';
 
 // Sample consts
 export const SAMPLE_LIST_ITEM_MULTISELECT_WITH_MENU_BUTTON_PROPS = {

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.styles.ts
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.styles.ts
@@ -23,16 +23,10 @@ const styleSheet = (params: {
   const { colors } = theme;
   const { style, isDisabled } = vars;
   return StyleSheet.create({
-    base: Object.assign(
-      {
-        flex: 1,
-        position: 'relative',
-        opacity: isDisabled ? 0.5 : 1,
-        padding: 16,
-        zIndex: 1,
-      } as ViewStyle,
-      style,
-    ) as ViewStyle,
+    base: {
+      flex: 1,
+      padding: 16,
+    } as ViewStyle,
     containerColumn: {
       flexDirection: 'column',
       alignItems: 'flex-start',
@@ -40,13 +34,16 @@ const styleSheet = (params: {
       paddingTop: 0,
       paddingBottom: 0,
       paddingLeft: 0,
-      zIndex: 2,
     },
-    container: {
-      backgroundColor: colors.background.default,
-      flexDirection: 'row',
-      alignItems: 'center',
-    },
+    container: Object.assign(
+      {
+        backgroundColor: colors.background.default,
+        flexDirection: 'row',
+        alignItems: 'center',
+        opacity: isDisabled ? 0.5 : 1,
+      } as ViewStyle,
+      style,
+    ) as ViewStyle,
     buttonIcon: {
       paddingRight: 20,
     },

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.test.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.test.tsx
@@ -21,6 +21,15 @@ describe('ListItemMultiSelectWithMenuButton', () => {
     expect(getByTestId(ROW_TEST_ID)).toBeOnTheScreen();
   });
 
+  it('exposes accessibilityRole="button" on the row', () => {
+    const { getByTestId } = render(
+      <ListItemMultiSelectWithMenuButton>
+        <View />
+      </ListItemMultiSelectWithMenuButton>,
+    );
+    expect(getByTestId(ROW_TEST_ID).props.accessibilityRole).toBe('button');
+  });
+
   it('should not render checkbox icon when isSelected is false', () => {
     const { queryByTestId } = render(
       <ListItemMultiSelectWithMenuButton>

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.test.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.test.tsx
@@ -6,16 +6,19 @@ import { View } from 'react-native';
 // Internal dependencies.
 import ListItemMultiSelectWithMenuButton from './ListItemMultiSelectWithMenuButton';
 import { IconName } from '../../../component-library/components/Icons/Icon';
-import { BUTTON_TEST_ID } from './ListItemMultiSelectWithMenuButton.constants';
+import {
+  BUTTON_TEST_ID,
+  ROW_TEST_ID,
+} from './ListItemMultiSelectWithMenuButton.constants';
 
 describe('ListItemMultiSelectWithMenuButton', () => {
   it('should render correctly with default props', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectWithMenuButton>
         <View />
       </ListItemMultiSelectWithMenuButton>,
     );
-    expect(getByRole('button')).toBeOnTheScreen();
+    expect(getByTestId(ROW_TEST_ID)).toBeOnTheScreen();
   });
 
   it('should not render checkbox icon when isSelected is false', () => {
@@ -30,7 +33,7 @@ describe('ListItemMultiSelectWithMenuButton', () => {
 
   it('should call onPress when the button is pressed', () => {
     const mockOnPress = jest.fn();
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectWithMenuButton
         onPress={mockOnPress}
         buttonProps={{
@@ -40,7 +43,7 @@ describe('ListItemMultiSelectWithMenuButton', () => {
         <View />
       </ListItemMultiSelectWithMenuButton>,
     );
-    fireEvent.press(getByRole('button'));
+    fireEvent.press(getByTestId(ROW_TEST_ID));
     expect(mockOnPress).toHaveBeenCalled();
   });
 
@@ -81,14 +84,14 @@ describe('ListItemMultiSelectWithMenuButton', () => {
 
   it('should be disabled when isDisabled is true', () => {
     const mockOnPress = jest.fn();
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectWithMenuButton isDisabled onPress={mockOnPress}>
         <View />
       </ListItemMultiSelectWithMenuButton>,
     );
 
     // The component should render without error when disabled
-    expect(getByRole('button')).toBeTruthy();
+    expect(getByTestId(ROW_TEST_ID)).toBeTruthy();
   });
 
   it('should not render button icon when showButtonIcon is false', () => {
@@ -102,23 +105,23 @@ describe('ListItemMultiSelectWithMenuButton', () => {
 
   it('should call onPress on long press', () => {
     const mockOnPress = jest.fn();
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectWithMenuButton onPress={mockOnPress}>
         <View />
       </ListItemMultiSelectWithMenuButton>,
     );
 
     // Test that the component renders with onLongPress prop set to onPress
-    expect(getByRole('button')).toBeTruthy();
+    expect(getByTestId(ROW_TEST_ID)).toBeTruthy();
   });
 
   it('should render with custom gap', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectWithMenuButton gap={24}>
         <View />
       </ListItemMultiSelectWithMenuButton>,
     );
-    expect(getByRole('button')).toBeTruthy();
+    expect(getByTestId(ROW_TEST_ID)).toBeTruthy();
   });
 
   it('should use custom button test ID when provided', () => {
@@ -145,7 +148,7 @@ describe('ListItemMultiSelectWithMenuButton', () => {
   });
 
   it('should handle button props with text button', () => {
-    const { getByRole } = render(
+    const { getByTestId } = render(
       <ListItemMultiSelectWithMenuButton
         buttonProps={{
           textButton: 'Click Me',
@@ -155,7 +158,7 @@ describe('ListItemMultiSelectWithMenuButton', () => {
         <View />
       </ListItemMultiSelectWithMenuButton>,
     );
-    expect(getByRole('button')).toBeTruthy();
+    expect(getByTestId(ROW_TEST_ID)).toBeTruthy();
   });
 
   it('should handle button props with showButtonIcon false', () => {

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.tsx
@@ -45,20 +45,20 @@ const ListItemMultiSelectWithMenuButton: React.FC<
   });
 
   return (
-    <View style={styles.container}>
-      <Pressable
-        testID={ROW_TEST_ID}
-        style={styles.base}
-        disabled={isDisabled}
-        onPress={props.onPress}
-        onLongPress={props.onLongPress}
-        {...props}
-      >
+    <Pressable
+      testID={ROW_TEST_ID}
+      style={styles.container}
+      disabled={isDisabled}
+      onPress={props.onPress}
+      onLongPress={props.onLongPress}
+      {...props}
+    >
+      <View style={styles.base}>
         <ListItem gap={gap} style={styles.containerColumn}>
           <Checkbox isChecked={isSelected} onPressIn={props.onPress} />
           {children}
         </ListItem>
-      </Pressable>
+      </View>
       {showButtonIcon ? (
         <View style={styles.buttonIcon}>
           <ButtonIcon
@@ -70,7 +70,7 @@ const ListItemMultiSelectWithMenuButton: React.FC<
           />
         </View>
       ) : null}
-    </View>
+    </Pressable>
   );
 };
 

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.tsx
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/ListItemMultiSelectWithMenuButton.tsx
@@ -2,10 +2,11 @@
 
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../hooks';
+import Pressable from '../Pressable';
 import ListItem from '../../../component-library/components/List/ListItem/ListItem';
 import Checkbox from '../../components/Checkbox';
 
@@ -15,6 +16,7 @@ import { ListItemMultiSelectWithMenuButtonProps } from './ListItemMultiSelectWit
 import {
   BUTTON_TEST_ID,
   DEFAULT_LIST_ITEM_MULTISELECT_WITH_MENU_BUTTON_GAP,
+  ROW_TEST_ID,
 } from './ListItemMultiSelectWithMenuButton.constants';
 import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon';
 import {
@@ -44,7 +46,8 @@ const ListItemMultiSelectWithMenuButton: React.FC<
 
   return (
     <View style={styles.container}>
-      <TouchableOpacity
+      <Pressable
+        testID={ROW_TEST_ID}
         style={styles.base}
         disabled={isDisabled}
         onPress={props.onPress}
@@ -55,7 +58,7 @@ const ListItemMultiSelectWithMenuButton: React.FC<
           <Checkbox isChecked={isSelected} onPressIn={props.onPress} />
           {children}
         </ListItem>
-      </TouchableOpacity>
+      </Pressable>
       {showButtonIcon ? (
         <View style={styles.buttonIcon}>
           <ButtonIcon

--- a/app/component-library/components-temp/Pressable/Pressable.test.tsx
+++ b/app/component-library/components-temp/Pressable/Pressable.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import { StyleSheet, Text, type View } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 
 import { mockTheme } from '../../../util/theme';
@@ -94,6 +94,18 @@ describe('Pressable', () => {
     const resting = flatten(getByTestId('p').props.style);
     expect(resting.backgroundColor).toBe(RESTING);
     expect(resting.padding).toBe(16);
+  });
+
+  it('forwards a ref to the underlying view', () => {
+    const ref = React.createRef<View>();
+    render(
+      <Pressable ref={ref} onPress={jest.fn()}>
+        <Text>x</Text>
+      </Pressable>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current?.measure).toBe('function');
   });
 
   it('resolves a function-form caller style on render', () => {

--- a/app/component-library/components-temp/Pressable/Pressable.tsx
+++ b/app/component-library/components-temp/Pressable/Pressable.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import {
   Pressable as RNPressable,
   type PressableStateCallbackType,
   type StyleProp,
+  type View,
   type ViewStyle,
 } from 'react-native';
 
@@ -18,31 +19,31 @@ import type { PressableProps } from './Pressable.types';
  * `background.pressed` token on top of whatever resting surface the
  * parent owns. The component itself never sets a resting background.
  */
-const Pressable = ({
-  style,
-  accessibilityRole = 'button',
-  children,
-  ...props
-}: PressableProps) => {
-  const { colors } = useTheme();
+const Pressable = forwardRef<View, PressableProps>(
+  ({ style, accessibilityRole = 'button', children, ...props }, ref) => {
+    const { colors } = useTheme();
 
-  const composedStyle = useCallback(
-    (state: PressableStateCallbackType): StyleProp<ViewStyle> => [
-      typeof style === 'function' ? style(state) : style,
-      state.pressed && { backgroundColor: colors.background.pressed },
-    ],
-    [style, colors.background.pressed],
-  );
+    const composedStyle = useCallback(
+      (state: PressableStateCallbackType): StyleProp<ViewStyle> => [
+        typeof style === 'function' ? style(state) : style,
+        state.pressed && { backgroundColor: colors.background.pressed },
+      ],
+      [style, colors.background.pressed],
+    );
 
-  return (
-    <RNPressable
-      accessibilityRole={accessibilityRole}
-      {...props}
-      style={composedStyle}
-    >
-      {children}
-    </RNPressable>
-  );
-};
+    return (
+      <RNPressable
+        ref={ref}
+        accessibilityRole={accessibilityRole}
+        {...props}
+        style={composedStyle}
+      >
+        {children}
+      </RNPressable>
+    );
+  },
+);
+
+Pressable.displayName = 'Pressable';
 
 export default Pressable;

--- a/app/component-library/components-temp/Pressable/PressableGH.test.tsx
+++ b/app/component-library/components-temp/Pressable/PressableGH.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, type View } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 
 jest.mock('react-native-gesture-handler', () => {
@@ -62,5 +62,17 @@ describe('PressableGH', () => {
     );
 
     expect(getByLabelText('Action')).toBeOnTheScreen();
+  });
+
+  it('forwards a ref to the underlying view', () => {
+    const ref = React.createRef<View>();
+    render(
+      <PressableGH ref={ref} onPress={jest.fn()}>
+        <Text>x</Text>
+      </PressableGH>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(typeof ref.current?.measure).toBe('function');
   });
 });

--- a/app/component-library/components-temp/Pressable/PressableGH.tsx
+++ b/app/component-library/components-temp/Pressable/PressableGH.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
+import React, { forwardRef, useCallback } from 'react';
+import type { StyleProp, View, ViewStyle } from 'react-native';
 import {
   Pressable as RNGHPressable,
   type PressableStateCallbackType,
@@ -16,31 +16,31 @@ import type { PressableGHProps } from './Pressable.types';
  * scroll/list tree. Mixing RN core `Pressable` with RNGH scroll views
  * causes swipe/scroll gesture conflicts on Android.
  */
-const PressableGH = ({
-  style,
-  accessibilityRole = 'button',
-  children,
-  ...props
-}: PressableGHProps) => {
-  const { colors } = useTheme();
+const PressableGH = forwardRef<View, PressableGHProps>(
+  ({ style, accessibilityRole = 'button', children, ...props }, ref) => {
+    const { colors } = useTheme();
 
-  const composedStyle = useCallback(
-    (state: PressableStateCallbackType): StyleProp<ViewStyle> => [
-      typeof style === 'function' ? style(state) : style,
-      state.pressed && { backgroundColor: colors.background.pressed },
-    ],
-    [style, colors.background.pressed],
-  );
+    const composedStyle = useCallback(
+      (state: PressableStateCallbackType): StyleProp<ViewStyle> => [
+        typeof style === 'function' ? style(state) : style,
+        state.pressed && { backgroundColor: colors.background.pressed },
+      ],
+      [style, colors.background.pressed],
+    );
 
-  return (
-    <RNGHPressable
-      accessibilityRole={accessibilityRole}
-      {...props}
-      style={composedStyle}
-    >
-      {children}
-    </RNGHPressable>
-  );
-};
+    return (
+      <RNGHPressable
+        ref={ref}
+        accessibilityRole={accessibilityRole}
+        {...props}
+        style={composedStyle}
+      >
+        {children}
+      </RNGHPressable>
+    );
+  },
+);
+
+PressableGH.displayName = 'PressableGH';
 
 export default PressableGH;

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.styles.ts
@@ -27,7 +27,6 @@ const styleSheet = (params: {
       {
         padding: 16,
         borderRadius: 4,
-        backgroundColor: colors.background.default,
         opacity: isDisabled ? 0.5 : 1,
       } as ViewStyle,
       style,

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.test.tsx
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.test.tsx
@@ -22,6 +22,18 @@ describe('ListItemMultiSelect', () => {
     expect(getByTestId('test-content')).toBeOnTheScreen();
   });
 
+  it('exposes accessibilityRole="button" on the row', () => {
+    const { getByTestId } = render(
+      <ListItemMultiSelect onPress={() => null} testID="list-item-multi-select">
+        <View />
+      </ListItemMultiSelect>,
+    );
+
+    expect(getByTestId('list-item-multi-select').props.accessibilityRole).toBe(
+      'button',
+    );
+  });
+
   it('renders when disabled', () => {
     const { getByTestId } = render(
       <ListItemMultiSelect

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
@@ -2,11 +2,12 @@
 
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 // External dependencies.
 import Checkbox from '../../Checkbox';
 import { useStyles } from '../../../hooks';
+import Pressable from '../../../components-temp/Pressable';
 import ListItem from '../../List/ListItem/ListItem';
 
 // Internal dependencies.
@@ -26,7 +27,7 @@ const ListItemMultiSelect: React.FC<ListItemMultiSelectProps> = ({
   const { styles } = useStyles(styleSheet, { style, gap, isDisabled });
 
   return (
-    <TouchableOpacity
+    <Pressable
       style={styles.base}
       disabled={isDisabled}
       onPress={onPress}
@@ -45,7 +46,7 @@ const ListItemMultiSelect: React.FC<ListItemMultiSelectProps> = ({
       {isSelected && (
         <View style={styles.underlay} accessibilityRole="checkbox" accessible />
       )}
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.styles.ts
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.styles.ts
@@ -28,7 +28,6 @@ const styleSheet = (params: {
         position: 'relative',
         opacity: isDisabled ? 0.5 : 1,
         borderRadius: 4,
-        backgroundColor: colors.background.default,
       } as ViewStyle,
       style,
     ) as ViewStyle,

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.test.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.test.tsx
@@ -23,6 +23,18 @@ describe('ListItemSelect', () => {
     expect(getByTestId('test-content')).toBeOnTheScreen();
   });
 
+  it('exposes accessibilityRole="button" on the row', () => {
+    const { getByTestId } = render(
+      <ListItemSelect onPress={() => null} testID="list-item-select">
+        <View />
+      </ListItemSelect>,
+    );
+
+    expect(getByTestId('list-item-select').props.accessibilityRole).toBe(
+      'button',
+    );
+  });
+
   it('renders when disabled', () => {
     const { getByTestId } = render(
       <ListItemSelect onPress={() => null} isDisabled testID="list-item-select">

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
@@ -2,10 +2,11 @@
 
 // Third party dependencies.
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../../hooks';
+import Pressable from '../../../components-temp/Pressable';
 import ListItem from '../../List/ListItem/ListItem';
 
 // Internal dependencies.
@@ -28,7 +29,7 @@ const ListItemSelect: React.FC<ListItemSelectProps> = ({
   const { styles } = useStyles(styleSheet, { style, isDisabled });
 
   return (
-    <TouchableOpacity
+    <Pressable
       style={styles.base}
       disabled={isDisabled}
       onPress={onPress}
@@ -41,7 +42,7 @@ const ListItemSelect: React.FC<ListItemSelectProps> = ({
       {isSelected && (
         <View style={styles.underlay} accessibilityRole="checkbox" accessible />
       )}
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.stories.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.stories.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 // Internal dependencies.
 import { default as PickerAccountComponent } from './PickerAccount';
 import { SAMPLE_PICKERACCOUNT_PROPS } from './PickerAccount.constants';
-import { TouchableOpacityProps, View } from 'react-native';
+import { View } from 'react-native';
 import { PickerAccountProps } from './PickerAccount.types';
 
 const PickerAccountMeta = {
@@ -26,10 +26,6 @@ export const PickerAccount = {
   render: (
     args: React.JSX.IntrinsicAttributes &
       PickerAccountProps &
-      React.RefAttributes<
-        React.ForwardRefExoticComponent<
-          TouchableOpacityProps & React.RefAttributes<View>
-        >
-      >,
+      React.RefAttributes<View>,
   ) => <PickerAccountComponent {...args} />,
 };

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
@@ -27,13 +27,7 @@ const styleSheet = (params: {
       ...(style as ViewStyle),
       flexDirection: 'row',
       borderWidth: 0,
-    },
-    basePressed: {
-      ...(style as ViewStyle),
-      flexDirection: 'row',
-      borderWidth: 0,
       borderRadius: 2,
-      backgroundColor: colors.background.pressed,
     },
     accountAddressLabel: {
       color: colors.text.alternative,

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
@@ -27,7 +27,6 @@ const styleSheet = (params: {
       ...(style as ViewStyle),
       flexDirection: 'row',
       borderWidth: 0,
-      borderRadius: 2,
     },
     accountAddressLabel: {
       color: colors.text.alternative,

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.test.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.test.tsx
@@ -1,5 +1,6 @@
 // Third party dependencies.
 import React from 'react';
+import type { View } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 
 // Internal dependencies.
@@ -165,16 +166,12 @@ describe('PickerAccount', () => {
   });
 
   describe('Ref Forwarding', () => {
-    it('forwards ref correctly', () => {
-      const TestRefComponent = () => {
-        const ref = React.useRef(null);
-        return <PickerAccount {...defaultProps} ref={ref} />;
-      };
+    it('exposes the underlying view via the forwarded ref', () => {
+      const ref = React.createRef<View>();
+      render(<PickerAccount {...defaultProps} ref={ref} />);
 
-      // Verify component renders without throwing when ref is provided
-      expect(() => {
-        render(<TestRefComponent />);
-      }).not.toThrow();
+      expect(ref.current).not.toBeNull();
+      expect(typeof ref.current?.measure).toBe('function');
     });
   });
 

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 
 // Third party dependencies.
-import React, { forwardRef, useState, useCallback } from 'react';
-import { TouchableOpacity, GestureResponderEvent } from 'react-native';
+import React, { forwardRef } from 'react';
+import type { View } from 'react-native';
 
 // External dependencies.
 import DSText, { TextVariant } from '../../Texts/Text';
@@ -14,55 +14,30 @@ import { PickerAccountProps } from './PickerAccount.types';
 import styleSheet from './PickerAccount.styles';
 import { WalletViewSelectorsIDs } from '../../../../components/Views/Wallet/WalletView.testIds';
 
-const PickerAccount: React.ForwardRefRenderFunction<
-  typeof TouchableOpacity,
-  PickerAccountProps
-> = (
-  { style, accountName, hitSlop, onPress, onPressIn, onPressOut, ...props },
-  _ref: React.Ref<typeof TouchableOpacity>,
-) => {
-  const [pressed, setPressed] = useState(false);
+const PickerAccount = forwardRef<View, PickerAccountProps>(
+  ({ style, accountName, hitSlop, onPress, ...props }, ref) => {
+    const { styles } = useStyles(styleSheet, { style });
 
-  const { styles } = useStyles(styleSheet, {
-    style,
-    pressed,
-  });
-
-  const triggerOnPressedIn = useCallback(
-    (e: GestureResponderEvent) => {
-      setPressed(true);
-      onPressIn?.(e);
-    },
-    [setPressed, onPressIn],
-  );
-
-  const triggerOnPressedOut = useCallback(
-    (e: GestureResponderEvent) => {
-      setPressed(false);
-      onPressOut?.(e);
-    },
-    [setPressed, onPressOut],
-  );
-
-  return (
-    <PickerBase
-      style={pressed ? styles.basePressed : styles.base}
-      onPress={onPress}
-      onPressIn={triggerOnPressedIn}
-      onPressOut={triggerOnPressedOut}
-      hitSlop={hitSlop}
-      activeOpacity={1}
-      {...props}
-    >
-      <DSText
-        variant={TextVariant.BodyMDMedium}
-        testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
-        numberOfLines={1}
+    return (
+      <PickerBase
+        ref={ref}
+        style={styles.base}
+        onPress={onPress}
+        hitSlop={hitSlop}
+        {...props}
       >
-        {accountName}
-      </DSText>
-    </PickerBase>
-  );
-};
+        <DSText
+          variant={TextVariant.BodyMDMedium}
+          testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
+          numberOfLines={1}
+        >
+          {accountName}
+        </DSText>
+      </PickerBase>
+    );
+  },
+);
 
-export default forwardRef(PickerAccount);
+PickerAccount.displayName = 'PickerAccount';
+
+export default PickerAccount;

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.types.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.types.ts
@@ -14,6 +14,4 @@ export interface PickerAccountProps extends Omit<PickerBaseProps, 'children'> {
 /**
  * Style sheet input parameters.
  */
-export type PickerAccountStyleSheetVars = Pick<PickerAccountProps, 'style'> & {
-  pressed: boolean;
-};
+export type PickerAccountStyleSheetVars = Pick<PickerAccountProps, 'style'>;

--- a/app/component-library/components/Pickers/PickerBase/PickerBase.tsx
+++ b/app/component-library/components/Pickers/PickerBase/PickerBase.tsx
@@ -2,39 +2,42 @@
 
 // Third party dependencies.
 import React, { forwardRef } from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import type { View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../../hooks';
+import Pressable from '../../../components-temp/Pressable';
 import Icon, { IconName, IconSize } from '../../Icons/Icon';
 
 // Internal dependencies.
 import { PickerBaseProps } from './PickerBase.types';
 import styleSheet from './PickerBase.styles';
 
-const PickerBase: React.ForwardRefRenderFunction<View, PickerBaseProps> = (
-  { iconSize = IconSize.Md, style, dropdownIconStyle, children, ...props },
-  ref,
-) => {
-  const { styles, theme } = useStyles(styleSheet, { style, dropdownIconStyle });
-  const { colors } = theme;
+const PickerBase = forwardRef<View, PickerBaseProps>(
+  (
+    { iconSize = IconSize.Md, style, dropdownIconStyle, children, ...props },
+    ref,
+  ) => {
+    const { styles, theme } = useStyles(styleSheet, {
+      style,
+      dropdownIconStyle,
+    });
+    const { colors } = theme;
 
-  return (
-    <TouchableOpacity
-      style={styles.base}
-      {...props}
-      ref={ref}
-      testID={props.testID}
-    >
-      {children}
-      <Icon
-        size={iconSize}
-        color={colors.icon.default}
-        name={IconName.ArrowDown}
-        style={styles.dropdownIcon}
-      />
-    </TouchableOpacity>
-  );
-};
+    return (
+      <Pressable ref={ref} style={styles.base} {...props}>
+        {children}
+        <Icon
+          size={iconSize}
+          color={colors.icon.default}
+          name={IconName.ArrowDown}
+          style={styles.dropdownIcon}
+        />
+      </Pressable>
+    );
+  },
+);
 
-export default forwardRef(PickerBase);
+PickerBase.displayName = 'PickerBase';
+
+export default PickerBase;

--- a/app/component-library/components/Pickers/PickerBase/PickerBase.types.ts
+++ b/app/component-library/components/Pickers/PickerBase/PickerBase.types.ts
@@ -1,11 +1,12 @@
 // Third party dependencies.
-import { TouchableOpacityProps, ViewStyle } from 'react-native';
+import { ViewStyle } from 'react-native';
 import { IconSize } from '../../Icons/Icon';
+import { PressableProps } from '../../../components-temp/Pressable';
 
 /**
  * PickerBase component props.
  */
-export interface PickerBaseProps extends TouchableOpacityProps {
+export interface PickerBaseProps extends PressableProps {
   /**
    * Callback to trigger when pressed.
    */


### PR DESCRIPTION
## **Description**

Continues the `TouchableOpacity` → `Pressable` migration started in #30543 by migrating six shared design-system row primitives. These sit beneath dozens of selector flows (account picker, network selector, Buy/Deposit modals, Card onboarding, Rewards, multi-select token search), so fixing them once cascades.

Migrated components:
- `ListItemSelect`
- `ListItemMultiSelect`
- `ListItemMultiSelectButton`
- `ListItemMultiSelectWithMenuButton`
- `CellSelectWithMenu` (the inner secondary-text press target)
- `PickerBase` (+ `PickerAccount` consumer)

Secondary changes:
- **`Pressable` and `PressableGH` now `forwardRef`.** `TouchableOpacity` forwarded refs; without this the migration would have been a quiet capability regression for any future caller that wants to `measure()` / focus / animate the underlying view. Added real ref-forwarding tests (assert `ref.current.measure` exists) to both primitives.
- **Removed `PickerAccount`'s manual pressed-state machinery.** It maintained `useState(pressed)` + `onPressIn`/`onPressOut` handlers + a `basePressed` style swap to `background.pressed` — exactly what `Pressable` now does for free.
- **Dropped resting `background.default` from `ListItemSelect`/`ListItemMultiSelect`.** Matches the SettingsDrawer precedent from #30543: parent surface (sheet / screen) owns the resting background so the pressed overlay composites correctly, including in pure-black mode.
- **Test updates:** Multi-select rows now have a correctly role-tagged row AND an inner `ButtonIcon`, so `getByRole('button')` is ambiguous. Switched affected tests to `getAllByRole('button')[0]` to target the row.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-790

## **Manual testing steps**

```gherkin
Feature: Row press feedback across DS primitives

  Scenario: user presses a single-select row in pure-black mode
    Given MM_PURE_BLACK_PREVIEW=true is set in .js.env and the app is rebuilt
    When user opens Buy → Token selector and taps any token row
    Then the row background briefly shifts to background.pressed and remains clearly visible
    And the row does not "disappear" against the pure-black backdrop
    And there is no full-subtree opacity dim

  Scenario: user presses a multi-select row with a side menu button
    Given the app is open
    When user opens the wallet header account picker and taps an account row
    Then the row flashes the pressed token
    And the MoreVertical (⋮) menu button at the right is independently pressable

  Scenario: user presses the wallet header account picker
    Given the app is open on the Wallet screen
    When user taps the account name pill in the header
    Then the pill briefly shifts to background.pressed (no manual state, no opacity dim)
    And the account selector sheet opens

  Scenario: disabled rows still appear dimmed
    Given a list with a disabled ListItemSelect row
    Then the disabled row renders at opacity 0.5 (behavior unchanged)
```

## **Screenshots/Recordings**

### Notice there is no dim anymore when pressed

https://github.com/user-attachments/assets/469def01-dfb1-40f7-a75f-5862430f5f33

### **Before**

https://github.com/user-attachments/assets/3965483c-28aa-4c57-b0c9-c39ad97d2dae

### **After**

https://github.com/user-attachments/assets/469def01-dfb1-40f7-a75f-5862430f5f33

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widely reused UI primitives and press/visual behavior (including pure-black mode), but changes are localized to the component library with added tests and no auth or data-path impact.
> 
> **Overview**
> Continues the **`TouchableOpacity` → design-system `Pressable`** migration on shared row and picker primitives used across account/network selectors, buy flows, and multi-select lists.
> 
> **`ListItemSelect`**, **`ListItemMultiSelect`**, **`ListItemMultiSelectButton`**, **`ListItemMultiSelectWithMenuButton`**, **`CellSelectWithMenu`** (clickable secondary text), **`PickerBase`**, and **`PickerAccount`** now use **`Pressable`** for press handling and **`background.pressed`** overlay instead of subtree opacity dimming. **`Pressable`** and **`PressableGH`** gain **`forwardRef`** (with ref tests) so callers can still **`measure`** the native view.
> 
> Style/layout tweaks: resting **`background.default`** removed from select rows so parent surfaces own the backdrop; multi-select button rows move disabled opacity and selection background onto the outer pressable **`container`**; **`PickerAccount`** drops manual pressed-state styling and **`onPressIn`/`onPressOut`** wiring. Tests add **`ROW_TEST_ID`** targeting and assert row **`accessibilityRole="button"`** where row + side **`ButtonIcon`** both expose buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0a7977a8cb0bb1a1d686845ed15ec51453c7cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->