### PR TITLE
ci: Update `add-team-label` and `check-template-and-add-labels` workflows to use OIDC token exchange cp-7.80.0

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -2,6 +2,8 @@ name: Add team label
 
 on:
   pull_request:
+    types:
+      - opened
 
 jobs:
   add-team-label:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -11,7 +11,16 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: write
+
       - name: Add team label
         uses: MetaMask/github-tools/.github/actions/add-team-label@v1
         with:
-          team-label-token: ${{ secrets.TEAM_LABEL_TOKEN }}
+          team-label-token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -13,8 +13,17 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - name: Get access token
-        id: get-token
+      - name: Get planning token
+        id: planning-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          target-repository: MetaMask/metamask-planning
+          permissions: |
+            contents: read
+
+      - name: Get label token
+        id: label-token
         uses: MetaMask/github-tools/.github/actions/get-token@v1
         with:
           token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
@@ -25,4 +34,5 @@ jobs:
       - name: Add team label
         uses: MetaMask/github-tools/.github/actions/add-team-label@v1
         with:
-          team-label-token: ${{ steps.get-token.outputs.token }}
+          planning-token: ${{ steps.planning-token.outputs.token }}
+          team-label-token: ${{ steps.label-token.outputs.token }}

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -10,6 +10,8 @@ jobs:
     name: Add team label
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Get access token
         id: get-token

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -2,8 +2,6 @@ name: Add team label
 
 on:
   pull_request:
-    types:
-      - opened
 
 jobs:
   add-team-label:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -16,7 +16,7 @@ jobs:
         uses: MetaMask/github-tools/.github/actions/get-token@v1
         with:
           token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
-          target-repository: MetaMask/metamask-planning
+          target-repository: MetaMask/MetaMask-planning
           permissions: |
             contents: read
 

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Check template and add labels
         id: check-template-and-add-labels
         env:
-          LABEL_TOKEN: ${{ secrets.LABEL_TOKEN }}
+          LABEL_TOKEN: ${{ steps.get-token.outputs.token }}
         run: npm run check-template-and-add-labels
         working-directory: '.github/scripts'

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -46,6 +46,16 @@ jobs:
           retry_wait_seconds: 30
           command: cd .github/scripts && yarn --immutable
 
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            issues: write
+            members: read
+            pull_requests: write
+
       - name: Check template and add labels
         id: check-template-and-add-labels
         env:

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [is-fork-pull-request]
     if: ${{ always() && github.event_name != 'merge_group' && (github.event_name == 'issues' || (github.event_name == 'pull_request_target' && needs.is-fork-pull-request.outputs.IS_FORK == 'false')) }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This updates the `add-team-label` and `check-template-and-add-labels` workflows to use OIDC token exchange.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how automation authenticates to GitHub (and planning); misconfiguration could break PR/issue labeling until tokens and permissions are correct.
> 
> **Overview**
> Two GitHub Actions workflows now obtain GitHub API tokens through **OIDC token exchange** (`MetaMask/github-tools` `get-token@v1` and `vars.TOKEN_EXCHANGE_URL`) instead of repository **secrets** (`TEAM_LABEL_TOKEN`, `LABEL_TOKEN`).
> 
> **`add-team-label`** grants `id-token: write`, mints a read-only token for `MetaMask/MetaMask-planning`, a separate token with `pull_requests: write`, and passes both into `add-team-label@v1` as `planning-token` and `team-label-token`.
> 
> **`check-template-and-add-labels`** adds `contents: read` and `id-token: write`, fetches a scoped token (`issues: write`, `members: read`, `pull_requests: write`), and wires `LABEL_TOKEN` to that output for the existing script step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51e09a4f673485b2ac279c5cd537218c3fc99b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->