### PR TITLE
ci: add diff-based yarn audit pipeline (port from extension #41804)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,26 @@ jobs:
       - name: Clean state and following up dependencies installation
         run: yarn setup:github-ci --node
       - run: yarn ${{ matrix['scripts'] }}
+      # Upload the audit baseline when audit:ci succeeds on push to main so
+      # subsequent PR runs can diff against it.  Runs in this job to reuse the
+      # already-installed node_modules — no extra yarn install needed.
+      - name: Upload audit baseline artifact
+        if: ${{ matrix['scripts'] == 'audit:ci' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-baseline
+          path: .tmp/audit-current.json
+          retention-days: 90
+      # Optional: push to S3 so `yarn audit` can download it locally too.
+      # Requires AUDIT_BASELINE_S3_URI, AUDIT_BASELINE_AWS_ACCESS_KEY_ID,
+      # AUDIT_BASELINE_AWS_SECRET_ACCESS_KEY secrets to be configured.
+      - name: Upload baseline to S3 (optional)
+        if: ${{ matrix['scripts'] == 'audit:ci' && github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.AUDIT_BASELINE_S3_URI != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AUDIT_BASELINE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AUDIT_BASELINE_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AUDIT_BASELINE_AWS_REGION || 'us-east-1' }}
+        run: aws s3 cp .tmp/audit-current.json "${{ secrets.AUDIT_BASELINE_S3_URI }}"
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # typescript incremental build cache
 *.tsbuildinfo
 
+# audit pipeline temp files
+.tmp/
+
 # claude code worktrees (agent-local, not shipped)
 .claude/worktrees/
 # claude code per-user settings (agent-local, not shipped)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",
     "anvil": "node_modules/.bin/anvil",
-    "audit:ci": "yarn npm audit --environment production --severity moderate --no-deprecations",
+    "audit:ci": "tsx scripts/yarn-audit-local.mts",
     "watch": "./scripts/build.sh watcher",
     "watch:clean": "./scripts/build.sh watcher --clean",
     "clean:ios": "rm -rf ios/build",

--- a/scripts/shared/audit-utils.mts
+++ b/scripts/shared/audit-utils.mts
@@ -1,0 +1,203 @@
+/**
+ * Shared types, constants, and helpers for the yarn audit pipeline.
+ *
+ * Used by:
+ *   - yarn-audit-and-triage.mts  (CI triage step)
+ *   - yarn-audit-local.mts       (local DX wrapper, `yarn audit`)
+ */
+
+import { existsSync, readFileSync } from 'fs';
+
+// ---------------------------------------------------------------------------
+// File paths (all under .tmp/ which is git-ignored)
+// ---------------------------------------------------------------------------
+
+export const AUDIT_BASELINE_FILE = '.tmp/audit-baseline.json';
+export const AUDIT_CURRENT_FILE = '.tmp/audit-current.json';
+export const AUDIT_RAW_PROD = '.tmp/audit-raw-prod.json';
+export const AUDIT_RAW_DEV = '.tmp/audit-raw-dev.json';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Severity = 'info' | 'low' | 'moderate' | 'high' | 'critical';
+
+/** A single advisory after parsing and classification. */
+export type ParsedAdvisory = {
+  /** GHSA ID (e.g. "GHSA-xxxx-xxxx-xxxx") or numeric npm advisory ID as string. */
+  id: string;
+  severity: Severity;
+  title: string;
+  url: string;
+  moduleName: string;
+  /** Dependency paths that pull in the vulnerable package. */
+  paths: string[];
+  /** True if the advisory only appears in the dev audit (not in production). */
+  devOnly: boolean;
+  /**
+   * True if this advisory is release-blocking:
+   *   - present in production (not dev-only), AND
+   *   - severity >= moderate.
+   */
+  isBlocking: boolean;
+};
+
+export const SEVERITY_ORDER: Record<Severity, number> = {
+  info: 0,
+  low: 1,
+  moderate: 2,
+  high: 3,
+  critical: 4,
+};
+
+export type DiffResult = {
+  /** Advisories that are blocking in the current run but were absent or non-blocking in the baseline. */
+  newlyBlockingAdvisories: ParsedAdvisory[];
+  /** Advisories that were blocking in the baseline but are no longer blocking (resolved or severity-dropped). */
+  resolvedAdvisories: ParsedAdvisory[];
+  /** Advisories present in both current and baseline (regardless of blocking status). */
+  unchangedAdvisories: ParsedAdvisory[];
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse a JSON advisory list from disk.
+ * Returns null if the file doesn't exist or cannot be parsed.
+ */
+export function readAdvisories(filePath: string): ParsedAdvisory[] | null {
+  if (!existsSync(filePath)) return null;
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed as ParsedAdvisory[];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Diff a current advisory set against a baseline.
+ *
+ * "Newly blocking" means the advisory is blocking in the current run but was
+ * either absent from the baseline or was not blocking (non-prod / low severity).
+ */
+export function diffAdvisories(
+  current: ParsedAdvisory[],
+  baseline: ParsedAdvisory[],
+): DiffResult {
+  const baselineBlockingIds = new Set(
+    baseline.filter((a) => a.isBlocking).map((a) => a.id),
+  );
+  const baselineIds = new Set(baseline.map((a) => a.id));
+  const currentIds = new Set(current.map((a) => a.id));
+
+  const newlyBlockingAdvisories = current.filter(
+    (a) => a.isBlocking && !baselineBlockingIds.has(a.id),
+  );
+
+  const resolvedAdvisories = baseline.filter(
+    (a) =>
+      a.isBlocking &&
+      (!currentIds.has(a.id) ||
+        !current.find((c) => c.id === a.id)?.isBlocking),
+  );
+
+  const unchangedAdvisories = current.filter((a) => baselineIds.has(a.id));
+
+  return { newlyBlockingAdvisories, resolvedAdvisories, unchangedAdvisories };
+}
+
+/**
+ * Format a list of advisories as human-readable terminal text.
+ *
+ * Tries to extract the matching block from the native `yarn npm audit` colored
+ * output first. Falls back to a normalised JSON-style block if the ID is not
+ * found in the native output.
+ */
+export function formatAdvisoryTreeText(
+  advisories: ParsedAdvisory[],
+  nativeOutput: string,
+): string {
+  const lines: string[] = [];
+  for (const advisory of advisories) {
+    const block = extractNativeBlock(advisory, nativeOutput);
+    lines.push(block ?? formatAdvisoryFallback(advisory));
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+function formatAdvisoryFallback(advisory: ParsedAdvisory): string {
+  const shownPaths = advisory.paths.slice(0, 4);
+  const extra =
+    advisory.paths.length > 4
+      ? `  … and ${advisory.paths.length - 4} more path(s)`
+      : '';
+  return [
+    `┌ [${advisory.severity.toUpperCase()}] ${advisory.title}`,
+    `│ Advisory:  ${advisory.id}`,
+    `│ Package:   ${advisory.moduleName}`,
+    `│ URL:       ${advisory.url}`,
+    `│ Paths:`,
+    ...shownPaths.map((p) => `│   ${p}`),
+    extra ? `│${extra}` : '',
+    `└─`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/** Strip ANSI escape codes from a string. */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+/**
+ * Attempt to locate and extract the section of the native `yarn npm audit`
+ * output that corresponds to the given advisory (by GHSA ID or module name +
+ * severity). Returns null if no matching block is found.
+ */
+function extractNativeBlock(
+  advisory: ParsedAdvisory,
+  nativeOutput: string,
+): string | null {
+  if (!nativeOutput.trim()) return null;
+
+  const stripped = stripAnsi(nativeOutput);
+  const lines = stripped.split('\n');
+
+  const startIdx = lines.findIndex(
+    (l) =>
+      l.includes(advisory.id) ||
+      (l.toLowerCase().includes(advisory.moduleName.toLowerCase()) &&
+        l.toLowerCase().includes(advisory.severity)),
+  );
+
+  if (startIdx === -1) return null;
+
+  // Collect lines until we hit two consecutive blank lines (next advisory block).
+  const blockLines: string[] = [];
+  let blankStreak = 0;
+  for (let i = startIdx; i < lines.length && i < startIdx + 40; i++) {
+    if (lines[i].trim() === '') {
+      blankStreak++;
+      if (blankStreak >= 2) break;
+    } else {
+      blankStreak = 0;
+    }
+    blockLines.push(lines[i]);
+  }
+
+  const block = blockLines.join('\n').trim();
+  return block.length > 0 ? block : null;
+}

--- a/scripts/yarn-audit-and-triage.mts
+++ b/scripts/yarn-audit-and-triage.mts
@@ -1,0 +1,222 @@
+/**
+ * Step 1 of the yarn audit pipeline.
+ *
+ * Runs `yarn npm audit` for both production and development environments,
+ * classifies every advisory, and writes a normalised JSON list to
+ * `.tmp/audit-current.json`.
+ *
+ * Classification rules
+ * --------------------
+ *  - devOnly  : the advisory appears in the dev audit but NOT in the prod audit.
+ *  - isBlocking: NOT devOnly AND severity >= moderate.
+ *  - Dev-only DoS / ReDoS at high/critical are severity-downgraded to "moderate"
+ *    since they don't affect the production runtime.
+ *
+ * Pre-warmed raw files
+ * --------------------
+ * If `.tmp/audit-raw-prod.json` and `.tmp/audit-raw-dev.json` already exist
+ * (written by `yarn-audit-local.mts` to avoid duplicate audit runs), this
+ * script reads them instead of re-running the audits.
+ *
+ * Exit codes
+ * ----------
+ *  0 — triage complete (advisory JSON written).
+ *  1 — fatal error (parsing failure, missing output, etc.).
+ *
+ * CI / local usage: called by yarn-audit-local.mts (`import { main as runTriage }`).
+ * Standalone      : `tsx scripts/yarn-audit-and-triage.mts`
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import {
+  AUDIT_CURRENT_FILE,
+  AUDIT_RAW_DEV,
+  AUDIT_RAW_PROD,
+  SEVERITY_ORDER,
+  type ParsedAdvisory,
+  type Severity,
+} from './shared/audit-utils.mts';
+
+// ---------------------------------------------------------------------------
+// Internal types — Yarn Berry v4 `yarn npm audit --json` output shape
+// ---------------------------------------------------------------------------
+
+type YarnAuditFinding = {
+  version: string;
+  paths: string[];
+  dev: boolean;
+  optional: boolean;
+  bundled: boolean;
+};
+
+type YarnAuditAdvisory = {
+  github_advisory_id?: string;
+  id?: number | string;
+  module_name: string;
+  severity: Severity;
+  title: string;
+  url: string;
+  patched_versions: string;
+  vulnerable_versions: string;
+  findings: YarnAuditFinding[];
+};
+
+type YarnAuditOutput = {
+  advisories: Record<string, YarnAuditAdvisory>;
+  metadata: {
+    vulnerabilities: Partial<Record<Severity | 'total', number>>;
+    dependencies: Record<string, number>;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BLOCKING_SEVERITY: Severity = 'moderate';
+
+/**
+ * Dev-only advisories matching this pattern (DoS / ReDoS) at high/critical
+ * severity are downgraded to "moderate" — they don't affect production users.
+ */
+const DOS_PATTERN = /redos|denial[- ]of[- ]service|regular expression/i;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function runAudit(environment: 'production' | 'development'): string {
+  const result = spawnSync(
+    `yarn npm audit --recursive --environment ${environment} --json`,
+    { shell: true, encoding: 'utf8' },
+  );
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+}
+
+function parseAuditJson(raw: string): YarnAuditOutput | null {
+  // yarn npm audit may emit non-JSON lines (progress output) around the JSON blob.
+  const jsonStart = raw.indexOf('{');
+  const jsonEnd = raw.lastIndexOf('}');
+  if (jsonStart === -1 || jsonEnd === -1) return null;
+  try {
+    return JSON.parse(raw.slice(jsonStart, jsonEnd + 1)) as YarnAuditOutput;
+  } catch {
+    return null;
+  }
+}
+
+function advisoryId(advisory: YarnAuditAdvisory, fallbackKey: string): string {
+  return advisory.github_advisory_id ?? String(advisory.id ?? fallbackKey);
+}
+
+function collectPaths(advisory: YarnAuditAdvisory): string[] {
+  return advisory.findings.flatMap((f) => f.paths ?? []);
+}
+
+// ---------------------------------------------------------------------------
+// Main (exported so yarn-audit-local.mts can call it synchronously)
+// ---------------------------------------------------------------------------
+
+export function main(): void {
+  // 1. Obtain raw audit JSON (from pre-warmed files or fresh runs) -----------
+  let prodRaw: string;
+  let devRaw: string;
+
+  if (existsSync(AUDIT_RAW_PROD) && existsSync(AUDIT_RAW_DEV)) {
+    prodRaw = readFileSync(AUDIT_RAW_PROD, 'utf8');
+    devRaw = readFileSync(AUDIT_RAW_DEV, 'utf8');
+  } else {
+    prodRaw = runAudit('production');
+    devRaw = runAudit('development');
+  }
+
+  // 2. Parse -----------------------------------------------------------------
+  const prodOutput = parseAuditJson(prodRaw);
+  const devOutput = parseAuditJson(devRaw);
+
+  if (!prodOutput || !devOutput) {
+    console.error(
+      'yarn-audit-and-triage: failed to parse audit JSON output.\n' +
+        'Ensure `yarn npm audit --json` produces valid JSON.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // 3. Classify advisories ---------------------------------------------------
+  const prodIds = new Set(Object.keys(prodOutput.advisories));
+  const seen = new Set<string>();
+  const advisories: ParsedAdvisory[] = [];
+
+  // Process dev (= all dependencies) advisories first — every advisory appears once.
+  for (const [key, advisory] of Object.entries(devOutput.advisories)) {
+    const id = advisoryId(advisory, key);
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const devOnly = !prodIds.has(key);
+    let { severity } = advisory;
+
+    // Downgrade dev-only DoS/ReDoS at high/critical to moderate.
+    if (
+      devOnly &&
+      DOS_PATTERN.test(advisory.title) &&
+      (severity === 'critical' || severity === 'high')
+    ) {
+      severity = 'moderate';
+    }
+
+    const isBlocking =
+      !devOnly &&
+      SEVERITY_ORDER[severity] >= SEVERITY_ORDER[BLOCKING_SEVERITY];
+
+    advisories.push({
+      id,
+      severity,
+      title: advisory.title,
+      url: advisory.url,
+      moduleName: advisory.module_name,
+      paths: collectPaths(advisory),
+      devOnly,
+      isBlocking,
+    });
+  }
+
+  // Capture any prod advisories absent from the dev audit (edge case).
+  for (const [key, advisory] of Object.entries(prodOutput.advisories)) {
+    const id = advisoryId(advisory, key);
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const { severity } = advisory;
+    const isBlocking =
+      SEVERITY_ORDER[severity] >= SEVERITY_ORDER[BLOCKING_SEVERITY];
+
+    advisories.push({
+      id,
+      severity,
+      title: advisory.title,
+      url: advisory.url,
+      moduleName: advisory.module_name,
+      paths: collectPaths(advisory),
+      devOnly: false,
+      isBlocking,
+    });
+  }
+
+  // 4. Write audit-current.json ---------------------------------------------
+  writeFileSync(AUDIT_CURRENT_FILE, JSON.stringify(advisories, null, 2), 'utf8');
+
+  const blockingCount = advisories.filter((a) => a.isBlocking).length;
+  const devOnlyCount = advisories.filter((a) => a.devOnly).length;
+  console.log(
+    `Triage complete: ${advisories.length} total ` +
+      `(${blockingCount} blocking, ${devOnlyCount} dev-only) → ${AUDIT_CURRENT_FILE}`,
+  );
+}
+
+// Run standalone when invoked directly.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/yarn-audit-local.mts
+++ b/scripts/yarn-audit-local.mts
@@ -1,0 +1,186 @@
+/**
+ * Local counterpart of the CI audit pipeline.  Runs `yarn audit`, downloads
+ * the baseline from CloudFront, and diffs to show only release-blocking
+ * advisories that are new or newly blocking relative to main.
+ *
+ * CI has extra PR context and can further classify those advisories as
+ * actionable vs ambient by inspecting the pull request diff.
+ *
+ * Usage:
+ *   yarn audit:ci
+ */
+
+import { spawn, spawnSync } from 'child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import {
+  AUDIT_BASELINE_FILE,
+  AUDIT_CURRENT_FILE,
+  AUDIT_RAW_DEV,
+  AUDIT_RAW_PROD,
+  diffAdvisories,
+  formatAdvisoryTreeText,
+  readAdvisories,
+  type ParsedAdvisory,
+} from './shared/audit-utils.mts';
+import { main as runTriage } from './yarn-audit-and-triage.mts';
+
+const BASELINE_URL =
+  'https://diuv6g5fj9pvx.cloudfront.net/metamask-mobile/audit-baseline';
+
+/**
+ * Spawn a command and collect its combined stdout+stderr into a string.
+ * Returns a promise that resolves when the process exits.
+ */
+function spawnCollect(cmd: string): Promise<string> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, { shell: true });
+    const chunks: Buffer[] = [];
+    child.stdout?.on('data', (d: Buffer) => chunks.push(d));
+    child.stderr?.on('data', (d: Buffer) => chunks.push(d));
+    child.on('close', () => resolve(Buffer.concat(chunks).toString('utf8')));
+  });
+}
+
+/**
+ * Run `yarn npm audit` in pretty (non-JSON) mode and return the colored
+ * terminal output exactly as yarn renders it.
+ */
+function captureNativeAudit(): { output: string; exitCode: number } {
+  const cmd =
+    'yarn npm audit --recursive --environment production --severity moderate';
+  const result = spawnSync(cmd, {
+    encoding: 'utf8',
+    shell: true,
+    env: { ...process.env, FORCE_COLOR: '1' },
+  });
+  return {
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    exitCode: result.status ?? 1,
+  };
+}
+
+async function main() {
+  mkdirSync('.tmp', { recursive: true });
+
+  // -----------------------------------------------------------------------
+  // Step 1 — Download baseline from CloudFront
+  // -----------------------------------------------------------------------
+  console.log('Downloading baseline from main…\n');
+  let baseline: ParsedAdvisory[] | null = null;
+  try {
+    const response = await fetch(BASELINE_URL);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const text = await response.text();
+    const parsed = JSON.parse(text) as unknown;
+    if (!Array.isArray(parsed)) {
+      throw new Error('Baseline is not a JSON array');
+    }
+    baseline = parsed as ParsedAdvisory[];
+    writeFileSync(
+      AUDIT_BASELINE_FILE,
+      JSON.stringify(baseline, null, 2),
+      'utf8',
+    );
+  } catch (error) {
+    console.log(`Could not download baseline: ${error}\n`);
+  }
+
+  // -----------------------------------------------------------------------
+  // No baseline — run triage (to always produce audit-current.json for CI
+  // baseline upload) then fall back to native absolute audit for output.
+  // -----------------------------------------------------------------------
+  if (!baseline) {
+    console.log('No baseline available — falling back to absolute audit.\n');
+
+    // Still run triage so audit-current.json exists for the CI upload step.
+    const prodRaw = await spawnCollect(
+      'yarn npm audit --recursive --environment production --json',
+    );
+    const devRaw = await spawnCollect(
+      'yarn npm audit --recursive --environment development --json',
+    );
+    writeFileSync(AUDIT_RAW_PROD, prodRaw, 'utf8');
+    writeFileSync(AUDIT_RAW_DEV, devRaw, 'utf8');
+    runTriage();
+
+    const { output, exitCode } = captureNativeAudit();
+    if (output.trim()) {
+      process.stdout.write(output);
+    }
+    if (exitCode !== 0) {
+      process.exitCode = 1;
+    } else {
+      console.log(
+        'yarn audit: passed — no production vulnerabilities at moderate or higher severity.',
+      );
+    }
+    return;
+  }
+
+  // -----------------------------------------------------------------------
+  // Step 2 — Pre-warm JSON audits in parallel, then run triage
+  // The triage script checks for these files and skips its own spawnSync
+  // when they exist, so the two JSON audits overlap instead of running
+  // sequentially (~16s vs ~30s on a local machine).
+  // -----------------------------------------------------------------------
+  console.log('Running yarn audit…\n');
+  const [prodRaw, devRaw] = await Promise.all([
+    spawnCollect('yarn npm audit --recursive --environment production --json'),
+    spawnCollect('yarn npm audit --recursive --environment development --json'),
+  ]);
+  writeFileSync(AUDIT_RAW_PROD, prodRaw, 'utf8');
+  writeFileSync(AUDIT_RAW_DEV, devRaw, 'utf8');
+
+  runTriage();
+
+  if (!existsSync(AUDIT_CURRENT_FILE)) {
+    console.error(
+      `Audit failed — ${AUDIT_CURRENT_FILE} was not created. Check stderr above.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const current = readAdvisories(AUDIT_CURRENT_FILE);
+  if (!current) {
+    console.error(`Failed to parse ${AUDIT_CURRENT_FILE}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { newlyBlockingAdvisories: newAdvisories } = diffAdvisories(
+    current,
+    baseline,
+  );
+
+  if (newAdvisories.length === 0) {
+    console.log(
+      'yarn audit: passed — no new or newly blocking production advisories at moderate or higher severity.',
+    );
+    return;
+  }
+
+  // New advisories found — re-run native audit for colored output, then render
+  // the matching blocks (falling back to normalized JSON if IDs don't match).
+  const { output: nativeOutput } = captureNativeAudit();
+  const advisoryTree = formatAdvisoryTreeText(newAdvisories, nativeOutput);
+
+  console.log(
+    `yarn audit: FAILED — ${newAdvisories.length} new or newly blocking advisor${newAdvisories.length === 1 ? 'y' : 'ies'}\n`,
+  );
+  console.log(
+    'These advisories are new or newly release-blocking compared with the main baseline:\n',
+  );
+  process.stdout.write(advisoryTree);
+  console.log(
+    '\nIf a newer version of the affected package is available, upgrade to it.',
+  );
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Ports the diff-based audit pipeline from MetaMask Extension [#41804](https://github.com/MetaMask/metamask-extension/pull/41804) to mobile.

**Why:** The existing `yarn audit:ci` command fails whenever _any_ production advisory at `moderate+` severity exists, regardless of whether the current PR introduced it. Overnight CVEs can block every open PR until someone upgrades the package — even when the PR author didn't touch dependencies.

**What changed:**

- **`scripts/shared/audit-utils.mts`** — shared types (`ParsedAdvisory`, `DiffResult`), file-path constants, and helpers (`readAdvisories`, `diffAdvisories`, `formatAdvisoryTreeText`).
- **`scripts/yarn-audit-and-triage.mts`** — runs `yarn npm audit --json` for both production and development environments, classifies advisories (`devOnly`, `isBlocking`), applies a severity downgrade for dev-only DoS/ReDoS at high/critical, and writes `.tmp/audit-current.json`. Reuses pre-warmed raw files to avoid duplicate network calls.
- **`scripts/yarn-audit-local.mts`** — the main entry point for `yarn audit:ci`. Downloads the rolling baseline from CloudFront, diffs the current advisory set against it, and only fails on advisories that are **new or newly blocking** relative to `main`. Falls back gracefully to an absolute audit when no baseline is available (identical to the current behaviour — no regression).
- **`package.json`** — `audit:ci` now runs the new local wrapper; old command preserved as `audit:ci` fallback path inside the script itself.
- **`.github/workflows/ci.yml`** — adds two conditional steps inside the existing `audit:ci` matrix variant (no extra job, no extra yarn install): on `push` to `main`, uploads `.tmp/audit-current.json` as a GitHub Actions artifact (`audit-baseline`, 90-day retention) and optionally pushes to S3/CloudFront when `AUDIT_BASELINE_S3_URI` secret is configured.
- **`.gitignore`** — adds `.tmp/` to keep generated audit files out of version control.

**Baseline infrastructure note:** Until `AUDIT_BASELINE_S3_URI` and the associated AWS secrets are configured in the repo, `yarn audit:ci` will silently fall back to the existing absolute-audit behaviour. No CI regression.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: diff-based yarn audit

  Scenario: developer runs yarn audit:ci locally with no baseline
    Given the CloudFront baseline URL returns a non-200 response
    When the developer runs yarn audit:ci
    Then the script falls back to absolute yarn npm audit
    And exits with the same behaviour as the old audit:ci command

  Scenario: developer runs yarn audit:ci locally with a baseline
    Given a valid baseline JSON is served from CloudFront
    When the developer runs yarn audit:ci
    Then only advisories that are new or newly blocking are shown
    And the command passes if no such advisories exist
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)