### PR TITLE
fix(MUSD-879): reduce mUSD token icon to Sm to match other asset icons

### DIFF
--- a/app/components/UI/Money/components/MoneyMusdTokenRow/MoneyMusdTokenRow.tsx
+++ b/app/components/UI/Money/components/MoneyMusdTokenRow/MoneyMusdTokenRow.tsx
@@ -57,7 +57,7 @@ const MoneyMusdTokenRow = ({
         <AvatarToken
           name={MUSD_TOKEN.symbol}
           src={MUSD_TOKEN.imageSource as ImageOrSvgSrc}
-          size={AvatarTokenSize.Md}
+          size={AvatarTokenSize.Sm}
         />
         <Box twClassName="flex-1">
           <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>


### PR DESCRIPTION
## **Description**

The MetaMask USD (mUSD) token icon in the "How it works" section of the Money home screen was rendered at `AvatarTokenSize.Md` (32px), while the asset icons in the "Earn on your crypto" list below use `AvatarTokenSize.Sm` (24px). This PR changes `MoneyMusdTokenRow` to use `AvatarTokenSize.Sm` so the mUSD icon is consistent with the rest of the token list.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-879

## **Manual testing steps**

```gherkin
Feature: Money home screen mUSD icon size

  Scenario: User views the How it works section
    Given the user is on the Money tab
    And the home screen is in the empty (non-milestone) state

    When they scroll to the "How it works" section
    Then the MetaMask USD icon is the same size as the token icons in the "Earn on your crypto" list below
```

## **Screenshots/Recordings**

### **Before**

<!-- mUSD icon noticeably larger (32px) than other token icons (24px) -->

### **After**

<!-- mUSD icon matches other token icons at 24px -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
