### PR TITLE
fix: require money hub enabled flag for mUSD cash section filtering

### DIFF
--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -532,7 +532,7 @@ describe('Tokens', () => {
       });
     });
 
-    it('excludes mUSD from token list when both conversion flow and homepage sections are enabled', async () => {
+    it('excludes mUSD from token list when conversion flow, money hub, and homepage sections are all enabled', async () => {
       const stateWithBothEnabled = clone(initialRootState);
       (
         stateWithBothEnabled as Record<string, unknown> &
@@ -542,6 +542,10 @@ describe('Tokens', () => {
           .RemoteFeatureFlagController,
         remoteFeatureFlags: {
           earnMusdConversionFlowEnabled: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+          },
+          earnMoneyHubEnabled: {
             enabled: true,
             minimumVersion: '1.0.0',
           },

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -44,6 +44,7 @@ import { isMusdToken } from '../Earn/constants/musd';
 import RemoveTokenBottomSheet from './TokenList/RemoveTokenBottomSheet';
 import { useMusdConversionEligibility } from '../Earn/hooks/useMusdConversionEligibility';
 import { strings } from '../../../../locales/i18n';
+import { selectMoneyHubEnabledFlag } from '../Money/selectors/featureFlags';
 
 interface TokensProps {
   /**
@@ -117,14 +118,14 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
     const isMusdConversionFlowEnabled = useSelector(
       selectIsMusdConversionFlowEnabledFlag,
     );
+    const isMoneyHubEnabled = useSelector(selectMoneyHubEnabledFlag);
     const { isEligible: isGeoEligible } = useMusdConversionEligibility();
-    const isCashSectionEnabled = isMusdConversionFlowEnabled && isGeoEligible;
+    const isCashSectionEnabled =
+      isMusdConversionFlowEnabled && isMoneyHubEnabled && isGeoEligible;
+
     const isHomepageSectionsV1Enabled = useSelector(
       selectHomepageSectionsV1Enabled,
     );
-    // Only exclude mUSD from the main list when the Cash section is both enabled
-    // AND actually rendered (homepage sections redesign). Without this guard,
-    // the legacy wallet tab view would filter mUSD out with no Cash section to show it.
     const shouldExcludeMusdFromMainList =
       isCashSectionEnabled && isHomepageSectionsV1Enabled;
 

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -82,6 +82,10 @@ jest.mock('../../../../UI/Earn/selectors/featureFlags', () => ({
   selectIsMusdConversionFlowEnabledFlag: jest.fn(() => false),
 }));
 
+jest.mock('../../../../UI/Money/selectors/featureFlags', () => ({
+  selectMoneyHubEnabledFlag: jest.fn(() => false),
+}));
+
 const mockUseMusdConversionEligibility = jest.fn(() => ({ isEligible: false }));
 jest.mock('../../../../UI/Earn/hooks/useMusdConversionEligibility', () => ({
   useMusdConversionEligibility: () => mockUseMusdConversionEligibility(),
@@ -440,6 +444,9 @@ describe('TokensSection', () => {
     jest
       .requireMock('../../../../UI/Earn/selectors/featureFlags')
       .selectIsMusdConversionFlowEnabledFlag.mockReturnValue(false);
+    jest
+      .requireMock('../../../../UI/Money/selectors/featureFlags')
+      .selectMoneyHubEnabledFlag.mockReturnValue(false);
     mockUseMusdConversionEligibility.mockReturnValue({ isEligible: false });
     mockUseHomepageTrendingTransactionActiveAbTests.mockReturnValue(undefined);
   });
@@ -586,11 +593,14 @@ describe('TokensSection', () => {
     expect(screen.queryByTestId('token-item-0xtoken7')).toBeNull();
   });
 
-  it('filters out mUSD from displayed tokens (mUSD is shown only in Cash section)', () => {
+  it('filters out mUSD from displayed tokens when Cash section is enabled', () => {
     const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
     jest
       .requireMock('../../../../UI/Earn/selectors/featureFlags')
       .selectIsMusdConversionFlowEnabledFlag.mockReturnValue(true);
+    jest
+      .requireMock('../../../../UI/Money/selectors/featureFlags')
+      .selectMoneyHubEnabledFlag.mockReturnValue(true);
     mockUseMusdConversionEligibility.mockReturnValue({ isEligible: true });
     mockUseIsZeroBalanceAccount.mockReturnValue(false);
     mockSortedTokenKeys.mockReturnValue([
@@ -909,6 +919,9 @@ describe('TokensSection', () => {
       jest
         .requireMock('../../../../UI/Earn/selectors/featureFlags')
         .selectIsMusdConversionFlowEnabledFlag.mockReturnValue(true);
+      jest
+        .requireMock('../../../../UI/Money/selectors/featureFlags')
+        .selectMoneyHubEnabledFlag.mockReturnValue(true);
       mockUseMusdConversionEligibility.mockReturnValue({ isEligible: true });
       mockSortedTokenKeys.mockReturnValue([
         {

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -49,6 +49,7 @@ import TrendingTokensSkeleton from '../../../../UI/Trending/components/TrendingT
 import { WalletViewSelectorsIDs } from '../../../Wallet/WalletView.testIds';
 import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
 import { useHomepageTrendingTransactionActiveAbTests } from '../../hooks/useHomepageTrendingTransactionActiveAbTests';
+import { selectMoneyHubEnabledFlag } from '../../../../UI/Money/selectors/featureFlags';
 
 interface TokensSectionProps {
   sectionIndex: number;
@@ -145,8 +146,10 @@ const TokensSectionMain = forwardRef<SectionRefreshHandle, TokensSectionProps>(
     const isMusdConversionFlowEnabled = useSelector(
       selectIsMusdConversionFlowEnabledFlag,
     );
+    const isMoneyHubEnabled = useSelector(selectMoneyHubEnabledFlag);
     const { isEligible: isGeoEligible } = useMusdConversionEligibility();
-    const isCashSectionEnabled = isMusdConversionFlowEnabled && isGeoEligible;
+    const isCashSectionEnabled =
+      isMoneyHubEnabled && isMusdConversionFlowEnabled && isGeoEligible;
 
     const title = titleOverride ?? strings('homepage.sections.tokens');
     const analyticsName = sectionNameOverride ?? HomeSectionNames.TOKENS;

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.test.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.test.ts
@@ -42,6 +42,10 @@ jest.mock('../../../../../UI/Earn/selectors/featureFlags', () => ({
   selectIsMusdConversionFlowEnabledFlag: jest.fn(),
 }));
 
+jest.mock('../../../../../UI/Money/selectors/featureFlags', () => ({
+  selectMoneyHubEnabledFlag: jest.fn(),
+}));
+
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockHandleFetch = handleFetch as jest.MockedFunction<typeof handleFetch>;
 
@@ -208,10 +212,11 @@ describe('usePopularTokens', () => {
   it('excludes mUSD from tokens when Cash section is enabled', async () => {
     mockHandleFetch.mockResolvedValue({});
     mockUseMusdConversionEligibility.mockReturnValue({ isEligible: true });
-    // First call: selectCurrentCurrency → 'usd'; second: selectIsMusdConversionFlowEnabledFlag → true.
-    // Later calls (re-renders) keep Cash enabled so mUSD stays filtered.
+    // Selector call order: selectCurrentCurrency → 'usd', selectIsMusdConversionFlowEnabledFlag → true,
+    // selectMoneyHubEnabledFlag → true. Later calls (re-renders) keep Cash enabled so mUSD stays filtered.
     mockUseSelector
       .mockReturnValueOnce('usd')
+      .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
       .mockReturnValue(true);
 

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../UI/Earn/constants/musd';
 import { selectIsMusdConversionFlowEnabledFlag } from '../../../../../UI/Earn/selectors/featureFlags';
 import { useMusdConversionEligibility } from '../../../../../UI/Earn/hooks/useMusdConversionEligibility';
+import { selectMoneyHubEnabledFlag } from '../../../../../UI/Money/selectors/featureFlags';
 
 /**
  * Popular token metadata with CAIP-19 asset IDs
@@ -121,8 +122,10 @@ export const usePopularTokens = () => {
   const isMusdConversionFlowEnabled = useSelector(
     selectIsMusdConversionFlowEnabledFlag,
   );
+  const isMoneyHubEnabled = useSelector(selectMoneyHubEnabledFlag);
   const { isEligible: isGeoEligible } = useMusdConversionEligibility();
-  const isCashSectionEnabled = isMusdConversionFlowEnabled && isGeoEligible;
+  const isCashSectionEnabled =
+    isMoneyHubEnabled && isMusdConversionFlowEnabled && isGeoEligible;
   const [rawTokens, setRawTokens] = useState<
     {
       assetId: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Updates Token list mUSD filtering to include check for Money hub enablement. When Money hub is disabled mUSD is included in the Token list.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update token list mUSD filtering to include check for money hub enablement; when money hub is disabled mUSD is included in the Token list.

## **Related issues**

Fixes: [MUSD-856: Can't see mUSD in the token list since Money Hub was released](https://consensyssoftware.atlassian.net/browse/MUSD-856)

## **Manual testing steps**

```gherkin
Feature: mUSD cash section token filtering

  Scenario: user has Money Hub enabled with mUSD balance
    Given user has the Money Hub, mUSD conversion flow, and geo eligibility all enabled
    And user holds mUSD on a supported network

    When user views the homepage token list
    Then mUSD is hidden from the token list
    And mUSD is shown only in the Cash section

  Scenario: user has Money Hub disabled
    Given user has the Money Hub feature flag disabled

    When user views the homepage token list
    Then mUSD appears in the token list alongside other tokens
    And no Cash section filtering is applied
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

#### When Money Hub feature is disabled

<img width="494" height="1020" alt="image" src="https://github.com/user-attachments/assets/204d2dd2-7bf7-4418-a6df-e825cd39ed29" />

<img width="494" height="1020" alt="image" src="https://github.com/user-attachments/assets/38f11eba-51ca-41f1-8f19-c76c614c3394" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only feature-flag gating for token list filtering with matching test updates; no auth, payments, or persistence changes.
> 
> **Overview**
> **mUSD** is no longer removed from homepage and wallet token lists unless the **Money Hub** feature flag is on, in addition to the existing mUSD conversion flow, geo eligibility, and (for the main `Tokens` list) homepage sections checks.
> 
> The shared **Cash section** gate (`isCashSectionEnabled`) now requires `selectMoneyHubEnabledFlag` in `Tokens`, `TokensSection`, and `usePopularTokens`, so filtering and popular-token exclusions only run when Cash/Money Hub is actually available. Tests and feature-flag setup were updated to cover the three-way flag combination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c32e4c88c5ca1d48dd57da35b301114727f1eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->