### PR TITLE
feat(STX-583): move STX allowed RPC hosts config to flags

### DIFF
--- a/.github/scripts/known-feature-flag-constants.ts
+++ b/.github/scripts/known-feature-flag-constants.ts
@@ -24,6 +24,7 @@ const FILE_SOURCES: Array<{ key: string; file: string; exportName: string }> = [
   { key: 'BRAZE_BANNER_HOME_FLAG_KEY', file: sel('brazeBannerHome'), exportName: 'BRAZE_BANNER_HOME_FLAG_KEY' },
   { key: 'TOKEN_DETAILS_OHLCV_WS_INTEGRATION_FLAG_KEY', file: sel('tokenDetailsOhlcvWsIntegration'), exportName: 'TOKEN_DETAILS_OHLCV_WS_INTEGRATION_FLAG_KEY' },
   { key: 'SOCIAL_AI_ASSET_DETAILS_QUICK_BUY_FLAG_KEY', file: sel('socialAiAssetDetailsQuickBuy'), exportName: 'SOCIAL_AI_ASSET_DETAILS_QUICK_BUY_FLAG_KEY' },
+  { key: 'SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG', file: sel('smartTransactions'), exportName: 'SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG' },
 ];
 
 function resolveConstantFromFile(filePath: string, constantName: string): string | undefined {

--- a/app/selectors/featureFlagController/smartTransactions/index.test.ts
+++ b/app/selectors/featureFlagController/smartTransactions/index.test.ts
@@ -1,0 +1,74 @@
+import {
+  selectAllowedSmartTransactionsRpcHosts,
+  SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG,
+  DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS,
+} from '.';
+import mockedEngine from '../../../core/__mocks__/MockedEngine';
+import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
+
+jest.mock('../../../core/Engine', () => ({
+  init: () => mockedEngine.init(),
+}));
+
+const originalEnv = process.env;
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  jest.clearAllMocks();
+});
+
+const getMockedFeatureFlag = (hosts: string | string[] = []) => ({
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {
+          [SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG]: hosts,
+        },
+        cacheTimestamp: 0,
+      },
+    },
+  },
+});
+
+describe('selectAllowedSmartTransactionsRpcHosts', () => {
+  it('returns the default allowed RPC hosts if the flag state is undefined', () => {
+    expect(
+      selectAllowedSmartTransactionsRpcHosts(mockedUndefinedFlagsState),
+    ).toEqual(DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS);
+  });
+  it('returns the default allowed RPC hosts if the flag is not set', () => {
+    expect(
+      selectAllowedSmartTransactionsRpcHosts(mockedEmptyFlagsState),
+    ).toEqual(DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS);
+  });
+  it('returns the allowed RPC hosts if the flag is set', () => {
+    expect(
+      selectAllowedSmartTransactionsRpcHosts(
+        getMockedFeatureFlag(['example.com']),
+      ),
+    ).toEqual(['example.com']);
+  });
+  it('returns the default allowed RPC hosts if the flag is set to an empty array', () => {
+    expect(
+      selectAllowedSmartTransactionsRpcHosts(getMockedFeatureFlag([])),
+    ).toEqual(DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS);
+  });
+  it('returns the allowed RPC hosts if the flag is set to an array of strings', () => {
+    expect(
+      selectAllowedSmartTransactionsRpcHosts(
+        getMockedFeatureFlag(['mainnet.base.org', 'rpc.linea.build']),
+      ),
+    ).toEqual(['mainnet.base.org', 'rpc.linea.build']);
+  });
+  it('returns the default allowed RPC hosts if the flag is set to a non-array value', () => {
+    expect(
+      selectAllowedSmartTransactionsRpcHosts(
+        getMockedFeatureFlag('mainnet.base.org'),
+      ),
+    ).toEqual(DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS);
+  });
+});

--- a/app/selectors/featureFlagController/smartTransactions/index.ts
+++ b/app/selectors/featureFlagController/smartTransactions/index.ts
@@ -1,0 +1,23 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+
+export const DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS: string[] = [
+  '.infura.io',
+  '.binance.org',
+];
+
+export const SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG =
+  'smartTransactionsAllowedRpcHosts';
+
+export const selectAllowedSmartTransactionsRpcHosts = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): string[] => {
+    const allowedRpcHosts =
+      remoteFeatureFlags?.[SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG];
+    return Array.isArray(allowedRpcHosts) &&
+      allowedRpcHosts.length > 0 &&
+      allowedRpcHosts.every((host): host is string => typeof host === 'string')
+      ? allowedRpcHosts
+      : DEFAULT_SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS;
+  },
+);

--- a/app/selectors/smartTransactionsController.ts
+++ b/app/selectors/smartTransactionsController.ts
@@ -15,6 +15,7 @@ import { selectSelectedAccountGroupInternalAccounts } from './multichainAccounts
 import { getAllowedSmartTransactionsChainIds } from '../../app/constants/smartTransactions';
 import { createDeepEqualSelector } from './util';
 import { CaipChainId, Hex } from '@metamask/utils';
+import { selectAllowedSmartTransactionsRpcHosts } from './featureFlagController/smartTransactions';
 import { getIsAllowedRpcUrlForSmartTransactions } from '../util/smart-transactions';
 import { getFeatureFlagDeviceKey } from '../reducers/swaps/utils';
 
@@ -68,6 +69,7 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
   [
     selectSelectedInternalAccountFormattedAddress,
     selectEvmChainId,
+    selectAllowedSmartTransactionsRpcHosts,
     (_state: RootState, chainId?: Hex) => chainId,
     (state: RootState, chainId?: Hex) =>
       selectRpcUrlByChainId(state, chainId || selectEvmChainId(state)),
@@ -82,6 +84,7 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
   (
     selectedAddress,
     globalChainId,
+    allowedSmartTransactionsRpcHosts,
     transactionChainId,
     providerConfigRpcUrl,
     smartTransactionsFeatureFlags,
@@ -101,7 +104,10 @@ export const selectSmartTransactionsEnabled = createDeepEqualSelector(
     return Boolean(
       isAllowedNetwork &&
         !addressIsHardwareAccount &&
-        getIsAllowedRpcUrlForSmartTransactions(providerConfigRpcUrl) &&
+        getIsAllowedRpcUrlForSmartTransactions(
+          allowedSmartTransactionsRpcHosts,
+          providerConfigRpcUrl,
+        ) &&
         isSmartTransactionEnabledOnNetworkWithFeatureFlags &&
         smartTransactionsLivenessByChainId?.[effectiveChainId],
     );

--- a/app/util/smart-transactions/index.test.ts
+++ b/app/util/smart-transactions/index.test.ts
@@ -338,18 +338,38 @@ describe('Smart Transactions utils', () => {
       isProductionMock.mockRestore();
     });
 
-    it('returns true for Infura URLs in production', () => {
+    it('returns false in production if no allowed hosts are provided', () => {
       isProductionMock.mockReturnValue(true);
       const result = getIsAllowedRpcUrlForSmartTransactions(
+        [],
+        'https://mainnet.infura.io/v3/abc123',
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns true for for suffix/subdomain match URLs in production', () => {
+      isProductionMock.mockReturnValue(true);
+      const result = getIsAllowedRpcUrlForSmartTransactions(
+        ['.infura.io', '.binance.org'],
         'https://mainnet.infura.io/v3/abc123',
       );
       expect(result).toBe(true);
     });
 
-    it('returns true for Binance URLs in production', () => {
+    it('returns false for not exact domain match URLs in production', () => {
       isProductionMock.mockReturnValue(true);
       const result = getIsAllowedRpcUrlForSmartTransactions(
-        'https://bsc-dataseed.binance.org/',
+        ['mainnet.base.org'],
+        'https://developer-access-mainnet.base.org/',
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns true for exact domain match URLs in production', () => {
+      isProductionMock.mockReturnValue(true);
+      const result = getIsAllowedRpcUrlForSmartTransactions(
+        ['mainnet.base.org'],
+        'https://mainnet.base.org/',
       );
       expect(result).toBe(true);
     });
@@ -357,6 +377,7 @@ describe('Smart Transactions utils', () => {
     it('returns false for other URLs in production', () => {
       isProductionMock.mockReturnValue(true);
       const result = getIsAllowedRpcUrlForSmartTransactions(
+        ['.infura.io', '.binance.org'],
         'https://example.com/rpc',
       );
       expect(result).toBe(false);
@@ -364,13 +385,17 @@ describe('Smart Transactions utils', () => {
 
     it('returns false for undefined URL in production', () => {
       isProductionMock.mockReturnValue(true);
-      const result = getIsAllowedRpcUrlForSmartTransactions(undefined);
+      const result = getIsAllowedRpcUrlForSmartTransactions(
+        ['.infura.io', '.binance.org'],
+        undefined,
+      );
       expect(result).toBe(false);
     });
 
     it('returns true for any URL in non-production environments', () => {
       isProductionMock.mockReturnValue(false);
       const result = getIsAllowedRpcUrlForSmartTransactions(
+        ['.infura.io', '.binance.org'],
         'https://example.com/rpc',
       );
       expect(result).toBe(true);
@@ -378,7 +403,10 @@ describe('Smart Transactions utils', () => {
 
     it('returns true for undefined URL in non-production environments', () => {
       isProductionMock.mockReturnValue(false);
-      const result = getIsAllowedRpcUrlForSmartTransactions(undefined);
+      const result = getIsAllowedRpcUrlForSmartTransactions(
+        ['.infura.io', '.binance.org'],
+        undefined,
+      );
       expect(result).toBe(true);
     });
   });

--- a/app/util/smart-transactions/index.ts
+++ b/app/util/smart-transactions/index.ts
@@ -90,7 +90,10 @@ export const getGasIncludedTransactionFees = (quote: GasIncludedQuote) => {
   return transactionFees;
 };
 
-export const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
+export const getIsAllowedRpcUrlForSmartTransactions = (
+  allowedHosts: string[],
+  rpcUrl?: string,
+) => {
   // Allow in non-production environments.
   if (!isProduction()) {
     return true;
@@ -98,10 +101,14 @@ export const getIsAllowedRpcUrlForSmartTransactions = (rpcUrl?: string) => {
 
   const hostname = rpcUrl && new URL(rpcUrl).hostname;
 
-  return (
-    hostname?.endsWith('.infura.io') ||
-    hostname?.endsWith('.binance.org') ||
-    false
+  return Boolean(
+    hostname &&
+      allowedHosts.some((host) =>
+        // A leading dot denotes a suffix/subdomain match (e.g. `.infura.io`
+        // matches `mainnet.infura.io`); otherwise require an exact host match
+        // so `mainnet.base.org` does not match `developer-access-mainnet.base.org`.
+        host.startsWith('.') ? hostname.endsWith(host) : hostname === host,
+      ),
   );
 };
 

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4813,6 +4813,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     },
     status: FeatureFlagStatus.Active,
   },
+
+  smartTransactionsAllowedRpcHosts: {
+    name: 'smartTransactionsAllowedRpcHosts',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: ['.infura.io', '.binance.org'],
+    status: FeatureFlagStatus.Active,
+  },
 };
 
 // ============================================================================


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Move to LD flag for allowed RPC host for STX.
- Keep the current ones as hardcoded defaults
- Allow for more generic public hosts like mainnet.base.org and rpc.linea.build to be added to mechanically increase smart-transaction availability for users.
- True custom RPC providers remain excluded

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production smart-transaction eligibility now depends on a remotely updatable RPC host list; misconfiguration could enable or disable STX for large user segments on specific networks.
> 
> **Overview**
> Smart transactions **allowed RPC hosts** move from hardcoded Infura/Binance suffix checks to the remote flag **`smartTransactionsAllowedRpcHosts`**, with client defaults **`.infura.io`** and **`.binance.org`** when the flag is missing or invalid.
> 
> A new selector resolves the host list and **`selectSmartTransactionsEnabled`** passes it into **`getIsAllowedRpcUrlForSmartTransactions`**, which now takes an explicit allowlist: entries starting with **`.`** match host suffixes; other entries require an **exact hostname** match (so related subdomains like developer-access hosts are not implied). Non-production builds still allow any RPC URL.
> 
> The change is wired into the **feature-flag registry**, **CI known-flag constants**, and **unit tests** for the selector and RPC helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee03bb68ef76d8520fb7db4b658fe1c06e1cb03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->