### PR TITLE
chore(perps): [DO NOT MERGE] ADR58 POC debug banner for open BTC position

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -232,6 +232,8 @@ export const PerpsHomeViewSelectorsIDs = {
   POSITIONS_PNL_VALUE: 'perps-home-positions-pnl-value',
   SERVICE_INTERRUPTION_BANNER: 'perps-service-interruption-banner',
   COMPETITION_BANNER: 'perps-home-competition-banner',
+  // ADR58 POC (DO NOT MERGE): debug banner shown when an open BTC position exists
+  ADR58_DEBUG_BANNER: 'perps-home-adr58-debug-banner',
   // TabBar mock items (for testing)
   TAB_BAR_WALLET: 'tab-bar-item-wallet',
   TAB_BAR_BROWSER: 'tab-bar-item-browser',

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
@@ -135,6 +135,14 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingTop: 28,
       marginBottom: 36,
     },
+    // ADR58 POC (DO NOT MERGE): debug banner shown when an open BTC position exists
+    adr58DebugBanner: {
+      backgroundColor: colors.error.default,
+      padding: 12,
+    },
+    adr58DebugBannerText: {
+      color: colors.error.inverse,
+    },
   });
 };
 

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -745,6 +745,54 @@ describe('PerpsHomeView', () => {
     expect(queryByText('perps.home.orders')).toBeNull();
   });
 
+  // ADR58 POC (DO NOT MERGE): debug banner shown when an open BTC position exists
+  describe('ADR58 POC debug banner', () => {
+    const btcPosition = {
+      symbol: 'BTC',
+      size: '0.5',
+      entryPrice: '50000',
+      positionValue: '25000',
+      unrealizedPnl: '100',
+      marginUsed: '1000',
+      leverage: { type: 'cross' as const, value: 25 },
+      liquidationPrice: '48000',
+      maxLeverage: 50,
+      returnOnEquity: '10',
+      cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+      roi: '10',
+      takeProfitPrice: undefined,
+      stopLossPrice: undefined,
+      takeProfitCount: 0,
+      stopLossCount: 0,
+      marketPrice: '50200',
+      timestamp: Date.now(),
+    };
+
+    it('shows the red banner with exact text when an open BTC position exists', () => {
+      mockUsePerpsHomeData.mockReturnValue({
+        ...mockDefaultData,
+        positions: [btcPosition],
+      });
+
+      const { getByTestId, getByText } = render(<PerpsHomeView />);
+
+      const banner = getByTestId('perps-home-adr58-debug-banner');
+      expect(banner).toBeTruthy();
+      expect(getByText('ADR58 POC: BTC POSITION DETECTED')).toBeTruthy();
+    });
+
+    it('does not show the banner when there is no open BTC position', () => {
+      mockUsePerpsHomeData.mockReturnValue({
+        ...mockDefaultData,
+        positions: [{ ...btcPosition, symbol: 'ETH' }],
+      });
+
+      const { queryByTestId } = render(<PerpsHomeView />);
+
+      expect(queryByTestId('perps-home-adr58-debug-banner')).toBeNull();
+    });
+  });
+
   it('navigates to wallet home when back button is pressed', () => {
     // Arrange
     const { getByTestId } = render(<PerpsHomeView />);

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useMemo,
 } from 'react';
-import { View, Modal, NativeScrollEvent } from 'react-native';
+import { View, Modal, NativeScrollEvent, Text } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   SafeAreaView,
@@ -535,6 +535,18 @@ const PerpsHomeView = ({
         <PerpsCompetitionBanner
           testID={PerpsHomeViewSelectorsIDs.COMPETITION_BANNER}
         />
+
+        {/* ADR58 POC (DO NOT MERGE): red debug banner when an open BTC position exists */}
+        {positions.some((position) => position.symbol === 'BTC') && (
+          <View
+            testID={PerpsHomeViewSelectorsIDs.ADR58_DEBUG_BANNER}
+            style={styles.adr58DebugBanner}
+          >
+            <Text style={styles.adr58DebugBannerText}>
+              ADR58 POC: BTC POSITION DETECTED
+            </Text>
+          </View>
+        )}
 
         {/* Positions Section */}
         <PerpsHomeSection


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE** — debug-only POC (TAT-3215, ADR58).

## Description

Renders a red debug banner `ADR58 POC: BTC POSITION DETECTED` (white text) directly above the Perps home positions list, shown only when the account has an open BTC Perps position. Minimal and trivially revertible: one conditional block + one testID + two themed style entries.

## Changelog

CHANGELOG entry: null

## Related issues

Fixes: TAT-3215

## Validation

- `yarn lint:tsc` clean · eslint **0 errors** · `jest PerpsHomeView.test.tsx` **32 passed** (incl. 2 new tests: banner present with BTC position + exact text, absent for non-BTC).
- ⚠️ **Live on-device visual proof is BLOCKED** on this checkout: the iOS app cannot build (`react-native-worklets-core` missing from `node_modules` → `pod install` fails). This is unrelated to the change (JS/TS only — zero native/dependency edits). A graph-valid validation recipe is ready to capture the AC1/AC2 screenshots once the dependency is restored (`yarn install`).

## Manual testing steps

```gherkin
Feature: ADR58 POC debug banner on Perps home
  Scenario: Banner hidden with no BTC position
    Given a perps-ready account with no open BTC position
    When the user opens the Perps home page
    Then the red "ADR58 POC: BTC POSITION DETECTED" banner is not shown
  Scenario: Banner shown above positions with an open BTC position
    Given the account has an open BTC Perps position
    When the user opens the Perps home page
    Then a red banner with white text "ADR58 POC: BTC POSITION DETECTED" is shown above the open positions list
```
