### PR TITLE
fix: Improve URL detection in `SitesSearchFooter`

### DIFF
--- a/app/components/UI/Sites/components/SitesSearchFooter/SitesSearchFooter.test.tsx
+++ b/app/components/UI/Sites/components/SitesSearchFooter/SitesSearchFooter.test.tsx
@@ -95,6 +95,14 @@ describe('SitesSearchFooter', () => {
       expect(getByTestId('trending-search-footer-url-link')).toBeOnTheScreen();
     });
 
+    it('detects localhost URLs', () => {
+      const { getByTestId } = render(
+        <SitesSearchFooter searchQuery="http://localhost:8000" />,
+      );
+
+      expect(getByTestId('trending-search-footer-url-link')).toBeOnTheScreen();
+    });
+
     it('detects URLs with path', () => {
       const { getByTestId } = render(
         <SitesSearchFooter searchQuery="metamask.io/portfolio" />,

--- a/app/components/UI/Sites/components/SitesSearchFooter/SitesSearchFooter.tsx
+++ b/app/components/UI/Sites/components/SitesSearchFooter/SitesSearchFooter.tsx
@@ -15,6 +15,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { selectSearchEngine } from '../../../../../reducers/browser/selectors';
 import { SEARCH_ENGINE_URLS, SearchEngine } from '../../../../../util/browser';
 import AppConstants from '../../../../../core/AppConstants';
+import isUrlFn from 'is-url';
 
 // TODO: @MetaMask/design-system-engineers
 // Use the concrete Box component props here instead of BoxProps.
@@ -39,11 +40,14 @@ export interface SitesSearchFooterProps {
   containerStyle?: BoxComponentProps['style'];
 }
 
+// Note: This regex intentionally does not require a fully valid URL
+const URL_REGEX = /^(https?:\/\/)?[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+([/?].*)?$/;
+
 /**
  * Checks if a string looks like a URL
  */
 function looksLikeUrl(str: string): boolean {
-  return /^(https?:\/\/)?[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+([/?].*)?$/.test(str);
+  return isUrlFn(str) || URL_REGEX.test(str);
 }
 
 export const useSearchFooterBrowserNavigation = () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Ensure valid URLs are treated as valid by URL detection in `SitesSearchFooter`. Additionally move out the existing regex to not have to redeclare/recompile it for every check.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where certain URLs would not be consider valid in the in-app browser

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to how search footer classifies input; no auth, payments, or data-layer impact.
> 
> **Overview**
> **Sites search footer** now treats more inputs as URLs when deciding whether to show the direct “open URL” action alongside the search-engine link.
> 
> `looksLikeUrl` combines the existing **`is-url`** check with the prior domain-style regex (hoisted to a module-level **`URL_REGEX`** so it isn’t recompiled on every call). That fixes cases like **`http://localhost:8000`** that the regex alone missed. A unit test covers localhost URLs with a scheme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6c8550dbb3a3ba21037147fc9eb65a711a22c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->