### PR TITLE
fix: MUSD-887 filter out non-EVM tokens in useMoneyDepositTokens

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyDepositTokens.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyDepositTokens.test.ts
@@ -12,6 +12,7 @@ import { isTokenBlocked } from '../../../Views/confirmations/utils/transaction-p
 import { useAccountTokens } from '../../../Views/confirmations/hooks/send/useAccountTokens';
 import { useTransactionPayBlockedTokens } from '../../../Views/confirmations/hooks/pay/useTransactionPayBlockedTokens';
 import { AssetType } from '../../../Views/confirmations/types/token';
+import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 
 jest.mock('react-redux');
 jest.mock('../selectors/featureFlags');
@@ -49,6 +50,7 @@ const makeToken = (overrides: Partial<AssetType> = {}): AssetType =>
     isETH: false,
     aggregators: [],
     image: '',
+    accountType: EthAccountType.Eoa,
     ...overrides,
   }) as AssetType;
 
@@ -128,6 +130,40 @@ describe('useMoneyDepositTokens', () => {
 
       expect(result.current.tokens).not.toContainEqual(USDC);
       expect(result.current.tokens).toContainEqual(USDT);
+    });
+
+    it('excludes non-EVM tokens', () => {
+      const solanaToken = makeToken({
+        address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        symbol: 'USDC',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        accountType: SolAccountType.DataAccount,
+        fiat: { balance: 400, currency: 'usd', conversionRate: 1 },
+      });
+      mockUseAccountTokens.mockReturnValue([solanaToken, USDC]);
+
+      const { result } = renderHook(() => useMoneyDepositTokens());
+
+      expect(result.current.tokens).not.toContainEqual(solanaToken);
+      expect(result.current.tokens).toContainEqual(USDC);
+    });
+
+    it('excludes non-EVM tokens before the MM Pay blocklist check', () => {
+      const solanaToken = makeToken({
+        address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        symbol: 'USDC',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        accountType: SolAccountType.DataAccount,
+        fiat: { balance: 400, currency: 'usd', conversionRate: 1 },
+      });
+      mockUseAccountTokens.mockReturnValue([solanaToken]);
+
+      renderHook(() => useMoneyDepositTokens());
+
+      expect(mockIsTokenBlocked).not.toHaveBeenCalledWith(
+        solanaToken,
+        expect.anything(),
+      );
     });
 
     it('excludes tokens on the Money blocklist', () => {

--- a/app/components/UI/Money/hooks/useMoneyDepositTokens.ts
+++ b/app/components/UI/Money/hooks/useMoneyDepositTokens.ts
@@ -11,7 +11,10 @@ import {
   selectMoneyDepositMinBalance,
   MoneyTokensSortMode,
 } from '../selectors/featureFlags';
-import { AssetType } from '../../../Views/confirmations/types/token';
+import {
+  AssetType,
+  TokenStandard,
+} from '../../../Views/confirmations/types/token';
 import { TokenI } from '../../Tokens/types';
 import { safeFormatChainIdToHex } from '../../Card/util/safeFormatChainIdToHex';
 
@@ -45,6 +48,11 @@ export const useMoneyDepositTokens = ({
   const sortMode: MoneyTokensSortMode = sortModeOverride ?? remoteSortMode;
 
   const allTokens = useAccountTokens({ includeNoBalance: false });
+
+  const isEvmToken = useCallback(
+    (token: AssetType) => Boolean(token.accountType?.includes('eip155')),
+    [],
+  );
 
   const isMMPayBlocked = useCallback(
     (token: AssetType) => isTokenBlocked(token, mmPayBlockedTokens),
@@ -83,11 +91,13 @@ export const useMoneyDepositTokens = ({
     (tokens: AssetType[]): AssetType[] =>
       tokens.filter(
         (token) =>
+          // Must run before isMMPayBlocked since MM Pay only supports EVM tokens.
+          isEvmToken(token) &&
           !isMMPayBlocked(token) &&
           !isMoneyBlocklisted(token) &&
           meetsMinBalance(token),
       ),
-    [isMMPayBlocked, isMoneyBlocklisted, meetsMinBalance],
+    [isEvmToken, isMMPayBlocked, isMoneyBlocklisted, meetsMinBalance],
   );
 
   const byFiatDesc = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fixes a crash occurring when navigating to the Money Home screen when user holds non-EVM tokens. The crash was caused because we were trying to access `address` property on non-EVM tokens.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix crash when navigating to Money Home screen when user holds non-EVM tokens

## **Related issues**

Fixes: [MUSD-887: useMoneyDeposit Tokens crash when user holds non-EVM tokens](https://consensyssoftware.atlassian.net/browse/MUSD-887)

## **Manual testing steps**

```gherkin
Feature: Fix crash when navigating to Money Home screen

  Scenario: Money Home redirect
    Given user has non-EVM tokens in their wallet

    When user navigates to Money Home
    Then app doesn't crash
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow filtering change in deposit token selection with unit test coverage; no auth or payment flow changes.
> 
> **Overview**
> **Money deposit token eligibility** now drops non-EVM assets (e.g. Solana) by requiring `accountType` to include `eip155` in `useMoneyDepositTokens`, applied as the first step in `filterAllowedTokens` so MM Pay blocklist logic is not invoked for unsupported chains.
> 
> Tests set default EVM `accountType` on fixtures and cover Solana exclusion plus the ordering guarantee that `isTokenBlocked` is not called for filtered non-EVM tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc13195452f5c5a9e83e6e8c3ef3c2fa84b11f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->