### PR TITLE
fix(MUSD-872): reduce estimated earnings tooltip icon size to Sm

### DIFF
--- a/app/components/UI/Money/components/MoneySectionHeader/MoneySectionHeader.tsx
+++ b/app/components/UI/Money/components/MoneySectionHeader/MoneySectionHeader.tsx
@@ -66,7 +66,7 @@ const MoneySectionHeader = ({
       {onInfoPress && (
         <ButtonIcon
           iconName={IconName.Info}
-          iconProps={{ color: IconColor.IconAlternative }}
+          iconProps={{ color: IconColor.IconAlternative, size: IconSize.Sm }}
           size={ButtonIconSize.Sm}
           onPress={onInfoPress}
           accessibilityLabel={infoAccessibilityLabel}


### PR DESCRIPTION
## **Description**

The info (ⓘ) icon next to "Estimated earnings" in the Money home screen was rendering at the default `IconSize.Md` (20px) inside the `ButtonIconSize.Sm` button container, making it appear oversized relative to the surrounding text. This fix passes `size: IconSize.Sm` (16px) explicitly via `iconProps` on the `ButtonIcon` in `MoneySectionHeader`, bringing it in line with the Figma spec.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-872

## **Manual testing steps**

```gherkin
Feature: Money account estimated earnings tooltip icon

  Scenario: User views the Estimated earnings section
    Given the user has a funded Money account
    And they are on the Money tab

    When they scroll to the "Estimated earnings" section
    Then the ⓘ icon next to the section title is visually smaller
    And matches the size of other info icons in the Money UI
```

## **Screenshots/Recordings**

### **Before**
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-02 at 22 08 33" src="https://github.com/user-attachments/assets/d1bc2c55-ad0e-4190-ac37-a46accc0059c" />


### **After**
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-02 at 22 08 41" src="https://github.com/user-attachments/assets/30482e02-0580-4c2f-b552-dbe11ab413ea" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single visual prop on a shared Money UI header; no logic, auth, or data changes.
> 
> **Overview**
> The shared **Money** section header now renders the optional info **ⓘ** control at **`IconSize.Sm` (16px)** by passing `size: IconSize.Sm` through `iconProps` on `ButtonIcon`, instead of leaving the icon at the default medium size inside a small button.
> 
> Any Money home sections that use `MoneySectionHeader` with `onInfoPress`—including **Estimated earnings**—get the smaller icon so it aligns with the Figma spec and surrounding heading text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 893ae00994969774a71f5b40c8823a6ad6d3835a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->