### PR TITLE
fix: filter out low quality tokens on explore

### DIFF
--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.test.tsx
@@ -337,6 +337,7 @@ describe('TrendingTokensFullView', () => {
       sortBy: undefined,
       chainIds: null,
       searchQuery: undefined,
+      filterLowQuality: true,
     });
   });
 
@@ -352,6 +353,7 @@ describe('TrendingTokensFullView', () => {
       sortBy: 'h1_trending',
       chainIds: null,
       searchQuery: undefined,
+      filterLowQuality: true,
     });
   });
 
@@ -390,6 +392,7 @@ describe('TrendingTokensFullView', () => {
           sortBy: 'h6_trending',
           chainIds: null,
           searchQuery: undefined,
+          filterLowQuality: true,
         });
       },
     },
@@ -408,6 +411,7 @@ describe('TrendingTokensFullView', () => {
           sortBy: undefined,
           chainIds: ['eip155:1'],
           searchQuery: undefined,
+          filterLowQuality: true,
         });
       },
     },

--- a/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx
+++ b/app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx
@@ -141,6 +141,7 @@ const TrendingTokensFullView = () => {
     searchQuery: filters.searchQuery || undefined,
     sortBy,
     chainIds: filters.selectedNetwork,
+    filterLowQuality: true,
   });
 
   const trendingTokens = useMemo(() => {

--- a/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
+++ b/app/components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts
@@ -9,6 +9,7 @@ import { useStableArray } from '../../../Perps/hooks/useStableArray';
 import { TRENDING_NETWORKS_LIST } from '../../utils/trendingNetworksList';
 import { NetworkToCaipChainId } from '../../../NetworkMultiSelector/NetworkMultiSelector.constants';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
+import { filterLowQualityTokens } from '../../utils/filterTrendingTokens';
 
 /**
  * Baseline thresholds for multi-chain requests
@@ -145,6 +146,12 @@ interface FetchOptions {
 export const useTrendingRequest = (
   options: {
     chainIds?: CaipChainId[];
+    /**
+     * When true, removes tokens that lack a meaningful symbol/name or are
+     * flagged as risky (Warning/Spam/Malicious) by the Token API security scan.
+     * Defaults to false. Set to true on surfaces that should hide low-quality tokens.
+     */
+    filterLowQuality?: boolean;
   } & TrendingTokensQueryParams,
 ) => {
   const {
@@ -155,6 +162,7 @@ export const useTrendingRequest = (
     maxVolume24hUsd,
     minMarketCap = 0,
     maxMarketCap,
+    filterLowQuality = false,
   } = options;
 
   // Get user's selected currency from Redux store (default to 'usd' if not set)
@@ -296,8 +304,13 @@ export const useTrendingRequest = (
     };
   }, [isLoading, results.length, error, fetchTrendingTokens]);
 
+  const filteredResults = useMemo(
+    () => (filterLowQuality ? filterLowQualityTokens(results) : results),
+    [filterLowQuality, results],
+  );
+
   return {
-    results,
+    results: filteredResults,
     isLoading,
     error,
     fetch: fetchTrendingTokens,

--- a/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
+++ b/app/components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts
@@ -40,6 +40,7 @@ export const useTrendingSearch = (opts?: {
   enableDebounce?: boolean;
   includeMarketData?: boolean;
   includeStocks?: boolean;
+  filterLowQuality?: boolean;
   sortTrendingTokensOptions?: {
     option: PriceChangeOption;
     direction: SortDirection;
@@ -53,6 +54,7 @@ export const useTrendingSearch = (opts?: {
     enableDebounce = true,
     includeMarketData = true,
     includeStocks = false,
+    filterLowQuality = false,
     sortTrendingTokensOptions = {
       option: PriceChangeOption.PriceChange,
       direction: SortDirection.Descending,
@@ -93,6 +95,7 @@ export const useTrendingSearch = (opts?: {
   } = useTrendingRequest({
     sort: sortBy,
     chainIds: chainIds ?? undefined,
+    filterLowQuality,
   });
 
   const data = useMemo(() => {

--- a/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
@@ -49,7 +49,7 @@ describe('filterLowQualityTokens', () => {
     expect(filterLowQualityTokens(tokens)).toHaveLength(1);
   });
 
-  it('removes Warning tokens', () => {
+  it('keeps Warning tokens', () => {
     const tokens = [
       buildToken({
         symbol: 'WRN',
@@ -59,10 +59,10 @@ describe('filterLowQualityTokens', () => {
       }),
     ];
 
-    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+    expect(filterLowQualityTokens(tokens)).toHaveLength(1);
   });
 
-  it('removes Spam tokens', () => {
+  it('keeps Spam tokens', () => {
     const tokens = [
       buildToken({
         symbol: 'SPM',
@@ -70,10 +70,10 @@ describe('filterLowQualityTokens', () => {
       }),
     ];
 
-    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+    expect(filterLowQualityTokens(tokens)).toHaveLength(1);
   });
 
-  it('removes Malicious tokens', () => {
+  it('keeps Malicious tokens', () => {
     const tokens = [
       buildToken({
         symbol: 'MAL',
@@ -83,7 +83,7 @@ describe('filterLowQualityTokens', () => {
       }),
     ];
 
-    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+    expect(filterLowQualityTokens(tokens)).toHaveLength(1);
   });
 
   it('removes tokens with empty symbol', () => {
@@ -110,7 +110,7 @@ describe('filterLowQualityTokens', () => {
     expect(filterLowQualityTokens(tokens)).toHaveLength(0);
   });
 
-  it('applies both filters together', () => {
+  it('only filters out tokens missing symbol/name, keeps risky tokens', () => {
     const tokens = [
       buildToken({ symbol: 'GOOD', name: 'Good Token' }),
       buildToken({ symbol: '', name: 'No Ticker' }),
@@ -130,20 +130,13 @@ describe('filterLowQualityTokens', () => {
 
     expect(filterLowQualityTokens(tokens).map((t) => t.symbol)).toEqual([
       'GOOD',
+      'RISKY',
       'SAFE',
     ]);
   });
 
-  it('returns empty array when all tokens are filtered out', () => {
-    const tokens = [
-      buildToken({ symbol: '' }),
-      buildToken({
-        symbol: 'MAL',
-        securityData: {
-          resultType: 'Malicious',
-        } as TrendingAsset['securityData'],
-      }),
-    ];
+  it('returns empty array when all tokens lack symbol/name', () => {
+    const tokens = [buildToken({ symbol: '' }), buildToken({ name: '' })];
 
     expect(filterLowQualityTokens(tokens)).toHaveLength(0);
   });

--- a/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.test.ts
@@ -1,0 +1,154 @@
+import type { TrendingAsset } from '@metamask/assets-controllers';
+import { filterLowQualityTokens } from './filterTrendingTokens';
+
+const buildToken = (overrides: Partial<TrendingAsset> = {}): TrendingAsset =>
+  ({
+    assetId: 'eip155:1/erc20:0xaaa',
+    symbol: 'TOK',
+    name: 'Token',
+    decimals: 18,
+    price: '1.00',
+    aggregatedUsdVolume: 1_000_000,
+    marketCap: 5_000_000,
+    ...overrides,
+  }) as unknown as TrendingAsset;
+
+describe('filterLowQualityTokens', () => {
+  it('keeps tokens with valid symbol, name, and no security issues', () => {
+    const tokens = [
+      buildToken({ symbol: 'ETH', name: 'Ether' }),
+      buildToken({ symbol: 'USDC', name: 'USD Coin' }),
+    ];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(2);
+  });
+
+  it('keeps Verified and Benign tokens', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'VER',
+        securityData: {
+          resultType: 'Verified',
+        } as TrendingAsset['securityData'],
+      }),
+      buildToken({
+        symbol: 'BEN',
+        securityData: { resultType: 'Benign' } as TrendingAsset['securityData'],
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens).map((t) => t.symbol)).toEqual([
+      'VER',
+      'BEN',
+    ]);
+  });
+
+  it('keeps unscanned tokens (no securityData)', () => {
+    const tokens = [buildToken({ symbol: 'UNS', securityData: undefined })];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(1);
+  });
+
+  it('removes Warning tokens', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'WRN',
+        securityData: {
+          resultType: 'Warning',
+        } as TrendingAsset['securityData'],
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('removes Spam tokens', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'SPM',
+        securityData: { resultType: 'Spam' } as TrendingAsset['securityData'],
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('removes Malicious tokens', () => {
+    const tokens = [
+      buildToken({
+        symbol: 'MAL',
+        securityData: {
+          resultType: 'Malicious',
+        } as TrendingAsset['securityData'],
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('removes tokens with empty symbol', () => {
+    const tokens = [buildToken({ symbol: '' })];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('removes tokens with whitespace-only symbol', () => {
+    const tokens = [buildToken({ symbol: '   ' })];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('removes tokens with empty name', () => {
+    const tokens = [buildToken({ name: '' })];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('removes tokens with whitespace-only name', () => {
+    const tokens = [buildToken({ name: '   ' })];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('applies both filters together', () => {
+    const tokens = [
+      buildToken({ symbol: 'GOOD', name: 'Good Token' }),
+      buildToken({ symbol: '', name: 'No Ticker' }),
+      buildToken({
+        symbol: 'RISKY',
+        name: 'Risky Token',
+        securityData: {
+          resultType: 'Warning',
+        } as TrendingAsset['securityData'],
+      }),
+      buildToken({
+        symbol: 'SAFE',
+        name: 'Safe Token',
+        securityData: undefined,
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens).map((t) => t.symbol)).toEqual([
+      'GOOD',
+      'SAFE',
+    ]);
+  });
+
+  it('returns empty array when all tokens are filtered out', () => {
+    const tokens = [
+      buildToken({ symbol: '' }),
+      buildToken({
+        symbol: 'MAL',
+        securityData: {
+          resultType: 'Malicious',
+        } as TrendingAsset['securityData'],
+      }),
+    ];
+
+    expect(filterLowQualityTokens(tokens)).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterLowQualityTokens([])).toHaveLength(0);
+  });
+});

--- a/app/components/UI/Trending/utils/filterTrendingTokens.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.ts
@@ -1,0 +1,37 @@
+import type { TrendingAsset } from '@metamask/assets-controllers';
+
+/**
+ * Result types considered risky by the Token API security scan.
+ * Tokens with these types are hidden from surfaces that opt into quality filtering.
+ */
+const RISKY_RESULT_TYPES = new Set(['Warning', 'Spam', 'Malicious']);
+
+/**
+ * Returns true when a token's security data indicates risk.
+ */
+const isRiskyToken = (token: TrendingAsset): boolean => {
+  const resultType = token.securityData?.resultType;
+  return !!resultType && RISKY_RESULT_TYPES.has(resultType);
+};
+
+/**
+ * Returns true when a token lacks a meaningful ticker (symbol).
+ * Tokens without a symbol render blank placeholders in the UI.
+ */
+const lacksTickerOrName = (token: TrendingAsset): boolean =>
+  !token.symbol?.trim() || !token.name?.trim();
+
+/**
+ * Filters out low-quality and risky tokens from a trending list.
+ *
+ * Removed tokens:
+ * - Missing or empty `symbol` / `name` (no useful ticker or display name)
+ * - Security `resultType` of Warning, Spam, or Malicious
+ *
+ * The filter is designed to be configurable: callers that don't want it
+ * (e.g. a future "meme" section) simply skip calling this function.
+ */
+export const filterLowQualityTokens = (
+  tokens: TrendingAsset[],
+): TrendingAsset[] =>
+  tokens.filter((token) => !lacksTickerOrName(token) && !isRiskyToken(token));

--- a/app/components/UI/Trending/utils/filterTrendingTokens.ts
+++ b/app/components/UI/Trending/utils/filterTrendingTokens.ts
@@ -1,37 +1,17 @@
 import type { TrendingAsset } from '@metamask/assets-controllers';
 
 /**
- * Result types considered risky by the Token API security scan.
- * Tokens with these types are hidden from surfaces that opt into quality filtering.
- */
-const RISKY_RESULT_TYPES = new Set(['Warning', 'Spam', 'Malicious']);
-
-/**
- * Returns true when a token's security data indicates risk.
- */
-const isRiskyToken = (token: TrendingAsset): boolean => {
-  const resultType = token.securityData?.resultType;
-  return !!resultType && RISKY_RESULT_TYPES.has(resultType);
-};
-
-/**
- * Returns true when a token lacks a meaningful ticker (symbol).
- * Tokens without a symbol render blank placeholders in the UI.
+ * Returns true when a token lacks a meaningful ticker (symbol) or display name.
+ * Tokens without these render blank placeholders in the UI.
  */
 const lacksTickerOrName = (token: TrendingAsset): boolean =>
   !token.symbol?.trim() || !token.name?.trim();
 
 /**
- * Filters out low-quality and risky tokens from a trending list.
- *
- * Removed tokens:
- * - Missing or empty `symbol` / `name` (no useful ticker or display name)
- * - Security `resultType` of Warning, Spam, or Malicious
- *
- * The filter is designed to be configurable: callers that don't want it
- * (e.g. a future "meme" section) simply skip calling this function.
+ * Filters out tokens that lack a meaningful symbol or name.
+ * Risky tokens (Warning/Spam/Malicious) are intentionally kept — they are
+ * surfaced with appropriate warnings via the security badge in the UI.
  */
 export const filterLowQualityTokens = (
   tokens: TrendingAsset[],
-): TrendingAsset[] =>
-  tokens.filter((token) => !lacksTickerOrName(token) && !isRiskyToken(token));
+): TrendingAsset[] => tokens.filter((token) => !lacksTickerOrName(token));

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.test.ts
@@ -101,6 +101,7 @@ describe('useTokensFeed', () => {
     expect(mockUseTrendingSearch).toHaveBeenCalledWith({
       searchQuery: 'sol',
       enableDebounce: false,
+      filterLowQuality: true,
       sortBy: undefined,
       sortTrendingTokensOptions: undefined,
     });
@@ -116,6 +117,7 @@ describe('useTokensFeed', () => {
     expect(mockUseTrendingSearch).toHaveBeenCalledWith({
       searchQuery: undefined,
       enableDebounce: false,
+      filterLowQuality: true,
       sortBy: 'h1_trending',
       sortTrendingTokensOptions: {
         option: 'price_change',

--- a/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
+++ b/app/components/Views/TrendingView/feeds/tokens/useTokensFeed.ts
@@ -55,6 +55,7 @@ export const useTokensFeed = ({
     searchQuery: query,
     enableDebounce: false,
     sortBy,
+    filterLowQuality: true,
     sortTrendingTokensOptions: timeOption
       ? {
           option: PriceChangeOption.PriceChange,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Implements client-side filtering for trending token lists on the Explore page. Tokens are filtered out if they:
- Lack a meaningful ticker (`symbol`) or display name (`name`)

The filter is applied at the `useTrendingRequest` data source level via a new `filterLowQuality` option (defaults to `false`). Explore page surfaces opt in by passing `filterLowQuality: true`. Non-Explore consumers (swap screen, homepage) are unaffected.
When a user manually searches for a token on the Explore page, search API results are not filtered — only the trending portion is cleaned up.
The filtering mechanism is configurable: future sections (e.g. a dedicated "meme" category) can opt out by not passing the flag.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Filtered out  low-quality tokens from trending lists on the Explore page


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3300


## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tokens users see on Explore using security scan data; misclassification or over-filtering could hide legitimate assets, though the flag is opt-in and defaults off elsewhere.
> 
> **Overview**
> Adds **opt-in client-side quality filtering** for trending token lists on Explore via a new `filterLowQuality` flag (default `false`) on `useTrendingRequest` / `useTrendingSearch`.
> 
> When enabled, trending results are passed through `filterLowQualityTokens`, which drops assets with blank `symbol`/`name` and Token API security `resultType` of **Warning**, **Spam**, or **Malicious**; Verified, Benign, and unscanned tokens stay. **Explore** entry points (`TrendingTokensFullView`, `useTokensFeed`) pass `filterLowQuality: true`; other `useTrendingSearch` callers keep the default and are unchanged.
> 
> Unit tests cover the filter helper and updated hook call expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4bf623c329fc6047469ab3d68afb7992dbc9115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->