### PR TITLE
revert: "ci: Add temporary fallback to Patroll token in `check-template-and-add-labels`"

### DIFF
--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Get access token
         id: get-token
         uses: MetaMask/github-tools/.github/actions/get-token@v1
-        continue-on-error: true
         with:
           token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
           permissions: |
@@ -63,6 +62,6 @@ jobs:
       - name: Check template and add labels
         id: check-template-and-add-labels
         env:
-          LABEL_TOKEN: ${{ steps.get-token.outputs.token || secrets.LABEL_TOKEN }}
+          LABEL_TOKEN: ${{ steps.get-token.outputs.token }}
         run: npm run check-template-and-add-labels
         working-directory: '.github/scripts'


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#30875.

The fallback is no longer necessary, as the original issue has been resolved and the Patroll token will eventually be removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that removes a secrets fallback; labeling jobs may fail if token exchange regresses, with no app or security surface impact.
> 
> **Overview**
> Reverts the temporary **Patroll** (`secrets.LABEL_TOKEN`) fallback in the **Check template and add labels** workflow.
> 
> The **Get access token** step no longer uses `continue-on-error: true`, so a failed token exchange fails the job instead of continuing. **`LABEL_TOKEN`** is set only from `steps.get-token.outputs.token` (the `|| secrets.LABEL_TOKEN` fallback is removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85d70cddfeb78807eddac5a16dbbea687a3e2ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->