### PR TITLE
chore: bump @metamask/bitcoin-wallet-snap to ^1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "@metamask/assets-controllers": "^108.3.0",
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",
-    "@metamask/bitcoin-wallet-snap": "^1.11.0",
+    "@metamask/bitcoin-wallet-snap": "^1.12.0",
     "@metamask/bridge-controller": "^73.2.0",
     "@metamask/bridge-status-controller": "^72.0.0",
     "@metamask/chain-agnostic-permission": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8074,10 +8074,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@metamask/bitcoin-wallet-snap@npm:1.11.0"
-  checksum: 10/1784489c84fddeff9d89bd71fdd50ffd204ca2cb58a257181dfa25afd6f0650013e0620cb9fc294f8962f0b225a032ee5c08f7f4392f2e7f2721ccf624e28237
+"@metamask/bitcoin-wallet-snap@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@metamask/bitcoin-wallet-snap@npm:1.12.0"
+  checksum: 10/ff8fd75953ddcb376c60381cca9e80a30d0c42a7f53bfb3da7f91bc4039456d0f5ec3cfe1dec0d5571e849c284c51a540cb4f05556bc5a86c57e6886464f5ed1
   languageName: node
   linkType: hard
 
@@ -35344,7 +35344,7 @@ __metadata:
     "@metamask/authenticated-user-storage": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/bitcoin-wallet-snap": "npm:^1.11.0"
+    "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
     "@metamask/bridge-controller": "npm:^73.2.0"
     "@metamask/bridge-status-controller": "npm:^72.0.0"
     "@metamask/browser-passworder": "npm:^5.0.0"


### PR DESCRIPTION
## **Description**

Bumps the bundled Bitcoin wallet Snap (`@metamask/bitcoin-wallet-snap`) from `1.11.0` to `1.12.0` by updating the dependency in `package.json` and refreshing `yarn.lock`. There are no mobile source changes — only the dependency resolution and checksum for the new Snap release.

The `1.12.0` Snap release includes: a self-send warning in the send confirmation, the filled PSBT shown in the `signPsbt` confirmation dialog, and the new `createMany` account use case.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Bitcoin wallet Snap bump

  Scenario: user uses Bitcoin account after the Snap bump
    Given the app is built from this branch
    And the user has a Bitcoin account

    When the user opens the Bitcoin account and starts a send
    Then the account balance loads and the send confirmation renders correctly
    And a self-send warning is shown when sending to the user's own address
```

## **Screenshots/Recordings**

N/A — dependency bump only, no UI changes in this repo.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no mobile code changes; risk is limited to bundled Snap behavior for Bitcoin send, PSBT signing, and account creation flows.
> 
> **Overview**
> Bumps the bundled **`@metamask/bitcoin-wallet-snap`** dependency from **1.11.0** to **1.12.0** in `package.json` and updates **`yarn.lock`** (resolution + checksum). There are **no app source changes** in this repo; Bitcoin UX and behavior come from the new Snap release at runtime.
> 
> Users on this build get Snap **1.12.0** behavior, including a **self-send warning** on send confirmation, the **filled PSBT** shown in **`signPsbt`** confirmation, and support for the **`createMany`** account use case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15b77a610619fb298e1cf0c24a26400524a97f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->