### PR TITLE
fix(confirmations): prevent descender cropping on "Paid by MetaMask" badge

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -91,6 +91,10 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     gap: 2,
   },
+  paidByMetaMask: {
+    height: undefined,
+    paddingVertical: 2,
+  },
 });
 
 interface BridgeTransactionDetailsProps {
@@ -105,12 +109,12 @@ interface BridgeTransactionDetailsProps {
 const PaidByMetaMask = () => (
   <TagColored
     color={TagColor.Success}
+    style={styles.paidByMetaMask}
     labelProps={{
       variant: TextVariant.BodySM,
       style: {
         textTransform: 'none',
         textAlign: 'center',
-        bottom: 1,
         fontWeight: 'normal',
       },
       testID: 'paid-by-metamask',

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.styles.ts
@@ -51,6 +51,10 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingBottom: 8,
       paddingHorizontal: 8,
     },
+    paidByMetaMask: {
+      height: undefined,
+      paddingVertical: 2,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -47,23 +47,26 @@ import TagColored, {
 } from '../../../../../../../component-library/components-temp/TagColored';
 import { shouldApplyGasFeeSponsorship } from '../../../../utils/transaction';
 
-const PaidByMetaMask = () => (
-  <TagColored
-    color={TagColor.Success}
-    labelProps={{
-      variant: TextVariant.BodySM,
-      style: {
-        textTransform: 'none',
-        textAlign: 'center',
-        bottom: 1,
-        fontWeight: 'normal',
-      },
-      testID: 'paid-by-metamask',
-    }}
-  >
-    {strings('transactions.paid_by_metamask')}
-  </TagColored>
-);
+const PaidByMetaMask = () => {
+  const { styles } = useStyles(styleSheet, {});
+  return (
+    <TagColored
+      color={TagColor.Success}
+      style={styles.paidByMetaMask}
+      labelProps={{
+        variant: TextVariant.BodySM,
+        style: {
+          textTransform: 'none',
+          textAlign: 'center',
+          fontWeight: 'normal',
+        },
+        testID: 'paid-by-metamask',
+      }}
+    >
+      {strings('transactions.paid_by_metamask')}
+    </TagColored>
+  );
+};
 
 const SkeletonEstimationInfo = () => {
   const { styles } = useStyles(styleSheet, {});


### PR DESCRIPTION
## **Description**

The "Paid by MetaMask" tag is rendered with TagColored, whose container hard-codes height: 20 with only horizontal padding. The two call sites override the default text variant to BodySM (line box taller than 20px) and previously nudged the text with `bottom: 1`, which pushed descenders into the clipped region instead of fixing it. The result was cropped 'y' and 'p' tails, visible on the Swap (iOS) and Send (Android) gas rows.

Release the fixed container height and add 2px of vertical padding so the tag grows with its content, and drop the `bottom: 1` workaround.

Affects:
- app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/
- app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed "Paid by MetaMask" badge display

## **Related issues**

Fixes: descender cropping on "Paid by MetaMask" badge

## **Manual testing steps**

```gherkin
  1. Setup - Use an account that triggers gas sponsorship (e.g., account on Monad) funded with ≥2 USDC.
  2. iOS Swap (screenshot 1) - Swap USDC → MON, wait for the quote. On the Network fee row, the green "Paid by MetaMask" pill must show full y and p descenders with ~2px of green below the baseline.
  3. Android Send (screenshot 2) - Send 2 USDC from the sponsored account on the same network. On the confirm sheet, the same pill must render without clipped descenders and match the iOS height.
  4. Text scaling - Set system font size to maximum (iOS: Larger Text; Android: Font size). Re-check both screens - the pill must grow with the text and stay un-clipped. This proves height is content-driven, not capped at 20px.
  5. Non-sponsored regression - On a non-sponsored network (e.g., Mainnet), repeat a Send and a Swap. The pill must not appear, and the Network fee row layout must match main - confirms the change is scoped to the sponsored branch.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="400" height="850" alt="before-Swap" src="https://github.com/user-attachments/assets/769d809b-2940-40fc-9365-9ef499472285" />


### **After**

<img width="400" height="800" alt="after-swap" src="https://github.com/user-attachments/assets/eb7fee25-0236-49d1-84b4-3b70c518aa7b" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only styling for a sponsorship label on two screens; no transaction, auth, or fee logic changes.
> 
> **Overview**
> Fixes **descender clipping** on the green **"Paid by MetaMask"** `TagColored` badge on gas-fee rows (confirmations **Send/Swap**) and bridge **transaction details**.
> 
> Both call sites apply a shared override: **`height: undefined`** (so the tag is no longer locked to `TagColored`'s default 20px) plus **`paddingVertical: 2`**, and they **remove** the label **`bottom: 1`** offset that pushed **BodySM** text into the clipped area. The confirmations row wires the style through **`useStyles`** on `PaidByMetaMask`; bridge uses the same rules on its local `PaidByMetaMask` component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3e6692ff5d89a46e6a335acd4c455539b0a113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->