### PR TITLE
feat: [MUSD-862] implement send txn bottom sheet

### DIFF
--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.styles.ts
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    container: {
+      paddingInline: 16,
+    },
+    hero: {
+      marginVertical: 12,
+    },
+    button: {
+      marginTop: 24,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.test.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import {
+  type TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+  CHAIN_IDS,
+} from '@metamask/transaction-controller';
+import { merge } from 'lodash';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { fireEvent } from '@testing-library/react-native';
+import { useTransactionDetails } from '../../../../Views/confirmations/hooks/activity/useTransactionDetails';
+import { otherControllersMock } from '../../../../Views/confirmations/__mocks__/controllers/other-controllers-mock';
+import { MUSD_TOKEN_ADDRESS } from '../../../Earn/constants/musd';
+import { MoneySentDetails } from './MoneySentDetails';
+
+const mockNavigate = jest.fn();
+
+jest.mock(
+  '../../../../Views/confirmations/hooks/activity/useTransactionDetails',
+);
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
+}));
+jest.mock(
+  '../../../../Views/confirmations/components/activity/transaction-details-status',
+  () => {
+    const { Text } = jest.requireActual('react-native');
+    return {
+      TransactionDetailsStatus: () => (
+        <Text testID="status-mock">Confirmed</Text>
+      ),
+    };
+  },
+);
+jest.mock(
+  '../../../../Views/confirmations/components/activity/transaction-details-date-row',
+  () => ({ TransactionDetailsDateRow: jest.fn(() => null) }),
+);
+jest.mock('../../../Name/Name', () => {
+  const { Text } = jest.requireActual('react-native');
+  // eslint-disable-next-line react/display-name
+  return ({ value }: { value: string }) => (
+    <Text testID="name-mock">{value}</Text>
+  );
+});
+jest.mock('../../../../Views/confirmations/components/token-icon', () => ({
+  TokenIcon: () => null,
+  TokenIconVariant: { Row: 'row', Hero: 'hero', Default: 'default' },
+}));
+jest.mock('../../../../Views/confirmations/hooks/useNetworkInfo', () => ({
+  __esModule: true,
+  default: () => ({ networkName: 'Ethereum', networkImage: 1 }),
+}));
+jest.mock('../../../../hooks/DisplayName/useAccountNames', () => ({
+  useAccountNames: () => ['Defi account'],
+}));
+// The fee/paid-with rows are the shared confirmation components, exercised by
+// their own tests. Here we only assert MoneySentDetails renders them.
+jest.mock(
+  '../../../../Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row',
+  () => {
+    const { Text } = jest.requireActual('react-native');
+    return {
+      TransactionDetailsNetworkFeeRow: () => (
+        <Text testID="network-fee-row">network-fee</Text>
+      ),
+    };
+  },
+);
+jest.mock(
+  '../../../../Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row',
+  () => {
+    const { Text } = jest.requireActual('react-native');
+    return {
+      TransactionDetailsBridgeFeeRow: () => (
+        <Text testID="bridge-fee-row">bridge-fee</Text>
+      ),
+    };
+  },
+);
+jest.mock(
+  '../../../../Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row',
+  () => {
+    const { Text } = jest.requireActual('react-native');
+    return {
+      TransactionDetailsPaidWithRow: () => (
+        <Text testID="paid-with-row">paid-with</Text>
+      ),
+    };
+  },
+);
+jest.mock(
+  '../../../../Views/confirmations/hooks/pay/usePayFiatFormatter',
+  () => ({
+    usePayFiatFormatter: () => (value: { toFixed: (n: number) => string }) =>
+      `$${value.toFixed(2)}`,
+  }),
+);
+
+const FROM_MOCK = '0x1111111111111111111111111111111111111111';
+const RECIPIENT_MOCK = '0x2222222222222222222222222222222222222222';
+const DAI_MOCK = '0x3333333333333333333333333333333333333333';
+const TELLER_MOCK = '0x4444444444444444444444444444444444444444';
+
+/**
+ * Encodes real ERC-20 `transfer(recipient, amount)` calldata so the decoders
+ * (`getTokenTransferData` → `parseStandardTokenTransactionData`) run for real.
+ */
+function encodeTransfer(to: string, minimalUnitAmount: string): string {
+  const toSlot = to.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+  const amountSlot = BigInt(minimalUnitAmount).toString(16).padStart(64, '0');
+  return `0xa9059cbb${toSlot}${amountSlot}`;
+}
+
+// Production shape: a withdrawal is an EIP-7702 `batch` whose mUSD transfer
+// lives in `nestedTransactions` (index 1, after the teller withdraw call) with
+// no top-level `transferInformation` — so the amount/recipient are decoded from
+// the nested transfer calldata, exactly as at runtime.
+const baseTransactionMeta = {
+  id: 'tx-1',
+  chainId: CHAIN_IDS.MONAD,
+  status: TransactionStatus.confirmed,
+  time: Date.UTC(2026, 4, 21, 14, 16),
+  hash: '0xhash',
+  type: TransactionType.batch,
+  txParams: {
+    from: FROM_MOCK,
+  },
+  nestedTransactions: [
+    // Teller withdraw call — not an ERC-20 transfer, ignored by the decoders.
+    {
+      type: TransactionType.moneyAccountWithdraw,
+      to: TELLER_MOCK,
+      data: '0xabcdef01',
+    },
+    // mUSD ERC-20 transfer to the recipient.
+    {
+      type: TransactionType.tokenMethodTransfer,
+      to: MUSD_TOKEN_ADDRESS,
+      data: encodeTransfer(RECIPIENT_MOCK, '33930000'),
+    },
+  ],
+  metamaskPay: {
+    tokenAddress: DAI_MOCK,
+    chainId: CHAIN_IDS.MONAD,
+    networkFeeFiat: '1.23',
+    bridgeFeeFiat: '0.05',
+    totalFiat: '34.54',
+  },
+} as unknown as TransactionMeta;
+
+function render(overrides: Partial<TransactionMeta> = {}) {
+  jest.mocked(useTransactionDetails).mockReturnValue({
+    transactionMeta: {
+      ...baseTransactionMeta,
+      ...overrides,
+    } as TransactionMeta,
+  });
+  return renderWithProvider(<MoneySentDetails />, {
+    state: merge({}, otherControllersMock),
+  });
+}
+
+describe('MoneySentDetails', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the hero with the negative mUSD amount', () => {
+    const { getByTestId, getByText } = render();
+    expect(getByTestId('money-sent-hero')).toBeOnTheScreen();
+    expect(getByText('You sent')).toBeOnTheScreen();
+    expect(getByText('-33.93 mUSD')).toBeOnTheScreen();
+  });
+
+  it('renders the To row with the recipient decoded from the nested transfer calldata', () => {
+    const { getByTestId, getByText } = render();
+    expect(getByText('To')).toBeOnTheScreen();
+    expect(getByTestId('name-mock').props.children).toBe(RECIPIENT_MOCK);
+  });
+
+  it('omits the To row when the batch has no decodable transfer', () => {
+    const { queryByText } = render({
+      nestedTransactions: [
+        {
+          type: TransactionType.moneyAccountWithdraw,
+          to: TELLER_MOCK,
+          data: '0xabcdef01',
+        },
+      ],
+    } as unknown as Partial<TransactionMeta>);
+    expect(queryByText('To')).toBeNull();
+  });
+
+  it('renders the network row', () => {
+    const { getAllByText } = render();
+    expect(getAllByText('Ethereum').length).toBeGreaterThan(0);
+  });
+
+  it('renders the shared network-fee, provider-fee and paid-with rows', () => {
+    const { getByTestId } = render();
+    expect(getByTestId('network-fee-row')).toBeOnTheScreen();
+    expect(getByTestId('bridge-fee-row')).toBeOnTheScreen();
+    expect(getByTestId('paid-with-row')).toBeOnTheScreen();
+  });
+
+  it('renders the status on a single row', () => {
+    const { getByText, getByTestId } = render();
+    expect(getByText('Status')).toBeOnTheScreen();
+    expect(getByTestId('status-mock')).toBeOnTheScreen();
+  });
+
+  it('renders the total amount from metamaskPay via the pay fiat formatter', () => {
+    const { getByText } = render();
+    expect(getByText('Total amount')).toBeOnTheScreen();
+    expect(getByText('$34.54')).toBeOnTheScreen();
+  });
+
+  it('navigates to the block explorer when the button is pressed', () => {
+    const { getByText } = render();
+    fireEvent.press(getByText('View on block explorer'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'Webview',
+      expect.objectContaining({ screen: 'SimpleWebview' }),
+    );
+  });
+
+  it('omits the total row when metamaskPay is absent', () => {
+    const { queryByText } = render({
+      metamaskPay: undefined,
+    });
+    expect(queryByText('Total amount')).toBeNull();
+  });
+});

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
@@ -129,25 +129,26 @@ export function MoneySentDetails() {
       <Box style={styles.container} gap={12}>
         {primaryAmount && tokenMeta ? (
           <Box testID="money-sent-hero" gap={8} style={styles.hero}>
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
-              {strings('transaction_details.label.you_sent')}
-            </Text>
-            <Box
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
-              gap={8}
-            >
-              <TokenIcon
-                chainId={chainId}
-                address={tokenMeta.contractAddress as Hex}
-                symbol={tokenMeta.symbol}
-                variant={TokenIconVariant.Hero}
-                showNetwork={false}
-              />
-              <Text variant={TextVariant.DisplayMd}>{primaryAmount}</Text>
+            <Box gap={8}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {strings('transaction_details.label.you_sent')}
+              </Text>
+              <Box
+                flexDirection={FlexDirection.Row}
+                alignItems={AlignItems.center}
+                gap={12}
+              >
+                <TokenIcon
+                  chainId={chainId}
+                  address={tokenMeta.contractAddress as Hex}
+                  symbol={tokenMeta.symbol}
+                  showNetwork={false}
+                />
+                <Text variant={TextVariant.HeadingLg}>{primaryAmount}</Text>
+              </Box>
             </Box>
           </Box>
         ) : null}

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useMemo } from 'react';
+import { ScrollView } from 'react-native';
+import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
+import { type Hex } from '@metamask/utils';
+import BigNumber from 'bignumber.js';
+import {
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import Routes from '../../../../../constants/navigation/Routes';
+import { RPC } from '../../../../../constants/network';
+import {
+  findBlockExplorerUrlForChain,
+  getBlockExplorerTxUrl,
+} from '../../../../../util/networks';
+import { formatAddress } from '../../../../../util/address';
+import { useStyles } from '../../../../../component-library/hooks';
+import Button, {
+  ButtonVariants,
+  ButtonSize,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
+import AvatarAccount from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
+import AvatarNetwork from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
+import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+import { Box } from '../../../Box/Box';
+import { AlignItems, FlexDirection } from '../../../Box/box.types';
+import Name from '../../../Name/Name';
+import { NameType } from '../../../Name/Name.types';
+import { TransactionDetailDivider } from '../../../../Views/confirmations/components/activity/transaction-detail-divider/transaction-detail-divider';
+import { TransactionDetailsDateRow } from '../../../../Views/confirmations/components/activity/transaction-details-date-row';
+import { TransactionDetailsRow } from '../../../../Views/confirmations/components/activity/transaction-details-row/transaction-details-row';
+import { TransactionDetailsStatus } from '../../../../Views/confirmations/components/activity/transaction-details-status';
+import { TransactionDetailsNetworkFeeRow } from '../../../../Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row';
+import { TransactionDetailsBridgeFeeRow } from '../../../../Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row';
+import { TransactionDetailsPaidWithRow } from '../../../../Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row';
+import {
+  TokenIcon,
+  TokenIconVariant,
+} from '../../../../Views/confirmations/components/token-icon';
+import { useTransactionDetails } from '../../../../Views/confirmations/hooks/activity/useTransactionDetails';
+import useNetworkInfo from '../../../../Views/confirmations/hooks/useNetworkInfo';
+import { usePayFiatFormatter } from '../../../../Views/confirmations/hooks/pay/usePayFiatFormatter';
+import { getTokenTransferData } from '../../../../Views/confirmations/utils/transaction-pay';
+import { parseStandardTokenTransactionData } from '../../../../Views/confirmations/utils/transaction';
+import { useAccountNames } from '../../../../hooks/DisplayName/useAccountNames';
+import {
+  getMusdDisplayAmountFromTransactionMeta,
+  resolveMusdTransferMeta,
+} from '../../constants/activityStyles';
+import styleSheet from './MoneySentDetails.styles';
+
+/**
+ * Decodes the ERC-20 transfer recipient (`_to`) from the nested mUSD transfer of
+ * a Money Account withdrawal. `txParams.to` points at the token/teller contract,
+ * not the actual recipient, so we read it from the decoded transfer calldata.
+ */
+function useRecipient(): Hex | undefined {
+  const { transactionMeta } = useTransactionDetails();
+  return useMemo(() => {
+    const { data } = getTokenTransferData(transactionMeta) ?? {};
+    if (!data) {
+      return undefined;
+    }
+    const parsed = parseStandardTokenTransactionData(data);
+    return parsed?.args?._to?.toString() as Hex | undefined;
+  }, [transactionMeta]);
+}
+
+export function MoneySentDetails() {
+  const { styles } = useStyles(styleSheet, {});
+  const navigation = useNavigation();
+  const { transactionMeta } = useTransactionDetails();
+  const networkConfigurations = useSelector(selectNetworkConfigurations);
+
+  const chainId = transactionMeta.chainId as Hex;
+  const from = transactionMeta.txParams?.from;
+  const recipient = useRecipient();
+
+  const tokenMeta = resolveMusdTransferMeta(transactionMeta);
+  const primaryAmount =
+    getMusdDisplayAmountFromTransactionMeta(transactionMeta);
+
+  const accountName = useAccountNames(
+    from
+      ? [{ value: from, variation: chainId, type: NameType.EthereumAddress }]
+      : [],
+  )?.[0];
+
+  const { networkName, networkImage } = useNetworkInfo(chainId);
+
+  // `metamaskPay` fees are USD-denominated for withdrawals (moneyAccountWithdraw
+  // is not a USER_CURRENCY_TYPE), so the pay formatter resolves to USD — keeping
+  // the "Total amount" row consistent with the reused fee rows below.
+  const formatFiat = usePayFiatFormatter();
+  const totalFiat = transactionMeta.metamaskPay?.totalFiat;
+
+  const handleViewOnExplorer = useCallback(() => {
+    const { hash } = transactionMeta;
+    if (!hash) {
+      return;
+    }
+    const rpcBlockExplorer = findBlockExplorerUrlForChain(
+      chainId,
+      networkConfigurations,
+    );
+    const { url, title } = getBlockExplorerTxUrl(RPC, hash, rpcBlockExplorer);
+    if (!url) {
+      return;
+    }
+    navigation.navigate(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: { url, title },
+    });
+  }, [chainId, navigation, networkConfigurations, transactionMeta]);
+
+  return (
+    <ScrollView>
+      <Box style={styles.container} gap={12}>
+        {primaryAmount && tokenMeta ? (
+          <Box testID="money-sent-hero" gap={8} style={styles.hero}>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              {strings('transaction_details.label.you_sent')}
+            </Text>
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={8}
+            >
+              <TokenIcon
+                chainId={chainId}
+                address={tokenMeta.contractAddress as Hex}
+                symbol={tokenMeta.symbol}
+                variant={TokenIconVariant.Hero}
+                showNetwork={false}
+              />
+              <Text variant={TextVariant.DisplayMd}>{primaryAmount}</Text>
+            </Box>
+          </Box>
+        ) : null}
+
+        <TransactionDetailsRow label={strings('transactions.status')}>
+          <TransactionDetailsStatus transactionMeta={transactionMeta} />
+        </TransactionDetailsRow>
+        <TransactionDetailsDateRow />
+
+        {from ? (
+          <TransactionDetailsRow
+            label={strings('transaction_details.label.account')}
+          >
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={6}
+            >
+              <BadgeWrapper
+                badgePosition={BadgePosition.BottomRight}
+                badgeElement={
+                  <Badge
+                    variant={BadgeVariant.Network}
+                    imageSource={networkImage}
+                    name={networkName}
+                  />
+                }
+              >
+                <AvatarAccount accountAddress={from} size={AvatarSize.Sm} />
+              </BadgeWrapper>
+              <Text>{accountName ?? formatAddress(from, 'short')}</Text>
+            </Box>
+          </TransactionDetailsRow>
+        ) : null}
+
+        {recipient ? (
+          <TransactionDetailsRow
+            label={strings('transaction_details.label.to')}
+          >
+            <Name
+              type={NameType.EthereumAddress}
+              value={recipient}
+              variation={chainId}
+            />
+          </TransactionDetailsRow>
+        ) : null}
+
+        {networkName ? (
+          <TransactionDetailsRow
+            label={strings('transaction_details.label.network')}
+          >
+            <Box
+              flexDirection={FlexDirection.Row}
+              alignItems={AlignItems.center}
+              gap={6}
+            >
+              <AvatarNetwork
+                name={networkName}
+                imageSource={networkImage}
+                size={AvatarSize.Xs}
+              />
+              <Text>{networkName}</Text>
+            </Box>
+          </TransactionDetailsRow>
+        ) : null}
+
+        <TransactionDetailsPaidWithRow />
+
+        <TransactionDetailDivider />
+
+        <TransactionDetailsNetworkFeeRow />
+        <TransactionDetailsBridgeFeeRow />
+
+        {totalFiat ? (
+          <TransactionDetailsRow
+            label={strings('transaction_details.label.total_amount')}
+          >
+            <Text>{formatFiat(new BigNumber(totalFiat))}</Text>
+          </TransactionDetailsRow>
+        ) : null}
+
+        <Button
+          variant={ButtonVariants.Secondary}
+          size={ButtonSize.Lg}
+          width={ButtonWidthTypes.Full}
+          style={styles.button}
+          label={strings('transaction_details.view_on_block_explorer')}
+          onPress={handleViewOnExplorer}
+        />
+      </Box>
+    </ScrollView>
+  );
+}

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneyTransactionDetailsSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneyTransactionDetailsSheet.test.tsx
@@ -44,15 +44,27 @@ jest.mock('./MoneyReceivedDetails', () => {
       ),
   };
 });
+jest.mock('./MoneySentDetails', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    MoneySentDetails: () =>
+      ReactActual.createElement(Text, { testID: 'money-sent-details' }, 'sent'),
+  };
+});
 
 const CHAIN_ID_MOCK = '0x8f';
 
-function render(type: TransactionType) {
+function render(
+  type: TransactionType,
+  nestedTransactions?: { type: TransactionType }[],
+) {
   jest.mocked(useTransactionDetails).mockReturnValue({
     transactionMeta: {
       id: 'tx-1',
       chainId: CHAIN_ID_MOCK,
       type,
+      nestedTransactions,
     } as unknown as TransactionMeta,
   });
   return renderWithProvider(<MoneyTransactionDetailsSheet />, {
@@ -73,13 +85,31 @@ describe('MoneyTransactionDetailsSheet', () => {
     expect(queryByTestId('shared-transaction-details')).not.toBeOnTheScreen();
   });
 
+  it('renders MoneySentDetails for moneyAccountWithdraw', () => {
+    const { getByTestId, queryByTestId } = render(
+      TransactionType.moneyAccountWithdraw,
+    );
+    expect(getByTestId('money-sent-details')).toBeOnTheScreen();
+    expect(queryByTestId('shared-transaction-details')).not.toBeOnTheScreen();
+  });
+
+  it('renders MoneySentDetails for a batch with a nested moneyAccountWithdraw', () => {
+    const { getByTestId, queryByTestId } = render(TransactionType.batch, [
+      { type: TransactionType.moneyAccountWithdraw },
+      { type: TransactionType.tokenMethodTransfer },
+    ]);
+    expect(getByTestId('money-sent-details')).toBeOnTheScreen();
+    expect(queryByTestId('money-received-details')).not.toBeOnTheScreen();
+    expect(queryByTestId('shared-transaction-details')).not.toBeOnTheScreen();
+  });
+
   it.each([
     TransactionType.moneyAccountDeposit,
-    TransactionType.moneyAccountWithdraw,
     TransactionType.musdConversion,
   ])('renders shared TransactionDetails for %s', (type) => {
     const { getByTestId, queryByTestId } = render(type);
     expect(getByTestId('shared-transaction-details')).toBeOnTheScreen();
     expect(queryByTestId('money-received-details')).not.toBeOnTheScreen();
+    expect(queryByTestId('money-sent-details')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneyTransactionDetailsSheet.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneyTransactionDetailsSheet.tsx
@@ -14,14 +14,19 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import { TransactionDetails } from '../../../../Views/confirmations/components/activity/transaction-details/transaction-details';
 import { useTransactionDetails } from '../../../../Views/confirmations/hooks/activity/useTransactionDetails';
+import { hasTransactionType } from '../../../../Views/confirmations/utils/transaction';
 import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
+import { resolveMusdTransferMeta } from '../../constants/activityStyles';
 import { MoneyReceivedDetails } from './MoneyReceivedDetails';
+import { MoneySentDetails } from './MoneySentDetails';
 
 const RECEIVED_TYPES: TransactionType[] = [
   TransactionType.incoming,
   TransactionType.tokenMethodTransfer,
   TransactionType.tokenMethodTransferFrom,
 ];
+
+const SENT_TYPES: TransactionType[] = [TransactionType.moneyAccountWithdraw];
 
 const TITLE_KEYS: Partial<Record<TransactionType, string>> = {
   [TransactionType.moneyAccountDeposit]:
@@ -50,6 +55,12 @@ function getTitle(tx: TransactionMeta | undefined): string {
       ? ((tx.nestedTransactions?.find((n) => n.type && n.type in TITLE_KEYS)
           ?.type as TransactionType | undefined) ?? tx.type)
       : tx?.type;
+  // Sent transactions are titled "Sent {symbol}" (e.g. "Sent mUSD").
+  if (tx && hasTransactionType(tx, SENT_TYPES)) {
+    return strings('transaction_details.title.money_account_sent', {
+      symbol: resolveMusdTransferMeta(tx)?.symbol ?? 'mUSD',
+    });
+  }
   return strings(
     (type && TITLE_KEYS[type]) ?? 'transaction_details.title.default',
   );
@@ -61,9 +72,15 @@ const MoneyTransactionDetailsSheet = () => {
   const { transactionMeta } = useTransactionDetails();
   const surfaceClass = useElevatedSurface();
   const title = getTitle(transactionMeta);
+  // `isReceived` checks the top-level type only: a sent withdrawal is an
+  // EIP-7702 batch that *contains* a nested tokenMethodTransfer, so a
+  // nested-aware check would misclassify it as received. `isSent` is
+  // nested-aware because the withdrawal's `moneyAccountWithdraw` lives in the
+  // batch's nested transactions.
   const isReceived = Boolean(
     transactionMeta?.type && RECEIVED_TYPES.includes(transactionMeta.type),
   );
+  const isSent = hasTransactionType(transactionMeta, SENT_TYPES);
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -80,7 +97,13 @@ const MoneyTransactionDetailsSheet = () => {
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingMd}>{title}</Text>
       </BottomSheetHeader>
-      {isReceived ? <MoneyReceivedDetails /> : <TransactionDetails />}
+      {isReceived ? (
+        <MoneyReceivedDetails />
+      ) : isSent ? (
+        <MoneySentDetails />
+      ) : (
+        <TransactionDetails />
+      )}
     </BottomSheet>
   );
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9173,6 +9173,7 @@
       "predict_withdraw": "Withdrawal",
       "money_account_deposit": "Deposit to Money Account",
       "money_account_withdraw": "Transfer from Money Account",
+      "money_account_sent": "Sent {{symbol}}",
       "money_account_received": "Received",
       "default": "Transaction details"
     },
@@ -9184,11 +9185,16 @@
       "receive_token": "Receive token",
       "retry_button": "Try again",
       "total": "Total",
+      "total_amount": "Total amount",
       "account": "Account",
       "received_total": "Received total",
       "from": "From",
+      "to": "To",
+      "network": "Network",
+      "you_sent": "You sent",
       "token_received": "Token received"
     },
+    "view_on_block_explorer": "View on block explorer",
     "summary_title": {
       "bridge_approval": "Approve {{approveSymbol}}",
       "bridge_approval_loading": "Approve",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**
Implement the sent transaction modal for the money account activity list.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: implement sent txn modal for money account activity list

## **Related issues**

Fixes: [MUSD-862](https://consensyssoftware.atlassian.net/browse/MUSD-862?atlOrigin=eyJpIjoiNmI3MWE0ODkyOTRhNDM0MTgyNWQ4OTU3NzEyZmFjZjMiLCJwIjoiaiJ9)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="554" height="1041" alt="Screenshot 2026-06-02 at 12 07 46" src="https://github.com/user-attachments/assets/25d534a9-dc56-4052-976c-943d7ae8b421" />

<!-- [screenshots/recordings] -->

### **After**
<img width="554" height="1041" alt="Screenshot 2026-06-02 at 12 09 10" src="https://github.com/user-attachments/assets/a3e04365-0a89-42e7-beae-f0358227b6bd" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-862]: https://consensyssoftware.atlassian.net/browse/MUSD-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Money activity details with thorough unit tests; no auth, payments backend, or shared transaction execution changes.
> 
> **Overview**
> Adds a dedicated **sent** transaction bottom sheet for Money Account withdrawals, so `moneyAccountWithdraw` (including EIP-7702 **batch** txs with a nested withdraw) no longer use the generic confirmation `TransactionDetails` view.
> 
> `MoneyTransactionDetailsSheet` now routes sent txs to new `MoneySentDetails`, with a **Sent {symbol}** title and nested-aware detection via `hasTransactionType`, while received detection stays top-level-only so batches with nested transfers are not misclassified as received.
> 
> `MoneySentDetails` shows amount/recipient decoded from nested mUSD transfer calldata, account/network/to rows, shared fee/paid-with rows, optional `metamaskPay` total, and block explorer navigation. New i18n keys support the labels and title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e224de5bdcf874116007a2afd546c288efeb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->