### PR TITLE
fix(ci): normalize package.json to base before OTA fingerprint comparison

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -311,6 +311,25 @@ jobs:
           fi
           echo "✅ Artifacts verified"
 
+      - name: Normalize package.json to base branch for fingerprint comparison
+        run: |
+          # Replace the target branch package.json with the base branch version before
+          # computing the fingerprint. This prevents JS-only dependency updates (which
+          # do not change native builds) from causing a false fingerprint mismatch.
+          #
+          # Native changes are still detected correctly via:
+          #   - ios/ and android/ directory hashes
+          #   - Autolinking output (computed from the installed node_modules)
+          #   - yarn patches (.yarn/patches)
+          #   - react-native.config.js and build scripts
+          #
+          # Without this step, adding or bumping a JS package on the release branch
+          # would change the `packageJson:scripts` or `dependencies` sections captured
+          # by @expo/fingerprint, causing an OTA block even though no native code changed.
+          echo "📦 Replacing package.json with base branch (${BASE_BRANCH_REF}) version..."
+          cp main/package.json package.json
+          echo "✅ package.json normalized — fingerprint will reflect native changes only"
+
       - name: Generate fingerprint (target commit)
         id: branch_fingerprint
         run: |


### PR DESCRIPTION

## **Description**

<!-- What is the reason for this change? What does it improve or solve? -->

### Problem

When pushing an OTA update, the `fingerprint-comparison` CI job compares the Expo fingerprint of the release branch against the fingerprint of the binary's build tag. If `package.json` was modified on the release branch — even for JS-only dependency updates that have no effect on native code — `@expo/fingerprint` would capture those changes (via the `packageJson:scripts` content source) and produce a different hash, causing the OTA workflow to fail with a false "native changes detected" error.

The previous workaround required manually editing the `fingerprint:generate` script to check out the original `package.json` from the release tag before running the hash, which was error-prone and had to be reverted after every OTA.

### Solution

Add a **"Normalize package.json to base branch for fingerprint comparison"** step in the `fingerprint-comparison` job of `push-eas-update.yml`, immediately before the target-commit fingerprint is generated.

The step replaces the target branch's `package.json` with the one from the base branch (the build tag already checked out into the `main/` directory). This means both sides of the comparison see the same `package.json`, so the fingerprint difference only reflects real native changes:

- `ios/` and `android/` directory hashes
- Autolinking output (computed from the installed `node_modules`)
- `.yarn/patches`
- `react-native.config.js` and build scripts

This change is scoped entirely to CI and does not affect local development, the published OTA bundle, or any other workflow.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
Refs:

## **Manual testing steps**

N/A — this change is CI-only (GitHub Actions workflow). Verification is done by triggering the OTA workflow from a release branch that has JS-only `package.json` changes and confirming the fingerprint comparison passes.

```gherkin
Given a release branch with JS-only package.json updates (no native code changes)
When the OTA workflow is triggered via runway-ota-production
Then the fingerprint-comparison job passes
And the OTA update is pushed successfully
```

## **Screenshots/Recordings**

### Before

N/A

### After

N/A

## **Pre-merge author checklist**

- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
- [x] I've properly set the pull request status:
  - [x] Set as a draft: I consider it not ready for review
  - [ ] Set as open: I consider it ready for review, I select this if I don't want a mandatory period of time for the maintainers to review the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, test buttons, input fields, interactions)
- [ ] I confirm that this PR addresses all acceptance criteria described in the linked issue(s) (if applicable)
- [ ] I confirm that this PR does not break any existing automated tests

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)