### PR TITLE
feat(perps): add product pills row to Perps home screen

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -232,6 +232,7 @@ export const PerpsHomeViewSelectorsIDs = {
   POSITIONS_PNL_VALUE: 'perps-home-positions-pnl-value',
   SERVICE_INTERRUPTION_BANNER: 'perps-service-interruption-banner',
   COMPETITION_BANNER: 'perps-home-competition-banner',
+  PRODUCT_PILLS: 'perps-product-pills',
   // TabBar mock items (for testing)
   TAB_BAR_WALLET: 'tab-bar-item-wallet',
   TAB_BAR_BROWSER: 'tab-bar-item-browser',

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -81,6 +81,7 @@ import PerpsNavigationCard, {
 } from '../../components/PerpsNavigationCard/PerpsNavigationCard';
 import PerpsServiceInterruptionBanner from '../../components/PerpsServiceInterruptionBanner';
 import PerpsCompetitionBanner from '../../components/PerpsCompetitionBanner';
+import PerpsProductPills from '../../components/PerpsProductPills';
 
 interface PerpsHomeViewProps {
   hideHeader?: boolean;
@@ -579,6 +580,12 @@ const PerpsHomeView = ({
             ))}
           </View>
         </PerpsHomeSection>
+
+        {/* Product Pills Row */}
+        <PerpsProductPills
+          source={PERPS_EVENT_VALUE.SOURCE.PERPS_HOME}
+          transactionActiveAbTests={transactionActiveAbTests}
+        />
 
         {/* Watchlist Section */}
         <PerpsWatchlistMarkets

--- a/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.styles.ts
+++ b/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.styles.ts
@@ -1,0 +1,33 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../util/theme/models';
+
+export const styleSheet = (_params: { theme: Theme }) => {
+  const { theme } = _params;
+
+  return StyleSheet.create({
+    container: {
+      paddingVertical: 8,
+      marginBottom: 8,
+    },
+    scrollContent: {
+      flexDirection: 'row',
+      gap: 8,
+      paddingHorizontal: 16,
+    },
+    pill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      borderRadius: 99,
+      backgroundColor: theme.colors.background.muted,
+    },
+    pillPressed: {
+      opacity: 0.7,
+    },
+    pillLabel: {
+      color: theme.colors.text.default,
+    },
+  });
+};

--- a/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import PerpsProductPills from './PerpsProductPills';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+
+const mockNavigateToMarketList = jest.fn();
+const mockTrack = jest.fn();
+
+jest.mock('../../hooks/usePerpsNavigation', () => ({
+  usePerpsNavigation: () => ({
+    navigateToMarketList: mockNavigateToMarketList,
+  }),
+}));
+
+jest.mock('../../hooks/usePerpsEventTracking', () => ({
+  usePerpsEventTracking: () => ({
+    track: mockTrack,
+  }),
+}));
+
+describe('PerpsProductPills', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all product pills', () => {
+    const { getByTestId } = renderWithProvider(<PerpsProductPills />);
+
+    expect(getByTestId('perps-product-pills')).toBeDefined();
+    expect(getByTestId('perps-product-pills-crypto')).toBeDefined();
+    expect(getByTestId('perps-product-pills-stocks')).toBeDefined();
+    expect(getByTestId('perps-product-pills-commodities')).toBeDefined();
+    expect(getByTestId('perps-product-pills-forex')).toBeDefined();
+  });
+
+  it('navigates to market list with correct filter on pill press', () => {
+    const { getByTestId } = renderWithProvider(<PerpsProductPills />);
+
+    fireEvent.press(getByTestId('perps-product-pills-crypto'));
+
+    expect(mockNavigateToMarketList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultMarketTypeFilter: 'crypto',
+        source: 'perps_home__product_pill',
+        fromHome: true,
+      }),
+    );
+  });
+
+  it('tracks analytics event on pill press', () => {
+    const { getByTestId } = renderWithProvider(<PerpsProductPills />);
+
+    fireEvent.press(getByTestId('perps-product-pills-stocks'));
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEvents.PERPS_UI_INTERACTION,
+      expect.objectContaining({
+        product: 'stocks',
+        pill_position: 1,
+      }),
+    );
+  });
+
+  it('passes transactionActiveAbTests to navigation', () => {
+    const abTests = [{ testId: 'test-1', variantId: 'variant-a' }];
+    const { getByTestId } = renderWithProvider(
+      <PerpsProductPills transactionActiveAbTests={abTests as never} />,
+    );
+
+    fireEvent.press(getByTestId('perps-product-pills-forex'));
+
+    expect(mockNavigateToMarketList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultMarketTypeFilter: 'forex',
+        transactionActiveAbTests: abTests,
+      }),
+    );
+  });
+
+  it('tracks correct pill_position for each pill', () => {
+    const { getByTestId } = renderWithProvider(<PerpsProductPills />);
+
+    fireEvent.press(getByTestId('perps-product-pills-commodities'));
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEvents.PERPS_UI_INTERACTION,
+      expect.objectContaining({
+        product: 'commodities',
+        pill_position: 2,
+      }),
+    );
+  });
+});

--- a/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.test.tsx
@@ -48,8 +48,10 @@ describe('PerpsProductPills', () => {
     );
   });
 
-  it('tracks analytics event on pill press', () => {
-    const { getByTestId } = renderWithProvider(<PerpsProductPills />);
+  it('tracks analytics event on pill press with source', () => {
+    const { getByTestId } = renderWithProvider(
+      <PerpsProductPills source="perps_home" />,
+    );
 
     fireEvent.press(getByTestId('perps-product-pills-stocks'));
 
@@ -58,6 +60,7 @@ describe('PerpsProductPills', () => {
       expect.objectContaining({
         product: 'stocks',
         pill_position: 1,
+        source: 'perps_home',
       }),
     );
   });

--- a/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.tsx
+++ b/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.tsx
@@ -65,6 +65,7 @@ const PerpsProductPills: React.FC<PerpsProductPillsProps> = ({
         [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]: `product_pill_tapped`,
         [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
           PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+        [PERPS_EVENT_PROPERTY.SOURCE]: source,
         product: category,
         pill_position: index,
       });
@@ -80,7 +81,7 @@ const PerpsProductPills: React.FC<PerpsProductPillsProps> = ({
           : {}),
       });
     },
-    [track, perpsNavigation, transactionActiveAbTests],
+    [track, perpsNavigation, source, transactionActiveAbTests],
   );
 
   return (

--- a/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.tsx
+++ b/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback } from 'react';
+import { Pressable, ScrollView } from 'react-native';
+import {
+  Text,
+  TextVariant,
+  FontWeight,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+} from '@metamask/design-system-react-native';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+  type MarketTypeFilter,
+} from '@metamask/perps-controller';
+import { useStyles } from '../../../../../component-library/hooks';
+import { usePerpsNavigation } from '../../hooks/usePerpsNavigation';
+import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { strings } from '../../../../../../locales/i18n';
+import { styleSheet } from './PerpsProductPills.styles';
+import type {
+  PerpsProductPillsProps,
+  ProductPillConfig,
+} from './PerpsProductPills.types';
+
+const PRODUCT_PILLS: ProductPillConfig[] = [
+  {
+    category: 'crypto',
+    labelKey: 'perps.home.tabs.crypto',
+    icon: IconName.Coin,
+  },
+  {
+    category: 'stocks',
+    labelKey: 'perps.home.tabs.stocks',
+    icon: IconName.Graph,
+  },
+  {
+    category: 'commodities',
+    labelKey: 'perps.home.tabs.commodities',
+    icon: IconName.MoneyBag,
+  },
+  {
+    category: 'forex',
+    labelKey: 'perps.home.tabs.forex',
+    icon: IconName.Global,
+  },
+];
+
+const PerpsProductPills: React.FC<PerpsProductPillsProps> = ({
+  source,
+  transactionActiveAbTests,
+  testID = 'perps-product-pills',
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+  const perpsNavigation = usePerpsNavigation();
+  const { track } = usePerpsEventTracking();
+
+  const handlePillPress = useCallback(
+    (category: Exclude<MarketTypeFilter, 'all'>, index: number) => {
+      track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]: `product_pill_tapped`,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+        product: category,
+        pill_position: index,
+      });
+
+      perpsNavigation.navigateToMarketList({
+        defaultMarketTypeFilter: category,
+        source: 'perps_home__product_pill',
+        fromHome: true,
+        button_clicked: `product_pill_tapped`,
+        button_location: PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_HOME,
+        ...(transactionActiveAbTests?.length
+          ? { transactionActiveAbTests }
+          : {}),
+      });
+    },
+    [track, perpsNavigation, transactionActiveAbTests],
+  );
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.scrollContent}
+      style={styles.container}
+      testID={testID}
+    >
+      {PRODUCT_PILLS.map((pill, index) => (
+        <Pressable
+          key={pill.category}
+          style={({ pressed }) => [styles.pill, pressed && styles.pillPressed]}
+          onPress={() => handlePillPress(pill.category, index)}
+          testID={`${testID}-${pill.category}`}
+          accessibilityRole="button"
+          accessibilityLabel={strings(pill.labelKey)}
+        >
+          <Icon name={pill.icon} size={IconSize.Sm} color={IconColor.Default} />
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            style={styles.pillLabel}
+          >
+            {strings(pill.labelKey)}
+          </Text>
+        </Pressable>
+      ))}
+    </ScrollView>
+  );
+};
+
+export default PerpsProductPills;

--- a/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.types.ts
+++ b/app/components/UI/Perps/components/PerpsProductPills/PerpsProductPills.types.ts
@@ -1,0 +1,15 @@
+import { type MarketTypeFilter } from '@metamask/perps-controller';
+import { type IconName } from '@metamask/design-system-react-native';
+import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+
+export interface ProductPillConfig {
+  category: Exclude<MarketTypeFilter, 'all'>;
+  labelKey: string;
+  icon: IconName;
+}
+
+export interface PerpsProductPillsProps {
+  source?: string;
+  transactionActiveAbTests?: TransactionActiveAbTestEntry[];
+  testID?: string;
+}

--- a/app/components/UI/Perps/components/PerpsProductPills/index.ts
+++ b/app/components/UI/Perps/components/PerpsProductPills/index.ts
@@ -1,0 +1,5 @@
+export { default } from './PerpsProductPills';
+export type {
+  PerpsProductPillsProps,
+  ProductPillConfig,
+} from './PerpsProductPills.types';

--- a/app/components/Views/AddAsset/AddAsset.tsx
+++ b/app/components/Views/AddAsset/AddAsset.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -48,22 +48,6 @@ const AddAsset = () => {
 
   const sheetRef = useRef<BottomSheetRef>(null);
 
-  const renderNetworkSelector = useCallback(
-    () => (
-      <NetworkListBottomSheet
-        selectedNetwork={selectedNetwork}
-        setSelectedNetwork={async (network) => {
-          setSelectedNetwork(network);
-        }}
-        setOpenNetworkSelector={setOpenNetworkSelector}
-        sheetRef={sheetRef}
-        displayEvmNetworksOnly={assetType === 'collectible'}
-      />
-    ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [openNetworkSelector, networkConfigurations, selectedNetwork, assetType],
-  );
-
   return (
     <SafeAreaView
       edges={['left', 'right', 'bottom']}
@@ -95,7 +79,15 @@ const AddAsset = () => {
         />
       )}
 
-      {openNetworkSelector ? renderNetworkSelector() : null}
+      {openNetworkSelector && (
+        <NetworkListBottomSheet
+          selectedNetwork={selectedNetwork}
+          setSelectedNetwork={setSelectedNetwork}
+          setOpenNetworkSelector={setOpenNetworkSelector}
+          sheetRef={sheetRef}
+          displayEvmNetworksOnly={assetType === 'collectible'}
+        />
+      )}
     </SafeAreaView>
   );
 };

--- a/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.tsx
+++ b/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -6,6 +6,7 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../locales/i18n';
 import { useNavigation } from '@react-navigation/native';
 import getHeaderCompactStandardNavbarOptions from '../../../../../component-library/components-temp/HeaderCompactStandard/getHeaderCompactStandardNavbarOptions';
+import Logger from '../../../../../util/Logger';
 import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
@@ -40,23 +41,21 @@ const ConfirmAddAsset = () => {
   const { selectedAsset, networkName, addTokenList } = useParams<{
     selectedAsset: ImportAsset[];
     networkName: string;
-    addTokenList: () => void;
+    addTokenList: () => Promise<void>;
   }>();
 
   const tw = useTailwind();
   const navigation = useNavigation();
+  const [isImporting, setIsImporting] = useState(false);
 
-  /**
-   * Go to wallet page
-   */
-  const goToWalletPage = () => {
+  const goToWalletPage = useCallback(() => {
     navigation.navigate(Routes.WALLET.HOME, {
       screen: Routes.WALLET.TAB_STACK_FLOW,
       params: {
         screen: Routes.WALLET_VIEW,
       },
     });
-  };
+  }, [navigation]);
 
   const updateNavBar = useCallback(() => {
     navigation.setOptions(
@@ -71,6 +70,22 @@ const ConfirmAddAsset = () => {
   useEffect(() => {
     updateNavBar();
   }, [updateNavBar]);
+
+  const handleImport = useCallback(async () => {
+    if (isImporting) {
+      return;
+    }
+
+    setIsImporting(true);
+
+    try {
+      await addTokenList();
+      goToWalletPage();
+    } catch (error) {
+      Logger.error(error as Error, 'ConfirmAddAsset: failed to import tokens');
+      setIsImporting(false);
+    }
+  }, [addTokenList, goToWalletPage, isImporting]);
 
   return (
     <SafeAreaView
@@ -104,13 +119,11 @@ const ConfirmAddAsset = () => {
                   />
                 }
               >
-                {asset.image && (
-                  <AvatarToken
-                    name={asset.symbol}
-                    imageSource={{ uri: asset.image }}
-                    size={AvatarSize.Lg}
-                  />
-                )}
+                <AvatarToken
+                  name={asset.symbol}
+                  imageSource={asset.image ? { uri: asset.image } : undefined}
+                  size={AvatarSize.Lg}
+                />
               </BadgeWrapper>
             </Box>
 
@@ -136,15 +149,15 @@ const ConfirmAddAsset = () => {
             label: strings('confirmation_modal.cancel_cta'),
             variant: ButtonVariants.Secondary,
             size: ButtonSize.Lg,
+            isDisabled: isImporting,
           },
           {
-            onPress: async () => {
-              await addTokenList();
-              goToWalletPage();
-            },
+            onPress: handleImport,
             label: strings('swaps.Import'),
             variant: ButtonVariants.Primary,
             size: ButtonSize.Lg,
+            isDisabled: isImporting,
+            loading: isImporting,
           },
         ]}
         buttonsAlignment={ButtonsAlignment.Horizontal}

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -528,7 +528,6 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
           searchQuery={searchQuery}
           handleSelectAsset={handleSelectAsset}
           selectedAsset={selectedAssets}
-          chainId={selectedChainId ?? ''}
           networkName={networkName}
           alreadyAddedTokens={alreadyAddedTokens}
           isLoading={isLoading}

--- a/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.test.tsx
@@ -35,7 +35,6 @@ const defaultProps = {
   handleSelectAsset: mockHandleSelectAsset,
   selectedAsset: [] as ImportAsset[],
   searchQuery: '',
-  chainId: '0x1',
   networkName: 'Ethereum',
   alreadyAddedTokens: undefined as Set<string> | undefined,
   isLoading: false,

--- a/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenResults/SearchTokenResults.tsx
@@ -44,10 +44,6 @@ interface Props {
    */
   searchQuery: string;
   /**
-   * ChainID of the network
-   */
-  chainId: string;
-  /**
    * Symbol of the network
    */
   ticker?: string;
@@ -164,13 +160,11 @@ const SearchTokenResults = ({
                   />
                 }
               >
-                {image && (
-                  <AvatarToken
-                    name={symbol}
-                    imageSource={{ uri: image }}
-                    size={AvatarSize.Lg}
-                  />
-                )}
+                <AvatarToken
+                  name={symbol}
+                  imageSource={image ? { uri: image } : undefined}
+                  size={AvatarSize.Lg}
+                />
               </BadgeWrapper>
             </Box>
             <Box twClassName="flex-1 justify-center px-1">


### PR DESCRIPTION
## **Description**

Adds a horizontally scrollable row of product category pills (Crypto, Stocks, Commodities, Forex) to the Perps home screen, placed below the positions/orders section and above the watchlist/market sections.

**Motivation:** Most users who open MetaMask Perps assume it is crypto-only. There is no visible signal on the home screen that stocks, commodities, and forex markets exist. This widget provides fast-path navigation to each product category and improves first-time discovery.

**Solution:** A new `PerpsProductPills` component renders a horizontal scroll of pill-shaped buttons, each with an icon and label. Tapping a pill navigates to the Market List screen pre-filtered to that category. Analytics events (`PERPS_UI_INTERACTION` with `button_clicked = 'product_pill_tapped'`) are tracked with product name and pill position.

## **Changelog**

CHANGELOG entry: Added product category pills to Perps home screen for faster market discovery

## **Related issues**

Fixes: N/A (internal initiative — TAT-3159 / MMCPR-355)

## **Manual testing steps**

```gherkin
Feature: Perps Product Pills

  Scenario: user taps a product pill on Perps home
    Given the user is on the Perps home screen
    And the product pills row is visible below the orders section

    When user taps the "Stocks" pill
    Then the Market List screen opens filtered to Stocks markets
    And the active category filter matches "Stocks"

  Scenario: product pills row is horizontally scrollable
    Given the user is on the Perps home screen
    And there are more pills than fit the screen width

    When user swipes the pill row horizontally
    Then additional pills scroll into view without clipping

  Scenario: analytics event is tracked on pill tap
    Given the user is on the Perps home screen

    When user taps the "Commodities" pill
    Then a PERPS_UI_INTERACTION event is tracked
    And the event contains product="commodities" and pill_position=2
```

## **Screenshots/Recordings**

### **Before**

N/A — product pills did not exist on the home screen.

### **After**

N/A — requires device build to capture. The pill row appears between the orders section and the watchlist section.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
