### PR TITLE
fix: downgrade Rive fallback log and shorten splash timeout

### DIFF
--- a/app/components/UI/FoxLoader/FoxLoader.test.tsx
+++ b/app/components/UI/FoxLoader/FoxLoader.test.tsx
@@ -74,6 +74,7 @@ jest.mock('../../../component-library/hooks', () => ({
 
 jest.mock('../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 describe('FoxLoader', () => {
@@ -300,7 +301,7 @@ describe('FoxLoader', () => {
     expect(onAnimationComplete).not.toHaveBeenCalled();
 
     act(() => {
-      jest.advanceTimersByTime(5_000);
+      jest.advanceTimersByTime(3_000);
     });
 
     expect(onAnimationComplete).toHaveBeenCalledTimes(1);
@@ -456,7 +457,7 @@ describe('FoxLoader', () => {
     );
 
     await act(async () => {
-      jest.advanceTimersByTime(5_000);
+      jest.advanceTimersByTime(3_000);
     });
 
     expect(Logger.error).toHaveBeenCalledWith(

--- a/app/components/UI/FoxLoader/FoxLoader.tsx
+++ b/app/components/UI/FoxLoader/FoxLoader.tsx
@@ -24,7 +24,7 @@ const SPLASH_STATE_MACHINE = 'Splash_animation';
 const SPLASH_IDLE_STATE = 'Blink and look around (Shorter)';
 // Maximum time to wait for the animation to complete before forcing the app to show.
 // Guards against silent failures: corrupted .riv file, stuck state machine, unsupported renderer.
-const ANIMATION_TIMEOUT_MS = 5_000;
+const ANIMATION_TIMEOUT_MS = 3_000;
 
 // Persist across remounts so animation state is consistent for the app session
 let animationStarted = false;
@@ -141,14 +141,11 @@ const FoxLoaderAnimation = ({
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (!isCompleteRef.current) {
-        // Only log an error if the animation genuinely got stuck globally.
-        // If animationComplete is true, the primary instance finished successfully —
-        // this is a secondary instance (LockScreen, AppFlow) that mounted mid-animation.
+        // Expected on devices where Rive can't play (e.g. unsupported renderer on
+        // low-end Android); the static fox fallback handles it. Log without
+        // raising a Sentry error.
         if (!animationComplete) {
-          Logger.error(
-            new Error('Splash animation timed out'),
-            'FoxLoader: forcing app reveal after timeout',
-          );
+          Logger.log('FoxLoader: forcing app reveal after timeout');
         }
         // Ensure the native splash is hidden even if onLoad never fired on the static fox image.
         hideAsync().catch((error: unknown) =>


### PR DESCRIPTION
## **Description**

When Rive can't play the splash animation (corrupted file, stuck state machine, unsupported renderer — typically low-end Android), `FoxLoader` falls back to the static fox and forces app reveal via a timeout. Two problems with the current behavior:

1. The timeout was 5s, which is longer than necessary on devices where Rive will *never* play — users stare at the static fox for an avoidable ~2s.
2. The timeout fired `Logger.error`, which generates Sentry noise for what is expected, recoverable behavior on unsupported hardware.

This PR reduces `ANIMATION_TIMEOUT_MS` from 5s → 3s and downgrades the timeout log from `Logger.error` to `Logger.log`. The other two `Logger.error` calls in the file (hideAsync rejection in the timeout path; onError bail-out) are unchanged — those remain genuine failures worth a Sentry signal.

No functional change to the fallback itself; the static fox path was already working.

## **Changelog**


CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-717

## **Manual testing steps**

```gherkin
Feature: Splash fallback on Rive failure

  Scenario: Rive fails to play on launch
    Given a device where Rive cannot render (e.g. low-end Android, or a forced Rive onError in dev)
    When the user launches the app
    Then the static fox is shown
    And the app reveals within 3 seconds
    And no Sentry error is emitted for the timeout
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and timing tweak only; splash fallback behavior and error logging for real hideAsync failures are unchanged.
> 
> **Overview**
> **FoxLoader** shortens the splash **animation timeout** from **5s to 3s** so devices where Rive never plays reveal the app sooner on the existing static-fox fallback.
> 
> When that timeout fires and the animation never completed globally, logging is **downgraded from `Logger.error` to `Logger.log`** so expected unsupported-hardware cases stop creating Sentry noise; **`hideAsync` failures** on the same path still use **`Logger.error`**.
> 
> Tests mock **`Logger.log`** and advance fake timers by **3s** to match the new constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c756cd0ee1a3e391b3fcf852a914ebd52dd7558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->