### PR TITLE
refactor: Added SectionDivider and aligned spacing for wallet sections

### DIFF
--- a/app/component-library/components-temp/SectionHeader/SectionHeader.test.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.test.tsx
@@ -186,9 +186,9 @@ describe('SectionHeader', () => {
   });
 
   describe('full component', () => {
-    it('renders title, endAccessory, and trailing icon together', () => {
+    it('renders title and trailing icon when onPress and endAccessory are both provided', () => {
       const onPress = jest.fn();
-      const { getByText, getByTestId } = render(
+      const { getByText, getByTestId, queryByText } = render(
         <SectionHeader
           title="Tokens"
           onPress={onPress}
@@ -198,7 +198,7 @@ describe('SectionHeader', () => {
       );
 
       expect(getByText('Tokens')).toBeOnTheScreen();
-      expect(getByText('Badge')).toBeOnTheScreen();
+      expect(queryByText('Badge')).not.toBeOnTheScreen();
       expect(getByTestId(ARROW_ICON_TEST_ID)).toBeOnTheScreen();
       expect(getByTestId(CONTAINER_TEST_ID)).toBeOnTheScreen();
     });

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -1,43 +1,25 @@
 // Third party dependencies.
 import React from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 
 // External dependencies.
 import {
-  Text,
-  Icon,
+  SectionHeader as MMDSSectionHeader,
   IconName,
   IconSize,
-  TextVariant,
-  TextColor,
   IconColor,
+  BoxJustifyContent,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // Internal dependencies.
 import { SectionHeaderProps } from './SectionHeader.types';
 
 /**
- * SectionHeader — homepage section header with optional press-to-navigate.
+ * SectionHeader — wallet and homepage section header with optional press-to-navigate.
  *
- * @version 1 - UX Team (interim component)
- *
- * This is a v1 implementation created by the UX team to unblock RC milestones
- * while the Design System team works on an official v2. Once the DS package
- * ships a canonical section-header component, this file should be removed from
- * components-temp and the DS version adopted in its place.
- *
- * @example
- * ```tsx
- * // Navigable header with arrow icon
- * <SectionHeader title="Tokens" onPress={handleViewAll} />
- *
- * // Static header with an inline accessory
- * <SectionHeader title="DeFi" endAccessory={<InfoButton />} />
- *
- * // Custom icon and container padding override
- * <SectionHeader title="NFTs" onPress={handleViewAll} endIconName={IconName.Arrow2Right} twClassName="px-6" />
- * ```
+ * Renders {@link MMDSSectionHeader} from the design system. When `onPress` is
+ * provided, the header is wrapped in a pressable container and shows a trailing
+ * chevron via `endIconName` and `endIconProps`.
  */
 const SectionHeader: React.FC<SectionHeaderProps> = ({
   title,
@@ -50,41 +32,33 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   twClassName,
   testID,
 }) => {
-  const tw = useTailwind();
+  const containerTwClassName = [
+    'px-4',
+    justifyContent === BoxJustifyContent.Between
+      ? 'justify-between'
+      : undefined,
+    twClassName,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
-  // Default horizontal padding + row layout; apply style to this same container so callers can override padding (e.g. paddingHorizontal: 0)
-  const containerTwClassName = twClassName
-    ? `px-4 flex-row items-center ${twClassName}`
-    : 'px-4 flex-row items-center';
-  const containerStyle = StyleSheet.flatten([
-    tw.style(containerTwClassName),
-    justifyContent ? tw.style(justifyContent) : undefined,
-    style,
-  ]);
-
-  const innerContent = (
-    <>
-      {typeof title === 'string' ? (
-        <Text variant={TextVariant.HeadingMd} color={TextColor.TextDefault}>
-          {title}
-        </Text>
-      ) : (
-        title
-      )}
-
-      {/* Arrow icon: visual indicator only, no touch handling */}
-      {onPress && (
-        <Icon
-          testID="section-header-arrow-icon"
-          name={endIconName}
-          size={IconSize.Md}
-          color={endIconColor}
-          style={tw.style('ml-1')}
-        />
-      )}
-
-      {endAccessory}
-    </>
+  const header = (
+    <MMDSSectionHeader
+      title={title}
+      endAccessory={endAccessory}
+      endIconName={onPress ? endIconName : undefined}
+      endIconProps={
+        onPress
+          ? {
+              testID: 'section-header-arrow-icon',
+              size: IconSize.Md,
+              color: endIconColor,
+            }
+          : undefined
+      }
+      twClassName={containerTwClassName}
+      testID={onPress ? undefined : testID}
+    />
   );
 
   if (onPress) {
@@ -92,20 +66,16 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
       <TouchableOpacity
         testID={testID}
         onPress={onPress}
-        style={containerStyle}
+        style={style}
         accessibilityRole="button"
         accessibilityLabel={typeof title === 'string' ? title : undefined}
       >
-        {innerContent}
+        {header}
       </TouchableOpacity>
     );
   }
 
-  return (
-    <View testID={testID} style={containerStyle}>
-      {innerContent}
-    </View>
-  );
+  return header;
 };
 
 export default SectionHeader;

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.types.ts
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.types.ts
@@ -12,7 +12,8 @@ import {
 /**
  * SectionHeader component props.
  *
- * @version 1 - UX Team (interim, pending Design System v2)
+ * Wraps {@link MMDSSectionHeader} from `@metamask/design-system-react-native`
+ * and adds optional press-to-navigate via `onPress`.
  */
 export interface SectionHeaderProps {
   /**

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -284,9 +284,7 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
           value={trendingAbTestContextValue}
         >
           <Box
-            gap={8}
             marginBottom={8}
-            paddingTop={6}
             testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
             accessible={false}
           >
@@ -314,9 +312,7 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
                       totalSectionsLoaded={totalSectionsLoaded}
                       mode={sectionMode}
                     />
-                    <Box gap={8}>
-                      {renderTreatmentNonPerpsSections(trendingPerpsSection)}
-                    </Box>
+                    <>{renderTreatmentNonPerpsSections(trendingPerpsSection)}</>
                   </>
                 );
                 return perpsProvidersHoisted ? (
@@ -338,9 +334,7 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
         value={trendingAbTestContextValue}
       >
         <Box
-          gap={8}
           marginBottom={8}
-          paddingTop={6}
           testID={WalletViewSelectorsIDs.HOMEPAGE_CONTAINER}
           accessible={false}
         >

--- a/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashSection.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
-import { Box } from '@metamask/design-system-react-native';
+import { Box, SectionDivider } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import SectionRow from '../../components/SectionRow';
 import { strings } from '../../../../../../locales/i18n';
@@ -94,6 +94,7 @@ const CashSection = forwardRef<SectionRefreshHandle, CashSectionProps>(
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
+        <SectionDivider />
         <Box gap={3}>
           <SectionHeader
             title={title}

--- a/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
+++ b/app/components/Views/Homepage/Sections/DeFi/DeFiSection.tsx
@@ -4,13 +4,14 @@ import React, {
   useImperativeHandle,
   useRef,
 } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../util/theme';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
+import { SectionDivider, Box } from '@metamask/design-system-react-native';
 import SectionRow from '../../components/SectionRow';
 import ErrorState from '../../components/ErrorState';
 import { SectionRefreshHandle } from '../../types';
@@ -29,10 +30,6 @@ import { useSectionPerformance } from '../../hooks/useSectionPerformance';
 import { WalletViewSelectorsIDs } from '../../../Wallet/WalletView.testIds';
 
 const MAX_POSITIONS_DISPLAYED = 5;
-
-const styles = StyleSheet.create({
-  sectionGap: { gap: 12 },
-});
 
 interface DeFiSectionProps {
   sectionIndex: number;
@@ -151,48 +148,50 @@ const DeFiSection = forwardRef<SectionRefreshHandle, DeFiSectionProps>(
     // Show retry UI on error
     if (!isLoading && hasError) {
       return (
-        <View
-          ref={sectionViewRef}
-          onLayout={onLayout}
-          style={styles.sectionGap}
-        >
-          <SectionHeader
-            title={title}
-            onPress={handleViewAllDeFi}
-            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('defi')}
-          />
-          <ErrorState
-            title={strings('homepage.error.unable_to_load', {
-              section: title.toLowerCase(),
-            })}
-            onRetry={refresh}
-          />
+        <View ref={sectionViewRef} onLayout={onLayout}>
+          <SectionDivider />
+          <Box gap={3}>
+            <SectionHeader
+              title={title}
+              onPress={handleViewAllDeFi}
+              testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('defi')}
+            />
+            <ErrorState
+              title={strings('homepage.error.unable_to_load', {
+                section: title.toLowerCase(),
+              })}
+              onRetry={refresh}
+            />
+          </Box>
         </View>
       );
     }
 
     return (
-      <View ref={sectionViewRef} onLayout={onLayout} style={styles.sectionGap}>
-        <SectionHeader
-          title={title}
-          onPress={handleViewAllDeFi}
-          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('defi')}
-        />
-        <SectionRow>
-          {isLoading ? (
-            <DeFiPositionsSkeleton />
-          ) : (
-            positions.map((position: DeFiPositionEntry) => (
-              <DeFiPositionsListItem
-                key={`${position.chainId}-${position.protocolAggregate.protocolDetails.name}`}
-                chainId={position.chainId}
-                protocolId={position.protocolId}
-                protocolAggregate={position.protocolAggregate}
-                privacyMode={privacyMode}
-              />
-            ))
-          )}
-        </SectionRow>
+      <View ref={sectionViewRef} onLayout={onLayout}>
+        <SectionDivider />
+        <Box gap={3}>
+          <SectionHeader
+            title={title}
+            onPress={handleViewAllDeFi}
+            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('defi')}
+          />
+          <SectionRow>
+            {isLoading ? (
+              <DeFiPositionsSkeleton />
+            ) : (
+              positions.map((position: DeFiPositionEntry) => (
+                <DeFiPositionsListItem
+                  key={`${position.chainId}-${position.protocolAggregate.protocolDetails.name}`}
+                  chainId={position.chainId}
+                  protocolId={position.protocolId}
+                  protocolAggregate={position.protocolAggregate}
+                  privacyMode={privacyMode}
+                />
+              ))
+            )}
+          </SectionRow>
+        </Box>
       </View>
     );
   },

--- a/app/components/Views/Homepage/Sections/More/MoreSection.styles.ts
+++ b/app/components/Views/Homepage/Sections/More/MoreSection.styles.ts
@@ -1,7 +1,6 @@
 import { StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
-  sectionGap: { gap: 8 },
   row: {
     alignItems: 'center',
     flexDirection: 'row',

--- a/app/components/Views/Homepage/Sections/More/MoreSection.tsx
+++ b/app/components/Views/Homepage/Sections/More/MoreSection.tsx
@@ -8,6 +8,8 @@ import {
   IconColor,
   IconName,
   IconSize,
+  SectionDivider,
+  Box,
   Text,
   TextColor,
   TextVariant,
@@ -121,32 +123,34 @@ const MoreSection = () => {
   }, [createEventBuilder, navigation, trackEvent]);
 
   return (
-    <View
-      style={styles.sectionGap}
-      testID={HomepageMoreSelectorsIDs.HOMEPAGE_MORE_SECTION}
-    >
-      <SectionHeader title={strings('homepage.sections.more.title')} />
-      <SectionRow>
-        <MoreActionRow
-          label={strings('homepage.sections.more.import_token')}
-          startIconName={IconName.Add}
-          onPress={handleImportToken}
-          testID={HomepageMoreSelectorsIDs.IMPORT_TOKEN_BUTTON}
-        />
-        <MoreActionRow
-          label={strings('homepage.sections.more.import_nft')}
-          startIconName={IconName.Add}
-          onPress={handleImportNft}
-          testID={HomepageMoreSelectorsIDs.IMPORT_NFT_BUTTON}
-        />
-        <MoreActionRow
-          label={strings('homepage.sections.more.contact_support')}
-          startIconName={IconName.MessageQuestion}
-          endIconName={IconName.Export}
-          onPress={handleContactSupport}
-          testID={HomepageMoreSelectorsIDs.HOMEPAGE_MORE_CONTACT_SUPPORT_BUTTON}
-        />
-      </SectionRow>
+    <View testID={HomepageMoreSelectorsIDs.HOMEPAGE_MORE_SECTION}>
+      <SectionDivider />
+      <Box gap={3}>
+        <SectionHeader title={strings('homepage.sections.more.title')} />
+        <SectionRow>
+          <MoreActionRow
+            label={strings('homepage.sections.more.import_token')}
+            startIconName={IconName.Add}
+            onPress={handleImportToken}
+            testID={HomepageMoreSelectorsIDs.IMPORT_TOKEN_BUTTON}
+          />
+          <MoreActionRow
+            label={strings('homepage.sections.more.import_nft')}
+            startIconName={IconName.Add}
+            onPress={handleImportNft}
+            testID={HomepageMoreSelectorsIDs.IMPORT_NFT_BUTTON}
+          />
+          <MoreActionRow
+            label={strings('homepage.sections.more.contact_support')}
+            startIconName={IconName.MessageQuestion}
+            endIconName={IconName.Export}
+            onPress={handleContactSupport}
+            testID={
+              HomepageMoreSelectorsIDs.HOMEPAGE_MORE_CONTACT_SUPPORT_BUTTON
+            }
+          />
+        </SectionRow>
+      </Box>
     </View>
   );
 };

--- a/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+++ b/app/components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
@@ -8,7 +8,11 @@ import React, {
 } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
+import {
+  Box,
+  BoxFlexDirection,
+  SectionDivider,
+} from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import SectionRow from '../../components/SectionRow';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -30,7 +34,6 @@ const MAX_NFTS_DISPLAYED = 6;
 const NFTS_PER_ROW = 3;
 
 const styles = StyleSheet.create({
-  sectionGap: { gap: 12 },
   flex1: { flex: 1 },
 });
 
@@ -99,41 +102,47 @@ const NFTsSection = forwardRef<SectionRefreshHandle, NFTsSectionProps>(
     }
 
     return (
-      <View ref={sectionViewRef} onLayout={onLayout} style={styles.sectionGap}>
-        <SectionHeader
-          title={title}
-          onPress={handleViewAllNfts}
-          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('nfts')}
-        />
-        <SectionRow gap={3}>
-          {nftRows.map((row, rowIndex) => (
-            <Box
-              key={`nft-row-${rowIndex}`}
-              flexDirection={BoxFlexDirection.Row}
-              gap={3}
-            >
-              {row.map((nft) => (
-                <View
-                  key={`${nft.address}-${nft.tokenId}`}
-                  style={styles.flex1}
-                >
-                  <NftGridItem
-                    item={nft}
-                    onLongPress={handleLongPress}
-                    source="mobile-nft-list"
-                  />
-                </View>
-              ))}
-              {/* Add empty boxes to maintain grid alignment for incomplete rows */}
-              {row.length < NFTS_PER_ROW &&
-                Array.from({ length: NFTS_PER_ROW - row.length }).map(
-                  (__, i) => (
-                    <Box key={`empty-${rowIndex}-${i}`} twClassName="flex-1" />
-                  ),
-                )}
-            </Box>
-          ))}
-        </SectionRow>
+      <View ref={sectionViewRef} onLayout={onLayout}>
+        <SectionDivider />
+        <Box gap={3}>
+          <SectionHeader
+            title={title}
+            onPress={handleViewAllNfts}
+            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('nfts')}
+          />
+          <SectionRow gap={3}>
+            {nftRows.map((row, rowIndex) => (
+              <Box
+                key={`nft-row-${rowIndex}`}
+                flexDirection={BoxFlexDirection.Row}
+                gap={3}
+              >
+                {row.map((nft) => (
+                  <View
+                    key={`${nft.address}-${nft.tokenId}`}
+                    style={styles.flex1}
+                  >
+                    <NftGridItem
+                      item={nft}
+                      onLongPress={handleLongPress}
+                      source="mobile-nft-list"
+                    />
+                  </View>
+                ))}
+                {/* Add empty boxes to maintain grid alignment for incomplete rows */}
+                {row.length < NFTS_PER_ROW &&
+                  Array.from({ length: NFTS_PER_ROW - row.length }).map(
+                    (__, i) => (
+                      <Box
+                        key={`empty-${rowIndex}-${i}`}
+                        twClassName="flex-1"
+                      />
+                    ),
+                  )}
+              </Box>
+            ))}
+          </SectionRow>
+        </Box>
         <NftGridItemBottomSheet
           isVisible={longPressedNft !== null}
           onClose={() => setLongPressedNft(null)}

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { View } from 'react-native';
-import { Box } from '@metamask/design-system-react-native';
+import { Box, SectionDivider } from '@metamask/design-system-react-native';
 import { useSelector } from 'react-redux';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
@@ -336,6 +336,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     if (connectionError) {
       return (
         <View ref={sectionViewRef} onLayout={onLayout}>
+          <SectionDivider />
           <Box gap={3}>
             <SectionHeader
               title={title}
@@ -359,23 +360,22 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
+        <SectionDivider />
         <Box gap={3}>
-          <Box gap={1}>
-            <SectionHeader
-              title={title}
-              onPress={handleViewAllPerps}
-              testID={homepageSectionTitleTestId(analyticsName)}
+          <SectionHeader
+            title={title}
+            onPress={handleViewAllPerps}
+            testID={homepageSectionTitleTestId(analyticsName)}
+          />
+          {showHomepageUnrealizedPnl && (
+            <HomepageSectionUnrealizedPnlRow
+              isLoading={perpsAccountLoading}
+              valueText={homepageUnrealizedPnl?.valueText}
+              tone={homepageUnrealizedPnl?.tone ?? 'neutral'}
+              label={strings('perps.unrealized_pnl')}
+              testID="homepage-perps-unrealized-pnl"
             />
-            {showHomepageUnrealizedPnl && (
-              <HomepageSectionUnrealizedPnlRow
-                isLoading={perpsAccountLoading}
-                valueText={homepageUnrealizedPnl?.valueText}
-                tone={homepageUnrealizedPnl?.tone ?? 'neutral'}
-                label={strings('perps.unrealized_pnl')}
-                testID="homepage-perps-unrealized-pnl"
-              />
-            )}
-          </Box>
+          )}
           {showSkeleton || pendingTrending || hasItems ? (
             <SectionRow>
               {showSkeleton || pendingTrending ? (

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionTrendingOnly.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionTrendingOnly.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import { View } from 'react-native';
-import { Box } from '@metamask/design-system-react-native';
+import { Box, SectionDivider } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
 import SectionRow from '../../components/SectionRow';
 import PerpsPositionSkeleton from './components/PerpsPositionSkeleton';
@@ -75,6 +75,7 @@ const PerpsSectionTrendingOnly = forwardRef<
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
+        <SectionDivider />
         <Box gap={3}>
           <SectionHeader
             title={title}

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsTrendingCarousel.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsTrendingCarousel.tsx
@@ -30,7 +30,7 @@ const PerpsTrendingCarousel = ({
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
-      contentContainerStyle={tw.style('px-4 gap-2.5 py-3')}
+      contentContainerStyle={tw.style('px-4 gap-2.5')}
       testID="homepage-trending-perps-carousel"
     >
       {markets.map((market) => (

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictPositions.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictPositions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@metamask/design-system-react-native';
+import { Box, SectionDivider } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../../component-library/components-temp/SectionHeader';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../../../../Wallet/WalletView.testIds';
@@ -41,49 +41,56 @@ const HomepagePredictPositions = ({
   onPositionPress,
   showHeader = true,
 }: HomepagePredictPositionsProps) => (
-  <Box gap={3}>
-    {showHeader && (
-      <Box gap={1}>
-        <SectionHeader
-          title={title}
-          onPress={onViewAll}
-          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('predictions')}
-        />
-        {predictHomepageUnrealizedPnl.show && (
-          <HomepageSectionUnrealizedPnlRow
-            isLoading={predictHomepageUnrealizedPnl.isLoading}
-            valueText={predictHomepageUnrealizedPnl.valueText}
-            tone={predictHomepageUnrealizedPnl.tone}
-            label={strings('predict.unrealized_pnl_label')}
-            testID="homepage-predict-unrealized-pnl"
+  <>
+    {showHeader && <SectionDivider />}
+    <Box gap={3}>
+      {showHeader && (
+        <Box gap={1}>
+          <SectionHeader
+            title={title}
+            onPress={onViewAll}
+            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+              'predictions',
+            )}
           />
+          {predictHomepageUnrealizedPnl.show && (
+            <HomepageSectionUnrealizedPnlRow
+              isLoading={predictHomepageUnrealizedPnl.isLoading}
+              valueText={predictHomepageUnrealizedPnl.valueText}
+              tone={predictHomepageUnrealizedPnl.tone}
+              label={strings('predict.unrealized_pnl_label')}
+              testID="homepage-predict-unrealized-pnl"
+            />
+          )}
+        </Box>
+      )}
+      {isLoadingPositions ? (
+        <>
+          <PredictPositionRowSkeleton />
+          <PredictPositionRowSkeleton />
+        </>
+      ) : (
+        positions.map((position) => (
+          <PredictPositionRow
+            key={`${position.outcomeId}:${position.outcomeIndex}`}
+            position={position}
+            onPress={onPositionPress}
+            privacyMode={Boolean(privacyMode)}
+          />
+        ))
+      )}
+      {!isLoadingPositions &&
+        !isLoadingClaimable &&
+        totalClaimableValue > 0 && (
+          <Box paddingHorizontal={4} paddingTop={1} paddingBottom={3}>
+            <PredictClaimButton
+              amount={privacyMode ? undefined : totalClaimableValue}
+              onPress={onClaim}
+            />
+          </Box>
         )}
-      </Box>
-    )}
-    {isLoadingPositions ? (
-      <>
-        <PredictPositionRowSkeleton />
-        <PredictPositionRowSkeleton />
-      </>
-    ) : (
-      positions.map((position) => (
-        <PredictPositionRow
-          key={`${position.outcomeId}:${position.outcomeIndex}`}
-          position={position}
-          onPress={onPositionPress}
-          privacyMode={Boolean(privacyMode)}
-        />
-      ))
-    )}
-    {!isLoadingPositions && !isLoadingClaimable && totalClaimableValue > 0 && (
-      <Box paddingHorizontal={4} paddingTop={1} paddingBottom={3}>
-        <PredictClaimButton
-          amount={privacyMode ? undefined : totalClaimableValue}
-          onPress={onClaim}
-        />
-      </Box>
-    )}
-  </Box>
+    </Box>
+  </>
 );
 
 export default HomepagePredictPositions;

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingCarousel.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingCarousel.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { ScrollView } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box } from '@metamask/design-system-react-native';
+import { Box, SectionDivider } from '@metamask/design-system-react-native';
 import SectionHeader from '../../../../../../component-library/components-temp/SectionHeader';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../../../../Wallet/WalletView.testIds';
@@ -44,38 +44,43 @@ const HomepagePredictTrendingCarousel = ({
   }, [onViewAll, transactionActiveAbTests]);
 
   return (
-    <Box gap={3}>
-      <SectionHeader
-        title={title}
-        onPress={handleViewAll}
-        testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(headerTestIdKey)}
-      />
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={tw.style('px-4 gap-3 py-3')}
-      >
-        {isLoadingMarkets ? (
-          CAROUSEL_SKELETON_KEYS.map((key) => (
-            <PredictMarketCardSkeleton key={key} />
-          ))
-        ) : (
-          <>
-            {markets.map((market) => (
-              <PredictMarketCard
-                key={market.id}
-                market={market}
-                transactionActiveAbTests={transactionActiveAbTests}
+    <>
+      <SectionDivider />
+      <Box gap={3}>
+        <SectionHeader
+          title={title}
+          onPress={handleViewAll}
+          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+            headerTestIdKey,
+          )}
+        />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={tw.style('px-4 gap-3')}
+        >
+          {isLoadingMarkets ? (
+            CAROUSEL_SKELETON_KEYS.map((key) => (
+              <PredictMarketCardSkeleton key={key} />
+            ))
+          ) : (
+            <>
+              {markets.map((market) => (
+                <PredictMarketCard
+                  key={market.id}
+                  market={market}
+                  transactionActiveAbTests={transactionActiveAbTests}
+                />
+              ))}
+              <ViewMoreCard
+                onPress={handleViewAll}
+                twClassName="w-[180px] flex-1"
               />
-            ))}
-            <ViewMoreCard
-              onPress={handleViewAll}
-              twClassName="w-[180px] flex-1"
-            />
-          </>
-        )}
-      </ScrollView>
-    </Box>
+            </>
+          )}
+        </ScrollView>
+      </Box>
+    </>
   );
 };
 

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import { Box } from '@metamask/design-system-react-native';
+import { Box, SectionDivider } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
@@ -236,38 +236,43 @@ const HomepagePredictWorldCupDiscovery: React.FC<
   }, [championshipCtaCategoryName, onTreatmentCtaClick]);
 
   return (
-    <Box>
-      <SectionHeader
-        title={title}
-        onPress={handleViewAll}
-        testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(headerTestIdKey)}
-      />
-      <PredictEntryPointProvider
-        entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
-      >
-        <Box twClassName="px-4 mt-3">
-          <BtcLiveRow
-            onPress={handleBtcRow}
-            btcSpotUsd={btcSpotUsd}
-            priceToBeat={priceToBeat}
-            countdown={btcCountdown}
-          />
-          <ChampionshipRow
-            state={championshipRow}
-            onPress={handleChampionshipRowPress}
-            transactionActiveAbTests={transactionActiveAbTests}
-          />
-          <MensWorldCupRow
-            onPress={handleMensRow}
-            eventCountLabel={eventCountLabel}
-          />
-        </Box>
-        <BracketPills
-          onPropsPress={handlePropsPill}
-          onStagePress={goToWorldCup}
+    <>
+      <SectionDivider />
+      <Box gap={3}>
+        <SectionHeader
+          title={title}
+          onPress={handleViewAll}
+          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE(
+            headerTestIdKey,
+          )}
         />
-      </PredictEntryPointProvider>
-    </Box>
+        <PredictEntryPointProvider
+          entryPoint={PredictEventValues.ENTRY_POINT.HOME_SECTION}
+        >
+          <Box twClassName="px-4">
+            <BtcLiveRow
+              onPress={handleBtcRow}
+              btcSpotUsd={btcSpotUsd}
+              priceToBeat={priceToBeat}
+              countdown={btcCountdown}
+            />
+            <ChampionshipRow
+              state={championshipRow}
+              onPress={handleChampionshipRowPress}
+              transactionActiveAbTests={transactionActiveAbTests}
+            />
+            <MensWorldCupRow
+              onPress={handleMensRow}
+              eventCountLabel={eventCountLabel}
+            />
+          </Box>
+          <BracketPills
+            onPropsPress={handlePropsPill}
+            onStagePress={goToWorldCup}
+          />
+        </PredictEntryPointProvider>
+      </Box>
+    </>
   );
 };
 

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx
@@ -7,10 +7,11 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
+import { SectionDivider, Box } from '@metamask/design-system-react-native';
 import ErrorState from '../../components/ErrorState';
 import Routes from '../../../../../constants/navigation/Routes';
 import SectionRow from '../../components/SectionRow';
@@ -63,10 +64,6 @@ interface TokensSectionProps {
 }
 
 const MAX_TOKENS_DISPLAYED = 5;
-
-const styles = StyleSheet.create({
-  sectionGap: { gap: 12 },
-});
 
 /**
  * TokensSection - Displays user's token balances on the homepage
@@ -243,7 +240,8 @@ const TokensSectionMain = forwardRef<SectionRefreshHandle, TokensSectionProps>(
 
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
-        <View style={styles.sectionGap}>
+        <SectionDivider />
+        <Box gap={3}>
           <SectionHeader
             title={title}
             onPress={handleViewAllTokens}
@@ -282,7 +280,7 @@ const TokensSectionMain = forwardRef<SectionRefreshHandle, TokensSectionProps>(
               )}
             </SectionRow>
           )}
-        </View>
+        </Box>
         <ScamWarningModal
           showScamWarningModal={showScamWarningModal}
           setShowScamWarningModal={setShowScamWarningModal}
@@ -359,27 +357,30 @@ const TokensSectionTrendingOnly = forwardRef<
     }
 
     return (
-      <View ref={sectionViewRef} onLayout={onLayout} style={styles.sectionGap}>
-        <SectionHeader
-          title={title}
-          onPress={handleViewAllTokens}
-          testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('tokens')}
-        />
-        <SectionRow>
-          {isTrendingLoading
-            ? Array.from({ length: 3 }, (_, i) => (
-                <TrendingTokensSkeleton key={`skeleton-${i}`} />
-              ))
-            : trendingTokensToDisplay.map((token, index) => (
-                <TrendingTokenRowItem
-                  key={token.assetId}
-                  token={token}
-                  position={index}
-                  tokenDetailsSource={TokenDetailsSource.HomepageTrending}
-                  transactionActiveAbTests={trendingTransactionActiveAbTests}
-                />
-              ))}
-        </SectionRow>
+      <View ref={sectionViewRef} onLayout={onLayout}>
+        <SectionDivider />
+        <Box gap={3}>
+          <SectionHeader
+            title={title}
+            onPress={handleViewAllTokens}
+            testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('tokens')}
+          />
+          <SectionRow>
+            {isTrendingLoading
+              ? Array.from({ length: 3 }, (_, i) => (
+                  <TrendingTokensSkeleton key={`skeleton-${i}`} />
+                ))
+              : trendingTokensToDisplay.map((token, index) => (
+                  <TrendingTokenRowItem
+                    key={token.assetId}
+                    token={token}
+                    position={index}
+                    tokenDetailsSource={TokenDetailsSource.HomepageTrending}
+                    transactionActiveAbTests={trendingTransactionActiveAbTests}
+                  />
+                ))}
+          </SectionRow>
+        </Box>
       </View>
     );
   },

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -13,6 +13,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import SectionHeader from '../../../../../component-library/components-temp/SectionHeader';
+import { SectionDivider } from '@metamask/design-system-react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 import type { RootStackParamList } from '../../../../../core/NavigationService/types';
 import { selectSocialLeaderboardEnabled } from '../../../../../selectors/featureFlagController/socialLeaderboard';
@@ -150,6 +151,7 @@ const TopTradersSection = forwardRef<
         onLayout={onLayout}
         testID="homepage-top-traders-section-root"
       >
+        <SectionDivider />
         <Box gap={3}>
           <SectionHeader
             title={title}
@@ -175,6 +177,7 @@ const TopTradersSection = forwardRef<
       onLayout={onLayout}
       testID="homepage-top-traders-section-root"
     >
+      <SectionDivider />
       <Box gap={3}>
         <SectionHeader
           title={title}
@@ -185,7 +188,7 @@ const TopTradersSection = forwardRef<
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('px-4 gap-3 py-3')}
+          contentContainerStyle={tw.style('px-4 gap-3')}
           testID="homepage-top-traders-carousel"
         >
           {showSkeletons

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.styles.ts
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.styles.ts
@@ -18,6 +18,9 @@ const styleSheet = (_params: { theme: Theme }) =>
     },
     portfolioScrollContent: {
       paddingTop: 14,
+    },
+    portfolioHeaderCluster: {
+      flexDirection: 'column',
       gap: 16,
     },
   });

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -362,7 +362,9 @@ const HomepageDiscoveryTabs = forwardRef<
                     refreshControl={refreshControl}
                     contentContainerStyle={styles.portfolioScrollContent}
                   >
-                    {portfolioHeader}
+                    <View style={styles.portfolioHeaderCluster}>
+                      {portfolioHeader}
+                    </View>
                     <Homepage ref={homepageRef} perpsProvidersHoisted />
                   </Reanimated.ScrollView>
                 </DiscoveryTabView>

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -223,8 +223,11 @@ const createStyles = ({ colors }: Theme) =>
     wrapper: {
       flex: 1,
       backgroundColor: colors.background.default,
-      gap: 16,
       flexDirection: 'column',
+    },
+    portfolioHeaderCluster: {
+      flexDirection: 'column',
+      gap: 16,
     },
     tabContainer: {
       flex: 1,
@@ -1378,17 +1381,17 @@ const Wallet = ({
   ) : null;
 
   const portfolioHeaderBase = (
-    <>
+    <View style={styles.portfolioHeaderCluster}>
       {bannerContent}
       <AccountGroupBalance {...walletHomeAccountGroupBalanceProps} />
       {walletHomeMainAssetDetailsActions}
       {homeGrowthBannerContent}
       {isMoneyAccountEnabled && <MoneyBalanceCard />}
-    </>
+    </View>
   );
 
   const portfolioHeader = (
-    <>
+    <View style={styles.portfolioHeaderCluster}>
       {bannerContent}
       <View style={styles.accountGroupBalanceContainer}>
         <AccountGroupBalance {...walletHomeAccountGroupBalanceProps} />
@@ -1396,7 +1399,7 @@ const Wallet = ({
       {walletHomeMainAssetDetailsActions}
       {homeGrowthBannerContent}
       {isMoneyAccountEnabled && <MoneyBalanceCard />}
-    </>
+    </View>
   );
 
   // Legacy scroll view content — used only when the sections redesign is off.


### PR DESCRIPTION
## **Description**

This PR updates the wallet homepage section layout to match the new design system patterns.

**Why:** Section headers were inconsistent — spacing above/below headers varied across sections, and the interim `SectionHeader` duplicated what MMDS already provides.

**What changed:**

1. **Migrated `SectionHeader` to MMDS** — The temp component now wraps `@metamask/design-system-react-native`'s `SectionHeader`. Press-to-navigate still uses `TouchableOpacity` with `endIconName` / `endIconProps` for the chevron.

2. **Added `SectionDivider` above every homepage section** — Perpetuals, Predictions, Top Traders, DeFi, NFTs, Tokens, Cash, More, etc. each render `<SectionDivider />` directly above the section header.

3. **Standardized section spacing**
   - **Divider → header:** `SectionDivider` sits *outside* any `Box gap={3}` container so flex gap doesn't add extra space between the divider and header.
   - **Header → content:** Header and content are wrapped in `Box gap={3}` (12px), matching Perpetuals.
   - **Carousels:** Removed redundant `py-3` from Top Traders and Predictions carousel scroll content so header-to-content spacing isn't doubled.

4. **Removed extra gap above the first section** — Moved `gap: 16` from the wallet scroll wrapper onto a `portfolioHeaderCluster` wrapper so spacing applies only between balance/banner elements, not between the money card and the first section.

5. **Removed homepage container spacing** — Dropped `gap={8}` and `paddingTop={6}` from the homepage `Box` container.

## **Changelog**

CHANGELOG entry: Updated wallet homepage section layout with dividers between sections and consistent spacing above section headers and content.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-769

## **Manual testing steps**

```gherkin
Feature: Wallet homepage section layout

  Scenario: First section appears directly below portfolio header
    Given the user is on the wallet home tab with the sections redesign enabled
    And the user has a money balance card visible

    When the user scrolls to the first homepage section
    Then there is no extra gap between the money balance card and the section divider
    And the section divider sits flush above the section header

  Scenario: Consistent spacing between divider, header, and content
    Given the user is on the wallet home tab with multiple sections visible
      | Perpetuals |
      | Predictions |
      | Top Traders |
      | DeFi |
      | NFTs |
      | More |

    When the user views each section
    Then a horizontal divider appears above each section header
    And there is no extra gap between the divider and the section header
    And there is 12px spacing between the section header and its content

  Scenario: Navigable section headers still work
    Given the user is on the wallet home tab

    When the user taps a section header with a chevron (e.g. Perpetuals, Predictions, Tokens)
    Then the user is navigated to the corresponding full view

  Scenario: Section header with end accessory (More section)
    Given the user scrolls to the More section

    When the section renders
    Then the More header displays without a chevron
    And import token, import NFT, and contact support actions render below the header with correct spacing
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/0e4ffec3-b1c3-4714-b2d2-e77b717d8506

### **After**

https://github.com/user-attachments/assets/05fc0d1b-480a-4cbb-8690-21af3e29010a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/layout refactor on wallet home and a temp header wrapper; no auth, payments, or data-layer changes. Review pressable headers and divider spacing on device.
> 
> **Overview**
> Aligns the wallet homepage with design-system section patterns: **`SectionHeader`** now delegates to MMDS `SectionHeader`, still wrapping **`onPress`** in `TouchableOpacity` and driving the chevron via `endIconName` / `endIconProps`.
> 
> **`SectionDivider`** is added above each homepage section (Cash, Tokens, Perps, Predictions, Top Traders, DeFi, NFTs, More, etc.), placed *outside* `Box gap={3}` so flex gap does not sit between the divider and the title. Header and body share **`Box gap={3}`** (~12px). Horizontal carousels drop extra **`py-3`** on scroll content to avoid doubled header-to-content spacing.
> 
> **`Homepage`** drops container `gap` and top padding; **`Wallet`** / discovery tabs move **`gap: 16`** from the scroll wrapper into **`portfolioHeaderCluster`** so spacing stays between balance/banner/actions, not between the money card and the first section.
> 
> Tests note that when **`onPress`** and **`endAccessory`** are both set, the accessory may not render (MMDS/chevron layout); production sections mostly use either navigable headers or static “More” without that combo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18288fa8120121d0fc60852b8cdb06b8489c9ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->