### PR TITLE
fix(MUSD-876): remove progress indicator from onboarding stepper card

### DIFF
--- a/app/component-library/components-temp/StepperCard/StepperCard.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.tsx
@@ -18,7 +18,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../locales/i18n';
 import { StepperCardProps } from './StepperCard.types';
-import SegmentedProgressBar from '../SegmentedProgressBar';
 
 const StepperCard = ({
   steps,
@@ -57,15 +56,6 @@ const StepperCard = ({
       twClassName="rounded-2xl bg-muted overflow-hidden"
       testID={getTestId('container')}
     >
-      {/* Progress Bar */}
-      <Box twClassName="p-4 gap-2">
-        <SegmentedProgressBar
-          current={currentStep + 1}
-          total={totalSteps}
-          testID={getTestId('progress-bar')}
-        />
-      </Box>
-
       {/* Image */}
       <Box
         alignItems={BoxAlignItems.Center}


### PR DESCRIPTION
## **Description**

The `StepperCard` component rendered a `SegmentedProgressBar` at the top of the onboarding card on the Money home screen. The design no longer calls for this progress indicator. This PR removes the progress bar block and its unused `SegmentedProgressBar` import from `StepperCard`. Combined with the spacing fix in MUSD-875, this ensures the "Add funds" CTA is visible above the fold on most devices.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-876

## **Manual testing steps**

```gherkin
Feature: Money onboarding stepper card

  Scenario: User views the onboarding card
    Given the user is on the Money tab
    And the onboarding stepper card is visible

    When they look at the top of the onboarding card
    Then there is no progress bar / step indicator at the top
    And the card image is the first element visible
```

## **Screenshots/Recordings**

### **Before**

<!-- Green segmented progress bar visible at top of stepper card -->

### **After**

<!-- Progress bar removed; card image appears at the top -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
