### PR TITLE
fix(MUSD-881): present Card Education screen as modal (slide from bottom)

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1471,7 +1471,11 @@ const MainNavigator = () => {
       {
         ///: END:ONLY_INCLUDE_IF
       }
-      <Stack.Screen name={Routes.CARD.ROOT} component={CardRoutes} />
+      <Stack.Screen
+        name={Routes.CARD.ROOT}
+        component={CardRoutes}
+        options={{ presentation: 'modal' }}
+      />
       <Stack.Screen
         name={Routes.RAMP.MODALS.PROCESSING_INFO}
         component={ProcessingInfoModal}


### PR DESCRIPTION
## **Description**

The Card screens (including the "SPEND AND EARN" card education page shown to non-cardholders) were being pushed onto the navigation stack from the side, like a standard screen transition. The design specifies that this screen should slide up from the bottom as a modal. This PR adds `options={{ presentation: 'modal' }}` to the `Routes.CARD.ROOT` `Stack.Screen` registration in `MainNavigator.js`. No UI changes to the screen itself are required.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MUSD-881

## **Manual testing steps**

```gherkin
Feature: Card Education page entry animation

  Scenario: User navigates to the Card flow from the Money tab
    Given the user is on the Money tab
    And the user does not have a MetaMask Card

    When they tap the "Card" action button
    Then the Card Education ("SPEND AND EARN") screen slides up from the bottom
    And does not push in from the right side
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/4858d7dc-04dd-4d18-8eb6-8e6498823158



### **After**


https://github.com/user-attachments/assets/82aadc3f-1d07-4cbc-aa08-bfdfe11679b8


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single navigation presentation option on the Card root screen; no auth, data, or Card feature logic changes.
> 
> **Overview**
> The Card flow entry from the main stack (including the **SPEND AND EARN** education screen for non-cardholders) now uses a **modal** presentation instead of the default push-from-the-right transition.
> 
> In `MainNavigator.js`, the `Routes.CARD.ROOT` `Stack.Screen` is updated to pass `options={{ presentation: 'modal' }}` so the whole `CardRoutes` subtree slides up from the bottom per design. No changes to Card screen UI or business logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3132450d3083905dc8fc1a02b3bed9c1cd111263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->