### PR TITLE
fix: perps safe area design regressions

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1664,9 +1664,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           style={[
             styles.infoSection,
             // eslint-disable-next-line react-native/no-inline-styles
-            { marginBottom: orderValidation.errors.length > 0 ? 16 : 8 },
+            { marginBottom: orderValidation.errors.length > 0 ? 8 : 0 },
             // eslint-disable-next-line react-native/no-inline-styles
-            { marginTop: isInputFocused ? 16 : 0 },
+            { marginTop: isInputFocused ? 8 : 0 },
           ]}
         >
           <View style={styles.infoRow}>

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1428,6 +1428,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         orderType={orderForm.type}
         direction={orderForm.direction}
         onOrderTypePress={() => setIsOrderTypeVisible(true)}
+        onBack={() => navigation.goBack()}
       />
       <ScrollView
         style={styles.scrollView}

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -17,7 +17,6 @@ import {
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 import { PerpsOrderViewSelectorsIDs } from '../../Perps.testIds';
-
 import {
   Button as DSButton,
   ButtonVariant,
@@ -25,6 +24,10 @@ import {
   TextVariant,
   TextColor,
   Text,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
 } from '@metamask/design-system-react-native';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
@@ -33,11 +36,6 @@ import { strings } from '../../../../../../locales/i18n';
 import ButtonSemantic, {
   ButtonSemanticSeverity,
 } from '../../../../../component-library/components-temp/Buttons/ButtonSemantic';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import ListItem from '../../../../../component-library/components/List/ListItem';
 import ListItemColumn, {
   WidthType,
@@ -1502,7 +1500,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                       <Icon
                         name={IconName.Info}
                         size={IconSize.Sm}
-                        color={IconColor.Alternative}
+                        color={IconColor.IconAlternative}
                         testID={PerpsOrderViewSelectorsIDs.LEVERAGE_INFO_ICON}
                       />
                     </TouchableOpacity>
@@ -1582,7 +1580,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                         <Icon
                           name={IconName.Info}
                           size={IconSize.Sm}
-                          color={IconColor.Alternative}
+                          color={IconColor.IconAlternative}
                           testID={PerpsOrderViewSelectorsIDs.TP_SL_INFO_ICON}
                         />
                       </TouchableOpacity>
@@ -1698,7 +1696,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 <Icon
                   name={IconName.Info}
                   size={IconSize.Sm}
-                  color={IconColor.Alternative}
+                  color={IconColor.IconAlternative}
                   testID={PerpsOrderViewSelectorsIDs.MARGIN_INFO_ICON}
                 />
               </TouchableOpacity>
@@ -1731,7 +1729,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 <Icon
                   name={IconName.Info}
                   size={IconSize.Sm}
-                  color={IconColor.Alternative}
+                  color={IconColor.IconAlternative}
                   testID={
                     PerpsOrderViewSelectorsIDs.LIQUIDATION_PRICE_INFO_ICON
                   }
@@ -1794,7 +1792,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                   <Icon
                     name={IconName.Edit}
                     size={IconSize.Sm}
-                    color={IconColor.Alternative}
+                    color={IconColor.IconAlternative}
                   />
                 </View>
               </View>
@@ -1815,7 +1813,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 <Icon
                   name={IconName.Info}
                   size={IconSize.Sm}
-                  color={IconColor.Alternative}
+                  color={IconColor.IconAlternative}
                   testID={PerpsOrderViewSelectorsIDs.FEES_INFO_ICON}
                 />
               </TouchableOpacity>
@@ -1857,7 +1855,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                     <Icon
                       name={IconName.Info}
                       size={IconSize.Sm}
-                      color={IconColor.Alternative}
+                      color={IconColor.IconAlternative}
                     />
                   </TouchableOpacity>
                 </View>

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -22,6 +22,9 @@ import {
   Button as DSButton,
   ButtonVariant,
   ButtonSize as ButtonSizeRNDesignSystem,
+  TextVariant,
+  TextColor,
+  Text,
 } from '@metamask/design-system-react-native';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
@@ -40,10 +43,6 @@ import ListItemColumn, {
   WidthType,
 } from '../../../../../component-library/components/List/ListItemColumn';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import useTooltipModal from '../../../../../components/hooks/useTooltipModal';
 import Routes from '../../../../../constants/navigation/Routes';
 import Engine from '../../../../../core/Engine';
@@ -1491,8 +1490,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 <ListItemColumn widthType={WidthType.Fill}>
                   <View style={styles.detailLeft}>
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
                     >
                       {strings('perps.order.leverage')}
                     </Text>
@@ -1510,7 +1509,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                   </View>
                 </ListItemColumn>
                 <ListItemColumn widthType={WidthType.Auto}>
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {isLoadingMarketData ? '...' : `${orderForm.leverage}x`}
                   </Text>
                 </ListItemColumn>
@@ -1531,16 +1533,16 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 <ListItem style={styles.detailItemWrapper}>
                   <ListItemColumn widthType={WidthType.Fill}>
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
                     >
                       {strings('perps.order.limit_price')}
                     </Text>
                   </ListItemColumn>
                   <ListItemColumn widthType={WidthType.Auto}>
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Default}
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextDefault}
                     >
                       {orderForm.limitPrice !== undefined &&
                       orderForm.limitPrice !== null
@@ -1568,8 +1570,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                   <ListItemColumn widthType={WidthType.Fill}>
                     <View style={styles.detailLeft}>
                       <Text
-                        variant={TextVariant.BodyMD}
-                        color={TextColor.Alternative}
+                        variant={TextVariant.BodyMd}
+                        color={TextColor.TextAlternative}
                       >
                         {strings('perps.order.tp_sl')}
                       </Text>
@@ -1588,8 +1590,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                   </ListItemColumn>
                   <ListItemColumn widthType={WidthType.Auto}>
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Default}
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextDefault}
                     >
                       {tpSlDisplayText}
                     </Text>
@@ -1608,7 +1610,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             )}
             {hasInsufficientPayTokenBalance && (
               <View style={styles.insufficientPayTokenWarning}>
-                <Text variant={TextVariant.BodySM} color={TextColor.Warning}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
                   {strings(
                     'perps.order.validation.insufficient_funds_to_cover_trade',
                   )}
@@ -1617,7 +1622,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             )}
             {!hideTPSL && doesStopLossRiskLiquidation && (
               <View style={styles.stopLossLiquidationWarning}>
-                <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
                   {strings('perps.tpsl.stop_loss_order_view_warning', {
                     direction:
                       orderForm.direction === 'long'
@@ -1629,7 +1637,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             )}
             {!hideTPSL && isTakeProfitPriceInvalid && (
               <View style={styles.stopLossLiquidationWarning}>
-                <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
                   {strings('perps.tpsl.take_profit_wrong_side_warning', {
                     direction:
                       orderForm.direction === 'long'
@@ -1642,7 +1653,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             )}
             {!hideTPSL && isStopLossPriceInvalid && (
               <View style={styles.stopLossLiquidationWarning}>
-                <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
                   {strings('perps.tpsl.stop_loss_wrong_side_warning', {
                     direction:
                       orderForm.direction === 'long'
@@ -1671,7 +1685,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         >
           <View style={styles.infoRow}>
             <View style={styles.detailLeft}>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.order.margin')}
               </Text>
               <TouchableOpacity
@@ -1687,8 +1704,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               </TouchableOpacity>
             </View>
             <Text
-              variant={TextVariant.BodySM}
-              color={TextColor.Alternative}
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
               testID={PerpsOrderViewSelectorsIDs.MARGIN_VALUE}
             >
               {marginRequired !== undefined && marginRequired !== null
@@ -1701,7 +1718,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
           <View style={styles.infoRow}>
             <View style={styles.detailLeft}>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.order.liquidation_price')}
               </Text>
               <TouchableOpacity
@@ -1719,8 +1739,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               </TouchableOpacity>
             </View>
             <Text
-              variant={TextVariant.BodySM}
-              color={TextColor.Alternative}
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
               testID={PerpsOrderViewSelectorsIDs.LIQUIDATION_PRICE_VALUE}
             >
               {hasValidAmount
@@ -1747,17 +1767,19 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
             >
               <View style={styles.infoRow}>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.slippage.slippage')}
                 </Text>
                 <View style={styles.slippageValueRow}>
                   <Text
                     testID={PerpsOrderViewSelectorsIDs.SLIPPAGE_VALUE}
-                    variant={TextVariant.BodySM}
+                    variant={TextVariant.BodySm}
                     color={
-                      exceedsMaxSlippage ? TextColor.Error : TextColor.Default
+                      exceedsMaxSlippage
+                        ? TextColor.ErrorDefault
+                        : TextColor.TextDefault
                     }
                   >
                     {estimatedSlippagePctDisplay === null
@@ -1780,7 +1802,10 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
           )}
           <View style={styles.infoRow}>
             <View style={styles.detailLeft}>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.order.fees')}
               </Text>
               <TouchableOpacity
@@ -1806,7 +1831,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 }
                 placeholder={PERPS_CONSTANTS.FallbackDataDisplay}
                 testID={PerpsOrderViewSelectorsIDs.FEES_VALUE}
-                variant={TextVariant.BodySM}
+                variant={TextVariant.BodySm}
               />
             )}
           </View>
@@ -1820,8 +1845,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
               <View style={styles.infoRow}>
                 <View style={styles.detailLeft}>
                   <Text
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
                   >
                     {strings('perps.estimated_points')}
                   </Text>
@@ -1929,8 +1954,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 {filteredErrors.map((error) => (
                   <Text
                     key={error}
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Error}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.ErrorDefault}
                   >
                     {error}
                   </Text>
@@ -1940,7 +1965,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
           {hasBlockingPayAlerts && !!blockingPayAlertMessage && (
             <View style={styles.validationContainer}>
-              <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+              <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
                 {blockingPayAlertMessage}
               </Text>
             </View>

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.styles.ts
@@ -22,7 +22,9 @@ export const createStyles = (colors: Theme['colors']) =>
     headerBackButton: {
       position: 'absolute',
       left: 16,
+      bottom: 12,
       zIndex: 1,
+      justifyContent: 'center',
     },
     headerTitleContainer: {
       flex: 1,

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -17,6 +17,9 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  TextVariant,
+  TextColor,
+  Text,
 } from '@metamask/design-system-react-native';
 import ButtonIcon, {
   ButtonIconSizes,
@@ -25,10 +28,6 @@ import {
   IconColor,
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import Keypad from '../../../../../components/Base/Keypad';
 import { useTheme } from '../../../../../util/theme';
 
@@ -498,10 +497,11 @@ const PerpsTPSLView: React.FC = () => {
           />
         </View>
         <View style={styles.headerTitleContainer}>
-          <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
             {strings('perps.tpsl.title')}
           </Text>
         </View>
+        <View />
       </View>
       <ScrollView
         ref={scrollViewRef}
@@ -522,12 +522,15 @@ const PerpsTPSLView: React.FC = () => {
             {position && (
               <View style={styles.priceInfoRow}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.tpsl.entry_price')}
                 </Text>
-                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                >
                   {position.entryPrice !== undefined &&
                   position.entryPrice !== null &&
                   position.entryPrice !== 'null' &&
@@ -540,14 +543,17 @@ const PerpsTPSLView: React.FC = () => {
               </View>
             )}
             <View style={styles.priceInfoRow}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {orderType === 'limit' &&
                 limitPrice &&
                 parseFloat(limitPrice) > 0
                   ? strings('perps.order.limit_price')
                   : strings('perps.tpsl.current_price')}
               </Text>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {currentPrice !== undefined && currentPrice !== null
                   ? formatPerpsFiat(currentPrice, {
                       ranges: PRICE_RANGES_UNIVERSAL,
@@ -556,10 +562,13 @@ const PerpsTPSLView: React.FC = () => {
               </Text>
             </View>
             <View style={styles.priceInfoRow}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.tpsl.liquidation_price')}
               </Text>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {displayLiquidationPrice !== undefined &&
                 displayLiquidationPrice !== null &&
                 displayLiquidationPrice !== 'null' &&
@@ -576,7 +585,10 @@ const PerpsTPSLView: React.FC = () => {
           <View style={focusedInput ? styles.sectionCondensed : styles.section}>
             {/* Section title row with Clear button */}
             <View style={styles.sectionTitleRow}>
-              <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+              <Text
+                variant={TextVariant.HeadingSm}
+                color={TextColor.TextDefault}
+              >
                 {actualDirection === 'short'
                   ? strings('perps.tpsl.take_profit_short')
                   : strings('perps.tpsl.take_profit_long')}
@@ -586,7 +598,10 @@ const PerpsTPSLView: React.FC = () => {
                   onPress={handleTakeProfitClear}
                   disabled={inputsDisabled}
                 >
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Primary}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {strings('perps.tpsl.clear')}
                   </Text>
                 </TouchableOpacity>
@@ -606,8 +621,8 @@ const PerpsTPSLView: React.FC = () => {
                   disabled={inputsDisabled}
                 >
                   <Text
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Default}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextDefault}
                     numberOfLines={1}
                     adjustsFontSizeToFit
                   >
@@ -627,10 +642,10 @@ const PerpsTPSLView: React.FC = () => {
                 ]}
               >
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
-                  {strings('perps.tpsl.usd_label')}
+                  {strings('perps.tpsl.usd_perps_label')}
                 </Text>
                 <TextInput
                   ref={takeProfitPriceRef}
@@ -693,8 +708,8 @@ const PerpsTPSLView: React.FC = () => {
                   cursorColor={colors.primary.default}
                 />
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   %
                 </Text>
@@ -705,8 +720,8 @@ const PerpsTPSLView: React.FC = () => {
             {Boolean(takeProfitPrice) &&
               expectedTakeProfitPnL !== undefined && (
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                   style={styles.expectedPnLText}
                 >
                   {expectedTakeProfitPnL >= 0
@@ -731,8 +746,8 @@ const PerpsTPSLView: React.FC = () => {
             {Boolean(takeProfitPrice) &&
               expectedTakeProfitPnL === undefined && (
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                   style={styles.expectedPnLText}
                 >
                   {PERPS_CONSTANTS.FallbackDataDisplay}
@@ -741,7 +756,7 @@ const PerpsTPSLView: React.FC = () => {
 
             {/* Error message */}
             {!isValid && Boolean(takeProfitError) && (
-              <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+              <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
                 {takeProfitError}
               </Text>
             )}
@@ -751,7 +766,10 @@ const PerpsTPSLView: React.FC = () => {
           <View style={focusedInput ? styles.sectionCondensed : styles.section}>
             {/* Section title row with Clear button */}
             <View style={styles.sectionTitleRow}>
-              <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+              <Text
+                variant={TextVariant.HeadingSm}
+                color={TextColor.TextDefault}
+              >
                 {actualDirection === 'short'
                   ? strings('perps.tpsl.stop_loss_short')
                   : strings('perps.tpsl.stop_loss_long')}
@@ -761,7 +779,10 @@ const PerpsTPSLView: React.FC = () => {
                   onPress={handleStopLossClear}
                   disabled={inputsDisabled}
                 >
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Primary}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {strings('perps.tpsl.clear')}
                   </Text>
                 </TouchableOpacity>
@@ -781,8 +802,8 @@ const PerpsTPSLView: React.FC = () => {
                   disabled={inputsDisabled}
                 >
                   <Text
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Default}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextDefault}
                     numberOfLines={1}
                     adjustsFontSizeToFit
                   >
@@ -802,8 +823,8 @@ const PerpsTPSLView: React.FC = () => {
                 ]}
               >
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.tpsl.usd_label')}
                 </Text>
@@ -868,8 +889,8 @@ const PerpsTPSLView: React.FC = () => {
                   cursorColor={colors.primary.default}
                 />
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   %
                 </Text>
@@ -879,8 +900,8 @@ const PerpsTPSLView: React.FC = () => {
             {/* Expected Profit/Loss for Stop Loss */}
             {Boolean(stopLossPrice) && expectedStopLossPnL !== undefined && (
               <Text
-                variant={TextVariant.BodyMD}
-                color={TextColor.Alternative}
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
                 style={styles.expectedPnLText}
               >
                 {expectedStopLossPnL >= 0
@@ -898,8 +919,8 @@ const PerpsTPSLView: React.FC = () => {
             )}
             {Boolean(stopLossPrice) && expectedStopLossPnL === undefined && (
               <Text
-                variant={TextVariant.BodyMD}
-                color={TextColor.Alternative}
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
                 style={styles.expectedPnLText}
               >
                 {PERPS_CONSTANTS.FallbackDataDisplay}
@@ -908,7 +929,7 @@ const PerpsTPSLView: React.FC = () => {
 
             {/* Error message */}
             {!isValid && Boolean(stopLossError || stopLossLiquidationError) && (
-              <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+              <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
                 {stopLossError || stopLossLiquidationError}
               </Text>
             )}

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -645,7 +645,7 @@ const PerpsTPSLView: React.FC = () => {
                   variant={TextVariant.BodyMd}
                   color={TextColor.TextAlternative}
                 >
-                  {strings('perps.tpsl.usd_perps_label')}
+                  {strings('perps.tpsl.usd_label')}
                 </Text>
                 <TextInput
                   ref={takeProfitPriceRef}

--- a/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.styles.ts
+++ b/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.styles.ts
@@ -5,7 +5,7 @@ const createStyles = (colors: Theme['colors']) =>
   StyleSheet.create({
     container: {
       alignItems: 'center',
-      paddingTop: 24,
+      paddingTop: 48,
       paddingHorizontal: 24,
     },
     label: {

--- a/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.styles.ts
+++ b/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.styles.ts
@@ -5,8 +5,8 @@ const createStyles = (colors: Theme['colors']) =>
   StyleSheet.create({
     container: {
       alignItems: 'center',
-      paddingTop: 48,
-      paddingHorizontal: 24,
+      paddingTop: 32,
+      paddingHorizontal: 8,
     },
     label: {
       marginBottom: 8,

--- a/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.styles.ts
+++ b/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.styles.ts
@@ -5,7 +5,7 @@ const createStyles = (colors: Theme['colors']) =>
   StyleSheet.create({
     container: {
       alignItems: 'center',
-      paddingTop: 48,
+      paddingTop: 24,
       paddingHorizontal: 24,
     },
     label: {

--- a/app/components/UI/Perps/components/PerpsCloseSummary/PerpsCloseSummary.tsx
+++ b/app/components/UI/Perps/components/PerpsCloseSummary/PerpsCloseSummary.tsx
@@ -6,15 +6,6 @@ import {
   type ViewStyle,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
 import {
   formatPerpsFiat,
@@ -30,6 +21,15 @@ import { useStyles } from '../../../../hooks/useStyles';
 import createStyles from './PerpsCloseSummary.styles';
 import Routes from '../../../../../constants/navigation/Routes';
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import {
+  Text,
+  TextColor,
+  TextVariant,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+} from '@metamask/design-system-react-native';
 
 export interface PerpsCloseSummaryProps {
   /** Total margin including P&L */
@@ -165,23 +165,25 @@ const PerpsCloseSummary: React.FC<PerpsCloseSummaryProps> = ({
       {/* Margin with P&L breakdown */}
       <View style={styles.summaryRow}>
         <View style={styles.summaryLabel}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('perps.close_position.margin')}
           </Text>
         </View>
         <View style={styles.summaryValue}>
-          <Text testID={testIDs?.marginValue} variant={TextVariant.BodyMD}>
+          <Text testID={testIDs?.marginValue} variant={TextVariant.BodyMd}>
             {formatPerpsFiat(totalMargin, {
               ranges: PRICE_RANGES_MINIMAL_VIEW,
             })}
           </Text>
           <View style={styles.inclusiveFeeRow}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+            <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
               {strings('perps.close_position.includes_pnl')}
             </Text>
             <Text
-              variant={TextVariant.BodySM}
-              color={totalPnl < 0 ? TextColor.Error : TextColor.Success}
+              variant={TextVariant.BodySm}
+              color={
+                totalPnl < 0 ? TextColor.ErrorDefault : TextColor.SuccessDefault
+              }
             >
               {totalPnl < 0 ? '-' : '+'}
               {formatPerpsFiat(Math.abs(totalPnl), {
@@ -208,17 +210,23 @@ const PerpsCloseSummary: React.FC<PerpsCloseSummaryProps> = ({
               style={styles.labelWithTooltip}
               testID={testIDs?.feesTooltip}
             >
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.close_position.fees')}
               </Text>
               <Icon
                 name={IconName.Info}
                 size={IconSize.Sm}
-                color={IconColor.Muted}
+                color={IconColor.IconMuted}
               />
             </TouchableOpacity>
           ) : (
-            <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
               {strings('perps.close_position.fees')}
             </Text>
           )}
@@ -237,10 +245,10 @@ const PerpsCloseSummary: React.FC<PerpsCloseSummaryProps> = ({
               fee={totalFees}
               originalFee={originalTotalFees}
               testID={testIDs?.feesValue}
-              variant={TextVariant.BodyMD}
+              variant={TextVariant.BodyMd}
             />
           ) : (
-            <Text variant={TextVariant.BodyMD}>--</Text>
+            <Text variant={TextVariant.BodyMd}>--</Text>
           )}
         </View>
       </View>
@@ -254,25 +262,25 @@ const PerpsCloseSummary: React.FC<PerpsCloseSummaryProps> = ({
               style={styles.labelWithTooltip}
               testID={testIDs?.receiveTooltip}
             >
-              <Text variant={TextVariant.BodyMD}>
+              <Text variant={TextVariant.BodyMd}>
                 {strings('perps.close_position.you_receive')}
               </Text>
               <Icon
                 name={IconName.Info}
                 size={IconSize.Sm}
-                color={IconColor.Muted}
+                color={IconColor.IconMuted}
               />
             </TouchableOpacity>
           ) : (
-            <Text variant={TextVariant.BodyMD}>
+            <Text variant={TextVariant.BodyMd}>
               {strings('perps.close_position.you_receive')}
             </Text>
           )}
         </View>
         <View style={styles.summaryValue}>
           <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Default}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
             testID={testIDs?.receiveValue}
           >
             {formatPerpsFiat(receiveAmount, {
@@ -294,17 +302,23 @@ const PerpsCloseSummary: React.FC<PerpsCloseSummaryProps> = ({
                   style={styles.labelWithTooltip}
                   testID={testIDs?.pointsTooltip}
                 >
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {strings('perps.estimated_points')}
                   </Text>
                   <Icon
                     name={IconName.Info}
                     size={IconSize.Sm}
-                    color={IconColor.Muted}
+                    color={IconColor.IconMuted}
                   />
                 </TouchableOpacity>
               ) : (
-                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                >
                   {strings('perps.estimated_points')}
                 </Text>
               )}

--- a/app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.tsx
+++ b/app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import RewardsVipBadge from '../../../Rewards/components/RewardsVipBadge/RewardsVipBadge';
 import { createStyles } from './PerpsFeesDisplay.styles';
 import { useTheme } from '../../../../../util/theme';
@@ -11,6 +7,11 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../utils/formatUtils';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 
 interface PerpsFeesDisplayProps {
   /**
@@ -41,7 +42,7 @@ const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
   originalFee,
   placeholder = '--',
   testID,
-  variant = TextVariant.BodyMD,
+  variant = TextVariant.BodyMd,
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -74,7 +75,7 @@ const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
       {originalFeeText !== undefined ? (
         <Text
           variant={variant}
-          color={TextColor.Alternative}
+          color={TextColor.TextAlternative}
           // eslint-disable-next-line react-native/no-inline-styles
           style={{ textDecorationLine: 'line-through' }}
           testID={testID ? `${testID}-original` : undefined}
@@ -82,7 +83,7 @@ const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
           {originalFeeText}
         </Text>
       ) : null}
-      <Text variant={variant} color={TextColor.Alternative} testID={testID}>
+      <Text variant={variant} color={TextColor.TextAlternative} testID={testID}>
         {feeText}
       </Text>
     </View>

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
@@ -242,16 +242,22 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => {
   };
 });
 
-jest.mock('../../../../../component-library/components/Icons/Icon', () => {
+jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
+  __esModule: true,
+  default: () => null,
+  IconName: { ArrowRight: 'ArrowRight' },
+  IconSize: { Md: 'Md' },
+  IconColor: { Default: 'Default' },
+}));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   const ReactModule = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
   return {
-    __esModule: true,
-    default: ({ name }: { name: string }) =>
+    ...actual,
+    Icon: ({ name }: { name: string }) =>
       ReactModule.createElement(View, { accessibilityLabel: name }),
-    IconName: { ArrowRight: 'ArrowRight' },
-    IconSize: { Md: 'Md' },
-    IconColor: { Default: 'Default' },
   };
 });
 

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.tsx
@@ -9,15 +9,6 @@ import BottomSheetHeader from '../../../../../component-library/components/Botto
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import {
   ButtonSize,
   ButtonVariants,
@@ -39,6 +30,15 @@ import RewardsAnimations, {
   RewardAnimationState,
 } from '../../../Rewards/components/RewardPointsAnimation';
 import { useVipTier } from '../../../Rewards/hooks/useVipTier';
+import {
+  Text,
+  TextColor,
+  TextVariant,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
+} from '@metamask/design-system-react-native';
 
 const PerpsFlipPositionConfirmSheet: React.FC<
   PerpsFlipPositionConfirmSheetProps
@@ -180,7 +180,7 @@ const PerpsFlipPositionConfirmSheet: React.FC<
       testID={PerpsFlipPositionConfirmSheetSelectorsIDs.SHEET}
     >
       <BottomSheetHeader onClose={handleCloseInternal}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingMd}>
           {strings('perps.flip_position.title')}
         </Text>
       </BottomSheetHeader>
@@ -193,8 +193,8 @@ const PerpsFlipPositionConfirmSheet: React.FC<
               color={theme.colors.primary.default}
             />
             <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
               style={styles.loadingText}
             >
               {strings('perps.flip_position.flipping')}
@@ -214,13 +214,13 @@ const PerpsFlipPositionConfirmSheet: React.FC<
                 ]}
               >
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.flip_position.direction')}
                 </Text>
                 <View style={styles.directionContainer}>
-                  <Text variant={TextVariant.BodyMD}>
+                  <Text variant={TextVariant.BodyMd}>
                     {currentDirection === 'long'
                       ? strings('perps.order.long_label')
                       : strings('perps.order.short_label')}
@@ -228,9 +228,9 @@ const PerpsFlipPositionConfirmSheet: React.FC<
                   <Icon
                     name={IconName.ArrowRight}
                     size={IconSize.Md}
-                    color={IconColor.Default}
+                    color={IconColor.IconDefault}
                   />
-                  <Text variant={TextVariant.BodyMD}>
+                  <Text variant={TextVariant.BodyMd}>
                     {oppositeDirection === 'long'
                       ? strings('perps.order.long_label')
                       : strings('perps.order.short_label')}
@@ -248,14 +248,14 @@ const PerpsFlipPositionConfirmSheet: React.FC<
                 ]}
               >
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.flip_position.est_size')}
                 </Text>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Default}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
                   testID={
                     PerpsFlipPositionConfirmSheetSelectorsIDs.EST_SIZE_VALUE
                   }
@@ -267,7 +267,10 @@ const PerpsFlipPositionConfirmSheet: React.FC<
 
             {/* Fees */}
             <View style={styles.infoRow}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.order.fees')}
               </Text>
               <PerpsFeesDisplay
@@ -283,7 +286,7 @@ const PerpsFlipPositionConfirmSheet: React.FC<
                     : feeResults.undiscountedTotalFee
                 }
                 testID={PerpsFlipPositionConfirmSheetSelectorsIDs.FEES_VALUE}
-                variant={TextVariant.BodyMD}
+                variant={TextVariant.BodyMd}
               />
             </View>
 
@@ -293,8 +296,8 @@ const PerpsFlipPositionConfirmSheet: React.FC<
               rewardsState.accountOptedIn && (
                 <View style={styles.infoRow}>
                   <Text
-                    variant={TextVariant.BodyMD}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextAlternative}
                   >
                     {strings('perps.estimated_points')}
                   </Text>

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
@@ -19,11 +19,11 @@ export const createStyles = (colors: Theme['colors']) =>
       paddingBottom: 24,
       marginHorizontal: 12,
     },
-    // leverageText: {
-    //   fontSize: 48,
-    //   fontWeight: '600',
-    //   lineHeight: 56,
-    // },
+    leverageText: {
+      fontSize: 48,
+      fontWeight: '600',
+      lineHeight: 56,
+    },
     leverageTextSafe: {
       color: LEVERAGE_COLORS.SAFE, // Green - safe leverage
     },

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
@@ -19,11 +19,11 @@ export const createStyles = (colors: Theme['colors']) =>
       paddingBottom: 24,
       marginHorizontal: 12,
     },
-    leverageText: {
-      fontSize: 48,
-      fontWeight: '600',
-      lineHeight: 56,
-    },
+    // leverageText: {
+    //   fontSize: 48,
+    //   fontWeight: '600',
+    //   lineHeight: 56,
+    // },
     leverageTextSafe: {
       color: LEVERAGE_COLORS.SAFE, // Green - safe leverage
     },
@@ -71,6 +71,8 @@ export const createStyles = (colors: Theme['colors']) =>
     warningTextContainer: {
       flex: 1,
       minWidth: 0,
+      flexDirection: 'row',
+      alignItems: 'center',
     },
     warningText: {
       flex: 1,
@@ -97,6 +99,10 @@ export const createStyles = (colors: Theme['colors']) =>
       borderRadius: 8,
       marginBottom: 32,
       marginHorizontal: 12,
+      // Reserve vertical space whether price data is available or not,
+      // preventing a layout jump when switching between the two states.
+      minHeight: 100,
+      justifyContent: 'center',
     },
     priceRow: {
       flexDirection: 'row',
@@ -191,5 +197,8 @@ export const createStyles = (colors: Theme['colors']) =>
       backgroundColor: colors.border.muted,
       borderRadius: 2,
       top: 2,
+    },
+    footerButtonContainer: {
+      marginBottom: 16,
     },
   });

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -81,6 +81,9 @@ jest.mock('../../../../../../locales/i18n', () => ({
     if (key === 'perps.order.leverage_modal.rises') {
       return 'rises';
     }
+    if (key === 'perps.order.leverage_modal.price_unavailable') {
+      return 'Price information unavailable';
+    }
     return key;
   }),
 }));

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -13,7 +13,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { ScrollView, TouchableOpacity, View } from 'react-native';
 import {
   Gesture,
   GestureDetector,
@@ -26,25 +26,6 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated';
 import { strings } from '../../../../../../locales/i18n';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetFooter from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../../component-library/components/Buttons/Button';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
-
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
 import { useTheme } from '../../../../../util/theme';
 import { Theme } from '../../../../../util/theme/models';
@@ -68,6 +49,21 @@ import {
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { createStyles } from './PerpsLeverageBottomSheet.styles';
 import { usePerpsLivePrices } from '../../hooks';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  BottomSheetRef,
+  ButtonSize,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 
 interface PerpsLeverageBottomSheetProps {
   isVisible: boolean;
@@ -620,21 +616,21 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
         return {
           textStyle: styles.warningTextSafe,
           containerStyle: styles.warningContainerSafe,
-          iconColor: IconColor.Success,
+          iconColor: IconColor.SuccessDefault,
           priceColor: colors.text.alternative,
         };
       case 'caution':
         return {
           textStyle: styles.warningTextCaution,
           containerStyle: styles.warningContainerCaution,
-          iconColor: IconColor.Warning,
+          iconColor: IconColor.WarningDefault,
           priceColor: LEVERAGE_COLORS.CAUTION,
         };
       case 'medium':
         return {
           textStyle: styles.warningTextMedium,
           containerStyle: styles.warningContainerMedium,
-          iconColor: IconColor.Warning,
+          iconColor: IconColor.WarningDefault,
           priceColor: LEVERAGE_COLORS.MEDIUM,
         };
       case 'high':
@@ -642,7 +638,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
         return {
           textStyle: styles.warningTextHigh,
           containerStyle: styles.warningContainerHigh,
-          iconColor: IconColor.Error,
+          iconColor: IconColor.ErrorDefault,
           priceColor: colors.error.default,
         };
     }
@@ -660,105 +656,104 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
 
   const displayLeverage = isDragging ? draggingLeverage : tempLeverage;
 
-  const footerButtonProps = [
-    {
-      label: strings('perps.order.leverage_modal.set_leverage', {
-        leverage: displayLeverage,
-      }),
-      variant: ButtonVariants.Primary,
-      size: ButtonSize.Lg,
-      onPress: handleConfirm,
-    },
-  ];
+  // const footerButtonProps = [
+  //   {
+  //     label: strings('perps.order.leverage_modal.set_leverage', {
+  //       leverage: displayLeverage,
+  //     }),
+  //     variant: ButtonVariant.Primary,
+  //     size: ButtonSize.Lg,
+  //     onPress: handleConfirm,
+  //   },
+  // ];
 
   if (!isVisible) return null;
 
   return (
     <BottomSheet
       ref={bottomSheetRef}
-      shouldNavigateBack={false}
+      // shouldNavigateBack={false}
       onClose={onClose}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
           {strings('perps.order.leverage_modal.title')}
         </Text>
       </BottomSheetHeader>
 
-      <View style={styles.container}>
-        {/* Large leverage display */}
-        <View style={styles.leverageDisplay}>
-          <Text
-            variant={TextVariant.DisplayMD}
-            style={[styles.leverageText, getLeverageTextStyle()]}
-          >
-            {displayLeverage}x
-          </Text>
-        </View>
-
-        {/* Liquidation warning */}
-        <View style={[styles.warningContainer, warningStyles.containerStyle]}>
-          <Icon
-            name={IconName.Danger}
-            size={IconSize.Sm}
-            color={warningStyles.iconColor}
-            style={styles.warningIcon}
-          />
-          <View style={styles.warningTextContainer}>
-            {isRecalculating ? (
-              <SkeletonPlaceholder>
-                <SkeletonPlaceholder.Item
-                  width="80%"
-                  height={14}
-                  borderRadius={4}
-                />
-              </SkeletonPlaceholder>
-            ) : (
-              <Text
-                variant={TextVariant.BodySM}
-                style={[warningStyles.textStyle, styles.warningText]}
-              >
-                {strings('perps.order.leverage_modal.liquidation_warning', {
-                  direction:
-                    direction === 'long'
-                      ? strings('perps.order.leverage_modal.drops')
-                      : strings('perps.order.leverage_modal.rises'),
-                  percentage: displayLiquidationPercentage ?? '--',
-                })}
-              </Text>
-            )}
+      <ScrollView
+        bounces={false}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.container}>
+          {/* Large leverage display */}
+          <View style={styles.leverageDisplay}>
+            <Text
+              variant={TextVariant.DisplayLg}
+              fontWeight={FontWeight.Bold}
+              style={getLeverageTextStyle()}
+            >
+              {displayLeverage}x
+            </Text>
           </View>
-        </View>
 
-        {/* Price information */}
-        {currentPrice ? (
-          <View style={styles.priceInfoContainer}>
-            <View style={styles.priceRow}>
-              <Text
-                variant={TextVariant.BodyMD}
-                style={{ color: warningStyles.priceColor }}
-              >
-                {strings('perps.order.leverage_modal.liquidation_price')}
-              </Text>
-              <View style={styles.priceValueContainer}>
-                {isRecalculating ? (
-                  <SkeletonPlaceholder>
-                    <SkeletonPlaceholder.Item
-                      width={80}
-                      height={16}
-                      borderRadius={4}
-                    />
-                  </SkeletonPlaceholder>
-                ) : (
-                  <>
-                    <Icon
-                      name={IconName.Danger}
-                      size={IconSize.Xs}
-                      color={warningStyles.priceColor}
-                      style={styles.priceIcon}
-                    />
+          {/* Liquidation warning */}
+          <View style={[styles.warningContainer, warningStyles.containerStyle]}>
+            <Icon
+              name={IconName.Danger}
+              size={IconSize.Sm}
+              color={warningStyles.iconColor}
+              style={styles.warningIcon}
+            />
+            <View style={styles.warningTextContainer}>
+              {isRecalculating ? (
+                <SkeletonPlaceholder>
+                  <SkeletonPlaceholder.Item
+                    width="80%"
+                    height={14}
+                    borderRadius={4}
+                  />
+                </SkeletonPlaceholder>
+              ) : (
+                <Text
+                  variant={TextVariant.BodySm}
+                  style={[warningStyles.textStyle, styles.warningText]}
+                >
+                  {strings('perps.order.leverage_modal.liquidation_warning', {
+                    direction:
+                      direction === 'long'
+                        ? strings('perps.order.leverage_modal.drops')
+                        : strings('perps.order.leverage_modal.rises'),
+                    percentage: displayLiquidationPercentage ?? '--',
+                  })}
+                </Text>
+              )}
+            </View>
+          </View>
+
+          {/* Price information */}
+          {currentPrice ? (
+            <View style={styles.priceInfoContainer}>
+              <View style={styles.priceRow}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  style={{ color: warningStyles.priceColor }}
+                >
+                  {strings('perps.order.leverage_modal.liquidation_price')}
+                </Text>
+                <View style={styles.priceValueContainer}>
+                  {isRecalculating ? (
+                    <SkeletonPlaceholder>
+                      <SkeletonPlaceholder.Item
+                        width={80}
+                        height={16}
+                        borderRadius={4}
+                      />
+                    </SkeletonPlaceholder>
+                  ) : (
                     <Text
-                      variant={TextVariant.BodyMD}
+                      variant={TextVariant.BodyMd}
                       style={{ color: warningStyles.priceColor }}
                     >
                       {displayLiquidationPrice
@@ -767,113 +762,139 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
                           })
                         : '--'}
                     </Text>
-                  </>
-                )}
+                  )}
+                </View>
+              </View>
+              <View style={styles.priceRow}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
+                >
+                  {strings('perps.order.leverage_modal.current_price')}
+                </Text>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                >
+                  {formatPerpsFiat(currentPrice, {
+                    ranges: PRICE_RANGES_UNIVERSAL,
+                  })}
+                </Text>
               </View>
             </View>
-            <View style={styles.priceRow}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
-                {strings('perps.order.leverage_modal.current_price')}
-              </Text>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-                {formatPerpsFiat(currentPrice, {
-                  ranges: PRICE_RANGES_UNIVERSAL,
-                })}
+          ) : (
+            <View style={styles.priceInfoContainer}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+                style={styles.emptyPriceInfo}
+              >
+                {strings('perps.order.leverage_modal.price_unavailable')}
               </Text>
             </View>
-          </View>
-        ) : (
-          <View style={styles.priceInfoContainer}>
-            <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Alternative}
-              style={styles.emptyPriceInfo}
-            >
-              Price information unavailable
-            </Text>
-          </View>
-        )}
+          )}
 
-        {/* Custom Leverage Slider */}
-        <View style={styles.sliderContainer}>
-          <LeverageSlider
-            value={isDragging ? draggingLeverage : tempLeverage}
-            onValueChange={(newValue) => {
-              if (isDragging) {
-                setDraggingLeverage(newValue);
-              } else {
-                setTempLeverage(newValue);
-              }
-            }}
-            onDragStart={() => {
-              setIsDragging(true);
-              setDraggingLeverage(tempLeverage);
-            }}
-            onDragEnd={(finalValue) => {
-              setIsDragging(false);
-              if (finalValue !== tempLeverage) {
-                leverageChangeTime.current = Date.now();
-                setLeverageChanged(true);
-                lastValidLiquidationPrice.current = null;
-              }
-              setTempLeverage(finalValue);
-              setInputMethod('slider');
-            }}
-            minValue={minLeverage}
-            maxValue={maxLeverage}
-            colors={colors}
-            onInteraction={() => setInputMethod('slider')}
-          />
-          <View style={styles.sliderLabels}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-              {minLeverage}x
-            </Text>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-              {Math.floor((minLeverage + maxLeverage) / 2)}x
-            </Text>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-              {maxLeverage}x
-            </Text>
-          </View>
-        </View>
-
-        {/* Quick select buttons */}
-        <View style={styles.quickSelectButtons}>
-          {quickSelectValues.map((value) => (
-            <TouchableOpacity
-              key={value}
-              style={[
-                styles.quickSelectButton,
-                tempLeverage === value && styles.quickSelectButtonActive,
-              ]}
-              onPress={() => {
-                setIsDragging(false); // Ensure we're not in dragging state
-                if (value !== tempLeverage) {
+          {/* Custom Leverage Slider */}
+          <View style={styles.sliderContainer}>
+            <LeverageSlider
+              value={isDragging ? draggingLeverage : tempLeverage}
+              onValueChange={(newValue) => {
+                if (isDragging) {
+                  setDraggingLeverage(newValue);
+                } else {
+                  setTempLeverage(newValue);
+                }
+              }}
+              onDragStart={() => {
+                setIsDragging(true);
+                setDraggingLeverage(tempLeverage);
+              }}
+              onDragEnd={(finalValue) => {
+                setIsDragging(false);
+                if (finalValue !== tempLeverage) {
                   leverageChangeTime.current = Date.now();
                   setLeverageChanged(true);
                   lastValidLiquidationPrice.current = null;
                 }
-                setTempLeverage(value);
-                setInputMethod('preset');
-                // Add haptic feedback for quick select buttons
-                playSelection();
+                setTempLeverage(finalValue);
+                setInputMethod('slider');
               }}
-            >
+              minValue={minLeverage}
+              maxValue={maxLeverage}
+              colors={colors}
+              onInteraction={() => setInputMethod('slider')}
+            />
+            <View style={styles.sliderLabels}>
               <Text
-                variant={TextVariant.BodyLGMedium}
-                color={
-                  tempLeverage === value ? TextColor.Inverse : TextColor.Default
-                }
-                style={styles.quickSelectText}
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
               >
-                {value}x
+                {minLeverage}x
               </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-      </View>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {Math.floor((minLeverage + maxLeverage) / 2)}x
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {maxLeverage}x
+              </Text>
+            </View>
+          </View>
 
-      <BottomSheetFooter buttonPropsArray={footerButtonProps} />
+          {/* Quick select buttons */}
+          <View style={styles.quickSelectButtons}>
+            {quickSelectValues.map((value) => (
+              <TouchableOpacity
+                key={value}
+                style={[
+                  styles.quickSelectButton,
+                  tempLeverage === value && styles.quickSelectButtonActive,
+                ]}
+                onPress={() => {
+                  setIsDragging(false); // Ensure we're not in dragging state
+                  if (value !== tempLeverage) {
+                    leverageChangeTime.current = Date.now();
+                    setLeverageChanged(true);
+                    lastValidLiquidationPrice.current = null;
+                  }
+                  setTempLeverage(value);
+                  setInputMethod('preset');
+                  // Add haptic feedback for quick select buttons
+                  playSelection();
+                }}
+              >
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={
+                    tempLeverage === value
+                      ? TextColor.PrimaryInverse
+                      : TextColor.TextDefault
+                  }
+                  style={styles.quickSelectText}
+                >
+                  {value}x
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      </ScrollView>
+
+      <BottomSheetFooter
+        primaryButtonProps={{
+          size: ButtonSize.Lg,
+          onPress: handleConfirm,
+          children: strings('perps.order.leverage_modal.set_leverage', {
+            leverage: displayLeverage,
+          }),
+          style: styles.footerButtonContainer,
+        }}
+      />
     </BottomSheet>
   );
 };

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -99,7 +99,10 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [priceChange, price]);
 
   const headerStyle = useMemo(
-    () => [styles.header, topInset > 0 ? { top: topInset } : undefined],
+    () => [
+      styles.header,
+      topInset > 0 ? { paddingTop: topInset + 16 } : undefined,
+    ],
     [styles.header, topInset],
   );
 

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -99,10 +99,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   }, [priceChange, price]);
 
   const headerStyle = useMemo(
-    () => [
-      styles.header,
-      topInset > 0 ? { paddingTop: 16 + topInset } : undefined,
-    ],
+    () => [styles.header, topInset > 0 ? { top: topInset } : undefined],
     [styles.header, topInset],
   );
 

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -101,7 +101,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
   const headerStyle = useMemo(
     () => [
       styles.header,
-      topInset > 0 ? { paddingTop: topInset + 16 } : undefined,
+      topInset > 0 ? { paddingTop: 16 + topInset } : undefined,
     ],
     [styles.header, topInset],
   );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1436,7 +1436,8 @@
         "liquidation_warning": "You will be liquidated if price {{direction}} by {{percentage}}",
         "drops": "drops",
         "rises": "rises",
-        "set_leverage": "Set {{leverage}}x"
+        "set_leverage": "Set {{leverage}}x",
+        "price_unavailable": "Price information unavailable"
       },
       "type": {
         "title": "Order type",


### PR DESCRIPTION
## **Description**

Fix Perps UI layout and rendering issues
This PR addresses a collection of visual bugs found across the Perps order flow on iOS and Android.

What changed
Order header back button overlap The header was applying top: topInset as a relative offset, which visually shifted it down without affecting the layout box. This caused the back button to render on top of the amount input, making taps on the back button focus the input instead. Changed to paddingTop: topInset so the header grows correctly in the flex layout.

Android safe area for the order button The fixed "Place Order" button was jumping on re-render on Android. The root cause was spreading a StyleSheet object into a plain object inside useMemo, which made the base style reference unstable and caused Fabric to flash the un-overridden bottom: 0 before the dynamic value resolved. Separated the stable StyleSheet reference from the dynamic safe area padding using a style array.

TPSL back button vertical alignment The absolutely-positioned back button was missing top/bottom anchors, so it defaulted to top: 0 and ignored the parent's alignItems. Added top: 0, bottom: 0, and justifyContent: center so the icon sits centered with the header title.

Leverage bottom sheet button off-screen on iOS The bottom sheet's overflow: hidden was clipping the footer button when content exceeded the available height. Wrapped the scrollable content in a ScrollView with flexShrink: 1 and moved the footer outside it so the button is always visible and never clipped.

Leverage price icon color The Icon component's color prop was not being applied because a raw hex string was passed via the style prop instead of the color prop. Moved the color to the correct prop.

i18n and test coverage

- Added the price_unavailable string to the leverage bottom sheet's i18n mock in tests (previously fell through to returning the key itself).
- Fixed the PerpsFlipPositionConfirmSheet test's Icon mock to target @metamask/design-system-react-native instead of the local component library, which is what the component actually imports from.

Also replaced several instances of deprecated component library components. Namely `Text` and `Icon`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: SafeArea view style polish

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

Before:
<img width="443" height="900" alt="Screenshot 2026-06-02 at 8 09 13 AM" src="https://github.com/user-attachments/assets/7c6f967e-b5a3-4dee-88df-279977177918" />

After:
<img width="442" height="900" alt="Screenshot 2026-06-02 at 10 06 51 AM" src="https://github.com/user-attachments/assets/2358c496-db21-4dd7-a992-95070033d86e" />

Also after (back arrow aligned):
<img width="437" height="898" alt="Screenshot 2026-06-02 at 10 06 27 AM" src="https://github.com/user-attachments/assets/0baa1343-7f87-4269-b9a4-978909cb3d90" />

Also after (order button not cut off on Samsung Galaxy):
<img width="433" height="927" alt="Screenshot 2026-06-02 at 5 23 30 PM" src="https://github.com/user-attachments/assets/854a8ebf-c52d-4610-ac5d-c1fb2510f03c" />


## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-only changes across Perps trading UI with no trading logic or auth changes; test mocks updated for design-system imports.
> 
> **Overview**
> Fixes **Perps order-flow layout and safe-area regressions** on iOS/Android, and aligns several screens with **`@metamask/design-system-react-native`** for `Text`/`Icon` (replacing deprecated component-library tokens like `BodyMD` → `BodyMd`, `TextColor.Default` → `TextColor.TextDefault`).
> 
> **Order & TP/SL:** `PerpsOrderView` wires **`onBack`** on `PerpsOrderHeader` and tightens info-section margins; **`PerpsAmountDisplay`** reduces top/horizontal padding. **TP/SL** header back control is repositioned (`bottom` + `justifyContent: 'center'`) and gets a balancing empty column for title centering.
> 
> **Leverage sheet:** Content moves into a **`ScrollView`** so the confirm action stays visible; footer uses design-system **`BottomSheetFooter`** with `primaryButtonProps`; warning row layout and **`minHeight`** on the price block reduce jumps when price is missing; unavailable price copy is **`perps.order.leverage_modal.price_unavailable`** in `en.json` and tests.
> 
> **Shared components:** `PerpsCloseSummary`, `PerpsFeesDisplay`, and `PerpsFlipPositionConfirmSheet` get the same design-system migration; flip-confirm tests mock **`Icon`** from the design-system package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef5198938e86dc0cd567af3786797990348913c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->