### PR TITLE
refactor(card): migrate card routes to native stack

### DIFF
--- a/app/components/UI/Card/routes/index.test.tsx
+++ b/app/components/UI/Card/routes/index.test.tsx
@@ -7,10 +7,10 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import CardRoutes from './index';
 
-jest.mock('@react-navigation/stack', () => {
+jest.mock('@react-navigation/native-stack', () => {
   const { View, Text } = require('react-native');
   return {
-    createStackNavigator: () => ({
+    createNativeStackNavigator: () => ({
       Navigator: ({
         children,
         screenOptions,

--- a/app/components/UI/Card/routes/index.tsx
+++ b/app/components/UI/Card/routes/index.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
 import {
-  createStackNavigator,
-  StackNavigationOptions,
-} from '@react-navigation/stack';
+  createNativeStackNavigator,
+  NativeStackNavigationOptions,
+} from '@react-navigation/native-stack';
 import Routes from '../../../../constants/navigation/Routes';
 import CardHome from '../Views/CardHome/CardHome';
 import CardWelcome from '../Views/CardWelcome/CardWelcome';
@@ -29,14 +29,17 @@ import SpendingLimitOptionsSheet from '../Views/SpendingLimit/components/Spendin
 import WaitlistFormModal from '../components/WaitlistFormModal/WaitlistFormModal';
 import OrderCompleted from '../Views/OrderCompleted/OrderCompleted';
 import Cashback from '../Views/Cashback/Cashback';
-import { clearStackNavigatorOptions } from '../../../../constants/navigation/clearStackNavigatorOptions';
+import {
+  clearNativeStackNavigatorOptions,
+  transparentModalScreenOptions,
+} from '../../../../constants/navigation/clearStackNavigatorOptions';
 
-const Stack = createStackNavigator();
-const ModalsStack = createStackNavigator();
+const Stack = createNativeStackNavigator();
+const ModalsStack = createNativeStackNavigator();
 
 // All Card main screens render their own header via HeaderStandard, so hide
 // the navigator chrome by default.
-const mainScreenOptions: StackNavigationOptions = { headerShown: false };
+const mainScreenOptions: NativeStackNavigationOptions = { headerShown: false };
 
 // SpendingLimit's onboarding flow renders a close (X) header and must not be
 // swipe-dismissable; all other flows keep the default gesture behavior.
@@ -44,7 +47,7 @@ const spendingLimitScreenOptions = ({
   route,
 }: {
   route: { params?: { flow?: 'manage' | 'enable' | 'onboarding' } };
-}): StackNavigationOptions => ({
+}): NativeStackNavigationOptions => ({
   headerShown: false,
   gestureEnabled: route.params?.flow !== 'onboarding',
 });
@@ -95,7 +98,10 @@ const MainRoutes = () => {
 
 const CardModalsRoutes = () => (
   <ModalsStack.Navigator
-    screenOptions={{ ...clearStackNavigatorOptions, presentation: 'modal' }}
+    screenOptions={{
+      ...clearNativeStackNavigatorOptions,
+      ...transparentModalScreenOptions,
+    }}
   >
     <ModalsStack.Screen
       name={Routes.CARD.MODALS.ADD_FUNDS}
@@ -150,8 +156,8 @@ const CardRoutes = () => (
       name={Routes.CARD.MODALS.ID}
       component={CardModalsRoutes}
       options={{
-        ...clearStackNavigatorOptions,
-        detachPreviousScreen: false,
+        ...clearNativeStackNavigatorOptions,
+        ...transparentModalScreenOptions,
       }}
     />
   </Stack.Navigator>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Migrates the Card feature's route navigators (`app/components/UI/Card/routes/index.tsx`) from `@react-navigation/stack` (JS stack) to `@react-navigation/native-stack`.

Both the main Card stack and the Card modals stack now use `createNativeStackNavigator`, bringing the Card feature in line with the native-stack pattern already used across the app (Perps, Earn, Money, Bridge, Predict, etc.) and improving navigation performance/feel by using the platform-native navigation primitives.

Key changes:
- Swap `createStackNavigator` → `createNativeStackNavigator` for both `Stack` and `ModalsStack`.
- Replace `StackNavigationOptions` types with `NativeStackNavigationOptions`.
- Replace the JS-stack modal options (`clearStackNavigatorOptions` + `presentation: 'modal'` + `detachPreviousScreen: false`) with the native-stack equivalents: `clearNativeStackNavigatorOptions` + `transparentModalScreenOptions`.
- Preserve existing behavior:
  - Main screens keep `headerShown: false` (screens render their own `HeaderStandard`).
  - SpendingLimit's onboarding flow keeps its non-swipe-dismissable gesture handling (`gestureEnabled: route.params?.flow !== 'onboarding'`).
- Update `routes/index.test.tsx` to mock `@react-navigation/native-stack` / `createNativeStackNavigator` instead of the JS stack.
No routes, screen names, or params were added or removed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card native-stack navigation
  
Scenario: Main Card screens navigate correctly
    Given I am in the Card feature
    When I navigate between Home, Welcome, ChooseYourCard, ReviewOrder, OrderCompleted, Cashback, Authentication, 
SpendingLimit, and Onboarding
    Then each screen renders with its own header and the correct transitions
  
Scenario: Card modals present correctly
    Given I am on a Card screen
    When I open each modal (AddFunds, AssetSelection, RegionSelection, Confirm, Password, RecurringFee, DaimoPay, ViewPin, SpendingLimitOptions, WaitlistForm)
    Then the modal presents as a transparent modal over the underlying screen
    And dismissing the modal returns to the previous screen
  
Scenario: SpendingLimit onboarding gesture
    Given I open SpendingLimit with flow "onboarding"
    Then the screen cannot be swipe-dismissed
    And other SpendingLimit flows (manage/enable) keep default gesture behavior
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

|before|after|
|---|---|
|<img width="370" height="768" alt="Card routes before" src="https://github.com/user-attachments/assets/4b91b870-66f1-44c0-9b72-ecbe6eee5dc9" />|<img width="370" height="768" alt="Card routes after" src="https://github.com/user-attachments/assets/08dc83ab-1c0f-4df8-b01d-0228c97a3e9a" />|

### **Before**
iOS
https://github.com/user-attachments/assets/8167ef3d-5a04-45fb-8d62-dddc4e217e9a
Android
https://github.com/user-attachments/assets/b4e5be48-3de3-4d58-8b30-42d5bfbd291e

### **After**
iOS
https://github.com/user-attachments/assets/e672a50d-a383-4049-a9f8-1038923de3a8
Android
https://github.com/user-attachments/assets/ae584d78-cfb4-4b08-bc61-26c9a66df6b3

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Navigation stack and modal presentation behavior change at the framework level; regressions could affect all Card screens and bottom-sheet modals even though routes are unchanged.
> 
> **Overview**
> Card navigation is switched from the JavaScript `@react-navigation/stack` implementation to `@react-navigation/native-stack` for both the main Card stack and the nested modals stack, matching other app areas and using platform-native transitions.
> 
> Modal presentation no longer uses `clearStackNavigatorOptions` with `presentation: 'modal'` and `detachPreviousScreen: false`. It now uses **`clearNativeStackNavigatorOptions`** plus **`transparentModalScreenOptions`** (`presentation: 'transparentModal'`). Main screens still hide the default header, and **SpendingLimit** still disables swipe-back when `flow` is `onboarding`.
> 
> Tests mock **`createNativeStackNavigator`** instead of the JS stack. Route names and screens are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c156896664be3e34423c092262f61c74d2d5335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->