### PR TITLE
chore: upgrade @metamask/design-system-react-native to 0.27.0

### DIFF
--- a/app/components/UI/Compliance/AccessRestrictedModal/AccessRestrictedModal.tsx
+++ b/app/components/UI/Compliance/AccessRestrictedModal/AccessRestrictedModal.tsx
@@ -28,7 +28,7 @@ const AccessRestrictedModal: React.FC<AccessRestrictedModalProps> = ({
     >
       <BottomSheetHeader
         onClose={onClose}
-        titleTestID={AccessRestrictedModalSelectorsIDs.TITLE}
+        textProps={{ testID: AccessRestrictedModalSelectorsIDs.TITLE }}
       >
         {strings('access_restricted.title')}
       </BottomSheetHeader>

--- a/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
+++ b/app/components/UI/Money/components/MoneyHeader/MoneyHeader.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import {
   HeaderBase,
-  HeaderBaseVariant,
   IconName,
+  Text,
+  TextVariant,
 } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import { MoneyHeaderTestIds } from './MoneyHeader.testIds';
 
@@ -14,23 +16,28 @@ interface MoneyHeaderProps {
   onMenuPress: () => void;
 }
 
-const MoneyHeader = ({ onMenuPress }: MoneyHeaderProps) => (
-  <HeaderBase
-    testID={MoneyHeaderTestIds.CONTAINER}
-    variant={HeaderBaseVariant.Display}
-    twClassName="px-4"
-    titleTestID={MoneyHeaderTestIds.TITLE}
-    endButtonIconProps={[
-      {
-        iconName: IconName.MoreVertical,
-        onPress: onMenuPress,
-        accessibilityLabel: 'Menu',
-        testID: MoneyHeaderTestIds.MENU_BUTTON,
-      },
-    ]}
-  >
-    {strings('money.title')}
-  </HeaderBase>
-);
+const MoneyHeader = ({ onMenuPress }: MoneyHeaderProps) => {
+  const tw = useTailwind();
+
+  return (
+    <HeaderBase
+      testID={MoneyHeaderTestIds.CONTAINER}
+      twClassName="px-4"
+      childrenWrapperProps={{ style: tw.style('flex-1') }}
+      endButtonIconProps={[
+        {
+          iconName: IconName.MoreVertical,
+          onPress: onMenuPress,
+          accessibilityLabel: 'Menu',
+          testID: MoneyHeaderTestIds.MENU_BUTTON,
+        },
+      ]}
+    >
+      <Text variant={TextVariant.HeadingLg} testID={MoneyHeaderTestIds.TITLE}>
+        {strings('money.title')}
+      </Text>
+    </HeaderBase>
+  );
+};
 
 export default MoneyHeader;

--- a/app/components/UI/Predict/components/PredictPreviewSheet/PredictPreviewSheet.tsx
+++ b/app/components/UI/Predict/components/PredictPreviewSheet/PredictPreviewSheet.tsx
@@ -1,7 +1,6 @@
 import {
   BottomSheet,
   BottomSheetHeader,
-  BottomSheetHeaderVariant,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -72,8 +71,8 @@ const PredictPreviewSheet = forwardRef<
       >
         <BottomSheetHeader
           onClose={closeSheet}
-          variant={BottomSheetHeaderVariant.Display}
           twClassName="px-6 py-4"
+          childrenWrapperProps={{ style: tw.style('flex-1') }}
         >
           {renderHeader ? (
             renderHeader()

--- a/app/components/UI/Predict/components/PredictWithdrawUnavailableSheet/PredictWithdrawUnavailableSheet.tsx
+++ b/app/components/UI/Predict/components/PredictWithdrawUnavailableSheet/PredictWithdrawUnavailableSheet.tsx
@@ -50,7 +50,9 @@ const PredictWithdrawUnavailableSheet = forwardRef<PredictBottomSheetRef>(
           closeButtonProps={{
             testID: PREDICT_BALANCE_TEST_IDS.WITHDRAW_UNAVAILABLE_CLOSE_BUTTON,
           }}
-          titleTestID={PREDICT_BALANCE_TEST_IDS.WITHDRAW_UNAVAILABLE_TITLE}
+          textProps={{
+            testID: PREDICT_BALANCE_TEST_IDS.WITHDRAW_UNAVAILABLE_TITLE,
+          }}
         >
           {strings('predict.withdraw.unavailable_title')}
         </BottomSheetHeader>

--- a/app/components/Views/MultichainAccounts/AccountDetails/AccountTypes/BaseAccountDetails/index.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/AccountTypes/BaseAccountDetails/index.tsx
@@ -105,7 +105,7 @@ export const BaseAccountDetails = ({
     <SafeAreaView style={styles.safeArea}>
       <HeaderBase
         style={styles.header}
-        titleTestID={HEADER_BASE_TITLE_TEST_ID}
+        textProps={{ testID: HEADER_BASE_TITLE_TEST_ID }}
         startButtonIconProps={{
           testID: AccountDetailsIds.BACK_BUTTON,
           iconName: IconName.ArrowLeft,

--- a/app/components/Views/MultichainAccounts/AccountDetails/components/SmartAccountModal/SmartAccountModal.tsx
+++ b/app/components/Views/MultichainAccounts/AccountDetails/components/SmartAccountModal/SmartAccountModal.tsx
@@ -75,7 +75,7 @@ const SmartAccountModal = () => {
     >
       <HeaderBase
         style={styles.header}
-        titleTestID={HEADER_BASE_TITLE_TEST_ID}
+        textProps={{ testID: HEADER_BASE_TITLE_TEST_ID }}
         startButtonIconProps={{
           testID: SwitchAccountModalSelectorIDs.SMART_ACCOUNT_BACK_BUTTON,
           iconName: IconName.ArrowLeft,

--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
     "@metamask/core-backend": "^6.3.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.26.0",
+    "@metamask/design-system-react-native": "^0.27.0",
     "@metamask/design-system-twrnc-preset": "^0.4.2",
     "@metamask/design-tokens": "^8.4.0",
     "@metamask/earn-controller": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8455,11 +8455,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.26.0":
-  version: 0.26.0
-  resolution: "@metamask/design-system-react-native@npm:0.26.0"
+"@metamask/design-system-react-native@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "@metamask/design-system-react-native@npm:0.27.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.19.0"
+    "@metamask/design-system-shared": "npm:^0.20.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8472,18 +8472,18 @@ __metadata:
     react-native-gesture-handler: ">=2.25.0"
     react-native-reanimated: ">=3.17.0"
     react-native-safe-area-context: ">=5.0.0"
-  checksum: 10/6decfe0d4414c1ee325a87eae3444e7e29c6247da8d10969d56ffeb1bad4701cd9c6f955bb75d6a747bc9976bf8bf20f247240384e471360fac1b2de8b3bd244
+  checksum: 10/fc74755b3448bb0e6282c00f83293be3281cd92f62d89e1cbc1ecfca1a92c00f93bdb930c58d738e33989217f816a87ce6812889433d99e4a4d421b19e3275b6
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.19.0":
-  version: 0.19.0
-  resolution: "@metamask/design-system-shared@npm:0.19.0"
+"@metamask/design-system-shared@npm:^0.20.0":
+  version: 0.20.0
+  resolution: "@metamask/design-system-shared@npm:0.20.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/72b178fb72250db0f39b3d83686cefb2ec7ac46b75acb8ca5c903f84175f329897a4a728d739b0cba198b205efd11614fc69eea4a924023712cfa1c49b7c96dc
+  checksum: 10/1c66a9b98f014ca631dcb6b579dbd1b5c83d759ac05e0afe8f522a0c11d37d77ca87a6b8d3cc40fbbc9d6bbf731f24b10e2fc4a2476aef82cfcbb4e102401397
   languageName: node
   linkType: hard
 
@@ -35565,7 +35565,7 @@ __metadata:
     "@metamask/core-backend": "npm:^6.3.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.26.0"
+    "@metamask/design-system-react-native": "npm:^0.27.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.4.2"
     "@metamask/design-tokens": "npm:^8.4.0"
     "@metamask/earn-controller": "npm:^12.1.0"


### PR DESCRIPTION
## Summary

- Bumps `@metamask/design-system-react-native` from `0.26.0` → `0.27.0` (pulls in `@metamask/design-system-shared` `0.20.0`).
- Migrates all consumers off the variant-based title API that `0.27.0` removed from `HeaderBase` and `BottomSheetHeader` (drops `variant`, `HeaderBaseVariant`, `BottomSheetHeaderVariant`, and `titleTestID` — see the [design system migration guide](https://github.com/MetaMask/metamask-design-system/pull/1103)).

### Changes

| File | Change |
|---|---|
| `AccessRestrictedModal` | `titleTestID` → `textProps={{ testID }}` (no visual change) |
| `PredictWithdrawUnavailableSheet` | `titleTestID` → `textProps={{ testID }}` (no visual change) |
| `BaseAccountDetails` | `titleTestID` → `textProps={{ testID }}` (no visual change) |
| `SmartAccountModal` | `titleTestID` → `textProps={{ testID }}` (no visual change) |
| `MoneyHeader` | previously used `variant={Display}`; preserved the large left-aligned title via a custom `HeadingLg` `Text` + `childrenWrapperProps` `flex-1` wrapper |
| `PredictPreviewSheet` | previously used `variant={Display}`; preserved the left-aligned, full-width custom header via `childrenWrapperProps` `flex-1` so long titles keep truncating on a single line |

### Why the two non-trivial fixes

The removed `Display` variant did two things: rendered string titles as `HeadingLg` and used a `flex-1` (left-aligned/full-width) title wrapper instead of the now-default `flex-1 items-center` (centered). Simply dropping the prop would have made the Money title small + centered and caused the Predict preview header to shrink-center and break its one-line title truncation. `childrenWrapperProps` restores the prior layout.

## Test plan

- [x] `yarn lint:tsc` passes (8 type errors from the bump resolved)
- [x] No new linter errors in edited files
- [ ] **Money screen**: large left-aligned "Money" title + working ⋮ menu (verified via screenshot)
- [ ] **Predict preview sheet**: open a market with a long title — image + title left-aligned, title truncates with "…" on one line
- [ ] Smoke-check the 4 rename-only screens still render their titles (Access Restricted modal, Predict withdraw-unavailable sheet, Account Details header, Smart Account modal)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and UI header API migration only; test IDs are preserved and layout fixes target visual parity, not auth or data paths.
> 
> **Overview**
> Upgrades **`@metamask/design-system-react-native`** from **0.26.0** to **0.27.0** (and **`@metamask/design-system-shared`** to **0.20.0** via the lockfile) so the app matches the design system’s removal of variant-based titles on **`HeaderBase`** and **`BottomSheetHeader`**.
> 
> Most call sites only swap **`titleTestID`** for **`textProps={{ testID: … }}`** on sheet and account headers (Access Restricted, Predict withdraw-unavailable, Account Details, Smart Account). **Money** and **Predict preview** previously relied on the removed **Display** variant: they now render titles explicitly (**`HeadingLg`** on Money) and use **`childrenWrapperProps`** with a **`flex-1`** wrapper so titles stay left-aligned and long Predict preview titles still truncate on one line instead of centering or shrinking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee9dac9ef4f02ce3c4ade65d3e34f4943a1f874a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->