### PR TITLE
fix: cp-7.80.0 prevent send flow from submitting to zero address after clearing pasted recipient 

### DIFF
--- a/app/components/Views/confirmations/components/recipient-input/recipient-input.test.tsx
+++ b/app/components/Views/confirmations/components/recipient-input/recipient-input.test.tsx
@@ -329,6 +329,39 @@ describe('RecipientInput', () => {
     jest.advanceTimersByTime(100);
   });
 
+  it('clears pastedRecipient when clear button is pressed', () => {
+    mockUseSendContext.mockReturnValue({
+      to: '0x1234567890123456789012345678901234567890',
+      updateTo: mockUpdateTo,
+      asset: undefined,
+      chainId: undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fromAccount: {} as any,
+      from: '',
+      maxValueMode: false,
+      updateAsset: jest.fn(),
+      updateValue: jest.fn(),
+      value: undefined,
+    });
+
+    const mockSetPastedRecipient = jest.fn();
+    const { getByText } = renderWithProvider(
+      <RecipientInput
+        isRecipientSelectedFromList={false}
+        resetStateOnInput={noop}
+        setPastedRecipient={mockSetPastedRecipient}
+      />,
+    );
+
+    const clearButton = getByText('Clear');
+    fireEvent.press(clearButton);
+
+    expect(mockUpdateTo).toHaveBeenCalledWith('');
+    expect(mockSetPastedRecipient).toHaveBeenCalledWith(undefined);
+
+    jest.advanceTimersByTime(100);
+  });
+
   it('maintains correct button state based on isRecipientSelectedFromList prop', () => {
     mockUseSendContext.mockReturnValue({
       to: '0x123...',

--- a/app/components/Views/confirmations/components/recipient-input/recipient-input.tsx
+++ b/app/components/Views/confirmations/components/recipient-input/recipient-input.tsx
@@ -49,10 +49,11 @@ export const RecipientInput = ({
 
   const handleClearInput = useCallback(() => {
     updateTo('');
+    setPastedRecipient(undefined);
     setTimeout(() => {
       inputRef.current?.blur();
     }, 100);
-  }, [updateTo, inputRef]);
+  }, [updateTo, inputRef, setPastedRecipient]);
 
   const handleTextChange = useCallback(
     async (toAddress: string) => {

--- a/app/components/Views/confirmations/components/send/recipient/recipient.test.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.test.tsx
@@ -770,6 +770,44 @@ describe('Recipient pastedRecipient effect gating (lines 96-101)', () => {
     expect(mockHandleSubmitPressLocal).not.toHaveBeenCalled();
   });
 
+  it('does not submit when recipient address is empty', () => {
+    mockUseToAddressValidation.mockReturnValue({
+      loading: false,
+      resolvedAddress: undefined,
+      toAddressError: undefined,
+      toAddressValidated: undefined,
+      toAddressWarning: undefined,
+    });
+
+    mockUseSendAlerts.mockReturnValue({
+      alerts: [],
+      hasUnacknowledgedAlerts: false,
+      acknowledgeAlerts: jest.fn(),
+      isAlertCheckPending: false,
+    });
+
+    mockUseSendContext.mockReturnValue({
+      to: '',
+      updateTo: jest.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      asset: {} as any,
+      chainId: '0x1',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fromAccount: {} as any,
+      from: '',
+      maxValueMode: false,
+      updateAsset: jest.fn(),
+      updateValue: jest.fn(),
+      value: undefined,
+    });
+
+    const { getByTestId } = renderWithProvider(<Recipient />);
+
+    fireEvent.press(getByTestId('set-pasted'));
+
+    expect(mockHandleSubmitPressLocal).not.toHaveBeenCalled();
+  });
+
   it('handles reviews exits early if toAddressError is defined', () => {
     // Given: valid to address, no errors/warnings/loading, but missing asset
     mockUseToAddressValidation.mockReturnValue({

--- a/app/components/Views/confirmations/components/send/recipient/recipient.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.tsx
@@ -86,6 +86,10 @@ export const Recipient = () => {
       if (!asset || !chainId) {
         return;
       }
+      const recipientAddress = resolvedAddress || to;
+      if (!recipientAddress) {
+        return;
+      }
       setIsSubmittingTransaction(true);
       setPastedRecipient(undefined);
       captureRecipientSelected(


### PR DESCRIPTION
## **Description**

When a user pastes an address in the send flow, an auto-review `useEffect` is triggered to streamline the UX. If the "New address" alert modal appears and the user cancels it, then presses the "Clear" button, the `pastedRecipient` state was not being cleared. This caused a race condition: `handleClearInput` would set `to` to empty, which caused `hasUnacknowledgedAlerts` to become `false` (no alerts for empty addresses), while `pastedRecipient` and `toAddressValidated` still held the old address. The auto-review `useEffect` would then see all conditions pass and fire `handleSubmitPress` with an empty `to` value, which got cast to `0x0000...0000`.

**Fix:**
1. Clear `pastedRecipient` in `handleClearInput` so the auto-review effect cannot re-trigger with stale state after clearing.
2. Add a defense-in-depth guard in `proceedWithSubmit` to reject empty recipient addresses.

## **Changelog**

CHANGELOG entry: Fixed a bug where clearing a pasted recipient address in the send flow could trigger a transaction to the zero address

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Send flow clear button

  Scenario: user clears pasted address after cancelling new address alert
    Given the user is on the send recipient screen

    When user pastes a valid address using the Paste button
    And user presses the Review button
    And the "New address" alert modal appears
    And user presses Cancel on the alert modal
    And user presses the Clear button
    Then the input field is cleared
    And no transaction is submitted
    And the user remains on the recipient screen

  Scenario: user clears pasted address without triggering review first
    Given the user is on the send recipient screen

    When user pastes a valid address using the Paste button
    And user presses the Clear button before auto-review triggers
    Then the input field is cleared
    And no transaction is submitted
```

## **Screenshots/Recordings**

### **Before**

Pressing Clear after cancelling the "New address" alert triggers a transaction submission to `0x0000...0000`.

### **After**

Pressing Clear correctly resets the input without triggering any transaction submission.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes send submission guards and recipient state on a user-facing money path; scope is small and covered by tests, but incorrect gating could block valid sends or miss edge cases.
> 
> **Overview**
> Fixes a send-flow bug where **Clear** after canceling the "New address" alert could still auto-advance review because **`pastedRecipient`** stayed set while **`to`** was emptied.
> 
> **`RecipientInput`** now resets **`pastedRecipient`** in **`handleClearInput`** (along with **`updateTo('')`**) so the paste auto-review **`useEffect`** cannot re-fire on stale paste state. **`Recipient`** **`proceedWithSubmit`** also bails out when there is no **`resolvedAddress`** or **`to`**, blocking submission with an empty recipient (e.g. zero address). Tests cover clear + empty-recipient paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636fbc988bb01333149643ce9e663603663341bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->