### PR TITLE
fix(rewards): perps trading campaign dtos and ineligible state

### DIFF
--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.test.tsx
@@ -342,7 +342,7 @@ function toMockLeaderboardPosition(
   position: {
     rank: number;
     neighbors: unknown[];
-    notionalVolume?: number;
+    volume?: number;
   } | null,
 ): PerpsTradingCampaignLeaderboardPositionDto | null {
   if (!position) {
@@ -350,9 +350,11 @@ function toMockLeaderboardPosition(
   }
   return {
     rank: position.rank,
+    totalParticipants: 0,
     pnl: 0,
-    notionalVolume: position.notionalVolume ?? 10_000,
-    qualified: true,
+    volume: position.volume ?? 10_000,
+    eligible: true,
+    minVolumeForEligibility: 25_000,
     neighbors: position.neighbors as PerpsTradingCampaignLeaderboardEntry[],
     computedAt: '2025-08-15T12:00:00.000Z',
   };
@@ -363,6 +365,7 @@ const defaultLeaderboardHook = {
     campaignId: 'perps-campaign-1',
     entries: [],
     totalParticipants: 0,
+    minVolumeForEligibility: 25_000,
     computedAt: '2025-08-15T12:00:00.000Z',
   },
   isLoading: false,
@@ -389,7 +392,7 @@ function setupHooks(
     position?: {
       rank: number;
       neighbors: unknown[];
-      notionalVolume?: number;
+      volume?: number;
     } | null;
     isPositionLoading?: boolean;
     totalParticipants?: number;
@@ -626,7 +629,7 @@ describe('PerpsTradingCampaignDetailsView', () => {
   it('shows stats header when user has positive notional volume', () => {
     setupHooks({
       participant: { optedIn: true },
-      position: { rank: 3, neighbors: [], notionalVolume: 10_000 },
+      position: { rank: 3, neighbors: [], volume: 10_000 },
     });
 
     const { getByTestId } = render(<PerpsTradingCampaignDetailsView />);
@@ -636,7 +639,7 @@ describe('PerpsTradingCampaignDetailsView', () => {
   it('hides stats summary when user has a rank but zero notional volume', () => {
     setupHooks({
       participant: { optedIn: true },
-      position: { rank: 3, neighbors: [], notionalVolume: 0 },
+      position: { rank: 3, neighbors: [], volume: 0 },
     });
 
     const { queryByTestId } = render(<PerpsTradingCampaignDetailsView />);
@@ -649,7 +652,7 @@ describe('PerpsTradingCampaignDetailsView', () => {
       position: {
         rank: 3,
         neighbors: [],
-        notionalVolume: Number.NaN,
+        volume: Number.NaN,
       },
     });
 

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.test.tsx
@@ -339,7 +339,11 @@ function buildPerpsCampaign(overrides: Partial<CampaignDto> = {}): CampaignDto {
 }
 
 function toMockLeaderboardPosition(
-  position: { rank: number; neighbors: unknown[] } | null,
+  position: {
+    rank: number;
+    neighbors: unknown[];
+    notionalVolume?: number;
+  } | null,
 ): PerpsTradingCampaignLeaderboardPositionDto | null {
   if (!position) {
     return null;
@@ -347,7 +351,7 @@ function toMockLeaderboardPosition(
   return {
     rank: position.rank,
     pnl: 0,
-    notionalVolume: 0,
+    notionalVolume: position.notionalVolume ?? 10_000,
     qualified: true,
     neighbors: position.neighbors as PerpsTradingCampaignLeaderboardEntry[],
     computedAt: '2025-08-15T12:00:00.000Z',
@@ -382,7 +386,11 @@ function setupHooks(
     isCampaignsLoading?: boolean;
     hasCampaignsError?: boolean;
     participant?: { optedIn: boolean };
-    position?: { rank: number; neighbors: unknown[] } | null;
+    position?: {
+      rank: number;
+      neighbors: unknown[];
+      notionalVolume?: number;
+    } | null;
     isPositionLoading?: boolean;
     totalParticipants?: number;
     outcome?: PerpsTradingCampaignParticipantOutcomeDto | null;
@@ -615,14 +623,38 @@ describe('PerpsTradingCampaignDetailsView', () => {
     expect(getByTestId('campaign-how-it-works')).toBeDefined();
   });
 
-  it('shows stats header when user has a leaderboard position', () => {
+  it('shows stats header when user has positive notional volume', () => {
     setupHooks({
       participant: { optedIn: true },
-      position: { rank: 3, neighbors: [] },
+      position: { rank: 3, neighbors: [], notionalVolume: 10_000 },
     });
 
     const { getByTestId } = render(<PerpsTradingCampaignDetailsView />);
     expect(getByTestId('perps-campaign-stats-summary-container')).toBeDefined();
+  });
+
+  it('hides stats summary when user has a rank but zero notional volume', () => {
+    setupHooks({
+      participant: { optedIn: true },
+      position: { rank: 3, neighbors: [], notionalVolume: 0 },
+    });
+
+    const { queryByTestId } = render(<PerpsTradingCampaignDetailsView />);
+    expect(queryByTestId('perps-campaign-stats-summary-container')).toBeNull();
+  });
+
+  it('hides stats summary when notional volume is not finite', () => {
+    setupHooks({
+      participant: { optedIn: true },
+      position: {
+        rank: 3,
+        neighbors: [],
+        notionalVolume: Number.NaN,
+      },
+    });
+
+    const { queryByTestId } = render(<PerpsTradingCampaignDetailsView />);
+    expect(queryByTestId('perps-campaign-stats-summary-container')).toBeNull();
   });
 
   it('navigates to stats when stats header row is pressed and user has a position', () => {

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
@@ -140,9 +140,7 @@ const PerpsTradingCampaignDetailsView: React.FC = () => {
     [position],
   );
   const hasPosition =
-    position != null &&
-    Number.isFinite(position.notionalVolume) &&
-    position.notionalVolume > 0;
+    position != null && Number.isFinite(position.volume) && position.volume > 0;
   const totalParticipants = leaderboard?.totalParticipants ?? 0;
 
   const {

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignDetailsView.tsx
@@ -139,8 +139,10 @@ const PerpsTradingCampaignDetailsView: React.FC = () => {
         : null,
     [position],
   );
-
-  const hasPosition = Boolean(leaderboardUserPosition);
+  const hasPosition =
+    position != null &&
+    Number.isFinite(position.notionalVolume) &&
+    position.notionalVolume > 0;
   const totalParticipants = leaderboard?.totalParticipants ?? 0;
 
   const {

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.test.tsx
@@ -147,9 +147,11 @@ const mockUseGetParticipant =
 
 const basePosition: PerpsTradingCampaignLeaderboardPositionDto = {
   rank: 4,
+  totalParticipants: 50,
   pnl: 1000,
-  notionalVolume: 10_000,
-  qualified: true,
+  volume: 10_000,
+  eligible: true,
+  minVolumeForEligibility: 25_000,
   neighbors: [],
   computedAt: '2025-01-01T00:00:00.000Z',
 };
@@ -158,8 +160,9 @@ const leaderboardHookDefaults = {
   leaderboard: {
     campaignId: CAMPAIGN_ID,
     computedAt: '2025-01-01T00:00:00.000Z',
-    entries: [{ rank: 1, referralCode: 'A', pnl: 1, qualified: true }],
+    entries: [{ rank: 1, referralCode: 'A', pnl: 1, volume: 30_000 }],
     totalParticipants: 50,
+    minVolumeForEligibility: 25_000,
   },
   isLoading: false,
   hasError: false,
@@ -288,7 +291,7 @@ describe('PerpsTradingCampaignLeaderboardView', () => {
         ...basePosition,
         rank: null,
         neighbors: null,
-        notionalVolume: 0,
+        volume: 0,
       } as unknown as PerpsTradingCampaignLeaderboardPositionDto,
       isLoading: false,
       hasError: false,
@@ -316,7 +319,7 @@ describe('PerpsTradingCampaignLeaderboardView', () => {
     mockUseGetPosition.mockReturnValue({
       position: {
         ...basePosition,
-        notionalVolume: 0,
+        volume: 0,
       },
       isLoading: false,
       hasError: false,

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.test.tsx
@@ -288,6 +288,7 @@ describe('PerpsTradingCampaignLeaderboardView', () => {
         ...basePosition,
         rank: null,
         neighbors: null,
+        notionalVolume: 0,
       } as unknown as PerpsTradingCampaignLeaderboardPositionDto,
       isLoading: false,
       hasError: false,
@@ -303,6 +304,81 @@ describe('PerpsTradingCampaignLeaderboardView', () => {
         userPosition: null,
       }),
     );
+  });
+
+  it('does not render the stats header when opted in with rank but zero notional volume', () => {
+    mockUseGetParticipant.mockReturnValue({
+      status: { optedIn: true, participantCount: 10 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetPosition.mockReturnValue({
+      position: {
+        ...basePosition,
+        notionalVolume: 0,
+      },
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+      refetch: jest.fn(),
+    });
+
+    const { queryByTestId } = render(<PerpsTradingCampaignLeaderboardView />);
+
+    expect(queryByTestId('perps-lb-stats-header-mock')).toBeNull();
+    expect(mockPerpsLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userPosition: { rank: basePosition.rank, neighbors: [] },
+      }),
+    );
+  });
+
+  it('passes isCampaignComplete to the stats header and leaderboard when campaign ended', () => {
+    const completedCampaign = {
+      ...mockCampaign,
+      startDate: '2024-01-01T00:00:00Z',
+      endDate: '2025-01-01T00:00:00Z',
+    };
+    mockUseSelector.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({
+        rewards: {
+          referralCode: 'REFCODE99',
+          campaigns: [completedCampaign],
+        },
+      }),
+    );
+    mockUseGetParticipant.mockReturnValue({
+      status: { optedIn: true, participantCount: 10 },
+      isLoading: false,
+      hasError: false,
+      refetch: jest.fn(),
+    });
+    mockUseGetPosition.mockReturnValue({
+      position: basePosition,
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+      refetch: jest.fn(),
+    });
+
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-08-15T12:00:00.000Z'));
+
+    render(<PerpsTradingCampaignLeaderboardView />);
+
+    expect(mockPerpsStatsHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isCampaignComplete: true,
+      }),
+    );
+    expect(mockPerpsLeaderboard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isCampaignComplete: true,
+      }),
+    );
+
+    jest.useRealTimers();
   });
 
   it('passes leaderboard data and user position to PerpsTradingCampaignLeaderboard', () => {

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.tsx
@@ -74,9 +74,7 @@ const PerpsTradingCampaignLeaderboardView: React.FC = () => {
     [position],
   );
   const hasPosition =
-    position != null &&
-    Number.isFinite(position.notionalVolume) &&
-    position.notionalVolume > 0;
+    position != null && Number.isFinite(position.volume) && position.volume > 0;
   const isCampaignComplete =
     campaign != null && getCampaignStatus(campaign) === 'complete';
 

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignLeaderboardView.tsx
@@ -73,7 +73,10 @@ const PerpsTradingCampaignLeaderboardView: React.FC = () => {
         : null,
     [position],
   );
-  const hasPosition = Boolean(leaderboardUserPosition);
+  const hasPosition =
+    position != null &&
+    Number.isFinite(position.notionalVolume) &&
+    position.notionalVolume > 0;
   const isCampaignComplete =
     campaign != null && getCampaignStatus(campaign) === 'complete';
 

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignStatsView.test.tsx
@@ -171,9 +171,11 @@ const mockUsePerpsTradingCampaignParticipantOutcome =
 
 const basePosition: PerpsTradingCampaignLeaderboardPositionDto = {
   rank: 4,
+  totalParticipants: 100,
   pnl: 1500.25,
-  notionalVolume: 30_000,
-  qualified: true,
+  volume: 30_000,
+  eligible: true,
+  minVolumeForEligibility: 25_000,
   neighbors: [],
   computedAt: '2025-01-01T00:00:00.000Z',
 };
@@ -294,8 +296,8 @@ describe('PerpsTradingCampaignStatsView', () => {
       position: {
         ...basePosition,
         pnl: null,
-        notionalVolume: null,
-        qualified: false,
+        volume: null,
+        eligible: false,
       } as unknown as PerpsTradingCampaignLeaderboardPositionDto,
       isLoading: false,
       hasError: false,
@@ -406,8 +408,8 @@ describe('PerpsTradingCampaignStatsView', () => {
     mockUseGetPosition.mockReturnValue({
       position: {
         ...basePosition,
-        qualified: false,
-        notionalVolume: 5_000,
+        eligible: false,
+        volume: 5_000,
       },
       isLoading: false,
       hasError: false,

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignStatsView.tsx
@@ -89,9 +89,9 @@ const PerpsTradingCampaignStatsView: React.FC = () => {
 
   const pnl =
     position != null && Number.isFinite(position.pnl) ? position.pnl : null;
-  const notionalVolume =
-    position != null && Number.isFinite(position.notionalVolume)
-      ? position.notionalVolume
+  const volume =
+    position != null && Number.isFinite(position.volume)
+      ? position.volume
       : null;
 
   const pnlValue = pnl != null ? formatSignedUsd(pnl) : '—';
@@ -102,23 +102,24 @@ const PerpsTradingCampaignStatsView: React.FC = () => {
         : TextColor.ErrorDefault
       : TextColor.TextDefault;
 
-  const volumeValue = notionalVolume != null ? formatUsd(notionalVolume) : '—';
-  const isQualified = position != null && position.qualified;
-  const isPending = position != null && !position.qualified;
+  const volumeValue = volume != null ? formatUsd(volume) : '—';
+  const isEligible = position != null && position.eligible;
+  const isPending = position != null && !position.eligible;
 
   const isCampaignComplete =
     campaign != null && getCampaignStatus(campaign) === 'complete';
 
-  const notionalGap =
-    notionalVolume != null
-      ? Math.max(0, PERPS_QUALIFICATION_NOTIONAL_USD - notionalVolume)
-      : 0;
+  const minVolumeForEligibility =
+    position?.minVolumeForEligibility ?? PERPS_QUALIFICATION_NOTIONAL_USD;
+
+  const volumeGap =
+    volume != null ? Math.max(0, minVolumeForEligibility - volume) : 0;
 
   const showQualifiedCard =
-    !isCampaignComplete && isQualified && position != null;
+    !isCampaignComplete && isEligible && position != null;
 
   const showQualifyForRankCard =
-    !isCampaignComplete && isPending && position != null && notionalGap > 0;
+    !isCampaignComplete && isPending && position != null && volumeGap > 0;
 
   const positionError = hasError && !position;
 
@@ -188,7 +189,7 @@ const PerpsTradingCampaignStatsView: React.FC = () => {
                   label={strings('rewards.perps_trading_campaign.label_volume')}
                   value={volumeValue}
                   isLoading={isLoading}
-                  suffix={isQualified ? <CheckIcon /> : undefined}
+                  suffix={isEligible ? <CheckIcon /> : undefined}
                   testID={PERPS_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_VOLUME}
                 />
               ) : (
@@ -248,7 +249,7 @@ const PerpsTradingCampaignStatsView: React.FC = () => {
                   {strings(
                     'rewards.perps_trading_campaign.stats_qualify_for_rank_description',
                     {
-                      notionalRemaining: formatUsd(notionalGap),
+                      notionalRemaining: formatUsd(volumeGap),
                     },
                   )}
                 </Text>

--- a/app/components/UI/Rewards/Views/PerpsTradingCampaignWinningView.test.tsx
+++ b/app/components/UI/Rewards/Views/PerpsTradingCampaignWinningView.test.tsx
@@ -69,8 +69,10 @@ describe('PerpsTradingCampaignWinningView', () => {
       position: {
         rank: 3,
         pnl: 1500.25,
-        notionalVolume: 30000,
-        qualified: true,
+        volume: 30000,
+        eligible: true,
+        minVolumeForEligibility: 25000,
+        totalParticipants: 50,
         neighbors: [],
         computedAt: '2025-08-15T12:00:00.000Z',
       },

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
@@ -272,4 +272,37 @@ describe('PerpsCampaignStatsSummary', () => {
       queryByTestId('campaign-outcome-banner-pending-PERPS-WINNER-123'),
     ).toBeNull();
   });
+
+  it('renders em dash for rank when rank is not finite', () => {
+    const { getByTestId } = render(
+      <PerpsCampaignStatsSummary
+        leaderboardPosition={
+          {
+            ...basePosition,
+            rank: Number.NaN,
+          } as PerpsTradingCampaignLeaderboardPositionDto
+        }
+        leaderboard={mockLeaderboard}
+      />,
+    );
+
+    expect(getByTestId(TEST_IDS.RANK).props.children).toBe('—');
+  });
+
+  it('renders em dash for pnl when pnl is not finite', () => {
+    const { getByTestId } = render(
+      <PerpsCampaignStatsSummary
+        leaderboardPosition={
+          {
+            ...basePosition,
+            pnl: Number.POSITIVE_INFINITY,
+          } as PerpsTradingCampaignLeaderboardPositionDto
+        }
+        leaderboard={mockLeaderboard}
+      />,
+    );
+
+    expect(getByTestId(TEST_IDS.PNL).props.children).toBe('—');
+    expect(getByTestId(TEST_IDS.PNL).props.color).toBe(TextColor.TextDefault);
+  });
 });

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
@@ -62,9 +62,11 @@ const mockLeaderboard = {
 
 const basePosition: PerpsTradingCampaignLeaderboardPositionDto = {
   rank: 7,
+  totalParticipants: 100,
   pnl: 1500.25,
-  notionalVolume: 30_000,
-  qualified: true,
+  volume: 30_000,
+  eligible: true,
+  minVolumeForEligibility: 25_000,
   neighbors: [],
   computedAt: '2025-01-01T00:00:00.000Z',
 };
@@ -126,7 +128,7 @@ describe('PerpsCampaignStatsSummary', () => {
     const { getByTestId, queryByTestId } = render(
       <PerpsCampaignStatsSummary
         isCampaignComplete={false}
-        leaderboardPosition={{ ...basePosition, qualified: false }}
+        leaderboardPosition={{ ...basePosition, eligible: false }}
         leaderboard={mockLeaderboard}
       />,
     );
@@ -150,7 +152,7 @@ describe('PerpsCampaignStatsSummary', () => {
     const { queryByTestId } = render(
       <PerpsCampaignStatsSummary
         isCampaignComplete
-        leaderboardPosition={{ ...basePosition, qualified: false }}
+        leaderboardPosition={{ ...basePosition, eligible: false }}
         leaderboard={mockLeaderboard}
       />,
     );
@@ -212,8 +214,8 @@ describe('PerpsCampaignStatsSummary', () => {
         isCampaignComplete={false}
         leaderboardPosition={{
           ...basePosition,
-          qualified: false,
-          notionalVolume: 5_000,
+          eligible: false,
+          volume: 5_000,
         }}
         leaderboard={mockLeaderboard}
       />,
@@ -228,8 +230,8 @@ describe('PerpsCampaignStatsSummary', () => {
         isCampaignComplete={false}
         leaderboardPosition={{
           ...basePosition,
-          qualified: false,
-          notionalVolume: 30_000,
+          eligible: false,
+          volume: 30_000,
         }}
         leaderboard={mockLeaderboard}
       />,

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
@@ -4,7 +4,10 @@ import { TextColor } from '@metamask/design-system-react-native';
 import PerpsCampaignStatsSummary, {
   PERPS_CAMPAIGN_STATS_SUMMARY_TEST_IDS,
 } from './PerpsCampaignStatsSummary';
-import type { PerpsTradingCampaignLeaderboardPositionDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
+import type {
+  PerpsTradingCampaignLeaderboardDto,
+  PerpsTradingCampaignLeaderboardPositionDto,
+} from '../../../../../core/Engine/controllers/rewards-controller/types';
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -53,11 +56,12 @@ jest.mock('./CampaignOutcomeBanners', () => {
 
 const TEST_IDS = PERPS_CAMPAIGN_STATS_SUMMARY_TEST_IDS;
 
-const mockLeaderboard = {
+const mockLeaderboard: PerpsTradingCampaignLeaderboardDto = {
   campaignId: 'c1',
   computedAt: '2025-01-01T00:00:00.000Z',
   entries: [],
   totalParticipants: 0,
+  minVolumeForEligibility: 25_000,
 };
 
 const basePosition: PerpsTradingCampaignLeaderboardPositionDto = {

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
@@ -311,4 +311,38 @@ describe('PerpsCampaignStatsSummary', () => {
     expect(getByTestId(TEST_IDS.PNL).props.children).toBe('—');
     expect(getByTestId(TEST_IDS.PNL).props.color).toBe(TextColor.TextDefault);
   });
+
+  it('renders em dash for volume when volume is not finite', () => {
+    const { getByTestId } = render(
+      <PerpsCampaignStatsSummary
+        leaderboardPosition={
+          {
+            ...basePosition,
+            volume: Number.NaN,
+          } as PerpsTradingCampaignLeaderboardPositionDto
+        }
+        leaderboard={mockLeaderboard}
+      />,
+    );
+
+    expect(getByTestId(TEST_IDS.NOTIONAL_VOLUME).props.children).toBe('—');
+  });
+
+  it('hides Qualify for rank card when volume is not finite', () => {
+    const { queryByTestId } = render(
+      <PerpsCampaignStatsSummary
+        isCampaignComplete={false}
+        leaderboardPosition={
+          {
+            ...basePosition,
+            eligible: false,
+            volume: Number.NaN,
+          } as PerpsTradingCampaignLeaderboardPositionDto
+        }
+        leaderboard={mockLeaderboard}
+      />,
+    );
+
+    expect(queryByTestId(TEST_IDS.QUALIFY_FOR_RANK_CARD)).toBeNull();
+  });
 });

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
@@ -65,6 +65,10 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
     leaderboardPosition != null && Number.isFinite(leaderboardPosition.pnl)
       ? leaderboardPosition.pnl
       : null;
+  const volume =
+    leaderboardPosition != null && Number.isFinite(leaderboardPosition.volume)
+      ? leaderboardPosition.volume
+      : null;
 
   const rankDisplay = rank != null ? String(rank).padStart(2, '0') : '—';
 
@@ -77,17 +81,14 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
         : TextColor.ErrorDefault
       : TextColor.TextDefault;
 
-  const volumeDisplay = leaderboardPosition
-    ? formatUsd(leaderboardPosition.volume)
-    : '—';
+  const volumeDisplay = volume != null ? formatUsd(volume) : '—';
 
   const minVolumeForEligibility =
     leaderboardPosition?.minVolumeForEligibility ??
     PERPS_QUALIFICATION_NOTIONAL_USD;
 
-  const volumeGap = leaderboardPosition
-    ? Math.max(0, minVolumeForEligibility - leaderboardPosition.volume)
-    : 0;
+  const volumeGap =
+    volume != null ? Math.max(0, minVolumeForEligibility - volume) : 0;
 
   const showQualifiedCard =
     !isCampaignComplete && isQualified && leaderboardPosition != null;

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
@@ -61,20 +61,25 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
     leaderboardPosition != null && !leaderboardPosition.qualified;
   const isQualified =
     leaderboardPosition != null && leaderboardPosition.qualified;
+  const rank =
+    leaderboardPosition != null && Number.isFinite(leaderboardPosition.rank)
+      ? leaderboardPosition.rank
+      : null;
+  const pnl =
+    leaderboardPosition != null && Number.isFinite(leaderboardPosition.pnl)
+      ? leaderboardPosition.pnl
+      : null;
 
-  const rankDisplay = leaderboardPosition
-    ? String(leaderboardPosition.rank).padStart(2, '0')
-    : '—';
+  const rankDisplay = rank != null ? String(rank).padStart(2, '0') : '—';
 
-  const pnlDisplay = leaderboardPosition
-    ? formatSignedUsd(leaderboardPosition.pnl)
-    : '—';
+  const pnlDisplay = pnl != null ? formatSignedUsd(pnl) : '—';
 
-  const pnlColor = leaderboardPosition
-    ? leaderboardPosition.pnl >= 0
-      ? TextColor.SuccessDefault
-      : TextColor.ErrorDefault
-    : TextColor.TextDefault;
+  const pnlColor =
+    pnl != null
+      ? pnl >= 0
+        ? TextColor.SuccessDefault
+        : TextColor.ErrorDefault
+      : TextColor.TextDefault;
 
   const volumeDisplay = leaderboardPosition
     ? formatUsd(leaderboardPosition.notionalVolume)

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
@@ -23,10 +23,6 @@ import { PERPS_QUALIFICATION_NOTIONAL_USD } from '../../utils/perpsCampaignConst
 import { PendingTag, StatCell } from './OndoCampaignStatsSummary';
 import { CampaignOutcomeBanner } from './CampaignOutcomeBanners';
 
-const PERPS_NOTIONAL_THRESHOLD_LABEL = formatUsd(
-  PERPS_QUALIFICATION_NOTIONAL_USD,
-);
-
 export const PERPS_CAMPAIGN_STATS_SUMMARY_TEST_IDS = {
   CONTAINER: 'perps-campaign-stats-summary-container',
   RANK: 'perps-campaign-stats-summary-rank',
@@ -58,9 +54,9 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
   onWinnerPress,
 }) => {
   const isPending =
-    leaderboardPosition != null && !leaderboardPosition.qualified;
+    leaderboardPosition != null && !leaderboardPosition.eligible;
   const isQualified =
-    leaderboardPosition != null && leaderboardPosition.qualified;
+    leaderboardPosition != null && leaderboardPosition.eligible;
   const rank =
     leaderboardPosition != null && Number.isFinite(leaderboardPosition.rank)
       ? leaderboardPosition.rank
@@ -82,14 +78,15 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
       : TextColor.TextDefault;
 
   const volumeDisplay = leaderboardPosition
-    ? formatUsd(leaderboardPosition.notionalVolume)
+    ? formatUsd(leaderboardPosition.volume)
     : '—';
 
-  const notionalGap = leaderboardPosition
-    ? Math.max(
-        0,
-        PERPS_QUALIFICATION_NOTIONAL_USD - leaderboardPosition.notionalVolume,
-      )
+  const minVolumeForEligibility =
+    leaderboardPosition?.minVolumeForEligibility ??
+    PERPS_QUALIFICATION_NOTIONAL_USD;
+
+  const volumeGap = leaderboardPosition
+    ? Math.max(0, minVolumeForEligibility - leaderboardPosition.volume)
     : 0;
 
   const showQualifiedCard =
@@ -99,7 +96,7 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
     !isCampaignComplete &&
     isPending &&
     leaderboardPosition != null &&
-    notionalGap > 0;
+    volumeGap > 0;
 
   return (
     <Box
@@ -180,7 +177,7 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
             {strings(
               'rewards.perps_trading_campaign.stats_qualify_for_rank_description',
               {
-                notionalRemaining: formatUsd(notionalGap),
+                notionalRemaining: formatUsd(volumeGap),
               },
             )}
           </Text>

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignEndedStats.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignEndedStats.test.tsx
@@ -61,12 +61,12 @@ jest.mock('../../utils/formatUtils', () => ({
 const makeEntry = (
   rank: number,
   pnl: number,
-  qualified = true,
+  volume = 30_000,
 ): PerpsTradingCampaignLeaderboardEntry => ({
   rank,
   referralCode: `T-${rank}`,
   pnl,
-  qualified,
+  volume,
 });
 
 const makeLeaderboard = (
@@ -81,6 +81,7 @@ const makeLeaderboard = (
     campaignId: 'perps-1',
     computedAt: '2026-01-01T00:00:00Z',
     totalParticipants: totalParticipants ?? entriesCount,
+    minVolumeForEligibility: 25_000,
     entries,
   };
 };
@@ -176,6 +177,7 @@ describe('PerpsTradingCampaignEndedStats', () => {
       campaignId: 'perps-1',
       computedAt: '2026-01-01T00:00:00Z',
       totalParticipants: 0,
+      minVolumeForEligibility: 25_000,
       entries: [],
     };
 
@@ -259,6 +261,7 @@ describe('PerpsTradingCampaignEndedStats', () => {
       campaignId: 'perps-1',
       computedAt: '2026-01-01T00:00:00Z',
       totalParticipants: 1,
+      minVolumeForEligibility: 25_000,
       entries: [makeEntry(1, -5_000)],
     };
 

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
@@ -63,7 +63,7 @@ const createPerpsEntry = (
   rank: 1,
   referralCode: 'REF001',
   pnl: 100,
-  qualified: true,
+  volume: 30_000,
   ...overrides,
 });
 

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
@@ -197,7 +197,7 @@ const PerpsTradingCampaignLeaderboard: React.FC<
         {visibleEntries.map((entry) => (
           <CampaignLeaderboardEntryRow
             key={`${entry.rank}-${entry.referralCode}`}
-            entry={entry}
+            entry={{ ...entry, qualified: true }}
             isCurrentUser={isCurrentUser(entry)}
             showCrown={!isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS}
             isCampaignComplete={isCampaignComplete}
@@ -211,7 +211,7 @@ const PerpsTradingCampaignLeaderboard: React.FC<
             {userPosition.neighbors.map((entry) => (
               <CampaignLeaderboardEntryRow
                 key={`neighbor-${entry.rank}-${entry.referralCode}`}
-                entry={entry}
+                entry={{ ...entry, qualified: true }}
                 isCurrentUser={isCurrentUser(entry)}
                 showCrown={
                   !isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignStatsHeader.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignStatsHeader.test.tsx
@@ -51,9 +51,11 @@ const TEST_IDS = PERPS_STATS_HEADER_TEST_IDS;
 
 const basePosition: PerpsTradingCampaignLeaderboardPositionDto = {
   rank: 7,
+  totalParticipants: 100,
   pnl: 1500.25,
-  notionalVolume: 30_000,
-  qualified: true,
+  volume: 30_000,
+  eligible: true,
+  minVolumeForEligibility: 25_000,
   neighbors: [],
   computedAt: '2025-01-01T00:00:00.000Z',
 };
@@ -69,7 +71,7 @@ describe('PerpsTradingCampaignStatsHeader', () => {
     ).toBeDefined();
   });
 
-  it('shows padded rank, positive PnL with success color, and qualified icon when qualified', () => {
+  it('shows padded rank, positive PnL with success color, and eligible icon when eligible', () => {
     const { getByTestId, getByText, queryByTestId } = render(
       <PerpsTradingCampaignStatsHeader
         position={basePosition}
@@ -88,17 +90,17 @@ describe('PerpsTradingCampaignStatsHeader', () => {
   it('uses error color and minus sign in display for negative PnL', () => {
     const { getByTestId } = render(
       <PerpsTradingCampaignStatsHeader
-        position={{ ...basePosition, pnl: -100, qualified: true }}
+        position={{ ...basePosition, pnl: -100, eligible: true }}
       />,
     );
     const pnl = getByTestId(TEST_IDS.PNL_VALUE);
     expect(pnl.props.color).toBe(TextColor.ErrorDefault);
   });
 
-  it('shows pending tag and no qualified icon when not qualified', () => {
+  it('shows pending tag and no eligible icon when not eligible', () => {
     const { getByTestId, queryByTestId } = render(
       <PerpsTradingCampaignStatsHeader
-        position={{ ...basePosition, qualified: false }}
+        position={{ ...basePosition, eligible: false }}
       />,
     );
     expect(getByTestId(TEST_IDS.PENDING_TAG)).toBeDefined();
@@ -108,7 +110,7 @@ describe('PerpsTradingCampaignStatsHeader', () => {
   it('hides the pending tag when the campaign is complete', () => {
     const { queryByTestId } = render(
       <PerpsTradingCampaignStatsHeader
-        position={{ ...basePosition, qualified: false }}
+        position={{ ...basePosition, eligible: false }}
         isCampaignComplete
       />,
     );

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignStatsHeader.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignStatsHeader.tsx
@@ -53,8 +53,8 @@ const PerpsTradingCampaignStatsHeader: React.FC<
 }) => {
   const tw = useTailwind();
 
-  const isPending = position != null && !position.qualified;
-  const isQualified = position != null && position.qualified;
+  const isPending = position != null && !position.eligible;
+  const isQualified = position != null && position.eligible;
   const rank =
     position != null && Number.isFinite(position.rank) ? position.rank : null;
   const pnl =

--- a/app/components/UI/Rewards/hooks/useGetPerpsTradingCampaignLeaderboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetPerpsTradingCampaignLeaderboard.test.ts
@@ -55,10 +55,11 @@ const MOCK_LEADERBOARD: PerpsTradingCampaignLeaderboardDto = {
   campaignId: CAMPAIGN_ID,
   computedAt: '2024-03-20T12:00:00.000Z',
   entries: [
-    { rank: 1, referralCode: 'ABC123', pnl: 1500, qualified: true },
-    { rank: 2, referralCode: 'DEF456', pnl: 800, qualified: true },
+    { rank: 1, referralCode: 'ABC123', pnl: 1500, volume: 30_000 },
+    { rank: 2, referralCode: 'DEF456', pnl: 800, volume: 28_000 },
   ],
   totalParticipants: 50,
+  minVolumeForEligibility: 25_000,
 };
 
 interface SelectorState {

--- a/app/components/UI/Rewards/hooks/useGetPerpsTradingCampaignLeaderboardPosition.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetPerpsTradingCampaignLeaderboardPosition.test.ts
@@ -62,9 +62,11 @@ const CAMPAIGN_ID = 'campaign-123';
 const SUBSCRIPTION_ID = 'sub-456';
 const MOCK_POSITION: PerpsTradingCampaignLeaderboardPositionDto = {
   rank: 5,
+  totalParticipants: 50,
   pnl: 1500,
-  notionalVolume: 30000,
-  qualified: true,
+  volume: 30000,
+  eligible: true,
+  minVolumeForEligibility: 25000,
   neighbors: [],
   computedAt: '2024-03-20T12:00:00.000Z',
 };

--- a/app/components/UI/Rewards/utils/perpsCampaignConstants.ts
+++ b/app/components/UI/Rewards/utils/perpsCampaignConstants.ts
@@ -1,6 +1,6 @@
 /**
- * Notional volume (USD) required to qualify for the perps trading competition leaderboard.
- * Aligns with backend / UI rules for `qualified` on leaderboard position.
+ * Default minimum volume (USD) required to qualify for the perps trading
+ * competition leaderboard when the API does not provide `minVolumeForEligibility`.
  */
 export const PERPS_QUALIFICATION_NOTIONAL_USD = 25_000;
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -17749,18 +17749,22 @@ describe('RewardsController', () => {
       } as OndoGmActivityState;
       initialState.perpsTradingCampaignLeaderboardPositions[campaignKey1] = {
         rank: 4,
+        totalParticipants: 0,
         pnl: 0,
-        notionalVolume: 0,
-        qualified: true,
+        volume: 0,
+        eligible: true,
+        minVolumeForEligibility: 25000,
         neighbors: [],
         computedAt: '',
         lastFetched: Date.now(),
       } as PerpsTradingCampaignLeaderboardPositionState;
       initialState.perpsTradingCampaignLeaderboardPositions[campaignKey2] = {
         rank: 6,
+        totalParticipants: 0,
         pnl: 0,
-        notionalVolume: 0,
-        qualified: true,
+        volume: 0,
+        eligible: true,
+        minVolumeForEligibility: 25000,
         neighbors: [],
         computedAt: '',
         lastFetched: Date.now(),
@@ -17945,9 +17949,11 @@ describe('RewardsController', () => {
       } as OndoGmActivityState;
       initialState.perpsTradingCampaignLeaderboardPositions[campaignKey1] = {
         rank: 4,
+        totalParticipants: 0,
         pnl: 0,
-        notionalVolume: 0,
-        qualified: true,
+        volume: 0,
+        eligible: true,
+        minVolumeForEligibility: 25000,
         neighbors: [],
         computedAt: '',
         lastFetched: Date.now(),
@@ -17955,9 +17961,11 @@ describe('RewardsController', () => {
       initialState.perpsTradingCampaignLeaderboardPositions[otherCampaignKey] =
         {
           rank: 1,
+          totalParticipants: 0,
           pnl: 0,
-          notionalVolume: 0,
-          qualified: true,
+          volume: 0,
+          eligible: true,
+          minVolumeForEligibility: 25000,
           neighbors: [],
           computedAt: '',
           lastFetched: Date.now(),

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -4770,7 +4770,13 @@ export class RewardsController extends BaseController<
     campaignId: string,
   ): Promise<PerpsTradingCampaignLeaderboardDto> {
     if (!this.isRewardsFeatureEnabled()) {
-      return { campaignId, computedAt: '', entries: [], totalParticipants: 0 };
+      return {
+        campaignId,
+        computedAt: '',
+        entries: [],
+        totalParticipants: 0,
+        minVolumeForEligibility: 0,
+      };
     }
 
     const result = await wrapWithCache<PerpsTradingCampaignLeaderboardDto>({
@@ -4785,6 +4791,7 @@ export class RewardsController extends BaseController<
             computedAt: cached.computedAt,
             entries: cached.entries,
             totalParticipants: cached.totalParticipants,
+            minVolumeForEligibility: cached.minVolumeForEligibility,
           },
           lastFetched: cached.lastFetched,
         };
@@ -4805,6 +4812,7 @@ export class RewardsController extends BaseController<
             computedAt: payload.computedAt,
             entries: payload.entries,
             totalParticipants: payload.totalParticipants,
+            minVolumeForEligibility: payload.minVolumeForEligibility,
             lastFetched: Date.now(),
           };
         });
@@ -4849,9 +4857,11 @@ export class RewardsController extends BaseController<
           return {
             payload: {
               rank: cached.rank,
+              totalParticipants: cached.totalParticipants,
               pnl: cached.pnl,
-              notionalVolume: cached.notionalVolume,
-              qualified: cached.qualified,
+              volume: cached.volume,
+              eligible: cached.eligible,
+              minVolumeForEligibility: cached.minVolumeForEligibility,
               neighbors: cached.neighbors,
               computedAt: cached.computedAt,
             },
@@ -4881,9 +4891,11 @@ export class RewardsController extends BaseController<
             this.update((state) => {
               state.perpsTradingCampaignLeaderboardPositions[k] = {
                 rank: payload.rank,
+                totalParticipants: payload.totalParticipants,
                 pnl: payload.pnl,
-                notionalVolume: payload.notionalVolume,
-                qualified: payload.qualified,
+                volume: payload.volume,
+                eligible: payload.eligible,
+                minVolumeForEligibility: payload.minVolumeForEligibility,
                 neighbors: payload.neighbors,
                 computedAt: payload.computedAt,
                 lastFetched: Date.now(),

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -5264,6 +5264,7 @@ describe('RewardsDataService', () => {
       computedAt: '2025-08-15T12:00:00.000Z',
       entries: [],
       totalParticipants: 0,
+      minVolumeForEligibility: 25_000,
     };
 
     beforeEach(() => {
@@ -5299,9 +5300,11 @@ describe('RewardsDataService', () => {
     const mockToken = 'test-bearer-token';
     const mockPosition = {
       rank: 4,
+      totalParticipants: 50,
       pnl: 12.5,
-      notionalVolume: 8000,
-      qualified: true,
+      volume: 8000,
+      eligible: true,
+      minVolumeForEligibility: 25000,
       neighbors: [],
       computedAt: '2025-08-15T12:00:00.000Z',
     };

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -886,8 +886,8 @@ export interface PerpsTradingCampaignLeaderboardEntry {
   referralCode: string;
   /** Signed USD PnL for the campaign window */
   pnl: number;
-  /** true when notional volume ≥ $25k */
-  qualified: boolean;
+  /** Cumulative volume traded during the competition window (USD) */
+  volume: number;
 }
 
 /**
@@ -898,21 +898,30 @@ export interface PerpsTradingCampaignLeaderboardDto {
   /** ISO timestamp — display as "last updated" (refreshes ~every 15 min) */
   computedAt: string;
   entries: PerpsTradingCampaignLeaderboardEntry[];
+  /** Number of eligible participants in this campaign */
   totalParticipants: number;
+  /** Minimum cumulative volume (USD) required to appear on the leaderboard */
+  minVolumeForEligibility: number;
 }
 
 /**
  * Response DTO for GET /perps-trading/:campaignId/leaderboard/me (authenticated).
  */
 export interface PerpsTradingCampaignLeaderboardPositionDto {
-  rank: number;
+  /** Null when the participant has not yet met the volume threshold. */
+  rank: number | null;
+  /** Number of eligible participants in this campaign */
+  totalParticipants: number;
   /** Signed USD PnL */
   pnl: number;
-  /** Cumulative notional volume traded during the competition window (USD) */
-  notionalVolume: number;
-  qualified: boolean;
-  neighbors: PerpsTradingCampaignLeaderboardEntry[];
+  /** Cumulative volume traded during the competition window (USD) */
+  volume: number;
   computedAt: string;
+  neighbors: PerpsTradingCampaignLeaderboardEntry[];
+  /** Whether this participant has met the minimum volume threshold */
+  eligible: boolean;
+  /** Minimum cumulative volume (USD) required to become eligible */
+  minVolumeForEligibility: number;
 }
 
 /**
@@ -931,23 +940,26 @@ export type PerpsTradingCampaignLeaderboardState = {
     rank: number;
     referralCode: string;
     pnl: number;
-    qualified: boolean;
+    volume: number;
   }[];
   totalParticipants: number;
+  minVolumeForEligibility: number;
   lastFetched: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type PerpsTradingCampaignLeaderboardPositionFoundState = {
-  rank: number;
+  rank: number | null;
+  totalParticipants: number;
   pnl: number;
-  notionalVolume: number;
-  qualified: boolean;
+  volume: number;
+  eligible: boolean;
+  minVolumeForEligibility: number;
   neighbors: {
     rank: number;
     referralCode: string;
     pnl: number;
-    qualified: boolean;
+    volume: number;
   }[];
   computedAt: string;
   lastFetched: number;

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -5837,13 +5837,16 @@ const mockPerpsLeaderboard: PerpsTradingCampaignLeaderboardDto = {
   computedAt: '2025-08-15T12:00:00.000Z',
   entries: [],
   totalParticipants: 42,
+  minVolumeForEligibility: 25_000,
 };
 
 const mockPerpsPosition: PerpsTradingCampaignLeaderboardPositionDto = {
   rank: 2,
+  totalParticipants: 42,
   pnl: 100,
-  notionalVolume: 5000,
-  qualified: true,
+  volume: 5000,
+  eligible: true,
+  minVolumeForEligibility: 25000,
   neighbors: [],
   computedAt: '2025-08-15T12:00:00.000Z',
 };

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "{{amount}} $ erforderlich",
       "stats_qualified_title": "Sie sind qualifiziert",
       "stats_qualified_description": "Handeln Sie weiter, um Ihren GuV zu verbessern und in der Bestenliste aufzusteigen, bevor der Wettbewerb endet.",
-      "stats_qualify_for_rank_title": "Für diesen Rang qualifizieren",
+      "stats_qualify_for_rank_title": "Für die Rangliste qualifizieren",
       "stats_qualify_for_rank_description": "Handeln Sie {{notionalRemaining}} mehr an Nominalvolumen, um berechtigt zu sein.",
       "stats_error_title": "Statistiken konnten nicht geladen werden",
       "stats_error_description": "Wir hatten ein Problem beim Laden Ihrer Statistik. Bitte versuchen Sie es erneut.",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "Απαιτούνται ${{amount}}",
       "stats_qualified_title": "Πληροίτε τις προϋποθέσεις",
       "stats_qualified_description": "Συνεχίστε να κάνετε συναλλαγές για να βελτιώσετε τα Κέρδη & Ζημιές σας και να ανεβείτε στην κατάταξη πριν λήξει ο διαγωνισμός.",
-      "stats_qualify_for_rank_title": "Πληροίτε τα κριτήρια για αυτή την κατηγορία",
+      "stats_qualify_for_rank_title": "Προκριθείτε για τον πίνακα κατάταξης",
       "stats_qualify_for_rank_description": "Κάντε συναλλαγές επιπλέον {{notionalRemaining}} σε ονομαστικό όγκο για να πληροίτε τα κριτήρια.",
       "stats_error_title": "Δεν ήταν δυνατή η φόρτωση των στατιστικών",
       "stats_error_description": "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση των στατιστικών σας. Προσπαθήστε ξανά.",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9104,7 +9104,7 @@
       "stats_notional_volume_threshold": "${{amount}} required",
       "stats_qualified_title": "You're qualified",
       "stats_qualified_description": "Keep trading to improve your PnL and climb the leaderboard before the competition ends.",
-      "stats_qualify_for_rank_title": "Qualify for this rank",
+      "stats_qualify_for_rank_title": "Qualify for the leaderboard",
       "stats_qualify_for_rank_description": "Trade {{notionalRemaining}} more in notional volume to become eligible.",
       "stats_error_title": "Unable to load stats",
       "stats_error_description": "We had a problem loading your stats. Please try again.",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "Se requiere ${{amount}}",
       "stats_qualified_title": "Estás calificado",
       "stats_qualified_description": "Sigue operando para mejorar tu P&L (ganancias y pérdidas) y subir en la clasificación antes de que termine la competencia.",
-      "stats_qualify_for_rank_title": "Califica para este rango",
+      "stats_qualify_for_rank_title": "Califica para la clasificación",
       "stats_qualify_for_rank_description": "Opera {{notionalRemaining}} más en volumen nocional para poder participar.",
       "stats_error_title": "No se pueden cargar las estadísticas",
       "stats_error_description": "Hubo un problema al cargar tus estadísticas. Inténtalo de nuevo.",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -8900,7 +8900,7 @@
       "stats_notional_volume_threshold": "{{amount}} $ requis",
       "stats_qualified_title": "Vous êtes qualifié",
       "stats_qualified_description": "Continuez à trader pour améliorer votre résultat net et grimper dans le classement avant la fin de la compétition.",
-      "stats_qualify_for_rank_title": "Se qualifier pour ce classement",
+      "stats_qualify_for_rank_title": "Se qualifier pour le classement",
       "stats_qualify_for_rank_description": "Tradez {{notionalRemaining}} de plus en volume notionnel pour devenir admissible.",
       "stats_error_title": "Impossible de charger les statistiques",
       "stats_error_description": "Nous avons rencontré un problème lors du chargement de vos statistiques. Veuillez réessayer.",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "${{amount}} ज़रूरी है",
       "stats_qualified_title": "आप क्वालिफ़ाई कर चुके हैं",
       "stats_qualified_description": "लीडरबोर्ड में ऊपर आने और अपने PnL को बेहतर बनाने के लिए प्रतियोगिता खत्म होने से पहले ट्रेडिंग जारी रखें।",
-      "stats_qualify_for_rank_title": "इस रैंक के लिए क्वालिफ़ाई करें",
+      "stats_qualify_for_rank_title": "लीडरबोर्ड के लिए क्वालिफ़ाई करें",
       "stats_qualify_for_rank_description": "योग्य बनने के लिए नोशनल वॉल्यूम में {{notionalRemaining}} और ट्रेड करें।",
       "stats_error_title": "स्टैट्स लोड नहीं हो पा रहे हैं",
       "stats_error_description": "हमें आपके स्टैट्स लोड करने में दिक्कत हुई। कृपया फिर से कोशिश करें।",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "${{amount}} diperlukan",
       "stats_qualified_title": "Anda memenuhi syarat",
       "stats_qualified_description": "Terus lakukan perdagangan untuk meningkatkan PnL dan naiki papan peringkat sebelum kompetisi berakhir.",
-      "stats_qualify_for_rank_title": "Memenuhi syarat untuk peringkat ini",
+      "stats_qualify_for_rank_title": "Memenuhi syarat untuk papan peringkat",
       "stats_qualify_for_rank_description": "Lakukan perdagangan {{notionalRemaining}} lagi dalam volume notional untuk memenuhi syarat.",
       "stats_error_title": "Tidak dapat memuat statistik",
       "stats_error_description": "Terjadi masalah saat memuat statistik. Coba lagi.",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "${{amount}}が必要です",
       "stats_qualified_title": "対象となります",
       "stats_qualified_description": "取引を続けて損益を改善し、コンテンストが終了するまでリーダーボードの順位を上げていきましょう。",
-      "stats_qualify_for_rank_title": "このランクの資格を満たすには",
+      "stats_qualify_for_rank_title": "リーダーボードの資格を満たすには",
       "stats_qualify_for_rank_description": "名目取引量があと{{notionalRemaining}}で条件が満たされます。",
       "stats_error_title": "統計を読み込めません",
       "stats_error_description": "統計の読み込み中に問題が発生しました。もう一度お試しください。",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "${{amount}} 필요함",
       "stats_qualified_title": "자격 충족",
       "stats_qualified_description": "대회 종료 전까지 계속 거래해 손익을 개선하고 리더보드 순위도 올려보세요.",
-      "stats_qualify_for_rank_title": "이 등급 자격 획득하기",
+      "stats_qualify_for_rank_title": "리더보드 자격 획득하기",
       "stats_qualify_for_rank_description": "참가 자격을 획득하려면 명목 거래량 기준으로 {{notionalRemaining}}만큼 더 거래해야 합니다.",
       "stats_error_title": "통계를 불러올 수 없음",
       "stats_error_description": "통계를 불러오는 중에 문제가 발생했습니다. 다시 시도하세요.",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "${{amount}} obrigatório",
       "stats_qualified_title": "Você se qualifica",
       "stats_qualified_description": "Continue negociando para aumentar seu PnL e subir na tabela de classificação antes do fim do concurso.",
-      "stats_qualify_for_rank_title": "Qualifica para esta classificação",
+      "stats_qualify_for_rank_title": "Qualifique-se para a tabela de classificação",
       "stats_qualify_for_rank_description": "Negocie mais {{notionalRemaining}} em volume nocional para se qualificar.",
       "stats_error_title": "Não foi possível carregar estatísticas",
       "stats_error_description": "Tivemos um problema ao carregar suas estatísticas. Tente novamente.",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "Требуется {{amount}} $",
       "stats_qualified_title": "Вы соответствуете требованиям",
       "stats_qualified_description": "Продолжайте торговать, чтобы улучшить свой показатель прибыли и убытков (П/У) и подняться в таблице лидеров до окончания соревнования.",
-      "stats_qualify_for_rank_title": "Квалифицироваться на этот ранг",
+      "stats_qualify_for_rank_title": "Квалифицироваться для таблицы лидеров",
       "stats_qualify_for_rank_description": "Наторгуйте еще {{notionalRemaining}} номинального объема, чтобы получить право на участие.",
       "stats_error_title": "Не удалось загрузить статистику",
       "stats_error_description": "У нас возникла проблема с загрузкой вашей статистики. Пожалуйста, попробуйте еще раз.",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "${{amount}} ang kinakailangan",
       "stats_qualified_title": "Kwalipikado ka",
       "stats_qualified_description": "Patuloy na mag-trade para mas mapaganda ang PnL mo at makaakyat ka sa leaderboard bago matapos ang kumpetisyon.",
-      "stats_qualify_for_rank_title": "Maging kwalipikado para sa rank na ito",
+      "stats_qualify_for_rank_title": "Maging kwalipikado para sa leaderboard",
       "stats_qualify_for_rank_description": "Mag-trade ng {{notionalRemaining}} pang notional na dami para maging kwalipikado.",
       "stats_error_title": "Hindi nai-load ang mga stat",
       "stats_error_description": "Nagkaproblema kami sa pag-load ng mga stat mo. Subukan ulit.",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "{{amount}}$ gereklidir",
       "stats_qualified_title": "Uygunsunuz",
       "stats_qualified_description": "Yarışma sona ermeden Kazanç/Zarar durumunuzu iyileştirmek ve liderlik tablosunda yükselmek için işlem yapmaya devam edin.",
-      "stats_qualify_for_rank_title": "Bu sıralama için uygunluk kazanın",
+      "stats_qualify_for_rank_title": "Liderlik tablosu için uygunluk kazanın",
       "stats_qualify_for_rank_description": "Uygunluk kazanmak için {{notionalRemaining}} daha nominal hacimli işlem yapın.",
       "stats_error_title": "İstatistikler yüklenemiyor",
       "stats_error_description": "İstatistikleriniz yüklenirken bir problem yaşadık. Lütfen tekrar deneyin.",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "Yêu cầu ${{amount}}",
       "stats_qualified_title": "Bạn đủ điều kiện",
       "stats_qualified_description": "Tiếp tục giao dịch để cải thiện Lãi/Lỗ và leo lên bảng xếp hạng trước khi cuộc thi kết thúc.",
-      "stats_qualify_for_rank_title": "Đủ điều kiện cho hạng này",
+      "stats_qualify_for_rank_title": "Đủ điều kiện vào bảng xếp hạng",
       "stats_qualify_for_rank_description": "Giao dịch thêm {{notionalRemaining}} khối lượng danh nghĩa để đủ điều kiện tham gia.",
       "stats_error_title": "Không thể tải số liệu thống kê",
       "stats_error_description": "Chúng tôi đã gặp sự cố khi tải số liệu thống kê của bạn. Vui lòng thử lại.",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -8901,7 +8901,7 @@
       "stats_notional_volume_threshold": "需要 {{amount}} 美元",
       "stats_qualified_title": "您已具备资格",
       "stats_qualified_description": "在比赛结束前继续交易，提升您的盈亏（PnL）表现并冲击排行榜。",
-      "stats_qualify_for_rank_title": "符合此排名的资格",
+      "stats_qualify_for_rank_title": "符合排行榜的资格",
       "stats_qualify_for_rank_description": "还需完成{{notionalRemaining}}名义交易量即可获得资格。",
       "stats_error_title": "无法加载统计数据",
       "stats_error_description": "加载您的统计数据时遇到问题。请重试。",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
- Fix DTO shapes `PerpsTradingCampaignLeaderboardDto`, `PerpsTradingCampaignLeaderboardEntry` and `PerpsTradingCampaignLeaderboardPositionDto`
- Fix 'pending' state where rank is null but user has positive Perps volume, modify card title 'Qualify for this rank' to 'Qualify for the leaderboard'

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-01 at 20 54 06" src="https://github.com/user-attachments/assets/816dc734-de29-4dee-853f-4cc10d9b9a6d" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-01 at 20 54 10" src="https://github.com/user-attachments/assets/aa5c3968-5bc7-4074-a50e-0a9420349a91" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-01 at 20 54 21" src="https://github.com/user-attachments/assets/d258a26e-2f21-4f87-8175-c0338bf4990a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rewards API mapping and broad campaign UI eligibility gating; behavior changes for users below volume threshold but no auth or payment paths.
> 
> **Overview**
> Aligns the perps trading campaign with updated leaderboard API shapes and eligibility rules end to end.
> 
> **Data layer:** Leaderboard and position types/cache now use `volume` and `eligible` instead of `notionalVolume` and `qualified`, add `minVolumeForEligibility` and `totalParticipants`, and allow `rank` to be null when the user has not met the volume threshold.
> 
> **UI behavior:** Stats summary and leaderboard stats header show only when the user has **finite, positive** `volume` (not merely a rank). Pending/qualify flows use API `minVolumeForEligibility` (with a constant fallback) for the remaining volume message. Copy is updated from “Qualify for this rank” to **“Qualify for the leaderboard”** across locales.
> 
> **Tests:** View and component tests cover zero/invalid volume, completed campaigns, and non-finite stat fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a32a0283f3e7664fe57ab8ae4dfb255973d705f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->