### PR TITLE
feat(rewards): send wallet address with benefit impression

### DIFF
--- a/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../../../util/test/analyticsMock';
 import { SubscriptionBenefitDto } from '../../../../core/Engine/controllers/rewards-controller/types.ts';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
@@ -39,7 +38,7 @@ const mockBenefit: SubscriptionBenefitDto = {
   thumbnail: 'https://example.com/thumb.png',
   validFrom: '2026-01-01T00:00:00Z',
   validTo: '2026-12-31T23:59:59Z',
-  url: 'https://benefits.example.com/claim',
+  url: 'https://benefits.example.com/claim?wallet=0x1111111111111111111111111111111111111111',
   actionDate: '2026-12-30T00:00:00Z',
   companyName: 'Pudgy Penguins',
   chain: 'ethereum',
@@ -120,19 +119,14 @@ const MOCK_WALLET_ADDRESS = '0x1111111111111111111111111111111111111111';
 
 describe('BenefitFullView', () => {
   let mockSubscriptionId: string | null;
-  let mockSelectedAccount: { address: string } | undefined;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteBenefit = mockBenefit;
     mockSubscriptionId = 'subscription-123';
-    mockSelectedAccount = { address: MOCK_WALLET_ADDRESS };
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === selectRewardsSubscriptionId) {
         return mockSubscriptionId;
-      }
-      if (selector === selectSelectedInternalAccount) {
-        return mockSelectedAccount;
       }
       return undefined;
     });
@@ -175,7 +169,7 @@ describe('BenefitFullView', () => {
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
-  it('posts benefit impression on mount with the selected wallet address when subscription exists', async () => {
+  it('posts benefit impression on mount with the wallet address from the benefit click URL', async () => {
     render(<BenefitFullView />);
 
     await waitFor(() => {
@@ -189,8 +183,31 @@ describe('BenefitFullView', () => {
     });
   });
 
-  it('posts benefit impression with an undefined wallet address when no account is selected', async () => {
-    mockSelectedAccount = undefined;
+  it('posts the wallet from the click URL even when it is not the first account in the wallet list', async () => {
+    const otherWallet = '0x2222222222222222222222222222222222222222';
+    mockRouteBenefit = {
+      ...mockBenefit,
+      url: `https://benefits.example.com/claim?wallet=${otherWallet}&ref=abc`,
+    };
+
+    render(<BenefitFullView />);
+
+    await waitFor(() => {
+      expect(mockPostBenefitImpression).toHaveBeenCalledWith(
+        'RewardsController:postBenefitImpression',
+        'subscription-123',
+        mockBenefit.id,
+        mockBenefit.type.id,
+        otherWallet,
+      );
+    });
+  });
+
+  it('posts benefit impression with an undefined wallet address when the URL has no wallet param', async () => {
+    mockRouteBenefit = {
+      ...mockBenefit,
+      url: 'https://benefits.example.com/claim',
+    };
 
     render(<BenefitFullView />);
 
@@ -203,6 +220,42 @@ describe('BenefitFullView', () => {
         undefined,
       );
     });
+  });
+
+  it('posts benefit impression with an undefined wallet address when the benefit has no URL', async () => {
+    mockRouteBenefit = { ...mockBenefit, url: '' };
+
+    render(<BenefitFullView />);
+
+    await waitFor(() => {
+      expect(mockPostBenefitImpression).toHaveBeenCalledWith(
+        'RewardsController:postBenefitImpression',
+        'subscription-123',
+        mockBenefit.id,
+        mockBenefit.type.id,
+        undefined,
+      );
+    });
+  });
+
+  it('posts exactly one benefit impression when the subscription hydrates after mount', async () => {
+    mockSubscriptionId = null;
+    const { rerender } = render(<BenefitFullView />);
+    expect(mockPostBenefitImpression).not.toHaveBeenCalled();
+
+    mockSubscriptionId = 'subscription-123';
+    rerender(<BenefitFullView />);
+
+    await waitFor(() => {
+      expect(mockPostBenefitImpression).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPostBenefitImpression).toHaveBeenCalledWith(
+      'RewardsController:postBenefitImpression',
+      'subscription-123',
+      mockBenefit.id,
+      mockBenefit.type.id,
+      MOCK_WALLET_ADDRESS,
+    );
   });
 
   it('does not post benefit impression when subscription is missing', async () => {

--- a/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
@@ -11,6 +11,8 @@ import {
   createMockUseAnalyticsHook,
 } from '../../../../util/test/analyticsMock';
 import { SubscriptionBenefitDto } from '../../../../core/Engine/controllers/rewards-controller/types.ts';
+import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
@@ -114,11 +116,26 @@ jest.mock('../../../../util/Logger', () => ({
   },
 }));
 
+const MOCK_WALLET_ADDRESS = '0x1111111111111111111111111111111111111111';
+
 describe('BenefitFullView', () => {
+  let mockSubscriptionId: string | null;
+  let mockSelectedAccount: { address: string } | undefined;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteBenefit = mockBenefit;
-    mockUseSelector.mockReturnValue('subscription-123');
+    mockSubscriptionId = 'subscription-123';
+    mockSelectedAccount = { address: MOCK_WALLET_ADDRESS };
+    mockUseSelector.mockImplementation((selector: unknown) => {
+      if (selector === selectRewardsSubscriptionId) {
+        return mockSubscriptionId;
+      }
+      if (selector === selectSelectedInternalAccount) {
+        return mockSelectedAccount;
+      }
+      return undefined;
+    });
     mockFormatDateRemaining.mockReturnValue('1mo 3d');
     jest.mocked(useAnalytics).mockReturnValue(
       createMockUseAnalyticsHook({
@@ -158,7 +175,7 @@ describe('BenefitFullView', () => {
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
-  it('posts benefit impression on mount when subscription exists', async () => {
+  it('posts benefit impression on mount with the selected wallet address when subscription exists', async () => {
     render(<BenefitFullView />);
 
     await waitFor(() => {
@@ -167,12 +184,29 @@ describe('BenefitFullView', () => {
         'subscription-123',
         mockBenefit.id,
         mockBenefit.type.id,
+        MOCK_WALLET_ADDRESS,
+      );
+    });
+  });
+
+  it('posts benefit impression with an undefined wallet address when no account is selected', async () => {
+    mockSelectedAccount = undefined;
+
+    render(<BenefitFullView />);
+
+    await waitFor(() => {
+      expect(mockPostBenefitImpression).toHaveBeenCalledWith(
+        'RewardsController:postBenefitImpression',
+        'subscription-123',
+        mockBenefit.id,
+        mockBenefit.type.id,
+        undefined,
       );
     });
   });
 
   it('does not post benefit impression when subscription is missing', async () => {
-    mockUseSelector.mockReturnValue(null);
+    mockSubscriptionId = null;
 
     render(<BenefitFullView />);
 

--- a/app/components/UI/Rewards/Views/BenefitFullView.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.tsx
@@ -28,13 +28,24 @@ import { strings } from '../../../../../locales/i18n';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import Routes from '../../../../constants/navigation/Routes.ts';
 import { useSelector } from 'react-redux';
+import URLParse from 'url-parse';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import Engine from '../../../../core/Engine';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 const BENEFIT_CLAIM_BUTTON_TYPE = 'claim';
+const BENEFIT_URL_WALLET_PARAM = 'wallet';
+
+const getBenefitWalletAddress = (url: string): string | undefined => {
+  if (!url) return undefined;
+  try {
+    const { query } = new URLParse(url, true);
+    return query[BENEFIT_URL_WALLET_PARAM] || undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const BenefitFullView = () => {
   const tw = useTailwind();
@@ -42,8 +53,12 @@ const BenefitFullView = () => {
   const route = useRoute<BenefitFullViewRouteProp>();
   const { benefit } = route.params;
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
-  const selectedAccount = useSelector(selectSelectedInternalAccount);
   const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const walletAddress = useMemo(
+    () => getBenefitWalletAddress(benefit.url),
+    [benefit.url],
+  );
 
   useEffect(() => {
     trackEvent(
@@ -65,10 +80,10 @@ const BenefitFullView = () => {
         subscriptionId,
         benefit.id,
         benefit.type.id,
-        selectedAccount?.address,
+        walletAddress,
       )
       .catch();
-  }, [benefit, subscriptionId, selectedAccount?.address]);
+  }, [benefit, subscriptionId, walletAddress]);
 
   const handleClaim = () => {
     trackEvent(

--- a/app/components/UI/Rewards/Views/BenefitFullView.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.tsx
@@ -29,6 +29,7 @@ import ErrorBoundary from '../../../Views/ErrorBoundary';
 import Routes from '../../../../constants/navigation/Routes.ts';
 import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import Engine from '../../../../core/Engine';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -41,6 +42,7 @@ const BenefitFullView = () => {
   const route = useRoute<BenefitFullViewRouteProp>();
   const { benefit } = route.params;
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const selectedAccount = useSelector(selectSelectedInternalAccount);
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   useEffect(() => {
@@ -63,9 +65,10 @@ const BenefitFullView = () => {
         subscriptionId,
         benefit.id,
         benefit.type.id,
+        selectedAccount?.address,
       )
       .catch();
-  }, [benefit, subscriptionId]);
+  }, [benefit, subscriptionId, selectedAccount?.address]);
 
   const handleClaim = () => {
     trackEvent(

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -715,6 +715,7 @@ export type RewardsControllerGetVipRefereeDashboardAction = {
  * @param subscriptionId - The subscription ID for authentication
  * @param benefitId - The specific benefit ID that was impressed
  * @param benefitType - The type of the benefit that was impressed
+ * @param walletAddress - The wallet address that viewed the benefit (optional)
  * @returns Promise<SubscriptionBenefitsState> - The benefits data
  */
 export type RewardsControllerPostBenefitImpressionAction = {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7766,6 +7766,27 @@ describe('RewardsController', () => {
         mockSubscriptionId,
         mockBenefitId,
         mockBenefitType,
+        undefined,
+      );
+    });
+
+    it('forwards the wallet address to RewardsDataService when provided', async () => {
+      mockMessenger.call.mockResolvedValue(undefined);
+      const mockWalletAddress = '0xabc';
+
+      await controller.postBenefitImpression(
+        mockSubscriptionId,
+        mockBenefitId,
+        mockBenefitType,
+        mockWalletAddress,
+      );
+
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:postBenefitImpression',
+        mockSubscriptionId,
+        mockBenefitId,
+        mockBenefitType,
+        mockWalletAddress,
       );
     });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -4707,12 +4707,14 @@ export class RewardsController extends BaseController<
    * @param subscriptionId - The subscription ID for authentication
    * @param benefitId - The specific benefit ID that was impressed
    * @param benefitType - The type of the benefit that was impressed
+   * @param walletAddress - The wallet address that viewed the benefit (optional)
    * @returns Promise<SubscriptionBenefitsState> - The benefits data
    */
   async postBenefitImpression(
     subscriptionId: string,
     benefitId: number,
     benefitType: number,
+    walletAddress?: string,
   ): Promise<void> {
     try {
       Logger.log(
@@ -4726,6 +4728,7 @@ export class RewardsController extends BaseController<
             subscriptionId,
             benefitId,
             benefitType,
+            walletAddress,
           ),
         subscriptionId,
       );

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -4684,6 +4684,41 @@ describe('RewardsDataService', () => {
       );
     });
 
+    it('includes the wallet address in the payload when provided', async () => {
+      const mockWalletAddress = '0xabc';
+
+      await service.postBenefitImpression(
+        mockSubscriptionId,
+        mockBenefitId,
+        mockBenefitType,
+        mockWalletAddress,
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://uat.rewards.test/benefits/impression',
+        expect.objectContaining({
+          body: JSON.stringify({
+            benefitId: mockBenefitId,
+            benefitType: mockBenefitType,
+            walletAddress: mockWalletAddress,
+          }),
+        }),
+      );
+    });
+
+    it('omits the wallet address from the payload when not provided', async () => {
+      await service.postBenefitImpression(
+        mockSubscriptionId,
+        mockBenefitId,
+        mockBenefitType,
+      );
+
+      const requestBody = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(requestBody).not.toHaveProperty('walletAddress');
+    });
+
     it('throws when post benefit impression response is not ok', async () => {
       mockFetch.mockResolvedValue({
         ok: false,

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -1662,12 +1662,14 @@ export class RewardsDataService {
    * @param subscriptionId - The subscription ID for authentication.
    * @param benefitId - The benefit ID to record impression for.
    * @param benefitType - The benefit type to record impression for.
+   * @param walletAddress - The wallet address that viewed the benefit. Optional; omitted from the body when not provided.
    * @returns Promise that resolves when the impression is recorded successfully.
    */
   async postBenefitImpression(
     subscriptionId: string,
     benefitId: number,
     benefitType: number,
+    walletAddress?: string,
   ): Promise<void> {
     const response = await this.makeRequest(
       `/benefits/impression`,
@@ -1676,6 +1678,7 @@ export class RewardsDataService {
         body: JSON.stringify({
           benefitId,
           benefitType,
+          ...(walletAddress ? { walletAddress } : {}),
         }),
       },
       subscriptionId,


### PR DESCRIPTION
## **Description**

Benefit-impression events sent to the rewards backend identified *which* benefit was viewed but not *which wallet* viewed it, so there was no per-wallet visibility into benefit engagement.

This adds the currently selected account's address to the `POST /benefits/impression` request body. The address is threaded through `RewardsController.postBenefitImpression` and the rewards data service, and is omitted from the body when no account is selected so existing behaviour is preserved. The rewards backend then attributes the impression to that wallet.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Benefit impression wallet attribution

  Scenario: user opens a benefit detail with an account selected
    Given the user is signed in to rewards with a selected account
    When the user opens a benefit's full view
    Then a POST /benefits/impression request is sent
    And the request body includes the selected account's walletAddress

  Scenario: no account is selected
    Given the user has no selected internal account
    When the user opens a benefit's full view
    Then a POST /benefits/impression request is sent
    And the request body omits walletAddress
```

## **Screenshots/Recordings**

<!-- Non-UI change: no visual difference. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional analytics field on an existing rewards API call; no auth or payment logic changes, with broad test coverage.
> 
> **Overview**
> Benefit detail views now attribute **benefit impressions** to a wallet by sending an optional `walletAddress` on `POST /benefits/impression`.
> 
> `BenefitFullView` parses the **`wallet` query parameter** from the benefit’s claim/click URL (`url-parse`) and passes that value into `RewardsController:postBenefitImpression`. If the URL is missing, empty, or has no `wallet` param, the impression is still posted with **`walletAddress` omitted** (same as before).
> 
> The optional argument is threaded through **`RewardsController.postBenefitImpression`** and **`RewardsDataService.postBenefitImpression`**, which only adds `walletAddress` to the JSON body when it is defined. Tests cover URL parsing, omitted wallet, subscription hydration (single impression), and controller/service forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e570ffc6db5d3fa5bfd82c2a9553ef0d3f2113c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->