### PR TITLE
fix: auto-select fiat payment method for supported transaction types

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -23,6 +23,7 @@ import {
   SetPayTokenRequest,
   useAutomaticTransactionPayToken,
 } from '../../../hooks/pay/useAutomaticTransactionPayToken';
+import { useIsFiatPaymentAvailable } from '../../../hooks/pay/useIsFiatPaymentAvailable';
 import { useTransactionPayPostQuote } from '../../../hooks/pay/useTransactionPayPostQuote';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { AlertMessage } from '../../alerts/alert-message';
@@ -135,9 +136,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const { isNative: isNativePayToken } = useTransactionPayToken();
     const { styles } = useStyles(styleSheet, {});
     const [isKeyboardVisible, setIsKeyboardVisible] = useState(true);
-    const { hasTokens } = useTransactionPayAvailableTokens();
+    const { hasTokens: hasAvailableTokens } =
+      useTransactionPayAvailableTokens();
     const fiatPayment = useTransactionPayFiatPayment();
     const selectedFiatPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
+    const isFiatAvailable = useIsFiatPaymentAvailable();
+    const hasPaymentOption = hasAvailableTokens || isFiatAvailable;
     const fiatEverSelectedRef = useRef(false);
     if (selectedFiatPaymentMethodId) {
       fiatEverSelectedRef.current = true;
@@ -228,7 +232,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             currency={currency}
             hasAlert={Boolean(alertMessage)}
             onPress={handleAmountPress}
-            disabled={!hasTokens}
+            disabled={!hasPaymentOption}
           />
           {!hidePayTokenAmount &&
             disablePay !== true &&
@@ -237,7 +241,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             ) : (
               <PayTokenAmount
                 amountHuman={amountHuman}
-                disabled={!hasTokens || isAccountSelectionNeeded}
+                disabled={!hasPaymentOption || isAccountSelectionNeeded}
               />
             ))}
           {!hidePayTokenAmount && children}
@@ -255,7 +259,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
                 !shouldHideAccountSelector && (
                   <PayAccountSelector style={styles.separator} />
                 )}
-              {disablePay !== true && hasTokens && <PayWithRow />}
+              {disablePay !== true && hasPaymentOption && <PayWithRow />}
             </>
           )}
           {isResultReady && (
@@ -263,7 +267,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {supportAccountSelection &&
                 !selectedFiatPaymentMethodId &&
                 !shouldHideAccountSelector && <PayAccountSelector />}
-              {disablePay !== true && hasTokens && <PayWithRow />}
+              {disablePay !== true && hasPaymentOption && <PayWithRow />}
               {showPaymentDetails && (
                 <>
                   <BridgeFeeRow />
@@ -287,7 +291,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               {footerText}
             </Text>
           )}
-          {isKeyboardVisible && hasTokens && (
+          {isKeyboardVisible && hasPaymentOption && (
             <DepositKeyboard
               hidePercentageButtons={
                 Boolean(selectedFiatPaymentMethodId) ||
@@ -302,7 +306,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               hasMax={hasMax && (isWithdraw || !isNativePayToken)}
             />
           )}
-          {!hasTokens && <BuySection />}
+          {!hasPaymentOption && <BuySection />}
           {!isKeyboardVisible && (
             <ConfirmButton
               alertTitle={alertTitle}

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -13,7 +13,6 @@ import { transactionApprovalControllerMock } from '../../__mocks__/controllers/a
 import {
   MetaMaskPayTokensFlags,
   selectMetaMaskPayTokensFlags,
-  selectMetaMaskPayFiatFlags,
 } from '../../../../../selectors/featureFlagController/confirmations';
 import {
   isHardwareAccount,
@@ -38,6 +37,8 @@ import { useTransactionAccountOverride } from '../transactions/useTransactionAcc
 import { MUSD_TOKEN_ADDRESS } from '../../../../UI/Earn/constants/musd';
 import { selectLastWithdrawTokenByType } from '../../../../../selectors/transactionController';
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
+import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../transactions/useTransactionAccountOverride');
@@ -48,6 +49,8 @@ jest.mock('./useTransactionPayData');
 jest.mock('./useTransactionPayAvailableTokens');
 jest.mock('./useWithdrawTokenFilter');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+jest.mock('./useIsFiatPaymentAvailable');
+jest.mock('./useMMPayFiatConfig');
 jest.mock('../../../../../selectors/transactionController', () => ({
   ...jest.requireActual('../../../../../selectors/transactionController'),
   selectLastWithdrawTokenByType: jest.fn(),
@@ -59,7 +62,6 @@ jest.mock(
       '../../../../../selectors/featureFlagController/confirmations',
     ),
     selectMetaMaskPayTokensFlags: jest.fn(),
-    selectMetaMaskPayFiatFlags: jest.fn(),
   }),
 );
 
@@ -121,9 +123,6 @@ describe('useAutomaticTransactionPayToken', () => {
   );
   const selectMetaMaskPayTokensFlagsMock = jest.mocked(
     selectMetaMaskPayTokensFlags,
-  );
-  const selectMetaMaskPayFiatFlagsMock = jest.mocked(
-    selectMetaMaskPayFiatFlags,
   );
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
@@ -187,7 +186,8 @@ describe('useAutomaticTransactionPayToken', () => {
       error: null,
     });
 
-    selectMetaMaskPayFiatFlagsMock.mockReturnValue({
+    jest.mocked(useIsFiatPaymentAvailable).mockReturnValue(false);
+    jest.mocked(useMMPayFiatConfig).mockReturnValue({
       enabledTransactionTypes: [],
       maxDelayMinutesForPaymentMethods: 10,
     });
@@ -220,7 +220,7 @@ describe('useAutomaticTransactionPayToken', () => {
     });
   });
 
-  it('selects target token if no tokens with balance', () => {
+  it('does not select token when no tokens with balance and fiat unavailable', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue({
       availableTokens: [] as AssetType[],
       hasTokens: false,
@@ -228,10 +228,7 @@ describe('useAutomaticTransactionPayToken', () => {
 
     runHook();
 
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_ADDRESS_1_MOCK,
-      chainId: CHAIN_ID_1_MOCK,
-    });
+    expect(setPayTokenMock).not.toHaveBeenCalled();
   });
 
   it('does nothing if no required tokens', () => {
@@ -418,7 +415,7 @@ describe('useAutomaticTransactionPayToken', () => {
     });
   });
 
-  it('selects target token when preferred payment token provided but no tokens available', () => {
+  it('does not select token when preferred payment token provided but no tokens available and fiat unavailable', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue({
       availableTokens: [] as AssetType[],
       hasTokens: false,
@@ -431,10 +428,7 @@ describe('useAutomaticTransactionPayToken', () => {
       },
     });
 
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_ADDRESS_1_MOCK,
-      chainId: CHAIN_ID_1_MOCK,
-    });
+    expect(setPayTokenMock).not.toHaveBeenCalled();
   });
 
   it('selects first available token when preferred token not in available tokens', () => {

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -28,10 +28,11 @@ import {
 import { useSelector } from 'react-redux';
 import {
   selectMetaMaskPayTokensFlags,
-  selectMetaMaskPayFiatFlags,
   PreferredToken,
   getPreferredTokensForTransactionType,
 } from '../../../../../selectors/featureFlagController/confirmations';
+import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 import { RootState } from '../../../../../reducers';
 import { selectLastWithdrawTokenByType } from '../../../../../selectors/transactionController';
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
@@ -160,11 +161,8 @@ export function useAutomaticTransactionPayToken({
   const automaticToken = useMemo(() => selectBestToken(), [selectBestToken]);
 
   const { paymentMethods } = useRampsPaymentMethods();
-  const fiatFlags = useSelector(selectMetaMaskPayFiatFlags);
-  const isFiatEnabled = hasTransactionType(
-    transactionMeta,
-    fiatFlags.enabledTransactionTypes,
-  );
+  const { maxDelayMinutesForPaymentMethods } = useMMPayFiatConfig();
+  const isFiatEnabled = useIsFiatPaymentAvailable();
 
   useEffect(() => {
     if (
@@ -177,20 +175,13 @@ export function useAutomaticTransactionPayToken({
       return;
     }
 
-    if (!automaticToken) {
-      log('No automatic pay token found');
-      return;
-    }
-
-    if (autoSelectFiatPayment) {
+    if (autoSelectFiatPayment || tokens.length === 0) {
       if (!isFiatEnabled || paymentMethods.length === 0) {
         return;
       }
 
       const eligibleMethod = paymentMethods.find(
-        (pm) =>
-          !pm.delay ||
-          pm.delay[1] <= fiatFlags.maxDelayMinutesForPaymentMethods,
+        (pm) => !pm.delay || pm.delay[1] <= maxDelayMinutesForPaymentMethods,
       );
 
       if (eligibleMethod) {
@@ -207,6 +198,11 @@ export function useAutomaticTransactionPayToken({
       return;
     }
 
+    if (!automaticToken) {
+      log('No automatic pay token found');
+      return;
+    }
+
     setPayToken({
       address: automaticToken.address,
       chainId: automaticToken.chainId,
@@ -219,9 +215,9 @@ export function useAutomaticTransactionPayToken({
     autoSelectFiatPayment,
     automaticToken,
     disable,
-    fiatFlags,
     hasFiatPaymentSelected,
     isFiatEnabled,
+    maxDelayMinutesForPaymentMethods,
     payToken,
     paymentMethods,
     requiredTokens,

--- a/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.ts
@@ -4,10 +4,10 @@ import Engine from '../../../../../core/Engine';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
 import { formatDelayFromArray } from '../../../../UI/Ramp/Aggregator/utils';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
 import { useTransactionPayFiatPayment } from './useTransactionPayData';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { HighlightedItem } from '../../types/token';
-import { hasTransactionType } from '../../utils/transaction';
 
 /**
  * Converts available Ramps payment methods into {@link HighlightedItem}s for
@@ -16,20 +16,16 @@ import { hasTransactionType } from '../../utils/transaction';
  * `fiatPayment.selectedPaymentMethodId` on the current transaction.
  */
 export function useFiatPaymentHighlightedActions(): HighlightedItem[] {
-  const { enabledTransactionTypes, maxDelayMinutesForPaymentMethods } =
-    useMMPayFiatConfig();
+  const { maxDelayMinutesForPaymentMethods } = useMMPayFiatConfig();
   const { paymentMethods } = useRampsPaymentMethods();
   const fiatPayment = useTransactionPayFiatPayment();
   const transactionMeta = useTransactionMetadataRequest();
   const transactionId = transactionMeta?.id ?? '';
   const selectedPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
-  const isFiatEnabled = hasTransactionType(
-    transactionMeta,
-    enabledTransactionTypes,
-  );
+  const isFiatAvailable = useIsFiatPaymentAvailable();
 
   return useMemo(() => {
-    if (!isFiatEnabled || paymentMethods.length === 0) {
+    if (!isFiatAvailable) {
       return [];
     }
 
@@ -39,7 +35,7 @@ export function useFiatPaymentHighlightedActions(): HighlightedItem[] {
         toHighlightedItem(pm, transactionId, selectedPaymentMethodId),
       );
   }, [
-    isFiatEnabled,
+    isFiatAvailable,
     maxDelayMinutesForPaymentMethods,
     paymentMethods,
     transactionId,

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { TransactionType } from '@metamask/transaction-controller';
+import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+
+jest.mock('./useMMPayFiatConfig');
+jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+jest.mock('../transactions/useTransactionMetadataRequest');
+
+describe('useIsFiatPaymentAvailable', () => {
+  const useMMPayFiatConfigMock = jest.mocked(useMMPayFiatConfig);
+  const useRampsPaymentMethodsMock = jest.mocked(useRampsPaymentMethods);
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useMMPayFiatConfigMock.mockReturnValue({
+      enabledTransactionTypes: [TransactionType.perpsDeposit],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+
+    useRampsPaymentMethodsMock.mockReturnValue({
+      paymentMethods: [{ id: 'apple-pay' }],
+    } as unknown as ReturnType<typeof useRampsPaymentMethods>);
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.perpsDeposit,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+  });
+
+  it('returns true when transaction type is enabled and payment methods exist', () => {
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when transaction type is not in enabledTransactionTypes', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.simpleSend,
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when enabledTransactionTypes is empty', () => {
+    useMMPayFiatConfigMock.mockReturnValue({
+      enabledTransactionTypes: [],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when no payment methods exist', () => {
+    useRampsPaymentMethodsMock.mockReturnValue({
+      paymentMethods: [],
+    } as unknown as ReturnType<typeof useRampsPaymentMethods>);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when transaction metadata is undefined', () => {
+    useTransactionMetadataRequestMock.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true for batch transaction with matching nested type', () => {
+    useMMPayFiatConfigMock.mockReturnValue({
+      enabledTransactionTypes: [TransactionType.predictDeposit],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.batch,
+      nestedTransactions: [{ type: TransactionType.predictDeposit }],
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(true);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
@@ -1,0 +1,20 @@
+import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { hasTransactionType } from '../../utils/transaction';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+
+/**
+ * Returns whether fiat payment is available for the current transaction.
+ * True when the transaction type is fiat-enabled via remote feature flags
+ * AND at least one Ramps payment method exists.
+ */
+export function useIsFiatPaymentAvailable(): boolean {
+  const transactionMeta = useTransactionMetadataRequest();
+  const { enabledTransactionTypes } = useMMPayFiatConfig();
+  const { paymentMethods } = useRampsPaymentMethods();
+
+  return (
+    hasTransactionType(transactionMeta, enabledTransactionTypes) &&
+    paymentMethods.length > 0
+  );
+}

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -118,6 +118,32 @@ describe('useTransactionPayAvailableTokens', () => {
     );
   });
 
+  it('returns hasTokens false when all tokens are disabled', () => {
+    const disabledToken = { ...TOKEN_MOCK, disabled: true };
+    jest.mocked(getAvailableTokens).mockReturnValue([disabledToken]);
+
+    const { result } = renderHookWithProvider(useTransactionPayAvailableTokens);
+
+    expect(result.current.availableTokens).toHaveLength(1);
+    expect(result.current.hasTokens).toBe(false);
+  });
+
+  it('returns hasTokens true when at least one token is not disabled', () => {
+    const disabledToken = { ...TOKEN_MOCK, disabled: true };
+    const enabledToken = {
+      ...TOKEN_MOCK,
+      address: '0xEnabled',
+      disabled: false,
+    };
+    jest
+      .mocked(getAvailableTokens)
+      .mockReturnValue([disabledToken, enabledToken]);
+
+    const { result } = renderHookWithProvider(useTransactionPayAvailableTokens);
+
+    expect(result.current.hasTokens).toBe(true);
+  });
+
   it('passes default blocklist when transaction type has no override', () => {
     const defaultBlocked = {
       chainIds: ['0x1'],

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -22,8 +22,10 @@ export function useTransactionPayAvailableTokens() {
   );
 
   // For post-quote transactions, tokens are always available
-  // (the supported destination tokens from the bridge API)
-  const hasTokens = isPostQuote || availableTokens.length > 0;
+  // (the supported destination tokens from the bridge API).
+  // Disabled tokens (e.g. required tokens with no gas) are excluded
+  // so the UI can correctly fall back to fiat payment or BuySection.
+  const hasTokens = isPostQuote || availableTokens.some((t) => !t.disabled);
 
   return { availableTokens, hasTokens };
 }


### PR DESCRIPTION
## **Description**

When a transaction type has fiat payments enabled via the `confirmations_pay_fiat` remote feature flag, the app should automatically select a fiat payment method (e.g. Apple Pay) if the user has no usable crypto tokens. Previously, fiat auto-selection only happened when explicitly requested via the `autoSelectFiatPayment` navigation parameter (used only by the Money Account "Deposit funds" flow).

This change makes fiat auto-selection work for **all** fiat-enabled transaction types (e.g. Perps Deposit, Predict Deposit) when no usable tokens are available, while preserving crypto as the preferred payment method when tokens exist.

### Changes

1. **`useIsFiatPaymentAvailable` (new hook)** — Shared hook encapsulating the fiat-availability check (`hasTransactionType` + payment methods exist). Replaces duplicated inline logic across 3 consumers.

2. **`useAutomaticTransactionPayToken`** — Core fix: when `tokens.length === 0` (no usable non-disabled tokens), attempt fiat auto-selection before giving up. The `autoSelectFiatPayment` explicit opt-in still works as before.

3. **`useTransactionPayAvailableTokens`** — `hasTokens` now checks `availableTokens.some(t => !t.disabled)` instead of `availableTokens.length > 0`. Required tokens with zero balance were counted as "available" despite being disabled (no gas), which prevented the `BuySection` from rendering.

4. **`custom-amount-info.tsx`** — Renamed `hasTokens` → `hasPaymentOption` to clarify the variable includes fiat availability. Uses the new `useIsFiatPaymentAvailable` hook to prevent BuySection flash when fiat will be auto-selected.

5. **`useFiatPaymentHighlightedActions`** — Replaced inline fiat-enabled check with `useIsFiatPaymentAvailable`.

## **Changelog**

CHANGELOG entry: Fixed fiat payment method auto-selection for supported transaction types when user has no crypto tokens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1435

## **Manual testing steps**

```gherkin
Feature: Fiat payment auto-selection

  Scenario: User with no usable tokens opens fiat-enabled deposit
    Given the user has no tokens with balance on the relevant chain
    And the transaction type (e.g. perpsDeposit) is in the fiat enabledTransactionTypes feature flag
    And at least one Ramps payment method is available

    When user opens the Add Funds screen for that transaction type
    Then a fiat payment method (e.g. Apple Pay) is automatically selected
    And the deposit keyboard is shown (not the Buy crypto button)

  Scenario: User with tokens opens fiat-enabled deposit
    Given the user has tokens with balance
    And the transaction type is in the fiat enabledTransactionTypes feature flag

    When user opens the Add Funds screen
    Then a crypto token is automatically selected (fiat is not forced)

  Scenario: User with no tokens opens non-fiat-enabled deposit
    Given the user has no usable tokens
    And the transaction type is NOT in the fiat enabledTransactionTypes feature flag

    When user opens the Add Funds screen
    Then the Buy crypto button is shown
```

## **Screenshots/Recordings**

### **Before**

### **After**

In the recordings `perpsDeposit` is fiat payment enabled, `predictDeposit` is fiat payment disabled:


https://github.com/user-attachments/assets/ae22c510-0a21-4a30-be63-dbe25b387249


https://github.com/user-attachments/assets/1b7749c2-5858-4768-bfa8-333868286f66



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default payment selection and deposit UI for multiple transaction types; behavior depends on remote fiat flags and Ramps payment methods, with test coverage but real-device flows should be spot-checked.
> 
> **Overview**
> Fiat-enabled deposit flows now **auto-select a Ramps payment method** when the user has no usable crypto tokens, not only when `autoSelectFiatPayment` is passed from Money Account deposit.
> 
> A new **`useIsFiatPaymentAvailable`** hook centralizes “transaction type allowed by fiat flags + at least one payment method.” **`useAutomaticTransactionPayToken`** runs fiat auto-selection when `autoSelectFiatPayment` is set **or** the filtered usable token list is empty, and stops falling back to a required target token when fiat is unavailable. **`useTransactionPayAvailableTokens`** treats `hasTokens` as “any non-disabled token” so disabled required tokens no longer block fiat/Buy UI. **`custom-amount-info`** uses **`hasPaymentOption`** (crypto or fiat) for keyboard, Pay With, and Buy section so fiat-enabled screens avoid a Buy flash before auto-selection.
> 
> Tests cover the new hook, disabled-token `hasTokens` behavior, and updated auto-select expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1971439663192d6d478831789dee2919bd7cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->