### PR TITLE
refactor: remove homepage sections v1 feature flag

### DIFF
--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.test.tsx
@@ -31,7 +31,6 @@ jest.mock('../../../../../selectors/assets/balances', () => ({
 
 // Mock homepage feature flags (BalanceEmptyState and AccountGroupBalance use these)
 jest.mock('../../../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: jest.fn(() => true),
   selectWalletHomeOnboardingStepsEnabled: jest.fn(() => false),
 }));
 

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx
@@ -15,10 +15,7 @@ import {
   selectBalanceChangeBySelectedAccountGroup,
   selectAccountGroupBalanceForEmptyState,
 } from '../../../../../selectors/assets/balances';
-import {
-  selectHomepageSectionsV1Enabled,
-  selectWalletHomeOnboardingStepsEnabled,
-} from '../../../../../selectors/featureFlagController/homepage';
+import { selectWalletHomeOnboardingStepsEnabled } from '../../../../../selectors/featureFlagController/homepage';
 import {
   selectShouldShowWalletHomeOnboardingSteps,
   selectWalletHomeOnboardingSkipInitialBalanceWait,
@@ -70,9 +67,6 @@ const AccountGroupBalance = ({
   const { PreferencesController } = Engine.context;
   const styles = createStyles();
   const { formatCurrency } = useFormatters();
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
   const isWalletHomeOnboardingStepsEnabled = useSelector(
     selectWalletHomeOnboardingStepsEnabled,
   );
@@ -88,14 +82,12 @@ const AccountGroupBalance = ({
   const { popularNetworks } = useNetworkEnablement();
 
   // Stabilize chain IDs by content so selector identity doesn't change every render (avoids max depth / infinite loop).
-  // FF on: balance for all popular networks; FF off: balance for enabled networks only (selector uses state when undefined).
   const popularChainIdsKey = (popularNetworks ?? []).join(',');
   const chainIdsForBalance = useMemo(
-    () =>
-      isHomepageSectionsV1Enabled ? [...(popularNetworks ?? [])] : undefined,
+    () => [...(popularNetworks ?? [])],
     // popularChainIdsKey stabilizes by content; popularNetworks is a new array ref every render from the hook
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isHomepageSectionsV1Enabled, popularChainIdsKey],
+    [popularChainIdsKey],
   );
 
   const groupBalanceSelector = useMemo(
@@ -207,16 +199,12 @@ const AccountGroupBalance = ({
   // Check if current network is a testnet
   const isCurrentNetworkTestnet = TEST_NETWORK_IDS.includes(selectedChainId);
 
-  // Show empty state on accounts with an aggregated mainnet balance of zero (sections v1)
+  // Show empty state on accounts with an aggregated mainnet balance of zero
   const shouldShowEmptyState =
-    hasZeroAccountGroupBalance &&
-    isHomepageSectionsV1Enabled &&
-    !isCurrentNetworkTestnet;
+    hasZeroAccountGroupBalance && !isCurrentNetworkTestnet;
 
   const inWalletHomePostOnboardingFlow =
-    isHomepageSectionsV1Enabled &&
-    isWalletHomeOnboardingStepsEnabled &&
-    shouldShowWalletHomeOnboardingSteps;
+    isWalletHomeOnboardingStepsEnabled && shouldShowWalletHomeOnboardingSteps;
 
   /** While the flow is active, always use the checklist surface — never the balance row (avoids a flash before loading/empty state is known). */
   const showWalletHomeOnboardingStepsTile = inWalletHomePostOnboardingFlow;

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.walletHomeOnboarding.test.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.walletHomeOnboarding.test.tsx
@@ -27,7 +27,6 @@ jest.mock('../../../../../selectors/assets/balances', () => ({
 }));
 
 jest.mock('../../../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: jest.fn(() => true),
   selectWalletHomeOnboardingStepsEnabled: jest.fn(() => true),
 }));
 

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalancePerChain.test.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalancePerChain.test.tsx
@@ -10,10 +10,6 @@ jest.mock('../../../../../selectors/assets/balances', () => ({
   selectBalanceBySelectedAccountGroup: jest.fn(() => () => null),
 }));
 
-jest.mock('../../../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: jest.fn(() => true),
-}));
-
 const mockFormatCurrency = jest.fn((value: number, currency: string) =>
   currency.toUpperCase() === 'USD'
     ? `$${value.toFixed(2)}`
@@ -37,14 +33,10 @@ describe('AccountGroupBalancePerChain', () => {
     const { selectPrivacyMode } = jest.requireMock(
       '../../../../../selectors/preferencesController',
     );
-    const { selectHomepageSectionsV1Enabled } = jest.requireMock(
-      '../../../../../selectors/featureFlagController/homepage',
-    );
     (selectBalanceBySelectedAccountGroup as jest.Mock).mockImplementation(
       () => () => null,
     );
     (selectPrivacyMode as jest.Mock).mockReturnValue(false);
-    (selectHomepageSectionsV1Enabled as jest.Mock).mockReturnValue(true);
   });
 
   it('calls selectBalanceBySelectedAccountGroup with single-element array containing caipChainId', () => {
@@ -133,29 +125,5 @@ describe('AccountGroupBalancePerChain', () => {
     });
 
     expect(selectPrivacyMode).toHaveBeenCalled();
-  });
-
-  it('renders null when homepage sections v1 is disabled', () => {
-    const balanceValue = {
-      totalBalanceInUserCurrency: 100,
-      userCurrency: 'USD',
-    };
-    const { selectBalanceBySelectedAccountGroup } = jest.requireMock(
-      '../../../../../selectors/assets/balances',
-    );
-    const { selectHomepageSectionsV1Enabled } = jest.requireMock(
-      '../../../../../selectors/featureFlagController/homepage',
-    );
-    (selectBalanceBySelectedAccountGroup as jest.Mock).mockImplementation(
-      () => () => balanceValue,
-    );
-    (selectHomepageSectionsV1Enabled as jest.Mock).mockReturnValue(false);
-
-    const { queryByText } = renderWithProvider(
-      <AccountGroupBalancePerChain caipChainId="eip155:1" />,
-      { state: testState },
-    );
-
-    expect(queryByText('$100.00')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalancePerChain.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalancePerChain.tsx
@@ -8,7 +8,6 @@ import SensitiveText, {
 } from '../../../../../component-library/components/Texts/SensitiveText';
 import { TextVariant } from '../../../../../component-library/components/Texts/Text';
 import { useFormatters } from '../../../../hooks/useFormatters';
-import { selectHomepageSectionsV1Enabled } from '../../../../../selectors/featureFlagController/homepage';
 
 export interface AccountGroupBalancePerChainProps {
   caipChainId: CaipChainId;
@@ -23,9 +22,6 @@ const AccountGroupBalancePerChain = ({
 }: AccountGroupBalancePerChainProps) => {
   const { formatCurrency } = useFormatters();
   const privacyMode = useSelector(selectPrivacyMode);
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
 
   const balanceSelector = useMemo(
     () => selectBalanceBySelectedAccountGroup([caipChainId]),
@@ -41,7 +37,7 @@ const AccountGroupBalancePerChain = ({
   const userCurrency = groupBalance?.userCurrency ?? 'USD';
   const displayBalance = formatCurrency(totalBalance, userCurrency);
 
-  return isHomepageSectionsV1Enabled ? (
+  return (
     <SensitiveText
       isHidden={privacyMode}
       length={SensitiveTextLength.Short}
@@ -49,7 +45,7 @@ const AccountGroupBalancePerChain = ({
     >
       {displayBalance}
     </SensitiveText>
-  ) : null;
+  );
 };
 
 export default AccountGroupBalancePerChain;

--- a/app/components/UI/DeFiPositions/DeFiPositionsControlBar.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsControlBar.test.tsx
@@ -17,10 +17,6 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-jest.mock('../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: () => false,
-}));
-
 jest.mock('../../../selectors/networkController', () => ({
   selectIsAllNetworks: () => false,
   selectIsPopularNetwork: () => true,
@@ -162,10 +158,6 @@ describe('DeFiPositionsControlBar', () => {
   beforeEach(() => {
     store = mockStore(createMockState());
     jest.clearAllMocks();
-    const homepageModule = jest.requireMock(
-      '../../../selectors/featureFlagController/homepage',
-    );
-    homepageModule.selectHomepageSectionsV1Enabled = () => false;
   });
 
   it('should render correctly with default state', () => {
@@ -279,7 +271,7 @@ describe('DeFiPositionsControlBar', () => {
     );
   });
 
-  it('should be disabled when on testnet and homepage sections V1 is disabled', () => {
+  it('is not disabled on testnet', () => {
     const networksModule = jest.requireMock('../../../util/networks');
     networksModule.isTestNet.mockReturnValue(true);
 
@@ -310,58 +302,16 @@ describe('DeFiPositionsControlBar', () => {
       </Provider>,
     );
 
-    const filterButton = getByTestId('defi-positions-network-filter');
-    expect(filterButton).toBeDisabled();
+    expect(getByTestId('defi-positions-network-filter')).not.toBeDisabled();
   });
 
-  it('is not disabled when on testnet if homepage sections V1 is enabled', () => {
-    const homepageModule = jest.requireMock(
-      '../../../selectors/featureFlagController/homepage',
-    );
-    homepageModule.selectHomepageSectionsV1Enabled = () => true;
-
-    const networksModule = jest.requireMock('../../../util/networks');
-    networksModule.isTestNet.mockReturnValue(true);
-
-    const mockState = createMockState({
-      engine: {
-        backgroundState: {
-          NetworkController: {
-            provider: {
-              chainId: CHAIN_IDS.GOERLI,
-              type: 'goerli',
-            },
-          },
-          MultichainNetworkController: {
-            isEvmSelected: true,
-          },
-          PreferencesController: {
-            selectedAddress: '0x123',
-          },
-        },
-      },
-    });
-
-    store = mockStore(mockState);
-
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <DeFiPositionsControlBar />
-      </Provider>,
-    );
-
-    const filterButton = getByTestId('defi-positions-network-filter');
-    expect(filterButton).not.toBeDisabled();
-  });
-
-  it('should be disabled when not on popular network and homepage sections V1 is disabled', () => {
+  it('is not disabled when not on popular network', () => {
     const networkControllerModule = jest.requireMock(
       '../../../selectors/networkController',
     );
     networkControllerModule.selectIsPopularNetwork = () => false;
 
-    const mockState = createMockState();
-    store = mockStore(mockState);
+    store = mockStore(createMockState());
 
     const { getByTestId } = render(
       <Provider store={store}>
@@ -369,32 +319,7 @@ describe('DeFiPositionsControlBar', () => {
       </Provider>,
     );
 
-    const filterButton = getByTestId('defi-positions-network-filter');
-    expect(filterButton).toBeDisabled();
-  });
-
-  it('is not disabled when not on popular network if homepage sections V1 is enabled', () => {
-    const homepageModule = jest.requireMock(
-      '../../../selectors/featureFlagController/homepage',
-    );
-    homepageModule.selectHomepageSectionsV1Enabled = () => true;
-
-    const networkControllerModule = jest.requireMock(
-      '../../../selectors/networkController',
-    );
-    networkControllerModule.selectIsPopularNetwork = () => false;
-
-    const mockState = createMockState();
-    store = mockStore(mockState);
-
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <DeFiPositionsControlBar />
-      </Provider>,
-    );
-
-    const filterButton = getByTestId('defi-positions-network-filter');
-    expect(filterButton).not.toBeDisabled();
+    expect(getByTestId('defi-positions-network-filter')).not.toBeDisabled();
   });
 
   it('should render sort button with filter icon', () => {

--- a/app/components/UI/DeFiPositions/DeFiPositionsControlBar.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsControlBar.tsx
@@ -1,34 +1,13 @@
 import React from 'react';
-import { Hex } from '@metamask/utils';
-import { useSelector } from 'react-redux';
-import {
-  selectIsPopularNetwork,
-  selectChainId,
-} from '../../../selectors/networkController';
-import { isTestNet } from '../../../util/networks';
 import { WalletViewSelectorsIDs } from '../../Views/Wallet/WalletView.testIds';
 import BaseControlBar from '../shared/BaseControlBar/BaseControlBar';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 
-const DeFiPositionsControlBar: React.FC = () => {
-  const isPopularNetwork = useSelector(selectIsPopularNetwork);
-  const currentChainId = useSelector(selectChainId) as Hex;
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
-
-  // Custom disabled logic for DeFi positions
-  const isDisabled = isHomepageSectionsV1Enabled
-    ? false
-    : isTestNet(currentChainId) || !isPopularNetwork;
-
-  return (
-    <BaseControlBar
-      networkFilterTestId={WalletViewSelectorsIDs.DEFI_POSITIONS_NETWORK_FILTER}
-      isDisabled={isDisabled}
-      customWrapper="none"
-    />
-  );
-};
+const DeFiPositionsControlBar: React.FC = () => (
+  <BaseControlBar
+    networkFilterTestId={WalletViewSelectorsIDs.DEFI_POSITIONS_NETWORK_FILTER}
+    isDisabled={false}
+    customWrapper="none"
+  />
+);
 
 export default DeFiPositionsControlBar;

--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -491,7 +491,7 @@ describe('Tokens', () => {
       });
     });
 
-    it('includes mUSD when conversion flow is enabled but homepage sections are disabled (legacy wallet view)', async () => {
+    it('includes mUSD when conversion flow is enabled but Money Hub is disabled', async () => {
       const stateWithMusdEnabled = clone(initialRootState);
       (
         stateWithMusdEnabled as Record<string, unknown> &
@@ -532,7 +532,7 @@ describe('Tokens', () => {
       });
     });
 
-    it('excludes mUSD from token list when conversion flow, money hub, and homepage sections are all enabled', async () => {
+    it('excludes mUSD from token list when conversion flow and Money Hub are enabled', async () => {
       const stateWithBothEnabled = clone(initialRootState);
       (
         stateWithBothEnabled as Record<string, unknown> &
@@ -546,10 +546,6 @@ describe('Tokens', () => {
             minimumVersion: '1.0.0',
           },
           earnMoneyHubEnabled: {
-            enabled: true,
-            minimumVersion: '1.0.0',
-          },
-          homepageSectionsV1: {
             enabled: true,
             minimumVersion: '1.0.0',
           },

--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -72,6 +72,10 @@ jest.mock('./TokenList/TokenList', () => ({
   TokenList: jest.fn().mockImplementation(() => null),
 }));
 
+jest.mock('./TokenListControlBar/TokenListControlBar', () => ({
+  TokenListControlBar: jest.fn().mockImplementation(() => null),
+}));
+
 /**
  * For these unit tests, we do not need to test all the actual components, and can mock them.
  * If we do need to test the actual components in this test, we can use `mockReset` to get back the original component

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -35,7 +35,6 @@ import { selectSortedAssetsBySelectedAccountGroup } from '../../../selectors/ass
 import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
 import { SolScope } from '@metamask/keyring-api';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 import { useRemoveToken } from './hooks/useRemoveToken';
 import { TokensEmptyState } from '../TokensEmptyState';
 import MusdConversionAssetListCta from '../Earn/components/Musd/MusdConversionAssetListCta';
@@ -123,11 +122,7 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
     const isCashSectionEnabled =
       isMusdConversionFlowEnabled && isMoneyHubEnabled && isGeoEligible;
 
-    const isHomepageSectionsV1Enabled = useSelector(
-      selectHomepageSectionsV1Enabled,
-    );
-    const shouldExcludeMusdFromMainList =
-      isCashSectionEnabled && isHomepageSectionsV1Enabled;
+    const shouldExcludeMusdFromMainList = isCashSectionEnabled;
 
     const [hasInitialLoad, setHasInitialLoad] = useState(false);
     const hasTrackedScreenViewRef = useRef(false);
@@ -137,7 +132,7 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
       selectSortedAssetsBySelectedAccountGroup,
     );
 
-    // When showOnlyMusd: only mUSD. When Cash section enabled + homepage sections on: exclude mUSD (shown in Cash section). Otherwise include all.
+    // When showOnlyMusd: only mUSD. When Cash section is enabled: exclude mUSD (shown in Cash section). Otherwise include all.
     const tokenKeysForList = useMemo(
       () =>
         showOnlyMusd

--- a/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
@@ -16,6 +16,14 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    PreferencesController: {
+      setTokenSortConfig: jest.fn(),
+    },
+  },
+}));
+
 jest.mock('../../UI/DeFiPositions/DeFiPositionsList', () => {
   const React = jest.requireActual('react');
   const { View, Text } = jest.requireActual('react-native');

--- a/app/components/Views/DeFiFullView/DeFiFullView.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -13,25 +12,19 @@ import { Box } from '@metamask/design-system-react-native';
 import DeFiPositionsList from '../../UI/DeFiPositions/DeFiPositionsList';
 import Engine from '../../../core/Engine';
 import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 
 const DeFiFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
 
   useFocusEffect(
     useCallback(
       () => () => {
-        if (isHomepageSectionsV1Enabled) {
-          Engine.context.PreferencesController.setTokenSortConfig(
-            DEFAULT_TOKEN_SORT_CONFIG,
-          );
-        }
+        Engine.context.PreferencesController.setTokenSortConfig(
+          DEFAULT_TOKEN_SORT_CONFIG,
+        );
       },
-      [isHomepageSectionsV1Enabled],
+      [],
     ),
   );
 

--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -362,6 +362,8 @@ jest.mock('../../UI/Earn/hooks/useMusdConversionTokens', () => ({
 }));
 
 const mockEnableAllPopularNetworks = jest.fn();
+let mockPopularNetworks: string[] = [];
+const mockIsNetworkEnabled = jest.fn(() => true);
 jest.mock('../../hooks/useNetworkEnablement/useNetworkEnablement', () => ({
   useNetworkEnablement: () => ({
     namespace: 'eip155',
@@ -374,8 +376,8 @@ jest.mock('../../hooks/useNetworkEnablement/useNetworkEnablement', () => ({
     enableAllPopularNetworks: mockEnableAllPopularNetworks,
     popularEvmNetworks: [],
     popularMultichainNetworks: [],
-    popularNetworks: [],
-    isNetworkEnabled: jest.fn(),
+    popularNetworks: mockPopularNetworks,
+    isNetworkEnabled: mockIsNetworkEnabled,
     hasOneEnabledNetwork: false,
     tryEnableEvmNetwork: jest.fn(),
   }),
@@ -425,12 +427,26 @@ describe('Homepage', () => {
     mockUseMusdConversionEligibility.mockReturnValue({ isEligible: false });
     mockUseABTest.mockImplementation(defaultUseABTestImplementation);
     mockUseOwnedNfts.mockReturnValue([]);
+    mockPopularNetworks = [];
+    mockIsNetworkEnabled.mockReturnValue(true);
   });
 
-  it('calls enableAllPopularNetworks when Homepage is focused (useFocusEffect)', () => {
+  it('calls enableAllPopularNetworks when Homepage is focused and a popular network is disabled', () => {
+    mockPopularNetworks = ['eip155:1'];
+    mockIsNetworkEnabled.mockReturnValue(false);
+
     renderWithProvider(<Homepage />, { state: stateWithPreferences });
 
     expect(mockEnableAllPopularNetworks).toHaveBeenCalled();
+  });
+
+  it('does not call enableAllPopularNetworks when all popular networks are already enabled', () => {
+    mockPopularNetworks = ['eip155:1'];
+    mockIsNetworkEnabled.mockReturnValue(true);
+
+    renderWithProvider(<Homepage />, { state: stateWithPreferences });
+
+    expect(mockEnableAllPopularNetworks).not.toHaveBeenCalled();
   });
 
   it('triggers NFT detection when Homepage is focused', () => {

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -96,8 +96,19 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
     const ownedNfts = useOwnedNfts();
     const hasNfts = ownedNfts.length > 0;
 
-    const { enableAllPopularNetworks } = useNetworkEnablement();
+    const { enableAllPopularNetworks, isNetworkEnabled, popularNetworks } =
+      useNetworkEnablement();
     const { detectNfts, abortDetection } = useNftDetection();
+    const popularNetworksKey = popularNetworks.join(',');
+    const areAllPopularNetworksEnabled = useMemo(
+      () =>
+        popularNetworks.every((chainId) =>
+          isNetworkEnabled(chainId as Parameters<typeof isNetworkEnabled>[0]),
+        ),
+      // popularNetworksKey stabilizes by content; popularNetworks is a new array ref every render from the hook
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [isNetworkEnabled, popularNetworksKey],
+    );
 
     // useFocusEffect (not useEffect) so we run every time the user focuses this screen
     // (e.g. switches to Wallet tab or returns from a section). With useEffect we would
@@ -105,8 +116,10 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
     // they come back to the homepage.
     useFocusEffect(
       useCallback(() => {
-        enableAllPopularNetworks();
-      }, [enableAllPopularNetworks]),
+        if (!areAllPopularNetworksEnabled) {
+          enableAllPopularNetworks();
+        }
+      }, [areAllPopularNetworksEnabled, enableAllPopularNetworks]),
     );
 
     useFocusEffect(

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.test.ts
@@ -8,14 +8,6 @@ jest.mock('../../../../../../selectors/defiPositionsController', () => ({
     mockSelectDefiPositionsByChainIds(),
 }));
 
-jest.mock('../../../../../../selectors/networkEnablementController', () => ({
-  selectEVMEnabledNetworks: () => [],
-}));
-
-jest.mock('../../../../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: () => false,
-}));
-
 jest.mock(
   '../../../../../hooks/useNetworkEnablement/useNetworkEnablement',
   () => ({

--- a/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
+++ b/app/components/Views/Homepage/Sections/DeFi/hooks/useDeFiPositionsForHomepage.ts
@@ -6,9 +6,8 @@ import { toHex } from '@metamask/controller-utils';
 import { selectDefiPositionsByChainIds } from '../../../../../../selectors/defiPositionsController';
 import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { RootState } from '../../../../../../reducers';
+
 import { sortAssets } from '../../../../../UI/Tokens/util';
-import { selectHomepageSectionsV1Enabled } from '../../../../../../selectors/featureFlagController/homepage';
-import { selectEVMEnabledNetworks } from '../../../../../../selectors/networkEnablementController';
 
 /** Homepage always sorts DeFi by market value; View all uses user preference. */
 const HOMEPAGE_DEFI_SORT_BY_VALUE = {
@@ -54,20 +53,10 @@ const MAX_POSITIONS_DEFAULT = 5;
 export const useDeFiPositionsForHomepage = (
   maxPositions: number = MAX_POSITIONS_DEFAULT,
 ): UseDeFiPositionsForHomepageResult => {
-  const evmEnabledNetworks = useSelector(selectEVMEnabledNetworks);
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
   const { popularEvmNetworks } = useNetworkEnablement();
 
-  const popularEvmChainIds = useMemo(
-    () =>
-      isHomepageSectionsV1Enabled ? popularEvmNetworks : evmEnabledNetworks,
-    [isHomepageSectionsV1Enabled, popularEvmNetworks, evmEnabledNetworks],
-  );
-
   const defiPositionsByChainIds = useSelector((state: RootState) =>
-    selectDefiPositionsByChainIds(state, popularEvmChainIds),
+    selectDefiPositionsByChainIds(state, popularEvmNetworks),
   );
 
   const result = useMemo((): UseDeFiPositionsForHomepageResult => {

--- a/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.test.ts
+++ b/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.test.ts
@@ -9,7 +9,7 @@ jest.mock('react-redux', () => ({
 jest.mock(
   '../../../../../hooks/useNetworkEnablement/useNetworkEnablement',
   () => ({
-    useNetworkEnablement: () => ({ popularNetworks: [] }),
+    useNetworkEnablement: () => ({ popularNetworks: ['eip155:1'] }),
   }),
 );
 
@@ -28,21 +28,19 @@ const createMockNft = (
 });
 
 /**
- * Hook calls useSelector 3 times: selectedAccountGroupInternalAccounts,
- * selectHomepageSectionsV1Enabled, then multichainCollectiblesByEnabledNetworksSelector result.
+ * Hook calls useSelector twice: selectedAccountGroupInternalAccounts,
+ * then multichainCollectiblesByEnabledNetworksSelector result.
  */
 const mockSelectors = (
   nftsByChain: Record<string, unknown[]>,
   overrides?: {
     selectedGroupAccounts?: { address: string }[];
-    isHomepageSectionsV1Enabled?: boolean;
   },
 ) => {
   let callCount = 0;
   mockUseSelector.mockImplementation(() => {
     callCount += 1;
     if (callCount === 1) return overrides?.selectedGroupAccounts ?? [];
-    if (callCount === 2) return overrides?.isHomepageSectionsV1Enabled ?? false;
     return nftsByChain;
   });
 };
@@ -129,27 +127,6 @@ describe('useOwnedNfts', () => {
     expect(result.current).toContainEqual(chain1Nfts[0]);
     expect(result.current).toContainEqual(chain1Nfts[1]);
     expect(result.current).toContainEqual(chain2Nfts[0]);
-  });
-
-  it('returns owned NFTs when homepage sections V1 is enabled', () => {
-    const ownedNft = createMockNft('0x123', '1', true);
-    mockSelectors({ '0x1': [ownedNft] }, { isHomepageSectionsV1Enabled: true });
-
-    const { result } = renderHook(() => useOwnedNfts());
-
-    expect(result.current).toEqual([ownedNft]);
-  });
-
-  it('returns owned NFTs when homepage sections V1 is disabled', () => {
-    const ownedNft = createMockNft('0x123', '1', true);
-    mockSelectors(
-      { '0x1': [ownedNft] },
-      { isHomepageSectionsV1Enabled: false },
-    );
-
-    const { result } = renderHook(() => useOwnedNfts());
-
-    expect(result.current).toEqual([ownedNft]);
   });
 
   it('uses selected group accounts when provided for addressesOverride', () => {

--- a/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.ts
+++ b/app/components/Views/Homepage/Sections/NFTs/hooks/useOwnedNfts.ts
@@ -5,12 +5,10 @@ import { RootState } from '../../../../../../reducers';
 import { multichainCollectiblesByEnabledNetworksSelector } from '../../../../../../reducers/collectibles';
 import { useNetworkEnablement } from '../../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../../../selectors/multichainAccounts/accountTreeController';
-import { selectHomepageSectionsV1Enabled } from '../../../../../../selectors/featureFlagController/homepage';
 
 /**
  * Hook to get all owned NFTs for the currently selected account.
- * When homepage sections V1 is enabled, uses popular networks (from useNetworkEnablement);
- * otherwise uses enabled networks from state.
+ * Uses popular networks (from useNetworkEnablement).
  * Aggregates from all addresses in the selected account group so NFTs show when
  * e.g. Solana is selected (NFTs are keyed by EVM address in controller).
  * Only returns NFTs that are currently owned (isCurrentlyOwned === true),
@@ -23,9 +21,6 @@ const useOwnedNfts = (): Nft[] => {
   const selectedGroupAccounts = useSelector(
     selectSelectedAccountGroupInternalAccounts,
   );
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
 
   const addressesOverride = useMemo(
     () =>
@@ -35,11 +30,8 @@ const useOwnedNfts = (): Nft[] => {
     [selectedGroupAccounts],
   );
   const popularChainIds = useMemo(
-    () =>
-      isHomepageSectionsV1Enabled && popularNetworks?.length > 0
-        ? popularNetworks
-        : undefined,
-    [isHomepageSectionsV1Enabled, popularNetworks],
+    () => (popularNetworks?.length > 0 ? popularNetworks : undefined),
+    [popularNetworks],
   );
 
   const nftsByChain = useSelector((state: RootState) =>

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { InteractionManager, Text } from 'react-native';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
-import type { SectionRefreshHandle } from '../../types';
+import type {
+  HomepageDiscoveryTabsHandle,
+  SectionRefreshHandle,
+} from '../../types';
 import HomepageDiscoveryTabs from './HomepageDiscoveryTabs';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import { HomeTabNames } from '../../hooks/useTabViewedEvent';
@@ -200,19 +203,19 @@ describe('HomepageDiscoveryTabs', () => {
 
   describe('ref / imperative handle', () => {
     it('exposes a refresh method via ref', () => {
-      const ref = React.createRef<{ refresh: () => Promise<void> }>();
+      const ref = React.createRef<HomepageDiscoveryTabsHandle>();
       render(<HomepageDiscoveryTabs ref={ref} />);
       expect(typeof ref.current?.refresh).toBe('function');
     });
 
     it('exposes goToPerpsTab via ref', () => {
-      const ref = React.createRef<{ goToPerpsTab: () => void }>();
+      const ref = React.createRef<HomepageDiscoveryTabsHandle>();
       render(<HomepageDiscoveryTabs ref={ref} />);
       expect(typeof ref.current?.goToPerpsTab).toBe('function');
     });
 
     it('calling refresh does not throw', async () => {
-      const ref = React.createRef<{ refresh: () => Promise<void> }>();
+      const ref = React.createRef<HomepageDiscoveryTabsHandle>();
       render(<HomepageDiscoveryTabs ref={ref} />);
       await act(async () => {
         await ref.current?.refresh();

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -205,6 +205,12 @@ describe('HomepageDiscoveryTabs', () => {
       expect(typeof ref.current?.refresh).toBe('function');
     });
 
+    it('exposes goToPerpsTab via ref', () => {
+      const ref = React.createRef<{ goToPerpsTab: () => void }>();
+      render(<HomepageDiscoveryTabs ref={ref} />);
+      expect(typeof ref.current?.goToPerpsTab).toBe('function');
+    });
+
     it('calling refresh does not throw', async () => {
       const ref = React.createRef<{ refresh: () => Promise<void> }>();
       render(<HomepageDiscoveryTabs ref={ref} />);

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -208,10 +208,16 @@ describe('HomepageDiscoveryTabs', () => {
       expect(typeof ref.current?.refresh).toBe('function');
     });
 
-    it('exposes goToPerpsTab via ref', () => {
+    it('exposes goToPerpsTab via ref', async () => {
       const ref = React.createRef<HomepageDiscoveryTabsHandle>();
       render(<HomepageDiscoveryTabs ref={ref} />);
       expect(typeof ref.current?.goToPerpsTab).toBe('function');
+
+      await act(async () => {
+        ref.current?.goToPerpsTab();
+      });
+
+      expect(screen.getByTestId('perps-home-view')).toBeOnTheScreen();
     });
 
     it('calling refresh does not throw', async () => {

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -32,7 +32,7 @@ import {
   getStreamManagerInstance,
 } from '../../../../UI/Perps/providers/PerpsStreamManager';
 import { PredictPreviewSheetProvider } from '../../../../UI/Predict/contexts';
-import { HomepageDiscoveryTabsHandle } from '../../types';
+import { HomepageDiscoveryTabsHandle, SectionRefreshHandle } from '../../types';
 import { IconName } from '../../../../../component-library/components/Icons/Icon/Icon.types';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './HomepageDiscoveryTabs.styles';

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -32,7 +32,7 @@ import {
   getStreamManagerInstance,
 } from '../../../../UI/Perps/providers/PerpsStreamManager';
 import { PredictPreviewSheetProvider } from '../../../../UI/Predict/contexts';
-import { SectionRefreshHandle } from '../../types';
+import { HomepageDiscoveryTabsHandle } from '../../types';
 import { IconName } from '../../../../../component-library/components/Icons/Icon/Icon.types';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './HomepageDiscoveryTabs.styles';
@@ -148,7 +148,7 @@ export interface HomepageDiscoveryTabsProps {
  * - Predictions: PredictFeed wrapped in preview sheet provider
  */
 const HomepageDiscoveryTabs = forwardRef<
-  SectionRefreshHandle,
+  HomepageDiscoveryTabsHandle,
   HomepageDiscoveryTabsProps
 >(
   (
@@ -225,6 +225,9 @@ const HomepageDiscoveryTabs = forwardRef<
     useImperativeHandle(ref, () => ({
       refresh: async () => {
         await homepageRef.current?.refresh();
+      },
+      goToPerpsTab: () => {
+        tabsRef.current?.goToTabIndex(TAB_INDEX.PERPETUALS);
       },
     }));
 

--- a/app/components/Views/Homepage/types.ts
+++ b/app/components/Views/Homepage/types.ts
@@ -5,6 +5,11 @@ export interface SectionRefreshHandle {
   refresh: () => Promise<void>;
 }
 
+/** Imperative handle for HomepageDiscoveryTabs (refresh + deeplink tab selection). */
+export interface HomepageDiscoveryTabsHandle extends SectionRefreshHandle {
+  goToPerpsTab: () => void;
+}
+
 /**
  * Rendering mode for homepage sections that have both positions and trending content.
  *

--- a/app/components/Views/TokensFullView/TokensFullView.test.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.test.tsx
@@ -22,6 +22,14 @@ jest.mock('../../hooks/AssetPolling/AssetPollingProvider', () => ({
   AssetPollingProvider: () => null,
 }));
 
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    PreferencesController: {
+      setTokenSortConfig: jest.fn(),
+    },
+  },
+}));
+
 // Mock Tokens component to avoid complex Redux state setup
 jest.mock('../../UI/Tokens', () => {
   const React = jest.requireActual('react');

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import HeaderBase from '../../../component-library/components/HeaderBase';
@@ -13,24 +12,18 @@ import Tokens from '../../UI/Tokens';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
 import Engine from '../../../core/Engine';
 import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
 
 const TokensFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
 
   useEffect(
     () => () => {
-      if (isHomepageSectionsV1Enabled) {
-        Engine.context.PreferencesController.setTokenSortConfig(
-          DEFAULT_TOKEN_SORT_CONFIG,
-        );
-      }
+      Engine.context.PreferencesController.setTokenSortConfig(
+        DEFAULT_TOKEN_SORT_CONFIG,
+      );
     },
-    [isHomepageSectionsV1Enabled],
+    [],
   );
 
   const handleBackPress = useCallback(() => {

--- a/app/components/Views/Wallet/hooks/useBalanceRefresh.test.ts
+++ b/app/components/Views/Wallet/hooks/useBalanceRefresh.test.ts
@@ -30,14 +30,6 @@ jest.mock('../../../../selectors/networkController', () => ({
   selectNetworkConfigurations: jest.fn(() => ({})),
 }));
 
-jest.mock('../../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: jest.fn(() => true),
-}));
-
-jest.mock('../../../../selectors/networkEnablementController', () => ({
-  selectEVMEnabledNetworks: jest.fn(() => []),
-}));
-
 jest.mock('../../../../selectors/preferencesController', () => ({
   selectUseNftDetection: jest.fn(() => true),
 }));
@@ -71,17 +63,9 @@ describe('useBalanceRefresh', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockPopularEvmNetworks = ['0x1', '0x89'];
-    const { selectHomepageSectionsV1Enabled } = jest.requireMock(
-      '../../../../selectors/featureFlagController/homepage',
-    );
-    const { selectEVMEnabledNetworks } = jest.requireMock(
-      '../../../../selectors/networkEnablementController',
-    );
     const { selectUseNftDetection } = jest.requireMock(
       '../../../../selectors/preferencesController',
     );
-    (selectHomepageSectionsV1Enabled as jest.Mock).mockReturnValue(true);
-    (selectEVMEnabledNetworks as jest.Mock).mockReturnValue([]);
     (selectUseNftDetection as jest.Mock).mockReturnValue(true);
     (
       Engine.context.AccountTrackerController.refresh as jest.Mock
@@ -148,7 +132,7 @@ describe('useBalanceRefresh', () => {
   });
 
   describe('NftDetectionController', () => {
-    it('calls detectNfts with popular chain IDs and firstPageOnly when sections v1 is enabled', async () => {
+    it('calls detectNfts with popular chain IDs and firstPageOnly', async () => {
       const { result } = renderHook(() => useBalanceRefresh());
 
       await act(async () => {
@@ -158,27 +142,6 @@ describe('useBalanceRefresh', () => {
       expect(
         Engine.context.NftDetectionController.detectNfts,
       ).toHaveBeenCalledWith(['0x1', '0x89'], { firstPageOnly: true });
-    });
-
-    it('does not call detectNfts when sections v1 is disabled', async () => {
-      const { selectHomepageSectionsV1Enabled } = jest.requireMock(
-        '../../../../selectors/featureFlagController/homepage',
-      );
-      const { selectEVMEnabledNetworks } = jest.requireMock(
-        '../../../../selectors/networkEnablementController',
-      );
-      (selectHomepageSectionsV1Enabled as jest.Mock).mockReturnValue(false);
-      (selectEVMEnabledNetworks as jest.Mock).mockReturnValue(['0x1']);
-
-      const { result } = renderHook(() => useBalanceRefresh());
-
-      await act(async () => {
-        await result.current.refreshBalance();
-      });
-
-      expect(
-        Engine.context.NftDetectionController.detectNfts,
-      ).not.toHaveBeenCalled();
     });
 
     it('does not call detectNfts when user has disabled NFT detection in settings', async () => {

--- a/app/components/Views/Wallet/hooks/useBalanceRefresh.ts
+++ b/app/components/Views/Wallet/hooks/useBalanceRefresh.ts
@@ -7,8 +7,6 @@ import {
   selectNativeNetworkCurrencies,
 } from '../../../../selectors/networkController';
 import { useNetworkEnablement } from '../../../hooks/useNetworkEnablement/useNetworkEnablement';
-import { selectHomepageSectionsV1Enabled } from '../../../../selectors/featureFlagController/homepage';
-import { selectEVMEnabledNetworks } from '../../../../selectors/networkEnablementController';
 import { selectUseNftDetection } from '../../../../selectors/preferencesController';
 
 const REFRESH_TIMEOUT_MS = 5000;
@@ -29,33 +27,20 @@ export const useBalanceRefresh = () => {
   const [refreshing, setRefreshing] = useState(false);
   const { popularEvmNetworks: evmChainIds } = useNetworkEnablement();
 
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
-
   const isNftDetectionEnabled = useSelector(selectUseNftDetection);
-
-  const evmEnabledChainIds = useSelector(selectEVMEnabledNetworks);
 
   const evmNetworkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
 
-  // Sections enabled: refresh popular EVM chains. Sections disabled: refresh enabled eip155 only.
-  const evmChainIdsForRefresh = useMemo(
-    () =>
-      isHomepageSectionsV1Enabled ? evmChainIds : (evmEnabledChainIds ?? []),
-    [isHomepageSectionsV1Enabled, evmChainIds, evmEnabledChainIds],
-  );
-
   const evmNetworkConfigurationsFiltered = useMemo(() => {
-    const allowed = new Set<string>(evmChainIdsForRefresh);
+    const allowed = new Set<string>(evmChainIds);
     return Object.fromEntries(
       Object.entries(evmNetworkConfigurations).filter(([chainId]) =>
         allowed.has(chainId),
       ),
     );
-  }, [evmNetworkConfigurations, evmChainIdsForRefresh]);
+  }, [evmNetworkConfigurations, evmChainIds]);
 
   const nativeCurrencies = useSelector(selectNativeNetworkCurrencies);
 
@@ -80,14 +65,14 @@ export const useBalanceRefresh = () => {
           AccountTrackerController.refresh(networkClientIds),
           CurrencyRateController.updateExchangeRate(nativeCurrencies),
           TokenDetectionController.detectTokens({
-            chainIds: evmChainIdsForRefresh,
+            chainIds: evmChainIds,
           }),
           TokenBalancesController.updateBalances({
-            chainIds: evmChainIdsForRefresh,
+            chainIds: evmChainIds,
           }),
-          ...(isHomepageSectionsV1Enabled && isNftDetectionEnabled
+          ...(isNftDetectionEnabled
             ? [
-                NftDetectionController.detectNfts(evmChainIdsForRefresh, {
+                NftDetectionController.detectNfts(evmChainIds, {
                   firstPageOnly: true,
                 }),
               ]
@@ -110,9 +95,8 @@ export const useBalanceRefresh = () => {
     }
   }, [
     evmNetworkConfigurationsFiltered,
-    evmChainIdsForRefresh,
+    evmChainIds,
     nativeCurrencies,
-    isHomepageSectionsV1Enabled,
     isNftDetectionEnabled,
   ]);
 

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -84,12 +84,9 @@ jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
   ),
 }));
 
-// Control homepage feature flags per test (default false so existing tests are unaffected)
-let mockHomepageSectionsEnabled = false;
 let mockWalletHomeOnboardingStepsEnabled = false;
 jest.mock('../../../selectors/featureFlagController/homepage', () => ({
   selectHomepageRedesignV1Enabled: jest.fn(() => false),
-  selectHomepageSectionsV1Enabled: jest.fn(() => mockHomepageSectionsEnabled),
   selectWalletHomeOnboardingStepsEnabled: jest.fn(
     () => mockWalletHomeOnboardingStepsEnabled,
   ),
@@ -175,8 +172,6 @@ jest.mock('../../UI/Carousel', () => {
 });
 
 // Capture the HomepageScrollContext value by rendering a context-aware mock Homepage.
-// The mock is only invoked when mockHomepageSectionsEnabled=true (sections flag on),
-// so existing tests that leave the flag false are completely unaffected.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let capturedContext: any = null;
 jest.mock('../Homepage', () => {
@@ -744,15 +739,14 @@ describe('Wallet', () => {
   it('should render correctly', () => {
     //@ts-expect-error we are ignoring the navigation params on purpose because we do not want to mock setOptions to test the navbar
     render(Wallet);
-    expect(mockTabsListComponent).toHaveBeenCalled();
+    expect(capturedContext).toBeDefined();
   });
 
-  it('should render TabsList', () => {
+  it('should render homepage scroll context', () => {
     //@ts-expect-error we are ignoring the navigation params on purpose because we do not want to mock setOptions to test the navbar
     render(Wallet);
 
-    // Check if TabsList mock was called
-    expect(mockTabsListComponent).toHaveBeenCalled();
+    expect(capturedContext).toBeDefined();
   });
 
   it('should render correctly when Solana support is enabled', () => {
@@ -763,7 +757,7 @@ describe('Wallet', () => {
       );
     //@ts-expect-error we are ignoring the navigation params on purpose
     render(Wallet);
-    expect(mockTabsListComponent).toHaveBeenCalled();
+    expect(capturedContext).toBeDefined();
   });
 
   describe('AssetDetailsActions', () => {
@@ -1133,326 +1127,6 @@ describe('Wallet', () => {
     });
   });
 
-  describe('Perps Tab Visibility', () => {
-    let mockPerpsTabView: jest.Mock;
-    let mockNavigation: NavigationProp<ParamListBase>;
-
-    beforeEach(() => {
-      // Get the actual mock that was created at the top
-      mockPerpsTabView = jest.requireMock(
-        '../../UI/Perps/Views/PerpsTabView',
-      ).default;
-      mockPerpsTabView.mockClear();
-
-      // Setup navigation mock
-      mockNavigation = {
-        navigate: mockNavigate,
-        setOptions: mockSetOptions,
-        addListener: jest.fn(() => jest.fn()),
-        isFocused: jest.fn(() => false),
-        dangerouslyGetParent: jest.fn(() => ({
-          dangerouslyGetState: jest.fn(() => ({ type: 'stack' })),
-          addListener: jest.fn(() => jest.fn()),
-          dangerouslyGetParent: jest.fn(() => ({
-            dangerouslyGetState: jest.fn(() => ({ type: 'tab' })),
-            addListener: jest.fn(() => jest.fn()),
-            dangerouslyGetParent: jest.fn(() => undefined),
-          })),
-        })),
-      } as unknown as NavigationProp<ParamListBase>;
-
-      // Default to enabled
-      mockPerpsEnabled = true;
-      mockPerpsGTMModalEnabled = false;
-      mockPredictEnabled = true;
-      mockPredictGTMModalEnabled = false;
-    });
-
-    afterEach(() => {
-      jest.clearAllMocks();
-      mockPerpsEnabled = true; // Reset to default
-      mockPerpsGTMModalEnabled = false; // Reset to default
-      mockPredictEnabled = true; // Reset to default
-      mockPredictGTMModalEnabled = false; // Reset to default
-    });
-
-    it('registers PerpsTabView visibility callback when Perps is enabled', () => {
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        ...(mockedPerpsFeatureFlagsEnabledState as unknown as Record<
-          string,
-          Json
-        >),
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      expect(mockTabsListComponent).toHaveBeenCalled();
-      expect(mockPerpsTabView).toHaveBeenCalled();
-
-      const perpsTabViewProps = mockPerpsTabView.mock.calls.at(-1)?.[0];
-      expect(perpsTabViewProps).toBeDefined();
-      if (!perpsTabViewProps) {
-        return;
-      }
-      // PerpsTabView now receives navigation and tabLabel props
-      expect(perpsTabViewProps.navigation).toBeDefined();
-    });
-
-    it('sets Perps tab as not visible while the tokens tab is selected', () => {
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        ...(mockedPerpsFeatureFlagsEnabledState as unknown as Record<
-          string,
-          Json
-        >),
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      const perpsTabViewProps = mockPerpsTabView.mock.calls.at(-1)?.[0];
-      expect(perpsTabViewProps).toBeDefined();
-      if (!perpsTabViewProps) {
-        return;
-      }
-      // PerpsTabView is rendered but visibility is managed by the tab system
-      expect(perpsTabViewProps.navigation).toBeDefined();
-    });
-
-    it('should not render PerpsTabView when Perps is disabled', () => {
-      // Set the flag to disabled for this test
-      mockPerpsEnabled = false;
-
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        perpsPerpTradingEnabled: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      // PerpsTabView should not be rendered
-      expect(mockPerpsTabView).not.toHaveBeenCalled();
-    });
-
-    it('does not mount PerpsTabView when Perps is disabled after a tab change', () => {
-      // Set the flag to disabled for this test
-      mockPerpsEnabled = false;
-
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        perpsPerpTradingEnabled: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      const tabsList = mockTabsListComponent.mock.calls.at(-1)?.[0];
-      if (!tabsList?.onChangeTab) {
-        throw new Error('Expected TabsList onChangeTab');
-      }
-      tabsList.onChangeTab({
-        i: 1,
-        ref: { props: { tabLabel: 'Perps' } },
-      });
-
-      expect(mockPerpsTabView).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Predict Tab Visibility', () => {
-    let mockPredictTabView: jest.Mock;
-    let mockNavigation: NavigationProp<ParamListBase>;
-
-    beforeEach(() => {
-      // Get the actual mock that was created at the top
-      mockPredictTabView = jest.requireMock(
-        '../../UI/Predict/views/PredictTabView',
-      ).default;
-      mockPredictTabView.mockClear();
-
-      // Setup navigation mock
-      mockNavigation = {
-        navigate: mockNavigate,
-        setOptions: mockSetOptions,
-        addListener: jest.fn(() => jest.fn()),
-        isFocused: jest.fn(() => false),
-        dangerouslyGetParent: jest.fn(() => ({
-          dangerouslyGetState: jest.fn(() => ({ type: 'stack' })),
-          addListener: jest.fn(() => jest.fn()),
-          dangerouslyGetParent: jest.fn(() => ({
-            dangerouslyGetState: jest.fn(() => ({ type: 'tab' })),
-            addListener: jest.fn(() => jest.fn()),
-            dangerouslyGetParent: jest.fn(() => undefined),
-          })),
-        })),
-      } as unknown as NavigationProp<ParamListBase>;
-
-      // Default to enabled
-      mockPerpsEnabled = true;
-      mockPerpsGTMModalEnabled = false;
-      mockPredictEnabled = true;
-      mockPredictGTMModalEnabled = false;
-    });
-
-    afterEach(() => {
-      jest.clearAllMocks();
-      mockPerpsEnabled = true; // Reset to default
-      mockPerpsGTMModalEnabled = false; // Reset to default
-      mockPredictEnabled = true; // Reset to default
-      mockPredictGTMModalEnabled = false; // Reset to default
-    });
-
-    it('renders PredictTabView when Predict is enabled', () => {
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        ...(mockedPerpsFeatureFlagsEnabledState as unknown as Record<
-          string,
-          Json
-        >),
-        predictTradingEnabled: {
-          enabled: true,
-          minimumVersion: '7.60.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      expect(mockTabsListComponent).toHaveBeenCalled();
-      expect(mockPredictTabView).toHaveBeenCalled();
-
-      const predictTabViewProps = mockPredictTabView.mock.calls.at(-1)?.[0];
-      expect(predictTabViewProps).toBeDefined();
-      if (!predictTabViewProps) {
-        return;
-      }
-      expect(predictTabViewProps.isVisible).toBe(false);
-    });
-
-    it('keeps Predict tab not visible while the tokens tab is selected when Perps is enabled', () => {
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        ...(mockedPerpsFeatureFlagsEnabledState as unknown as Record<
-          string,
-          Json
-        >),
-        predictTradingEnabled: {
-          enabled: true,
-          minimumVersion: '7.60.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      const predictTabViewProps = mockPredictTabView.mock.calls.at(-1)?.[0];
-      expect(predictTabViewProps).toBeDefined();
-      if (!predictTabViewProps) {
-        return;
-      }
-      expect(predictTabViewProps.isVisible).toBe(false);
-    });
-
-    it('keeps Predict tab not visible while the tokens tab is selected when Perps is disabled', () => {
-      // Set Perps to disabled for this test
-      mockPerpsEnabled = false;
-
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        perpsPerpTradingEnabled: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-        predictTradingEnabled: {
-          enabled: true,
-          minimumVersion: '7.60.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      const predictTabViewProps = mockPredictTabView.mock.calls.at(-1)?.[0];
-      expect(predictTabViewProps).toBeDefined();
-      if (!predictTabViewProps) {
-        return;
-      }
-      expect(predictTabViewProps.isVisible).toBe(false);
-    });
-
-    it('does not render PredictTabView when Predict is disabled', () => {
-      // Set the flag to disabled for this test
-      mockPredictEnabled = false;
-
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        ...(mockedPerpsFeatureFlagsEnabledState as unknown as Record<
-          string,
-          Json
-        >),
-        predictTradingEnabled: {
-          enabled: false,
-          minimumVersion: '7.60.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      // PredictTabView should not be rendered
-      expect(mockPredictTabView).not.toHaveBeenCalled();
-    });
-
-    it('does not mount PredictTabView when Predict is disabled after a tab change', () => {
-      // Set the flag to disabled for this test
-      mockPredictEnabled = false;
-
-      const state = mockInitialStateWithRemoteFeatureFlags({
-        ...(mockedPerpsFeatureFlagsEnabledState as unknown as Record<
-          string,
-          Json
-        >),
-        predictTradingEnabled: {
-          enabled: false,
-          minimumVersion: '7.60.0',
-        },
-      });
-
-      renderWithProvider(
-        <Wallet navigation={mockNavigation} currentRouteName="Wallet" />,
-        { state },
-      );
-
-      const tabsList = mockTabsListComponent.mock.calls.at(-1)?.[0];
-      if (!tabsList?.onChangeTab) {
-        throw new Error('Expected TabsList onChangeTab');
-      }
-      tabsList.onChangeTab({
-        i: 2,
-        ref: { props: { tabLabel: 'Predict' } },
-      });
-
-      expect(mockPredictTabView).not.toHaveBeenCalled();
-    });
-  });
-
   describe('Perps GTM Modal Navigation', () => {
     let mockNavigation: NavigationProp<ParamListBase>;
 
@@ -1649,7 +1323,6 @@ describe('Wallet post-onboarding checklist coordination', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockHomepageSectionsEnabled = true;
     mockWalletHomeOnboardingStepsEnabled = true;
     accountGroupBalanceMock.mockImplementation(
       RealAccountGroupBalance as (...args: unknown[]) => unknown,
@@ -1664,7 +1337,6 @@ describe('Wallet post-onboarding checklist coordination', () => {
   afterEach(() => {
     accountGroupBalanceMock.mockImplementation(() => null);
     mockWalletHomeOnboardingStepsEnabled = false;
-    mockHomepageSectionsEnabled = false;
   });
 
   it('does not mount main action buttons while wallet-home post-onboarding is active', () => {
@@ -1722,12 +1394,7 @@ describe('Wallet post-onboarding checklist coordination', () => {
 describe('HomepageScrollContext callbacks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockHomepageSectionsEnabled = true;
     capturedContext = null;
-  });
-
-  afterEach(() => {
-    mockHomepageSectionsEnabled = false;
   });
 
   const renderWalletWithSections = () =>
@@ -1797,7 +1464,6 @@ describe('HomepageDiscoveryTabs AB test', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockHomepageSectionsEnabled = true;
     mockDiscoveryTabsVariantName = 'control';
     mockHomepageDiscoveryTabs.mockClear();
 
@@ -1825,12 +1491,11 @@ describe('HomepageDiscoveryTabs AB test', () => {
   });
 
   afterEach(() => {
-    mockHomepageSectionsEnabled = false;
     mockDiscoveryTabsVariantName = 'control';
     jest.clearAllMocks();
   });
 
-  it('renders HomepageDiscoveryTabs when variant is treatment and sections flag is on', () => {
+  it('renders HomepageDiscoveryTabs when variant is treatment', () => {
     mockDiscoveryTabsVariantName = 'treatment';
 
     renderWithProvider(
@@ -1898,7 +1563,7 @@ describe('HomepageDiscoveryTabs AB test', () => {
     expect(typeof props.walletHeaderHeight).toBe('number');
   });
 
-  it('renders Homepage scroll view (not HomepageDiscoveryTabs) when variant is control and sections flag is on', () => {
+  it('renders Homepage scroll view (not HomepageDiscoveryTabs) when variant is control', () => {
     mockDiscoveryTabsVariantName = 'control';
 
     renderWithProvider(
@@ -1912,21 +1577,6 @@ describe('HomepageDiscoveryTabs AB test', () => {
     // HomepageDiscoveryTabs must not render; the legacy Homepage mock renders instead
     expect(mockHomepageDiscoveryTabs).not.toHaveBeenCalled();
     expect(capturedContext).toBeDefined();
-  });
-
-  it('does not render HomepageDiscoveryTabs when sections flag is off regardless of variant', () => {
-    mockHomepageSectionsEnabled = false;
-    mockDiscoveryTabsVariantName = 'treatment';
-
-    renderWithProvider(
-      <Wallet
-        navigation={mockNavigation}
-        currentRouteName={Routes.WALLET_VIEW}
-      />,
-      { state: mockInitialState },
-    );
-
-    expect(mockHomepageDiscoveryTabs).not.toHaveBeenCalled();
   });
 });
 
@@ -2053,12 +1703,10 @@ describe('MoneyBalanceCard slot', () => {
 
   afterEach(() => {
     mockMoneyAccountEnabled = false;
-    mockHomepageSectionsEnabled = false;
   });
 
-  it('renders the MoneyBalanceCard when both feature flags are enabled', () => {
+  it('renders the MoneyBalanceCard when Money account is enabled', () => {
     mockMoneyAccountEnabled = true;
-    mockHomepageSectionsEnabled = true;
 
     //@ts-expect-error navigation params intentionally omitted (same as render(Wallet))
     const { getByTestId } = render(Wallet);
@@ -2066,29 +1714,8 @@ describe('MoneyBalanceCard slot', () => {
     expect(getByTestId('money-balance-card-mock')).toBeOnTheScreen();
   });
 
-  it('does not render the MoneyBalanceCard when only the Money flag is enabled', () => {
-    mockMoneyAccountEnabled = true;
-    mockHomepageSectionsEnabled = false;
-
-    //@ts-expect-error navigation params intentionally omitted (same as render(Wallet))
-    const { queryByTestId } = render(Wallet);
-
-    expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
-  });
-
-  it('does not render the MoneyBalanceCard when only the Homepage sections flag is enabled', () => {
+  it('does not render the MoneyBalanceCard when Money account is disabled', () => {
     mockMoneyAccountEnabled = false;
-    mockHomepageSectionsEnabled = true;
-
-    //@ts-expect-error navigation params intentionally omitted (same as render(Wallet))
-    const { queryByTestId } = render(Wallet);
-
-    expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
-  });
-
-  it('does not render the MoneyBalanceCard when both feature flags are disabled', () => {
-    mockMoneyAccountEnabled = false;
-    mockHomepageSectionsEnabled = false;
 
     //@ts-expect-error navigation params intentionally omitted (same as render(Wallet))
     const { queryByTestId } = render(Wallet);

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -131,11 +131,17 @@ jest.mock('../../../hooks', () => ({
 
 // Track HomepageDiscoveryTabs renders
 const mockHomepageDiscoveryTabs = jest.fn();
+const mockHomepageDiscoveryTabsRefresh = jest.fn(async () => undefined);
+const mockHomepageDiscoveryTabsGoToPerpsTab = jest.fn();
 jest.mock('../Homepage/components/HomepageDiscoveryTabs', () => {
   const React = jest.requireActual('react');
   return {
     __esModule: true,
-    default: React.forwardRef((props: unknown, _ref: unknown) => {
+    default: React.forwardRef((props: unknown, ref: unknown) => {
+      React.useImperativeHandle(ref, () => ({
+        refresh: mockHomepageDiscoveryTabsRefresh,
+        goToPerpsTab: mockHomepageDiscoveryTabsGoToPerpsTab,
+      }));
       mockHomepageDiscoveryTabs(props);
       return null;
     }),
@@ -734,6 +740,11 @@ describe('Wallet', () => {
       .mockImplementation((callback: (state: unknown) => unknown) =>
         callback(mockInitialState),
       );
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'route',
+      name: 'route',
+      params: {},
+    });
   });
 
   it('should render correctly', () => {
@@ -1466,6 +1477,8 @@ describe('HomepageDiscoveryTabs AB test', () => {
     jest.clearAllMocks();
     mockDiscoveryTabsVariantName = 'control';
     mockHomepageDiscoveryTabs.mockClear();
+    mockHomepageDiscoveryTabsRefresh.mockClear();
+    mockHomepageDiscoveryTabsGoToPerpsTab.mockClear();
 
     mockNavigation = {
       navigate: mockNavigate,
@@ -1561,6 +1574,114 @@ describe('HomepageDiscoveryTabs AB test', () => {
     >;
     expect(typeof props.walletHeaderOffset).toBe('number');
     expect(typeof props.walletHeaderHeight).toBe('number');
+  });
+
+  it('selects the Perps discovery tab for Perps deeplinks in treatment', () => {
+    jest.useFakeTimers();
+    mockDiscoveryTabsVariantName = 'treatment';
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'route',
+      name: 'route',
+      params: { initialTab: 'perps' },
+    });
+
+    renderWithProvider(
+      <Wallet
+        navigation={mockNavigation}
+        currentRouteName={Routes.WALLET_VIEW}
+      />,
+      { state: mockInitialState },
+    );
+
+    const focusCallbacks = jest.mocked(useFocusEffect).mock.calls;
+    focusCallbacks.forEach(([callback]) => callback?.());
+    jest.advanceTimersByTime(PERFORMANCE_CONFIG.NavigationParamsDelayMs);
+
+    expect(mockHomepageDiscoveryTabsGoToPerpsTab).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { source: 'deeplink' },
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('navigates to Perps screen for Perps deeplinks in control', () => {
+    jest.useFakeTimers();
+    mockDiscoveryTabsVariantName = 'control';
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'route',
+      name: 'route',
+      params: { initialTab: 'perps' },
+    });
+
+    renderWithProvider(
+      <Wallet
+        navigation={mockNavigation}
+        currentRouteName={Routes.WALLET_VIEW}
+      />,
+      { state: mockInitialState },
+    );
+
+    const focusCallbacks = jest.mocked(useFocusEffect).mock.calls;
+    focusCallbacks.forEach(([callback]) => callback?.());
+    jest.advanceTimersByTime(PERFORMANCE_CONFIG.NavigationParamsDelayMs);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { source: 'deeplink' },
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('navigates to network selector from deeplink params', () => {
+    jest.useFakeTimers();
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'route',
+      name: 'route',
+      params: { openNetworkSelector: true },
+    });
+
+    renderWithProvider(
+      <Wallet
+        navigation={mockNavigation}
+        currentRouteName={Routes.WALLET_VIEW}
+      />,
+      { state: mockInitialState },
+    );
+
+    const focusCallbacks = jest.mocked(useFocusEffect).mock.calls;
+    focusCallbacks.forEach(([callback]) => callback?.());
+    jest.advanceTimersByTime(PERFORMANCE_CONFIG.NavigationParamsDelayMs);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.NETWORK_SELECTOR,
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('refreshes discovery tabs from the wallet refresh control in treatment', async () => {
+    mockDiscoveryTabsVariantName = 'treatment';
+
+    renderWithProvider(
+      <Wallet
+        navigation={mockNavigation}
+        currentRouteName={Routes.WALLET_VIEW}
+      />,
+      { state: mockInitialState },
+    );
+
+    const props = mockHomepageDiscoveryTabs.mock.calls.at(-1)?.[0] as {
+      refreshControl?: React.ReactElement<{ onRefresh: () => Promise<void> }>;
+    };
+
+    await act(async () => {
+      await props.refreshControl?.props.onRefresh();
+    });
+
+    expect(mockHomepageDiscoveryTabsRefresh).toHaveBeenCalled();
   });
 
   it('renders Homepage scroll view (not HomepageDiscoveryTabs) when variant is control', () => {

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1,16 +1,15 @@
 import { AccountGroupId } from '@metamask/account-api';
 import type { Theme } from '@metamask/design-tokens';
 import React, {
-  forwardRef,
   useCallback,
   useContext,
   useEffect,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
 } from 'react';
-import type { TabRefreshHandle, WalletTokensTabViewHandle } from './types';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { SectionRefreshHandle } from '../Homepage/types';
 import { useBalanceRefresh, useHomepageEntryPoint } from './hooks';
 
 import {
@@ -28,16 +27,11 @@ import {
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 import Reanimated, {
-  LinearTransition,
   useSharedValue,
   useAnimatedStyle,
 } from 'react-native-reanimated';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
-import {
-  TabsList,
-  TabsListRef,
-} from '../../../component-library/components-temp/Tabs';
 import { CONSENSYS_PRIVACY_POLICY } from '../../../constants/urls';
 import { isPastPrivacyPolicyDate } from '../../../reducers/legalNotices';
 import { shouldShowNewPrivacyToastSelector } from '../../../selectors/legalNotices';
@@ -52,7 +46,6 @@ import {
   PERPS_GTM_MODAL_SHOWN,
   PREDICT_GTM_MODAL_SHOWN,
 } from '../../../constants/storage';
-import Tokens from '../../UI/Tokens';
 import HeaderRoot from '../../../component-library/components-temp/HeaderRoot';
 import PickerAccount from '../../../component-library/components/Pickers/PickerAccount';
 import AddressCopy from '../../UI/AddressCopy';
@@ -118,7 +111,7 @@ import {
 } from '../../../selectors/notifications';
 import { selectSelectedAccountGroupId } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectShouldShowWalletHomeOnboardingSteps } from '../../../selectors/onboarding';
-import { getIsNetworkOnboarded, isTestNet } from '../../../util/networks';
+import { getIsNetworkOnboarded } from '../../../util/networks';
 import NotificationsService from '../../../util/notifications/services/NotificationService';
 import { useTheme } from '../../../util/theme';
 import { useAccountGroupName } from '../../hooks/multichainAccounts/useAccountGroupName';
@@ -128,11 +121,7 @@ import { PERFORMANCE_CONFIG } from '@metamask/perps-controller';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import ErrorBoundary from '../ErrorBoundary';
 
-import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
-import {
-  selectHomepageSectionsV1Enabled,
-  selectWalletHomeOnboardingStepsEnabled,
-} from '../../../selectors/featureFlagController/homepage';
+import { selectWalletHomeOnboardingStepsEnabled } from '../../../selectors/featureFlagController/homepage';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import Homepage from '../Homepage';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -145,8 +134,6 @@ import {
 } from '../Homepage/abTestConfig';
 import { useABTest } from '../../../hooks';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { SectionRefreshHandle } from '../Homepage/types';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { HomepageScrollContext } from '../Homepage/context/HomepageScrollContext';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { HomeSectionName } from '../Homepage/hooks/useHomeViewedEvent';
@@ -156,18 +143,15 @@ import useCheckMultiRpcModal from '../../hooks/useCheckMultiRpcModal';
 import { useMultichainAccountsIntroModal } from '../../hooks/useMultichainAccountsIntroModal';
 import { useAccountsWithNetworkActivitySync } from '../../hooks/useAccountsWithNetworkActivitySync';
 import Logger from '../../../util/Logger';
-import { useNftDetection } from '../../hooks/useNftDetection';
 import BrazeBanner from '../../UI/BrazeBanner';
 import ComponentErrorBoundary from '../../UI/ComponentErrorBoundary';
 import { BRAZE_BANNER_WALLET_HOME_PLACEMENT_ID } from '../../../core/Braze/constants';
 import NetworkConnectionBanner from '../../UI/NetworkConnectionBanner';
 
-import { selectAssetsDefiPositionsEnabled } from '../../../selectors/featureFlagController/assetsDefiPositions';
 import {
   SwapBridgeNavigationLocation,
   useSwapBridgeNavigation,
 } from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
-import DeFiPositionsList from '../../UI/DeFiPositions/DeFiPositionsList';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import AssetDetailsActions from '../AssetDetails/AssetDetailsActions';
 import AppConstants from '../../../core/AppConstants';
@@ -175,7 +159,6 @@ import AppConstants from '../../../core/AppConstants';
 import { useSendNonEvmAsset } from '../../hooks/useSendNonEvmAsset';
 ///: END:ONLY_INCLUDE_IF
 import { suppressWalletHomeOnboardingSteps } from '../../../actions/onboarding';
-import { WALLET_HOME_POST_ONBOARDING_REVEAL_MS } from '../../UI/WalletHomeOnboardingSteps';
 import { useWalletHomeOnboardingChecklistTradePress } from '../../UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress';
 import {
   IconColor,
@@ -189,32 +172,23 @@ import {
   selectPerpsGtmOnboardingModalEnabledFlag,
 } from '../../UI/Perps';
 import { PerpsAlwaysOnProvider } from '../../UI/Perps/providers/PerpsAlwaysOnProvider';
-import PerpsTabView from '../../UI/Perps/Views/PerpsTabView';
 import {
   selectPredictEnabledFlag,
   selectPredictGtmOnboardingModalEnabledFlag,
 } from '../../UI/Predict/selectors/featureFlags';
-import PredictTabView from '../../UI/Predict/views/PredictTabView';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { InitSendLocation } from '../confirmations/constants/send';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
 import { Carousel } from '../../UI/Carousel';
-import { SolScope } from '@metamask/keyring-api';
-import { useCurrentNetworkInfo } from '../../hooks/useCurrentNetworkInfo';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { createAddressListNavigationDetails } from '../../Views/MultichainAccounts/AddressList';
-import NftGrid from '../../UI/NftGrid/NftGrid';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
 import { usePna25BottomSheet } from '../../hooks/usePna25BottomSheet';
 import { useSafeChains } from '../../hooks/useSafeChains';
 import { useNetworkEnablement } from '../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { useHomeGrowthBanner } from './hooks/useHomeGrowthBanner';
 
-/** Reanimated layout when the top cluster height changes (e.g. checklist → balance). */
-const WALLET_HOME_MAIN_BELOW_CLUSTER_LAYOUT = LinearTransition.duration(
-  WALLET_HOME_POST_ONBOARDING_REVEAL_MS,
-);
 const createStyles = ({ colors }: Theme) =>
   RNStyleSheet.create({
     base: {
@@ -225,9 +199,6 @@ const createStyles = ({ colors }: Theme) =>
       backgroundColor: colors.background.default,
       gap: 16,
       flexDirection: 'column',
-    },
-    tabContainer: {
-      flex: 1,
     },
     loader: {
       backgroundColor: colors.background.default,
@@ -242,21 +213,6 @@ const createStyles = ({ colors }: Theme) =>
     },
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
-    },
-    /** Preserves `styles.wrapper` gap between balance and actions. */
-    walletTopCluster: {
-      flexDirection: 'column',
-      gap: 16,
-      zIndex: 1,
-    },
-    /** Homepage / tokens area below the balance cluster; solid background for carousel edge cases. */
-    walletPostOnboardingMainBelowCluster: {
-      backgroundColor: colors.background.default,
-    },
-    /** Shared column for balance cluster + main content; `overflow: hidden` contains the carousel. */
-    walletPostOnboardingStage: {
-      position: 'relative',
-      overflow: 'hidden',
     },
     headerActionButtonsContainer: {
       flexDirection: 'row',
@@ -280,16 +236,6 @@ interface WalletProps {
   shouldShowNewPrivacyToast: boolean;
   currentRouteName: string;
   storePrivacyPolicyClickedOrClosed: () => void;
-}
-
-interface WalletTokensTabViewProps {
-  navigation: WalletProps['navigation'];
-  onChangeTab: (changeTabProperties: {
-    i: number;
-    ref: React.ReactNode;
-  }) => void;
-  defiEnabled: boolean;
-  collectiblesEnabled: boolean;
 }
 
 interface WalletRouteParams {
@@ -364,269 +310,6 @@ export const useHomeDeepLinkEffects = (opts: {
   );
 };
 
-const WalletTokensTabView = forwardRef<
-  WalletTokensTabViewHandle,
-  WalletTokensTabViewProps
->((props, ref) => {
-  const isPerpsFlagEnabled = useSelector(selectPerpsEnabledFlag);
-  // With BIP-44 multichain accounts, perps is enabled for both EVM and non-EVM networks
-  const isPerpsEnabled = isPerpsFlagEnabled;
-  const isPredictFlagEnabled = useSelector(selectPredictEnabledFlag);
-  const isPredictEnabled = useMemo(
-    () => isPredictFlagEnabled,
-    [isPredictFlagEnabled],
-  );
-
-  const { navigation, onChangeTab, defiEnabled, collectiblesEnabled } = props;
-
-  const tabsListRef = useRef<TabsListRef>(null);
-  const { enabledNetworks: allEnabledNetworks } = useCurrentNetworkInfo();
-
-  const enabledNetworksIsSolana = useMemo(() => {
-    if (allEnabledNetworks.length === 1) {
-      return allEnabledNetworks.some(
-        (network) => network.chainId === SolScope.Mainnet,
-      );
-    }
-    return false;
-  }, [allEnabledNetworks]);
-
-  const theme = useTheme();
-  const styles = useMemo(() => createStyles(theme), [theme]);
-
-  // Track current tab index for Perps visibility
-  const [currentTabIndex, setCurrentTabIndex] = useState(0);
-
-  // Refs for tab components that have refresh functionality
-  const tokensRef = useRef<TabRefreshHandle>(null);
-  const predictRef = useRef<TabRefreshHandle>(null);
-  const nftsRef = useRef<TabRefreshHandle>(null);
-
-  const tokensTabProps = useMemo(
-    () => ({
-      key: 'tokens-tab',
-      tabLabel: strings('wallet.tokens'),
-      testID: WalletViewSelectorsIDs.TOKENS_TAB_ITEM,
-      navigation,
-    }),
-    [navigation],
-  );
-
-  const perpsTabProps = useMemo(
-    () => ({
-      key: 'perps-tab',
-      tabLabel: strings('wallet.perps'),
-      testID: WalletViewSelectorsIDs.PERPS_TAB_ITEM,
-      navigation,
-    }),
-    [navigation],
-  );
-
-  const predictTabProps = useMemo(
-    () => ({
-      key: 'predict-tab',
-      tabLabel: strings('wallet.predict'),
-      testID: WalletViewSelectorsIDs.PREDICT_TAB_ITEM,
-      navigation,
-    }),
-    [navigation],
-  );
-
-  const defiPositionsTabProps = useMemo(
-    () => ({
-      key: 'defi-tab',
-      tabLabel: strings('wallet.defi'),
-      testID: WalletViewSelectorsIDs.DEFI_TAB_ITEM,
-      navigation,
-    }),
-    [navigation],
-  );
-
-  const nftsTabProps = useMemo(
-    () => ({
-      key: 'nfts-tab',
-      tabLabel: strings('wallet.collectibles'),
-      testID: WalletViewSelectorsIDs.NFTS_TAB_ITEM,
-      navigation,
-    }),
-    [navigation],
-  );
-
-  // Handle tab changes and track current index
-  const handleTabChange = useCallback(
-    (changeTabProperties: { i: number; ref: React.ReactNode }) => {
-      setCurrentTabIndex(changeTabProperties.i);
-      onChangeTab(changeTabProperties);
-    },
-    [onChangeTab],
-  );
-
-  // Build ordered list of tab refs based on which tabs are enabled
-  // Returns null for tabs without refresh (Perps uses WebSocket, DeFi uses selectors)
-  const getTabRefByIndex = useCallback(
-    (index: number): React.RefObject<TabRefreshHandle | null> | null => {
-      // Build array matching tab order: [tokens, perps?, predict?, defi?, nfts?]
-      // Use null for tabs without refresh functionality
-      const tabRefs: (React.RefObject<TabRefreshHandle | null> | null)[] = [
-        tokensRef,
-      ];
-
-      if (isPerpsEnabled) {
-        tabRefs.push(null); // Perps uses WebSocket streaming, no refresh needed
-      }
-      if (isPredictEnabled) {
-        tabRefs.push(predictRef);
-      }
-      if (!enabledNetworksIsSolana) {
-        if (defiEnabled) {
-          tabRefs.push(null); // DeFi uses Redux selectors, no refresh needed
-        }
-        if (collectiblesEnabled) {
-          tabRefs.push(nftsRef);
-        }
-      }
-
-      return tabRefs[index] || null;
-    },
-    [
-      isPerpsEnabled,
-      isPredictEnabled,
-      defiEnabled,
-      collectiblesEnabled,
-      enabledNetworksIsSolana,
-    ],
-  );
-
-  // Expose refresh method to parent
-  useImperativeHandle(ref, () => ({
-    refresh: async (onBalanceRefresh: () => Promise<void>) => {
-      const activeTabRef = getTabRefByIndex(currentTabIndex);
-
-      // Always refresh balance + tab-specific content if available
-      const promises = [
-        onBalanceRefresh(),
-        activeTabRef?.current?.refresh(),
-      ].filter(Boolean);
-
-      await Promise.all(promises);
-    },
-  }));
-
-  // Calculate Predict tab visibility
-  let predictTabIndex = -1;
-  if (isPerpsEnabled && isPredictEnabled) {
-    predictTabIndex = 2;
-  } else if (isPredictEnabled) {
-    predictTabIndex = 1;
-  }
-  const isPredictTabVisible = currentTabIndex === predictTabIndex;
-
-  // Handle deep link effects
-  useHomeDeepLinkEffects({
-    navigation,
-    isPerpsEnabled,
-    onPerpsTabSelected: () => {
-      tabsListRef.current?.goToTabIndex(1);
-    },
-    onNetworkSelectorSelected: () => {
-      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.NETWORK_SELECTOR,
-      });
-    },
-  });
-
-  // Build tabs array dynamically based on enabled features
-  const tabsToRender = useMemo(() => {
-    const tabs = [
-      <Tokens ref={tokensRef} {...tokensTabProps} key={tokensTabProps.key} />,
-    ];
-
-    if (isPerpsEnabled) {
-      tabs.push(<PerpsTabView {...perpsTabProps} key={perpsTabProps.key} />);
-    }
-
-    if (isPredictEnabled) {
-      tabs.push(
-        <PredictTabView
-          ref={predictRef}
-          {...predictTabProps}
-          key={predictTabProps.key}
-          isVisible={isPredictTabVisible}
-        />,
-      );
-    }
-
-    if (enabledNetworksIsSolana) {
-      return tabs;
-    }
-
-    if (defiEnabled) {
-      tabs.push(
-        <DeFiPositionsList
-          {...defiPositionsTabProps}
-          key={defiPositionsTabProps.key}
-        />,
-      );
-    }
-
-    if (collectiblesEnabled) {
-      tabs.push(
-        <NftGrid ref={nftsRef} {...nftsTabProps} key={nftsTabProps.key} />,
-      );
-    }
-
-    return tabs;
-  }, [
-    tokensTabProps,
-    isPerpsEnabled,
-    perpsTabProps,
-    isPredictEnabled,
-    predictTabProps,
-    isPredictTabVisible,
-    defiEnabled,
-    defiPositionsTabProps,
-    collectiblesEnabled,
-    nftsTabProps,
-    enabledNetworksIsSolana,
-  ]);
-
-  // Create a key that changes when tab structure changes to force re-render
-  const tabsKey = useMemo(() => {
-    const enabledFeatures = [
-      isPerpsEnabled ? 'perps' : '',
-      isPredictEnabled ? 'predict' : '',
-      defiEnabled ? 'defi' : '',
-      collectiblesEnabled ? 'nfts' : '',
-      enabledNetworksIsSolana ? 'solana' : '',
-    ]
-      .filter(Boolean)
-      .join('-');
-    return `tabs-${enabledFeatures}`;
-  }, [
-    isPerpsEnabled,
-    isPredictEnabled,
-    defiEnabled,
-    collectiblesEnabled,
-    enabledNetworksIsSolana,
-  ]);
-
-  return (
-    <View style={styles.tabContainer}>
-      <TabsList
-        key={tabsKey}
-        ref={tabsListRef}
-        onChangeTab={handleTabChange}
-        tabsListContentTwClassName={'!flex-initial'}
-        testID={WalletViewSelectorsIDs.WALLET_TABS}
-      >
-        {tabsToRender}
-      </TabsList>
-    </View>
-  );
-});
-
-WalletTokensTabView.displayName = 'WalletTokensTabView';
-
 /**
  * Main view for the wallet
  */
@@ -638,13 +321,9 @@ const Wallet = ({
 }: WalletProps) => {
   const { navigate } = useNavigation();
   const walletRef = useRef(null);
-  const walletTokensTabViewRef = useRef<WalletTokensTabViewHandle>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const isMountedRef = useRef(true);
   const refreshInProgressRef = useRef(false);
-  const isHomepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
   const isWalletHomeOnboardingStepsEnabled = useSelector(
     selectWalletHomeOnboardingStepsEnabled,
   );
@@ -653,9 +332,7 @@ const Wallet = ({
   );
 
   const inWalletHomePostOnboardingFlow =
-    isHomepageSectionsV1Enabled &&
-    isWalletHomeOnboardingStepsEnabled &&
-    shouldShowWalletHomeOnboardingSteps;
+    isWalletHomeOnboardingStepsEnabled && shouldShowWalletHomeOnboardingSteps;
 
   const showWalletHomeMainActions = !inWalletHomePostOnboardingFlow;
 
@@ -727,16 +404,7 @@ const Wallet = ({
   const providerConfig = useSelector(selectProviderConfig);
   const chainId = useSelector(selectChainId);
 
-  const { enabledNetworks: allEnabledNetworks } = useCurrentNetworkInfo();
-
   const selectedAccountGroupId = useSelector(selectSelectedAccountGroupId);
-
-  const enabledNetworksHasTestNet = useMemo(() => {
-    if (allEnabledNetworks.length === 1) {
-      return allEnabledNetworks.some((network) => isTestNet(network.chainId));
-    }
-    return false;
-  }, [allEnabledNetworks]);
 
   const prevChainId = usePrevious(chainId);
 
@@ -857,20 +525,6 @@ const Wallet = ({
   const basicFunctionalityEnabled = useSelector(
     (state: RootState) => state.settings.basicFunctionalityEnabled,
   );
-
-  const assetsDefiPositionsEnabled = useSelector(
-    selectAssetsDefiPositionsEnabled,
-  );
-
-  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
-  const { isNetworkEnabledForDefi } = useCurrentNetworkInfo();
-
-  const collectiblesEnabled = useMemo(() => {
-    if (allEnabledNetworks.length === 1) {
-      return isEvmSelected;
-    }
-    return true;
-  }, [isEvmSelected, allEnabledNetworks]);
 
   const { isEnabled: getParticipationInMetaMetrics } = useAnalytics();
 
@@ -1049,8 +703,6 @@ const Wallet = ({
 
   const homeGrowthBanner = useHomeGrowthBanner();
 
-  const { detectNfts } = useNftDetection();
-
   /**
    * Shows Nft auto detect modal if the user is on mainnet, never saw the modal and have nft detection off
    */
@@ -1131,13 +783,12 @@ const Wallet = ({
 
   // Notifies scroll subscribers directly (no React state update = no re-renders).
   const handleHomepageScroll = useCallback(() => {
-    if (!isHomepageSectionsV1Enabled) return;
     const now = Date.now();
     if (now - lastScrollTickTimeRef.current >= 100) {
       lastScrollTickTimeRef.current = now;
       scrollSubscribersRef.current.forEach((cb) => cb());
     }
-  }, [isHomepageSectionsV1Enabled]);
+  }, []);
 
   const touchAreaSlop = useMemo(
     () => ({ top: 12, bottom: 12, left: 12, right: 12 }),
@@ -1173,45 +824,11 @@ const Wallet = ({
     navigation.navigate(Routes.TRANSACTIONS_VIEW);
   }, [navigation, trackEvent]);
 
-  const onChangeTab = useCallback(
-    (obj: { i: number; ref: React.ReactNode }) => {
-      const tabLabel =
-        React.isValidElement(obj.ref) && obj.ref.props
-          ? (obj.ref.props as { tabLabel?: string })?.tabLabel
-          : '';
-      if (tabLabel === strings('wallet.tokens')) {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.WALLET_TOKENS)
-            .addProperties({ action: 'Wallet View', name: 'Tokens' })
-            .build(),
-        );
-      } else if (tabLabel === strings('wallet.defi')) {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.DEFI_TAB_SELECTED).build(),
-        );
-      } else if (tabLabel === strings('wallet.collectibles')) {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.WALLET_COLLECTIBLES)
-            .addProperties({ action: 'Wallet View', name: 'Collectibles' })
-            .build(),
-        );
-        detectNfts();
-      }
-    },
-    [trackEvent, createEventBuilder, detectNfts],
-  );
-
   const turnOnBasicFunctionality = useCallback(() => {
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.SHEET.BASIC_FUNCTIONALITY,
     });
   }, [navigation]);
-
-  const defiEnabled =
-    isNetworkEnabledForDefi &&
-    !enabledNetworksHasTestNet &&
-    basicFunctionalityEnabled &&
-    assetsDefiPositionsEnabled;
 
   const scrollViewContentStyle = useMemo(
     () => [
@@ -1231,13 +848,7 @@ const Wallet = ({
     setRefreshing(true);
 
     try {
-      if (isHomepageSectionsV1Enabled) {
-        // Homepage sections mode - refresh homepage and balance
-        await Promise.all([refreshBalance(), homepageRef.current?.refresh()]);
-      } else {
-        // Legacy tab mode
-        await walletTokensTabViewRef.current?.refresh(refreshBalance);
-      }
+      await Promise.all([refreshBalance(), homepageRef.current?.refresh()]);
     } catch (error) {
       Logger.error(error as Error, 'Error refreshing wallet');
     } finally {
@@ -1248,7 +859,7 @@ const Wallet = ({
         setRefreshing(false);
       }
     }
-  }, [refreshBalance, isHomepageSectionsV1Enabled]);
+  }, [refreshBalance]);
 
   const subscribeToScroll = useCallback((cb: () => void) => {
     scrollSubscribersRef.current.add(cb);
@@ -1399,67 +1010,6 @@ const Wallet = ({
     </>
   );
 
-  // Legacy scroll view content — used only when the sections redesign is off.
-  const content = (
-    <>
-      <View style={styles.banner} accessible={false}>
-        {!basicFunctionalityEnabled ? (
-          <BannerAlert
-            severity={BannerAlertSeverity.Error}
-            title={strings('wallet.banner.title')}
-            description={
-              <CustomText
-                color={TextColor.Info}
-                onPress={turnOnBasicFunctionality}
-              >
-                {strings('wallet.banner.link')}
-              </CustomText>
-            }
-          />
-        ) : null}
-        <NetworkConnectionBanner />
-      </View>
-      <View style={styles.walletPostOnboardingStage}>
-        <View
-          testID={WalletViewSelectorsIDs.WALLET_TOP_CLUSTER_INNER}
-          style={styles.walletTopCluster}
-        >
-          <AccountGroupBalance {...walletHomeAccountGroupBalanceProps} />
-
-          {walletHomeMainAssetDetailsActions}
-        </View>
-
-        <Reanimated.View
-          layout={WALLET_HOME_MAIN_BELOW_CLUSTER_LAYOUT}
-          style={styles.walletPostOnboardingMainBelowCluster}
-        >
-          {homeGrowthBannerContent}
-
-          {isHomepageSectionsV1Enabled ? (
-            <>
-              {isFocused && <AssetPollingProvider chainIds={evmChainIds} />}
-              <HomepageScrollContext.Provider
-                value={homepageScrollContextValue}
-              >
-                <Homepage ref={homepageRef} />
-              </HomepageScrollContext.Provider>
-            </>
-          ) : (
-            <>
-              {isFocused && <AssetPollingProvider />}
-              <WalletTokensTabView
-                ref={walletTokensTabViewRef}
-                navigation={navigation}
-                onChangeTab={onChangeTab}
-                defiEnabled={defiEnabled}
-                collectiblesEnabled={collectiblesEnabled}
-              />
-            </>
-          )}
-        </Reanimated.View>
-      </View>
-    </>
-  );
   const renderLoader = useCallback(
     () => (
       <View style={styles.loader}>
@@ -1601,79 +1151,52 @@ const Wallet = ({
                   });
                 }}
               >
-                {isHomepageSectionsV1Enabled ? (
-                  <>
-                    {isFocused && (
-                      <AssetPollingProvider chainIds={evmChainIds} />
-                    )}
-                    <HomepageScrollContext.Provider
-                      value={homepageScrollContextValue}
-                    >
-                      {isDiscoveryTabsTreatment ? (
-                        <HomepageDiscoveryTabs
-                          ref={homepageRef}
-                          portfolioHeader={portfolioHeader}
-                          onPortfolioScroll={handleHomepageScroll}
-                          walletHeaderOffset={headerHeight + insets.top}
-                          walletHeaderHeight={headerHeight}
-                          walletHeaderTranslateY={walletHeaderTranslateY}
-                          refreshControl={
-                            <RefreshControl
-                              colors={[colors.primary.default]}
-                              tintColor={colors.icon.default}
-                              refreshing={refreshing}
-                              onRefresh={handleRefresh}
-                            />
-                          }
-                        />
-                      ) : (
-                        <ConditionalScrollView
-                          ref={scrollViewRef}
-                          isScrollEnabled
-                          scrollViewProps={{
-                            testID: WalletViewSelectorsIDs.WALLET_SCROLL_VIEW,
-                            contentContainerStyle: scrollViewContentStyle,
-                            showsVerticalScrollIndicator: false,
-                            onScroll: handleHomepageScroll,
-                            scrollEventThrottle: 16,
-                            refreshControl: (
-                              <RefreshControl
-                                colors={[colors.primary.default]}
-                                tintColor={colors.icon.default}
-                                refreshing={refreshing}
-                                onRefresh={handleRefresh}
-                              />
-                            ),
-                          }}
-                        >
-                          {portfolioHeaderBase}
-                          <Homepage ref={homepageRef} />
-                        </ConditionalScrollView>
-                      )}
-                    </HomepageScrollContext.Provider>
-                  </>
-                ) : (
-                  <ConditionalScrollView
-                    ref={scrollViewRef}
-                    isScrollEnabled
-                    scrollViewProps={{
-                      testID: WalletViewSelectorsIDs.WALLET_SCROLL_VIEW,
-                      contentContainerStyle: scrollViewContentStyle,
-                      showsVerticalScrollIndicator: false,
-                      scrollEventThrottle: 16,
-                      refreshControl: (
+                {isFocused && <AssetPollingProvider chainIds={evmChainIds} />}
+                <HomepageScrollContext.Provider
+                  value={homepageScrollContextValue}
+                >
+                  {isDiscoveryTabsTreatment ? (
+                    <HomepageDiscoveryTabs
+                      ref={homepageRef}
+                      portfolioHeader={portfolioHeader}
+                      onPortfolioScroll={handleHomepageScroll}
+                      walletHeaderOffset={headerHeight + insets.top}
+                      walletHeaderHeight={headerHeight}
+                      walletHeaderTranslateY={walletHeaderTranslateY}
+                      refreshControl={
                         <RefreshControl
                           colors={[colors.primary.default]}
                           tintColor={colors.icon.default}
                           refreshing={refreshing}
                           onRefresh={handleRefresh}
                         />
-                      ),
-                    }}
-                  >
-                    {content}
-                  </ConditionalScrollView>
-                )}
+                      }
+                    />
+                  ) : (
+                    <ConditionalScrollView
+                      ref={scrollViewRef}
+                      isScrollEnabled
+                      scrollViewProps={{
+                        testID: WalletViewSelectorsIDs.WALLET_SCROLL_VIEW,
+                        contentContainerStyle: scrollViewContentStyle,
+                        showsVerticalScrollIndicator: false,
+                        onScroll: handleHomepageScroll,
+                        scrollEventThrottle: 16,
+                        refreshControl: (
+                          <RefreshControl
+                            colors={[colors.primary.default]}
+                            tintColor={colors.icon.default}
+                            refreshing={refreshing}
+                            onRefresh={handleRefresh}
+                          />
+                        ),
+                      }}
+                    >
+                      {portfolioHeaderBase}
+                      <Homepage ref={homepageRef} />
+                    </ConditionalScrollView>
+                  )}
+                </HomepageScrollContext.Provider>
               </View>
             </>
           ) : (

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -10,6 +10,12 @@ import React, {
 } from 'react';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { SectionRefreshHandle } from '../Homepage/types';
+
+/** Matches HomepageDiscoveryTabs imperative handle (kept local for ADR-0020). */
+interface WalletDiscoveryTabsRef {
+  refresh: () => Promise<void>;
+  goToPerpsTab: () => void;
+}
 import { useBalanceRefresh, useHomepageEntryPoint } from './hooks';
 
 import {
@@ -766,6 +772,34 @@ const Wallet = ({
   const isDiscoveryTabsTreatment =
     discoveryTabsVariantName === HubPageDiscoveryTabsVariant.Treatment;
 
+  const isPerpsEnabled = isPerpsFlagEnabled;
+
+  const homepageDiscoveryTabsRef = useRef<WalletDiscoveryTabsRef>(null);
+
+  const handlePerpsTabDeepLink = useCallback(() => {
+    if (isDiscoveryTabsTreatment) {
+      homepageDiscoveryTabsRef.current?.goToPerpsTab();
+      return;
+    }
+    navigation.navigate(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { source: 'deeplink' },
+    });
+  }, [isDiscoveryTabsTreatment, navigation]);
+
+  const handleNetworkSelectorDeepLink = useCallback(() => {
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.NETWORK_SELECTOR,
+    });
+  }, [navigation]);
+
+  useHomeDeepLinkEffects({
+    navigation,
+    isPerpsEnabled,
+    onPerpsTabSelected: handlePerpsTabDeepLink,
+    onNetworkSelectorSelected: handleNetworkSelectorDeepLink,
+  });
+
   // translateY slides the header up; negative marginBottom collapses the layout
   // space it occupied so the content below moves up in sync.
   const animatedHeaderStyle = useAnimatedStyle(() => {
@@ -848,7 +882,10 @@ const Wallet = ({
     setRefreshing(true);
 
     try {
-      await Promise.all([refreshBalance(), homepageRef.current?.refresh()]);
+      const refreshHomepage = isDiscoveryTabsTreatment
+        ? homepageDiscoveryTabsRef.current?.refresh()
+        : homepageRef.current?.refresh();
+      await Promise.all([refreshBalance(), refreshHomepage]);
     } catch (error) {
       Logger.error(error as Error, 'Error refreshing wallet');
     } finally {
@@ -859,7 +896,7 @@ const Wallet = ({
         setRefreshing(false);
       }
     }
-  }, [refreshBalance]);
+  }, [refreshBalance, isDiscoveryTabsTreatment]);
 
   const subscribeToScroll = useCallback((cb: () => void) => {
     scrollSubscribersRef.current.add(cb);
@@ -1157,7 +1194,7 @@ const Wallet = ({
                 >
                   {isDiscoveryTabsTreatment ? (
                     <HomepageDiscoveryTabs
-                      ref={homepageRef}
+                      ref={homepageDiscoveryTabsRef}
                       portfolioHeader={portfolioHeader}
                       onPortfolioScroll={handleHomepageScroll}
                       walletHeaderOffset={headerHeight + insets.top}

--- a/app/components/Views/Wallet/types.ts
+++ b/app/components/Views/Wallet/types.ts
@@ -1,19 +1,7 @@
 /**
  * Interface for tab components that expose a refresh method.
- * Used by WalletTokensTabView to call refresh on the active tab.
+ * Used by Tokens, NftGrid, and PredictTabView in full-view flows.
  */
 export interface TabRefreshHandle {
   refresh: () => Promise<void>;
-}
-
-/**
- * Interface for WalletTokensTabView ref that exposes refresh method.
- * Used by Wallet component to trigger refresh on pull-to-refresh.
- */
-export interface WalletTokensTabViewHandle {
-  /**
-   * Refreshes both balance and the active tab's content.
-   * @param onBalanceRefresh - Function to refresh account balance and currency rates.
-   */
-  refresh: (onBalanceRefresh: () => Promise<void>) => Promise<void>;
 }

--- a/app/core/Engine/controllers/account-tracker-controller-init.test.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.test.ts
@@ -9,6 +9,8 @@ import {
   AccountTrackerControllerMessenger,
 } from '@metamask/assets-controllers';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { selectAssetsAccountApiBalancesEnabled } from '../../../selectors/featureFlagController/assetsAccountApiBalances';
+import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 
 jest.mock('@metamask/assets-controllers');
 
@@ -82,5 +84,33 @@ describe('accountTrackerControllerInit', () => {
 
       expect(isHomepageSectionsV1Enabled()).toBe(true);
     });
+  });
+
+  it('reads account-api chain IDs from state', () => {
+    accountTrackerControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AccountTrackerController);
+    const { accountsApiChainIds } = controllerMock.mock.calls[0][0] as {
+      accountsApiChainIds: () => `0x${string}`[];
+    };
+
+    jest.mocked(selectAssetsAccountApiBalancesEnabled).mockReturnValue(['0x1']);
+
+    expect(accountsApiChainIds()).toEqual(['0x1']);
+    expect(selectAssetsAccountApiBalancesEnabled).toHaveBeenCalled();
+  });
+
+  it('reads external services availability from settings state', () => {
+    accountTrackerControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AccountTrackerController);
+    const { allowExternalServices } = controllerMock.mock.calls[0][0] as {
+      allowExternalServices: () => boolean;
+    };
+
+    jest.mocked(selectBasicFunctionalityEnabled).mockReturnValue(false);
+
+    expect(allowExternalServices()).toBe(false);
+    expect(selectBasicFunctionalityEnabled).toHaveBeenCalled();
   });
 });

--- a/app/core/Engine/controllers/account-tracker-controller-init.test.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.test.ts
@@ -12,10 +12,6 @@ import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 
 jest.mock('@metamask/assets-controllers');
 
-jest.mock('../../../selectors/featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: jest.fn().mockReturnValue(false),
-}));
-
 jest.mock(
   '../../../selectors/featureFlagController/assetsAccountApiBalances',
   () => ({
@@ -48,61 +44,34 @@ function getInitRequestMock(): jest.Mocked<
       };
     }
 
-    throw new Error(`Controller "${name}" not found.`);
+    throw new Error(`Unexpected messenger client: ${name}`);
   });
 
   return requestMock;
 }
 
-describe('AccountTrackerControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = accountTrackerControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AccountTrackerController);
+describe('accountTrackerControllerInit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
   it('passes the proper arguments to the controller including isHomepageSectionsV1Enabled', () => {
     accountTrackerControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountTrackerController);
-    expect(controllerMock).toHaveBeenCalledWith({
-      messenger: expect.any(Object),
-      state: { accountsByChainId: {} },
-      includeStakedAssets: true,
-      getStakedBalanceForChain: expect.any(Function),
-      accountsApiChainIds: expect.any(Function),
-      allowExternalServices: expect.any(Function),
-      isHomepageSectionsV1Enabled: expect.any(Function),
-    });
+    expect(controllerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeStakedAssets: true,
+        getStakedBalanceForChain: expect.any(Function),
+        accountsApiChainIds: expect.any(Function),
+        allowExternalServices: expect.any(Function),
+        isHomepageSectionsV1Enabled: expect.any(Function),
+      }),
+    );
   });
 
   describe('isHomepageSectionsV1Enabled', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('returns false when feature flag is off', () => {
-      const { selectHomepageSectionsV1Enabled } = jest.requireMock(
-        '../../../selectors/featureFlagController/homepage',
-      );
-      selectHomepageSectionsV1Enabled.mockReturnValue(false);
-
-      accountTrackerControllerInit(getInitRequestMock());
-
-      const controllerMock = jest.mocked(AccountTrackerController);
-      const { isHomepageSectionsV1Enabled } = controllerMock.mock
-        .calls[0][0] as {
-        isHomepageSectionsV1Enabled: () => boolean;
-      };
-
-      expect(isHomepageSectionsV1Enabled()).toBe(false);
-    });
-
-    it('returns true when feature flag is on', () => {
-      const { selectHomepageSectionsV1Enabled } = jest.requireMock(
-        '../../../selectors/featureFlagController/homepage',
-      );
-      selectHomepageSectionsV1Enabled.mockReturnValue(true);
-
+    it('always returns true now that homepage sections UI is permanent', () => {
       accountTrackerControllerInit(getInitRequestMock());
 
       const controllerMock = jest.mocked(AccountTrackerController);

--- a/app/core/Engine/controllers/account-tracker-controller-init.ts
+++ b/app/core/Engine/controllers/account-tracker-controller-init.ts
@@ -5,8 +5,6 @@ import {
 } from '@metamask/assets-controllers';
 import { selectAssetsAccountApiBalancesEnabled } from '../../../selectors/featureFlagController/assetsAccountApiBalances';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
-import { selectHomepageSectionsV1Enabled } from '../../../selectors/featureFlagController/homepage';
-
 /**
  * Initialize the accountTracker controller.
  *
@@ -35,8 +33,7 @@ export const accountTrackerControllerInit: MessengerClientInitFunction<
     accountsApiChainIds: () =>
       selectAssetsAccountApiBalancesEnabled(getState()) as `0x${string}`[],
     allowExternalServices: () => selectBasicFunctionalityEnabled(getState()),
-    isHomepageSectionsV1Enabled: () =>
-      selectHomepageSectionsV1Enabled(getState()),
+    isHomepageSectionsV1Enabled: () => true,
   });
 
   return {

--- a/app/selectors/featureFlagController/homepage/index.test.ts
+++ b/app/selectors/featureFlagController/homepage/index.test.ts
@@ -1,5 +1,4 @@
 import {
-  selectHomepageSectionsV1Enabled,
   selectHubPageDiscoveryTabsABTest,
   selectWalletHomeOnboardingStepsEnabled,
   selectWalletHomePostOnboardingAbTest,
@@ -25,54 +24,6 @@ describe('Homepage Feature Flag Selectors', () => {
 
   afterEach(() => {
     mockHasMinimumRequiredVersion?.mockRestore();
-  });
-
-  describe('selectHomepageSectionsV1Enabled', () => {
-    it('returns true when remote flag is valid and enabled', () => {
-      const result = selectHomepageSectionsV1Enabled.resultFunc({
-        homepageSectionsV1: {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(result).toBe(true);
-    });
-
-    it('returns false when remote flag is valid but disabled', () => {
-      const result = selectHomepageSectionsV1Enabled.resultFunc({
-        homepageSectionsV1: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when version check fails', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(false);
-      const result = selectHomepageSectionsV1Enabled.resultFunc({
-        homepageSectionsV1: {
-          enabled: true,
-          minimumVersion: '99.0.0',
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote flag is invalid', () => {
-      const result = selectHomepageSectionsV1Enabled.resultFunc({
-        homepageSectionsV1: {
-          enabled: 'invalid',
-          minimumVersion: 123,
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote feature flags are empty', () => {
-      const result = selectHomepageSectionsV1Enabled.resultFunc({});
-      expect(result).toBe(false);
-    });
   });
 
   describe('selectHubPageDiscoveryTabsABTest', () => {

--- a/app/selectors/featureFlagController/homepage/index.ts
+++ b/app/selectors/featureFlagController/homepage/index.ts
@@ -1,9 +1,5 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
-import {
-  validatedVersionGatedFeatureFlag,
-  VersionGatedFeatureFlag,
-} from '../../../util/remoteFeatureFlag';
 import { resolveABTestAssignment } from '../../../util/abTest';
 import {
   HUB_PAGE_DISCOVERY_TABS_AB_KEY,
@@ -12,18 +8,6 @@ import {
   WALLET_HOME_POST_ONBOARDING_VARIANTS,
   WalletHomePostOnboardingVariant,
 } from '../../../components/Views/Homepage/abTestConfig';
-
-const homepageSectionsV1Key = 'homepageSectionsV1';
-
-export const selectHomepageSectionsV1Enabled = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    const remoteFlag = remoteFeatureFlags[
-      homepageSectionsV1Key
-    ] as unknown as VersionGatedFeatureFlag;
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
-  },
-);
 
 export const selectHubPageDiscoveryTabsABTest = createSelector(
   selectRemoteFeatureFlags,

--- a/app/selectors/onboarding/index.test.ts
+++ b/app/selectors/onboarding/index.test.ts
@@ -10,19 +10,12 @@ import {
 import { RootState } from '../../reducers';
 import { AccountType } from '../../constants/onboarding';
 import { WALLET_HOME_ONBOARDING_STEPS_INITIAL } from '../../constants/walletHomeOnboardingSteps';
-import {
-  selectHomepageSectionsV1Enabled,
-  selectWalletHomeOnboardingStepsEnabled,
-} from '../featureFlagController/homepage';
+import { selectWalletHomeOnboardingStepsEnabled } from '../featureFlagController/homepage';
 
 jest.mock('../featureFlagController/homepage', () => ({
-  selectHomepageSectionsV1Enabled: jest.fn(),
   selectWalletHomeOnboardingStepsEnabled: jest.fn(),
 }));
 
-const mockSelectHomepageSectionsV1Enabled = jest.mocked(
-  selectHomepageSectionsV1Enabled,
-);
 const mockSelectWalletHomeOnboardingStepsEnabled = jest.mocked(
   selectWalletHomeOnboardingStepsEnabled,
 );
@@ -119,28 +112,17 @@ describe('Onboarding selectors', () => {
       }) as RootState;
 
     beforeEach(() => {
-      mockSelectHomepageSectionsV1Enabled.mockReset();
       mockSelectWalletHomeOnboardingStepsEnabled.mockReset();
     });
 
-    it('is true when all three inputs are true', () => {
-      mockSelectHomepageSectionsV1Enabled.mockReturnValue(true);
+    it('is true when both inputs are true', () => {
       mockSelectWalletHomeOnboardingStepsEnabled.mockReturnValue(true);
       expect(
         selectWalletHomeOnboardingFlowVisible(stateWithShouldShow(true)),
       ).toBe(true);
     });
 
-    it('is false when sectionsV1 is false', () => {
-      mockSelectHomepageSectionsV1Enabled.mockReturnValue(false);
-      mockSelectWalletHomeOnboardingStepsEnabled.mockReturnValue(true);
-      expect(
-        selectWalletHomeOnboardingFlowVisible(stateWithShouldShow(true)),
-      ).toBe(false);
-    });
-
     it('is false when stepsEnabled is false', () => {
-      mockSelectHomepageSectionsV1Enabled.mockReturnValue(true);
       mockSelectWalletHomeOnboardingStepsEnabled.mockReturnValue(false);
       expect(
         selectWalletHomeOnboardingFlowVisible(stateWithShouldShow(true)),
@@ -148,7 +130,6 @@ describe('Onboarding selectors', () => {
     });
 
     it('is false when shouldShow is false', () => {
-      mockSelectHomepageSectionsV1Enabled.mockReturnValue(true);
       mockSelectWalletHomeOnboardingStepsEnabled.mockReturnValue(true);
       expect(
         selectWalletHomeOnboardingFlowVisible(stateWithShouldShow(false)),

--- a/app/selectors/onboarding/index.ts
+++ b/app/selectors/onboarding/index.ts
@@ -1,10 +1,7 @@
 import { RootState } from '../../reducers';
 import { createSelector } from 'reselect';
 import { WALLET_HOME_ONBOARDING_STEPS_INITIAL } from '../../constants/walletHomeOnboardingSteps';
-import {
-  selectHomepageSectionsV1Enabled,
-  selectWalletHomeOnboardingStepsEnabled,
-} from '../featureFlagController/homepage';
+import { selectWalletHomeOnboardingStepsEnabled } from '../featureFlagController/homepage';
 
 const selectOnboarding = (state: RootState) => state.onboarding;
 
@@ -58,6 +55,5 @@ export const selectShouldShowWalletHomeOnboardingSteps = createSelector(
 export const selectWalletHomeOnboardingFlowVisible = (
   state: RootState,
 ): boolean =>
-  selectHomepageSectionsV1Enabled(state) &&
   selectWalletHomeOnboardingStepsEnabled(state) &&
   selectShouldShowWalletHomeOnboardingSteps(state);

--- a/app/util/notifications/hooks/useStartupNotificationsEffect.test.ts
+++ b/app/util/notifications/hooks/useStartupNotificationsEffect.test.ts
@@ -383,9 +383,6 @@ describe('useEnableNotificationsByDefaultEffect', () => {
     const mockGetIsNotificationEnabledByDefaultFeatureFlag = jest
       .spyOn(Selectors, 'getIsNotificationEnabledByDefaultFeatureFlag')
       .mockReturnValue(true);
-    const mockSelectHomepageSectionsV1Enabled = jest
-      .spyOn(HomepageFeatureSelectors, 'selectHomepageSectionsV1Enabled')
-      .mockReturnValue(false);
     const mockSelectWalletHomeOnboardingStepsEnabled = jest
       .spyOn(HomepageFeatureSelectors, 'selectWalletHomeOnboardingStepsEnabled')
       .mockReturnValue(false);
@@ -399,7 +396,6 @@ describe('useEnableNotificationsByDefaultEffect', () => {
       mockSelectIsUnlocked,
       mockSelectIsSignedIn,
       mockGetIsNotificationEnabledByDefaultFeatureFlag,
-      mockSelectHomepageSectionsV1Enabled,
       mockSelectWalletHomeOnboardingStepsEnabled,
       mockSelectShouldShowWalletHomeOnboardingSteps,
     };
@@ -515,7 +511,6 @@ describe('useEnableNotificationsByDefaultEffect', () => {
 
   it('does not enable notifications when wallet home post-onboarding checklist is active', async () => {
     const mocks = arrange();
-    mocks.selectors.mockSelectHomepageSectionsV1Enabled.mockReturnValue(true);
     mocks.selectors.mockSelectWalletHomeOnboardingStepsEnabled.mockReturnValue(
       true,
     );

--- a/app/util/notifications/hooks/useStartupNotificationsEffect.ts
+++ b/app/util/notifications/hooks/useStartupNotificationsEffect.ts
@@ -2,10 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { selectIsSignedIn } from '../../../selectors/identity';
 import { selectIsUnlocked } from '../../../selectors/keyringController';
-import {
-  selectHomepageSectionsV1Enabled,
-  selectWalletHomeOnboardingStepsEnabled,
-} from '../../../selectors/featureFlagController/homepage';
+import { selectWalletHomeOnboardingStepsEnabled } from '../../../selectors/featureFlagController/homepage';
 import {
   getIsNotificationEnabledByDefaultFeatureFlag,
   selectIsMetamaskNotificationsEnabled,
@@ -120,9 +117,6 @@ export function useEnableNotificationsByDefaultEffect() {
   const isNotificationsEnabledByDefaultFeatureFlag = useSelector(
     getIsNotificationEnabledByDefaultFeatureFlag,
   );
-  const homepageSectionsV1Enabled = useSelector(
-    selectHomepageSectionsV1Enabled,
-  );
   const walletHomeOnboardingStepsRemoteEnabled = useSelector(
     selectWalletHomeOnboardingStepsEnabled,
   );
@@ -136,7 +130,6 @@ export function useEnableNotificationsByDefaultEffect() {
     const run = async () => {
       try {
         const isWalletHomePostOnboardingChecklistActive =
-          homepageSectionsV1Enabled &&
           walletHomeOnboardingStepsRemoteEnabled &&
           shouldShowWalletHomeOnboardingSteps;
 
@@ -164,7 +157,6 @@ export function useEnableNotificationsByDefaultEffect() {
     run();
   }, [
     enableAndRefresh,
-    homepageSectionsV1Enabled,
     isBasicFunctionalityEnabled,
     isNotificationsEnabledByDefaultFeatureFlag,
     isUnlocked,

--- a/tests/api-mocking/mock-responses/earn/lending-mocks.ts
+++ b/tests/api-mocking/mock-responses/earn/lending-mocks.ts
@@ -183,7 +183,6 @@ export async function setupLendingMocks(
   await setupRemoteFeatureFlagsMock(mockServer, {
     earnStablecoinLendingEnabled: { enabled: true, minimumVersion: '0.0.0' },
     homepageRedesignV1: { enabled: true, minimumVersion: '0.0.0' },
-    homepageSectionsV1: { enabled: true, minimumVersion: '0.0.0' },
   });
 
   // Accounts API v4 (multiaccount balances)

--- a/tests/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/tests/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -134,13 +134,6 @@ export const remoteFeatureFlagPredictEnabled = (enabled = true) => ({
   },
 });
 
-export const remoteFeatureFlagHomepageSectionsV1Enabled = (enabled = true) => ({
-  homepageSectionsV1: {
-    enabled,
-    minimumVersion: '0.0.0',
-  },
-});
-
 export const remoteFeatureFlagRampsUnifiedV1Enabled = (active = true) => ({
   rampsUnifiedBuyV1: {
     active,

--- a/tests/component-view/presets/wallet.ts
+++ b/tests/component-view/presets/wallet.ts
@@ -71,7 +71,14 @@ export const initialStateWallet = (options?: InitialStateWalletOptions) => {
           MultichainTransactionsController: {
             nonEvmTransactions: {},
           },
+          NftController: {
+            allNfts: {},
+            allNftContracts: {},
+          },
         },
+      },
+      collectibles: {
+        favorites: {},
       },
     } as unknown as DeepPartial<RootState>);
 

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3298,17 +3298,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  homepageSectionsV1: {
-    name: 'homepageSectionsV1',
-    type: FeatureFlagType.Remote,
-    inProd: true,
-    productionDefault: {
-      minimumVersion: '7.70.0',
-      enabled: true,
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
   homeTMCU610AbtestWalletHomePostOnboardingSteps: {
     name: 'homeTMCU610AbtestWalletHomePostOnboardingSteps',
     type: FeatureFlagType.Remote,

--- a/tests/helpers/analytics/expectations/predict-cash-out.analytics.ts
+++ b/tests/helpers/analytics/expectations/predict-cash-out.analytics.ts
@@ -8,7 +8,7 @@ const ACTIVITY_VIEWED = 'Predict Activity Viewed';
  *
  * Note: "Predict Position Viewed" is not asserted here. It is only emitted from legacy
  * `PredictHomePositions` inside `PredictTabView` when the wallet Predict tab is visible.
- * With homepage sections v1 (`remoteFeatureFlagHomepageSectionsV1Enabled`), the wallet uses
+ * The wallet uses the sections-based homepage UI.
  * `Homepage` + `PredictionsSection` instead — that path does not call `trackPositionViewed`.
  */
 export const predictCashOutFlowAnalyticsExpectations: AnalyticsExpectations = {

--- a/tests/performance/fixtures/test.spec.ts
+++ b/tests/performance/fixtures/test.spec.ts
@@ -8,7 +8,6 @@ import {
   mockPerpsGeolocation,
   PERPS_ARBITRUM_MOCKS,
 } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { LocalNodeType } from '../../framework';
 import { Hardfork } from '../../seeder/anvil-manager';
@@ -43,9 +42,7 @@ test.describe(Performance, () => {
         restartDevice: true,
         currentDeviceDetails,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
           await mockPerpsGeolocation(
             mockServer,

--- a/tests/regression/assets/asset-sort.spec.ts
+++ b/tests/regression/assets/asset-sort.spec.ts
@@ -11,7 +11,6 @@ import { MockApiEndpoint } from '../../framework';
 import { Mockttp } from 'mockttp';
 import { setupMockRequest } from '../../api-mocking/helpers/mockHelpers';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 const AAVE_MAINNET_DETAILS = {
   address: '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
@@ -72,9 +71,7 @@ describe(RegressionAssets('Import Tokens'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await setupMockRequest(mockServer, {
             requestMethod: 'GET',
             url: TOKEN_RESPONSE.urlEndpoint,
@@ -111,9 +108,7 @@ describe(RegressionAssets('Import Tokens'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await setupMockRequest(mockServer, {
             requestMethod: 'GET',
             url: TOKEN_RESPONSE.urlEndpoint,
@@ -153,9 +148,7 @@ describe(RegressionAssets('Import Tokens'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await setupMockRequest(mockServer, {
             requestMethod: 'GET',
             url: TOKEN_RESPONSE.urlEndpoint,

--- a/tests/regression/assets/defi/view-defi-tab.spec.ts
+++ b/tests/regression/assets/defi/view-defi-tab.spec.ts
@@ -7,7 +7,6 @@ import { WalletViewSelectorsText } from '../../../../app/components/Views/Wallet
 import { loginToApp } from '../../../flows/wallet.flow';
 import { setupMockRequest } from '../../../api-mocking/helpers/mockHelpers';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../../api-mocking/mock-responses/feature-flags-mocks';
 import { Mockttp } from 'mockttp';
 import {
   defiPositionsError,
@@ -24,9 +23,7 @@ describe(RegressionNetworkAbstractions('View DeFi tab'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
 
           const { urlEndpoint, response } = defiPositionsWithNoData;
           await setupMockRequest(mockServer, {
@@ -54,9 +51,7 @@ describe(RegressionNetworkAbstractions('View DeFi tab'), () => {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
 
           const { urlEndpoint, response } = defiPositionsError;
           await setupMockRequest(mockServer, {
@@ -97,9 +92,7 @@ describe(RegressionNetworkAbstractions('View DeFi tab'), () => {
         fixture: new FixtureBuilder().withPopularNetworks().build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
 
           const { urlEndpoint, response } = defiPositionsWithData;
           await setupMockRequest(mockServer, {

--- a/tests/regression/assets/nft-details.spec.ts
+++ b/tests/regression/assets/nft-details.spec.ts
@@ -17,7 +17,6 @@ import { LocalNode } from '../../framework';
 import { AnvilManager } from '../../seeder/anvil-manager';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 describe.skip(RegressionAssets('NFT Details page'), () => {
   const NFT_CONTRACT = SMART_CONTRACTS.NFTS;
@@ -58,9 +57,7 @@ describe.skip(RegressionAssets('NFT Details page'), () => {
         restartDevice: true,
         smartContracts: [NFT_CONTRACT],
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
         },
       },
       async ({ contractRegistry }) => {

--- a/tests/regression/assets/nft-detection-modal.spec.ts
+++ b/tests/regression/assets/nft-detection-modal.spec.ts
@@ -8,7 +8,6 @@ import NftDetectionModal from '../../page-objects/wallet/NftDetectionModal';
 import { RegressionAssets } from '../../tags';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 import { NftDetectionModalSelectorsText } from '../../../app/components/Views/NFTAutoDetectionModal/NftDetectionModal.testIds.ts';
 
@@ -28,9 +27,7 @@ describe.skip(RegressionAssets('NFT Detection Modal'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
         },
       },
       async () => {
@@ -62,9 +59,7 @@ describe.skip(RegressionAssets('NFT Detection Modal'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
         },
       },
       async () => {

--- a/tests/regression/assets/transaction.spec.ts
+++ b/tests/regression/assets/transaction.spec.ts
@@ -13,10 +13,7 @@ import TokenOverview from '../../page-objects/wallet/TokenOverview';
 import ToastModal from '../../page-objects/wallet/ToastModal';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import {
-  confirmationFeatureFlags,
-  remoteFeatureFlagHomepageSectionsV1Enabled,
-} from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { confirmationFeatureFlags } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { LocalNode } from '../../framework/types';
 import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
 import { AnvilManager } from '../../seeder/anvil-manager';
@@ -57,7 +54,6 @@ describe(RegressionAssets('Transaction'), () => {
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
             ...Object.assign({}, ...confirmationFeatureFlags),
           });
         },

--- a/tests/regression/wallet/send-ERC-token.spec.ts
+++ b/tests/regression/wallet/send-ERC-token.spec.ts
@@ -11,10 +11,7 @@ import Matchers from '../../framework/Matchers';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import {
-  confirmationFeatureFlags,
-  remoteFeatureFlagHomepageSectionsV1Enabled,
-} from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { confirmationFeatureFlags } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { SMART_CONTRACTS } from '../../../app/util/test/smart-contracts';
 import { Mockttp } from 'mockttp';
 import { LocalNode } from '../../framework/types';
@@ -58,7 +55,6 @@ describe(RegressionWalletPlatform('Send ERC Token'), () => {
         smartContracts: [SMART_CONTRACTS.HST],
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
             ...Object.assign({}, ...confirmationFeatureFlags),
           });
         },

--- a/tests/smoke/networks/homepage-sections-network-filter.spec.ts
+++ b/tests/smoke/networks/homepage-sections-network-filter.spec.ts
@@ -10,7 +10,6 @@ import NetworkManager from '../../page-objects/wallet/NetworkManager';
 import Assertions from '../../framework/Assertions';
 import { NetworkToCaipChainId } from '../../../app/components/UI/NetworkMultiSelector/NetworkMultiSelector.constants';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { Mockttp } from 'mockttp';
 import { SolScope } from '@metamask/keyring-api';
 import type { AssetsControllerState } from '@metamask/assets-controller';
@@ -254,9 +253,7 @@ describe(
             .build(),
           restartDevice: true,
           testSpecificMock: async (mockServer: Mockttp) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-            });
+            await setupRemoteFeatureFlagsMock(mockServer, {});
           },
         },
         async () => {
@@ -306,9 +303,7 @@ describe(
           })(),
           restartDevice: true,
           testSpecificMock: async (mockServer: Mockttp) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-            });
+            await setupRemoteFeatureFlagsMock(mockServer, {});
           },
         },
         async () => {
@@ -352,9 +347,7 @@ describe(
           fixture: createHomepageTokensFilterFixture(),
           restartDevice: true,
           testSpecificMock: async (mockServer: Mockttp) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-            });
+            await setupRemoteFeatureFlagsMock(mockServer, {});
           },
         },
         async () => {

--- a/tests/smoke/networks/network-manager2.spec.ts
+++ b/tests/smoke/networks/network-manager2.spec.ts
@@ -317,10 +317,6 @@ describe(SmokeNetworkAbstractions('Network Manager'), () => {
   });
 
   it('should preserve existing enabled networks when adding a network via dapp', async () => {
-    // This test uses navigateToBrowserView() which relies on the old tab bar
-    // structure. The homepageSectionsV1 flag changes the tab bar, so it must
-    // be disabled here. This test is about dapp network preservation, not
-    // homepage sections UI.
     const dappTestMock = async (mockServer: Mockttp) => {
       await setupRemoteFeatureFlagsMock(mockServer, {
         carouselBanners: false,

--- a/tests/smoke/perps/perps-add-funds.spec.ts
+++ b/tests/smoke/perps/perps-add-funds.spec.ts
@@ -20,7 +20,6 @@ import Utilities from '../../framework/Utilities';
 import { createLogger, LogLevel } from '../../framework/logger';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 const logger = createLogger({
   name: 'PerpsAddFundsSpec',
@@ -73,9 +72,7 @@ describe.skip(
             .build(),
           restartDevice: true,
           testSpecificMock: async (mockServer: Mockttp) => {
-            await setupRemoteFeatureFlagsMock(mockServer, {
-              ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-            });
+            await setupRemoteFeatureFlagsMock(mockServer, {});
             await PERPS_ARBITRUM_MOCKS(mockServer);
             await mockPerpsGeolocation(
               mockServer,

--- a/tests/smoke/perps/perps-limit-long-fill.spec.ts
+++ b/tests/smoke/perps/perps-limit-long-fill.spec.ts
@@ -17,7 +17,6 @@ import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers';
 import { TestSuiteParams } from '../../framework/types';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import Utilities from '../../framework/Utilities';
 describe(SmokePerps('Perps - ETH limit long fill'), () => {
   it('creates ETH limit long at Mid, shows open order, then fills after -15%', async () => {
@@ -46,9 +45,7 @@ describe(SmokePerps('Perps - ETH limit long fill'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
           await mockPerpsGeolocation(
             mockServer,

--- a/tests/smoke/perps/perps-position-liquidation.spec.ts
+++ b/tests/smoke/perps/perps-position-liquidation.spec.ts
@@ -17,7 +17,6 @@ import {
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import CommandQueueServer from '../../framework/fixtures/CommandQueueServer';
 import {
   openPosition,
@@ -52,9 +51,7 @@ const MARK_PRICE_BY_DIRECTION: Record<
 };
 
 const setupPerpsMocks = async (mockServer: Mockttp) => {
-  await setupRemoteFeatureFlagsMock(mockServer, {
-    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-  });
+  await setupRemoteFeatureFlagsMock(mockServer, {});
   await PERPS_ARBITRUM_MOCKS(mockServer);
   await mockPerpsGeolocation(mockServer, RampsRegions[RampsRegionsEnum.SPAIN]);
 };

--- a/tests/smoke/perps/perps-position-stop-loss.spec.ts
+++ b/tests/smoke/perps/perps-position-stop-loss.spec.ts
@@ -21,7 +21,6 @@ import {
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 const logger = createLogger({
   name: 'PerpsPositionStopLossSpec',
@@ -55,9 +54,7 @@ describe(SmokePerps('Perps Position Stop Loss'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
           await mockPerpsGeolocation(
             mockServer,

--- a/tests/smoke/perps/perps-position.spec.ts
+++ b/tests/smoke/perps/perps-position.spec.ts
@@ -16,7 +16,6 @@ import PerpsView from '../../page-objects/Perps/PerpsView';
 import { createLogger, LogLevel } from '../../framework';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagHomepageSectionsV1Enabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 
 // E2E environment setup - mocks auto-configure via isE2E flag
 
@@ -52,9 +51,7 @@ describe(SmokePerps('Perps Position'), () => {
           .build(),
         restartDevice: true,
         testSpecificMock: async (mockServer: Mockttp) => {
-          await setupRemoteFeatureFlagsMock(mockServer, {
-            ...remoteFeatureFlagHomepageSectionsV1Enabled(),
-          });
+          await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
           await mockPerpsGeolocation(
             mockServer,

--- a/tests/smoke/predict/predict-cash-out.spec.ts
+++ b/tests/smoke/predict/predict-cash-out.spec.ts
@@ -6,10 +6,7 @@ import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage';
 import PredictMarketList from '../../page-objects/Predict/PredictMarketList';
 import Assertions from '../../framework/Assertions';
 import WalletView from '../../page-objects/wallet/WalletView';
-import {
-  remoteFeatureFlagHomepageSectionsV1Enabled,
-  remoteFeatureFlagPredictEnabled,
-} from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { remoteFeatureFlagPredictEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import {
   POLYMARKET_COMPLETE_MOCKS,
   POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS,
@@ -42,7 +39,6 @@ const positionDetails = {
 
 const PredictionMarketFeature = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
-    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
     ...remoteFeatureFlagPredictEnabled(true),
     carouselBanners: false,
   });

--- a/tests/smoke/predict/predict-claim-positions.spec.ts
+++ b/tests/smoke/predict/predict-claim-positions.spec.ts
@@ -7,7 +7,6 @@ import WalletView from '../../page-objects/wallet/WalletView';
 import {
   remoteFeatureFlagPredictEnabled,
   confirmationFeatureFlags,
-  remoteFeatureFlagHomepageSectionsV1Enabled,
 } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import {
   POLYMARKET_COMPLETE_MOCKS,
@@ -55,7 +54,6 @@ Test Scenario: Claim winning positions
 
 const PredictionMarketFeature = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
-    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
     ...remoteFeatureFlagPredictEnabled(true),
     ...Object.assign({}, ...confirmationFeatureFlags),
     carouselBanners: false,

--- a/tests/smoke/predict/predict-geo-restriction.spec.ts
+++ b/tests/smoke/predict/predict-geo-restriction.spec.ts
@@ -9,10 +9,7 @@ import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage';
 import WalletView from '../../page-objects/wallet/WalletView';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import {
-  remoteFeatureFlagHomepageSectionsV1Enabled,
-  remoteFeatureFlagPredictEnabled,
-} from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { remoteFeatureFlagPredictEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import {
   POLYMARKET_COMPLETE_MOCKS,
   POLYMARKET_GEO_BLOCKED_MOCKS,
@@ -27,7 +24,6 @@ import { geoBlockedCombinedExpectations } from '../../helpers/analytics/expectat
 const predictionGeoBlockedFeature = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
     ...remoteFeatureFlagPredictEnabled(true),
-    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
     carouselBanners: false,
   });
   await POLYMARKET_MARKET_FEEDS_MOCKS(mockServer);

--- a/tests/smoke/predict/predict-open-position.spec.ts
+++ b/tests/smoke/predict/predict-open-position.spec.ts
@@ -5,10 +5,7 @@ import { loginToApp } from '../../flows/wallet.flow';
 import PredictMarketList from '../../page-objects/Predict/PredictMarketList';
 import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage';
 import Assertions from '../../framework/Assertions';
-import {
-  remoteFeatureFlagHomepageSectionsV1Enabled,
-  remoteFeatureFlagPredictEnabled,
-} from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { remoteFeatureFlagPredictEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import {
@@ -41,7 +38,6 @@ const positionDetails = {
 const PredictionMarketFeature = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
     ...remoteFeatureFlagPredictEnabled(true),
-    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
     carouselBanners: false,
   });
   await POLYMARKET_COMPLETE_MOCKS(mockServer);

--- a/tests/smoke/predict/predict-withdraw.spec.ts
+++ b/tests/smoke/predict/predict-withdraw.spec.ts
@@ -4,7 +4,6 @@ import { SmokePredictions } from '../../tags';
 import { loginToApp } from '../../flows/wallet.flow';
 import { Assertions } from '../../framework';
 import {
-  remoteFeatureFlagHomepageSectionsV1Enabled,
   remoteFeatureFlagPredictEnabled,
   confirmationFeatureFlags,
 } from '../../api-mocking/mock-responses/feature-flags-mocks';
@@ -34,7 +33,6 @@ const PredictionMarketFeature = async (mockServer: Mockttp) => {
   await POLYMARKET_POLYGON_RELAY_POLLING_MOCKS(mockServer);
   await setupRemoteFeatureFlagsMock(mockServer, {
     ...remoteFeatureFlagPredictEnabled(true),
-    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
     ...Object.assign({}, ...confirmationFeatureFlags),
     carouselBanners: false,
   }); // we need to mock the confirmations redesign Feature flag


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The homepageSectionsV1 experiment has concluded; the sections-based wallet home is now the default experience. This PR removes the feature flag and all associated conditional logic, deletes the legacy tab-based wallet UI, and simplifies consumers to always use the sections behavior.

**What changed:**

- Removed homepageSectionsV1 from remote feature flags, the feature-flag registry, and E2E mock helpers
- Deleted selectHomepageSectionsV1Enabled and updated all consumers (balance, DeFi, NFTs, tokens, onboarding, notifications, refresh hooks)
- Wallet (index.tsx): removed WalletTokensTabView and the flag-gated branch; wallet home always renders Homepage / HomepageDiscoveryTabs
- Simplified logic that previously branched on flag state (popular-network scope for balances/refresh/NFTs/DeFi, mUSD exclusion, DeFi control bar disabled state, token sort reset on full views)
- Cleaned up unit tests and removed homepageSectionsV1 mocks from smoke/regression E2E specs
- External package boundary: AccountTrackerController still receives isHomepageSectionsV1Enabled: () => true because @metamask/assets-controllers defaults this to false and uses it to decide whether balance refresh targets popular EVM networks vs enabled networks only. Removing it would regress refresh scope until the controller package drops the option.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Wallet home sections UI (permanent)

  Scenario: Wallet home shows sections layout
    Given a wallet with at least one account on mainnet
    When user opens the Wallet tab
    Then the homepage sections UI is shown (Tokens, DeFi, NFTs, etc.)
    And the legacy tabbed wallet view is not shown

  Scenario: Pull-to-refresh on wallet home
    Given user is on the Wallet tab with sections visible
    When user pulls to refresh
    Then balances update
    And token/NFT detection runs for popular EVM networks

  Scenario: View all tokens and DeFi
    Given user is on the Wallet tab
    When user taps "View all" on Tokens or DeFi sections
    Then the full-view screen opens with the network filter enabled
    And navigating back resets token sort to default

  Scenario: Zero-balance empty state
    Given an account with zero aggregated mainnet balance
    When user is on mainnet on the Wallet tab
    Then the balance empty state is shown

  Scenario: Wallet home onboarding checklist
    Given wallet home onboarding steps are enabled and eligible
    When user is on the Wallet tab
    Then the post-onboarding checklist flow renders correctly
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large wallet/navigation refactor and always-on popular-network balance/refresh scope; mitigated by extensive test updates and hardcoding AccountTrackerController to sections behavior.
> 
> **Overview**
> Removes the concluded **`homepageSectionsV1`** experiment and makes the sections-based wallet home the only path. The remote flag, **`selectHomepageSectionsV1Enabled`**, registry entries, and E2E helpers are deleted; unit tests no longer mock the flag.
> 
> **Wallet:** Drops the legacy **`WalletTokensTabView`** tab UI (Tokens / Perps / Predict / DeFi / NFTs tabs). The wallet always uses **`Homepage`** or the discovery-tabs AB variant, with pull-to-refresh wired through **`HomepageDiscoveryTabs`** when in treatment. Perps deeplinks call **`goToPerpsTab`** in treatment or navigate to the Perps stack in control; **`MoneyBalanceCard`** only depends on the Money account flag.
> 
> **Behavior now always “sections on”:** Balances and refresh use **popular** networks (not “enabled only”); zero-balance empty state and per-chain balances no longer gate on the flag; **DeFi** control bar is never disabled for testnet/unpopular networks; **mUSD** is excluded from the main token list when Money Hub + conversion flow apply (not when homepage sections were on); **DeFi/NFT** homepage hooks and **NFT detection on refresh** follow the popular-network path; **token sort** resets on leaving **TokensFullView** / **DeFiFullView** unconditionally. **Homepage** only calls **`enableAllPopularNetworks`** when some popular network is still disabled.
> 
> **Onboarding / notifications:** Post-onboarding checklist visibility no longer requires sections v1; startup auto-enable notifications still skips when the wallet-home checklist is active.
> 
> **Engine:** **`AccountTrackerController`** still gets **`isHomepageSectionsV1Enabled: () => true`** so **`@metamask/assets-controllers`** keeps refreshing popular EVM networks until the package removes that option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d92012d9e3585b3ac634fdca07c0777415da416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->