### PR TITLE
chore: improve crypto movers section in explore

### DIFF
--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -11,6 +11,7 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import TrendingTokensFullView, {
   TrendingTokensData,
   TrendingTokensDataProps,
+  TrendingTokensFullViewParams,
 } from './TrendingTokensFullView';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../hooks/useTrendingSearch/useTrendingSearch';
@@ -40,12 +41,17 @@ const initialMetrics: Metrics = {
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
+const mockUseRoute = jest.fn<
+  { params: TrendingTokensFullViewParams | undefined },
+  []
+>(() => ({ params: undefined }));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
     goBack: mockGoBack,
   }),
+  useRoute: () => mockUseRoute(),
   createNavigatorFactory: () => ({}),
 }));
 
@@ -244,6 +250,7 @@ describe('TrendingTokensFullView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseRoute.mockReturnValue({ params: undefined });
     const mocks = arrangeMocks();
     mocks.setTrendingRequestMock({ results: [createMockToken()] });
     mocks.setTrendingSearchMock({ data: [createMockToken()] });
@@ -328,6 +335,21 @@ describe('TrendingTokensFullView', () => {
 
     expect(mockUseTrendingSearch).toHaveBeenCalledWith({
       sortBy: undefined,
+      chainIds: null,
+      searchQuery: undefined,
+    });
+  });
+
+  it('applies initial time option from route params', () => {
+    mockUseRoute.mockReturnValue({
+      params: { initialTimeOption: TimeOption.OneHour },
+    });
+
+    const { getByTestId } = renderTrendingFullView();
+
+    expect(getByTestId('24h-button')).toHaveTextContent('1h');
+    expect(mockUseTrendingSearch).toHaveBeenCalledWith({
+      sortBy: 'h1_trending',
       chainIds: null,
       searchQuery: undefined,
     });

--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { View, TouchableOpacity, RefreshControl } from 'react-native';
+import { useRoute, type RouteProp } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import TrendingTokensList, {
@@ -21,6 +22,7 @@ import {
 } from '@metamask/design-system-react-native';
 import {
   TrendingTokenTimeBottomSheet,
+  mapTimeOptionToSortBy,
   PriceChangeOption,
   TimeOption,
 } from '../../components/TrendingTokensBottomSheet';
@@ -34,6 +36,10 @@ import { useSearchTracking } from '../../hooks/useSearchTracking/useSearchTracki
 import TokenListPageLayout from '../../components/TokenListPageLayout/TokenListPageLayout';
 import { TRENDING_NETWORKS_LIST } from '../../utils/trendingNetworksList';
 import type { Theme } from '../../../../../util/theme/models';
+
+export interface TrendingTokensFullViewParams {
+  initialTimeOption?: TimeOption;
+}
 
 export interface TrendingTokensDataProps {
   isLoading: boolean;
@@ -113,9 +119,16 @@ export const TrendingTokensData = (props: TrendingTokensDataProps) => {
 const TrendingTokensFullView = () => {
   const tw = useTailwind();
   const sessionManager = TrendingFeedSessionManager.getInstance();
-  const filters = useTokenListFilters();
+  const { params } =
+    useRoute<
+      RouteProp<{ TrendingTokensFullView: TrendingTokensFullViewParams }>
+    >();
+  const initialTimeOption = params?.initialTimeOption;
+  const filters = useTokenListFilters({ timeOption: initialTimeOption });
 
-  const [sortBy, setSortBy] = useState<SortTrendingBy | undefined>(undefined);
+  const [sortBy, setSortBy] = useState<SortTrendingBy | undefined>(
+    initialTimeOption ? mapTimeOptionToSortBy(initialTimeOption) : undefined,
+  );
   const [showTimeBottomSheet, setShowTimeBottomSheet] = useState(false);
 
   const {

--- a/app/components/UI/Trending/components/PillScrollList/PillScrollList.test.tsx
+++ b/app/components/UI/Trending/components/PillScrollList/PillScrollList.test.tsx
@@ -60,6 +60,26 @@ describe('PillScrollList', () => {
     expect(renderItem).toHaveBeenCalledTimes(3);
   });
 
+  it('supports a custom row count', () => {
+    const { getByTestId } = render(
+      <PillScrollList
+        data={[{ id: 'a' }, { id: 'b' }, { id: 'c' }]}
+        isLoading={false}
+        rowCount={3}
+        renderItem={(item: { id: string }, index: number) => (
+          <Text testID={`pill-${item.id}`}>{String(index)}</Text>
+        )}
+        keyExtractor={(item: { id: string }) => item.id}
+        Skeleton={Skeleton}
+        listTestId="pills-list"
+      />,
+    );
+
+    expect(getByTestId('pills-list-row-0')).toBeTruthy();
+    expect(getByTestId('pills-list-row-1')).toBeTruthy();
+    expect(getByTestId('pills-list-row-2')).toBeTruthy();
+  });
+
   it('respects maxPills when slicing data before splitting', () => {
     const { getByTestId, queryByTestId } = render(
       <PillScrollList

--- a/app/components/UI/Trending/components/PillScrollList/PillScrollList.tsx
+++ b/app/components/UI/Trending/components/PillScrollList/PillScrollList.tsx
@@ -8,11 +8,34 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 const DEFAULT_MAX_PILLS = 12;
+const DEFAULT_ROW_COUNT = 2;
 
-function splitIntoTwoRows<T>(items: T[]): [T[], T[]] {
-  if (items.length === 0) return [[], []];
-  const mid = Math.ceil(items.length / 2);
-  return [items.slice(0, mid), items.slice(mid)];
+interface PillRow<T> {
+  items: T[];
+  startIndex: number;
+}
+
+function splitIntoRows<T>(items: T[], rowCount: number): PillRow<T>[] {
+  if (items.length === 0) return [];
+
+  const normalizedRowCount = Math.max(1, Math.floor(rowCount));
+  const rows: PillRow<T>[] = [];
+  let start = 0;
+
+  for (let rowIndex = 0; rowIndex < normalizedRowCount; rowIndex++) {
+    const remainingItems = items.length - start;
+    const remainingRows = normalizedRowCount - rowIndex;
+    const rowSize = Math.ceil(remainingItems / remainingRows);
+    const row = items.slice(start, start + rowSize);
+
+    if (row.length > 0) {
+      rows.push({ items: row, startIndex: start });
+    }
+
+    start += rowSize;
+  }
+
+  return rows;
 }
 
 export interface PillScrollListProps<T> {
@@ -20,9 +43,11 @@ export interface PillScrollListProps<T> {
   isLoading: boolean;
   renderItem: (item: T, index: number) => React.ReactNode;
   keyExtractor: (item: T) => string;
-  Skeleton: React.ComponentType;
+  Skeleton: React.ComponentType<{ rowCount?: number }>;
   /** @default 12 */
   maxPills?: number;
+  /** @default 2 */
+  rowCount?: number;
   listTestId?: string;
   /**
    * Outer wrapper Tailwind classes. Defaults to Explore spacing (`mt-3 mb-9`).
@@ -33,8 +58,8 @@ export interface PillScrollListProps<T> {
 }
 
 /**
- * Two-row horizontal scroll of pill-shaped items. Used for "crypto movers".
- * Splits incoming data evenly between the two rows.
+ * Multi-row horizontal scroll of pill-shaped items. Used for compact movers sections.
+ * Splits incoming data evenly between rows.
  */
 const DEFAULT_WRAPPER_TW = '-mx-4 bg-transparent mt-3 mb-9' as const;
 
@@ -45,14 +70,15 @@ function PillScrollList<T>({
   keyExtractor,
   Skeleton,
   maxPills = DEFAULT_MAX_PILLS,
+  rowCount = DEFAULT_ROW_COUNT,
   listTestId,
   wrapperTwClassName = DEFAULT_WRAPPER_TW,
 }: PillScrollListProps<T>) {
   const tw = useTailwind();
   const displayData = useMemo(() => data.slice(0, maxPills), [data, maxPills]);
-  const [row1, row2] = useMemo(
-    () => splitIntoTwoRows(displayData),
-    [displayData],
+  const rows = useMemo(
+    () => splitIntoRows(displayData, rowCount),
+    [displayData, rowCount],
   );
 
   const renderRow = (items: T[], startIndex: number) =>
@@ -66,10 +92,10 @@ function PillScrollList<T>({
     <Box twClassName={wrapperTwClassName}>
       {isLoading && (
         <Box twClassName="px-4">
-          <Skeleton />
+          <Skeleton rowCount={rowCount} />
         </Box>
       )}
-      {!isLoading && (row1.length > 0 || row2.length > 0) && (
+      {!isLoading && rows.length > 0 && (
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
@@ -79,24 +105,19 @@ function PillScrollList<T>({
           contentContainerStyle={tw.style('flex-col px-4')}
         >
           <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-2">
-            {row1.length > 0 ? (
+            {rows.map((row, rowIndex) => (
               <Box
+                key={rowIndex}
                 flexDirection={BoxFlexDirection.Row}
                 alignItems={BoxAlignItems.Center}
                 twClassName="flex-nowrap gap-2"
+                testID={
+                  listTestId ? `${listTestId}-row-${rowIndex}` : undefined
+                }
               >
-                {renderRow(row1, 0)}
+                {renderRow(row.items, row.startIndex)}
               </Box>
-            ) : null}
-            {row2.length > 0 ? (
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                twClassName="flex-nowrap gap-2"
-              >
-                {renderRow(row2, row1.length)}
-              </Box>
-            ) : null}
+            ))}
           </Box>
         </ScrollView>
       )}

--- a/app/components/UI/Trending/components/PillScrollList/PillScrollList.tsx
+++ b/app/components/UI/Trending/components/PillScrollList/PillScrollList.tsx
@@ -15,16 +15,18 @@ interface PillRow<T> {
   startIndex: number;
 }
 
+const normalizeRowCount = (rowCount: number) =>
+  Math.max(1, Math.floor(rowCount));
+
 function splitIntoRows<T>(items: T[], rowCount: number): PillRow<T>[] {
   if (items.length === 0) return [];
 
-  const normalizedRowCount = Math.max(1, Math.floor(rowCount));
   const rows: PillRow<T>[] = [];
   let start = 0;
 
-  for (let rowIndex = 0; rowIndex < normalizedRowCount; rowIndex++) {
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
     const remainingItems = items.length - start;
-    const remainingRows = normalizedRowCount - rowIndex;
+    const remainingRows = rowCount - rowIndex;
     const rowSize = Math.ceil(remainingItems / remainingRows);
     const row = items.slice(start, start + rowSize);
 
@@ -76,9 +78,10 @@ function PillScrollList<T>({
 }: PillScrollListProps<T>) {
   const tw = useTailwind();
   const displayData = useMemo(() => data.slice(0, maxPills), [data, maxPills]);
+  const normalizedRowCount = normalizeRowCount(rowCount);
   const rows = useMemo(
-    () => splitIntoRows(displayData, rowCount),
-    [displayData, rowCount],
+    () => splitIntoRows(displayData, normalizedRowCount),
+    [displayData, normalizedRowCount],
   );
 
   const renderRow = (items: T[], startIndex: number) =>
@@ -92,7 +95,7 @@ function PillScrollList<T>({
     <Box twClassName={wrapperTwClassName}>
       {isLoading && (
         <Box twClassName="px-4">
-          <Skeleton rowCount={rowCount} />
+          <Skeleton rowCount={normalizedRowCount} />
         </Box>
       )}
       {!isLoading && rows.length > 0 && (

--- a/app/components/UI/Trending/components/SectionPillsSkeleton/SectionPillsSkeleton.tsx
+++ b/app/components/UI/Trending/components/SectionPillsSkeleton/SectionPillsSkeleton.tsx
@@ -46,6 +46,7 @@ const SectionPillsSkeleton: React.FC<SectionPillsSkeletonProps> = ({
   rowCount = 2,
 }) => {
   const tw = useTailwind();
+  const normalizedRowCount = Math.max(1, Math.floor(rowCount));
 
   return (
     <Box marginBottom={5} twClassName="bg-transparent">
@@ -56,7 +57,7 @@ const SectionPillsSkeleton: React.FC<SectionPillsSkeletonProps> = ({
         contentContainerStyle={tw.style('flex-col gap-2 pr-0')}
       >
         <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-2">
-          {Array.from({ length: rowCount }).map((_, rowIndex) => (
+          {Array.from({ length: normalizedRowCount }).map((_, rowIndex) => (
             <SkeletonRow key={rowIndex} prefix={`r${rowIndex}`} />
           ))}
         </Box>

--- a/app/components/UI/Trending/components/SectionPillsSkeleton/SectionPillsSkeleton.tsx
+++ b/app/components/UI/Trending/components/SectionPillsSkeleton/SectionPillsSkeleton.tsx
@@ -38,7 +38,13 @@ const SkeletonRow: React.FC<{ prefix: string }> = ({ prefix }) => (
   </Box>
 );
 
-const SectionPillsSkeleton: React.FC = () => {
+interface SectionPillsSkeletonProps {
+  rowCount?: number;
+}
+
+const SectionPillsSkeleton: React.FC<SectionPillsSkeletonProps> = ({
+  rowCount = 2,
+}) => {
   const tw = useTailwind();
 
   return (
@@ -50,8 +56,9 @@ const SectionPillsSkeleton: React.FC = () => {
         contentContainerStyle={tw.style('flex-col gap-2 pr-0')}
       >
         <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-2">
-          <SkeletonRow prefix="r1" />
-          <SkeletonRow prefix="r2" />
+          {Array.from({ length: rowCount }).map((_, rowIndex) => (
+            <SkeletonRow key={rowIndex} prefix={`r${rowIndex}`} />
+          ))}
         </Box>
       </ScrollView>
     </Box>

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.test.ts
@@ -9,6 +9,7 @@ import { sortTrendingTokens } from '../../utils/sortTrendingTokens';
 import {
   PriceChangeOption,
   SortDirection,
+  TimeOption,
 } from '../../components/TrendingTokensBottomSheet';
 
 // Mock dependencies
@@ -108,6 +109,7 @@ describe('useTrendingSearch', () => {
       mockTrendingResults,
       PriceChangeOption.PriceChange,
       SortDirection.Descending,
+      undefined,
     );
     expect(result.current.isLoading).toBe(false);
   });
@@ -133,6 +135,33 @@ describe('useTrendingSearch', () => {
       mockTrendingResults,
       PriceChangeOption.MarketCap,
       SortDirection.Ascending,
+      undefined,
+    );
+  });
+
+  it('passes custom time option to sortTrendingTokens', async () => {
+    const sortedResults = [mockTrendingResults[1], mockTrendingResults[0]];
+    mockSortTrendingTokens.mockReturnValue(sortedResults);
+
+    const { result } = renderHookWithProvider(() =>
+      useTrendingSearch({
+        sortTrendingTokensOptions: {
+          option: PriceChangeOption.PriceChange,
+          direction: SortDirection.Descending,
+          timeOption: TimeOption.OneHour,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(sortedResults);
+    });
+
+    expect(mockSortTrendingTokens).toHaveBeenCalledWith(
+      mockTrendingResults,
+      PriceChangeOption.PriceChange,
+      SortDirection.Descending,
+      TimeOption.OneHour,
     );
   });
 

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -7,6 +7,7 @@ import { sortTrendingTokens } from '../../utils/sortTrendingTokens';
 import {
   PriceChangeOption,
   SortDirection,
+  TimeOption,
 } from '../../components/TrendingTokensBottomSheet';
 import { isEqual } from 'lodash';
 
@@ -42,6 +43,7 @@ export const useTrendingSearch = (opts?: {
   sortTrendingTokensOptions?: {
     option: PriceChangeOption;
     direction: SortDirection;
+    timeOption?: TimeOption;
   };
 }) => {
   const {
@@ -99,6 +101,7 @@ export const useTrendingSearch = (opts?: {
         trendingResults,
         sortTrendingTokensOptions.option,
         sortTrendingTokensOptions.direction,
+        sortTrendingTokensOptions.timeOption,
       );
     }
 

--- a/app/components/Views/TrendingView/feeds/tokens/CryptoMoversPillItem.test.tsx
+++ b/app/components/Views/TrendingView/feeds/tokens/CryptoMoversPillItem.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import type { TrendingAsset } from '@metamask/assets-controllers';
+import { TimeOption } from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 import CryptoMoversPillItem from './CryptoMoversPillItem';
 
 const mockOnPress = jest.fn();
@@ -32,7 +33,7 @@ describe('CryptoMoversPillItem', () => {
     expect(mockOnPress).toHaveBeenCalledTimes(1);
   });
 
-  it('omits change label when 24h change is missing or not a number', () => {
+  it('omits change label when selected interval change is missing or not a number', () => {
     const { queryByText, rerender } = render(
       <CryptoMoversPillItem token={baseToken} index={0} />,
     );
@@ -52,11 +53,12 @@ describe('CryptoMoversPillItem', () => {
     expect(queryByText(/%/)).toBeNull();
   });
 
-  it('renders zero and signed positive and negative 24h changes', () => {
+  it('renders zero and signed positive and negative changes for the selected interval', () => {
     const { getByText, rerender } = render(
       <CryptoMoversPillItem
-        token={{ ...baseToken, priceChangePct: { h24: '0' } } as TrendingAsset}
+        token={{ ...baseToken, priceChangePct: { h1: '0' } } as TrendingAsset}
         index={0}
+        timeOption={TimeOption.OneHour}
       />,
     );
     expect(getByText('0.00%')).toBeTruthy();
@@ -64,9 +66,10 @@ describe('CryptoMoversPillItem', () => {
     rerender(
       <CryptoMoversPillItem
         token={
-          { ...baseToken, priceChangePct: { h24: '2.51' } } as TrendingAsset
+          { ...baseToken, priceChangePct: { h1: '2.51' } } as TrendingAsset
         }
         index={0}
+        timeOption={TimeOption.OneHour}
       />,
     );
     expect(getByText('+2.51%')).toBeTruthy();
@@ -74,9 +77,10 @@ describe('CryptoMoversPillItem', () => {
     rerender(
       <CryptoMoversPillItem
         token={
-          { ...baseToken, priceChangePct: { h24: '-1.2' } } as TrendingAsset
+          { ...baseToken, priceChangePct: { h1: '-1.2' } } as TrendingAsset
         }
         index={0}
+        timeOption={TimeOption.OneHour}
       />,
     );
     expect(getByText('-1.20%')).toBeTruthy();

--- a/app/components/Views/TrendingView/feeds/tokens/CryptoMoversPillItem.tsx
+++ b/app/components/Views/TrendingView/feeds/tokens/CryptoMoversPillItem.tsx
@@ -26,6 +26,7 @@ const LOGO_SIZE = 24;
 interface CryptoMoversPillItemProps {
   token: TrendingAsset;
   index: number;
+  timeOption?: TimeOption;
   /** Called synchronously before the card's press handler fires. */
   onCardPress?: () => void;
 }
@@ -33,6 +34,7 @@ interface CryptoMoversPillItemProps {
 const CryptoMoversPillItem: React.FC<CryptoMoversPillItemProps> = ({
   token,
   index,
+  timeOption = TimeOption.TwentyFourHours,
   onCardPress,
 }) => {
   const { onPress: defaultOnPress } = useTrendingTokenPress({
@@ -54,9 +56,9 @@ const CryptoMoversPillItem: React.FC<CryptoMoversPillItemProps> = ({
   }, [token.assetId]);
 
   const { changeLabel, changeTextColor } = useMemo(() => {
-    const key = getPriceChangeFieldKey(TimeOption.TwentyFourHours);
+    const key = getPriceChangeFieldKey(timeOption);
     return formatPercentChange(token.priceChangePct?.[key]);
-  }, [token.priceChangePct]);
+  }, [timeOption, token.priceChangePct]);
 
   const leading = useMemo(
     () => (

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
+import { TimeOption } from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
 import { useTokensFeed } from './useTokensFeed';
 
@@ -100,6 +101,39 @@ describe('useTokensFeed', () => {
     expect(mockUseTrendingSearch).toHaveBeenCalledWith({
       searchQuery: 'sol',
       enableDebounce: false,
+      sortBy: undefined,
+      sortTrendingTokensOptions: undefined,
+    });
+  });
+
+  it('passes sortBy option into useTrendingSearch', () => {
+    renderHook(() => useTokensFeed({ sortBy: 'h1_trending' }));
+
+    expect(mockUseTrendingSearch).toHaveBeenCalledWith({
+      searchQuery: undefined,
+      enableDebounce: false,
+      sortBy: 'h1_trending',
+      sortTrendingTokensOptions: undefined,
+    });
+  });
+
+  it('passes timeOption into local price-change sorting options', () => {
+    renderHook(() =>
+      useTokensFeed({
+        sortBy: 'h1_trending',
+        timeOption: TimeOption.OneHour,
+      }),
+    );
+
+    expect(mockUseTrendingSearch).toHaveBeenCalledWith({
+      searchQuery: undefined,
+      enableDebounce: false,
+      sortBy: 'h1_trending',
+      sortTrendingTokensOptions: {
+        option: 'price_change',
+        direction: 'descending',
+        timeOption: TimeOption.OneHour,
+      },
     });
   });
 

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -106,21 +106,9 @@ describe('useTokensFeed', () => {
     });
   });
 
-  it('passes sortBy option into useTrendingSearch', () => {
-    renderHook(() => useTokensFeed({ sortBy: 'h1_trending' }));
-
-    expect(mockUseTrendingSearch).toHaveBeenCalledWith({
-      searchQuery: undefined,
-      enableDebounce: false,
-      sortBy: 'h1_trending',
-      sortTrendingTokensOptions: undefined,
-    });
-  });
-
-  it('passes timeOption into local price-change sorting options', () => {
+  it('passes timeOption into request and local price-change sorting options', () => {
     renderHook(() =>
       useTokensFeed({
-        sortBy: 'h1_trending',
         timeOption: TimeOption.OneHour,
       }),
     );

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -1,13 +1,11 @@
 import { useMemo, useRef, useEffect } from 'react';
-import type {
-  SortTrendingBy,
-  TrendingAsset,
-} from '@metamask/assets-controllers';
+import type { TrendingAsset } from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
 import { fuseSearch, TOKEN_FUSE_OPTIONS } from '../search-utils';
 import {
+  mapTimeOptionToSortBy,
   PriceChangeOption,
   SortDirection,
   TimeOption,
@@ -22,9 +20,7 @@ interface UseTokensFeedOptions {
    * Use for surfaces that don't display a security badge.
    */
   hideRiskyTokens?: boolean;
-  /** Sort option forwarded to the trending tokens request. */
-  sortBy?: SortTrendingBy;
-  /** Time option used when locally sorting by price change. */
+  /** Time option used for request and local price-change sorting. */
   timeOption?: TimeOption;
 }
 
@@ -43,9 +39,10 @@ export const useTokensFeed = ({
   query,
   refresh,
   hideRiskyTokens = false,
-  sortBy,
   timeOption,
 }: UseTokensFeedOptions = {}): UseTokensFeedResult => {
+  const sortBy = timeOption ? mapTimeOptionToSortBy(timeOption) : undefined;
+
   const {
     data,
     isLoading,

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -1,9 +1,17 @@
 import { useMemo, useRef, useEffect } from 'react';
-import type { TrendingAsset } from '@metamask/assets-controllers';
+import type {
+  SortTrendingBy,
+  TrendingAsset,
+} from '@metamask/assets-controllers';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
 import { useFeedRefresh } from '../../hooks/useFeedRefresh';
 import type { RefreshConfig } from '../../hooks/useExploreRefresh';
 import { fuseSearch, TOKEN_FUSE_OPTIONS } from '../search-utils';
+import {
+  PriceChangeOption,
+  SortDirection,
+  TimeOption,
+} from '../../../../UI/Trending/components/TrendingTokensBottomSheet';
 
 interface UseTokensFeedOptions {
   /** Search query; when present, results are sorted by market cap descending. */
@@ -14,6 +22,10 @@ interface UseTokensFeedOptions {
    * Use for surfaces that don't display a security badge.
    */
   hideRiskyTokens?: boolean;
+  /** Sort option forwarded to the trending tokens request. */
+  sortBy?: SortTrendingBy;
+  /** Time option used when locally sorting by price change. */
+  timeOption?: TimeOption;
 }
 
 export interface UseTokensFeedResult {
@@ -31,6 +43,8 @@ export const useTokensFeed = ({
   query,
   refresh,
   hideRiskyTokens = false,
+  sortBy,
+  timeOption,
 }: UseTokensFeedOptions = {}): UseTokensFeedResult => {
   const {
     data,
@@ -43,6 +57,14 @@ export const useTokensFeed = ({
   } = useTrendingSearch({
     searchQuery: query,
     enableDebounce: false,
+    sortBy,
+    sortTrendingTokensOptions: timeOption
+      ? {
+          option: PriceChangeOption.PriceChange,
+          direction: SortDirection.Descending,
+          timeOption,
+        }
+      : undefined,
   });
 
   useFeedRefresh(refresh, refetch);

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -20,6 +20,22 @@ jest.mock('../feeds/tokens/useTokensFeed', () => ({
   useTokensFeed: jest.fn(() => ({ data: [], isLoading: false })),
 }));
 
+jest.mock('../feeds/tokens/CryptoMoversPillItem', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createElement } = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ token }: { token: { assetId: string; symbol: string } }) =>
+      createElement(
+        Text,
+        { testID: `section-pill-${token.assetId}` },
+        token.symbol,
+      ),
+  };
+});
+
 const mockUseABTest = jest.fn();
 jest.mock('../../../../hooks', () => ({
   useABTest: (...args: unknown[]) =>
@@ -121,6 +137,8 @@ import { selectPredictEnabledFlag } from '../../../UI/Predict';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import NowTab from './NowTab';
 import type { RefreshConfig } from '../hooks/useExploreRefresh';
+import { useTokensFeed } from '../feeds/tokens/useTokensFeed';
+import Routes from '../../../../constants/navigation/Routes';
 
 const defaultRefresh: RefreshConfig = { trigger: 0, silentRefresh: true };
 const defaultTabProps = {
@@ -176,6 +194,10 @@ const mockControlAbTest = () =>
     variantName: WhatsHappeningExploreVariant.Control,
     isActive: true,
   });
+
+const mockUseTokensFeed = useTokensFeed as jest.MockedFunction<
+  typeof useTokensFeed
+>;
 
 const mockTreatmentAbTest = () =>
   mockUseABTest.mockReturnValue({
@@ -360,5 +382,94 @@ describe('NowTab — Perps Movers "View All" navigation', () => {
     renderNowTab();
 
     expect(screen.queryByTestId('section-header-view-all-perps')).toBeNull();
+  });
+});
+
+describe('NowTab — Crypto Movers', () => {
+  const mockUseSelector = useSelector as jest.MockedFunction<
+    typeof useSelector
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectPerpsEnabledFlag) return false;
+      if (selector === selectPredictEnabledFlag) return false;
+      if (selector === selectWhatsHappeningEnabled) return false;
+      return undefined;
+    });
+    mockControlAbTest();
+    mockUseTokensFeed.mockReturnValue({
+      data: [
+        {
+          assetId: 'eip155:1/erc20:0x1',
+          symbol: 'ONE',
+          priceChangePct: { h1: '1.23' },
+        },
+        {
+          assetId: 'eip155:1/erc20:0x2',
+          symbol: 'TWO',
+          priceChangePct: { h1: '2.34' },
+        },
+        {
+          assetId: 'eip155:1/erc20:0x3',
+          symbol: 'THREE',
+          priceChangePct: { h1: '3.45' },
+        },
+      ] as never,
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+  });
+
+  it('requests and opens Crypto Movers with the 1h filter', () => {
+    renderNowTab();
+
+    expect(mockUseTokensFeed).toHaveBeenCalledWith({
+      refresh: defaultRefresh,
+      hideRiskyTokens: true,
+      sortBy: 'h1_trending',
+      timeOption: '1h',
+    });
+
+    fireEvent.press(
+      screen.getByTestId('section-header-view-all-crypto_movers'),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.WALLET.TRENDING_TOKENS_FULL_VIEW,
+      { initialTimeOption: '1h' },
+    );
+  });
+
+  it('renders Crypto Movers across three rows', () => {
+    renderNowTab();
+
+    expect(
+      screen.getByTestId('explore-crypto_movers-pills-list-row-0'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('explore-crypto_movers-pills-list-row-1'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('explore-crypto_movers-pills-list-row-2'),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders up to 18 Crypto Movers pills', () => {
+    mockUseTokensFeed.mockReturnValue({
+      data: Array.from({ length: 19 }, (_, index) => ({
+        assetId: `eip155:1/erc20:0x${index}`,
+        symbol: `T${index}`,
+        priceChangePct: { h1: String(index) },
+      })) as never,
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    renderNowTab();
+
+    expect(screen.getByTestId('section-pill-eip155:1/erc20:0x17')).toBeTruthy();
+    expect(screen.queryByTestId('section-pill-eip155:1/erc20:0x18')).toBeNull();
   });
 });

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -428,7 +428,6 @@ describe('NowTab — Crypto Movers', () => {
     expect(mockUseTokensFeed).toHaveBeenCalledWith({
       refresh: defaultRefresh,
       hideRiskyTokens: true,
-      sortBy: 'h1_trending',
       timeOption: '1h',
     });
 

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -17,6 +17,10 @@ import { TokenRowItem } from '../feeds/tokens/TokenRowItem';
 import CryptoMoversPillItem from '../feeds/tokens/CryptoMoversPillItem';
 import CryptoMoversSkeleton from '../feeds/tokens/CryptoMoversSkeleton';
 import TrendingTokensSkeleton from '../../../UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton';
+import {
+  mapTimeOptionToSortBy,
+  TimeOption,
+} from '../../../UI/Trending/components/TrendingTokensBottomSheet';
 import { usePerpsFeed, type PerpsFeedItem } from '../feeds/perps/usePerpsFeed';
 import PerpsSectionProvider from '../feeds/perps/PerpsSectionProvider';
 import PerpsPillItem from '../feeds/perps/PerpsPillItem';
@@ -98,6 +102,11 @@ const PerpsBlock: React.FC<PerpsBlockProps> = ({ refresh, navigation }) => {
   );
 };
 
+const CRYPTO_MOVERS_TIME_OPTION = TimeOption.OneHour;
+const CRYPTO_MOVERS_SORT_BY = mapTimeOptionToSortBy(CRYPTO_MOVERS_TIME_OPTION);
+const CRYPTO_MOVERS_ROW_COUNT = 3;
+const CRYPTO_MOVERS_MAX_PILLS = 18;
+
 const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const perpsNavigation =
@@ -118,7 +127,12 @@ const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
   }, [refresh.trigger]);
 
   const predictions = usePredictionsFeed({ refresh });
-  const cryptoMovers = useTokensFeed({ refresh, hideRiskyTokens: true });
+  const cryptoMovers = useTokensFeed({
+    refresh,
+    hideRiskyTokens: true,
+    sortBy: CRYPTO_MOVERS_SORT_BY,
+    timeOption: CRYPTO_MOVERS_TIME_OPTION,
+  });
   const stocks = useStocksFeed({ refresh });
 
   const renderTokenItem: ListRenderItem<TrendingAsset> = useCallback(
@@ -189,7 +203,9 @@ const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
           <SectionHeader
             title={strings('trending.crypto_movers')}
             onViewAll={() =>
-              navigation.navigate(Routes.WALLET.TRENDING_TOKENS_FULL_VIEW)
+              navigation.navigate(Routes.WALLET.TRENDING_TOKENS_FULL_VIEW, {
+                initialTimeOption: CRYPTO_MOVERS_TIME_OPTION,
+              })
             }
             testID="section-header-view-all-crypto_movers"
             tabName="Now"
@@ -202,6 +218,7 @@ const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
               <CryptoMoversPillItem
                 token={token}
                 index={index}
+                timeOption={CRYPTO_MOVERS_TIME_OPTION}
                 onCardPress={() =>
                   trackExploreInteracted({
                     interaction_type: 'section_item_tapped',
@@ -219,6 +236,8 @@ const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
             keyExtractor={(token) => token.assetId ?? ''}
             Skeleton={CryptoMoversSkeleton}
             listTestId="explore-crypto_movers-pills-list"
+            rowCount={CRYPTO_MOVERS_ROW_COUNT}
+            maxPills={CRYPTO_MOVERS_MAX_PILLS}
           />
         </Box>
       )}

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -17,10 +17,7 @@ import { TokenRowItem } from '../feeds/tokens/TokenRowItem';
 import CryptoMoversPillItem from '../feeds/tokens/CryptoMoversPillItem';
 import CryptoMoversSkeleton from '../feeds/tokens/CryptoMoversSkeleton';
 import TrendingTokensSkeleton from '../../../UI/Trending/components/TrendingTokenSkeleton/TrendingTokensSkeleton';
-import {
-  mapTimeOptionToSortBy,
-  TimeOption,
-} from '../../../UI/Trending/components/TrendingTokensBottomSheet';
+import { TimeOption } from '../../../UI/Trending/components/TrendingTokensBottomSheet';
 import { usePerpsFeed, type PerpsFeedItem } from '../feeds/perps/usePerpsFeed';
 import PerpsSectionProvider from '../feeds/perps/PerpsSectionProvider';
 import PerpsPillItem from '../feeds/perps/PerpsPillItem';
@@ -103,7 +100,6 @@ const PerpsBlock: React.FC<PerpsBlockProps> = ({ refresh, navigation }) => {
 };
 
 const CRYPTO_MOVERS_TIME_OPTION = TimeOption.OneHour;
-const CRYPTO_MOVERS_SORT_BY = mapTimeOptionToSortBy(CRYPTO_MOVERS_TIME_OPTION);
 const CRYPTO_MOVERS_ROW_COUNT = 3;
 const CRYPTO_MOVERS_MAX_PILLS = 18;
 
@@ -130,7 +126,6 @@ const NowTab: React.FC<TabProps> = ({ refresh, refreshing, onRefresh }) => {
   const cryptoMovers = useTokensFeed({
     refresh,
     hideRiskyTokens: true,
-    sortBy: CRYPTO_MOVERS_SORT_BY,
     timeOption: CRYPTO_MOVERS_TIME_OPTION,
   });
   const stocks = useStocksFeed({ refresh });

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -55,6 +55,7 @@ import type { OnboardingInterestQuestionnaireRouteParams } from '../../component
 
 // Perps navigation params
 import type { PerpsNavigationParamList } from '../../components/UI/Perps/types/navigation';
+import type { TrendingTokensFullViewParams } from '../../components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView';
 
 // QR Scanner params
 import type { QRScannerParams } from '../../components/Views/QRScanner/QRScanner.types';
@@ -519,7 +520,7 @@ export interface RootStackParamList extends ParamListBase {
   TokensFullView: undefined;
   CashTokensFullView: undefined;
   MoneyScreens: undefined;
-  TrendingTokensFullView: undefined;
+  TrendingTokensFullView: TrendingTokensFullViewParams | undefined;
   RWATokensFullView: undefined;
 
   // Vault recovery routes


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Improve crypto movers section in explore:
- Show 3 rows of pills instead of 2
- Based on 1h price change instead of 24h

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: improve crypto movers section in explore

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3297

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and trending feed/sort wiring only; no auth, payments, or security-sensitive paths.
> 
> **Overview**
> **Explore Crypto Movers** now uses **1h** price change (not 24h), shows pills in **three rows** with up to **18** items, and **View all** opens trending tokens full view with `initialTimeOption: 1h` so filters and API sort (`h1_trending`) match the section.
> 
> **PillScrollList** and **SectionPillsSkeleton** support a configurable **`rowCount`** (default still 2). **`useTokensFeed`** / **`useTrendingSearch`** accept **`timeOption`** for trending sort and local price-change sorting; **`CryptoMoversPillItem`** reads percent change for the selected interval. Navigation types add **`TrendingTokensFullViewParams`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc4bafd7b69fac6c97781c2fc520f3f47197de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->