### PR TITLE
fix: enhance token loading states and geolocation handling in navigation

### DIFF
--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.test.tsx
@@ -366,6 +366,40 @@ describe('TokenSelection Component', () => {
     ).toBeOnTheScreen();
   });
 
+  it('displays loading when tokens not yet loaded (legacy, null tokens and no error)', () => {
+    // Null tokens with isLoading:false (decision settling after geo recovery)
+    // must show the spinner, not a "No tokens match" flash.
+    mockUseRampsUnifiedV2Enabled.mockReturnValue(false);
+    mockUseRampTokens.mockReturnValue({
+      topTokens: null,
+      allTokens: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByTestId } = renderWithProvider(TokenSelection);
+
+    expect(
+      getByTestId(TokenSelectionSelectors.LOADING_INDICATOR),
+    ).toBeOnTheScreen();
+  });
+
+  it('does not show loading for a genuinely empty token list (legacy, empty array and no error)', () => {
+    // A genuinely empty result is [] (not null) and must not spin forever —
+    // guards against gating loading on length instead of null.
+    mockUseRampsUnifiedV2Enabled.mockReturnValue(false);
+    mockUseRampTokens.mockReturnValue({
+      topTokens: [],
+      allTokens: [],
+      isLoading: false,
+      error: null,
+    });
+
+    const { queryByTestId } = renderWithProvider(TokenSelection);
+
+    expect(queryByTestId(TokenSelectionSelectors.LOADING_INDICATOR)).toBeNull();
+  });
+
   it('displays loading indicator while fetching tokens (V2 enabled)', () => {
     mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
     mockUseRampsController.mockReturnValue({

--- a/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
+++ b/app/components/UI/Ramp/Views/TokenSelection/TokenSelection.tsx
@@ -81,7 +81,15 @@ function TokenSelection() {
 
   const { topTokens, allTokens, isLoading, error } = useMemo(() => {
     if (!isV2UnifiedEnabled) {
-      return legacyTokens;
+      // V1: useRampTokens returns null tokens with isLoading:false while the
+      // routing decision settles after geo recovery. Treat null (no error) as
+      // loading to avoid a "No tokens match" flash before the fetch. A finished
+      // fetch yields an array, so [] => genuinely empty, never an endless spinner.
+      const legacyNotYetLoaded = !legacyTokens.topTokens && !legacyTokens.error;
+      return {
+        ...legacyTokens,
+        isLoading: legacyTokens.isLoading || legacyNotYetLoaded,
+      };
     }
 
     const filterTokens = <T extends { chainId?: string }>(
@@ -96,10 +104,9 @@ function TokenSelection() {
       });
     };
 
-    // When tokens have never been loaded, controllerTokens is null and
-    // controllerTokensLoading is false (default state). Treat that as loading
-    // so we show spinner instead of "No tokens match" on first load before
-    // controller.init() has completed (e.g. fresh install or update).
+    // null = not loaded (pre-init, or refetch in flight after a region change)
+    // => spinner. A finished fetch yields an array, so [] => genuinely empty.
+    // Gate on null, not length, or an empty region would spin forever.
     const tokensNotYetLoaded =
       controllerTokens === null && !controllerTokensError;
 

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -47,6 +47,16 @@ jest.mock('../../../../reducers/fiatOrders', () => ({
   getRampRoutingDecision: jest.fn(),
 }));
 
+const mockRefreshGeolocation = jest.fn();
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    GeolocationController: {
+      refreshGeolocation: (...args: unknown[]) =>
+        mockRefreshGeolocation(...args),
+    },
+  },
+}));
+
 const mockNavigate = jest.fn();
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
@@ -89,6 +99,8 @@ describe('useRampNavigation', () => {
 
     mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
     mockUseRampsUnifiedV2Enabled.mockReturnValue(false);
+
+    mockRefreshGeolocation.mockResolvedValue('UNKNOWN');
 
     mockGetRampRoutingDecision.mockReturnValue(null);
 
@@ -267,20 +279,45 @@ describe('useRampNavigation', () => {
       });
 
       describe('error and unsupported routing takes precedence over V2', () => {
-        it('navigates to eligibility failed modal when routing decision is ERROR', () => {
+        it('refreshes geolocation and shows the eligibility failed modal when geolocation stays UNKNOWN', async () => {
           mockGetRampRoutingDecision.mockReturnValue(
             UnifiedRampRoutingType.ERROR,
           );
+          mockRefreshGeolocation.mockResolvedValue('UNKNOWN');
           const intent = { assetId: 'eip155:1/erc20:0x123' };
           const navDetails = createEligibilityFailedModalNavigationDetails();
 
           const { result } = renderHookWithProvider(() => useRampNavigation());
 
-          result.current.goToBuy(intent);
+          await result.current.goToBuy(intent);
 
+          expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
           expect(mockSetSelectedToken).not.toHaveBeenCalled();
           expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
           expect(mockCreateBuildQuoteNavDetails).not.toHaveBeenCalled();
+        });
+
+        it('refreshes geolocation and routes into the flow when geolocation recovers', async () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.ERROR,
+          );
+          mockRefreshGeolocation.mockResolvedValue('us-ca');
+          const intent = { assetId: 'eip155:1/erc20:0x123' };
+          const tokenSelectionNavDetails = createTokenSelectionNavDetails();
+          const eligibilityNavDetails =
+            createEligibilityFailedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation());
+
+          await result.current.goToBuy(intent);
+
+          expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
+          expect(mockNavigate).toHaveBeenCalledWith(
+            ...tokenSelectionNavDetails,
+          );
+          expect(mockNavigate).not.toHaveBeenCalledWith(
+            ...eligibilityNavDetails,
+          );
         });
 
         it('navigates to unsupported modal when routing decision is UNSUPPORTED', () => {
@@ -294,6 +331,7 @@ describe('useRampNavigation', () => {
 
           result.current.goToBuy(intent);
 
+          expect(mockRefreshGeolocation).not.toHaveBeenCalled();
           expect(mockSetSelectedToken).not.toHaveBeenCalled();
           expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
           expect(mockCreateBuildQuoteNavDetails).not.toHaveBeenCalled();
@@ -340,15 +378,37 @@ describe('useRampNavigation', () => {
       });
 
       describe('error and unsupported routing', () => {
-        it('navigates to eligibility failed modal when routing decision is ERROR', () => {
+        it('navigates to eligibility failed modal when routing decision is ERROR and geolocation stays UNKNOWN', async () => {
           mockGetRampRoutingDecision.mockReturnValue(
             UnifiedRampRoutingType.ERROR,
           );
+          mockRefreshGeolocation.mockResolvedValue('UNKNOWN');
           const navDetails = createEligibilityFailedModalNavigationDetails();
 
           const { result } = renderHookWithProvider(() => useRampNavigation());
 
-          result.current.goToBuy();
+          await result.current.goToBuy();
+
+          expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
+          expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
+          expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+          expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+          expect(
+            mockCreateTokenSelectionNavigationDetails,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('navigates to eligibility failed modal when routing decision is ERROR with intent and geolocation stays UNKNOWN', async () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.ERROR,
+          );
+          mockRefreshGeolocation.mockResolvedValue('UNKNOWN');
+          const intent = { assetId: 'eip155:1/erc20:0x123' };
+          const navDetails = createEligibilityFailedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation());
+
+          await result.current.goToBuy(intent);
 
           expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
           expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
@@ -358,23 +418,27 @@ describe('useRampNavigation', () => {
           ).not.toHaveBeenCalled();
         });
 
-        it('navigates to eligibility failed modal when routing decision is ERROR with intent', () => {
+        it('routes into the flow when routing decision is ERROR but geolocation recovers', async () => {
           mockGetRampRoutingDecision.mockReturnValue(
             UnifiedRampRoutingType.ERROR,
           );
+          mockRefreshGeolocation.mockResolvedValue('us-ca');
           const intent = { assetId: 'eip155:1/erc20:0x123' };
-          const navDetails = createEligibilityFailedModalNavigationDetails();
+          const tokenSelectionNavDetails = createTokenSelectionNavDetails();
+          const eligibilityNavDetails =
+            createEligibilityFailedModalNavigationDetails();
 
           const { result } = renderHookWithProvider(() => useRampNavigation());
 
-          result.current.goToBuy(intent);
+          await result.current.goToBuy(intent);
 
-          expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
-          expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
-          expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
-          expect(
-            mockCreateTokenSelectionNavigationDetails,
-          ).not.toHaveBeenCalled();
+          expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
+          expect(mockNavigate).toHaveBeenCalledWith(
+            ...tokenSelectionNavDetails,
+          );
+          expect(mockNavigate).not.toHaveBeenCalledWith(
+            ...eligibilityNavDetails,
+          );
         });
 
         it('navigates to unsupported modal when routing decision is UNSUPPORTED', () => {
@@ -386,6 +450,8 @@ describe('useRampNavigation', () => {
           const { result } = renderHookWithProvider(() => useRampNavigation());
 
           result.current.goToBuy();
+
+          expect(mockRefreshGeolocation).not.toHaveBeenCalled();
 
           expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
           expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -320,6 +320,64 @@ describe('useRampNavigation', () => {
           );
         });
 
+        it('routes into the flow from the geolocation already in state without refreshing', async () => {
+          // The startup geo fetch already landed a known location in state while
+          // the routing decision stayed a stale ERROR — use it, skip the network.
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.ERROR,
+          );
+          const intent = { assetId: 'eip155:1/erc20:0x123' };
+          const tokenSelectionNavDetails = createTokenSelectionNavDetails();
+          const eligibilityNavDetails =
+            createEligibilityFailedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation(), {
+            state: {
+              engine: {
+                backgroundState: {
+                  GeolocationController: { location: 'us-ca' },
+                },
+              },
+            },
+          });
+
+          await result.current.goToBuy(intent);
+
+          expect(mockRefreshGeolocation).not.toHaveBeenCalled();
+          expect(mockNavigate).toHaveBeenCalledWith(
+            ...tokenSelectionNavDetails,
+          );
+          expect(mockNavigate).not.toHaveBeenCalledWith(
+            ...eligibilityNavDetails,
+          );
+        });
+
+        it('refreshes geolocation when state location is still UNKNOWN', async () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.ERROR,
+          );
+          mockRefreshGeolocation.mockResolvedValue('us-ca');
+          const intent = { assetId: 'eip155:1/erc20:0x123' };
+          const tokenSelectionNavDetails = createTokenSelectionNavDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation(), {
+            state: {
+              engine: {
+                backgroundState: {
+                  GeolocationController: { location: 'UNKNOWN' },
+                },
+              },
+            },
+          });
+
+          await result.current.goToBuy(intent);
+
+          expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
+          expect(mockNavigate).toHaveBeenCalledWith(
+            ...tokenSelectionNavDetails,
+          );
+        });
+
         it('navigates to unsupported modal when routing decision is UNSUPPORTED', () => {
           mockGetRampRoutingDecision.mockReturnValue(
             UnifiedRampRoutingType.UNSUPPORTED,

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -21,6 +21,8 @@ import { createEligibilityFailedModalNavigationDetails } from '../components/Eli
 import { useRampsTokens } from './useRampsTokens';
 import { resolveRampControllerAssetId } from '../utils/resolveRampControllerAssetId';
 import Engine from '../../../../core/Engine';
+import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
+import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 
 enum RampMode {
   AGGREGATOR = 'AGGREGATOR',
@@ -41,6 +43,7 @@ export const useRampNavigation = () => {
   const isRampsUnifiedV1Enabled = useRampsUnifiedV1Enabled();
   const isRampsUnifiedV2Enabled = useRampsUnifiedV2Enabled();
   const rampRoutingDecision = useSelector(getRampRoutingDecision);
+  const geolocationLocation = useSelector(selectGeolocationLocation);
   const { setSelectedToken, tokens: rampsTokens } = useRampsTokens();
 
   const goToBuy = useCallback(
@@ -62,15 +65,18 @@ export const useRampNavigation = () => {
       // Check error states first (applies to both V1 and V2)
       if (isUnifiedRoutingEnabled) {
         if (rampRoutingDecision === UnifiedRampRoutingType.ERROR) {
-          // ERROR usually means geolocation was UNKNOWN at decision time (it's
-          // only fetched once at startup). Retry on tap: if geo now resolves to
-          // a real region, enter the flow — smart routing refines the decision
-          // in the background. Otherwise fall back to the modal.
-          const location = await Promise.resolve(
-            Engine.context.GeolocationController?.refreshGeolocation?.(),
-          ).catch(() => undefined);
+          // ERROR usually means geo was UNKNOWN at decision time. Prefer the
+          // location already in state, only refreshing if it's still unknown.
+          // A real region enters the flow; otherwise fall back to the modal.
+          let location: string | undefined = geolocationLocation;
 
-          if (location && location !== 'UNKNOWN') {
+          if (!location || location === UNKNOWN_LOCATION) {
+            location = await Promise.resolve(
+              Engine.context.GeolocationController?.refreshGeolocation?.(),
+            ).catch(() => undefined);
+          }
+
+          if (location && location !== UNKNOWN_LOCATION) {
             navigation.navigate(...createTokenSelectionNavDetails());
           } else {
             navigation.navigate(
@@ -163,6 +169,7 @@ export const useRampNavigation = () => {
       isRampsUnifiedV1Enabled,
       isRampsUnifiedV2Enabled,
       rampRoutingDecision,
+      geolocationLocation,
       rampsTokens?.allTokens,
     ],
   );

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -20,6 +20,7 @@ import { createRampUnsupportedModalNavigationDetails } from '../components/RampU
 import { createEligibilityFailedModalNavigationDetails } from '../components/EligibilityFailedModal/EligibilityFailedModal';
 import { useRampsTokens } from './useRampsTokens';
 import { resolveRampControllerAssetId } from '../utils/resolveRampControllerAssetId';
+import Engine from '../../../../core/Engine';
 
 enum RampMode {
   AGGREGATOR = 'AGGREGATOR',
@@ -43,7 +44,7 @@ export const useRampNavigation = () => {
   const { setSelectedToken, tokens: rampsTokens } = useRampsTokens();
 
   const goToBuy = useCallback(
-    (
+    async (
       intent?: RampIntent,
       options?: {
         mode?: RampMode;
@@ -61,9 +62,21 @@ export const useRampNavigation = () => {
       // Check error states first (applies to both V1 and V2)
       if (isUnifiedRoutingEnabled) {
         if (rampRoutingDecision === UnifiedRampRoutingType.ERROR) {
-          navigation.navigate(
-            ...createEligibilityFailedModalNavigationDetails(),
-          );
+          // ERROR usually means geolocation was UNKNOWN at decision time (it's
+          // only fetched once at startup). Retry on tap: if geo now resolves to
+          // a real region, enter the flow — smart routing refines the decision
+          // in the background. Otherwise fall back to the modal.
+          const location = await Promise.resolve(
+            Engine.context.GeolocationController?.refreshGeolocation?.(),
+          ).catch(() => undefined);
+
+          if (location && location !== 'UNKNOWN') {
+            navigation.navigate(...createTokenSelectionNavDetails());
+          } else {
+            navigation.navigate(
+              ...createEligibilityFailedModalNavigationDetails(),
+            );
+          }
           return;
         }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Eligible users were seeing the "Eligibility check failed" modal when tapping "Add funds", even with a valid region and no VPN (e.g. a user in France). The root cause is a race condition: geolocation is fetched once at app startup, and if that fetch is transiently missing or returns `UNKNOWN`, `useRampsSmartRouting` converts it into a terminal routing `ERROR`. Because nothing retries afterwards, the user is stuck on a dead-end modal even though their region is perfectly eligible.

This PR makes a missing/UNKNOWN geolocation a recoverable state instead of a terminal failure, without changing the routing decision logic itself.

What changed:

`useRampNavigation.goToBuy` now retries on user intent. When the routing decision is `ERROR` at the moment the user taps Buy, it refreshes geolocation and awaits the result. If geolocation now resolves to a real region, the user is sent into the flow (Token Selection) and `useRampsSmartRouting` refines the precise DEPOSIT/AGGREGATOR decision in the background; if geolocation still cannot be determined, we fall back to the eligibility modal as before. This covers all failure modes gracefully — the geolocation controller catches network failures internally and returns its stored location rather than throwing, and an additional `catch` on the call guarantees that a hard failure still routes to the modal rather than crashing.

`TokenSelection` no longer flashes an empty "No tokens match" state during recovery. When geolocation recovers and the screen opens, tokens are briefly null while the routing decision settles and the fetch kicks off. We now treat a null token catalog (with no error) as "still loading" so the spinner shows instead of the empty state, on both the V1 (`useRampTokens`) and V2 (`RampsController`) paths. The gate is deliberately on null rather than length: a completed fetch always yields an array, so a genuinely empty region renders the empty state and never spins forever.

## **Changelog**

CHANGELOG entry: Fixed an "Eligibility check failed" error that could incorrectly block eligible users from the "Add funds" flow when geolocation was momentarily missing or unknown.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3593

## **Manual testing steps**

```gherkin
Feature: Add funds resilience to transient geolocation failures

  Scenario: Geolocation is unknown at startup but recovers on tap
    Given the app started while geolocation returned UNKNOWN
    And the ramp routing decision is therefore ERROR
    When the user taps "Add funds"
    And geolocation now resolves to a supported region
    Then the user is taken into the buy flow (Token Selection)
    And the "Eligibility check failed" modal is not shown

  Scenario: Geolocation genuinely cannot be determined
    Given the app started while geolocation returned UNKNOWN
    When the user taps "Add funds"
    And geolocation still cannot be determined (UNKNOWN or the service is down)
    Then the "Eligibility check failed" modal is shown

  Scenario: No empty-state flash entering Token Selection
    Given geolocation has just recovered and the buy flow opens
    When Token Selection mounts before tokens have finished loading
    Then a loading spinner is shown
    And the "No tokens match" empty state is not flashed before the tokens appear
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="828" height="1792" alt="Capture d’écran 2026-05-20 à 17 31 35" src="https://github.com/user-attachments/assets/cd4f3664-dc54-43f2-a6e4-99b293fa7c7f" />


### **After**



https://github.com/user-attachments/assets/a2804614-6492-4a09-9d10-a29e8571a0a3


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes buy-flow navigation and async geolocation refresh on ERROR routing, which affects who enters ramps vs. the eligibility modal; token loading gating is UX-only but must not spin forever on empty lists (guarded by null vs. []).
> 
> **Overview**
> Fixes eligible users incorrectly hitting the **Eligibility check failed** modal when startup geolocation was transiently `UNKNOWN` and smart routing had already settled on `ERROR`.
> 
> **`goToBuy`** is now **async** and, on a stale `ERROR` routing decision, re-checks region before giving up: it uses **geolocation already in Redux** when available, otherwise **`refreshGeolocation`**, then routes to **Token Selection** if a real region is known and only shows the eligibility modal if location stays unknown (with a safe fallback if refresh throws).
> 
> **Token Selection** treats **null token catalogs with no error** as still loading on the legacy V1 path (same **null-not-length** rule as V2), so users recovering from geo do not briefly see **No tokens match** while tokens refetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7edd5d7f100d519e955b184d59b40954df1fbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->