### PR TITLE
fix: make "View cherry-picks" Slack link to navigate to the correct build comment

### DIFF
--- a/scripts/build-announce/cherry-picks-section.ts
+++ b/scripts/build-announce/cherry-picks-section.ts
@@ -177,7 +177,7 @@ function buildCommitTable(commits: { hash: string; subject: string }[]): string 
   return lines.join('\n');
 }
 
-export function buildWhatsInRcSection(result: WhatsInRcResult): string {
+export function buildWhatsInRcSection(result: WhatsInRcResult, buildNumber?: string): string {
   const { cherryPicks, changelog } = result;
 
   // If both are empty, return nothing
@@ -185,14 +185,17 @@ export function buildWhatsInRcSection(result: WhatsInRcResult): string {
     return '';
   }
 
+  // Use build number for unique anchors so Slack can link to the correct comment
+  const anchorSuffix = buildNumber ? `-${buildNumber}` : '';
+
   const lines: string[] = [
-    '<a id="whats-in-this-rc"></a>',
+    `<a id="whats-in-this-rc${anchorSuffix}"></a>`,
     '### :cherries: What\'s in this RC\n',
   ];
 
   // Cherry-picks section
   if (cherryPicks.length > 0) {
-    lines.push('<a id="cherry-picks"></a>');
+    lines.push(`<a id="cherry-picks${anchorSuffix}"></a>`);
     lines.push('<details>');
     lines.push(`<summary>Cherry-picks (${cherryPicks.length} commits)</summary>\n`);
     lines.push(buildCommitTable(cherryPicks));
@@ -201,7 +204,7 @@ export function buildWhatsInRcSection(result: WhatsInRcResult): string {
 
   // Changelog section
   if (changelog.length > 0) {
-    lines.push('<a id="changelog"></a>');
+    lines.push(`<a id="changelog${anchorSuffix}"></a>`);
     lines.push('<details>');
     lines.push(`<summary>Changelog (${changelog.length} commits from main at RC cut)</summary>\n`);
     lines.push(buildCommitTable(changelog));

--- a/scripts/build-announce/cherry-picks-section.ts
+++ b/scripts/build-announce/cherry-picks-section.ts
@@ -186,7 +186,8 @@ export function buildWhatsInRcSection(result: WhatsInRcResult, buildNumber?: str
   }
 
   // Use build number for unique anchors so Slack can link to the correct comment
-  const anchorSuffix = buildNumber ? `-${buildNumber}` : '';
+  const isValidBuildNumber = buildNumber && buildNumber !== 'Unknown' && buildNumber !== 'N/A';
+  const anchorSuffix = isValidBuildNumber ? `-${buildNumber}` : '';
 
   const lines: string[] = [
     `<a id="whats-in-this-rc${anchorSuffix}"></a>`,

--- a/scripts/build-announce/index.ts
+++ b/scripts/build-announce/index.ts
@@ -182,8 +182,9 @@ ${buildMoreInfoSection(buildInfo)}
   }
 
   // Add "What's in this RC" section (cherry-picks + changelog)
+  // Pass build number for unique anchor IDs (so Slack can link to correct comment)
   if (whatsInRc.result) {
-    const section = buildWhatsInRcSection(whatsInRc.result);
+    const section = buildWhatsInRcSection(whatsInRc.result, buildInfo.androidBuildNumber);
     if (section) {
       body += `---\n\n`;
       body += section;

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -126,8 +126,9 @@ function buildSlackMessage(options) {
   ];
 
   // Add link to cherry-picks section in PR comment
+  // Note: GitHub prefixes user-provided anchor IDs with 'user-content-' for security
   if (prNumber) {
-    const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#cherry-picks|View cherry-picks>`;
+    const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks|View cherry-picks>`;
     blocks.push(
       {
         type: 'divider',

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -70,6 +70,7 @@ function buildSlackMessage(options) {
   const {
     version,
     buildNumber,
+    androidBuildNumber,
     androidUrl,
     iosUrl,
     pipelineUrl,
@@ -126,9 +127,11 @@ function buildSlackMessage(options) {
   ];
 
   // Add link to cherry-picks section in PR comment
-  // Note: GitHub prefixes user-provided anchor IDs with 'user-content-' for security
+  // Note: GitHub prefixes user-provided anchor IDs with 'user-content-'
+  // We use build number in anchor to link to the correct comment (not older builds)
   if (prNumber) {
-    const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks|View cherry-picks>`;
+    const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
+    const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks${anchorSuffix}|View cherry-picks>`;
     blocks.push(
       {
         type: 'divider',
@@ -293,6 +296,7 @@ async function main() {
   const payload = buildSlackMessage({
     version,
     buildNumber,
+    androidBuildNumber,
     androidUrl,
     iosUrl,
     pipelineUrl,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
- Fix "View cherry-picks" Slack link to navigate to the correct build comment                               
- Each RC build comment now gets a unique anchor with the build number (e.g., `cherry-picks-5208`)          
- Slack notification uses matching anchor so it links to that specific build, not older comments  
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="604" height="289" alt="Screenshot 2026-05-29 at 1 19 06 AM" src="https://github.com/user-attachments/assets/5e935c27-d227-4ea6-ae0f-f5a13303d14b" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and notification scripts only; no app runtime, auth, or user data paths.
> 
> **Overview**
> RC build PR comments and Slack notifications now use **per-build HTML anchor IDs** (e.g. `cherry-picks-5208`) so deep links land on the right comment when multiple RC posts exist on the same PR.
> 
> `buildWhatsInRcSection` accepts an optional Android build number and appends it to the `whats-in-this-rc`, `cherry-picks`, and `changelog` anchors when the value is present and not `Unknown` / `N/A`. The build-announce script passes `androidBuildNumber` from parsed build info when posting the comment.
> 
> The Slack RC script builds the **View cherry-picks** URL with GitHub’s `user-content-` anchor prefix and the same build-number suffix so it matches the comment anchors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b918995190fec9e04209d5b3e422f5eda88d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->