### PR TITLE
fix: android crash for new social login users cp-7.79.0

### DIFF
--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -6,6 +6,7 @@ import {
   PREVIOUS_SCREEN,
   PROTECT,
 } from '../../../constants/navigation';
+import { ONBOARDING_SUCCESS_FLOW } from '../../../constants/onboarding';
 import Routes from '../../../constants/navigation/Routes';
 import { Provider } from 'react-redux';
 import { backgroundState } from '../../../util/test/initial-root-state';
@@ -699,7 +700,9 @@ describe('ChoosePassword', () => {
           routes: [
             {
               name: 'OnboardingSuccess',
-              params: { showPasswordHint: true },
+              params: {
+                successFlow: ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
+              },
             },
           ],
         });

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -60,6 +60,7 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   AccountType,
   getSocialAccountType,
+  ONBOARDING_SUCCESS_FLOW,
 } from '../../../constants/onboarding';
 import type {
   IMetaMetricsEvent,
@@ -355,7 +356,9 @@ const ChoosePassword = () => {
           routes: [
             {
               name: Routes.ONBOARDING.SUCCESS,
-              params: { showPasswordHint: true },
+              params: {
+                successFlow: ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
+              },
             },
           ],
         });

--- a/app/components/Views/OnboardingSuccess/index.tsx
+++ b/app/components/Views/OnboardingSuccess/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useLayoutEffect } from 'react';
+import { Platform } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -105,13 +106,19 @@ export const OnboardingSuccessComponent: React.FC<OnboardingSuccessProps> = ({
     return strings('onboarding_success.wallet_ready');
   };
 
+  const shouldSkipSuccessAnimation =
+    Platform.OS === 'android' &&
+    successFlow === ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING;
+
   const renderContent = () => (
     <>
-      <OnboardingSuccessEndAnimation
-        onAnimationComplete={() => {
-          // No-op: Animation completion not needed in success mode
-        }}
-      />
+      {!shouldSkipSuccessAnimation && (
+        <OnboardingSuccessEndAnimation
+          onAnimationComplete={() => {
+            // No-op: Animation completion not needed in success mode
+          }}
+        />
+      )}
       <Text
         variant={TextVariant.DisplayMd}
         fontFamily={FontFamily.Accent}

--- a/app/constants/onboarding.ts
+++ b/app/constants/onboarding.ts
@@ -69,6 +69,7 @@ export enum ONBOARDING_SUCCESS_FLOW {
   BACKED_UP_SRP = 'backedUpSRP',
   NO_BACKED_UP_SRP = 'noBackedUpSRP',
   IMPORT_FROM_SEED_PHRASE = 'importFromSeedPhrase',
+  SEEDLESS_ONBOARDING = 'seedlessOnboarding',
   SETTINGS_BACKUP = 'settingsBackup',
   REMINDER_BACKUP = 'reminderBackup',
 }

--- a/app/util/onboarding/walletHomeOnboardingStepsEligibility.test.ts
+++ b/app/util/onboarding/walletHomeOnboardingStepsEligibility.test.ts
@@ -6,6 +6,7 @@ describe('shouldMarkWalletHomeOnboardingStepsEligible', () => {
     ONBOARDING_SUCCESS_FLOW.BACKED_UP_SRP,
     ONBOARDING_SUCCESS_FLOW.NO_BACKED_UP_SRP,
     ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE,
+    ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING,
   ])('returns true for first-time onboarding flow %s', (flow) => {
     expect(shouldMarkWalletHomeOnboardingStepsEligible(flow)).toBe(true);
   });

--- a/app/util/onboarding/walletHomeOnboardingStepsEligibility.ts
+++ b/app/util/onboarding/walletHomeOnboardingStepsEligibility.ts
@@ -23,6 +23,7 @@ export function shouldMarkWalletHomeOnboardingStepsEligible(
   return (
     successFlow === ONBOARDING_SUCCESS_FLOW.BACKED_UP_SRP ||
     successFlow === ONBOARDING_SUCCESS_FLOW.NO_BACKED_UP_SRP ||
-    successFlow === ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE
+    successFlow === ONBOARDING_SUCCESS_FLOW.IMPORT_FROM_SEED_PHRASE ||
+    successFlow === ONBOARDING_SUCCESS_FLOW.SEEDLESS_ONBOARDING
   );
 }


### PR DESCRIPTION
## Description

Cherry-pick of #30765 with manual conflict resolution.

Skips success animation on Android for seedless onboarding flow to prevent crash on new social login users.

## Changes
- Add `SEEDLESS_ONBOARDING` to `ONBOARDING_SUCCESS_FLOW` enum
- Skip success animation on Android for seedless onboarding
- Include seedless onboarding in wallet home steps eligibility

## Original PR
https://github.com/MetaMask/metamask-mobile/pull/30765

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI/navigation guard on Android for one onboarding flow; no auth or wallet-core logic changes beyond existing success-flow routing.
> 
> **Overview**
> Fixes an **Android crash** when new **social (seedless) login** users finish password setup by skipping the Rive-based **onboarding success animation** on that platform for the new flow.
> 
> **Choose Password** now resets navigation to **Onboarding Success** with `successFlow: SEEDLESS_ONBOARDING` instead of `showPasswordHint: true`, and a matching **`SEEDLESS_ONBOARDING`** value is added to **`ONBOARDING_SUCCESS_FLOW`**. **Onboarding Success** conditionally omits **`OnboardingSuccessEndAnimation`** when `Platform.OS === 'android'` and the flow is seedless. **Wallet home onboarding steps** eligibility treats seedless onboarding like other first-time completion flows, with tests updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ce6486d11117d8e3cf5ca37c94da88a56e6042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->