### PR TITLE
chore: remove inconsistencies on token import flow

### DIFF
--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -48,22 +48,6 @@ const AddAsset = () => {
 
   const sheetRef = useRef<BottomSheetRef>(null);
 
-  const renderNetworkSelector = useCallback(
-    () => (
-      <NetworkListBottomSheet
-        selectedNetwork={selectedNetwork}
-        setSelectedNetwork={async (network) => {
-          setSelectedNetwork(network);
-        }}
-        setOpenNetworkSelector={setOpenNetworkSelector}
-        sheetRef={sheetRef}
-        displayEvmNetworksOnly={assetType === 'collectible'}
-      />
-    ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [openNetworkSelector, networkConfigurations, selectedNetwork, assetType],
-  );
-
   return (
     <SafeAreaView
       edges={['left', 'right', 'bottom']}
@@ -95,7 +79,15 @@ const AddAsset = () => {
         />
       )}
 
-      {openNetworkSelector ? renderNetworkSelector() : null}
+      {openNetworkSelector ? (
+        <NetworkListBottomSheet
+          selectedNetwork={selectedNetwork}
+          setSelectedNetwork={setSelectedNetwork}
+          setOpenNetworkSelector={setOpenNetworkSelector}
+          sheetRef={sheetRef}
+          displayEvmNetworksOnly={assetType === 'collectible'}
+        />
+      ) : null}
     </SafeAreaView>
   );
 };

--- a/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.test.tsx
+++ b/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.test.tsx
@@ -4,7 +4,12 @@ import { backgroundState } from '../../../../../util/test/initial-root-state';
 import renderWithProvider, {
   DeepPartial,
 } from '../../../../../util/test/renderWithProvider';
-import { userEvent } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  userEvent,
+  waitFor,
+} from '@testing-library/react-native';
 import { RootState } from '../../../../../reducers';
 import { mockNetworkState } from '../../../../../util/test/network';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
@@ -14,6 +19,7 @@ import {
   TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter/BottomSheetFooter.constants';
 import Routes from '../../../../../constants/navigation/Routes';
+import Logger from '../../../../../util/Logger';
 
 const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
@@ -37,6 +43,15 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   useRoute: jest.fn(),
   createNavigationDetails: jest.fn(),
 }));
+
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+const mockLoggerError = Logger.error as jest.Mock;
 
 const DEFAULT_ASSET = {
   address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
@@ -139,6 +154,78 @@ describe('ConfirmAddAsset', () => {
 
     expect(mockAddTokenList).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
+      screen: Routes.WALLET.TAB_STACK_FLOW,
+      params: {
+        screen: Routes.WALLET_VIEW,
+      },
+    });
+  });
+
+  it('shows loading feedback and prevents duplicate import presses', async () => {
+    let resolveImport: () => void = jest.fn();
+    const pendingImport = new Promise<void>((resolve) => {
+      resolveImport = resolve;
+    });
+    const addTokenList = jest.fn(() => pendingImport);
+    setupParams({ addTokenList });
+
+    const { getByTestId } = renderWithProvider(<ConfirmAddAsset />, {
+      state: mockInitialState,
+    });
+
+    fireEvent.press(getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT));
+
+    expect(addTokenList).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(
+        getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT),
+      ).toBeDisabled();
+      expect(getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON)).toBeDisabled();
+    });
+
+    fireEvent.press(getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT));
+    expect(addTokenList).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveImport();
+      await pendingImport;
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
+        screen: Routes.WALLET.TAB_STACK_FLOW,
+        params: {
+          screen: Routes.WALLET_VIEW,
+        },
+      });
+    });
+  });
+
+  it('resets loading state and logs when import fails', async () => {
+    const addTokenList = jest
+      .fn()
+      .mockRejectedValue(new Error('Import failed'));
+    setupParams({ addTokenList });
+
+    const { getByTestId } = renderWithProvider(<ConfirmAddAsset />, {
+      state: mockInitialState,
+    });
+
+    fireEvent.press(getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT));
+
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.any(Error),
+        'ConfirmAddAsset: failed to import tokens',
+      );
+    });
+
+    expect(
+      getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT),
+    ).toBeEnabled();
+    expect(getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON)).toBeEnabled();
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.WALLET.HOME, {
       screen: Routes.WALLET.TAB_STACK_FLOW,
       params: {
         screen: Routes.WALLET_VIEW,

--- a/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.tsx
+++ b/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -6,12 +6,6 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../locales/i18n';
 import { useNavigation } from '@react-navigation/native';
 import getHeaderCompactStandardNavbarOptions from '../../../../../component-library/components-temp/HeaderCompactStandard/getHeaderCompactStandardNavbarOptions';
-import Badge, {
-  BadgeVariant,
-} from '../../../../../component-library/components/Badges/Badge';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../component-library/components/Badges/BadgeWrapper';
 import {
   ButtonSize,
   ButtonVariants,
@@ -19,44 +13,37 @@ import {
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import ListItem from '../../../../../component-library/components/List/ListItem';
 import Routes from '../../../../../constants/navigation/Routes';
 import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
-import { Hex } from '@metamask/utils';
-import { NetworkBadgeSource } from '../../../../UI/AssetOverview/Balance/Balance';
-import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
-import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import { FlashList } from '@shopify/flash-list';
-import {
-  Box,
-  BoxFlexDirection,
-  BoxAlignItems,
-  Text,
-  TextVariant,
-  TextColor,
-} from '@metamask/design-system-react-native';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import { ImportAsset } from '../../utils/utils';
+import AddAssetTokenRow from '../../components/AddAssetTokenRow/AddAssetTokenRow';
+import Logger from '../../../../../util/Logger';
 
 const ConfirmAddAsset = () => {
   const { selectedAsset, networkName, addTokenList } = useParams<{
     selectedAsset: ImportAsset[];
     networkName: string;
-    addTokenList: () => void;
+    addTokenList: () => Promise<void>;
   }>();
 
   const tw = useTailwind();
   const navigation = useNavigation();
+  const [isImporting, setIsImporting] = useState(false);
 
   /**
    * Go to wallet page
    */
-  const goToWalletPage = () => {
+  const goToWalletPage = useCallback(() => {
     navigation.navigate(Routes.WALLET.HOME, {
       screen: Routes.WALLET.TAB_STACK_FLOW,
       params: {
         screen: Routes.WALLET_VIEW,
       },
     });
-  };
+  }, [navigation]);
 
   const updateNavBar = useCallback(() => {
     navigation.setOptions(
@@ -72,62 +59,47 @@ const ConfirmAddAsset = () => {
     updateNavBar();
   }, [updateNavBar]);
 
+  const handleImport = useCallback(async () => {
+    if (isImporting) {
+      return;
+    }
+
+    setIsImporting(true);
+
+    try {
+      await addTokenList();
+      goToWalletPage();
+    } catch (error) {
+      Logger.error(error as Error, 'ConfirmAddAsset: failed to import tokens');
+      setIsImporting(false);
+    }
+  }, [addTokenList, goToWalletPage, isImporting]);
+
   return (
     <SafeAreaView
-      style={tw.style('flex-1 py-4 bg-default')}
+      edges={['left', 'right', 'bottom']}
+      style={tw.style('flex-1 bg-default')}
       testID={ImportTokenViewSelectorsIDs.ADD_CONFIRM_CUSTOM_ASSET}
     >
-      <Text variant={TextVariant.BodyMd} style={tw.style('text-center')}>
-        {selectedAsset.length > 1
-          ? strings('wallet.import_tokens')
-          : strings('wallet.import_token')}
-      </Text>
+      <Box twClassName="flex-1 pt-2">
+        <Text variant={TextVariant.BodyMd} style={tw.style('text-center px-4')}>
+          {selectedAsset.length > 1
+            ? strings('wallet.import_tokens')
+            : strings('wallet.import_token')}
+        </Text>
 
-      <FlashList
-        data={selectedAsset}
-        style={tw.style('bg-default p-4')}
-        renderItem={({ item: asset, index }) => (
-          <Box
-            key={index}
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="mr-2.5 gap-5 py-2.5"
-          >
-            <Box>
-              <BadgeWrapper
-                badgePosition={BadgePosition.BottomRight}
-                badgeElement={
-                  <Badge
-                    variant={BadgeVariant.Network}
-                    imageSource={NetworkBadgeSource(asset.chainId as Hex)}
-                    name={networkName}
-                  />
-                }
-              >
-                {asset.image && (
-                  <AvatarToken
-                    name={asset.symbol}
-                    imageSource={{ uri: asset.image }}
-                    size={AvatarSize.Lg}
-                  />
-                )}
-              </BadgeWrapper>
-            </Box>
-
-            <Box>
-              <Text variant={TextVariant.BodyLg}>{asset.name}</Text>
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-                style={tw.style('uppercase')}
-              >
-                {asset.symbol}
-              </Text>
-            </Box>
-          </Box>
-        )}
-        keyExtractor={(_, index) => `token-search-row-${index}`}
-      />
+        <FlashList
+          data={selectedAsset}
+          style={tw.style('flex-1 bg-default')}
+          contentContainerStyle={tw.style('pt-6 px-6 pb-4')}
+          renderItem={({ item: asset, index }) => (
+            <ListItem key={index} gap={20} style={tw.style('p-0')}>
+              <AddAssetTokenRow asset={asset} networkName={networkName} />
+            </ListItem>
+          )}
+          keyExtractor={(_, index) => `token-search-row-${index}`}
+        />
+      </Box>
 
       <BottomSheetFooter
         buttonPropsArray={[
@@ -136,19 +108,19 @@ const ConfirmAddAsset = () => {
             label: strings('confirmation_modal.cancel_cta'),
             variant: ButtonVariants.Secondary,
             size: ButtonSize.Lg,
+            isDisabled: isImporting,
           },
           {
-            onPress: async () => {
-              await addTokenList();
-              goToWalletPage();
-            },
+            onPress: handleImport,
             label: strings('swaps.Import'),
             variant: ButtonVariants.Primary,
             size: ButtonSize.Lg,
+            loading: isImporting,
+            isDisabled: isImporting,
           },
         ]}
         buttonsAlignment={ButtonsAlignment.Horizontal}
-        style={tw.style('px-4 pt-6', Platform.OS !== 'android' && 'pb-4')}
+        style={tw.style('px-4 pt-4', Platform.OS !== 'android' && 'pb-4')}
       />
     </SafeAreaView>
   );

--- a/app/components/Views/AddAsset/components/AddAssetTokenRow/AddAssetTokenRow.tsx
+++ b/app/components/Views/AddAsset/components/AddAssetTokenRow/AddAssetTokenRow.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import BadgeNetwork from '../../../../../component-library/components/Badges/Badge/variants/BadgeNetwork';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
+import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { NetworkBadgeSource } from '../../../../UI/AssetOverview/Balance/Balance';
+import { ImportAsset } from '../../utils/utils';
+
+interface AddAssetTokenRowProps {
+  asset: ImportAsset;
+  networkName?: string;
+}
+
+const AddAssetTokenRow = ({ asset, networkName }: AddAssetTokenRowProps) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="flex-1 h-16"
+  >
+    <Box>
+      <BadgeWrapper
+        badgePosition={BadgePosition.BottomRight}
+        badgeElement={
+          <BadgeNetwork
+            imageSource={NetworkBadgeSource(asset.chainId as `0x${string}`)}
+            name={networkName}
+          />
+        }
+      >
+        {asset.image && (
+          <AvatarToken
+            name={asset.symbol}
+            imageSource={{ uri: asset.image }}
+            size={AvatarSize.Lg}
+          />
+        )}
+      </BadgeWrapper>
+    </Box>
+    <Box twClassName="flex-1 ml-5 justify-center">
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {asset.name}
+      </Text>
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+      >
+        {asset.symbol}
+      </Text>
+    </Box>
+  </Box>
+);
+
+export default AddAssetTokenRow;

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -1,11 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import {
-  InteractionManager,
-  TextInput,
-  TouchableOpacity,
-  LayoutAnimation,
-  Platform,
-} from 'react-native';
+import { InteractionManager, LayoutAnimation, Platform } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Engine from '../../../../../core/Engine';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -27,13 +21,8 @@ import {
   ButtonVariant,
   ButtonSize,
   Box,
-  BoxFlexDirection,
-  BoxAlignItems,
   Text,
-  Icon,
-  IconName,
-  IconSize,
-  IconColor,
+  TextFieldSearch,
 } from '@metamask/design-system-react-native';
 import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -484,42 +473,24 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
 
       <Box twClassName="flex-1">
         <Box twClassName="m-4">
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="bg-muted rounded-lg px-3"
-            style={tw.style('min-h-[44px]')}
-            testID={ImportTokenViewSelectorsIDs.ASSET_SEARCH_CONTAINER}
-          >
-            <Icon
-              name={IconName.Search}
-              size={IconSize.Md}
-              color={IconColor.IconMuted}
-              style={tw.style('mr-2')}
-            />
-            <TextInput
-              style={tw.style('flex-1 text-base text-default')}
+          <Box testID={ImportTokenViewSelectorsIDs.ASSET_SEARCH_CONTAINER}>
+            <TextFieldSearch
               value={searchQuery}
+              onChangeText={setSearchQuery}
+              onPressClearButton={() => setSearchQuery('')}
+              clearButtonProps={{
+                testID: ImportTokenViewSelectorsIDs.CLEAR_SEARCH_BAR,
+              }}
+              inputProps={{
+                autoCapitalize: 'none',
+                keyboardAppearance: themeAppearance,
+                testID: ImportTokenViewSelectorsIDs.SEARCH_BAR,
+              }}
               onFocus={() => setFocusState(true)}
               onBlur={() => setFocusState(false)}
+              autoFocus={false}
               placeholder={strings('token.search_tokens_placeholder')}
-              placeholderTextColor={colors.text.muted}
-              onChangeText={setSearchQuery}
-              testID={ImportTokenViewSelectorsIDs.SEARCH_BAR}
-              keyboardAppearance={themeAppearance}
             />
-            {searchQuery.length > 0 && (
-              <TouchableOpacity
-                onPress={() => setSearchQuery('')}
-                testID={ImportTokenViewSelectorsIDs.CLEAR_SEARCH_BAR}
-              >
-                <Icon
-                  name={IconName.CircleX}
-                  size={IconSize.Md}
-                  color={IconColor.IconAlternative}
-                />
-              </TouchableOpacity>
-            )}
           </Box>
         </Box>
 
@@ -528,7 +499,6 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
           searchQuery={searchQuery}
           handleSelectAsset={handleSelectAsset}
           selectedAsset={selectedAssets}
-          chainId={selectedChainId ?? ''}
           networkName={networkName}
           alreadyAddedTokens={alreadyAddedTokens}
           isLoading={isLoading}

--- a/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.test.tsx
@@ -35,7 +35,6 @@ const defaultProps = {
   handleSelectAsset: mockHandleSelectAsset,
   selectedAsset: [] as ImportAsset[],
   searchQuery: '',
-  chainId: '0x1',
   networkName: 'Ethereum',
   alreadyAddedTokens: undefined as Set<string> | undefined,
   isLoading: false,

--- a/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.tsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import ListItemMultiSelect from '../../../../../component-library/components/List/ListItemMultiSelect';
 import { Image } from 'react-native';
-import Badge, {
-  BadgeVariant,
-} from '../../../../../component-library/components/Badges/Badge';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { strings } from '../../../../../../locales/i18n';
 import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
-import { NetworkBadgeSource } from '../../../../UI/AssetOverview/Balance/Balance';
 import { FlashList } from '@shopify/flash-list';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { useAssetFromTheme } from '../../../../../util/theme';
@@ -18,13 +11,14 @@ import emptyStateDefiDark from '../../../../../images/empty-state-defi-dark.png'
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
   Text,
   TextVariant,
   TextColor,
 } from '@metamask/design-system-react-native';
-import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
-import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import { ImportAsset } from '../../utils/utils';
+import AddAssetTokenRow from '../AddAssetTokenRow/AddAssetTokenRow';
 
 interface Props {
   /**
@@ -43,10 +37,6 @@ interface Props {
    * Search query that generated "searchResults"
    */
   searchQuery: string;
-  /**
-   * ChainID of the network
-   */
-  chainId: string;
   /**
    * Symbol of the network
    */
@@ -69,13 +59,28 @@ const TokenSkeleton = () => {
   const tw = useTailwind();
 
   return (
-    <ListItemMultiSelect isDisabled style={tw.style('flex-1 py-2.5')}>
-      <Box twClassName="flex-col items-start px-0.5">
-        <Skeleton width={40} height={40} style={tw.style('rounded-[20px]')} />
-      </Box>
-      <Box twClassName="flex-1 justify-center px-1">
-        <Skeleton width={120} height={20} style={tw.style('mb-2')} />
-        <Skeleton width={60} height={16} />
+    <ListItemMultiSelect isDisabled gap={20} style={tw.style('flex-1 py-0')}>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        twClassName="flex-1 h-16"
+      >
+        <Box twClassName="relative">
+          <Skeleton width={40} height={40} style={tw.style('rounded-[20px]')} />
+          <Skeleton
+            width={20}
+            height={20}
+            style={tw.style('absolute -bottom-1 -right-1 rounded-[10px]')}
+          />
+        </Box>
+        <Box twClassName="flex-1 ml-5 justify-center">
+          <Skeleton width={160} height={20} style={tw.style('rounded-md')} />
+          <Skeleton
+            width={64}
+            height={16}
+            style={tw.style('mt-1 rounded-md')}
+          />
+        </Box>
       </Box>
     </ListItemMultiSelect>
   );
@@ -132,7 +137,7 @@ const SearchTokenResults = ({
     <FlashList
       data={searchResults}
       renderItem={({ item, index }) => {
-        const { symbol, name, address, image } = item || {};
+        const { address } = item || {};
         const isOnSelected = selectedAsset.some(
           (token) => token.address === address,
         );
@@ -146,37 +151,13 @@ const SearchTokenResults = ({
           <ListItemMultiSelect
             isSelected={isSelected || isAlreadyAdded}
             isDisabled={isDisabled}
-            style={tw.style('flex-1 py-2.5')}
+            gap={20}
+            style={tw.style('flex-1 py-0')}
             key={`search-result-${index}`}
             onPress={() => !isDisabled && handleSelectAsset(item)}
             testID={ImportTokenViewSelectorsIDs.SEARCH_TOKEN_RESULT}
           >
-            <Box twClassName="flex-col items-start px-0.5">
-              <BadgeWrapper
-                badgePosition={BadgePosition.BottomRight}
-                badgeElement={
-                  <Badge
-                    variant={BadgeVariant.Network}
-                    imageSource={NetworkBadgeSource(
-                      item?.chainId as `0x${string}`,
-                    )}
-                    name={networkName}
-                  />
-                }
-              >
-                {image && (
-                  <AvatarToken
-                    name={symbol}
-                    imageSource={{ uri: image }}
-                    size={AvatarSize.Lg}
-                  />
-                )}
-              </BadgeWrapper>
-            </Box>
-            <Box twClassName="flex-1 justify-center px-1">
-              <Text variant={TextVariant.BodyLg}>{name}</Text>
-              <Text variant={TextVariant.BodyMd}>{symbol}</Text>
-            </Box>
+            <AddAssetTokenRow asset={item} networkName={networkName} />
           </ListItemMultiSelect>
         );
       }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

- Reused a shared `AddAssetTokenRow` across import search results and confirmation.
- Aligned token row icon, badge, title, subtitle, spacing, and skeleton sizing.
- Updated the import search field to use the shared `TextFieldSearch` pattern.
- Added loading/disabled feedback for the confirmation import action.
- Added tests for import loading, duplicate press prevention, failure handling, and search behavior.
- Kept Explore search bar unchanged.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove inconsistencies on token import flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3294

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and UX changes in the add-token flow with no auth, security, or wallet-core logic changes; import behavior is guarded with loading and error recovery.
> 
> **Overview**
> Unifies how tokens look in the **add/import** flow and hardens the confirm step when users tap **Import**.
> 
> A new **`AddAssetTokenRow`** component is shared by **search results** and **confirm import**, so avatar, network badge, name, and symbol use the same layout and typography (including **`BadgeNetwork`**). Search uses the design-system **`TextFieldSearch`** instead of a custom search bar; list rows and loading skeletons are aligned to the same **`h-16`** row spacing. **`SearchTokenResults`** no longer takes a **`chainId`** prop (network context comes from each asset).
> 
> **`ConfirmAddAsset`** treats **`addTokenList`** as async: import shows **loading**, **disables** Cancel/Import to block double-taps, **logs** failures and re-enables buttons without navigating away on error. **`AddAsset`** inlines the network bottom sheet without a memoized render callback.
> 
> Tests cover in-flight import, duplicate presses, and failed import recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99573ec8d9d48072d4ee28e6db588a5b96ecab31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->