### PR TITLE
fix: optimize advanced chart range changes

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
@@ -951,6 +951,39 @@ describe('PriceAdvanced', () => {
       );
     });
 
+    it('ends trace with chart range metadata when the WebView proves the latest bar is visible', () => {
+      const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
+      const advancedChart = getByTestId('mock-advanced-chart');
+
+      mockEndTrace.mockClear();
+
+      act(() => {
+        advancedChart.props.onSkeletonHidden?.({
+          seriesGeneration: 2,
+          requestedFromMs: 1000,
+          requestedToMs: 2000,
+          actualFromSec: 1,
+          actualToSec: 2,
+          lastBarSec: 2,
+          latestBarVisible: true,
+          rangeStatus: 'applied',
+          rangeApplyRetryCount: 0,
+          webViewRemounted: false,
+        });
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            seriesGeneration: 2,
+            latestBarVisible: true,
+            rangeStatus: 'applied',
+            webViewRemounted: false,
+          }),
+        }),
+      );
+    });
+
     it('ends trace with error data when onError is called', () => {
       const { getByTestId } = render(<PriceAdvanced {...baseProps} />);
       const advancedChart = getByTestId('mock-advanced-chart');

--- a/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.test.tsx
@@ -969,6 +969,13 @@ describe('PriceAdvanced', () => {
           rangeStatus: 'applied',
           rangeApplyRetryCount: 0,
           webViewRemounted: false,
+          seriesStartToWebViewLoadEndMs: 20,
+          seriesStartToChartReadyMs: 40,
+          seriesStartToSetOhlcvDataMs: 50,
+          seriesStartToRangeAppliedMs: 75,
+          seriesStartToSkeletonHiddenMs: 90,
+          webViewLoadEndToChartReadyMs: 20,
+          setOhlcvDataToRangeAppliedMs: 25,
         });
       });
 
@@ -979,6 +986,8 @@ describe('PriceAdvanced', () => {
             latestBarVisible: true,
             rangeStatus: 'applied',
             webViewRemounted: false,
+            seriesStartToSkeletonHiddenMs: 90,
+            setOhlcvDataToRangeAppliedMs: 25,
           }),
         }),
       );

--- a/app/components/UI/AssetOverview/Price/Price.advanced.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.advanced.tsx
@@ -26,6 +26,7 @@ import { Skeleton } from '../../../../component-library/components-temp/Skeleton
 import { advancedChartLineChromePresets } from '../../Charts/AdvancedChart/advancedChartLineChrome.presets';
 import {
   ChartType,
+  type ChartRangeSettlePayload,
   type ChartInteractedPayload,
   type CrosshairData,
   type IndicatorType,
@@ -62,6 +63,7 @@ import {
   trace,
   TraceName,
   TraceOperation,
+  type TraceValue,
 } from '../../../../util/trace';
 import { selectTokenDetailsOhlcvWsEnabled } from '../../../../selectors/featureFlagController/tokenDetailsOhlcvWsIntegration';
 import { selectTokenDetailsTechnicalIndicatorsEnabled } from '../../../../selectors/featureFlagController/tokenDetailsTechnicalIndicators';
@@ -127,6 +129,28 @@ function getAdvancedChartVisibilityTraceRequest(
     name: TraceName.TokenOverviewAdvancedChartInitialVisible,
     op: TraceOperation.TokenOverviewAdvancedChart,
   };
+}
+
+function getAdvancedChartRangeTraceData(
+  payload?: ChartRangeSettlePayload,
+): Record<string, TraceValue> | undefined {
+  if (!payload) {
+    return undefined;
+  }
+
+  const data: Record<string, TraceValue> = {};
+
+  Object.entries(payload).forEach(([key, value]) => {
+    if (
+      typeof value === 'number' ||
+      typeof value === 'string' ||
+      typeof value === 'boolean'
+    ) {
+      data[key] = value;
+    }
+  });
+
+  return Object.keys(data).length > 0 ? data : undefined;
 }
 
 export interface PriceAdvancedProps {
@@ -419,25 +443,27 @@ const PriceAdvanced = ({
     traceName: TraceName;
   } | null>(null);
 
-  const completeVisibilityTrace = useCallback(() => {
+  const completeVisibilityTrace = useCallback((payload?: ChartRangeSettlePayload) => {
     const open = activeVisibilityTraceRef.current;
     if (!open || open.seriesKey !== visibilityTraceStartedRef.current) {
       return;
     }
+    const data = getAdvancedChartRangeTraceData(payload);
     endTrace({
       name: open.traceName,
       id: open.seriesKey,
+      ...(data ? { data } : {}),
     });
     activeVisibilityTraceRef.current = null;
   }, []);
 
-  const handleAdvancedChartSkeletonHidden = useCallback(() => {
+  const handleAdvancedChartSkeletonHidden = useCallback((payload?: ChartRangeSettlePayload) => {
     const isInitialReveal = !hasChartBeenRevealed;
     setHasChartBeenRevealed(true);
     setChartInitFailed(false);
     // Technical-indicators path: skeleton hides once; interval refreshes complete via layout settled.
     if (!isTechnicalIndicatorsEnabled || isInitialReveal) {
-      completeVisibilityTrace();
+      completeVisibilityTrace(payload);
     }
   }, [
     hasChartBeenRevealed,

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -165,6 +165,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const rangeSettlePayloadRef = useRef<ChartRangeSettlePayload | undefined>(
       undefined,
     );
+    const pendingSeriesSettleRef = useRef(false);
     const webViewRemountedGenerationsRef = useRef<Set<number>>(new Set());
     const markNextGenerationAsRemountedRef = useRef(false);
     const [webViewRemountNonce, setWebViewRemountNonce] = useState(0);
@@ -383,6 +384,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       activeSettleGenerationRef.current = null;
       activeSettleRequiresRangeProofRef.current = false;
       rangeSettlePayloadRef.current = undefined;
+      pendingSeriesSettleRef.current = false;
       setChartReadyCount(0);
       setWebViewLoaded(false);
       webViewLoadedRef.current = false;
@@ -413,8 +415,17 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     }, [htmlContent, resetWebViewRuntimeState]);
 
     const beginFullOhlcvLayoutSettle = useCallback(
-      (seriesGeneration?: number) => {
-        skeletonHiddenReportedRef.current = false;
+      (
+        seriesGeneration?: number,
+        shouldReportSkeleton = true,
+        shouldWaitForSettle = activeSettleRequiresRangeProofRef.current,
+      ) => {
+        if (shouldReportSkeleton) {
+          skeletonHiddenReportedRef.current = false;
+          pendingSeriesSettleRef.current = shouldWaitForSettle;
+        } else {
+          pendingSeriesSettleRef.current = false;
+        }
         rangeSettlePayloadRef.current = undefined;
         if (!isChartReady && !activeSettleRequiresRangeProofRef.current) {
           return;
@@ -440,6 +451,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
             };
             webViewRemountedGenerationsRef.current.delete(seriesGeneration);
           }
+          pendingSeriesSettleRef.current = false;
           setLayoutSettling(false);
         }, LAYOUT_SETTLE_FALLBACK_MS);
       },
@@ -475,6 +487,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         }
         activeSettleRequiresRangeProofRef.current = false;
         rangeSettlePayloadRef.current = payloadWithRemount;
+        pendingSeriesSettleRef.current = false;
         clearLayoutSettleTimeout();
         setLayoutSettling(false);
       },
@@ -487,30 +500,46 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       setWebViewRemountNonce((nonce) => nonce + 1);
     }, [resetWebViewRuntimeState]);
 
-    const beginPendingSeriesSettle = useCallback(() => {
-      skeletonHiddenReportedRef.current = false;
-      rangeSettlePayloadRef.current = undefined;
-      setLayoutSettling(true);
-      clearLayoutSettleTimeout();
-      layoutSettleTimeoutRef.current = setTimeout(() => {
-        layoutSettleTimeoutRef.current = null;
-        setLayoutSettling(false);
-      }, LAYOUT_SETTLE_FALLBACK_MS);
-    }, [clearLayoutSettleTimeout]);
-
     const useIntervalHotReload = webViewInstanceKey !== undefined;
+
+    const beginPendingSeriesSettle = useCallback(
+      (shouldReportSkeleton: boolean) => {
+        if (shouldReportSkeleton) {
+          skeletonHiddenReportedRef.current = false;
+          pendingSeriesSettleRef.current = true;
+        } else {
+          pendingSeriesSettleRef.current = false;
+        }
+        rangeSettlePayloadRef.current = undefined;
+        setLayoutSettling(true);
+        clearLayoutSettleTimeout();
+        layoutSettleTimeoutRef.current = setTimeout(() => {
+          layoutSettleTimeoutRef.current = null;
+          pendingSeriesSettleRef.current = false;
+          setLayoutSettling(false);
+        }, LAYOUT_SETTLE_FALLBACK_MS);
+      },
+      [clearLayoutSettleTimeout],
+    );
 
     useEffect(() => {
       if (ohlcvSeriesKey === undefined) {
         return;
       }
       resetChartTiming();
-      beginPendingSeriesSettle();
+      beginPendingSeriesSettle(
+        !useIntervalHotReload && prevOhlcvSeriesKeyRef.current !== undefined,
+      );
       ohlcvSeriesStaleSnapshotRef.current =
         prevOhlcvSeriesKeyRef.current !== undefined
           ? prevOhlcvDataRef.current
           : null;
-    }, [ohlcvSeriesKey, resetChartTiming, beginPendingSeriesSettle]);
+    }, [
+      ohlcvSeriesKey,
+      useIntervalHotReload,
+      resetChartTiming,
+      beginPendingSeriesSettle,
+    ]);
 
     // Remount only for explicit WebView instance changes (asset/currency) or fallback.
     useEffect(() => {
@@ -551,7 +580,13 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
           markNextGenerationAsRemountedRef.current = false;
           webViewRemountedGenerationsRef.current.add(seriesGeneration);
         }
-        beginFullOhlcvLayoutSettle(seriesGeneration);
+        beginFullOhlcvLayoutSettle(
+          seriesGeneration,
+          !useIntervalHotReload || !skeletonHiddenReportedRef.current,
+          activeSettleRequiresRangeProofRef.current ||
+            (!useIntervalHotReload &&
+              prevOhlcvSeriesKeyRef.current !== undefined),
+        );
         postMessage({
           type: 'SET_OHLCV_DATA',
           payload: {
@@ -563,7 +598,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
           },
         });
       },
-      [beginFullOhlcvLayoutSettle, postMessage],
+      [beginFullOhlcvLayoutSettle, postMessage, useIntervalHotReload],
     );
 
     const addIndicator = useCallback(
@@ -630,10 +665,10 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
 
     const handleMessage = useCallback(
       (event: WebViewMessageEvent) => {
-        let raw;
+        let raw: unknown;
         try {
           raw = JSON.parse(event.nativeEvent.data);
-        } catch (err) {
+        } catch {
           return;
         }
 
@@ -1069,6 +1104,12 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       if (webViewError) return;
       if (!onSkeletonHidden) return;
       if (isLoading || !isChartReady || layoutSettling) {
+        return;
+      }
+      if (
+        pendingSeriesSettleRef.current &&
+        rangeSettlePayloadRef.current === undefined
+      ) {
         return;
       }
 

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -27,6 +27,7 @@ import {
   resolveCurrentPriceColor,
   type AdvancedChartProps,
   type AdvancedChartRef,
+  type ChartRangeSettlePayload,
   type IndicatorType,
   type OHLCVBar,
   type OHLCVPaginationConfig,
@@ -149,7 +150,16 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const ohlcvSeriesStaleSnapshotRef = useRef<OHLCVBar[] | null>(null);
     const tradingViewOpenInterceptRef = useRef(0);
     const skeletonHiddenReportedRef = useRef(false);
-    const resolvedWebViewKey = webViewInstanceKey ?? ohlcvSeriesKey ?? '';
+    const seriesGenerationRef = useRef(0);
+    const activeSettleGenerationRef = useRef<number | null>(null);
+    const activeSettleRequiresRangeProofRef = useRef(false);
+    const rangeSettlePayloadRef = useRef<ChartRangeSettlePayload | undefined>(
+      undefined,
+    );
+    const webViewRemountedGenerationsRef = useRef<Set<number>>(new Set());
+    const markNextGenerationAsRemountedRef = useRef(false);
+    const [webViewRemountNonce, setWebViewRemountNonce] = useState(0);
+    const resolvedWebViewKey = `${webViewInstanceKey ?? 'default'}-${webViewRemountNonce}`;
 
     // Track the color overrides baked into the current HTML template so the
     // SET_THEME_COLORS effect can skip sending when colors haven't diverged.
@@ -212,26 +222,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       legendOverlay,
     ]);
 
-    // Reset all chart state when the WebView reloads due to htmlContent changes.
-    // Color refs are intentionally omitted here — they are snapshotted synchronously
-    // inside the useMemo above.
-    useEffect(() => {
-      skeletonHiddenReportedRef.current = false;
-      setChartReadyCount(0);
-      setWebViewLoaded(false);
-      webViewLoadedRef.current = false;
-      setWebViewError(null);
-      activeIndicatorsRef.current.clear();
-      setAppliedIndicatorCount(0);
-      setLegendRendered(false);
-      prevPositionLinesRef.current = undefined;
-      prevChartTypeRef.current = undefined;
-      prevOhlcvDataRef.current = [];
-      prevOhlcvSeriesKeyRef.current = undefined;
-      ohlcvSeriesStaleSnapshotRef.current = null;
-      themeColorsSentRef.current = false;
-    }, [htmlContent]); // eslint-disable-line react-hooks/exhaustive-deps
-
     // ---- Helpers ----
 
     const postMessage = useCallback((message: RNToWebViewMessage) => {
@@ -269,76 +259,140 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       }, INDICATORS_SYNC_FALLBACK_MS);
     }, [clearIndicatorsSyncFallback, markIndicatorsSyncReady]);
 
-    const beginFullOhlcvLayoutSettle = useCallback(() => {
-      if (!isChartReady) {
-        return;
-      }
+    const resetWebViewRuntimeState = useCallback(() => {
+      skeletonHiddenReportedRef.current = false;
+      activeSettleGenerationRef.current = null;
+      activeSettleRequiresRangeProofRef.current = false;
+      rangeSettlePayloadRef.current = undefined;
+      setChartReadyCount(0);
+      setWebViewLoaded(false);
+      webViewLoadedRef.current = false;
+      setLayoutSettling(false);
+      clearLayoutSettleTimeout();
+      setWebViewError(null);
+      activeIndicatorsRef.current.clear();
+      setAppliedIndicatorCount(0);
+      setLegendRendered(false);
+      setIndicatorsSyncReady(false);
+      clearIndicatorsSyncFallback();
+      prevPositionLinesRef.current = undefined;
+      prevChartTypeRef.current = undefined;
+      prevOhlcvDataRef.current = [];
+      prevOhlcvSeriesKeyRef.current = undefined;
+      ohlcvSeriesStaleSnapshotRef.current = null;
+      themeColorsSentRef.current = false;
+    }, [clearLayoutSettleTimeout, clearIndicatorsSyncFallback]);
+
+    // Reset all chart state when the WebView reloads due to htmlContent changes.
+    useEffect(() => {
+      resetWebViewRuntimeState();
+    }, [htmlContent, resetWebViewRuntimeState]);
+
+    const beginFullOhlcvLayoutSettle = useCallback(
+      (seriesGeneration?: number) => {
+        skeletonHiddenReportedRef.current = false;
+        rangeSettlePayloadRef.current = undefined;
+        if (!isChartReady && !activeSettleRequiresRangeProofRef.current) {
+          return;
+        }
+        setLayoutSettling(true);
+        clearLayoutSettleTimeout();
+        layoutSettleTimeoutRef.current = setTimeout(() => {
+          layoutSettleTimeoutRef.current = null;
+          if (
+            seriesGeneration !== undefined &&
+            activeSettleGenerationRef.current !== seriesGeneration
+          ) {
+            return;
+          }
+          if (seriesGeneration !== undefined) {
+            const remounted =
+              webViewRemountedGenerationsRef.current.has(seriesGeneration);
+            rangeSettlePayloadRef.current = {
+              seriesGeneration,
+              rangeStatus: 'fallback',
+              webViewRemounted: remounted,
+            };
+            webViewRemountedGenerationsRef.current.delete(seriesGeneration);
+          }
+          setLayoutSettling(false);
+        }, LAYOUT_SETTLE_FALLBACK_MS);
+      },
+      [isChartReady, clearLayoutSettleTimeout],
+    );
+
+    const completeLayoutSettle = useCallback(
+      (payload?: ChartRangeSettlePayload) => {
+        if (
+          !payload &&
+          activeSettleGenerationRef.current !== null &&
+          activeSettleRequiresRangeProofRef.current
+        ) {
+          return;
+        }
+        if (
+          payload?.seriesGeneration !== undefined &&
+          activeSettleGenerationRef.current !== payload.seriesGeneration
+        ) {
+          return;
+        }
+
+        const payloadWithRemount =
+          payload &&
+          webViewRemountedGenerationsRef.current.has(payload.seriesGeneration)
+            ? { ...payload, webViewRemounted: true }
+            : payload;
+
+        if (payload) {
+          webViewRemountedGenerationsRef.current.delete(
+            payload.seriesGeneration,
+          );
+        }
+        activeSettleRequiresRangeProofRef.current = false;
+        rangeSettlePayloadRef.current = payloadWithRemount;
+        clearLayoutSettleTimeout();
+        setLayoutSettling(false);
+      },
+      [clearLayoutSettleTimeout],
+    );
+
+    const requestFallbackRemount = useCallback(() => {
+      markNextGenerationAsRemountedRef.current = true;
+      resetWebViewRuntimeState();
+      setWebViewRemountNonce((nonce) => nonce + 1);
+    }, [resetWebViewRuntimeState]);
+
+    const beginPendingSeriesSettle = useCallback(() => {
+      skeletonHiddenReportedRef.current = false;
+      rangeSettlePayloadRef.current = undefined;
       setLayoutSettling(true);
       clearLayoutSettleTimeout();
       layoutSettleTimeoutRef.current = setTimeout(() => {
         layoutSettleTimeoutRef.current = null;
         setLayoutSettling(false);
       }, LAYOUT_SETTLE_FALLBACK_MS);
-    }, [isChartReady, clearLayoutSettleTimeout]);
-
-    const resetWebViewSessionState = useCallback(() => {
-      skeletonHiddenReportedRef.current = false;
-      setChartReadyCount(0);
-      setWebViewLoaded(false);
-      setLayoutSettling(false);
-      setIndicatorsSyncReady(false);
-      clearLayoutSettleTimeout();
-      clearIndicatorsSyncFallback();
-      activeIndicatorsRef.current.clear();
-      setAppliedIndicatorCount(0);
-      setLegendRendered(false);
-      prevPositionLinesRef.current = undefined;
-      prevChartTypeRef.current = undefined;
-    }, [clearLayoutSettleTimeout, clearIndicatorsSyncFallback]);
-
-    const resetForInstanceRemount = useCallback(() => {
-      resetWebViewSessionState();
-      webViewLoadedRef.current = false;
-      prevOhlcvDataRef.current = [];
-      prevOhlcvSeriesKeyRef.current = undefined;
-      ohlcvSeriesStaleSnapshotRef.current = null;
-    }, [resetWebViewSessionState]);
+    }, [clearLayoutSettleTimeout]);
 
     const useIntervalHotReload = webViewInstanceKey !== undefined;
 
-    // Default: WebView remounts when `ohlcvSeriesKey` changes (time range / legacy path).
     useEffect(() => {
-      if (useIntervalHotReload || ohlcvSeriesKey === undefined) {
+      if (ohlcvSeriesKey === undefined) {
         return;
       }
-      resetWebViewSessionState();
+      beginPendingSeriesSettle();
       ohlcvSeriesStaleSnapshotRef.current =
         prevOhlcvSeriesKeyRef.current !== undefined
           ? prevOhlcvDataRef.current
           : null;
-    }, [useIntervalHotReload, ohlcvSeriesKey, resetWebViewSessionState]);
+    }, [ohlcvSeriesKey, beginPendingSeriesSettle]);
 
-    // Technical-indicators path: remount only when `webViewInstanceKey` changes.
+    // Remount only for explicit WebView instance changes (asset/currency) or fallback.
     useEffect(() => {
-      if (!useIntervalHotReload || !resolvedWebViewKey) {
+      if (!useIntervalHotReload || !webViewInstanceKey) {
         return;
       }
-      resetForInstanceRemount();
-    }, [useIntervalHotReload, resolvedWebViewKey, resetForInstanceRemount]);
-
-    // Interval change within the same WebView — keep chart visible, skip stale sends.
-    useEffect(() => {
-      if (!useIntervalHotReload || ohlcvSeriesKey === undefined) {
-        return;
-      }
-      if (prevOhlcvSeriesKeyRef.current === ohlcvSeriesKey) {
-        return;
-      }
-      ohlcvSeriesStaleSnapshotRef.current =
-        prevOhlcvSeriesKeyRef.current !== undefined
-          ? prevOhlcvDataRef.current
-          : null;
-    }, [useIntervalHotReload, ohlcvSeriesKey]);
+      resetWebViewRuntimeState();
+    }, [useIntervalHotReload, webViewInstanceKey, resetWebViewRuntimeState]);
 
     useEffect(
       () => () => {
@@ -361,17 +415,28 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
 
     const sendOHLCVData = useCallback(
       (data: OHLCVBar[]) => {
+        const seriesGeneration = seriesGenerationRef.current + 1;
+        seriesGenerationRef.current = seriesGeneration;
+        activeSettleGenerationRef.current = seriesGeneration;
+        activeSettleRequiresRangeProofRef.current =
+          visibleFromMsRef.current !== undefined;
+        if (markNextGenerationAsRemountedRef.current) {
+          markNextGenerationAsRemountedRef.current = false;
+          webViewRemountedGenerationsRef.current.add(seriesGeneration);
+        }
+        beginFullOhlcvLayoutSettle(seriesGeneration);
         postMessage({
           type: 'SET_OHLCV_DATA',
           payload: {
             data,
+            seriesGeneration,
             pagination: paginationRef.current,
             visibleFromMs: visibleFromMsRef.current,
             visibleToMs: visibleToMsRef.current,
           },
         });
       },
-      [postMessage],
+      [beginFullOhlcvLayoutSettle, postMessage],
     );
 
     const addIndicator = useCallback(
@@ -455,20 +520,36 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
             setLegendRendered(false);
             prevPositionLinesRef.current = undefined;
             prevChartTypeRef.current = undefined;
-            clearLayoutSettleTimeout();
-            setLayoutSettling(false);
             setIndicatorsSyncReady(false);
             scheduleIndicatorsSyncFallback();
+            if (!activeSettleRequiresRangeProofRef.current) {
+              clearLayoutSettleTimeout();
+              setLayoutSettling(false);
+            }
             setChartReadyCount((c) => c + 1);
             setWebViewError(null);
             onChartReady?.();
             break;
 
           case 'CHART_LAYOUT_SETTLED':
-            clearLayoutSettleTimeout();
-            setLayoutSettling(false);
+            completeLayoutSettle(message.payload);
             markIndicatorsSyncReady();
             onChartLayoutSettled?.();
+            break;
+
+          case 'CHART_RANGE_APPLIED':
+            if (message.payload.latestBarVisible !== false) {
+              completeLayoutSettle(message.payload);
+            }
+            break;
+
+          case 'CHART_RANGE_APPLY_FAILED':
+            if (
+              activeSettleGenerationRef.current ===
+              message.payload.seriesGeneration
+            ) {
+              requestFallbackRemount();
+            }
             break;
 
           case 'INDICATOR_ADDED':
@@ -523,6 +604,8 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         clearLayoutSettleTimeout,
         scheduleIndicatorsSyncFallback,
         markIndicatorsSyncReady,
+        completeLayoutSettle,
+        requestFallbackRemount,
         onChartReady,
         onChartLayoutSettled,
         onError,
@@ -572,6 +655,10 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
           prevOhlcvDataRef.current = [];
           prevOhlcvSeriesKeyRef.current = undefined;
           ohlcvSeriesStaleSnapshotRef.current = null;
+          activeSettleGenerationRef.current = null;
+          activeSettleRequiresRangeProofRef.current = false;
+          rangeSettlePayloadRef.current = undefined;
+          markNextGenerationAsRemountedRef.current = false;
           webViewRef.current?.reload();
         },
       }),
@@ -604,7 +691,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         ohlcvSeriesKey !== undefined &&
         ohlcvSeriesKey !== prevOhlcvSeriesKeyRef.current
       ) {
-        beginFullOhlcvLayoutSettle();
         sendOHLCVData(ohlcvData);
         prevOhlcvDataRef.current = ohlcvData;
         prevOhlcvSeriesKeyRef.current = ohlcvSeriesKey;
@@ -616,7 +702,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         prevData.length === 0 ||
         Math.abs(ohlcvData.length - prevData.length) > 1
       ) {
-        beginFullOhlcvLayoutSettle();
         sendOHLCVData(ohlcvData);
         prevOhlcvDataRef.current = ohlcvData;
         if (ohlcvSeriesKey !== undefined) {
@@ -647,14 +732,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       }
 
       prevOhlcvDataRef.current = ohlcvData;
-    }, [
-      ohlcvData,
-      ohlcvSeriesKey,
-      webViewLoaded,
-      sendOHLCVData,
-      postMessage,
-      beginFullOhlcvLayoutSettle,
-    ]);
+    }, [ohlcvData, ohlcvSeriesKey, webViewLoaded, sendOHLCVData, postMessage]);
 
     // Send initial chartType as soon as WebView loads (before chart is ready)
     // This prevents the flash of default chart type during initialization
@@ -877,7 +955,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       // Hide skeleton
       if (skeletonHiddenReportedRef.current) return;
       skeletonHiddenReportedRef.current = true;
-      onSkeletonHidden();
+      onSkeletonHidden(rangeSettlePayloadRef.current);
     }, [
       isLoading,
       isChartReady,

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -12,6 +12,7 @@ import { WebView, WebViewMessageEvent } from '@metamask/react-native-webview';
 import type { WebViewOpenWindowEvent } from '@metamask/react-native-webview/lib/WebViewTypes';
 import { Text, TextVariant } from '@metamask/design-system-react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
+import performance from 'react-native-performance';
 import { Skeleton } from '../../../../component-library/components-temp/Skeleton';
 import { useStyles } from '../../../../component-library/hooks';
 import styleSheet, { DEFAULT_CHART_HEIGHT } from './AdvancedChart.styles';
@@ -73,6 +74,14 @@ const INDICATORS_SYNC_FALLBACK_MS = 500;
 
 /** Debounce TradingView external opens (redirect chains can fire multiple navigation requests). */
 const TRADINGVIEW_OPEN_DEBOUNCE_MS = 800;
+
+interface ChartTimingSnapshot {
+  seriesStartMs: number;
+  webViewLoadEndMs?: number;
+  chartReadyMs?: number;
+  setOhlcvDataMs?: number;
+  rangeAppliedMs?: number;
+}
 
 const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
   (
@@ -160,6 +169,9 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const markNextGenerationAsRemountedRef = useRef(false);
     const [webViewRemountNonce, setWebViewRemountNonce] = useState(0);
     const resolvedWebViewKey = `${webViewInstanceKey ?? 'default'}-${webViewRemountNonce}`;
+    const chartTimingRef = useRef<ChartTimingSnapshot>({
+      seriesStartMs: performance.now(),
+    });
 
     // Track the color overrides baked into the current HTML template so the
     // SET_THEME_COLORS effect can skip sending when colors haven't diverged.
@@ -259,6 +271,113 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       }, INDICATORS_SYNC_FALLBACK_MS);
     }, [clearIndicatorsSyncFallback, markIndicatorsSyncReady]);
 
+    const resetChartTiming = useCallback(() => {
+      chartTimingRef.current = { seriesStartMs: performance.now() };
+    }, []);
+
+    const getRoundedDuration = useCallback(
+      (startMs: number | undefined, endMs: number | undefined) => {
+        if (startMs === undefined || endMs === undefined) {
+          return undefined;
+        }
+        return Math.max(0, Math.round(endMs - startMs));
+      },
+      [],
+    );
+
+    const getChartTimingPayload = useCallback(
+      (
+        options: {
+          rangeAppliedMs?: number;
+          skeletonHiddenMs?: number;
+        } = {},
+      ): Partial<ChartRangeSettlePayload> => {
+        const {
+          seriesStartMs,
+          webViewLoadEndMs,
+          chartReadyMs,
+          setOhlcvDataMs,
+        } = chartTimingRef.current;
+        const rangeAppliedMs =
+          options.rangeAppliedMs ?? chartTimingRef.current.rangeAppliedMs;
+
+        return {
+          ...(getRoundedDuration(seriesStartMs, webViewLoadEndMs) !== undefined
+            ? {
+                seriesStartToWebViewLoadEndMs: getRoundedDuration(
+                  seriesStartMs,
+                  webViewLoadEndMs,
+                ),
+              }
+            : {}),
+          ...(getRoundedDuration(seriesStartMs, chartReadyMs) !== undefined
+            ? {
+                seriesStartToChartReadyMs: getRoundedDuration(
+                  seriesStartMs,
+                  chartReadyMs,
+                ),
+              }
+            : {}),
+          ...(getRoundedDuration(seriesStartMs, setOhlcvDataMs) !== undefined
+            ? {
+                seriesStartToSetOhlcvDataMs: getRoundedDuration(
+                  seriesStartMs,
+                  setOhlcvDataMs,
+                ),
+              }
+            : {}),
+          ...(getRoundedDuration(seriesStartMs, rangeAppliedMs) !== undefined
+            ? {
+                seriesStartToRangeAppliedMs: getRoundedDuration(
+                  seriesStartMs,
+                  rangeAppliedMs,
+                ),
+              }
+            : {}),
+          ...(getRoundedDuration(seriesStartMs, options.skeletonHiddenMs) !==
+          undefined
+            ? {
+                seriesStartToSkeletonHiddenMs: getRoundedDuration(
+                  seriesStartMs,
+                  options.skeletonHiddenMs,
+                ),
+              }
+            : {}),
+          ...(getRoundedDuration(webViewLoadEndMs, chartReadyMs) !== undefined
+            ? {
+                webViewLoadEndToChartReadyMs: getRoundedDuration(
+                  webViewLoadEndMs,
+                  chartReadyMs,
+                ),
+              }
+            : {}),
+          ...(getRoundedDuration(setOhlcvDataMs, rangeAppliedMs) !== undefined
+            ? {
+                setOhlcvDataToRangeAppliedMs: getRoundedDuration(
+                  setOhlcvDataMs,
+                  rangeAppliedMs,
+                ),
+              }
+            : {}),
+        };
+      },
+      [getRoundedDuration],
+    );
+
+    const withChartTimingPayload = useCallback(
+      (
+        payload: ChartRangeSettlePayload,
+        options?: {
+          rangeAppliedMs?: number;
+          skeletonHiddenMs?: number;
+        },
+      ): ChartRangeSettlePayload => ({
+        ...payload,
+        ...getChartTimingPayload(options),
+      }),
+      [getChartTimingPayload],
+    );
+
     const resetWebViewRuntimeState = useCallback(() => {
       skeletonHiddenReportedRef.current = false;
       activeSettleGenerationRef.current = null;
@@ -281,7 +400,12 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       prevOhlcvSeriesKeyRef.current = undefined;
       ohlcvSeriesStaleSnapshotRef.current = null;
       themeColorsSentRef.current = false;
-    }, [clearLayoutSettleTimeout, clearIndicatorsSyncFallback]);
+      resetChartTiming();
+    }, [
+      clearLayoutSettleTimeout,
+      clearIndicatorsSyncFallback,
+      resetChartTiming,
+    ]);
 
     // Reset all chart state when the WebView reloads due to htmlContent changes.
     useEffect(() => {
@@ -312,13 +436,14 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
               seriesGeneration,
               rangeStatus: 'fallback',
               webViewRemounted: remounted,
+              ...getChartTimingPayload(),
             };
             webViewRemountedGenerationsRef.current.delete(seriesGeneration);
           }
           setLayoutSettling(false);
         }, LAYOUT_SETTLE_FALLBACK_MS);
       },
-      [isChartReady, clearLayoutSettleTimeout],
+      [isChartReady, clearLayoutSettleTimeout, getChartTimingPayload],
     );
 
     const completeLayoutSettle = useCallback(
@@ -379,12 +504,13 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       if (ohlcvSeriesKey === undefined) {
         return;
       }
+      resetChartTiming();
       beginPendingSeriesSettle();
       ohlcvSeriesStaleSnapshotRef.current =
         prevOhlcvSeriesKeyRef.current !== undefined
           ? prevOhlcvDataRef.current
           : null;
-    }, [ohlcvSeriesKey, beginPendingSeriesSettle]);
+    }, [ohlcvSeriesKey, resetChartTiming, beginPendingSeriesSettle]);
 
     // Remount only for explicit WebView instance changes (asset/currency) or fallback.
     useEffect(() => {
@@ -420,6 +546,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         activeSettleGenerationRef.current = seriesGeneration;
         activeSettleRequiresRangeProofRef.current =
           visibleFromMsRef.current !== undefined;
+        chartTimingRef.current.setOhlcvDataMs = performance.now();
         if (markNextGenerationAsRemountedRef.current) {
           markNextGenerationAsRemountedRef.current = false;
           webViewRemountedGenerationsRef.current.add(seriesGeneration);
@@ -515,6 +642,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
 
         switch (message.type) {
           case 'CHART_READY':
+            chartTimingRef.current.chartReadyMs = performance.now();
             activeIndicatorsRef.current.clear();
             setAppliedIndicatorCount(0);
             setLegendRendered(false);
@@ -532,14 +660,22 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
             break;
 
           case 'CHART_LAYOUT_SETTLED':
-            completeLayoutSettle(message.payload);
+            completeLayoutSettle(
+              message.payload
+                ? withChartTimingPayload(message.payload)
+                : message.payload,
+            );
             markIndicatorsSyncReady();
             onChartLayoutSettled?.();
             break;
 
           case 'CHART_RANGE_APPLIED':
             if (message.payload.latestBarVisible !== false) {
-              completeLayoutSettle(message.payload);
+              const rangeAppliedMs = performance.now();
+              chartTimingRef.current.rangeAppliedMs = rangeAppliedMs;
+              completeLayoutSettle(
+                withChartTimingPayload(message.payload, { rangeAppliedMs }),
+              );
             }
             break;
 
@@ -548,6 +684,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
               activeSettleGenerationRef.current ===
               message.payload.seriesGeneration
             ) {
+              chartTimingRef.current.rangeAppliedMs = performance.now();
               requestFallbackRemount();
             }
             break;
@@ -613,6 +750,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
         onCrosshairMove,
         onChartInteracted,
         handleTradingViewOpen,
+        withChartTimingPayload,
       ],
     );
 
@@ -630,6 +768,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     );
 
     const handleLoadEnd = useCallback(() => {
+      chartTimingRef.current.webViewLoadEndMs = performance.now();
       setWebViewLoaded(true);
       webViewLoadedRef.current = true;
     }, []);
@@ -955,7 +1094,13 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       // Hide skeleton
       if (skeletonHiddenReportedRef.current) return;
       skeletonHiddenReportedRef.current = true;
-      onSkeletonHidden(rangeSettlePayloadRef.current);
+      onSkeletonHidden(
+        rangeSettlePayloadRef.current
+          ? withChartTimingPayload(rangeSettlePayloadRef.current, {
+              skeletonHiddenMs: performance.now(),
+            })
+          : rangeSettlePayloadRef.current,
+      );
     }, [
       isLoading,
       isChartReady,
@@ -966,6 +1111,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       appliedIndicatorCount,
       legendOverlay,
       legendRendered,
+      withChartTimingPayload,
     ]);
 
     // ---- Render ----

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -204,10 +204,14 @@ export type RNToWebViewMessageType =
 export type WebViewToRNMessageType =
   | 'CHART_READY'
   | 'CHART_LAYOUT_SETTLED'
+  | 'CHART_RANGE_APPLIED'
+  | 'CHART_RANGE_APPLY_FAILED'
   | 'INDICATOR_ADDED'
   | 'INDICATOR_REMOVED'
   | 'LEGEND_RENDERED'
   | 'CROSSHAIR_MOVE'
+  | 'CHART_INTERACTED'
+  | 'CHART_TRADINGVIEW_CLICKED'
   | 'ERROR'
   | 'DEBUG';
 
@@ -220,6 +224,8 @@ export interface OHLCVPaginationConfig {
 
 export interface SetOHLCVDataPayload {
   data: OHLCVBar[];
+  /** Monotonic id used to ignore stale WebView async callbacks after rapid range changes. */
+  seriesGeneration?: number;
   /** When provided, the WebView fetches older pages directly instead of round-tripping via RN. */
   pagination?: OHLCVPaginationConfig;
   /**
@@ -337,6 +343,20 @@ export interface ChartInteractedPayload {
   interaction_type: ChartInteractionType;
 }
 
+export interface ChartRangeSettlePayload {
+  seriesGeneration: number;
+  requestedFromMs?: number;
+  requestedToMs?: number;
+  actualFromSec?: number;
+  actualToSec?: number;
+  lastBarSec?: number;
+  latestBarVisible?: boolean;
+  rangeStatus?: 'applied' | 'failed' | 'fallback';
+  rangeApplyRetryCount?: number;
+  webViewRemounted?: boolean;
+  reason?: string;
+}
+
 export interface ErrorPayload {
   message: string;
   code?: string;
@@ -344,7 +364,9 @@ export interface ErrorPayload {
 
 export type WebViewToRNMessage =
   | { type: 'CHART_READY' }
-  | { type: 'CHART_LAYOUT_SETTLED' }
+  | { type: 'CHART_LAYOUT_SETTLED'; payload?: ChartRangeSettlePayload }
+  | { type: 'CHART_RANGE_APPLIED'; payload: ChartRangeSettlePayload }
+  | { type: 'CHART_RANGE_APPLY_FAILED'; payload: ChartRangeSettlePayload }
   | { type: 'INDICATOR_ADDED'; payload: IndicatorAddedPayload }
   | { type: 'INDICATOR_REMOVED'; payload: IndicatorRemovedPayload }
   | { type: 'LEGEND_RENDERED' }
@@ -360,6 +382,62 @@ export type WebViewToRNMessage =
 
 function isIndicatorType(value: unknown): value is IndicatorType {
   return typeof value === 'string' && value.length > 0;
+}
+
+function getOptionalNumber(
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = obj[key];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function parseChartRangeSettlePayload(
+  obj: Record<string, unknown>,
+): ChartRangeSettlePayload | null {
+  const seriesGeneration = getOptionalNumber(obj, 'seriesGeneration');
+  if (seriesGeneration === undefined) {
+    return null;
+  }
+
+  const rangeStatus =
+    obj.rangeStatus === 'applied' ||
+    obj.rangeStatus === 'failed' ||
+    obj.rangeStatus === 'fallback'
+      ? obj.rangeStatus
+      : undefined;
+
+  return {
+    seriesGeneration,
+    ...(getOptionalNumber(obj, 'requestedFromMs') !== undefined
+      ? { requestedFromMs: getOptionalNumber(obj, 'requestedFromMs') }
+      : {}),
+    ...(getOptionalNumber(obj, 'requestedToMs') !== undefined
+      ? { requestedToMs: getOptionalNumber(obj, 'requestedToMs') }
+      : {}),
+    ...(getOptionalNumber(obj, 'actualFromSec') !== undefined
+      ? { actualFromSec: getOptionalNumber(obj, 'actualFromSec') }
+      : {}),
+    ...(getOptionalNumber(obj, 'actualToSec') !== undefined
+      ? { actualToSec: getOptionalNumber(obj, 'actualToSec') }
+      : {}),
+    ...(getOptionalNumber(obj, 'lastBarSec') !== undefined
+      ? { lastBarSec: getOptionalNumber(obj, 'lastBarSec') }
+      : {}),
+    ...(typeof obj.latestBarVisible === 'boolean'
+      ? { latestBarVisible: obj.latestBarVisible }
+      : {}),
+    ...(rangeStatus ? { rangeStatus } : {}),
+    ...(getOptionalNumber(obj, 'rangeApplyRetryCount') !== undefined
+      ? { rangeApplyRetryCount: getOptionalNumber(obj, 'rangeApplyRetryCount') }
+      : {}),
+    ...(typeof obj.webViewRemounted === 'boolean'
+      ? { webViewRemounted: obj.webViewRemounted }
+      : {}),
+    ...(typeof obj.reason === 'string' ? { reason: obj.reason } : {}),
+  };
 }
 
 /**
@@ -380,8 +458,26 @@ export function parseWebViewMessage(raw: unknown): WebViewToRNMessage | null {
     case 'CHART_READY':
       return { type };
 
-    case 'CHART_LAYOUT_SETTLED':
-      return { type };
+    case 'CHART_LAYOUT_SETTLED': {
+      const parsedPayload = parseChartRangeSettlePayload(obj);
+      return parsedPayload ? { type, payload: parsedPayload } : { type };
+    }
+
+    case 'CHART_RANGE_APPLIED': {
+      const parsedPayload = parseChartRangeSettlePayload(obj);
+      if (parsedPayload) {
+        return { type, payload: parsedPayload };
+      }
+      return null;
+    }
+
+    case 'CHART_RANGE_APPLY_FAILED': {
+      const parsedPayload = parseChartRangeSettlePayload(obj);
+      if (parsedPayload) {
+        return { type, payload: parsedPayload };
+      }
+      return null;
+    }
 
     case 'DEBUG':
       return {
@@ -545,7 +641,7 @@ export interface AdvancedChartProps {
    * Fires once when the native skeleton overlay is removed (chart ready, layout settled,
    * and parent `isLoading` false). Resets when `webViewInstanceKey` or chart HTML reloads.
    */
-  onSkeletonHidden?: () => void;
+  onSkeletonHidden?: (payload?: ChartRangeSettlePayload) => void;
   /**
    * Fires when the WebView posts `CHART_LAYOUT_SETTLED` after OHLCV scale/layout apply.
    * Used by Token Details (technical-indicators path) to complete interval visibility traces

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -355,6 +355,13 @@ export interface ChartRangeSettlePayload {
   rangeApplyRetryCount?: number;
   webViewRemounted?: boolean;
   reason?: string;
+  seriesStartToWebViewLoadEndMs?: number;
+  seriesStartToChartReadyMs?: number;
+  seriesStartToSetOhlcvDataMs?: number;
+  seriesStartToRangeAppliedMs?: number;
+  seriesStartToSkeletonHiddenMs?: number;
+  webViewLoadEndToChartReadyMs?: number;
+  setOhlcvDataToRangeAppliedMs?: number;
 }
 
 export interface ErrorPayload {
@@ -437,6 +444,62 @@ function parseChartRangeSettlePayload(
       ? { webViewRemounted: obj.webViewRemounted }
       : {}),
     ...(typeof obj.reason === 'string' ? { reason: obj.reason } : {}),
+    ...(getOptionalNumber(obj, 'seriesStartToWebViewLoadEndMs') !== undefined
+      ? {
+          seriesStartToWebViewLoadEndMs: getOptionalNumber(
+            obj,
+            'seriesStartToWebViewLoadEndMs',
+          ),
+        }
+      : {}),
+    ...(getOptionalNumber(obj, 'seriesStartToChartReadyMs') !== undefined
+      ? {
+          seriesStartToChartReadyMs: getOptionalNumber(
+            obj,
+            'seriesStartToChartReadyMs',
+          ),
+        }
+      : {}),
+    ...(getOptionalNumber(obj, 'seriesStartToSetOhlcvDataMs') !== undefined
+      ? {
+          seriesStartToSetOhlcvDataMs: getOptionalNumber(
+            obj,
+            'seriesStartToSetOhlcvDataMs',
+          ),
+        }
+      : {}),
+    ...(getOptionalNumber(obj, 'seriesStartToRangeAppliedMs') !== undefined
+      ? {
+          seriesStartToRangeAppliedMs: getOptionalNumber(
+            obj,
+            'seriesStartToRangeAppliedMs',
+          ),
+        }
+      : {}),
+    ...(getOptionalNumber(obj, 'seriesStartToSkeletonHiddenMs') !== undefined
+      ? {
+          seriesStartToSkeletonHiddenMs: getOptionalNumber(
+            obj,
+            'seriesStartToSkeletonHiddenMs',
+          ),
+        }
+      : {}),
+    ...(getOptionalNumber(obj, 'webViewLoadEndToChartReadyMs') !== undefined
+      ? {
+          webViewLoadEndToChartReadyMs: getOptionalNumber(
+            obj,
+            'webViewLoadEndToChartReadyMs',
+          ),
+        }
+      : {}),
+    ...(getOptionalNumber(obj, 'setOhlcvDataToRangeAppliedMs') !== undefined
+      ? {
+          setOhlcvDataToRangeAppliedMs: getOptionalNumber(
+            obj,
+            'setOhlcvDataToRangeAppliedMs',
+          ),
+        }
+      : {}),
   };
 }
 

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -50,6 +50,12 @@ const MOCK_BARS: OHLCVBar[] = [
   { time: 1000300, open: 11, high: 13, low: 10, close: 12, volume: 200 },
 ];
 
+const getPostedMessages = () =>
+  mockPostMessage.mock.calls.map((call) => JSON.parse(call[0] as string));
+
+const getPostedMessagesByType = (type: string) =>
+  getPostedMessages().filter((message) => message.type === type);
+
 describe('AdvancedChart', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,7 +94,7 @@ describe('AdvancedChart', () => {
     expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
   });
 
-  it('shows skeleton until CHART_LAYOUT_SETTLED after full SET_OHLCV when chart is ready', () => {
+  it('shows skeleton until CHART_RANGE_APPLIED after full SET_OHLCV when chart is ready', () => {
     const altBars: OHLCVBar[] = [
       { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
       { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
@@ -119,20 +125,58 @@ describe('AdvancedChart', () => {
 
     const webViewAfterRerender = getByTestId('mock-webview');
     act(() => {
-      webViewAfterRerender.props.onLoadEnd();
-    });
-    act(() => {
       webViewAfterRerender.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: 'CHART_RANGE_APPLIED',
+            payload: {
+              seriesGeneration: 2,
+              latestBarVisible: true,
+              rangeStatus: 'applied',
+            },
+          }),
+        },
+      });
+    });
+
+    expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
+  });
+
+  it('waits for range proof after CHART_READY when visibleFromMs is provided', () => {
+    const { getByTestId, queryByTestId } = render(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        visibleFromMs={1000000}
+        visibleToMs={1000300}
+      />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onLoadEnd();
+    });
+
+    act(() => {
+      webView.props.onMessage({
         nativeEvent: {
           data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
         },
       });
     });
 
+    expect(getByTestId('advanced-chart-skeleton')).toBeOnTheScreen();
+
     act(() => {
-      webViewAfterRerender.props.onMessage({
+      webView.props.onMessage({
         nativeEvent: {
-          data: JSON.stringify({ type: 'CHART_LAYOUT_SETTLED', payload: {} }),
+          data: JSON.stringify({
+            type: 'CHART_RANGE_APPLIED',
+            payload: {
+              seriesGeneration: 1,
+              latestBarVisible: true,
+              rangeStatus: 'applied',
+            },
+          }),
         },
       });
     });
@@ -148,12 +192,12 @@ describe('AdvancedChart', () => {
       webView.props.onLoadEnd();
     });
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: MOCK_BARS },
-      }),
-    );
+        payload: { data: MOCK_BARS, seriesGeneration: 1 },
+      },
+    ]);
   });
 
   it('includes pagination config in SET_OHLCV_DATA when ohlcvPagination is provided', () => {
@@ -172,12 +216,12 @@ describe('AdvancedChart', () => {
       webView.props.onLoadEnd();
     });
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: MOCK_BARS, pagination },
-      }),
-    );
+        payload: { data: MOCK_BARS, seriesGeneration: 1, pagination },
+      },
+    ]);
   });
 
   it('does not send stale data when ohlcvSeriesKey changes; waits for fresh data', () => {
@@ -215,12 +259,6 @@ describe('AdvancedChart', () => {
     );
     expect(setOhlcvCallsAfterKeyChange).toHaveLength(0);
 
-    // Series key remounts the WebView; load must finish before sync runs. Stale wait still applies.
-    const webViewAfterKeyChange = getByTestId('mock-webview');
-    act(() => {
-      webViewAfterKeyChange.props.onLoadEnd();
-    });
-
     expect(
       mockPostMessage.mock.calls.filter((call) => {
         try {
@@ -235,12 +273,12 @@ describe('AdvancedChart', () => {
     mockPostMessage.mockClear();
     rerender(<AdvancedChart ohlcvData={freshBars} ohlcvSeriesKey="range-b" />);
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: freshBars },
-      }),
-    );
+        payload: { data: freshBars, seriesGeneration: 2 },
+      },
+    ]);
 
     const realtimeCalls = mockPostMessage.mock.calls.filter((call) => {
       try {
@@ -252,7 +290,7 @@ describe('AdvancedChart', () => {
     expect(realtimeCalls).toHaveLength(0);
   });
 
-  it('sends fresh data after a series change when the new array arrives before WebView load end', () => {
+  it('sends fresh data after a series change without waiting for another WebView load end', () => {
     const staleBars: OHLCVBar[] = [
       { time: 1000000, open: 10, high: 12, low: 9, close: 11, volume: 100 },
       { time: 1000300, open: 11, high: 13, low: 10, close: 12, volume: 200 },
@@ -276,19 +314,12 @@ describe('AdvancedChart', () => {
     rerender(<AdvancedChart ohlcvData={staleBars} ohlcvSeriesKey="range-b" />);
     rerender(<AdvancedChart ohlcvData={freshBars} ohlcvSeriesKey="range-b" />);
 
-    expect(mockPostMessage).not.toHaveBeenCalled();
-
-    const webViewAfterKeyChange = getByTestId('mock-webview');
-    act(() => {
-      webViewAfterKeyChange.props.onLoadEnd();
-    });
-
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: freshBars },
-      }),
-    );
+        payload: { data: freshBars, seriesGeneration: 2 },
+      },
+    ]);
   });
 
   it('reset() clears stale series snapshot so OHLCV sync runs after reload with the same data ref', () => {
@@ -423,7 +454,7 @@ describe('AdvancedChart', () => {
     expect(onSkeletonHidden).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onSkeletonHidden after CHART_LAYOUT_SETTLED when series key changes', () => {
+  it('calls onSkeletonHidden after CHART_RANGE_APPLIED when series key changes', () => {
     const altBars: OHLCVBar[] = [
       { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
       { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
@@ -466,25 +497,129 @@ describe('AdvancedChart', () => {
 
     const webViewAfter = getByTestId('mock-webview');
     act(() => {
-      webViewAfter.props.onLoadEnd();
-    });
-    act(() => {
       webViewAfter.props.onMessage({
         nativeEvent: {
-          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
-        },
-      });
-    });
-    act(() => {
-      webViewAfter.props.onMessage({
-        nativeEvent: {
-          data: JSON.stringify({ type: 'CHART_LAYOUT_SETTLED', payload: {} }),
+          data: JSON.stringify({
+            type: 'CHART_RANGE_APPLIED',
+            payload: {
+              seriesGeneration: 2,
+              latestBarVisible: true,
+              rangeStatus: 'applied',
+            },
+          }),
         },
       });
     });
 
     expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
-    expect(onSkeletonHidden).toHaveBeenCalledTimes(1);
+    expect(onSkeletonHidden).toHaveBeenCalledWith({
+      seriesGeneration: 2,
+      latestBarVisible: true,
+      rangeStatus: 'applied',
+    });
+  });
+
+  it('ignores stale range-settled events for an older generation', () => {
+    const altBars: OHLCVBar[] = [
+      { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
+      { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
+    ];
+
+    const { getByTestId, rerender } = render(
+      <AdvancedChart ohlcvData={MOCK_BARS} ohlcvSeriesKey="range-a" />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onLoadEnd();
+    });
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+
+    rerender(<AdvancedChart ohlcvData={altBars} ohlcvSeriesKey="range-b" />);
+
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: 'CHART_RANGE_APPLIED',
+            payload: {
+              seriesGeneration: 1,
+              latestBarVisible: true,
+              rangeStatus: 'applied',
+            },
+          }),
+        },
+      });
+    });
+
+    expect(getByTestId('advanced-chart-skeleton')).toBeOnTheScreen();
+  });
+
+  it('remounts once and resends current data when range application fails', () => {
+    const altBars: OHLCVBar[] = [
+      { time: 2000000, open: 20, high: 22, low: 19, close: 21, volume: 400 },
+      { time: 2000300, open: 21, high: 23, low: 20, close: 22, volume: 500 },
+    ];
+
+    const { getByTestId, rerender } = render(
+      <AdvancedChart ohlcvData={MOCK_BARS} ohlcvSeriesKey="range-a" />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onLoadEnd();
+    });
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({ type: 'CHART_READY', payload: {} }),
+        },
+      });
+    });
+
+    mockPostMessage.mockClear();
+    rerender(<AdvancedChart ohlcvData={altBars} ohlcvSeriesKey="range-b" />);
+
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
+        type: 'SET_OHLCV_DATA',
+        payload: { data: altBars, seriesGeneration: 2 },
+      },
+    ]);
+
+    mockPostMessage.mockClear();
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: 'CHART_RANGE_APPLY_FAILED',
+            payload: {
+              seriesGeneration: 2,
+              latestBarVisible: false,
+              rangeStatus: 'failed',
+              rangeApplyRetryCount: 1,
+            },
+          }),
+        },
+      });
+    });
+
+    act(() => {
+      getByTestId('mock-webview').props.onLoadEnd();
+    });
+
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
+        type: 'SET_OHLCV_DATA',
+        payload: { data: altBars, seriesGeneration: 3 },
+      },
+    ]);
   });
 
   it('does not call onSkeletonHidden when WebView error UI is shown', () => {

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -1430,12 +1430,12 @@ describe('AdvancedChart', () => {
       />,
     );
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: freshBars },
-      }),
-    );
+        payload: { data: freshBars, seriesGeneration: 2 },
+      },
+    ]);
   });
 
   it('with webViewInstanceKey, does not show skeleton after first reveal on series key change', () => {
@@ -1548,12 +1548,12 @@ describe('AdvancedChart', () => {
       />,
     );
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: freshBars },
-      }),
-    );
+        payload: { data: freshBars, seriesGeneration: 2 },
+      },
+    ]);
   });
 
   it('with webViewInstanceKey, calls onChartLayoutSettled on interval refresh without calling onSkeletonHidden again', () => {
@@ -1666,12 +1666,12 @@ describe('AdvancedChart', () => {
       webViewAfterInstanceChange.props.onLoadEnd();
     });
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      JSON.stringify({
+    expect(getPostedMessagesByType('SET_OHLCV_DATA')).toEqual([
+      {
         type: 'SET_OHLCV_DATA',
-        payload: { data: MOCK_BARS },
-      }),
-    );
+        payload: { data: MOCK_BARS, seriesGeneration: 2 },
+      },
+    ]);
   });
 
   it('does not show skeleton when adding indicators after initial reveal', () => {

--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -512,11 +512,17 @@ describe('AdvancedChart', () => {
     });
 
     expect(queryByTestId('advanced-chart-skeleton')).not.toBeOnTheScreen();
-    expect(onSkeletonHidden).toHaveBeenCalledWith({
-      seriesGeneration: 2,
-      latestBarVisible: true,
-      rangeStatus: 'applied',
-    });
+    expect(onSkeletonHidden).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seriesGeneration: 2,
+        latestBarVisible: true,
+        rangeStatus: 'applied',
+        seriesStartToSetOhlcvDataMs: expect.any(Number),
+        seriesStartToRangeAppliedMs: expect.any(Number),
+        seriesStartToSkeletonHiddenMs: expect.any(Number),
+        setOhlcvDataToRangeAppliedMs: expect.any(Number),
+      }),
+    );
   });
 
   it('ignores stale range-settled events for an older generation', () => {

--- a/app/components/UI/Charts/AdvancedChart/useOHLCVChart.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVChart.test.ts
@@ -7,6 +7,22 @@ import {
 } from './useOHLCVChart';
 import type { OHLCVTimePeriod } from './TimeRangeSelector';
 
+const mockTrace = jest.fn();
+const mockEndTrace = jest.fn();
+
+jest.mock('../../../../util/trace', () => ({
+  trace: (...args: unknown[]) => mockTrace(...args),
+  endTrace: (...args: unknown[]) => mockEndTrace(...args),
+  TraceName: {
+    TokenOverviewAdvancedChartOhlcvFetch:
+      'Token Overview Advanced Chart OHLCV Fetch',
+  },
+  TraceOperation: {
+    TokenOverviewAdvancedChartOhlcvFetch:
+      'token_overview.advanced_chart_ohlcv_fetch',
+  },
+}));
+
 const OHLCV_HOST = 'https://price.api.cx.metamask.io';
 
 const ASSET_ID = 'eip155:1/slip44:60';
@@ -66,6 +82,11 @@ function arrangeDefaultOptions(): Parameters<typeof useOHLCVChart>[0] {
 function renderUseOHLCVChart(options: Parameters<typeof useOHLCVChart>[0]) {
   return renderHook(() => useOHLCVChart(options));
 }
+
+beforeEach(() => {
+  mockTrace.mockClear();
+  mockEndTrace.mockClear();
+});
 
 describe('useOHLCVChart - initial load', () => {
   beforeEach(() => {
@@ -155,6 +176,85 @@ describe('useOHLCVChart - initial load', () => {
     expect(scope.isDone()).toBe(false);
     expect(result.current.ohlcvData).toEqual([]);
     expect(result.current.hasEmptyData).toBe(false);
+  });
+});
+
+describe('useOHLCVChart - performance tracing', () => {
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+  });
+
+  it('traces OHLCV fetch with success metadata', async () => {
+    arrangeNockOhlcvAPISuccessResponse(
+      createSuccessBody({
+        data: [
+          createAPICandle({ timestamp: 1 }),
+          createAPICandle({ timestamp: 2 }),
+        ],
+        hasNext: true,
+        nextCursor: 'next-page',
+      }),
+    );
+
+    const { result } = renderUseOHLCVChart(arrangeDefaultOptions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Token Overview Advanced Chart OHLCV Fetch',
+        op: 'token_overview.advanced_chart_ohlcv_fetch',
+        id: `${ASSET_ID}|1d||`,
+        data: expect.objectContaining({
+          assetId: ASSET_ID,
+          timePeriod: '1d',
+          interval: '',
+          vsCurrency: '',
+        }),
+      }),
+    );
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Token Overview Advanced Chart OHLCV Fetch',
+        id: `${ASSET_ID}|1d||`,
+        data: expect.objectContaining({
+          success: true,
+          hasEmptyData: false,
+          barCount: 2,
+          hasMore: true,
+        }),
+      }),
+    );
+  });
+
+  it('traces OHLCV fetch with error metadata', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    arrangeNockOhlcvAPI404Response();
+
+    const { result } = renderUseOHLCVChart(arrangeDefaultOptions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Token Overview Advanced Chart OHLCV Fetch',
+        id: `${ASSET_ID}|1d||`,
+        data: expect.objectContaining({
+          success: false,
+          aborted: false,
+          errorMessage: 'OHLCV API error: 404',
+        }),
+      }),
+    );
   });
 });
 

--- a/app/components/UI/Charts/AdvancedChart/useOHLCVChart.ts
+++ b/app/components/UI/Charts/AdvancedChart/useOHLCVChart.ts
@@ -1,4 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+  type TraceValue,
+} from '../../../../util/trace';
 import type { OHLCVBar } from './AdvancedChart.types';
 import type { OHLCVTimePeriod } from './TimeRangeSelector';
 
@@ -47,6 +54,29 @@ const mapCandle = (candle: OHLCVApiCandle): OHLCVBar => ({
   close: candle.close,
   volume: candle.volume,
 });
+
+function getOhlcvSeriesTraceId({
+  assetId,
+  timePeriod,
+  interval,
+  vsCurrency,
+}: UseOHLCVChartOptions): string {
+  return `${assetId}|${timePeriod}|${interval ?? ''}|${vsCurrency ?? ''}`;
+}
+
+function getOhlcvFetchTraceData({
+  assetId,
+  timePeriod,
+  interval,
+  vsCurrency,
+}: UseOHLCVChartOptions): Record<string, TraceValue> {
+  return {
+    assetId,
+    timePeriod,
+    interval: interval ?? '',
+    vsCurrency: vsCurrency ?? '',
+  };
+}
 
 async function fetchOHLCV(
   assetId: string,
@@ -122,12 +152,35 @@ export const useOHLCVChart = ({
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    const traceId = getOhlcvSeriesTraceId({
+      assetId,
+      timePeriod,
+      interval,
+      vsCurrency,
+    });
+    const traceData = getOhlcvFetchTraceData({
+      assetId,
+      timePeriod,
+      interval,
+      vsCurrency,
+    });
+    let endTraceData: Record<string, TraceValue> = {
+      ...traceData,
+      success: false,
+    };
 
     setIsLoading(true);
     setError(null);
     setNextCursor(null);
     setHasMore(false);
     setHasEmptyData(false);
+
+    trace({
+      name: TraceName.TokenOverviewAdvancedChartOhlcvFetch,
+      op: TraceOperation.TokenOverviewAdvancedChartOhlcvFetch,
+      id: traceId,
+      data: traceData,
+    });
 
     try {
       const result = await fetchOHLCV(
@@ -136,19 +189,38 @@ export const useOHLCVChart = ({
         controller.signal,
       );
 
+      const isEmpty = result.data.length === 0;
+      endTraceData = {
+        ...traceData,
+        success: true,
+        hasEmptyData: isEmpty,
+        barCount: result.data.length,
+        hasMore: result.hasNext,
+      };
+
       if (!controller.signal.aborted) {
-        const isEmpty = result.data.length === 0;
         setHasEmptyData(isEmpty);
         setOhlcvData(result.data.map(mapCandle));
         setNextCursor(result.nextCursor || null);
         setHasMore(result.hasNext);
       }
     } catch (e) {
+      endTraceData = {
+        ...traceData,
+        success: false,
+        aborted: controller.signal.aborted,
+        errorMessage: e instanceof Error ? e.message.slice(0, 200) : String(e),
+      };
       if (!controller.signal.aborted) {
         setOhlcvData([]); // Clear data on error to show error state
         setError(e instanceof Error ? e.message : 'Unknown error');
       }
     } finally {
+      endTrace({
+        name: TraceName.TokenOverviewAdvancedChartOhlcvFetch,
+        id: traceId,
+        data: endTraceData,
+      });
       if (!controller.signal.aborted) {
         setIsLoading(false);
       }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -110,12 +110,12 @@ function sendToReactNative(type, payload) {
  * `applyChartScaleLayout` / `refreshLineChartOverlays` before invoking this (see
  * `tryCompleteLayoutSettleAfterDataCore`).
  */
-function scheduleChartLayoutSettledNotify() {
+function scheduleChartLayoutSettledNotify(payload) {
   try {
     requestAnimationFrame(function () {
       requestAnimationFrame(function () {
         if (window.chartWidget && window.isChartReady) {
-          sendToReactNative('CHART_LAYOUT_SETTLED', {});
+          sendToReactNative('CHART_LAYOUT_SETTLED', payload || {});
         }
       });
     });
@@ -123,7 +123,7 @@ function scheduleChartLayoutSettledNotify() {
     try {
       setTimeout(function () {
         if (window.chartWidget && window.isChartReady) {
-          sendToReactNative('CHART_LAYOUT_SETTLED', {});
+          sendToReactNative('CHART_LAYOUT_SETTLED', payload || {});
         }
       }, 48);
     } catch (e2) {}
@@ -287,6 +287,47 @@ function abortDeferredLayoutSettleAndNotify() {
   window.__mmLayoutSettlePending = false;
   clearMmLayoutSettleFallbackTimer();
   scheduleChartLayoutSettledNotify();
+}
+
+function runAfterTwoAnimationFrames(callback) {
+  try {
+    requestAnimationFrame(function () {
+      requestAnimationFrame(callback);
+    });
+  } catch (e) {
+    setTimeout(callback, 32);
+  }
+}
+
+function postCurrentVisibleRangeApplied(rangeStatus, retryCount) {
+  if (!window.chartWidget || !window.isChartReady || !window.ohlcvGeneration) {
+    return;
+  }
+
+  var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+  var lastBarSec = lastBar ? Math.ceil(lastBar.time / 1000) : undefined;
+  var readback = null;
+  try {
+    readback = window.chartWidget.activeChart().getVisibleRange();
+  } catch (e) {}
+
+  var payload = {
+    seriesGeneration: window.ohlcvGeneration,
+    requestedFromMs:
+      window.visibleFromMs == null ? undefined : window.visibleFromMs,
+    requestedToMs: window.visibleToMs == null ? undefined : window.visibleToMs,
+    actualFromSec: readback ? readback.from : undefined,
+    actualToSec: readback ? readback.to : undefined,
+    lastBarSec: lastBarSec,
+    latestBarVisible:
+      lastBarSec === undefined ||
+      (readback && readback.from <= lastBarSec && readback.to >= lastBarSec),
+    rangeStatus: rangeStatus,
+    rangeApplyRetryCount: retryCount,
+  };
+
+  sendToReactNative('CHART_RANGE_APPLIED', payload);
+  scheduleChartLayoutSettledNotify(payload);
 }
 
 // ============================================
@@ -458,7 +499,12 @@ function handleSetOHLCVData(payload) {
 
   window.ohlcvData = payload.data;
   bumpLineChartOhlcvEpoch();
-  window.ohlcvGeneration++;
+  window.ohlcvGeneration =
+    typeof payload.seriesGeneration === 'number' &&
+    isFinite(payload.seriesGeneration)
+      ? payload.seriesGeneration
+      : window.ohlcvGeneration + 1;
+  var activeGeneration = window.ohlcvGeneration;
 
   if (payload.pagination) {
     window.ohlcvPagination = {
@@ -485,34 +531,168 @@ function handleSetOHLCVData(payload) {
 
   let newResolution = detectResolution(window.ohlcvData);
 
-  function scheduleVisibleRangeAfterDataLoad(chart) {
+  function buildRangePayload(rangeStatus, retryCount, reason) {
+    var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+    var lastBarSec = lastBar ? Math.ceil(lastBar.time / 1000) : undefined;
+    var payloadBase = {
+      seriesGeneration: activeGeneration,
+      requestedFromMs: visibleFromMs == null ? undefined : visibleFromMs,
+      requestedToMs: visibleToMs == null ? undefined : visibleToMs,
+      lastBarSec: lastBarSec,
+      latestBarVisible: false,
+      rangeStatus: rangeStatus,
+      rangeApplyRetryCount: retryCount,
+    };
+
+    if (reason) {
+      payloadBase.reason = reason;
+    }
+
+    return payloadBase;
+  }
+
+  function sendRangeApplied(readback, retryCount) {
+    var payloadBase = buildRangePayload('applied', retryCount);
+    if (readback) {
+      payloadBase.actualFromSec = readback.from;
+      payloadBase.actualToSec = readback.to;
+    }
+    payloadBase.latestBarVisible =
+      (readback == null && visibleFromMs == null) ||
+      payloadBase.lastBarSec === undefined ||
+      (payloadBase.actualFromSec !== undefined &&
+        payloadBase.actualToSec !== undefined &&
+        payloadBase.actualFromSec <= payloadBase.lastBarSec &&
+        payloadBase.actualToSec >= payloadBase.lastBarSec);
+    sendToReactNative('CHART_RANGE_APPLIED', payloadBase);
+    scheduleChartLayoutSettledNotify(payloadBase);
+  }
+
+  function sendRangeApplyFailed(retryCount, reason) {
+    sendToReactNative(
+      'CHART_RANGE_APPLY_FAILED',
+      buildRangePayload('failed', retryCount, reason),
+    );
+  }
+
+  function applyVisibleRange(chart, retryCount) {
+    if (activeGeneration !== window.ohlcvGeneration) {
+      return;
+    }
     if (visibleFromMs == null) {
       try {
         chart.getTimeScale().setRightOffset(2);
       } catch (e) {}
+      sendRangeApplied(null, retryCount);
       return;
     }
-    let capturedGeneration = window.ohlcvGeneration;
-    let sub = chart.onDataLoaded();
+
+    var fromSec = Math.floor(visibleFromMs / 1000);
+    var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+    var toSec =
+      visibleToMs != null
+        ? Math.ceil(visibleToMs / 1000)
+        : lastBar
+          ? Math.ceil(lastBar.time / 1000)
+          : Math.ceil(Date.now() / 1000);
+    // Pad `to` forward by 2 bar durations so the end dot clears the price axis.
+    // 1 bar was not enough for the 16px dot marker to fully clear the right edge.
+    var barPadSec = getApproxBarDurationSec() * 2;
+
+    function validateVisibleRange() {
+      if (activeGeneration !== window.ohlcvGeneration) {
+        return;
+      }
+      var readback = null;
+      try {
+        readback = chart.getVisibleRange();
+      } catch (e) {}
+
+      var lastBarSec = lastBar ? Math.ceil(lastBar.time / 1000) : undefined;
+      var latestVisible =
+        lastBarSec === undefined ||
+        (readback && readback.from <= lastBarSec && readback.to >= lastBarSec);
+
+      if (latestVisible) {
+        sendRangeApplied(readback, retryCount);
+        return;
+      }
+
+      if (retryCount < 1) {
+        runAfterTwoAnimationFrames(function () {
+          applyVisibleRange(chart, retryCount + 1);
+        });
+        return;
+      }
+
+      sendRangeApplyFailed(retryCount, 'latest_bar_not_visible');
+    }
+
+    try {
+      var rangePromise = chart.setVisibleRange(
+        { from: fromSec, to: toSec + barPadSec },
+        { percentRightMargin: 0 },
+      );
+      if (rangePromise && typeof rangePromise.then === 'function') {
+        rangePromise
+          .then(function () {
+            runAfterTwoAnimationFrames(validateVisibleRange);
+          })
+          .catch(function (error) {
+            if (retryCount < 1) {
+              runAfterTwoAnimationFrames(function () {
+                applyVisibleRange(chart, retryCount + 1);
+              });
+              return;
+            }
+            sendRangeApplyFailed(
+              retryCount,
+              error && error.message ? error.message : 'setVisibleRange_failed',
+            );
+          });
+      } else {
+        runAfterTwoAnimationFrames(validateVisibleRange);
+      }
+    } catch (e) {
+      if (retryCount < 1) {
+        runAfterTwoAnimationFrames(function () {
+          applyVisibleRange(chart, retryCount + 1);
+        });
+        return;
+      }
+      sendRangeApplyFailed(
+        retryCount,
+        e && e.message ? e.message : 'setVisibleRange_threw',
+      );
+    }
+  }
+
+  function scheduleVisibleRangeAfterDataLoad(chart) {
+    var capturedGeneration = activeGeneration;
+    var didRun = false;
+    var fallbackTimer = setTimeout(function () {
+      run();
+    }, LAYOUT_SETTLE_DATA_FALLBACK_MS + 80);
+
+    function run() {
+      if (didRun) {
+        return;
+      }
+      didRun = true;
+      clearTimeout(fallbackTimer);
+      if (capturedGeneration !== window.ohlcvGeneration) {
+        return;
+      }
+      applyVisibleRange(chart, 0);
+    }
+
+    var sub = chart.onDataLoaded();
     sub.subscribe(null, function onLoaded() {
       sub.unsubscribe(null, onLoaded);
       if (capturedGeneration !== window.ohlcvGeneration) {
         return;
       }
-      let fromSec = Math.floor(visibleFromMs / 1000);
-      let lastBar = window.ohlcvData[window.ohlcvData.length - 1];
-      let toSec = lastBar
-        ? Math.ceil(lastBar.time / 1000)
-        : Math.ceil(Date.now() / 1000);
-      let barPadSec = getApproxBarDurationSec() * 2;
-      try {
-        chart.setVisibleRange(
-          { from: fromSec, to: toSec + barPadSec },
-          { percentRightMargin: 0 },
-        );
-      } catch (e) {
-        // setVisibleRange can fail if chart is mid-teardown
-      }
+      run();
     });
   }
 
@@ -521,23 +701,41 @@ function handleSetOHLCVData(payload) {
     window.currentResolution = newResolution;
 
     try {
-      let chart = window.chartWidget.activeChart();
+      var chart = window.chartWidget.activeChart();
+      function resetTradingViewData() {
+        try {
+          if (
+            window.chartWidget &&
+            typeof window.chartWidget.resetCache === 'function'
+          ) {
+            window.chartWidget.resetCache();
+          }
+        } catch (resetCacheError) {}
+        beginDeferredLayoutSettleAfterOhlcvReload();
+        chart.resetData();
+        scheduleVisibleRangeAfterDataLoad(chart);
+      }
+
       if (previousResolution !== newResolution) {
-        chart.setResolution(newResolution, function () {
+        var resolutionPromise = chart.setResolution(newResolution, function () {
           try {
-            chart.resetData();
-            beginDeferredLayoutSettleAfterOhlcvReload();
-            scheduleVisibleRangeAfterDataLoad(chart);
+            resetTradingViewData();
           } catch (eR) {
             abortDeferredLayoutSettleAndNotify();
             return;
           }
         });
+        if (
+          resolutionPromise &&
+          typeof resolutionPromise.catch === 'function'
+        ) {
+          resolutionPromise.catch(function () {
+            abortDeferredLayoutSettleAndNotify();
+          });
+        }
       } else {
         try {
-          chart.resetData();
-          beginDeferredLayoutSettleAfterOhlcvReload();
-          scheduleVisibleRangeAfterDataLoad(chart);
+          resetTradingViewData();
         } catch (e) {
           abortDeferredLayoutSettleAndNotify();
           return;
@@ -4222,10 +4420,11 @@ let VARIABLE_TICK_SIZE = [
   '0.1', // prices ≥ $10000    →  1 dp
 ].join(' ');
 
-function filterBarsForRange(fromMs, toMs, countBack) {
-  let barsInRange = [];
-  for (let i = 0; i < window.ohlcvData.length; i++) {
-    let b = window.ohlcvData[i];
+function filterBarsForRange(fromMs, toMs, countBack, options) {
+  var exactRange = !!(options && options.exactRange);
+  var barsInRange = [];
+  for (var i = 0; i < window.ohlcvData.length; i++) {
+    var b = window.ohlcvData[i];
     if (b.time >= fromMs && b.time < toMs) {
       barsInRange.push({
         time: b.time,
@@ -4236,6 +4435,10 @@ function filterBarsForRange(fromMs, toMs, countBack) {
         volume: b.volume,
       });
     }
+  }
+
+  if (exactRange) {
+    return barsInRange;
   }
 
   if (barsInRange.length < countBack) {
@@ -4437,7 +4640,17 @@ let customDatafeed = {
         }
       }
 
-      let bars = filterBarsForRange(fromMs, toMs, countBack);
+      var exactPrimaryRange =
+        !!firstRequest &&
+        window.visibleFromMs != null &&
+        window.visibleToMs != null;
+      var requestFromMs = exactPrimaryRange ? window.visibleFromMs : fromMs;
+      // `filterBarsForRange` uses an exclusive `to`; include the last candle when RN anchors
+      // the visible window to its timestamp.
+      var requestToMs = exactPrimaryRange ? window.visibleToMs + 1 : toMs;
+      var bars = filterBarsForRange(requestFromMs, requestToMs, countBack, {
+        exactRange: exactPrimaryRange,
+      });
 
       if (bars.length > 0) {
         deliverBars(bars, { noData: false });
@@ -4844,6 +5057,11 @@ function initChart() {
       }
 
       sendToReactNative('CHART_READY', {});
+      if (window.visibleFromMs != null) {
+        runAfterTwoAnimationFrames(function () {
+          postCurrentVisibleRangeApplied('applied', 0);
+        });
+      }
 
       if (window.currentChartType !== 2) {
         scheduleInitialColdLayoutSettled();

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -119,12 +119,12 @@ function sendToReactNative(type, payload) {
  * \`applyChartScaleLayout\` / \`refreshLineChartOverlays\` before invoking this (see
  * \`tryCompleteLayoutSettleAfterDataCore\`).
  */
-function scheduleChartLayoutSettledNotify() {
+function scheduleChartLayoutSettledNotify(payload) {
   try {
     requestAnimationFrame(function () {
       requestAnimationFrame(function () {
         if (window.chartWidget && window.isChartReady) {
-          sendToReactNative('CHART_LAYOUT_SETTLED', {});
+          sendToReactNative('CHART_LAYOUT_SETTLED', payload || {});
         }
       });
     });
@@ -132,7 +132,7 @@ function scheduleChartLayoutSettledNotify() {
     try {
       setTimeout(function () {
         if (window.chartWidget && window.isChartReady) {
-          sendToReactNative('CHART_LAYOUT_SETTLED', {});
+          sendToReactNative('CHART_LAYOUT_SETTLED', payload || {});
         }
       }, 48);
     } catch (e2) {}
@@ -296,6 +296,47 @@ function abortDeferredLayoutSettleAndNotify() {
   window.__mmLayoutSettlePending = false;
   clearMmLayoutSettleFallbackTimer();
   scheduleChartLayoutSettledNotify();
+}
+
+function runAfterTwoAnimationFrames(callback) {
+  try {
+    requestAnimationFrame(function () {
+      requestAnimationFrame(callback);
+    });
+  } catch (e) {
+    setTimeout(callback, 32);
+  }
+}
+
+function postCurrentVisibleRangeApplied(rangeStatus, retryCount) {
+  if (!window.chartWidget || !window.isChartReady || !window.ohlcvGeneration) {
+    return;
+  }
+
+  var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+  var lastBarSec = lastBar ? Math.ceil(lastBar.time / 1000) : undefined;
+  var readback = null;
+  try {
+    readback = window.chartWidget.activeChart().getVisibleRange();
+  } catch (e) {}
+
+  var payload = {
+    seriesGeneration: window.ohlcvGeneration,
+    requestedFromMs:
+      window.visibleFromMs == null ? undefined : window.visibleFromMs,
+    requestedToMs: window.visibleToMs == null ? undefined : window.visibleToMs,
+    actualFromSec: readback ? readback.from : undefined,
+    actualToSec: readback ? readback.to : undefined,
+    lastBarSec: lastBarSec,
+    latestBarVisible:
+      lastBarSec === undefined ||
+      (readback && readback.from <= lastBarSec && readback.to >= lastBarSec),
+    rangeStatus: rangeStatus,
+    rangeApplyRetryCount: retryCount,
+  };
+
+  sendToReactNative('CHART_RANGE_APPLIED', payload);
+  scheduleChartLayoutSettledNotify(payload);
 }
 
 // ============================================
@@ -467,7 +508,12 @@ function handleSetOHLCVData(payload) {
 
   window.ohlcvData = payload.data;
   bumpLineChartOhlcvEpoch();
-  window.ohlcvGeneration++;
+  window.ohlcvGeneration =
+    typeof payload.seriesGeneration === 'number' &&
+    isFinite(payload.seriesGeneration)
+      ? payload.seriesGeneration
+      : window.ohlcvGeneration + 1;
+  var activeGeneration = window.ohlcvGeneration;
 
   if (payload.pagination) {
     window.ohlcvPagination = {
@@ -494,34 +540,170 @@ function handleSetOHLCVData(payload) {
 
   let newResolution = detectResolution(window.ohlcvData);
 
-  function scheduleVisibleRangeAfterDataLoad(chart) {
+  function buildRangePayload(rangeStatus, retryCount, reason) {
+    var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+    var lastBarSec = lastBar ? Math.ceil(lastBar.time / 1000) : undefined;
+    var payloadBase = {
+      seriesGeneration: activeGeneration,
+      requestedFromMs: visibleFromMs == null ? undefined : visibleFromMs,
+      requestedToMs: visibleToMs == null ? undefined : visibleToMs,
+      lastBarSec: lastBarSec,
+      latestBarVisible: false,
+      rangeStatus: rangeStatus,
+      rangeApplyRetryCount: retryCount,
+    };
+
+    if (reason) {
+      payloadBase.reason = reason;
+    }
+
+    return payloadBase;
+  }
+
+  function sendRangeApplied(readback, retryCount) {
+    var payloadBase = buildRangePayload('applied', retryCount);
+    if (readback) {
+      payloadBase.actualFromSec = readback.from;
+      payloadBase.actualToSec = readback.to;
+    }
+    payloadBase.latestBarVisible =
+      (readback == null && visibleFromMs == null) ||
+      payloadBase.lastBarSec === undefined ||
+      (payloadBase.actualFromSec !== undefined &&
+        payloadBase.actualToSec !== undefined &&
+        payloadBase.actualFromSec <= payloadBase.lastBarSec &&
+        payloadBase.actualToSec >= payloadBase.lastBarSec);
+    sendToReactNative('CHART_RANGE_APPLIED', payloadBase);
+    scheduleChartLayoutSettledNotify(payloadBase);
+  }
+
+  function sendRangeApplyFailed(retryCount, reason) {
+    sendToReactNative(
+      'CHART_RANGE_APPLY_FAILED',
+      buildRangePayload('failed', retryCount, reason),
+    );
+  }
+
+  function applyVisibleRange(chart, retryCount) {
+    if (activeGeneration !== window.ohlcvGeneration) {
+      return;
+    }
     if (visibleFromMs == null) {
       try {
         chart.getTimeScale().setRightOffset(2);
       } catch (e) {}
+      sendRangeApplied(null, retryCount);
       return;
     }
-    let capturedGeneration = window.ohlcvGeneration;
-    let sub = chart.onDataLoaded();
+
+    var fromSec = Math.floor(visibleFromMs / 1000);
+    var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
+    var toSec =
+      visibleToMs != null
+        ? Math.ceil(visibleToMs / 1000)
+        : lastBar
+          ? Math.ceil(lastBar.time / 1000)
+          : Math.ceil(Date.now() / 1000);
+    // Pad \`to\` forward by 2 bar durations so the end dot clears the price axis.
+    // 1 bar was not enough for the 16px dot marker to fully clear the right edge.
+    var barPadSec = getApproxBarDurationSec() * 2;
+
+    function validateVisibleRange() {
+      if (activeGeneration !== window.ohlcvGeneration) {
+        return;
+      }
+      var readback = null;
+      try {
+        readback = chart.getVisibleRange();
+      } catch (e) {}
+
+      var lastBarSec = lastBar ? Math.ceil(lastBar.time / 1000) : undefined;
+      var latestVisible =
+        lastBarSec === undefined ||
+        (readback &&
+          readback.from <= lastBarSec &&
+          readback.to >= lastBarSec);
+
+      if (latestVisible) {
+        sendRangeApplied(readback, retryCount);
+        return;
+      }
+
+      if (retryCount < 1) {
+        runAfterTwoAnimationFrames(function () {
+          applyVisibleRange(chart, retryCount + 1);
+        });
+        return;
+      }
+
+      sendRangeApplyFailed(retryCount, 'latest_bar_not_visible');
+    }
+
+    try {
+      var rangePromise = chart.setVisibleRange(
+        { from: fromSec, to: toSec + barPadSec },
+        { percentRightMargin: 0 },
+      );
+      if (rangePromise && typeof rangePromise.then === 'function') {
+        rangePromise
+          .then(function () {
+            runAfterTwoAnimationFrames(validateVisibleRange);
+          })
+          .catch(function (error) {
+            if (retryCount < 1) {
+              runAfterTwoAnimationFrames(function () {
+                applyVisibleRange(chart, retryCount + 1);
+              });
+              return;
+            }
+            sendRangeApplyFailed(
+              retryCount,
+              error && error.message ? error.message : 'setVisibleRange_failed',
+            );
+          });
+      } else {
+        runAfterTwoAnimationFrames(validateVisibleRange);
+      }
+    } catch (e) {
+      if (retryCount < 1) {
+        runAfterTwoAnimationFrames(function () {
+          applyVisibleRange(chart, retryCount + 1);
+        });
+        return;
+      }
+      sendRangeApplyFailed(
+        retryCount,
+        e && e.message ? e.message : 'setVisibleRange_threw',
+      );
+    }
+  }
+
+  function scheduleVisibleRangeAfterDataLoad(chart) {
+    var capturedGeneration = activeGeneration;
+    var didRun = false;
+    var fallbackTimer = setTimeout(function () {
+      run();
+    }, LAYOUT_SETTLE_DATA_FALLBACK_MS + 80);
+
+    function run() {
+      if (didRun) {
+        return;
+      }
+      didRun = true;
+      clearTimeout(fallbackTimer);
+      if (capturedGeneration !== window.ohlcvGeneration) {
+        return;
+      }
+      applyVisibleRange(chart, 0);
+    }
+
+    var sub = chart.onDataLoaded();
     sub.subscribe(null, function onLoaded() {
       sub.unsubscribe(null, onLoaded);
       if (capturedGeneration !== window.ohlcvGeneration) {
         return;
       }
-      let fromSec = Math.floor(visibleFromMs / 1000);
-      let lastBar = window.ohlcvData[window.ohlcvData.length - 1];
-      let toSec = lastBar
-        ? Math.ceil(lastBar.time / 1000)
-        : Math.ceil(Date.now() / 1000);
-      let barPadSec = getApproxBarDurationSec() * 2;
-      try {
-        chart.setVisibleRange(
-          { from: fromSec, to: toSec + barPadSec },
-          { percentRightMargin: 0 },
-        );
-      } catch (e) {
-        // setVisibleRange can fail if chart is mid-teardown
-      }
+      run();
     });
   }
 
@@ -530,23 +712,41 @@ function handleSetOHLCVData(payload) {
     window.currentResolution = newResolution;
 
     try {
-      let chart = window.chartWidget.activeChart();
+      var chart = window.chartWidget.activeChart();
+      function resetTradingViewData() {
+        try {
+          if (
+            window.chartWidget &&
+            typeof window.chartWidget.resetCache === 'function'
+          ) {
+            window.chartWidget.resetCache();
+          }
+        } catch (resetCacheError) {}
+        beginDeferredLayoutSettleAfterOhlcvReload();
+        chart.resetData();
+        scheduleVisibleRangeAfterDataLoad(chart);
+      }
+
       if (previousResolution !== newResolution) {
-        chart.setResolution(newResolution, function () {
+        var resolutionPromise = chart.setResolution(newResolution, function () {
           try {
-            chart.resetData();
-            beginDeferredLayoutSettleAfterOhlcvReload();
-            scheduleVisibleRangeAfterDataLoad(chart);
+            resetTradingViewData();
           } catch (eR) {
             abortDeferredLayoutSettleAndNotify();
             return;
           }
         });
+        if (
+          resolutionPromise &&
+          typeof resolutionPromise.catch === 'function'
+        ) {
+          resolutionPromise.catch(function () {
+            abortDeferredLayoutSettleAndNotify();
+          });
+        }
       } else {
         try {
-          chart.resetData();
-          beginDeferredLayoutSettleAfterOhlcvReload();
-          scheduleVisibleRangeAfterDataLoad(chart);
+          resetTradingViewData();
         } catch (e) {
           abortDeferredLayoutSettleAndNotify();
           return;
@@ -2533,7 +2733,10 @@ function handleSetPositionLines(payload) {
                 showLabel: true,
                 textcolor: line.color,
                 fontsize: 11,
-                horzLabelsAlign: 'right',
+                // Left-aligned so the Entry/TP/SL/Liq text sits on the left edge and does
+                // not overlap the most recent candles on the right. The price value still
+                // renders on the right price axis (showPrice is independent of label align).
+                horzLabelsAlign: 'left',
                 showPrice: true,
               },
             },
@@ -4231,10 +4434,11 @@ let VARIABLE_TICK_SIZE = [
   '0.1', // prices ≥ $10000    →  1 dp
 ].join(' ');
 
-function filterBarsForRange(fromMs, toMs, countBack) {
-  let barsInRange = [];
-  for (let i = 0; i < window.ohlcvData.length; i++) {
-    let b = window.ohlcvData[i];
+function filterBarsForRange(fromMs, toMs, countBack, options) {
+  var exactRange = !!(options && options.exactRange);
+  var barsInRange = [];
+  for (var i = 0; i < window.ohlcvData.length; i++) {
+    var b = window.ohlcvData[i];
     if (b.time >= fromMs && b.time < toMs) {
       barsInRange.push({
         time: b.time,
@@ -4245,6 +4449,10 @@ function filterBarsForRange(fromMs, toMs, countBack) {
         volume: b.volume,
       });
     }
+  }
+
+  if (exactRange) {
+    return barsInRange;
   }
 
   if (barsInRange.length < countBack) {
@@ -4446,7 +4654,15 @@ let customDatafeed = {
         }
       }
 
-      let bars = filterBarsForRange(fromMs, toMs, countBack);
+      var exactPrimaryRange =
+        !!firstRequest && window.visibleFromMs != null && window.visibleToMs != null;
+      var requestFromMs = exactPrimaryRange ? window.visibleFromMs : fromMs;
+      // \`filterBarsForRange\` uses an exclusive \`to\`; include the last candle when RN anchors
+      // the visible window to its timestamp.
+      var requestToMs = exactPrimaryRange ? window.visibleToMs + 1 : toMs;
+      var bars = filterBarsForRange(requestFromMs, requestToMs, countBack, {
+        exactRange: exactPrimaryRange,
+      });
 
       if (bars.length > 0) {
         deliverBars(bars, { noData: false });
@@ -4853,6 +5069,11 @@ function initChart() {
       }
 
       sendToReactNative('CHART_READY', {});
+      if (window.visibleFromMs != null) {
+        runAfterTwoAnimationFrames(function () {
+          postCurrentVisibleRangeApplied('applied', 0);
+        });
+      }
 
       if (window.currentChartType !== 2) {
         scheduleInitialColdLayoutSettled();

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -69,6 +69,8 @@ export enum TraceName {
   TokenOverviewAdvancedChartInitialVisible = 'Token Overview Advanced Chart Initial Visible',
   /** Token overview advanced chart: skeleton cleared after time range selector change only. */
   TokenOverviewAdvancedChartTimeRangeVisible = 'Token Overview Advanced Chart Time Range Visible',
+  /** Token overview advanced chart: OHLCV API fetch for initial load or time range change. */
+  TokenOverviewAdvancedChartOhlcvFetch = 'Token Overview Advanced Chart OHLCV Fetch',
   TransactionConfirmed = 'Transaction Confirmed',
   LoadCollectibles = 'Load Collectibles',
   DetectNfts = 'Detect Nfts',
@@ -281,6 +283,8 @@ export enum TraceOperation {
   TokenOverviewAdvancedChart = 'token_overview.advanced_chart',
   /** Token overview OHLCV WebView: time range change only */
   TokenOverviewAdvancedChartTimeRange = 'token_overview.advanced_chart_time_range',
+  /** Token overview OHLCV API fetch */
+  TokenOverviewAdvancedChartOhlcvFetch = 'token_overview.advanced_chart_ohlcv_fetch',
 }
 
 const ID_DEFAULT = 'default';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Optimizes Token Overview Advanced Chart time-range changes by keeping the WebView/TradingView widget persistent across OHLCV series
  updates instead of remounting on every `ohlcvSeriesKey` change.

  ## Motivation

  Time-range changes were spending most of their duration in WebView remount and TradingView re-initialization overhead. The chart could also preserve stale scroll/viewport state, causing the visible chart range to disagree with the header percentage calculation.

  ## Solution

  - Keep the WebView mounted for normal time-range changes.
  - Add generation-aware `SET_OHLCV_DATA` updates so stale async TradingView callbacks are ignored.
  - Reset TradingView data via `resetCache()` + `resetData()`.
  - Apply and verify the requested visible range with `setVisibleRange()` + `getVisibleRange()`.
  - Keep the skeleton visible until the latest-generation range is proven applied.
  - Add a one-transition remount fallback if TradingView cannot apply the expected range.
  - Add Sentry range metadata for validating performance and correctness.

  ## Testing

  - `yarn jest app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx`
  - `yarn jest app/components/UI/AssetOverview/Price/Price.advanced.test.tsx`
  - `yarn jest app/components/UI/Charts/AdvancedChart/useOHLCVChart.test.ts`
  - `yarn lint:tsc`
  - `node --check app/components/UI/Charts/AdvancedChart/webview/chartLogic.js`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Optimized advanced chart range changes

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/f6244812-5b6a-4f0e-a0ea-df96d601fbf7



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
