### PR TITLE
fix: strip URL fragment from address bar display

### DIFF
--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.test.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.test.tsx
@@ -273,7 +273,7 @@ describe('BrowserUrlBar', () => {
       { state: mockInitialState },
     );
 
-    const urlText = getByText('https://example.com');
+    const urlText = getByText('https://example.com/');
 
     // Press the URL text to trigger the focus callback
     fireEvent.press(urlText);

--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.test.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.test.tsx
@@ -578,6 +578,56 @@ describe('BrowserUrlBar', () => {
     });
   });
 
+  describe('URL fragment display', () => {
+    it('strips fragment from displayed URL when fragment is large', () => {
+      const baseUrl = 'https://example.com/page';
+      const urlWithLargeFragment = `${baseUrl}#${'A'.repeat(200)}other-domain.com`;
+      const props = {
+        ...propsWithoutUrlBarFocused,
+        activeUrl: urlWithLargeFragment,
+      };
+
+      const { queryByText, getByText } = renderWithProvider(
+        <BrowserUrlBar {...props} />,
+        { state: mockInitialState },
+      );
+
+      // Fragment should not appear in the URL bar
+      expect(queryByText(urlWithLargeFragment)).toBeNull();
+      // Origin + path should be displayed instead
+      expect(getByText(baseUrl)).toBeDefined();
+    });
+
+    it('displays URL without fragment when fragment is present', () => {
+      const props = {
+        ...propsWithoutUrlBarFocused,
+        activeUrl: 'https://example.com/page?q=1#section',
+      };
+
+      const { getByText, queryByText } = renderWithProvider(
+        <BrowserUrlBar {...props} />,
+        { state: mockInitialState },
+      );
+
+      expect(getByText('https://example.com/page?q=1')).toBeDefined();
+      expect(queryByText('https://example.com/page?q=1#section')).toBeNull();
+    });
+
+    it('displays URL unchanged when no fragment is present', () => {
+      const props = {
+        ...propsWithoutUrlBarFocused,
+        activeUrl: 'https://example.com/page',
+      };
+
+      const { getByText } = renderWithProvider(
+        <BrowserUrlBar {...props} />,
+        { state: mockInitialState },
+      );
+
+      expect(getByText('https://example.com/page')).toBeDefined();
+    });
+  });
+
   describe('Tabs Button', () => {
     it('renders tabs button when showTabs prop is provided and URL bar is not focused', () => {
       const mockShowTabs = jest.fn();

--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.test.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.test.tsx
@@ -619,10 +619,9 @@ describe('BrowserUrlBar', () => {
         activeUrl: 'https://example.com/page',
       };
 
-      const { getByText } = renderWithProvider(
-        <BrowserUrlBar {...props} />,
-        { state: mockInitialState },
-      );
+      const { getByText } = renderWithProvider(<BrowserUrlBar {...props} />, {
+        state: mockInitialState,
+      });
 
       expect(getByText('https://example.com/page')).toBeDefined();
     });

--- a/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
+++ b/app/components/UI/BrowserUrlBar/BrowserUrlBar.tsx
@@ -79,6 +79,23 @@ const BrowserUrlBar = forwardRef<BrowserUrlBarRef, BrowserUrlBarProps>(
         return '';
       }
     }, [activeUrl]);
+
+    /**
+     * URL to display in the unfocused address bar.
+     * Strips the fragment (hash) to prevent address bar spoofing via large
+     * URL fragments (e.g. #lns=) that cause misleading domain display when
+     * the text is head-truncated.
+     */
+    const displayUrl = useMemo(() => {
+      if (!activeUrl) return activeUrl;
+      try {
+        const parsed = new URLParse(activeUrl);
+        // Reconstruct URL without fragment: origin + pathname + query
+        return `${parsed.origin}${parsed.pathname}${parsed.query}`;
+      } catch {
+        return activeUrl;
+      }
+    }, [activeUrl]);
     const {
       styles,
       theme: { colors, themeAppearance },
@@ -291,7 +308,7 @@ const BrowserUrlBar = forwardRef<BrowserUrlBarRef, BrowserUrlBarProps>(
                 numberOfLines={1}
                 ellipsizeMode="head"
               >
-                {inputValueRef.current || activeUrl}
+                {inputValueRef.current || displayUrl}
               </Text>
             </TouchableWithoutFeedback>
           </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The address bar rendered the full URL including the fragment with ellipsizeMode="head", which could cause the visible portion to not accurately reflect the actual page origin. 

Strip the fragment before displaying the URL in the unfocused address bar.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where the address bar could display incorrect URL information when navigating to pages with large URL fragments

## **Related issues**

Fixes: MCWP-633

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

Watch the Browser URL bar

### **Before**

https://github.com/user-attachments/assets/fe38c43d-7b7c-44e7-88d3-c2962c16dd4d

### **After**

https://github.com/user-attachments/assets/90825112-a1e3-4907-9a92-ec799a132270


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
