### PR TITLE
fix(preflight): restore tsconfig.json and Podfile.lock on main after setup

### DIFF
--- a/scripts/perps/agentic/lib/build-cache.sh
+++ b/scripts/perps/agentic/lib/build-cache.sh
@@ -236,7 +236,12 @@ bc__mkdir_lock_stale() {
     owner_pid=$(cat "$owner_file" 2>/dev/null || true)
     case "$owner_pid" in
       ''|*[!0-9]*) ;;
-      *) kill -0 "$owner_pid" 2>/dev/null || return 0 ;;
+      *)
+        if kill -0 "$owner_pid" 2>/dev/null; then
+          return 1
+        fi
+        return 0
+        ;;
     esac
   fi
 

--- a/scripts/perps/agentic/lib/build-cache.sh
+++ b/scripts/perps/agentic/lib/build-cache.sh
@@ -224,6 +224,28 @@ bc_prune() {
   done <<< "$entries"
 }
 
+# Return true when a mkdir lock is clearly stale. New lock dirs record the
+# owning shell PID; if that process is gone, a crashed/timeout-killed preflight
+# must not block every retry until BUILD_CACHE_LOCK_TIMEOUT elapses.
+bc__mkdir_lock_stale() {
+  local lockdir="$1"
+  local stale_after="${BUILD_CACHE_STALE_LOCK_SECONDS:-1800}"
+  local owner_file="$lockdir/owner.pid"
+  if [ -f "$owner_file" ]; then
+    local owner_pid
+    owner_pid=$(cat "$owner_file" 2>/dev/null || true)
+    case "$owner_pid" in
+      ''|*[!0-9]*) ;;
+      *) kill -0 "$owner_pid" 2>/dev/null || return 0 ;;
+    esac
+  fi
+
+  local now mtime
+  now=$(date +%s)
+  mtime=$(stat -f %m "$lockdir" 2>/dev/null || stat -c %Y "$lockdir" 2>/dev/null || echo "$now")
+  [ $((now - mtime)) -gt "$stale_after" ]
+}
+
 # Persistent-fd lock helpers. Use these when the locked region is too large to
 # wrap in a single function call. Acquire returns 0 on success, 1 on timeout.
 # Release tears down whichever lock mechanism was used.
@@ -257,6 +279,11 @@ bc_lock_acquire() {
   local lockdir="${lock}.d"
   local waited=0
   while ! mkdir "$lockdir" 2>/dev/null; do
+    if bc__mkdir_lock_stale "$lockdir"; then
+      echo "build-cache: removing stale lock $lockdir" >&2
+      rm -rf "$lockdir"
+      continue
+    fi
     if [ "$waited" -ge "$timeout" ]; then
       echo "build-cache: timed out waiting for $lockdir" >&2
       return 1
@@ -264,6 +291,7 @@ bc_lock_acquire() {
     sleep 1
     waited=$((waited + 1))
   done
+  printf '%s\n' "$$" > "$lockdir/owner.pid" 2>/dev/null || true
   BUILD_CACHE_LOCK_KIND="mkdir"
   BUILD_CACHE_LOCK_PATH="$lockdir"
   return 0
@@ -275,7 +303,7 @@ bc_lock_release() {
       exec 9>&- 2>/dev/null || true
       ;;
     mkdir)
-      [ -n "${BUILD_CACHE_LOCK_PATH:-}" ] && rmdir "$BUILD_CACHE_LOCK_PATH" 2>/dev/null || true
+      [ -n "${BUILD_CACHE_LOCK_PATH:-}" ] && rm -rf "$BUILD_CACHE_LOCK_PATH" 2>/dev/null || true
       ;;
   esac
   unset BUILD_CACHE_LOCK_KIND BUILD_CACHE_LOCK_PATH

--- a/scripts/perps/agentic/lib/build-cache.sh
+++ b/scripts/perps/agentic/lib/build-cache.sh
@@ -287,6 +287,12 @@ bc_lock_acquire() {
     if bc__mkdir_lock_stale "$lockdir"; then
       echo "build-cache: removing stale lock $lockdir" >&2
       rm -rf "$lockdir"
+      sleep 1
+      waited=$((waited + 1))
+      if [ "$waited" -ge "$timeout" ]; then
+        echo "build-cache: timed out waiting for $lockdir" >&2
+        return 1
+      fi
       continue
     fi
     if [ "$waited" -ge "$timeout" ]; then

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -183,13 +183,19 @@ pods_clean_stale() {
 # Podfile.lock versions — neither change should be committed and both pollute
 # agentic diffs. Restore them to HEAD when running on main. On older branches
 # these diffs may be intentional, so we leave them alone.
+#
+# Do not restore ios/Podfile.lock between pod install and xcodebuild: CocoaPods'
+# [CP] Check Pods Manifest.lock phase diffs ios/Podfile.lock against
+# ios/Pods/Manifest.lock and fails when they diverge. Restore Podfile.lock only
+# at the final cleanup point after native build/install work is complete.
 maybe_restore_main_noise() {
   local branch
   branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   [ "$branch" = "main" ] || return 0
 
   local restored=()
-  for f in tsconfig.json ios/Podfile.lock; do
+  local f
+  for f in "$@"; do
     [ -f "$f" ] || continue
     if ! git diff --quiet HEAD -- "$f" 2>/dev/null; then
       if git restore --source=HEAD -- "$f" 2>/dev/null || git checkout HEAD -- "$f" 2>/dev/null; then
@@ -530,7 +536,7 @@ if $DO_CLEAN; then
     pods_save_marker
   fi
   ok "yarn setup complete"
-  maybe_restore_main_noise
+  maybe_restore_main_noise tsconfig.json
 fi
 
 # ══════════════════════════════════════════════════════════════════════
@@ -668,7 +674,7 @@ if [ "$PLAT" = "ios" ]; then
     if run_with_live_log "$POD_INSTALL_LOG" "$POD_CMD"; then
       pods_save_marker
       ok "pod install complete"
-      maybe_restore_main_noise
+      maybe_restore_main_noise tsconfig.json
     else
       # On non-clean modes, the failure may be a missing spec → retry once with --repo-update.
       if ! $DO_CLEAN; then
@@ -678,7 +684,7 @@ if [ "$PLAT" = "ios" ]; then
         if run_with_live_log "$POD_INSTALL_LOG" "cd ios && bundle exec pod install --repo-update --ansi"; then
           pods_save_marker
           ok "pod install complete (after --repo-update retry)"
-          maybe_restore_main_noise
+          maybe_restore_main_noise tsconfig.json
         else
           warn "pod install had issues — see $POD_INSTALL_LOG"
         fi
@@ -1175,7 +1181,7 @@ fi
 # Final guard for main: if future setup tooling mutates these tracked
 # infrastructure files after the earlier restore points, keep the prepared
 # baseline clean without hiding intentional branch work.
-maybe_restore_main_noise
+maybe_restore_main_noise tsconfig.json ios/Podfile.lock
 
 # ── Done ─────────────────────────────────────────────────────────────
 if [ -n "$CURRENT_STEP_NAME" ]; then

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -776,7 +776,7 @@ if [ "$PLAT" = "ios" ]; then
       fi
     fi
 
-    if [ "$APP_INSTALLED" -eq 0 ]; then
+    if [ "$APP_INSTALLED" -eq 0 ] || $DO_REBUILD; then
 
     # Must pass --port (never --no-bundler): @expo/cli rejects that combo
     # (resolveBundlerProps.js), and without --port expo's headless bundler silently

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -589,8 +589,7 @@ if [ "$PLAT" = "ios" ]; then
       if [ "$APP_INSTALLED" -gt 0 ] \
          && [ "$INSTALLED_FP" = "$FP" ] \
          && [ "$INSTALLED_TGT" = "$SIM_TARGET" ] \
-         && ! $DO_REBUILD \
-         && ! $DO_WALLET_SETUP; then
+         && ! $DO_REBUILD; then
         ok "Cache: installed app matches fingerprint ${FP:0:12} on $SIM_TARGET — no native action needed"
         CHECK_ONLY_FP_VERIFIED=true
         CHECK_ONLY_FP_VALUE="$FP"
@@ -609,10 +608,6 @@ if [ "$PLAT" = "ios" ]; then
             # the existing container data (wallet/app state), so no preemptive
             # uninstall is needed on the happy path. If install fails we
             # explicitly reset APP_INSTALLED to force the build branch.
-            if $DO_WALLET_SETUP; then
-              echo "  Wiping app data for wallet setup (uninstall + reinstall cached app)..."
-              xcrun simctl uninstall "$SIM_TARGET" "$BUNDLE_ID" 2>/dev/null || true
-            fi
             if xcrun simctl install "$SIM_TARGET" "$IOS_ARTIFACT"; then
               bc_record_install ios "$FP" "$SIM_TARGET"
               APP_INSTALLED=1

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -742,6 +742,10 @@ if [ "$PLAT" = "ios" ]; then
             echo -e "  ${GREEN}Cache hit after pod install:${NC} fp=${FP:0:12} — installing from shared cache"
             IOS_ARTIFACT=$(bc_artifact_path ios "$FP")
             if xcrun simctl install "$SIM_TARGET" "$IOS_ARTIFACT"; then
+              # Release the materialized-fingerprint lock before storing the
+              # optional source-fingerprint alias; lock helpers share global
+              # state/fd 9, so nested locks would clobber the outer lock.
+              bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
               if [ -n "$IOS_SOURCE_FP" ] && [ "$IOS_SOURCE_FP" != "$FP" ]; then
                 maybe_store_ios_source_cache_alias "$IOS_SOURCE_FP" "$FP" "$IOS_ARTIFACT"
                 bc_record_install ios "$IOS_SOURCE_FP" "$SIM_TARGET"
@@ -750,7 +754,6 @@ if [ "$PLAT" = "ios" ]; then
               fi
               APP_INSTALLED=1
               ok "Installed from cache: $IOS_ARTIFACT"
-              bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
             else
               APP_INSTALLED=0
               if [ "$MODE" = "fast" ]; then
@@ -919,6 +922,9 @@ if [ "$PLAT" = "ios" ]; then
         if $BC_LOCK_HELD; then
           if bc_store_artifact ios "$FP" "$APP_PATH"; then
             ok "Stored build in shared cache: fp=${FP:0:12}"
+            # Release the build lock before taking the source-alias lock; lock
+            # helpers use shared globals/fd 9 and are intentionally not nested.
+            bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
             maybe_store_ios_source_cache_alias "$IOS_SOURCE_FP" "$FP" "$APP_PATH"
             if [ -n "$IOS_SOURCE_FP" ] && [ "$IOS_SOURCE_FP" != "$FP" ]; then
               bc_record_install ios "$IOS_SOURCE_FP" "$SIM_TARGET"
@@ -928,8 +934,8 @@ if [ "$PLAT" = "ios" ]; then
             bc_prune ios "${BUILD_CACHE_RETAIN:-5}" 2>/dev/null || true
           else
             warn "Failed to store build in cache"
+            bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
           fi
-          bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
         else
           if bc_with_lock ios "$FP" bc_store_artifact ios "$FP" "$APP_PATH"; then
             ok "Stored build in shared cache: fp=${FP:0:12}"

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -1197,10 +1197,12 @@ step "Connecting CDP" "Waiting for app to expose debug target"
 stage_log "$CDP_LOG"
 printf '$ node %s/cdp-bridge.js status\n' "$SCRIPTS" > "$CDP_LOG"
 CDP_START=$(date +%s)
+CDP_CONNECTED=false
 while [ $(( $(date +%s) - CDP_START )) -lt "$CDP_WAIT_TIMEOUT" ]; do
   CDP_STATUS_OUTPUT=$(CDP_TIMEOUT="$CDP_STATUS_TIMEOUT_MS" CDP_DISCOVERY_RETRIES="$CDP_DISCOVERY_RETRIES" node "$SCRIPTS/cdp-bridge.js" status 2>&1 || true)
   printf '[attempt %s]\n%s\n' "$((CDP_RETRY + 1))" "$CDP_STATUS_OUTPUT" >>"$CDP_LOG"
   if echo "$CDP_STATUS_OUTPUT" | grep -q '"route"' 2>/dev/null; then
+    CDP_CONNECTED=true
     ok "CDP connected"
     break
   fi
@@ -1209,7 +1211,7 @@ while [ $(( $(date +%s) - CDP_START )) -lt "$CDP_WAIT_TIMEOUT" ]; do
   [ $CDP_RETRY -eq 5 ] && echo -e "  ${DIM}Still waiting... app may still be loading JS bundle${NC}"
   [ $CDP_RETRY -eq 15 ] && echo -e "  ${DIM}Taking longer than usual — check device${NC}"
 done
-if [ $(( $(date +%s) - CDP_START )) -ge "$CDP_WAIT_TIMEOUT" ]; then
+if ! $CDP_CONNECTED; then
   # Diagnostic: probe candidate ports before failing. The symptom we hit most
   # often is the app registering its Hermes inspector on 8081 instead of our
   # $PORT when a stale expo dev server lingers — surface that explicitly so we

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -218,6 +218,22 @@ maybe_restore_main_noise() {
   return 0
 }
 
+maybe_store_ios_source_cache_alias() {
+  local source_fp="$1" materialized_fp="$2" artifact_path="$3"
+  [ -n "$source_fp" ] || return 0
+  [ -n "$materialized_fp" ] || return 0
+  [ "$source_fp" != "$materialized_fp" ] || return 0
+  [ -e "$artifact_path" ] || return 0
+  if bc_has_artifact ios "$source_fp"; then
+    return 0
+  fi
+  if bc_with_lock ios "$source_fp" bc_store_artifact ios "$source_fp" "$artifact_path"; then
+    ok "Stored build in shared cache: fp=${source_fp:0:12} (source alias for ${materialized_fp:0:12})"
+  else
+    warn "Could not store source-fingerprint cache alias ${source_fp:0:12} for ${materialized_fp:0:12}"
+  fi
+}
+
 # ── Platform detection ─────────────────────────────────────────────
 detect_platform() {
   if [ -n "$FORCE_PLATFORM" ]; then echo "$FORCE_PLATFORM"; return; fi
@@ -588,12 +604,14 @@ if [ "$PLAT" = "ios" ]; then
   step "Checking app" "Looking for $BUNDLE_ID on simulator"
   APP_INSTALLED=$(xcrun simctl listapps "$SIM_TARGET" 2>/dev/null | grep -c "$BUNDLE_ID" || true)
   BC_LOCK_HELD=false  # set to true once we own the per-fingerprint build lock
+  IOS_SOURCE_FP=""
 
   # Cache validation runs in every mode except `clean` / `rebuild-native`,
   # which intentionally bypass the cache. This is a deliberate behaviour
   # change vs origin/main: default mode now opts into fingerprint-gated reuse.
   if $BUILD_CACHE_ENABLED && [ "$MODE" != "clean" ] && [ "$MODE" != "rebuild-native" ]; then
     FP=$(bc_fingerprint 2>/dev/null || true)
+    IOS_SOURCE_FP="$FP"
     if [ -n "$FP" ]; then
       INSTALLED_FP=$(bc_installed_fp ios)
       INSTALLED_TGT=$(bc_installed_target ios)
@@ -724,7 +742,12 @@ if [ "$PLAT" = "ios" ]; then
             echo -e "  ${GREEN}Cache hit after pod install:${NC} fp=${FP:0:12} — installing from shared cache"
             IOS_ARTIFACT=$(bc_artifact_path ios "$FP")
             if xcrun simctl install "$SIM_TARGET" "$IOS_ARTIFACT"; then
-              bc_record_install ios "$FP" "$SIM_TARGET"
+              if [ -n "$IOS_SOURCE_FP" ] && [ "$IOS_SOURCE_FP" != "$FP" ]; then
+                maybe_store_ios_source_cache_alias "$IOS_SOURCE_FP" "$FP" "$IOS_ARTIFACT"
+                bc_record_install ios "$IOS_SOURCE_FP" "$SIM_TARGET"
+              else
+                bc_record_install ios "$FP" "$SIM_TARGET"
+              fi
               APP_INSTALLED=1
               ok "Installed from cache: $IOS_ARTIFACT"
               bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
@@ -896,7 +919,12 @@ if [ "$PLAT" = "ios" ]; then
         if $BC_LOCK_HELD; then
           if bc_store_artifact ios "$FP" "$APP_PATH"; then
             ok "Stored build in shared cache: fp=${FP:0:12}"
-            bc_record_install ios "$FP" "$SIM_TARGET"
+            maybe_store_ios_source_cache_alias "$IOS_SOURCE_FP" "$FP" "$APP_PATH"
+            if [ -n "$IOS_SOURCE_FP" ] && [ "$IOS_SOURCE_FP" != "$FP" ]; then
+              bc_record_install ios "$IOS_SOURCE_FP" "$SIM_TARGET"
+            else
+              bc_record_install ios "$FP" "$SIM_TARGET"
+            fi
             bc_prune ios "${BUILD_CACHE_RETAIN:-5}" 2>/dev/null || true
           else
             warn "Failed to store build in cache"
@@ -905,7 +933,12 @@ if [ "$PLAT" = "ios" ]; then
         else
           if bc_with_lock ios "$FP" bc_store_artifact ios "$FP" "$APP_PATH"; then
             ok "Stored build in shared cache: fp=${FP:0:12}"
-            bc_record_install ios "$FP" "$SIM_TARGET"
+            maybe_store_ios_source_cache_alias "$IOS_SOURCE_FP" "$FP" "$APP_PATH"
+            if [ -n "$IOS_SOURCE_FP" ] && [ "$IOS_SOURCE_FP" != "$FP" ]; then
+              bc_record_install ios "$IOS_SOURCE_FP" "$SIM_TARGET"
+            else
+              bc_record_install ios "$FP" "$SIM_TARGET"
+            fi
             bc_prune ios "${BUILD_CACHE_RETAIN:-5}" 2>/dev/null || true
           else
             warn "Could not store build in cache (lock timeout?)"

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -589,7 +589,8 @@ if [ "$PLAT" = "ios" ]; then
       if [ "$APP_INSTALLED" -gt 0 ] \
          && [ "$INSTALLED_FP" = "$FP" ] \
          && [ "$INSTALLED_TGT" = "$SIM_TARGET" ] \
-         && ! $DO_REBUILD; then
+         && ! $DO_REBUILD \
+         && ! $DO_WALLET_SETUP; then
         ok "Cache: installed app matches fingerprint ${FP:0:12} on $SIM_TARGET — no native action needed"
         CHECK_ONLY_FP_VERIFIED=true
         CHECK_ONLY_FP_VALUE="$FP"
@@ -608,6 +609,10 @@ if [ "$PLAT" = "ios" ]; then
             # the existing container data (wallet/app state), so no preemptive
             # uninstall is needed on the happy path. If install fails we
             # explicitly reset APP_INSTALLED to force the build branch.
+            if $DO_WALLET_SETUP; then
+              echo "  Wiping app data for wallet setup (uninstall + reinstall cached app)..."
+              xcrun simctl uninstall "$SIM_TARGET" "$BUNDLE_ID" 2>/dev/null || true
+            fi
             if xcrun simctl install "$SIM_TARGET" "$IOS_ARTIFACT"; then
               bc_record_install ios "$FP" "$SIM_TARGET"
               APP_INSTALLED=1

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -65,7 +65,18 @@ DEPS_LOG="${LOG_DIR}/deps.log"
 POD_INSTALL_LOG="${LOG_DIR}/pod-install.log"
 CDP_LOG="${LOG_DIR}/cdp.log"
 WALLET_LOG="${LOG_DIR}/wallet-setup.log"
-CDP_WAIT_TIMEOUT=90
+CDP_WAIT_TIMEOUT="${CDP_WAIT_TIMEOUT:-300}"
+case "$CDP_WAIT_TIMEOUT" in
+  ''|*[!0-9]*) CDP_WAIT_TIMEOUT=300 ;;
+esac
+CDP_STATUS_TIMEOUT_MS="${CDP_STATUS_TIMEOUT_MS:-5000}"
+case "$CDP_STATUS_TIMEOUT_MS" in
+  ''|*[!0-9]*) CDP_STATUS_TIMEOUT_MS=5000 ;;
+esac
+CDP_DISCOVERY_RETRIES="${CDP_DISCOVERY_RETRIES:-1}"
+case "$CDP_DISCOVERY_RETRIES" in
+  ''|*[!0-9]*) CDP_DISCOVERY_RETRIES=1 ;;
+esac
 CDP_RETRY=0
 
 # Flags
@@ -627,6 +638,7 @@ if [ "$PLAT" = "ios" ]; then
             # Cache miss in auto/default mode. Whatever is installed (if anything)
             # is at the wrong fingerprint; force the build gate to fire so we
             # produce + install a fresh artifact instead of running a stale app.
+            echo -e "  ${YELLOW}Cache miss:${NC} fp=${FP:0:12} — native build required once"
             APP_INSTALLED=0
           fi
           # Lock stays held through native build; post-build store releases it.
@@ -693,6 +705,53 @@ if [ "$PLAT" = "ios" ]; then
       fi
     fi
 
+    # pod install can materialize native generated files that participate in
+    # Expo's fingerprint. Recompute after pods settle and re-check the shared
+    # cache before spending ~20+ minutes in xcodebuild. This preserves the
+    # expected idempotency when a slot starts from a pre-pod-install worktree
+    # but the post-pod native fingerprint already has a cached .app.
+    if $BUILD_CACHE_ENABLED && [ "$MODE" != "clean" ] && [ "$MODE" != "rebuild-native" ] && [ "$APP_INSTALLED" -eq 0 ]; then
+      if $BC_LOCK_HELD; then
+        bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
+      fi
+      bc_fingerprint_reset_memo
+      FP=$(bc_fingerprint 2>/dev/null || true)
+      if [ -n "$FP" ]; then
+        if bc_lock_acquire ios "$FP"; then
+          BC_LOCK_HELD=true
+          trap 'bc_lock_release' EXIT
+          if bc_has_artifact ios "$FP"; then
+            echo -e "  ${GREEN}Cache hit after pod install:${NC} fp=${FP:0:12} — installing from shared cache"
+            IOS_ARTIFACT=$(bc_artifact_path ios "$FP")
+            if xcrun simctl install "$SIM_TARGET" "$IOS_ARTIFACT"; then
+              bc_record_install ios "$FP" "$SIM_TARGET"
+              APP_INSTALLED=1
+              ok "Installed from cache: $IOS_ARTIFACT"
+              bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
+            else
+              APP_INSTALLED=0
+              if [ "$MODE" = "fast" ]; then
+                bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
+                fail "Mode 'fast': cached artifact install failed for fp ${FP:0:12}"
+              fi
+              warn "Post-pod cache install failed — falling through to native build"
+            fi
+          else
+            echo -e "  ${YELLOW}Cache miss after pod install:${NC} fp=${FP:0:12} — native build required once"
+          fi
+        else
+          if [ "$MODE" = "fast" ]; then
+            fail "Mode 'fast': could not acquire build-cache lock for fp ${FP:0:12}"
+          fi
+          warn "Could not acquire post-pod build-cache lock for fp ${FP:0:12} — proceeding without lock"
+        fi
+      else
+        warn "Could not compute post-pod fingerprint — proceeding with native build"
+      fi
+    fi
+
+    if [ "$APP_INSTALLED" -eq 0 ]; then
+
     # Must pass --port (never --no-bundler): @expo/cli rejects that combo
     # (resolveBundlerProps.js), and without --port expo's headless bundler silently
     # binds the hardcoded default 8081, which collides with other worktrees and
@@ -724,7 +783,10 @@ if [ "$PLAT" = "ios" ]; then
     WATCH_PID=$!
 
     APP_PATH=""
-    BUILD_TIMEOUT=900
+    BUILD_TIMEOUT="${IOS_BUILD_TIMEOUT:-1800}"
+    case "$BUILD_TIMEOUT" in
+      ''|*[!0-9]*) BUILD_TIMEOUT=1800 ;;
+    esac
     while :; do
       NOW=$(date +%s)
       ELAPSED=$((NOW - BUILD_START))
@@ -851,6 +913,7 @@ if [ "$PLAT" = "ios" ]; then
         fi
       fi
     fi
+    fi
   else
     if $BC_LOCK_HELD; then
       bc_lock_release; BC_LOCK_HELD=false; trap - EXIT
@@ -955,6 +1018,7 @@ else
           else
             # Cache miss in auto/default mode. Stale app must not pass the build
             # gate untouched; force a fresh build + install.
+            echo -e "  ${YELLOW}Cache miss:${NC} fp=${FP:0:12} — native build required once"
             APP_INSTALLED=0
           fi
         else
@@ -1093,8 +1157,9 @@ ok "Metro running on port $PORT"
 step "Connecting CDP" "Waiting for app to expose debug target"
 stage_log "$CDP_LOG"
 printf '$ node %s/cdp-bridge.js status\n' "$SCRIPTS" > "$CDP_LOG"
-while [ $CDP_RETRY -lt $CDP_WAIT_TIMEOUT ]; do
-  CDP_STATUS_OUTPUT=$(node "$SCRIPTS/cdp-bridge.js" status 2>&1 || true)
+CDP_START=$(date +%s)
+while [ $(( $(date +%s) - CDP_START )) -lt "$CDP_WAIT_TIMEOUT" ]; do
+  CDP_STATUS_OUTPUT=$(CDP_TIMEOUT="$CDP_STATUS_TIMEOUT_MS" CDP_DISCOVERY_RETRIES="$CDP_DISCOVERY_RETRIES" node "$SCRIPTS/cdp-bridge.js" status 2>&1 || true)
   printf '[attempt %s]\n%s\n' "$((CDP_RETRY + 1))" "$CDP_STATUS_OUTPUT" >>"$CDP_LOG"
   if echo "$CDP_STATUS_OUTPUT" | grep -q '"route"' 2>/dev/null; then
     ok "CDP connected"
@@ -1105,15 +1170,15 @@ while [ $CDP_RETRY -lt $CDP_WAIT_TIMEOUT ]; do
   [ $CDP_RETRY -eq 5 ] && echo -e "  ${DIM}Still waiting... app may still be loading JS bundle${NC}"
   [ $CDP_RETRY -eq 15 ] && echo -e "  ${DIM}Taking longer than usual — check device${NC}"
 done
-if [ $CDP_RETRY -ge $CDP_WAIT_TIMEOUT ]; then
+if [ $(( $(date +%s) - CDP_START )) -ge "$CDP_WAIT_TIMEOUT" ]; then
   # Diagnostic: probe candidate ports before failing. The symptom we hit most
   # often is the app registering its Hermes inspector on 8081 instead of our
   # $PORT when a stale expo dev server lingers — surface that explicitly so we
   # don't spend 15 tool calls diagnosing the same thing twice.
   probe_cdp_port() {
-    curl -s --max-time 2 "http://localhost:$1/json/list" 2>/dev/null \
-      | python3 -c 'import sys,json; d=json.loads(sys.stdin.read() or "[]"); print(len(d))' 2>/dev/null \
-      || echo 0
+    local body
+    body=$(curl -s --max-time 2 "http://localhost:$1/json/list" 2>/dev/null || true)
+    python3 -c 'import sys,json; d=json.loads(sys.stdin.read() or "[]"); print(len(d))' 2>/dev/null <<< "$body" || echo 0
   }
   echo ""
   echo -e "  ${RED}CDP timeout — diagnostic probe:${NC}"

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -179,6 +179,28 @@ pods_clean_stale() {
   return 1
 }
 
+# On main, yarn setup (expo) patches tsconfig.json and pod install bumps
+# Podfile.lock versions — neither change should be committed and both pollute
+# agentic diffs. Restore them to HEAD when running on main. On older branches
+# these diffs may be intentional, so we leave them alone.
+maybe_restore_main_noise() {
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  [ "$branch" = "main" ] || return 0
+
+  local restored=()
+  for f in tsconfig.json ios/Podfile.lock; do
+    [ -f "$f" ] || continue
+    if ! git diff --quiet HEAD -- "$f" 2>/dev/null; then
+      if git restore --source=HEAD -- "$f" 2>/dev/null || git checkout HEAD -- "$f" 2>/dev/null; then
+        restored+=("$f")
+      fi
+    fi
+  done
+  [ ${#restored[@]} -gt 0 ] && ok "Restored on main (setup noise): ${restored[*]}"
+  return 0
+}
+
 # ── Platform detection ─────────────────────────────────────────────
 detect_platform() {
   if [ -n "$FORCE_PLATFORM" ]; then echo "$FORCE_PLATFORM"; return; fi
@@ -508,6 +530,7 @@ if $DO_CLEAN; then
     pods_save_marker
   fi
   ok "yarn setup complete"
+  maybe_restore_main_noise
 fi
 
 # ══════════════════════════════════════════════════════════════════════
@@ -645,6 +668,7 @@ if [ "$PLAT" = "ios" ]; then
     if run_with_live_log "$POD_INSTALL_LOG" "$POD_CMD"; then
       pods_save_marker
       ok "pod install complete"
+      maybe_restore_main_noise
     else
       # On non-clean modes, the failure may be a missing spec → retry once with --repo-update.
       if ! $DO_CLEAN; then
@@ -654,6 +678,7 @@ if [ "$PLAT" = "ios" ]; then
         if run_with_live_log "$POD_INSTALL_LOG" "cd ios && bundle exec pod install --repo-update --ansi"; then
           pods_save_marker
           ok "pod install complete (after --repo-update retry)"
+          maybe_restore_main_noise
         else
           warn "pod install had issues — see $POD_INSTALL_LOG"
         fi
@@ -1146,6 +1171,11 @@ elif [ -n "$WALLET_PW" ]; then
   step "Unlocking wallet" "Using provided password"
   node "$SCRIPTS/cdp-bridge.js" unlock "$WALLET_PW" 2>/dev/null && ok "Wallet unlocked" || warn "Could not unlock wallet"
 fi
+
+# Final guard for main: if future setup tooling mutates these tracked
+# infrastructure files after the earlier restore points, keep the prepared
+# baseline clean without hiding intentional branch work.
+maybe_restore_main_noise
 
 # ── Done ─────────────────────────────────────────────────────────────
 if [ -n "$CURRENT_STEP_NAME" ]; then

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -159,11 +159,30 @@ fi
 # --- No Metro detected — start fresh ---
 > "$LOGFILE"
 
-# Clear Metro + Babel transpilation caches to ensure env vars are freshly inlined.
-# babel-plugin-transform-inline-environment-variables caches compiled values in
-# $TMPDIR/metro-cache. Without clearing, switching METAMASK_ENVIRONMENT between
-# 'e2e' and 'dev' may serve bundles with stale inlined values.
-rm -rf "${TMPDIR:-/tmp}/metro-cache" "${TMPDIR:-/tmp}/haste-map-"* 2>/dev/null || true
+# Clear Metro + Babel transpilation caches only when the inline environment
+# changes. Deleting them on every prepare defeats Metro's transform cache, makes
+# idempotent prepares rebundle the whole app, and can make CDP readiness time out
+# while the app is still compiling JS. Keep an explicit escape hatch for manual
+# debugging or env churn.
+METRO_CACHE_KEY_FILE=".agent/metro-cache-key"
+METRO_CACHE_KEY="$(
+  {
+    printf 'platform=%s\nport=%s\n' "$PLAT" "$PORT"
+    env | grep -E '^(METAMASK_|MM_|NODE_ENV=|EXPO_PUBLIC_|FEATURE_|SEGMENT_|SENTRY_)' | sort || true
+    [ -f .js.env ] && shasum .js.env
+    [ -f babel.config.js ] && shasum babel.config.js
+    [ -f metro.config.js ] && shasum metro.config.js
+  } | shasum | awk '{print $1}'
+)"
+if [ "${MM_CLEAR_METRO_CACHE:-0}" = "1" ] \
+   || [ ! -f "$METRO_CACHE_KEY_FILE" ] \
+   || [ "$(cat "$METRO_CACHE_KEY_FILE" 2>/dev/null || true)" != "$METRO_CACHE_KEY" ]; then
+  echo "Metro inline env changed — clearing transform cache..."
+  rm -rf "${TMPDIR:-/tmp}/metro-cache" "${TMPDIR:-/tmp}/haste-map-"* 2>/dev/null || true
+  printf '%s\n' "$METRO_CACHE_KEY" > "$METRO_CACHE_KEY_FILE"
+else
+  echo "Reusing Metro transform cache."
+fi
 
 echo "Starting Metro on port $PORT..."
 EXPO_NO_TYPESCRIPT_SETUP=1 yarn expo start --port "$PORT" >> "$LOGFILE" 2>&1 &

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -168,7 +168,7 @@ METRO_CACHE_KEY_FILE=".agent/metro-cache-key"
 METRO_CACHE_KEY="$(
   {
     printf 'platform=%s\nport=%s\n' "$PLAT" "$PORT"
-    env | grep -E '^(METAMASK_|MM_|NODE_ENV=|EXPO_PUBLIC_|FEATURE_|SEGMENT_|SENTRY_)' | sort || true
+    env | grep -E '^(METAMASK_|MM_|NODE_ENV=|EXPO_PUBLIC_|FEATURE_|SEGMENT_|SENTRY_)' | grep -v '^MM_CLEAR_METRO_CACHE=' | sort || true
     [ -f .js.env ] && shasum .js.env
     [ -f babel.config.js ] && shasum babel.config.js
     [ -f metro.config.js ] && shasum metro.config.js

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -179,6 +179,7 @@ if [ "${MM_CLEAR_METRO_CACHE:-0}" = "1" ] \
    || [ "$(cat "$METRO_CACHE_KEY_FILE" 2>/dev/null || true)" != "$METRO_CACHE_KEY" ]; then
   echo "Metro inline env changed — clearing transform cache..."
   rm -rf "${TMPDIR:-/tmp}/metro-cache" "${TMPDIR:-/tmp}/haste-map-"* 2>/dev/null || true
+  mkdir -p "$(dirname "$METRO_CACHE_KEY_FILE")"
   printf '%s\n' "$METRO_CACHE_KEY" > "$METRO_CACHE_KEY_FILE"
 else
   echo "Reusing Metro transform cache."


### PR DESCRIPTION
## **Description**

\`yarn a:setup:ios\` (\`preflight.sh --mode clean\`) leaves two tracked files dirty after every successful build on \`main\`:

- **\`tsconfig.json\`** — Expo's setup step adds \`"extends": "expo/tsconfig.base"\` and reformats inline arrays to multi-line. Infrastructure noise, not an intentional change.
- **\`ios/Podfile.lock\`** — \`pod install\` bumps pod versions (\`OpenSSL-Universal\`, \`react-native-aes\`). Genuine version updates but should not pollute agentic worktree diffs mid-session.

Both diffs contaminate \`git status\` after setup, making it harder for agents to distinguish intentional code changes from build side-effects.

Adds \`maybe_restore_main_noise()\` to \`preflight.sh\` — called after \`yarn setup\` and after each \`pod install\` path. On \`main\` it restores both files to HEAD. On any other branch it is a no-op (older branches may intentionally carry these diffs).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

\`\`\`gherkin
Feature: preflight setup noise suppression

  Scenario: user runs a:setup:ios on main
    Given the repo is on main with a clean working tree
    When user runs yarn a:setup:ios
    Then git status shows no changes to tsconfig.json or ios/Podfile.lock
\`\`\`

## **Screenshots/Recordings**

### **Before**

N/A — script-only change, no UI surface.

### **After**

N/A — script-only change, no UI surface.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agentic shell scripts (preflight, Metro start, build cache); no app runtime, auth, or payment logic. Main-branch `git restore` only affects `tsconfig.json` and `Podfile.lock` when on `main`.
> 
> **Overview**
> On **`main`**, agentic preflight now **reverts setup noise** in tracked files via **`maybe_restore_main_noise`**: **`tsconfig.json`** after **`yarn setup`** / **`pod install`**, and **`ios/Podfile.lock`** only at the **end** (so CocoaPods manifest checks still pass mid-pipeline).
> 
> **iOS build-cache** behavior is tightened: capture a **pre–`pod install` fingerprint**, **recompute after pods**, try a **shared cache install** before **`xcodebuild`**, and optionally **alias-store** artifacts under the earlier fingerprint. **Stale mkdir locks** are cleared using **`owner.pid`** / age in **`build-cache.sh`**.
> 
> **CDP** waits longer with configurable timeouts/retries; **`start-metro.sh`** clears Metro’s transform cache **only when inline env changes** (not every prepare), with **`MM_CLEAR_METRO_CACHE`** override. Minor UX: cache miss messages and configurable **iOS build timeout**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f25012d27c6ef608fbf4571597aceda76fc88d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->