### PR TITLE
ci(runway-ota): add `actions: read` permission for slack notification cp-7.79.1 cp-7.80.0

### DIFF
--- a/.github/workflows/runway-ota-rc.yml
+++ b/.github/workflows/runway-ota-rc.yml
@@ -22,6 +22,7 @@ on:
         type: string
 
 permissions:
+  actions: read # required by slack-rc-notification.yml
   contents: read
   pull-requests: read
   id-token: write # required by push-eas-update.yml


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `runway-ota-rc.yml` caller workflow was missing the `actions: read` permission required by the `slack-rc-notification.yml` reusable workflow.

GitHub Actions enforces that a reusable workflow cannot use permissions that the calling workflow has not already granted. `slack-rc-notification.yml` declares `actions: read` (needed by `actions/download-artifact@v4` to download the Android Play Store check report), but `runway-ota-rc.yml` only granted `contents: read`, `pull-requests: read`, and `id-token: write`. This caused the workflow validation step to fail with:

> Error calling workflow '…slack-rc-notification.yml…'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'.

The fix adds `actions: read` to the `permissions` block in `runway-ota-rc.yml`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI permission line; no app, auth, or release logic changes.
> 
> **Overview**
> Grants **`actions: read`** on the **Runway OTA RC** caller workflow so it can invoke **`slack-rc-notification.yml`** without GitHub rejecting the run.
> 
> Reusable workflows only get permissions the caller explicitly allows; the Slack workflow needs **`actions: read`** for **`actions/download-artifact@v4`** (Android Play Store check report). Without this line, validation fails with *actions: none* vs *actions: read*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d24e76cf76b3e0c7e822f3f4f1ba60c75e112a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->