### PR TITLE
fix(browser): initialize in-app browser bridge on committed navigation

### DIFF
--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -621,6 +621,79 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
       ],
     );
 
+    const initializeBackgroundBridge = useCallback(
+      (urlBridge: string, isMainFrame: boolean) => {
+        // First disconnect and reset bridge
+        backgroundBridgeRef.current?.onDisconnect();
+        backgroundBridgeRef.current = undefined;
+
+        //@ts-expect-error - We should type bacgkround bridge js file
+        const newBridge = new BackgroundBridge({
+          webview: webviewRef,
+          url: urlBridge,
+          getRpcMethodMiddleware: ({
+            getProviderState,
+          }: {
+            getProviderState: () => void;
+          }) =>
+            getRpcMethodMiddleware({
+              hostname: new URL(urlBridge).origin,
+              getProviderState,
+              navigation,
+              // Website info
+              url: resolvedUrlRef,
+              title: titleRef,
+              icon: iconRef,
+              tabId,
+              // TODO: This properties were missing, and were not optional
+              isWalletConnect: false,
+              isMMSDK: false,
+              analytics: {},
+            }),
+          isMainFrame,
+        });
+        backgroundBridgeRef.current = newBridge;
+      },
+      [navigation, tabId],
+    );
+
+    const sendActiveAccount = useCallback(
+      async (targetUrl?: string) => {
+        // Use targetUrl if explicitly provided (even if empty), otherwise fall back to resolvedUrlRef.current
+        const urlToCheck =
+          targetUrl !== undefined ? targetUrl : resolvedUrlRef.current;
+
+        if (!urlToCheck) {
+          // If no URL to check, send empty accounts
+          notifyAllConnections({
+            method: NOTIFICATION_NAMES.accountsChanged,
+            params: [],
+          });
+          return;
+        }
+
+        // Get permitted accounts for the target URL
+        const permissionsControllerState =
+          Engine.context.PermissionController.state;
+        let origin = ''; // notifyAllConnections will return empty array if ''
+        try {
+          origin = new URLParse(urlToCheck).origin;
+        } catch (err) {
+          Logger.log('Error parsing WebView URL', err);
+        }
+        const permittedAcc = getPermittedEvmAddressesByHostname(
+          permissionsControllerState,
+          origin,
+        );
+
+        notifyAllConnections({
+          method: NOTIFICATION_NAMES.accountsChanged,
+          params: permittedAcc,
+        });
+      },
+      [notifyAllConnections],
+    );
+
     /**
      * Handles state changes for when the url changes
      */
@@ -637,6 +710,16 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
         if (siteInfo.icon) iconRef.current = siteInfo.icon;
 
         const hostName = new URLParse(siteInfo.url).origin;
+
+        // Initialize the background bridge only once the navigation has
+        // committed, so the bridge origin always matches the page actually
+        // rendered in the WebView.
+        initializeBackgroundBridge(hostName, true);
+        // Send the active account after the bridge has been initialized for the
+        // committed origin, so account data is delivered through a bridge whose
+        // origin matches the rendered page.
+        sendActiveAccount(siteInfo.url);
+
         // Prevent url from being set when the url bar is focused
         !isUrlBarFocused &&
           urlBarRef.current?.setNativeProps({ text: hostName });
@@ -672,6 +755,8 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
         updateTabInfo,
         addToBrowserHistory,
         navigation,
+        initializeBackgroundBridge,
+        sendActiveAccount,
       ],
     );
 
@@ -909,79 +994,6 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
       [checkIFrameUrls, scrollY],
     );
 
-    const initializeBackgroundBridge = useCallback(
-      (urlBridge: string, isMainFrame: boolean) => {
-        // First disconnect and reset bridge
-        backgroundBridgeRef.current?.onDisconnect();
-        backgroundBridgeRef.current = undefined;
-
-        //@ts-expect-error - We should type bacgkround bridge js file
-        const newBridge = new BackgroundBridge({
-          webview: webviewRef,
-          url: urlBridge,
-          getRpcMethodMiddleware: ({
-            getProviderState,
-          }: {
-            getProviderState: () => void;
-          }) =>
-            getRpcMethodMiddleware({
-              hostname: new URL(urlBridge).origin,
-              getProviderState,
-              navigation,
-              // Website info
-              url: resolvedUrlRef,
-              title: titleRef,
-              icon: iconRef,
-              tabId,
-              // TODO: This properties were missing, and were not optional
-              isWalletConnect: false,
-              isMMSDK: false,
-              analytics: {},
-            }),
-          isMainFrame,
-        });
-        backgroundBridgeRef.current = newBridge;
-      },
-      [navigation, tabId],
-    );
-
-    const sendActiveAccount = useCallback(
-      async (targetUrl?: string) => {
-        // Use targetUrl if explicitly provided (even if empty), otherwise fall back to resolvedUrlRef.current
-        const urlToCheck =
-          targetUrl !== undefined ? targetUrl : resolvedUrlRef.current;
-
-        if (!urlToCheck) {
-          // If no URL to check, send empty accounts
-          notifyAllConnections({
-            method: NOTIFICATION_NAMES.accountsChanged,
-            params: [],
-          });
-          return;
-        }
-
-        // Get permitted accounts for the target URL
-        const permissionsControllerState =
-          Engine.context.PermissionController.state;
-        let origin = ''; // notifyAllConnections will return empty array if ''
-        try {
-          origin = new URLParse(urlToCheck).origin;
-        } catch (err) {
-          Logger.log('Error parsing WebView URL', err);
-        }
-        const permittedAcc = getPermittedEvmAddressesByHostname(
-          permissionsControllerState,
-          origin,
-        );
-
-        notifyAllConnections({
-          method: NOTIFICATION_NAMES.accountsChanged,
-          params: permittedAcc,
-        });
-      },
-      [notifyAllConnections],
-    );
-
     /**
      * Website started to load
      */
@@ -1020,18 +1032,13 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
           return false;
         }
 
-        sendActiveAccount(nativeEvent.url);
-
+        // The background bridge is intentionally not initialized here.
+        // `onLoadStart` fires before the navigation has committed, so the bridge
+        // is initialized and the active account sent only once the navigation
+        // has committed, in `handleSuccessfulPageResolution`.
         iconRef.current = undefined;
-
-        initializeBackgroundBridge(urlOrigin, true);
       },
-      [
-        isAllowedOrigin,
-        handleNotAllowedUrl,
-        sendActiveAccount,
-        initializeBackgroundBridge,
-      ],
+      [isAllowedOrigin, handleNotAllowedUrl],
     );
 
     /**

--- a/app/components/Views/BrowserTab/sendActiveAccount.test.tsx
+++ b/app/components/Views/BrowserTab/sendActiveAccount.test.tsx
@@ -277,7 +277,7 @@ describe('sendActiveAccount function', () => {
   });
 
   describe('security considerations', () => {
-    it('sends accounts only for the specific hostname requested', async () => {
+    it('sends accounts scoped to the requested origin, not the previously resolved one', async () => {
       const dapp1Url = 'https://dapp1.com';
       const dapp2Url = 'https://dapp2.com';
       const dapp1Accounts = [
@@ -319,21 +319,21 @@ describe('sendActiveAccount function', () => {
       });
     });
 
-    it('prevents cross-origin account leakage during navigation', async () => {
-      const authorizedUrl = 'https://authorized.com';
-      const unauthorizedUrl = 'https://unauthorized.com';
-      const authorizedAccounts = [
+    it('sends accounts for the requested origin, not the previously resolved one', async () => {
+      const permittedUrl = 'https://permitted-dapp.com';
+      const otherUrl = 'https://other-dapp.com';
+      const permittedAccounts = [
         '0x1234567890123456789012345678901234567890',
       ] as EthereumAddress[];
 
-      resolvedUrlRef.current = authorizedUrl; // Previous site
+      resolvedUrlRef.current = permittedUrl; // Previously resolved url
 
       mockGetPermittedEvmAddressesByHostname.mockImplementation(
         (_, hostname) =>
-          hostname === 'authorized.com' ? authorizedAccounts : [],
+          hostname === 'permitted-dapp.com' ? permittedAccounts : [],
       );
 
-      await sendActiveAccount(unauthorizedUrl);
+      await sendActiveAccount(otherUrl);
 
       expect(mockNotifyAllConnections).toHaveBeenCalledWith({
         method: NOTIFICATION_NAMES.accountsChanged,
@@ -341,30 +341,31 @@ describe('sendActiveAccount function', () => {
       });
     });
 
-    it('correctly handles targetUrl override during navigation vulnerability scenario', async () => {
-      const previousSiteUrl = 'https://victim-dapp.com';
-      const newSiteUrl = 'https://attacker-site.com';
-      const victimAccounts = [
+    it('uses the provided targetUrl rather than the previously resolved url', async () => {
+      const previousUrl = 'https://permitted-dapp.com';
+      const newUrl = 'https://other-dapp.com';
+      const permittedAccounts = [
         '0x1111111111111111111111111111111111111111',
         '0x2222222222222222222222222222222222222222',
       ] as EthereumAddress[];
 
-      // resolvedUrlRef still points to previous site (before onLoadEnd updates it)
-      resolvedUrlRef.current = previousSiteUrl;
+      // resolvedUrlRef still points to the previously resolved url
+      resolvedUrlRef.current = previousUrl;
 
       mockGetPermittedEvmAddressesByHostname.mockImplementation(
-        (_, hostname) => (hostname === 'victim-dapp.com' ? victimAccounts : []),
+        (_, hostname) =>
+          hostname === 'permitted-dapp.com' ? permittedAccounts : [],
       );
 
-      await sendActiveAccount(newSiteUrl);
+      await sendActiveAccount(newUrl);
 
       expect(mockGetPermittedEvmAddressesByHostname).toHaveBeenCalledWith(
         Engine.context.PermissionController.state,
-        'attacker-site.com', // Should use new site's hostname
+        'other-dapp.com', // Should use the provided targetUrl's hostname
       );
       expect(mockNotifyAllConnections).toHaveBeenCalledWith({
         method: NOTIFICATION_NAMES.accountsChanged,
-        params: [], // Empty because attacker site has no permissions
+        params: [], // Empty because the other origin has no permissions
       });
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Move background bridge initialization and the active-account
notification out of `onLoadStart` and into the committed-navigation
path (`handleSuccessfulPageResolution`).

`onLoadStart` fires before a navigation commits, so initializing the
bridge there could leave the bridge origin out of sync with the page
actually rendered in the WebView. Initializing on commit keeps the
bridge origin aligned with the rendered content, and sending the
active account afterward ensures account data is delivered through a
bridge whose origin matches that page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed in-app browser bridge initialization to occur on committed navigation, keeping the bridge origin aligned with the rendered page.

## **Related issues**

Fixes: [MCWP-593](https://consensyssoftware.atlassian.net/browse/MCWP-593)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/87c689a7-4b0b-4e14-8758-f1951e92df7a

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/1decbcf9-1be9-4760-ae20-19ae33f2c26f


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MCWP-593]: https://consensyssoftware.atlassian.net/browse/MCWP-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ