### PR TITLE
fix(e2e): import test IDs directly to fix E2E parse failure

### DIFF
--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -46,7 +46,7 @@ import PredictModalView from '../page-objects/Predict/PredictModalView';
 import OnboardingInterestQuestionnaireView from '../page-objects/Onboarding/OnboardingInterestQuestionnaireView';
 import ExperienceEnhancerBottomSheet from '../page-objects/Onboarding/ExperienceEnhancerBottomSheet';
 import { fetchProductionFeatureFlags } from '../performance/feature-flag-helper';
-import { ExistingUserSheetSelectorsIDs } from '../../app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet';
+import { ExistingUserSheetSelectorsIDs } from '../../app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.testIds';
 const logger = createLogger({
   name: 'WalletFlow',
 });


### PR DESCRIPTION
## **Description**

PR #30917 imported `ExistingUserSheetSelectorsIDs` from the barrel `index.ts` in `wallet.flow.ts`. That barrel re-exports the full `ExistingUserSheet` React component, which transitively pulls in `BottomSheet` → `@react-navigation/native` → `react-native/index.js`. The RN index file uses Flow-style `import typeof` syntax that Jest in the Detox E2E runner can't parse, causing every E2E test that imports `wallet.flow.ts` to fail with `SyntaxError: Cannot use import statement outside a module`.

Fix: import `ExistingUserSheetSelectorsIDs` directly from `ExistingUserSheet.testIds.ts` instead of the barrel export.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: E2E failures introduced by #30917

## **Manual testing steps**

\`\`\`gherkin
Feature: E2E smoke tests pass

  Scenario: E2E tests can parse wallet.flow.ts imports
    Given the E2E test suite runs in CI

    When any smoke test imports wallet.flow.ts
    Then the test suite should not fail with a SyntaxError
\`\`\`

## **Screenshots/Recordings**

N/A — CI-only fix, no UI changes.

### **Before**

All E2E smoke tests fail with:
\`\`\`
SyntaxError: Cannot use import statement outside a module
  at node_modules/react-native/index.js:27
\`\`\`

### **After**

E2E smoke tests parse successfully and run as expected.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-path change in E2E helpers; no app runtime or security behavior changes.
> 
> **Overview**
> **`wallet.flow.ts`** now imports **`ExistingUserSheetSelectorsIDs`** from **`ExistingUserSheet.testIds.ts`** instead of the **`ExistingUserSheet`** barrel. That avoids pulling the full sheet component (and **`react-native`** via navigation/bottom sheet) into the Detox/Jest graph, which was breaking module parsing for every test that imports this flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d9709a0159e28956a8c8c504921ec7f3b582de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->