### PR TITLE
chore(e2e): quarantine account activity WebSocket smoke test

### DIFF
--- a/tests/docs/WEBSOCKET_MOCKING.md
+++ b/tests/docs/WEBSOCKET_MOCKING.md
@@ -95,7 +95,7 @@ accountActivityWsServer.sendMessage(JSON.stringify(notification));
 
 ### Example spec
 
-See `tests/smoke/account-activity/web-socket-connection.spec.quarantine.ts` for a complete example with three tests covering subscribe-on-login, resubscribe-after-background, and resubscribe-after-lock.
+See `tests/smoke/account-activity/web-socket-connection.spec.ts` for a complete example with three tests covering subscribe-on-login, resubscribe-after-background, and resubscribe-after-lock.
 
 ## Adding a New WebSocket Service Mock
 

--- a/tests/docs/WEBSOCKET_MOCKING.md
+++ b/tests/docs/WEBSOCKET_MOCKING.md
@@ -95,7 +95,7 @@ accountActivityWsServer.sendMessage(JSON.stringify(notification));
 
 ### Example spec
 
-See `tests/smoke/account-activity/web-socket-connection.spec.ts` for a complete example with three tests covering subscribe-on-login, resubscribe-after-background, and resubscribe-after-lock.
+See `tests/smoke/account-activity/web-socket-connection.spec.quarantine.ts` for a complete example with three tests covering subscribe-on-login, resubscribe-after-background, and resubscribe-after-lock.
 
 ## Adding a New WebSocket Service Mock
 

--- a/tests/smoke/account-activity/web-socket-connection.spec.quarantine.ts
+++ b/tests/smoke/account-activity/web-socket-connection.spec.quarantine.ts
@@ -19,83 +19,86 @@ function assertEqual<T>(actual: T, expected: T, message?: string): void {
   }
 }
 
-describe.skip(SmokeWalletPlatform('Account Activity WebSocket Connection'), () => {
-  beforeAll(async () => {
-    jest.setTimeout(2500000);
-  });
+describe.skip(
+  SmokeWalletPlatform('Account Activity WebSocket Connection'),
+  () => {
+    beforeAll(async () => {
+      jest.setTimeout(2500000);
+    });
 
-  it('subscribes to account activity when user logs in', async () => {
-    await withFixtures(
-      {
-        fixture: new FixtureBuilder().build(),
-        restartDevice: true,
-      },
-      async () => {
-        const subscriptionPromise = waitForAccountActivitySubscription();
-        await loginToApp();
-        await subscriptionPromise;
-        assertEqual(
-          getAccountActivitySubscriptionCount(),
-          1,
-          `Expected 1 account activity subscription but found ${getAccountActivitySubscriptionCount()}`,
-        );
-      },
-    );
-  });
+    it('subscribes to account activity when user logs in', async () => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder().build(),
+          restartDevice: true,
+        },
+        async () => {
+          const subscriptionPromise = waitForAccountActivitySubscription();
+          await loginToApp();
+          await subscriptionPromise;
+          assertEqual(
+            getAccountActivitySubscriptionCount(),
+            1,
+            `Expected 1 account activity subscription but found ${getAccountActivitySubscriptionCount()}`,
+          );
+        },
+      );
+    });
 
-  it('resubscribes after app resumes from background', async () => {
-    await withFixtures(
-      {
-        fixture: new FixtureBuilder().build(),
-        restartDevice: true,
-      },
-      async () => {
-        const firstSubPromise = waitForAccountActivitySubscription();
-        await loginToApp();
-        await firstSubPromise;
-        assertEqual(getAccountActivitySubscriptionCount(), 1);
+    it('resubscribes after app resumes from background', async () => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder().build(),
+          restartDevice: true,
+        },
+        async () => {
+          const firstSubPromise = waitForAccountActivitySubscription();
+          await loginToApp();
+          await firstSubPromise;
+          assertEqual(getAccountActivitySubscriptionCount(), 1);
 
-        await device.sendToHome();
-        await waitForAccountActivityDisconnection();
+          await device.sendToHome();
+          await waitForAccountActivityDisconnection();
 
-        const resubPromise = waitForAccountActivitySubscription();
-        await device.launchApp({ newInstance: false });
-        await resubPromise;
-        assertEqual(
-          getAccountActivitySubscriptionCount(),
-          2,
-          `Expected 2 total subscriptions but found ${getAccountActivitySubscriptionCount()}`,
-        );
-      },
-    );
-  });
+          const resubPromise = waitForAccountActivitySubscription();
+          await device.launchApp({ newInstance: false });
+          await resubPromise;
+          assertEqual(
+            getAccountActivitySubscriptionCount(),
+            2,
+            `Expected 2 total subscriptions but found ${getAccountActivitySubscriptionCount()}`,
+          );
+        },
+      );
+    });
 
-  it('resubscribes after lock and unlock', async () => {
-    await withFixtures(
-      {
-        fixture: new FixtureBuilder().build(),
-        restartDevice: true,
-      },
-      async () => {
-        const firstSubPromise = waitForAccountActivitySubscription();
-        await loginToApp();
-        await firstSubPromise;
-        assertEqual(getAccountActivitySubscriptionCount(), 1);
+    it('resubscribes after lock and unlock', async () => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder().build(),
+          restartDevice: true,
+        },
+        async () => {
+          const firstSubPromise = waitForAccountActivitySubscription();
+          await loginToApp();
+          await firstSubPromise;
+          assertEqual(getAccountActivitySubscriptionCount(), 1);
 
-        await TabBarComponent.tapAccountsMenu();
-        await AccountMenu.tapLock();
-        await SettingsView.tapYesAlertButton();
-        await waitForAccountActivityDisconnection();
+          await TabBarComponent.tapAccountsMenu();
+          await AccountMenu.tapLock();
+          await SettingsView.tapYesAlertButton();
+          await waitForAccountActivityDisconnection();
 
-        const resubPromise = waitForAccountActivitySubscription();
-        await loginToApp();
-        await resubPromise;
-        assertEqual(
-          getAccountActivitySubscriptionCount(),
-          2,
-          `Expected 2 total subscriptions but found ${getAccountActivitySubscriptionCount()}`,
-        );
-      },
-    );
-  });
-});
+          const resubPromise = waitForAccountActivitySubscription();
+          await loginToApp();
+          await resubPromise;
+          assertEqual(
+            getAccountActivitySubscriptionCount(),
+            2,
+            `Expected 2 total subscriptions but found ${getAccountActivitySubscriptionCount()}`,
+          );
+        },
+      );
+    });
+  },
+);

--- a/tests/smoke/account-activity/web-socket-connection.spec.quarantine.ts
+++ b/tests/smoke/account-activity/web-socket-connection.spec.quarantine.ts
@@ -19,7 +19,7 @@ function assertEqual<T>(actual: T, expected: T, message?: string): void {
   }
 }
 
-describe(SmokeWalletPlatform('Account Activity WebSocket Connection'), () => {
+describe.skip(SmokeWalletPlatform('Account Activity WebSocket Connection'), () => {
   beforeAll(async () => {
     jest.setTimeout(2500000);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Quarantines the Account Activity WebSocket Connection smoke E2E suite so it no longer runs in Detox smoke CI:

- Wraps the suite in `describe.skip`
- Renames `web-socket-connection.spec.ts` → `web-socket-connection.spec.quarantine.ts` (excluded from Jest `testMatch: **/*.spec.{js,ts}`)


`tests/docs/WEBSOCKET_MOCKING.md` keeps the original example path (`web-socket-connection.spec.ts`) per review.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — test quarantine only; no app behavior change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (quarantine of existing E2E spec)
- [ ] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab6db6e7-b13d-4ea3-803a-7ba08bfba184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab6db6e7-b13d-4ea3-803a-7ba08bfba184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

