### PR TITLE
refactor(main navigator): migrate single routes in Main Navigator to native stack

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Image, StyleSheet, Keyboard, Platform } from 'react-native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useSelector, useDispatch } from 'react-redux';
 import { mainNavigatorReady } from '../../../actions/navigation';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -157,8 +158,10 @@ import { TokenDetails } from '../../UI/TokenDetails/Views/TokenDetails';
 import BenefitFullView from '../../UI/Rewards/Views/BenefitFullView';
 import BenefitsFullView from '../../UI/Rewards/Views/BenefitsFullView';
 import { getDeFiProtocolPositionDetailsNavbarOptions } from '../../UI/Navbar';
+import NavigationDevPanel from '../../Views/NavigationDevPanel/NavigationDevPanel';
 
 const Stack = createStackNavigator();
+const NativeStack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
 
 const styles = StyleSheet.create({
@@ -907,55 +910,51 @@ const HomeTabs = () => {
 };
 
 const Webview = () => (
-  <Stack.Navigator screenOptions={{ headerShown: false }}>
-    <Stack.Screen name="SimpleWebview" component={SimpleWebview} />
-  </Stack.Navigator>
+  <NativeStack.Navigator screenOptions={{ headerShown: false }}>
+    <NativeStack.Screen name="SimpleWebview" component={SimpleWebview} />
+  </NativeStack.Navigator>
 );
 
 /* eslint-disable react/prop-types */
 const NftDetailsModeView = (props) => (
-  <Stack.Navigator>
-    <Stack.Screen
+  <NativeStack.Navigator screenOptions={{ headerShown: false }}>
+    <NativeStack.Screen
       name=" " // No name here because this title will be displayed in the header of the page
       component={NftDetails}
       initialParams={{
         collectible: props.route.params?.collectible,
       }}
     />
-  </Stack.Navigator>
+  </NativeStack.Navigator>
 );
 
 /* eslint-disable react/prop-types */
 const NftDetailsFullImageModeView = (props) => (
-  <Stack.Navigator>
-    <Stack.Screen
+  <NativeStack.Navigator screenOptions={{ headerShown: false }}>
+    <NativeStack.Screen
       name=" " // No name here because this title will be displayed in the header of the page
       component={NftDetailsFullImage}
       initialParams={{
         collectible: props.route.params?.collectible,
       }}
     />
-  </Stack.Navigator>
+  </NativeStack.Navigator>
 );
 
 const AddBookmarkView = () => (
-  <Stack.Navigator>
-    <Stack.Screen
-      name="AddBookmark"
-      component={AddBookmark}
-      options={AddBookmark.navigationOptions}
-    />
-  </Stack.Navigator>
+  <NativeStack.Navigator screenOptions={{ headerShown: false }}>
+    <NativeStack.Screen name="AddBookmark" component={AddBookmark} />
+  </NativeStack.Navigator>
 );
 
 const OfflineModeView = () => (
-  <Stack.Navigator>
-    <Stack.Screen
+  <NativeStack.Navigator>
+    <NativeStack.Screen
       name="OfflineMode"
       component={OfflineMode}
       options={OfflineMode.navigationOptions}
     />
-  </Stack.Navigator>
+  </NativeStack.Navigator>
 );
 
 /* eslint-disable react/prop-types */
@@ -1031,9 +1030,12 @@ const SetPasswordFlow = () => (
 
 ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
 const SampleFeatureFlow = () => (
-  <Stack.Navigator>
-    <Stack.Screen name={Routes.SAMPLE_FEATURE} component={SampleFeature} />
-  </Stack.Navigator>
+  <NativeStack.Navigator>
+    <NativeStack.Screen
+      name={Routes.SAMPLE_FEATURE}
+      component={SampleFeature}
+    />
+  </NativeStack.Navigator>
 );
 ///: END:ONLY_INCLUDE_IF
 
@@ -1437,6 +1439,13 @@ const MainNavigator = () => {
           name={Routes.FEATURE_FLAG_OVERRIDE}
           component={FeatureFlagOverride}
           options={{ headerShown: false }}
+        />
+      )}
+      {process.env.METAMASK_ENVIRONMENT !== 'production' && (
+        <Stack.Screen
+          name={Routes.NAVIGATION_DEV_PANEL}
+          component={NavigationDevPanel}
+          options={{ headerShown: true, ...slideFromRightAnimation }}
         />
       )}
       <Stack.Screen

--- a/app/components/Nav/Main/MainNavigator.test.tsx
+++ b/app/components/Nav/Main/MainNavigator.test.tsx
@@ -17,6 +17,13 @@ jest.mock('@react-navigation/stack', () => ({
   }),
 }));
 
+jest.mock('@react-navigation/native-stack', () => ({
+  createNativeStackNavigator: jest.fn().mockReturnValue({
+    Navigator: 'Navigator',
+    Screen: 'Screen',
+  }),
+}));
+
 jest.mock('@react-navigation/bottom-tabs', () => ({
   createBottomTabNavigator: jest.fn().mockReturnValue({
     Navigator: 'TabNavigator',

--- a/app/components/Views/AddBookmark/index.js
+++ b/app/components/Views/AddBookmark/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { strings } from '../../../../locales/i18n';
 import { fontStyles } from '../../../styles/common';
 import ActionView from '../../UI/ActionView';
-import { getNavigationOptionsTitle } from '../../UI/Navbar';
+import { HeaderStandard } from '@metamask/design-system-react-native';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 
 import { AddBookmarkViewSelectorsIDs } from './AddBookmarkView.testIds';
@@ -57,28 +57,9 @@ export default class AddBookmark extends PureComponent {
     route: PropTypes.object,
   };
 
-  updateNavBar = () => {
-    const { navigation } = this.props;
-    const colors = this.context.colors || mockTheme.colors;
-
-    navigation.setOptions(
-      getNavigationOptionsTitle(
-        strings('add_favorite.title'),
-        navigation,
-        false,
-        colors,
-      ),
-    );
-  };
-
   componentDidMount() {
-    this.updateNavBar();
     this.loadInitialValues();
   }
-
-  componentDidUpdate = () => {
-    this.updateNavBar();
-  };
 
   loadInitialValues() {
     const { route } = this.props;
@@ -122,8 +103,14 @@ export default class AddBookmark extends PureComponent {
     return (
       <SafeAreaView
         style={styles.wrapper}
+        edges={['left', 'right', 'bottom']}
         testID={AddBookmarkViewSelectorsIDs.CONTAINER}
       >
+        <HeaderStandard
+          includesTopInset
+          title={strings('add_favorite.title')}
+          onBack={() => this.props.navigation.pop()}
+        />
         <ActionView
           cancelTestID={AddBookmarkViewSelectorsIDs.CANCEL_BUTTON}
           confirmTestID={AddBookmarkViewSelectorsIDs.CONFIRM_BUTTON}

--- a/app/components/Views/AddBookmark/index.js
+++ b/app/components/Views/AddBookmark/index.js
@@ -5,7 +5,11 @@ import PropTypes from 'prop-types';
 import { strings } from '../../../../locales/i18n';
 import { fontStyles } from '../../../styles/common';
 import ActionView from '../../UI/ActionView';
-import { HeaderStandard } from '@metamask/design-system-react-native';
+import {
+  HeaderStandard,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 
 import { AddBookmarkViewSelectorsIDs } from './AddBookmarkView.testIds';
@@ -109,6 +113,9 @@ export default class AddBookmark extends PureComponent {
         <HeaderStandard
           includesTopInset
           title={strings('add_favorite.title')}
+          titleProps={{
+            color: TextColor.PrimaryDefault,
+          }}
           onBack={() => this.props.navigation.pop()}
         />
         <ActionView

--- a/app/components/Views/NavigationDevPanel/NavigationDevPanel.mockParams.ts
+++ b/app/components/Views/NavigationDevPanel/NavigationDevPanel.mockParams.ts
@@ -1,0 +1,49 @@
+import type { Nft } from '@metamask/assets-controllers';
+
+/** Minimal NFT payload so NftDetails / NftDetailsFullImage render without crashing. */
+export const MOCK_NFT_COLLECTIBLE = {
+  name: 'Dev Panel NFT',
+  tokenId: '42',
+  image: 'https://via.placeholder.com/512',
+  imagePreview: 'https://via.placeholder.com/128',
+  address: '0x7c3Ea2b7B3beFA1115aB51c09F0C9f245C500B18',
+  backgroundColor: 'transparent',
+  tokenURI: 'https://example.com/token/42',
+  standard: 'ERC721',
+  chainId: 1,
+  description: 'Mock NFT for navigation dev panel testing.',
+  favorite: false,
+  isCurrentlyOwned: true,
+} as Nft;
+
+export const MOCK_WEBVIEW_PARAMS = {
+  screen: 'SimpleWebview',
+  params: {
+    url: 'https://metamask.io',
+    title: 'MetaMask',
+  },
+};
+
+export const MOCK_ADD_BOOKMARK_PARAMS = {
+  screen: 'AddBookmark',
+  params: {
+    title: 'MetaMask',
+    url: 'https://metamask.io',
+    onAddBookmark: () => {
+      // Dev panel noop — real flow persists via Redux + spotlight indexing.
+    },
+  },
+};
+
+export const MOCK_OFFLINE_MODE_PARAMS = {
+  screen: 'OfflineMode',
+};
+
+export const MOCK_NFT_DETAILS_PARAMS = {
+  collectible: MOCK_NFT_COLLECTIBLE,
+  source: 'mobile-nft-list' as const,
+};
+
+export const MOCK_NFT_FULL_IMAGE_PARAMS = {
+  collectible: MOCK_NFT_COLLECTIBLE,
+};

--- a/app/components/Views/NavigationDevPanel/NavigationDevPanel.tsx
+++ b/app/components/Views/NavigationDevPanel/NavigationDevPanel.tsx
@@ -1,0 +1,352 @@
+import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { TouchableOpacity } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Box,
+  Text,
+  TextColor,
+  TextVariant,
+  FontWeight,
+  TextFieldSearch,
+} from '@metamask/design-system-react-native';
+
+import { getNavigationOptionsTitle } from '../../UI/Navbar';
+import { useTheme } from '../../../util/theme';
+import Routes from '../../../constants/navigation/Routes';
+import {
+  MOCK_ADD_BOOKMARK_PARAMS,
+  MOCK_NFT_DETAILS_PARAMS,
+  MOCK_NFT_FULL_IMAGE_PARAMS,
+  MOCK_OFFLINE_MODE_PARAMS,
+  MOCK_WEBVIEW_PARAMS,
+} from './NavigationDevPanel.mockParams';
+
+/**
+ * Dev-only panel that lists every top-level route registered in MainNavigator
+ * so navigation behavior (animations, headers, gestures, presentation) can be
+ * eyeballed before/after the native-stack migration.
+ *
+ * Routes that need params ship with dev mocks in NavigationDevPanel.mockParams.ts
+ * so screens render without crashing when opened from this panel.
+ */
+
+interface RouteEntry {
+  /** Route name passed to navigation.navigate */
+  name: string;
+  /** Optional human label; defaults to the route name */
+  label?: string;
+  /** Optional default params so the screen renders something useful */
+  params?: Record<string, unknown>;
+  /** Marks routes known to require params (best opened from their real flow) */
+  needsParams?: boolean;
+}
+
+interface RouteGroup {
+  title: string;
+  routes: RouteEntry[];
+}
+
+// NOTE: Scoped to the PR1+PR2 work only — the trivial single-screen wrapper
+// navigators being migrated to native-stack first. All other route groups are
+// commented out below and will be re-enabled as each subsequent PR lands so the
+// panel always reflects exactly what's currently being migrated.
+const ROUTE_GROUPS: RouteGroup[] = [
+  {
+    title: 'PR2 — Single-screen wrappers',
+    routes: [
+      { name: 'Webview', label: 'Webview', params: MOCK_WEBVIEW_PARAMS },
+      {
+        name: 'AddBookmarkView',
+        label: 'Add Bookmark',
+        params: MOCK_ADD_BOOKMARK_PARAMS,
+      },
+      {
+        name: 'OfflineModeView',
+        label: 'Offline Mode',
+        params: MOCK_OFFLINE_MODE_PARAMS,
+      },
+      {
+        name: 'NftDetails',
+        label: 'NFT Details',
+        params: MOCK_NFT_DETAILS_PARAMS,
+      },
+      {
+        name: 'NftDetailsFullImage',
+        label: 'NFT Full Image',
+        params: MOCK_NFT_FULL_IMAGE_PARAMS,
+      },
+      ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
+      { name: Routes.SAMPLE_FEATURE, label: 'Sample Feature' },
+      ///: END:ONLY_INCLUDE_IF
+    ],
+  },
+  // --- Routes below are out of scope for the current PR. Uncomment a group
+  // --- when its migration PR begins. ---
+  // {
+  //   title: 'Home & Tabs',
+  //   routes: [
+  //     { name: Routes.HOME_TABS, label: 'Home (Tabs)' },
+  //     { name: Routes.SETTINGS_VIEW, label: 'Settings Flow' },
+  //     { name: Routes.NOTIFICATIONS.VIEW, label: 'Notifications' },
+  //     { name: Routes.QR_TAB_SWITCHER, label: 'QR Tab Switcher' },
+  //     { name: 'GeneralSettings' },
+  //     { name: 'SetPasswordFlow' },
+  //   ],
+  // },
+  // {
+  //   title: 'Assets',
+  //   routes: [
+  //     { name: 'Asset', needsParams: true },
+  //     { name: 'AddAsset' },
+  //     { name: 'ConfirmAddAsset', needsParams: true },
+  //     { name: Routes.WALLET.TOKENS_FULL_VIEW, label: 'Tokens Full View' },
+  //     { name: Routes.WALLET.NFTS_FULL_VIEW, label: 'NFTs Full View' },
+  //     { name: Routes.WALLET.DEFI_FULL_VIEW, label: 'DeFi Full View' },
+  //     {
+  //       name: Routes.WALLET.CASH_TOKENS_FULL_VIEW,
+  //       label: 'Cash Tokens Full View',
+  //     },
+  //     { name: 'TrendingTokensFullView' },
+  //     { name: 'RWATokensFullView' },
+  //     { name: 'CollectiblesDetails', needsParams: true },
+  //     {
+  //       name: 'DeFiProtocolPositionDetails',
+  //       label: 'DeFi Protocol Position Details',
+  //       needsParams: true,
+  //     },
+  //   ],
+  // },
+  // {
+  //   title: 'Explore & Browser',
+  //   routes: [
+  //     { name: Routes.EXPLORE_SEARCH, label: 'Explore Search' },
+  //     { name: Routes.SITES_FULL_VIEW, label: 'Sites Full View' },
+  //     { name: Routes.WHATS_HAPPENING_DETAIL, label: "What's Happening Detail" },
+  //     { name: Routes.BROWSER.HOME, label: 'Browser' },
+  //   ],
+  // },
+  // {
+  //   title: 'Send / Transactions',
+  //   routes: [
+  //     { name: 'Send' },
+  //     { name: Routes.TRANSACTIONS_VIEW, label: 'Transactions' },
+  //   ],
+  // },
+  // {
+  //   title: 'Ramp / Deposit',
+  //   routes: [
+  //     { name: Routes.RAMP.TOKEN_SELECTION, label: 'Ramp Token Selection' },
+  //     { name: Routes.RAMP.HEADLESS_ENTRY, label: 'Ramp Headless Entry' },
+  //     { name: Routes.RAMP.BUY, label: 'Ramp Buy' },
+  //     { name: Routes.RAMP.SELL, label: 'Ramp Sell' },
+  //     { name: Routes.DEPOSIT.ID, label: 'Deposit' },
+  //     {
+  //       name: Routes.RAMP.MODALS.PROCESSING_INFO,
+  //       label: 'Ramp Processing Info Modal',
+  //     },
+  //   ],
+  // },
+  // {
+  //   title: 'Bridge / Stake / Earn',
+  //   routes: [
+  //     { name: Routes.BRIDGE.ROOT, label: 'Bridge' },
+  //     { name: Routes.BRIDGE.MODALS.ROOT, label: 'Bridge Modals' },
+  //     { name: 'StakeScreens' },
+  //     { name: 'StakeModals' },
+  //     { name: Routes.EARN.ROOT, label: 'Earn Screens' },
+  //     { name: Routes.EARN.MODALS.ROOT, label: 'Earn Modals' },
+  //   ],
+  // },
+  // {
+  //   title: 'Money (flag)',
+  //   routes: [
+  //     { name: Routes.MONEY.ROOT, label: 'Money Screens' },
+  //     { name: Routes.MONEY.CONFIRMATIONS_ROOT, label: 'Money Confirmations' },
+  //     { name: Routes.MONEY.ONBOARDING, label: 'Money Onboarding' },
+  //     { name: Routes.MONEY.MODALS.ROOT, label: 'Money Modals' },
+  //   ],
+  // },
+  // {
+  //   title: 'Perps (flag)',
+  //   routes: [
+  //     { name: Routes.PERPS.ROOT, label: 'Perps' },
+  //     { name: Routes.PERPS.TUTORIAL, label: 'Perps Tutorial' },
+  //     { name: Routes.PERPS.MODALS.ROOT, label: 'Perps Modals' },
+  //     {
+  //       name: Routes.PERPS.POSITION_TRANSACTION,
+  //       label: 'Perps Position Transaction',
+  //       needsParams: true,
+  //     },
+  //     {
+  //       name: Routes.PERPS.ORDER_TRANSACTION,
+  //       label: 'Perps Order Transaction',
+  //       needsParams: true,
+  //     },
+  //     {
+  //       name: Routes.PERPS.FUNDING_TRANSACTION,
+  //       label: 'Perps Funding Transaction',
+  //       needsParams: true,
+  //     },
+  //   ],
+  // },
+  // {
+  //   title: 'Predict / Market Insights / Leaderboard (flag)',
+  //   routes: [
+  //     { name: Routes.PREDICT.ROOT, label: 'Predict' },
+  //     { name: Routes.PREDICT.MODALS.ROOT, label: 'Predict Modals' },
+  //     { name: Routes.MARKET_INSIGHTS.VIEW, label: 'Market Insights' },
+  //     { name: Routes.SOCIAL_LEADERBOARD.VIEW, label: 'Top Traders' },
+  //     {
+  //       name: Routes.SOCIAL_LEADERBOARD.PROFILE,
+  //       label: 'Trader Profile',
+  //       needsParams: true,
+  //     },
+  //     {
+  //       name: Routes.SOCIAL_LEADERBOARD.POSITION,
+  //       label: 'Trader Position',
+  //       needsParams: true,
+  //     },
+  //   ],
+  // },
+  // {
+  //   title: 'Rewards',
+  //   routes: [
+  //     { name: Routes.REWARDS_VIEW, label: 'Rewards' },
+  //     { name: Routes.REWARD_BENEFIT_FULL_VIEW, label: 'Benefit Full View' },
+  //     { name: Routes.REWARD_BENEFITS_FULL_VIEW, label: 'Benefits Full View' },
+  //   ],
+  // },
+  // {
+  //   title: 'Other',
+  //   routes: [
+  //     { name: Routes.CARD.ROOT, label: 'Card Screens' },
+  //     {
+  //       name: Routes.DEPRECATED_NETWORK_DETAILS,
+  //       label: 'Deprecated Network Details',
+  //       needsParams: true,
+  //     },
+  //     { name: Routes.FEATURE_FLAG_OVERRIDE, label: 'Feature Flag Override' },
+  //   ],
+  // },
+];
+
+const NavigationDevPanel = () => {
+  const navigation = useNavigation();
+  const theme = useTheme();
+  const { colors } = theme;
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const [search, setSearch] = useState('');
+
+  useLayoutEffect(() => {
+    navigation.setOptions(
+      getNavigationOptionsTitle(
+        'Navigation Dev Panel',
+        navigation,
+        false,
+        colors,
+        null,
+      ),
+    );
+  }, [navigation, colors]);
+
+  const handleNavigate = useCallback(
+    (entry: RouteEntry) => {
+      // Dev tool navigates to arbitrary registered routes, so the param list
+      // can't be statically typed here.
+      (
+        navigation as unknown as {
+          navigate: (name: string, params?: Record<string, unknown>) => void;
+        }
+      ).navigate(entry.name, entry.params);
+    },
+    [navigation],
+  );
+
+  const filteredGroups = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return ROUTE_GROUPS;
+    }
+    return ROUTE_GROUPS.map((group) => ({
+      ...group,
+      routes: group.routes.filter((route) =>
+        `${route.label ?? ''} ${route.name}`.toLowerCase().includes(query),
+      ),
+    })).filter((group) => group.routes.length > 0);
+  }, [search]);
+
+  return (
+    <Box twClassName="flex-1">
+      <Box twClassName="w-full px-4 py-2">
+        <TextFieldSearch
+          value={search}
+          onChangeText={setSearch}
+          placeholder="Filter routes..."
+          onPressClearButton={() => setSearch('')}
+        />
+      </Box>
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: bottomInset + 24 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        {filteredGroups.map((group) => (
+          <Box key={group.title} twClassName="mb-2">
+            <Text
+              twClassName="px-4 pt-4 pb-2"
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              fontWeight={FontWeight.Bold}
+            >
+              {group.title.toUpperCase()}
+            </Text>
+            {group.routes.map((route) => (
+              <TouchableOpacity
+                key={route.name}
+                onPress={() => handleNavigate(route)}
+                activeOpacity={0.6}
+              >
+                <Box twClassName="flex-row items-center justify-between px-4 py-3 border-b border-muted">
+                  <Box twClassName="flex-1 pr-2">
+                    <Text variant={TextVariant.BodyMd}>
+                      {route.label ?? route.name}
+                    </Text>
+                    {route.label && route.label !== route.name ? (
+                      <Text
+                        variant={TextVariant.BodyXs}
+                        color={TextColor.TextAlternative}
+                      >
+                        {route.name}
+                      </Text>
+                    ) : null}
+                  </Box>
+                  {route.needsParams ? (
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.WarningDefault}
+                    >
+                      needs params
+                    </Text>
+                  ) : null}
+                </Box>
+              </TouchableOpacity>
+            ))}
+          </Box>
+        ))}
+        {filteredGroups.length === 0 ? (
+          <Box twClassName="items-center py-8 px-4">
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              {`No routes match "${search}"`}
+            </Text>
+          </Box>
+        ) : null}
+      </ScrollView>
+    </Box>
+  );
+};
+
+export default NavigationDevPanel;

--- a/app/components/Views/NftDetails/NFtDetailsFullImage.tsx
+++ b/app/components/Views/NftDetails/NFtDetailsFullImage.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getNftFullImageNavbarOptions } from '../../UI/Navbar';
+import { HeaderStandard } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useParams } from '../../../util/navigation/navUtils';
 import { useStyles } from '../../../component-library/hooks';
@@ -13,23 +13,18 @@ const NftDetailsFullImage = () => {
   const navigation = useNavigation();
   const { collectible } = useParams<NftDetailsParams>();
 
-  const {
-    styles,
-    theme: { colors },
-  } = useStyles(styleSheet, {});
-
-  const updateNavBar = useCallback(() => {
-    navigation.setOptions(getNftFullImageNavbarOptions(navigation, colors));
-  }, [colors, navigation]);
-
-  useEffect(() => {
-    updateNavBar();
-  }, [updateNavBar]);
+  const { styles } = useStyles(styleSheet, {});
 
   return (
-    <SafeAreaView style={[styles.fullImageContainer]}>
-      <View style={[styles.fullImageItem]}>
-        <CollectibleMedia cover renderAnimation collectible={collectible} />
+    <SafeAreaView
+      style={styles.fullImageScreen}
+      edges={['left', 'right', 'bottom']}
+    >
+      <HeaderStandard includesTopInset onClose={() => navigation.goBack()} />
+      <View style={[styles.fullImageContainer]}>
+        <View style={[styles.fullImageItem]}>
+          <CollectibleMedia cover renderAnimation collectible={collectible} />
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/app/components/Views/NftDetails/NftDetails.styles.ts
+++ b/app/components/Views/NftDetails/NftDetails.styles.ts
@@ -132,6 +132,10 @@ const styleSheet = (params: { theme: Theme }) => {
     buttonSend: {
       flexGrow: 1,
     },
+    fullImageScreen: {
+      flex: 1,
+      backgroundColor: colors.background.default,
+    },
     fullImageContainer: {
       position: 'relative',
       flex: 1,

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -6,7 +6,6 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { getNftDetailsNavbarOptions } from '../../UI/Navbar';
 import Text from '../../../component-library/components/Texts/Text/Text';
 import { useNavigation } from '@react-navigation/native';
 import { useParams } from '../../../util/navigation/navUtils';
@@ -15,7 +14,12 @@ import styleSheet from './NftDetails.styles';
 import Routes from '../../../constants/navigation/Routes';
 import { NftDetailsParams } from './NftDetails.types';
 import { ScrollView } from 'react-native-gesture-handler';
-import { Button, ButtonVariant } from '@metamask/design-system-react-native';
+import {
+  Button,
+  ButtonVariant,
+  HeaderStandard,
+  IconName as DSIconName,
+} from '@metamask/design-system-react-native';
 import NftDetailsBox from './NftDetailsBox';
 import NftDetailsInformationRow from './NftDetailsInformationRow';
 import { renderShortAddress } from '../../../util/address';
@@ -78,26 +82,14 @@ const NftDetails = () => {
     theme: { colors },
   } = useStyles(styleSheet, {});
 
-  const updateNavBar = useCallback(() => {
-    navigation.setOptions(
-      getNftDetailsNavbarOptions(
-        navigation,
-        colors,
-        () =>
-          navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-            screen: 'NftOptions',
-            params: {
-              collectible,
-            },
-          }),
-        undefined,
-      ),
-    );
-  }, [collectible, colors, navigation]);
-
-  useEffect(() => {
-    updateNavBar();
-  }, [updateNavBar]);
+  const openNftOptions = useCallback(() => {
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: 'NftOptions',
+      params: {
+        collectible,
+      },
+    });
+  }, [collectible, navigation]);
 
   useEffect(() => {
     trackEvent(
@@ -300,7 +292,17 @@ const NftDetails = () => {
     collectible?.attributes && collectible?.attributes?.length !== 0;
 
   return (
-    <SafeAreaView style={styles.wrapper}>
+    <SafeAreaView style={styles.wrapper} edges={['left', 'right', 'bottom']}>
+      <HeaderStandard
+        includesTopInset
+        onBack={() => navigation.goBack()}
+        endButtonIconProps={[
+          {
+            iconName: DSIconName.MoreVertical,
+            onPress: openNftOptions,
+          },
+        ]}
+      />
       <ScrollView>
         <View style={styles.infoContainer}>
           <TouchableOpacity

--- a/app/components/Views/Settings/DeveloperOptions/NavigationDevPanelSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/NavigationDevPanelSection.tsx
@@ -20,7 +20,6 @@ export default function NavigationDevPanelSection() {
   const navigation = useNavigation();
 
   const handleOpen = useCallback(() => {
-    // @ts-expect-error dev-only navigation to top-level route
     navigation.navigate(Routes.NAVIGATION_DEV_PANEL);
   }, [navigation]);
 

--- a/app/components/Views/Settings/DeveloperOptions/NavigationDevPanelSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/NavigationDevPanelSection.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../component-library/components/Texts/Text';
+import { useTheme } from '../../../../util/theme';
+import { useStyles } from '../../../../component-library/hooks';
+import Routes from '../../../../constants/navigation/Routes';
+import styleSheet from './DeveloperOptions.styles';
+
+export default function NavigationDevPanelSection() {
+  const theme = useTheme();
+  const { styles } = useStyles(styleSheet, { theme });
+  const navigation = useNavigation();
+
+  const handleOpen = useCallback(() => {
+    // @ts-expect-error dev-only navigation to top-level route
+    navigation.navigate(Routes.NAVIGATION_DEV_PANEL);
+  }, [navigation]);
+
+  return (
+    <>
+      <Text
+        color={TextColor.Default}
+        variant={TextVariant.HeadingLG}
+        style={styles.heading}
+      >
+        {'Navigation'}
+      </Text>
+      <Text
+        color={TextColor.Alternative}
+        variant={TextVariant.BodyMD}
+        style={styles.desc}
+      >
+        {
+          'Open a panel listing every MainNavigator route to compare navigation behavior.'
+        }
+      </Text>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={handleOpen}
+        isFullWidth
+        style={styles.accessory}
+      >
+        {'Open Navigation Dev Panel'}
+      </Button>
+    </>
+  );
+}

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -25,6 +25,7 @@ import { CardDeveloperOptionsSection } from '../../../UI/Card/components/CardDev
 import { selectMoneyEnableMoneyAccountFlag } from '../../../UI/Money/selectors/featureFlags';
 import { MoneyUiDeveloperOptionsSection } from '../../../UI/Money/components/MoneyUiDeveloperOptionsSection';
 import NotificationsDeveloperOptionsSection from '../../../UI/Notification/DeveloperOptionsSection/NotificationsDeveloperOptionsSection';
+import NavigationDevPanelSection from './NavigationDevPanelSection';
 
 const DeveloperOptions = () => {
   const navigation = useNavigation();
@@ -58,6 +59,7 @@ const DeveloperOptions = () => {
       style={styles.wrapper}
       contentContainerStyle={styles.contentContainer}
     >
+      <NavigationDevPanelSection />
       <SentryTest />
       {
         ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -543,6 +543,7 @@ const Routes = {
   },
   FEATURE_FLAG_OVERRIDE: 'FeatureFlagOverride',
   SECURITY_TRUST: 'SecurityTrust',
+  NAVIGATION_DEV_PANEL: 'NavigationDevPanel',
 };
 
 export default Routes;

--- a/app/constants/navigation/clearStackNavigatorOptions.ts
+++ b/app/constants/navigation/clearStackNavigatorOptions.ts
@@ -50,3 +50,12 @@ export const clearNativeStackNavigatorOptions: NativeStackNavigationOptions = {
 export const transparentModalScreenOptions: NativeStackNavigationOptions = {
   presentation: 'transparentModal',
 };
+
+export const slideFromRightNativeOptions: NativeStackNavigationOptions = {
+  animation: 'slide_from_right',
+};
+
+export const fadeNativeOptions: NativeStackNavigationOptions = {
+  animation: 'fade',
+  gestureEnabled: false,
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
-First slice of the MainNavigator native-stack migration: convert six single-screen wrapper navigators to createNativeStackNavigator.
-Add native-stack animation helpers
-Switch Add Bookmark / NFT Details / NFT Full Image to in-screen HeaderStandard headers.
-Add a dev-only Navigation Dev Panel (Settings → Developer Options) scoped to these routes, with mock params so each screen opens without crashing.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: MainNavigator native-stack migration (PR1+PR2)
  Background:
    Given the app is running in a non-production build
    And Developer Options is enabled
  
Scenario: Open the Navigation Dev Panel
    When I go to Settings
    And I open Developer Options
    And I tap "Open Navigation Dev Panel"
    Then I see the Navigation Dev Panel
    And I see the "PR2 — Single-screen wrappers" route group
  
Scenario: Filter routes in the dev panel
    Given I am on the Navigation Dev Panel
    When I search for "NFT"
    Then I see "NFT Details"
    And I see "NFT Full Image"
    And I do not see unrelated routes
  
Scenario: Navigate to Webview from the dev panel
    Given I am on the Navigation Dev Panel
    When I tap "Webview"
    Then the Webview screen opens
    And I can go back to the Navigation Dev Panel
  
Scenario: Navigate to Add Bookmark from the dev panel
    Given I am on the Navigation Dev Panel
    When I tap "Add Bookmark"
    Then the Add Bookmark screen opens
    And I see a HeaderStandard header with the add-favorite title
    And I see a back button
    When I tap the back button
    Then I return to the Navigation Dev Panel
  
Scenario: Navigate to Offline Mode from the dev panel
    Given I am on the Navigation Dev Panel
    When I tap "Offline Mode"
    Then the Offline Mode screen opens
    And I can go back to the Navigation Dev Panel
  
Scenario: Navigate to NFT Details from the dev panel
    Given I am on the Navigation Dev Panel
    When I tap "NFT Details"
    Then the NFT Details screen opens with mock NFT data
    And I see a HeaderStandard header with a back button
    And I see a more-options button
    When I tap the back button
    Then I return to the Navigation Dev Panel
  
Scenario: Navigate to NFT Full Image from the dev panel
    Given I am on the Navigation Dev Panel
    When I tap "NFT Full Image"
    Then the NFT Full Image screen opens with mock NFT data
    And I see a HeaderStandard header with a close button
    When I tap the close button
    Then I return to the Navigation Dev Panel
  
Scenario: Open NFT Full Image from NFT Details
    Given I am on the NFT Details screen
    When I tap the NFT media
    Then the NFT Full Image screen opens
    And I see a close button in the header
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

|BEFORE|AFTER|
|---|---|
|<img width="368" height="762" alt="MainNavigator P2 before" src="https://github.com/user-attachments/assets/d4534884-3a02-40d7-8023-1dd509f50942" />|<img width="368" height="762" alt="MainNavigator P2 after" src="https://github.com/user-attachments/assets/d5660660-d4ba-4b08-a7a6-22535d070bcc" />|


Android after:
https://github.com/user-attachments/assets/bef5a6b7-a6bb-4cb2-acdf-2f6a157020c0




## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core post-login navigation and visible header/back behavior on bookmark and NFT flows; scope is limited to wrapper navigators and dev-only tooling, but regressions in transitions or deep links are possible.
> 
> **Overview**
> This PR is the first slice of migrating **MainNavigator** single-screen wrapper flows from `@react-navigation/stack` to **`createNativeStackNavigator`**. Affected wrappers include **Webview**, **AddBookmarkView**, **OfflineModeView**, **NftDetails** / **NftDetailsFullImage**, and **SampleFeatureFlow** (when compiled in).
> 
> **Add Bookmark**, **NFT Details**, and **NFT Full Image** drop stack `navigation.setOptions` / Navbar helpers and render **`HeaderStandard`** in-screen (back, close, and NFT options menu). Native stacks for those flows use **`headerShown: false`** on the navigator.
> 
> A **non-production Navigation Dev Panel** is added (`Routes.NAVIGATION_DEV_PANEL`, entry from **Developer Options**) with searchable route groups and **mock params** so the migrated routes can be opened for manual QA. **`slideFromRightNativeOptions`** and **`fadeNativeOptions`** are added to `clearStackNavigatorOptions.ts` for upcoming native-stack screen options; parent **MainNavigator** routes still use the existing JS `slideFromRightAnimation` where applicable.
> 
> Tests mock **`@react-navigation/native-stack`** alongside the stack mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6109de01f1d620ba11141227c21b9400199f9af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->