### PR TITLE
fix: lock Quick Buy bottom sheet height to prevent layout shift

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import QuickBuyPayWithScreen from './QuickBuyPayWithScreen';
 import { useQuickBuyContext } from './useQuickBuyContext';
@@ -168,5 +169,14 @@ describe('QuickBuyPayWithScreen', () => {
 
     expect(screen.getByTestId(getRowTestId(usdcToken))).toBeOnTheScreen();
     expect(screen.getByTestId(getRowTestId(usdtToken))).toBeOnTheScreen();
+  });
+
+  it('fills the available height so the token list scrolls within a fixed area', () => {
+    render(<QuickBuyPayWithScreen />);
+
+    const scrollView = screen.getByTestId('quick-buy-pay-with-scroll');
+    const flattenedStyle = StyleSheet.flatten(scrollView.props.style);
+
+    expect(flattenedStyle.flexGrow).toBe(1);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.tsx
@@ -4,10 +4,12 @@ import {
   BottomSheetHeader,
   Box,
   BoxAlignItems,
+  BoxJustifyContent,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../../locales/i18n';
 import QuickBuyPayWithChainFilter from './components/QuickBuyPayWithChainFilter';
 import QuickBuyPayWithRow from './components/QuickBuyPayWithRow';
@@ -16,6 +18,7 @@ import { getTokenKey } from './sourceTokenCandidates';
 import { useQuickBuyContext } from './useQuickBuyContext';
 
 const QuickBuyPayWithScreen: React.FC = () => {
+  const tw = useTailwind();
   const {
     sourceTokenOptions,
     selectedSourceToken,
@@ -84,7 +87,11 @@ const QuickBuyPayWithScreen: React.FC = () => {
       </BottomSheetHeader>
 
       {sourceTokenOptions.length === 0 ? (
-        <Box twClassName="px-4 py-8" alignItems={BoxAlignItems.Center}>
+        <Box
+          twClassName="flex-1 px-4 py-8"
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+        >
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('social_leaderboard.quick_buy.pay_with_no_tokens')}
           </Text>
@@ -100,7 +107,11 @@ const QuickBuyPayWithScreen: React.FC = () => {
           ) : null}
 
           {filteredTokens.length === 0 ? (
-            <Box twClassName="px-4 py-8" alignItems={BoxAlignItems.Center}>
+            <Box
+              twClassName="flex-1 px-4 py-8"
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+            >
               <Text
                 variant={TextVariant.BodyMd}
                 color={TextColor.TextAlternative}
@@ -110,6 +121,7 @@ const QuickBuyPayWithScreen: React.FC = () => {
             </Box>
           ) : (
             <GestureHandlerScrollView
+              style={tw.style('flex-1')}
               keyboardShouldPersistTaps="handled"
               showsVerticalScrollIndicator={false}
               testID="quick-buy-pay-with-scroll"

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { act, screen } from '@testing-library/react-native';
+import { act, fireEvent, screen } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import { TextColor } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import QuickBuyRoot from './QuickBuyRoot';
@@ -256,6 +257,61 @@ describe('QuickBuyRoot', () => {
       screen.getByText('social_leaderboard.quick_buy.unsupported_chain'),
     ).toBeOnTheScreen();
     expect(screen.queryByTestId('mock-amount-section')).not.toBeOnTheScreen();
+  });
+
+  it('locks the content container height after the first layout', () => {
+    renderWithProvider(
+      <QuickBuyRoot
+        isVisible
+        target={positionToQuickBuyTarget(createPosition())}
+        features={TOP_TRADERS_QUICK_BUY_FEATURES}
+        onClose={jest.fn()}
+      />,
+    );
+    act(() => {
+      storedOnOpenCallback?.();
+    });
+
+    const container = screen.getByTestId('quick-buy-content-container');
+    act(() => {
+      fireEvent(container, 'layout', {
+        nativeEvent: { layout: { height: 480 } },
+      });
+    });
+
+    expect(StyleSheet.flatten(container.props.style)).toMatchObject({
+      height: 480,
+    });
+  });
+
+  it('keeps the locked height when a later layout reports a different height', () => {
+    renderWithProvider(
+      <QuickBuyRoot
+        isVisible
+        target={positionToQuickBuyTarget(createPosition())}
+        features={TOP_TRADERS_QUICK_BUY_FEATURES}
+        onClose={jest.fn()}
+      />,
+    );
+    act(() => {
+      storedOnOpenCallback?.();
+    });
+
+    const container = screen.getByTestId('quick-buy-content-container');
+    act(() => {
+      fireEvent(container, 'layout', {
+        nativeEvent: { layout: { height: 480 } },
+      });
+    });
+    act(() => {
+      fireEvent(container, 'layout', {
+        nativeEvent: { layout: { height: 300 } },
+      });
+    });
+
+    expect(StyleSheet.flatten(container.props.style)).toMatchObject({
+      height: 480,
+    });
   });
 });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -1,9 +1,11 @@
 import {
   BottomSheet,
   type BottomSheetRef,
+  Box,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
 import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
@@ -70,6 +72,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const [isContentReady, setIsContentReady] = useState(false);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
+  const [lockedHeight, setLockedHeight] = useState<number | null>(null);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
   const surfaceClass = useElevatedSurface();
 
@@ -78,6 +81,19 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
       setIsContentReady(true);
     });
   }, []);
+
+  const handleContentLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      if (lockedHeight !== null) {
+        return;
+      }
+      const { height } = event.nativeEvent.layout;
+      if (height > 0) {
+        setLockedHeight(height);
+      }
+    },
+    [lockedHeight],
+  );
 
   return (
     <BottomSheet
@@ -95,7 +111,13 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           activeScreen={activeScreen}
           setActiveScreen={setActiveScreen}
         >
-          {renderActiveScreen(activeScreen, children)}
+          <Box
+            testID="quick-buy-content-container"
+            onLayout={handleContentLayout}
+            style={lockedHeight !== null ? { height: lockedHeight } : undefined}
+          >
+            {renderActiveScreen(activeScreen, children)}
+          </Box>
         </QuickBuyProvider>
       ) : (
         <AnimatedScrollView


### PR DESCRIPTION
## Summary


<img width="914" height="743" alt="image" src="https://github.com/user-attachments/assets/eaa554c6-4ad8-4411-be9c-dc49f3d6f6c1" />


- Changing the chain filter in the Quick Buy "Pay with" screen changed the number of token rows, which re-measured the content-sized bottom sheet and shifted the whole layout (poor UX).
- Introduces a single global height-locked container in `QuickBuyRoot` that wraps all screens. Its height is measured once (on the first layout) and locked, so navigating between screens (amount → pay with → buy, etc.) and toggling chain filters no longer resizes the sheet.
- `QuickBuyPayWithScreen` now lets the token list and empty states fill (`flex-1`) and scroll within the fixed height instead of dictating it.

## Changes

- `QuickBuyRoot.tsx`: add `lockedHeight` state + `handleContentLayout` that captures the height once; wrap `renderActiveScreen(...)` in a single `Box` container (`testID="quick-buy-content-container"`) with `onLayout` and a fixed `height` once locked.
- `QuickBuyPayWithScreen.tsx`: token list `ScrollView` and both empty states are `flex-1` (empty states centered) so they fill/scroll within the locked height.
- Tests: `QuickBuyRoot` locks height on first layout and ignores later differing heights; `QuickBuyPayWithScreen` asserts the list scroll view fills available space.
- 
## **Changelog**

CHANGELOG entry: Locked Quick Buy bottom sheet height to prevent layout shift

## Test plan

- [x] `yarn jest QuickBuyRoot.test.tsx QuickBuyPayWithScreen.test.tsx` — 18/18 passing
- [x] ESLint clean on changed files
- [ ] Manual: open Quick Buy → tap "Pay with" → toggle All/Base/Solana/Linea and confirm the sheet height stays constant across screens and filters

Made with [Cursor](https://cursor.com)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and flex styling in the Social Leaderboard Quick Buy flow; no auth, transactions, or data model changes.
> 
> **Overview**
> **Quick Buy** no longer resizes its bottom sheet when **Pay with** content changes (chain filters, fewer token rows, or switching screens). `QuickBuyRoot` wraps all routed screens in a container that records height on the **first** `onLayout` and keeps that fixed height afterward.
> 
> On **Pay with**, empty states and the token list use **`flex-1`** so content scrolls inside the locked area instead of driving sheet size. Tests cover first-layout lock, ignoring later layout events, and scroll view flex growth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10319c592f2fbc1c22be698fd0cc57f220add9c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->