### PR TITLE
feat(quick-buy): add direction-aware screen transitions

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.tsx
@@ -16,7 +16,7 @@ export interface QuickBuyContextValue extends UseQuickBuyControllerResult {
   analyticsContext?: QuickBuyAnalyticsContext;
   onClose: () => void;
   activeScreen: QuickBuyScreen;
-  setActiveScreen: React.Dispatch<React.SetStateAction<QuickBuyScreen>>;
+  setActiveScreen: (screen: QuickBuyScreen) => void;
   /**
    * Called by the Buy button. When the high-price-impact modal feature is
    * enabled and the active quote exceeds the error threshold, this navigates
@@ -34,7 +34,7 @@ interface QuickBuyProviderProps {
   features: QuickBuyFeatures;
   analyticsContext?: QuickBuyAnalyticsContext;
   activeScreen: QuickBuyScreen;
-  setActiveScreen: React.Dispatch<React.SetStateAction<QuickBuyScreen>>;
+  setActiveScreen: (screen: QuickBuyScreen) => void;
   children: React.ReactNode;
 }
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react-native';
-import { StyleSheet } from 'react-native';
+import { Pressable, StyleSheet, Text } from 'react-native';
 import { TextColor } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import QuickBuyRoot from './QuickBuyRoot';
@@ -379,6 +379,89 @@ describe('QuickBuyRoot', () => {
 
     expect(StyleSheet.flatten(container.props.style)).toMatchObject({
       height: 480,
+    });
+  });
+
+  describe('screen navigation', () => {
+    const NavigationProbe = () => {
+      const { activeScreen, setActiveScreen } = useQuickBuyContext();
+      return (
+        <>
+          <Text testID="active-screen">{activeScreen}</Text>
+          <Pressable
+            testID="nav-payWith"
+            onPress={() => setActiveScreen('payWith')}
+          />
+          <Pressable
+            testID="nav-quoteDetails"
+            onPress={() => setActiveScreen('quoteDetails')}
+          />
+          <Pressable
+            testID="nav-amount"
+            onPress={() => setActiveScreen('amount')}
+          />
+        </>
+      );
+    };
+
+    const renderWithNavigation = () => {
+      renderWithProvider(
+        <QuickBuyRoot
+          isVisible
+          target={positionToQuickBuyTarget(createPosition())}
+          features={TOP_TRADERS_QUICK_BUY_FEATURES}
+          onClose={jest.fn()}
+        >
+          <NavigationProbe />
+        </QuickBuyRoot>,
+      );
+      act(() => {
+        storedOnOpenCallback?.();
+      });
+    };
+
+    it('starts on the amount screen', () => {
+      renderWithNavigation();
+
+      expect(screen.getByTestId('active-screen')).toHaveTextContent('amount');
+    });
+
+    it('navigates forward to a deeper screen', () => {
+      renderWithNavigation();
+
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-payWith'));
+      });
+
+      expect(screen.getByTestId('active-screen')).toHaveTextContent('payWith');
+    });
+
+    it('navigates back to a shallower screen', () => {
+      renderWithNavigation();
+
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-payWith'));
+      });
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-amount'));
+      });
+
+      expect(screen.getByTestId('active-screen')).toHaveTextContent('amount');
+    });
+
+    it('navigates between equal-depth screens', () => {
+      renderWithNavigation();
+
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-payWith'));
+      });
+      act(() => {
+        fireEvent.press(screen.getByTestId('nav-quoteDetails'));
+      });
+
+      expect(screen.getByTestId('active-screen')).toHaveTextContent(
+        'quoteDetails',
+      );
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -4,10 +4,16 @@ import {
   Box,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
-import Animated from 'react-native-reanimated';
+import Animated, { useSharedValue } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
 import QuickBuyAmountScreen from './QuickBuyAmountScreen';
@@ -26,6 +32,11 @@ import type {
   QuickBuyTarget,
 } from './types';
 import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
+import {
+  makeScreenTransitions,
+  SCREEN_DEPTH,
+  type ScreenDirection,
+} from './transitions';
 
 export type { QuickBuyRootProps } from './types';
 
@@ -79,6 +90,27 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
   const surfaceClass = useElevatedSurface();
 
+  const directionSV = useSharedValue<ScreenDirection>(1);
+  // Suppresses the enter animation on the initial screen when the sheet opens;
+  // transitions only kick in once the user navigates between screens.
+  const [hasNavigated, setHasNavigated] = useState(false);
+  const { entering, exiting } = useMemo(
+    () => makeScreenTransitions(directionSV),
+    [directionSV],
+  );
+
+  const navigateToScreen = useCallback(
+    (next: QuickBuyScreen) => {
+      setHasNavigated(true);
+      setActiveScreen((current) => {
+        directionSV.value =
+          SCREEN_DEPTH[next] >= SCREEN_DEPTH[current] ? 1 : -1;
+        return next;
+      });
+    },
+    [directionSV],
+  );
+
   useEffect(() => {
     bottomSheetRef.current?.onOpenBottomSheet(() => {
       setIsContentReady(true);
@@ -112,14 +144,21 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           features={features}
           analyticsContext={analyticsContext}
           activeScreen={activeScreen}
-          setActiveScreen={setActiveScreen}
+          setActiveScreen={navigateToScreen}
         >
           <Box
             testID="quick-buy-content-container"
             onLayout={handleContentLayout}
             style={lockedHeight !== null ? { height: lockedHeight } : undefined}
           >
-            {renderActiveScreen(activeScreen, children)}
+            <Animated.View
+              key={activeScreen}
+              entering={hasNavigated ? entering : undefined}
+              exiting={exiting}
+              style={lockedHeight !== null ? tw.style('flex-1') : undefined}
+            >
+              {renderActiveScreen(activeScreen, children)}
+            </Animated.View>
           </Box>
         </QuickBuyProvider>
       ) : (

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.test.ts
@@ -1,0 +1,108 @@
+import type { SharedValue } from 'react-native-reanimated';
+import {
+  makeScreenTransitions,
+  SCREEN_DEPTH,
+  SCREEN_SLIDE_OFFSET,
+  type ScreenDirection,
+} from './transitions';
+
+jest.mock('react-native-reanimated', () => ({
+  withTiming: (toValue: number) => toValue,
+}));
+
+interface ResolvedAnimation {
+  initialValues: {
+    opacity: number;
+    transform: [{ translateX: number }];
+  };
+  animations: {
+    opacity: number;
+    transform: [{ translateX: number }];
+  };
+}
+
+const directionSV = (value: ScreenDirection): SharedValue<ScreenDirection> =>
+  ({ value }) as SharedValue<ScreenDirection>;
+
+const resolve = (fn: () => unknown): ResolvedAnimation =>
+  fn() as ResolvedAnimation;
+
+describe('SCREEN_DEPTH', () => {
+  it('maps every screen to its navigation depth', () => {
+    expect(SCREEN_DEPTH).toEqual({
+      amount: 0,
+      payWith: 1,
+      quoteDetails: 1,
+      selectQuote: 2,
+      priceImpactConfirm: 1,
+    });
+  });
+});
+
+describe('SCREEN_SLIDE_OFFSET', () => {
+  it('is a positive horizontal distance', () => {
+    expect(SCREEN_SLIDE_OFFSET).toBeGreaterThan(0);
+  });
+});
+
+describe('makeScreenTransitions', () => {
+  describe('forward direction (deeper)', () => {
+    const { entering, exiting } = makeScreenTransitions(directionSV(1));
+
+    it('enters from the right and fades in', () => {
+      const { initialValues, animations } = resolve(entering as () => unknown);
+
+      expect(initialValues.opacity).toBe(0);
+      expect(initialValues.transform[0].translateX).toBe(SCREEN_SLIDE_OFFSET);
+      expect(animations.opacity).toBe(1);
+      expect(animations.transform[0].translateX).toBe(0);
+    });
+
+    it('exits to the left and fades out', () => {
+      const { initialValues, animations } = resolve(exiting as () => unknown);
+
+      expect(initialValues.opacity).toBe(1);
+      expect(initialValues.transform[0].translateX).toBe(0);
+      expect(animations.opacity).toBe(0);
+      expect(animations.transform[0].translateX).toBe(-SCREEN_SLIDE_OFFSET);
+    });
+  });
+
+  describe('back direction (shallower)', () => {
+    const { entering, exiting } = makeScreenTransitions(directionSV(-1));
+
+    it('enters from the left and fades in', () => {
+      const { initialValues, animations } = resolve(entering as () => unknown);
+
+      expect(initialValues.opacity).toBe(0);
+      expect(initialValues.transform[0].translateX).toBe(-SCREEN_SLIDE_OFFSET);
+      expect(animations.opacity).toBe(1);
+      expect(animations.transform[0].translateX).toBe(0);
+    });
+
+    it('exits to the right and fades out', () => {
+      const { initialValues, animations } = resolve(exiting as () => unknown);
+
+      expect(initialValues.opacity).toBe(1);
+      expect(initialValues.transform[0].translateX).toBe(0);
+      expect(animations.opacity).toBe(0);
+      expect(animations.transform[0].translateX).toBe(SCREEN_SLIDE_OFFSET);
+    });
+  });
+
+  it('reads the direction lazily so a shared-value change flips the animation', () => {
+    const sv = directionSV(1);
+    const { entering } = makeScreenTransitions(sv);
+
+    const forward = resolve(entering as () => unknown);
+    expect(forward.initialValues.transform[0].translateX).toBe(
+      SCREEN_SLIDE_OFFSET,
+    );
+
+    sv.value = -1;
+    const back = resolve(entering as () => unknown);
+    expect(back.initialValues.transform[0].translateX).toBe(
+      -SCREEN_SLIDE_OFFSET,
+    );
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/transitions.ts
@@ -1,0 +1,73 @@
+import { AnimationDuration } from '@metamask/design-tokens';
+import {
+  withTiming,
+  type EntryExitAnimationFunction,
+  type SharedValue,
+} from 'react-native-reanimated';
+import type { QuickBuyScreen } from './types';
+
+/** Horizontal slide distance (px) for screen enter/exit. */
+export const SCREEN_SLIDE_OFFSET = 24;
+
+/** Navigation depth per screen; sign of the delta gives transition direction. */
+export const SCREEN_DEPTH: Record<QuickBuyScreen, number> = {
+  amount: 0,
+  payWith: 1,
+  quoteDetails: 1,
+  selectQuote: 2,
+  priceImpactConfirm: 1,
+};
+
+/** +1 = forward (deeper), -1 = back (shallower). */
+export type ScreenDirection = 1 | -1;
+
+const DURATION = AnimationDuration.Fast;
+
+/**
+ * Build direction-aware enter/exit animations bound to a shared direction value.
+ *
+ * Forward (dir=1): new screen enters from the right (+offset -> 0), old screen
+ * exits to the left (0 -> -offset). Back (dir=-1): mirrored. Both fade.
+ *
+ * Direction is read from `directionSV` when the animation starts (the next UI
+ * frame), so both the entering and exiting views see the up-to-date direction
+ * computed at navigation time.
+ */
+export const makeScreenTransitions = (
+  directionSV: SharedValue<ScreenDirection>,
+) => {
+  const entering: EntryExitAnimationFunction = () => {
+    'worklet';
+    const dir = directionSV.value;
+    return {
+      initialValues: {
+        opacity: 0,
+        transform: [{ translateX: dir * SCREEN_SLIDE_OFFSET }],
+      },
+      animations: {
+        opacity: withTiming(1, { duration: DURATION }),
+        transform: [{ translateX: withTiming(0, { duration: DURATION }) }],
+      },
+    };
+  };
+
+  const exiting: EntryExitAnimationFunction = () => {
+    'worklet';
+    const dir = directionSV.value;
+    return {
+      initialValues: { opacity: 1, transform: [{ translateX: 0 }] },
+      animations: {
+        opacity: withTiming(0, { duration: DURATION }),
+        transform: [
+          {
+            translateX: withTiming(-dir * SCREEN_SLIDE_OFFSET, {
+              duration: DURATION,
+            }),
+          },
+        ],
+      },
+    };
+  };
+
+  return { entering, exiting };
+};


### PR DESCRIPTION
## **Description**

Showcase of the transitions between views 👇 

https://github.com/user-attachments/assets/67300465-117f-4168-9e66-67e9a996fe37


QuickBuy screens previously swapped instantly. This PR animates the screen change inside `QuickBuyRoot` with a direction-aware slide + fade:

- **Forward** (going deeper, e.g. `amount -> payWith`, `quoteDetails -> selectQuote`): the new screen slides in from the right and fades in while the old screen slides out to the left and fades out.
- **Back** (going shallower): the motion is mirrored.

Direction is derived from a per-screen depth map (`SCREEN_DEPTH`) and stored in a reanimated shared value that the `entering`/`exiting` worklets read lazily, so both the entering (new) and exiting (old) views use the direction computed at navigation time rather than a stale value. The initial screen does not animate when the sheet first opens, and the content container keeps its locked height so the bottom sheet does not jump during transitions.

Motion reuses the existing `AnimationDuration.Fast` (150ms) token from `@metamask/design-tokens`. The navigation `setActiveScreen` is now a thin `(screen) => void` wrapper that computes direction before updating state, so all existing call sites are unchanged.

## **Changelog**

CHANGELOG entry: Animates transitions between views in the Quick Buy bottom sheet

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: QuickBuy screen transitions

  Scenario: user navigates forward through QuickBuy screens
    Given the QuickBuy bottom sheet is open on the amount screen
    When the user taps an action that opens a deeper screen (e.g. Pay with, or the rate to view quote details)
    Then the new screen slides in from the right and fades in while the previous screen slides out to the left

  Scenario: user navigates back
    Given the user is on a deeper QuickBuy screen
    When the user taps back
    Then the previous screen slides in from the left and fades in while the current screen slides out to the right

  Scenario: sheet opens without an awkward enter animation
    Given QuickBuy is triggered from the Buy button
    When the bottom sheet opens
    Then the amount screen appears without a slide/fade enter animation
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Quick Buy navigation and animation; trade/confirm logic is unchanged aside from routing through navigateToScreen.
> 
> **Overview**
> Quick Buy bottom sheet screens no longer swap instantly: **`QuickBuyRoot`** wraps the active screen in a keyed **`Animated.View`** with Reanimated **enter/exit** slide + fade, using a new **`transitions`** module (`SCREEN_DEPTH`, shared direction, `makeScreenTransitions`) and **`AnimationDuration.Fast`**.
> 
> **Forward** vs **back** motion follows depth (deeper vs shallower); same-depth moves (e.g. `payWith` ↔ `quoteDetails`) use forward-style animation. Direction is set in **`navigateToScreen`** before state updates and read lazily in worklets so entering and exiting views stay in sync. The **first** screen when the sheet opens does **not** enter-animate; locked container height behavior is unchanged.
> 
> Context **`setActiveScreen`** is typed as **`(screen) => void`** (still only screen-name calls from existing sites). Unit tests cover transition math and root navigation probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba1ab519e674fa0e3517a2552cc009e6462895c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->