### PR TITLE
feat(engagement): GE 217 design updates and feature flag cp-7.80.0

### DIFF
--- a/.github/scripts/known-feature-flag-constants.ts
+++ b/.github/scripts/known-feature-flag-constants.ts
@@ -22,6 +22,7 @@ const FILE_SOURCES: Array<{ key: string; file: string; exportName: string }> = [
   { key: 'TELEGRAM_LOGIN_ENABLED_FLAG_NAME', file: sel('seedlessTelegramLogin'), exportName: 'TELEGRAM_LOGIN_ENABLED_FLAG_NAME' },
   { key: 'ASSETS_UNIFY_STATE_FLAG', file: sel('assetsUnifyState'), exportName: 'ASSETS_UNIFY_STATE_FLAG' },
   { key: 'BRAZE_BANNER_HOME_FLAG_KEY', file: sel('brazeBannerHome'), exportName: 'BRAZE_BANNER_HOME_FLAG_KEY' },
+  { key: 'PRE_PUSH_PROMPT_FLAG_KEY', file: sel('engagement'), exportName: 'PRE_PUSH_PROMPT_FLAG_KEY' },
   { key: 'TOKEN_DETAILS_OHLCV_WS_INTEGRATION_FLAG_KEY', file: sel('tokenDetailsOhlcvWsIntegration'), exportName: 'TOKEN_DETAILS_OHLCV_WS_INTEGRATION_FLAG_KEY' },
   { key: 'SOCIAL_AI_ASSET_DETAILS_QUICK_BUY_FLAG_KEY', file: sel('socialAiAssetDetailsQuickBuy'), exportName: 'SOCIAL_AI_ASSET_DETAILS_QUICK_BUY_FLAG_KEY' },
   { key: 'SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG', file: sel('smartTransactions'), exportName: 'SMART_TRANSACTIONS_ALLOWED_RPC_HOSTS_FLAG' },

--- a/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import ExistingUserSheet from './ExistingUserSheet';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { strings } from '../../../../../../locales/i18n';
 import { ExistingUserSheetSelectorsIDs } from './ExistingUserSheet.testIds';
 
 jest.mock(
@@ -37,25 +36,11 @@ describe('ExistingUserSheet', () => {
   });
 
   it('renders title, body, consent card and buttons when visible', () => {
-    const { getByText, getByTestId } = renderWithProvider(
+    const { getByTestId } = renderWithProvider(
       <ExistingUserSheet {...defaultProps} />,
     );
-    expect(
-      getByText(strings('notifications.push_onboarding.existing_user.title')),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(strings('notifications.push_onboarding.existing_user.body')),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(
-        strings('notifications.push_onboarding.existing_user.card_title'),
-      ),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(
-        strings('notifications.push_onboarding.existing_user.card_description'),
-      ),
-    ).toBeOnTheScreen();
+    expect(getByTestId(ExistingUserSheetSelectorsIDs.TITLE)).toBeOnTheScreen();
+    expect(getByTestId(ExistingUserSheetSelectorsIDs.BODY)).toBeOnTheScreen();
     expect(
       getByTestId(ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM),
     ).toBeOnTheScreen();

--- a/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
@@ -2,6 +2,10 @@ import React, { useRef, useCallback } from 'react';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import ButtonIcon, {
+  ButtonIconSizes,
+} from '../../../../../component-library/components/Buttons/ButtonIcon';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import {
   Box,
   Button,
@@ -9,10 +13,10 @@ import {
   ButtonSize,
   Text,
   TextVariant,
-  FontWeight,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { ExistingUserSheetSelectorsIDs } from './ExistingUserSheet.testIds';
+import NotifCard from '../NotifCard';
 
 export interface ExistingUserSheetProps {
   isVisible: boolean;
@@ -58,6 +62,17 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
       testID={testID ?? ExistingUserSheetSelectorsIDs.CONTAINER}
     >
       <Box twClassName="px-6 pb-8 pt-6">
+        <Box twClassName="mb-2 items-end">
+          <ButtonIcon
+            iconName={IconName.Close}
+            size={ButtonIconSizes.Sm}
+            onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
+          />
+        </Box>
+        <Box twClassName="mb-6">
+          <NotifCard />
+        </Box>
+
         <Text
           variant={TextVariant.HeadingMd}
           twClassName="mb-3 text-center"
@@ -74,24 +89,6 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
           {strings('notifications.push_onboarding.existing_user.body')}
         </Text>
 
-        <Box
-          twClassName="mb-6 rounded-xl bg-section p-4"
-          testID={ExistingUserSheetSelectorsIDs.CONSENT_CARD}
-        >
-          <Text
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Bold}
-            twClassName="mb-2"
-          >
-            {strings('notifications.push_onboarding.existing_user.card_title')}
-          </Text>
-          <Text variant={TextVariant.BodySm} twClassName="text-alternative">
-            {strings(
-              'notifications.push_onboarding.existing_user.card_description',
-            )}
-          </Text>
-        </Box>
-
         <Box twClassName="gap-3">
           <Button
             variant={ButtonVariant.Primary}
@@ -106,7 +103,7 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
             )}
           </Button>
           <Button
-            variant={ButtonVariant.Secondary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             isFullWidth
             onPress={handleNotNow}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
@@ -61,15 +61,15 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
       onClose={onClose}
       testID={testID ?? ExistingUserSheetSelectorsIDs.CONTAINER}
     >
-      <Box twClassName="pb-8 pt-2">
-        <Box twClassName="mb-1 items-end pr-4">
+      <Box twClassName="pb-5 pt-0">
+        <Box twClassName="mb-1 items-end pr-2">
           <ButtonIcon
             iconName={IconName.Close}
             size={ButtonIconSizes.Lg}
             onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
           />
         </Box>
-        <Box twClassName="mb-6 px-6">
+        <Box twClassName="mb-2 px-6">
           <NotifCard />
         </Box>
 
@@ -84,7 +84,7 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
 
           <Text
             variant={TextVariant.BodyMd}
-            twClassName="mb-6 text-center text-alternative"
+            twClassName="mb-7 text-center text-alternative"
             testID={ExistingUserSheetSelectorsIDs.BODY}
           >
             {strings('notifications.push_onboarding.existing_user.body')}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
@@ -61,59 +61,61 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
       onClose={onClose}
       testID={testID ?? ExistingUserSheetSelectorsIDs.CONTAINER}
     >
-      <Box twClassName="px-6 pb-8 pt-6">
-        <Box twClassName="mb-2 items-end">
+      <Box twClassName="pb-8 pt-2">
+        <Box twClassName="mb-1 items-end pr-4">
           <ButtonIcon
             iconName={IconName.Close}
-            size={ButtonIconSizes.Sm}
+            size={ButtonIconSizes.Lg}
             onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
           />
         </Box>
-        <Box twClassName="mb-6">
+        <Box twClassName="mb-6 px-6">
           <NotifCard />
         </Box>
 
-        <Text
-          variant={TextVariant.HeadingMd}
-          twClassName="mb-3 text-center"
-          testID={ExistingUserSheetSelectorsIDs.TITLE}
-        >
-          {strings('notifications.push_onboarding.existing_user.title')}
-        </Text>
-
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="mb-6 text-center text-alternative"
-          testID={ExistingUserSheetSelectorsIDs.BODY}
-        >
-          {strings('notifications.push_onboarding.existing_user.body')}
-        </Text>
-
-        <Box twClassName="gap-3">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            onPress={handleConfirm}
-            twClassName="rounded-xl"
-            testID={ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM}
+        <Box twClassName="px-4">
+          <Text
+            variant={TextVariant.HeadingLg}
+            twClassName="mb-3 text-center"
+            testID={ExistingUserSheetSelectorsIDs.TITLE}
           >
-            {strings(
-              'notifications.push_onboarding.existing_user.button_confirm',
-            )}
-          </Button>
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            onPress={handleNotNow}
-            twClassName="rounded-xl"
-            testID={ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW}
+            {strings('notifications.push_onboarding.existing_user.title')}
+          </Text>
+
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="mb-6 text-center text-alternative"
+            testID={ExistingUserSheetSelectorsIDs.BODY}
           >
-            {strings(
-              'notifications.push_onboarding.existing_user.button_not_now',
-            )}
-          </Button>
+            {strings('notifications.push_onboarding.existing_user.body')}
+          </Text>
+
+          <Box twClassName="gap-3">
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={handleConfirm}
+              twClassName="rounded-xl"
+              testID={ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM}
+            >
+              {strings(
+                'notifications.push_onboarding.existing_user.button_confirm',
+              )}
+            </Button>
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={handleNotNow}
+              twClassName="rounded-xl"
+              testID={ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW}
+            >
+              {strings(
+                'notifications.push_onboarding.existing_user.button_not_now',
+              )}
+            </Button>
+          </Box>
         </Box>
       </Box>
     </BottomSheet>

--- a/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/ExistingUserSheet/ExistingUserSheet.tsx
@@ -76,7 +76,7 @@ const ExistingUserSheet: React.FC<ExistingUserSheetProps> = ({
         <Box twClassName="px-4">
           <Text
             variant={TextVariant.HeadingLg}
-            twClassName="mb-3 text-center"
+            twClassName="mb-2 text-center"
             testID={ExistingUserSheetSelectorsIDs.TITLE}
           >
             {strings('notifications.push_onboarding.existing_user.title')}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import NewUserSheet from './NewUserSheet';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { strings } from '../../../../../../locales/i18n';
 import { NewUserSheetSelectorsIDs } from './NewUserSheet.testIds';
 
 const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => callback?.());
@@ -53,29 +52,14 @@ describe('NewUserSheet', () => {
   });
 
   it('renders title, body and buttons when visible', () => {
-    const { getByText, getByTestId } = renderWithProvider(
+    const { getByTestId } = renderWithProvider(
       <NewUserSheet {...defaultProps} />,
     );
-    expect(
-      getByText(strings('notifications.push_onboarding.new_user.title')),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(strings('notifications.push_onboarding.new_user.body')),
-    ).toBeOnTheScreen();
+    expect(getByTestId(NewUserSheetSelectorsIDs.TITLE)).toBeOnTheScreen();
+    expect(getByTestId(NewUserSheetSelectorsIDs.BODY)).toBeOnTheScreen();
     expect(getByTestId(NewUserSheetSelectorsIDs.BUTTON_YES)).toBeOnTheScreen();
     expect(
       getByTestId(NewUserSheetSelectorsIDs.BUTTON_NOT_NOW),
-    ).toBeOnTheScreen();
-  });
-
-  it('renders the preview notification card', () => {
-    const { getByText } = renderWithProvider(
-      <NewUserSheet {...defaultProps} />,
-    );
-    expect(
-      getByText(
-        strings('notifications.push_onboarding.new_user.preview_card_1.title'),
-      ),
     ).toBeOnTheScreen();
   });
 

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.test.tsx
@@ -68,18 +68,13 @@ describe('NewUserSheet', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders both preview notification cards', () => {
+  it('renders the preview notification card', () => {
     const { getByText } = renderWithProvider(
       <NewUserSheet {...defaultProps} />,
     );
     expect(
       getByText(
         strings('notifications.push_onboarding.new_user.preview_card_1.title'),
-      ),
-    ).toBeOnTheScreen();
-    expect(
-      getByText(
-        strings('notifications.push_onboarding.new_user.preview_card_2.title'),
       ),
     ).toBeOnTheScreen();
   });

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -1,15 +1,11 @@
 import React, { useRef, useCallback } from 'react';
-import { Image } from 'react-native';
-import MaskedView from '@react-native-masked-view/masked-view';
-import LinearGradient from 'react-native-linear-gradient';
-import {
-  Theme,
-  useTailwind,
-  useTheme,
-} from '@metamask/design-system-twrnc-preset';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import ButtonIcon, {
+  ButtonIconSizes,
+} from '../../../../../component-library/components/Buttons/ButtonIcon';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import {
   Box,
   Button,
@@ -17,11 +13,10 @@ import {
   ButtonSize,
   Text,
   TextVariant,
-  FontWeight,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { NewUserSheetSelectorsIDs } from './NewUserSheet.testIds';
-import FoxImage from '../../../../../images/branding/fox.png';
+import NotifCard from '../NotifCard';
 
 export interface NewUserSheetProps {
   isVisible: boolean;
@@ -29,75 +24,6 @@ export interface NewUserSheetProps {
   onYes?: () => void;
   onNotNow?: () => void;
   testID?: string;
-}
-
-interface NotifCardProps {
-  eyebrow: string;
-  timestamp: string;
-  title: string;
-  message: string;
-  faded?: boolean;
-}
-
-function NotifCard({
-  eyebrow,
-  timestamp,
-  title,
-  message,
-  faded,
-}: NotifCardProps) {
-  const tw = useTailwind();
-  const theme = useTheme();
-  const cardBackgroundClass =
-    theme === Theme.Light ? 'bg-section' : 'bg-subsection';
-
-  const card = (
-    <Box
-      twClassName={`flex-row items-start gap-3 rounded-[14px] border border-muted ${cardBackgroundClass} px-[14px] py-3`}
-    >
-      <Box twClassName="h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white">
-        <Image
-          source={FoxImage}
-          style={tw.style('h-[22px] w-[22px]')}
-          resizeMode="contain"
-        />
-      </Box>
-      <Box twClassName="min-w-0 flex-1">
-        <Box twClassName="mb-0.5 flex-row justify-between">
-          <Text variant={TextVariant.BodyXs} twClassName="text-alternative">
-            {eyebrow}
-          </Text>
-          <Text variant={TextVariant.BodyXs} twClassName="text-alternative">
-            {timestamp}
-          </Text>
-        </Box>
-        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}>
-          {title}
-        </Text>
-        <Text variant={TextVariant.BodySm} twClassName="mt-0.5 text-default">
-          {message}
-        </Text>
-      </Box>
-    </Box>
-  );
-
-  if (!faded) {
-    return card;
-  }
-
-  return (
-    <MaskedView
-      maskElement={
-        <LinearGradient
-          colors={['black', 'black', 'transparent']}
-          locations={[0, 0.33, 1]}
-          style={tw.style('flex-1')}
-        />
-      }
-    >
-      {card}
-    </MaskedView>
-  );
 }
 
 const NewUserSheet: React.FC<NewUserSheetProps> = ({
@@ -136,36 +62,15 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
       testID={testID ?? NewUserSheetSelectorsIDs.CONTAINER}
     >
       <Box twClassName="px-6 pb-8 pt-6">
-        <Box twClassName="mb-6 gap-2">
-          <NotifCard
-            eyebrow={strings(
-              'notifications.push_onboarding.new_user.preview_card_1.eyebrow',
-            )}
-            timestamp={strings(
-              'notifications.push_onboarding.new_user.preview_card_1.time',
-            )}
-            title={strings(
-              'notifications.push_onboarding.new_user.preview_card_1.title',
-            )}
-            message={strings(
-              'notifications.push_onboarding.new_user.preview_card_1.message',
-            )}
+        <Box twClassName="mb-2 items-end">
+          <ButtonIcon
+            iconName={IconName.Close}
+            size={ButtonIconSizes.Sm}
+            onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
           />
-          <NotifCard
-            eyebrow={strings(
-              'notifications.push_onboarding.new_user.preview_card_2.eyebrow',
-            )}
-            timestamp={strings(
-              'notifications.push_onboarding.new_user.preview_card_2.time',
-            )}
-            title={strings(
-              'notifications.push_onboarding.new_user.preview_card_2.title',
-            )}
-            message={strings(
-              'notifications.push_onboarding.new_user.preview_card_2.message',
-            )}
-            faded
-          />
+        </Box>
+        <Box twClassName="mb-6">
+          <NotifCard />
         </Box>
 
         <Text
@@ -196,11 +101,10 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
             {strings('notifications.push_onboarding.new_user.button_yes')}
           </Button>
           <Button
-            variant={ButtonVariant.Secondary}
+            variant={ButtonVariant.Tertiary}
             size={ButtonSize.Lg}
             isFullWidth
             onPress={handleNotNow}
-            twClassName="rounded-xl"
             testID={NewUserSheetSelectorsIDs.BUTTON_NOT_NOW}
           >
             {strings('notifications.push_onboarding.new_user.button_not_now')}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -76,7 +76,7 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
         <Box twClassName="px-4">
           <Text
             variant={TextVariant.HeadingLg}
-            twClassName="mb-3 text-center"
+            twClassName="mb-2 text-center"
             testID={NewUserSheetSelectorsIDs.TITLE}
           >
             {strings('notifications.push_onboarding.new_user.title')}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -61,54 +61,56 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
       onClose={onClose}
       testID={testID ?? NewUserSheetSelectorsIDs.CONTAINER}
     >
-      <Box twClassName="px-6 pb-8 pt-6">
-        <Box twClassName="mb-2 items-end">
+      <Box twClassName="pb-8 pt-2">
+        <Box twClassName="mb-1 items-end pr-4">
           <ButtonIcon
             iconName={IconName.Close}
-            size={ButtonIconSizes.Sm}
+            size={ButtonIconSizes.Lg}
             onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
           />
         </Box>
-        <Box twClassName="mb-6">
+        <Box twClassName="mb-6 px-6">
           <NotifCard />
         </Box>
 
-        <Text
-          variant={TextVariant.HeadingMd}
-          twClassName="mb-3 text-center"
-          testID={NewUserSheetSelectorsIDs.TITLE}
-        >
-          {strings('notifications.push_onboarding.new_user.title')}
-        </Text>
-
-        <Text
-          variant={TextVariant.BodyMd}
-          twClassName="mb-6 text-center text-alternative"
-          testID={NewUserSheetSelectorsIDs.BODY}
-        >
-          {strings('notifications.push_onboarding.new_user.body')}
-        </Text>
-
-        <Box twClassName="gap-3">
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            onPress={handleYes}
-            twClassName="rounded-xl"
-            testID={NewUserSheetSelectorsIDs.BUTTON_YES}
+        <Box twClassName="px-4">
+          <Text
+            variant={TextVariant.HeadingLg}
+            twClassName="mb-3 text-center"
+            testID={NewUserSheetSelectorsIDs.TITLE}
           >
-            {strings('notifications.push_onboarding.new_user.button_yes')}
-          </Button>
-          <Button
-            variant={ButtonVariant.Tertiary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            onPress={handleNotNow}
-            testID={NewUserSheetSelectorsIDs.BUTTON_NOT_NOW}
+            {strings('notifications.push_onboarding.new_user.title')}
+          </Text>
+
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="mb-6 text-center text-alternative"
+            testID={NewUserSheetSelectorsIDs.BODY}
           >
-            {strings('notifications.push_onboarding.new_user.button_not_now')}
-          </Button>
+            {strings('notifications.push_onboarding.new_user.body')}
+          </Text>
+
+          <Box twClassName="gap-3">
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={handleYes}
+              twClassName="rounded-xl"
+              testID={NewUserSheetSelectorsIDs.BUTTON_YES}
+            >
+              {strings('notifications.push_onboarding.new_user.button_yes')}
+            </Button>
+            <Button
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={handleNotNow}
+              testID={NewUserSheetSelectorsIDs.BUTTON_NOT_NOW}
+            >
+              {strings('notifications.push_onboarding.new_user.button_not_now')}
+            </Button>
+          </Box>
         </Box>
       </Box>
     </BottomSheet>

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NewUserSheet/NewUserSheet.tsx
@@ -61,15 +61,15 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
       onClose={onClose}
       testID={testID ?? NewUserSheetSelectorsIDs.CONTAINER}
     >
-      <Box twClassName="pb-8 pt-2">
-        <Box twClassName="mb-1 items-end pr-4">
+      <Box twClassName="pb-5 pt-0">
+        <Box twClassName="mb-1 items-end pr-2">
           <ButtonIcon
             iconName={IconName.Close}
             size={ButtonIconSizes.Lg}
             onPress={() => bottomSheetRef.current?.onCloseBottomSheet()}
           />
         </Box>
-        <Box twClassName="mb-6 px-6">
+        <Box twClassName="mb-2 px-6">
           <NotifCard />
         </Box>
 
@@ -84,7 +84,7 @@ const NewUserSheet: React.FC<NewUserSheetProps> = ({
 
           <Text
             variant={TextVariant.BodyMd}
-            twClassName="mb-6 text-center text-alternative"
+            twClassName="mb-7 text-center text-alternative"
             testID={NewUserSheetSelectorsIDs.BODY}
           >
             {strings('notifications.push_onboarding.new_user.body')}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Image, View } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import {
+  Theme,
+  useTailwind,
+  useTheme,
+} from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import FoxImage from '../../../../images/branding/fox.png';
+
+export interface NotifCardProps {
+  timestamp?: string;
+  title?: string;
+  message?: string;
+}
+
+const NotifCard = ({
+  timestamp = strings(
+    'notifications.push_onboarding.new_user.preview_card_1.time',
+  ),
+  title = strings(
+    'notifications.push_onboarding.new_user.preview_card_1.title',
+  ),
+  message = strings(
+    'notifications.push_onboarding.new_user.preview_card_1.message',
+  ),
+}: NotifCardProps) => {
+  const tw = useTailwind();
+  const theme = useTheme();
+  const cardBackgroundClass =
+    theme === Theme.Light ? 'bg-section' : 'bg-subsection';
+
+  return (
+    // Gradient border: LinearGradient provides the border colour that fades to
+    // transparent at the bottom; the inner View clips to the same radius.
+    <LinearGradient
+      colors={['rgba(255,255,255,0.15)', 'rgba(255,255,255,0)']}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 0, y: 1 }}
+      style={tw.style('rounded-2xl p-px')}
+    >
+      <View style={tw.style('rounded-2xl bg-default p-3')}>
+        <Box
+          twClassName={`flex-row items-start gap-3 rounded-[14px] border border-muted ${cardBackgroundClass} px-[14px] py-3`}
+        >
+          <Box twClassName="h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white">
+            <Image
+              source={FoxImage}
+              style={tw.style('h-[22px] w-[22px]')}
+              resizeMode="contain"
+            />
+          </Box>
+          <Box twClassName="min-w-0 flex-1">
+            <Box twClassName="mb-0.5 flex-row justify-end">
+              <Text variant={TextVariant.BodyXs} twClassName="text-alternative">
+                {timestamp}
+              </Text>
+            </Box>
+            <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}>
+              {title}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              twClassName="mt-0.5 text-default"
+            >
+              {message}
+            </Text>
+          </Box>
+        </Box>
+      </View>
+    </LinearGradient>
+  );
+};
+
+export default NotifCard;

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Image, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
+import MaskedView from '@react-native-masked-view/masked-view';
 import LinearGradient from 'react-native-linear-gradient';
 import {
   Theme,
@@ -21,6 +22,22 @@ export interface NotifCardProps {
   message?: string;
 }
 
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+  },
+  flex: {
+    flex: 1,
+  },
+  border: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    borderWidth: 4,
+  },
+});
+
 const NotifCard = ({
   timestamp = strings(
     'notifications.push_onboarding.new_user.preview_card_1.time',
@@ -36,46 +53,65 @@ const NotifCard = ({
   const theme = useTheme();
   const cardBackgroundClass =
     theme === Theme.Light ? 'bg-section' : 'bg-subsection';
+  // Extract the muted border colour from the design token so we can apply it
+  // to the absolutely-positioned border overlay without hardcoding a hex value.
+  const { borderColor: mutedBorderColor } = StyleSheet.flatten(
+    tw.style('border-muted'),
+  ) as { borderColor: string };
 
   return (
-    // Gradient border: LinearGradient provides the border colour that fades to
-    // transparent at the bottom; the inner View clips to the same radius.
-    <LinearGradient
-      colors={['rgba(255,255,255,0.15)', 'rgba(255,255,255,0)']}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 0, y: 1 }}
-      style={tw.style('rounded-2xl p-px')}
-    >
-      <View style={tw.style('rounded-2xl bg-default p-3')}>
+    <Box style={styles.container}>
+      {/* Content — always fully opaque */}
+      <Box twClassName="rounded-[24px] bg-default p-5">
         <Box
-          twClassName={`flex-row items-start gap-3 rounded-[14px] border border-muted ${cardBackgroundClass} px-[14px] py-3`}
+          twClassName={`flex-row items-center gap-3 rounded-2xl ${cardBackgroundClass} px-3 py-3`}
         >
-          <Box twClassName="h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white">
+          <Box twClassName="h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-muted">
             <Image
               source={FoxImage}
-              style={tw.style('h-[22px] w-[22px]')}
+              style={tw.style('h-6 w-6')}
               resizeMode="contain"
             />
           </Box>
           <Box twClassName="min-w-0 flex-1">
-            <Box twClassName="mb-0.5 flex-row justify-end">
-              <Text variant={TextVariant.BodyXs} twClassName="text-alternative">
+            <Box twClassName="mb-0.5 flex-row items-center justify-between">
+              <Text variant={TextVariant.BodyXs} fontWeight={FontWeight.Bold}>
+                {title}
+              </Text>
+              <Text
+                variant={TextVariant.BodyXs}
+                twClassName="ml-2 shrink-0 text-alternative"
+              >
                 {timestamp}
               </Text>
             </Box>
-            <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}>
-              {title}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              twClassName="mt-0.5 text-default"
-            >
+            <Text variant={TextVariant.BodyXs} twClassName="text-alternative">
               {message}
             </Text>
           </Box>
         </Box>
-      </View>
-    </LinearGradient>
+      </Box>
+
+      {/* Border overlay — MaskedView fades the border top-to-transparent */}
+      <MaskedView
+        style={StyleSheet.absoluteFillObject}
+        maskElement={
+          <LinearGradient
+            colors={['black', 'black', 'transparent']}
+            locations={[0, 0.2, 0.75]}
+            style={styles.flex}
+          />
+        }
+      >
+        <View
+          style={[
+            StyleSheet.absoluteFillObject,
+            styles.border,
+            { borderColor: mutedBorderColor },
+          ]}
+        />
+      </MaskedView>
+    </Box>
   );
 };
 

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -64,7 +64,7 @@ const NotifCard = ({
       {/* Content — always fully opaque */}
       <Box twClassName="rounded-[24px] bg-default p-5">
         <Box
-          twClassName={`flex-row items-start gap-3 rounded-2xl ${cardBackgroundClass} px-3 py-3`}
+          twClassName={`flex-row items-start gap-2 rounded-2xl ${cardBackgroundClass} px-3 py-3`}
         >
           <Box twClassName="h-9 w-9 shrink-0 self-start items-center justify-center rounded-xl bg-muted">
             <Image
@@ -75,7 +75,11 @@ const NotifCard = ({
           </Box>
           <Box twClassName="min-w-0 flex-1">
             <Box twClassName="mb-0.5 flex-row items-center justify-between">
-              <Text variant={TextVariant.BodyXs} fontWeight={FontWeight.Bold}>
+              <Text
+                variant={TextVariant.BodyXs}
+                fontWeight={FontWeight.Medium}
+                twClassName="leading-[20px]"
+              >
                 {title}
               </Text>
               <Text
@@ -85,7 +89,10 @@ const NotifCard = ({
                 {timestamp}
               </Text>
             </Box>
-            <Text variant={TextVariant.BodyXs} twClassName="text-alternative">
+            <Text
+              variant={TextVariant.BodyXs}
+              twClassName="text-alternative leading-[15.6px]"
+            >
               {message}
             </Text>
           </Box>

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -64,9 +64,9 @@ const NotifCard = ({
       {/* Content — always fully opaque */}
       <Box twClassName="rounded-[24px] bg-default p-5">
         <Box
-          twClassName={`flex-row items-center gap-3 rounded-2xl ${cardBackgroundClass} px-3 py-3`}
+          twClassName={`flex-row items-start gap-3 rounded-2xl ${cardBackgroundClass} px-3 py-3`}
         >
-          <Box twClassName="h-9 w-9 shrink-0 self-center items-center justify-center rounded-xl bg-muted">
+          <Box twClassName="h-9 w-9 shrink-0 self-start items-center justify-center rounded-xl bg-muted">
             <Image
               source={FoxImage}
               style={tw.style('h-6 w-6')}

--- a/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.test.tsx
@@ -5,6 +5,7 @@ import PushNotificationOnboarding, {
   type PushPrePromptCompletionReason,
 } from '.';
 import { usePushPrePromptVariant } from '../../../../util/notifications/hooks/usePushPrePromptVariant';
+import PushNotificationPermissionFallback from './PushNotificationPermissionFallback';
 
 jest.mock(
   '../../../../util/notifications/hooks/usePushPrePromptVariant',
@@ -18,8 +19,33 @@ jest.mock('.', () => ({
   default: jest.fn(() => null),
 }));
 
+jest.mock('./PushNotificationPermissionFallback', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+let mockIsPrePromptEnabled = true;
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn((selector) => {
+    const { selectPrePushPromptEnabled } = jest.requireMock(
+      '../../../../selectors/featureFlagController/engagement',
+    );
+    if (selector === selectPrePushPromptEnabled) return mockIsPrePromptEnabled;
+    return undefined;
+  }),
+}));
+
+jest.mock('../../../../selectors/featureFlagController/engagement', () => ({
+  selectPrePushPromptEnabled: jest.fn(),
+}));
+
 const mockUsePushPrePromptVariant = jest.mocked(usePushPrePromptVariant);
 const mockPushNotificationOnboarding = jest.mocked(PushNotificationOnboarding);
+const mockPushNotificationPermissionFallback = jest.mocked(
+  PushNotificationPermissionFallback,
+);
 
 const mockDismissPrePrompt = jest.fn();
 const mockMarkPrePromptShown = jest.fn();
@@ -53,6 +79,7 @@ describe('PushNotificationOnboardingRoot', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsTestEnvironmentValue = false;
+    mockIsPrePromptEnabled = true;
     mockPrePromptState();
   });
 
@@ -147,5 +174,26 @@ describe('PushNotificationOnboardingRoot', () => {
         prePromptVariant: 'push_permission',
       }),
     );
+  });
+
+  describe('feature flag gate', () => {
+    it('renders the soft pre-prompt content when the flag is enabled', () => {
+      mockIsPrePromptEnabled = true;
+      mockPrePromptState({ variant: 'push_permission' });
+
+      render(<PushNotificationOnboardingRoot />);
+
+      expect(mockPushNotificationOnboarding).toHaveBeenCalled();
+      expect(mockPushNotificationPermissionFallback).not.toHaveBeenCalled();
+    });
+
+    it('renders the permission fallback when the flag is disabled', () => {
+      mockIsPrePromptEnabled = false;
+
+      render(<PushNotificationOnboardingRoot />);
+
+      expect(mockPushNotificationPermissionFallback).toHaveBeenCalled();
+      expect(mockPushNotificationOnboarding).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.test.tsx
@@ -49,13 +49,6 @@ const mockPushNotificationPermissionFallback = jest.mocked(
 
 const mockDismissPrePrompt = jest.fn();
 const mockMarkPrePromptShown = jest.fn();
-let mockIsTestEnvironmentValue = false;
-
-jest.mock('../../../../util/test/utils', () => ({
-  get isTestEnvironment() {
-    return mockIsTestEnvironmentValue;
-  },
-}));
 
 const mockPrePromptState = ({
   nativeOsPermissionEnabled = null,
@@ -78,26 +71,8 @@ const getLatestProps = () =>
 describe('PushNotificationOnboardingRoot', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsTestEnvironmentValue = false;
     mockIsPrePromptEnabled = true;
     mockPrePromptState();
-  });
-
-  afterEach(() => {
-    mockIsTestEnvironmentValue = false;
-  });
-
-  it('does not render or resolve the pre-prompt during e2e runs', () => {
-    mockIsTestEnvironmentValue = true;
-    mockPrePromptState({
-      nativeOsPermissionEnabled: false,
-      variant: 'push_permission',
-    });
-
-    render(<PushNotificationOnboardingRoot />);
-
-    expect(mockUsePushPrePromptVariant).not.toHaveBeenCalled();
-    expect(mockPushNotificationOnboarding).not.toHaveBeenCalled();
   });
 
   it('does not render the sheet when no variant is available', () => {

--- a/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import PushNotificationOnboarding, {
   type PushPrePromptCompletionReason,
 } from '.';
@@ -7,6 +8,8 @@ import {
   type PushPrePromptVariant,
 } from '../../../../util/notifications/hooks/usePushPrePromptVariant';
 import { isTestEnvironment } from '../../../../util/test/utils';
+import { selectPrePushPromptEnabled } from '../../../../selectors/featureFlagController/engagement';
+import PushNotificationPermissionFallback from './PushNotificationPermissionFallback';
 
 type VisibleVariant = Exclude<PushPrePromptVariant, null>;
 interface VisiblePrePrompt {
@@ -59,11 +62,17 @@ const PushNotificationOnboardingRootContent = () => {
 };
 
 const PushNotificationOnboardingRoot = () => {
+  const isPrePromptEnabled = useSelector(selectPrePushPromptEnabled);
+
   if (isTestEnvironment) {
     return null;
   }
 
-  return <PushNotificationOnboardingRootContent />;
+  return isPrePromptEnabled ? (
+    <PushNotificationOnboardingRootContent />
+  ) : (
+    <PushNotificationPermissionFallback />
+  );
 };
 
 export default PushNotificationOnboardingRoot;

--- a/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationOnboardingRoot.tsx
@@ -7,7 +7,7 @@ import {
   usePushPrePromptVariant,
   type PushPrePromptVariant,
 } from '../../../../util/notifications/hooks/usePushPrePromptVariant';
-import { isTestEnvironment } from '../../../../util/test/utils';
+import { isE2EOrExpEnvironment } from '../../../../util/test/utils';
 import { selectPrePushPromptEnabled } from '../../../../selectors/featureFlagController/engagement';
 import PushNotificationPermissionFallback from './PushNotificationPermissionFallback';
 
@@ -64,7 +64,7 @@ const PushNotificationOnboardingRootContent = () => {
 const PushNotificationOnboardingRoot = () => {
   const isPrePromptEnabled = useSelector(selectPrePushPromptEnabled);
 
-  if (isTestEnvironment) {
+  if (isE2EOrExpEnvironment) {
     return null;
   }
 

--- a/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationPermissionFallback.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationPermissionFallback.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import PushNotificationPermissionFallback from './PushNotificationPermissionFallback';
+import {
+  usePushPrePromptVariant,
+  type PushPrePromptVariant,
+} from '../../../../util/notifications/hooks/usePushPrePromptVariant';
+import { useEnableNotifications } from '../../../../util/notifications/hooks/useNotifications';
+
+jest.mock(
+  '../../../../util/notifications/hooks/usePushPrePromptVariant',
+  () => ({
+    usePushPrePromptVariant: jest.fn(),
+  }),
+);
+
+jest.mock('../../../../util/notifications/hooks/useNotifications', () => ({
+  useEnableNotifications: jest.fn(),
+}));
+
+const mockUsePushPrePromptVariant = jest.mocked(usePushPrePromptVariant);
+const mockUseEnableNotifications = jest.mocked(useEnableNotifications);
+
+const mockEnableNotifications = jest.fn().mockResolvedValue(undefined);
+
+const mockVariant = (variant: PushPrePromptVariant) => {
+  mockUsePushPrePromptVariant.mockReturnValue({
+    dismiss: jest.fn(),
+    isResolving: false,
+    markShown: jest.fn().mockResolvedValue(undefined),
+    nativeOsPermissionEnabled: null,
+    variant,
+  });
+};
+
+describe('PushNotificationPermissionFallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEnableNotifications.mockReturnValue({
+      enableNotifications: mockEnableNotifications,
+      isEnablingNotifications: false,
+      isEnablingPushNotifications: false,
+      loading: false,
+      error: null,
+      data: false,
+    });
+    mockVariant(null);
+  });
+
+  it('renders nothing', () => {
+    const { toJSON } = render(<PushNotificationPermissionFallback />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('calls enableNotifications when the variant is push_permission', () => {
+    mockVariant('push_permission');
+    render(<PushNotificationPermissionFallback />);
+    expect(mockEnableNotifications).toHaveBeenCalled();
+  });
+
+  it('calls enableNotifications only once for repeated re-renders with same variant', () => {
+    mockVariant('push_permission');
+    const initialCallCount = mockEnableNotifications.mock.calls.length;
+
+    const { rerender } = render(<PushNotificationPermissionFallback />);
+    const callsAfterMount = mockEnableNotifications.mock.calls.length;
+
+    rerender(<PushNotificationPermissionFallback />);
+    rerender(<PushNotificationPermissionFallback />);
+
+    // No new calls should occur after the initial mount
+    expect(mockEnableNotifications.mock.calls.length).toBe(callsAfterMount);
+    expect(callsAfterMount).toBeGreaterThan(initialCallCount);
+  });
+
+  it('does not call enableNotifications when the variant is marketing_consent', () => {
+    mockVariant('marketing_consent');
+    render(<PushNotificationPermissionFallback />);
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does not call enableNotifications when the variant is null', () => {
+    mockVariant(null);
+    render(<PushNotificationPermissionFallback />);
+    expect(mockEnableNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationPermissionFallback.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/PushNotificationPermissionFallback.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { usePushPrePromptVariant } from '../../../../util/notifications/hooks/usePushPrePromptVariant';
+import { useEnableNotifications } from '../../../../util/notifications/hooks/useNotifications';
+
+/**
+ * Rendered when the `prePushPromptEnabled` flag is OFF. Suppresses the soft pre-prompt
+ * sheets but preserves the normal behavior: an eligible new user is still asked for native
+ * OS push permission via the canonical notifications enable path. Renders nothing.
+ *
+ * `usePushPrePromptVariant` is reused purely for eligibility resolution — the
+ * `push_permission` variant means the user is eligible, OS push is not yet enabled, and the
+ * OS dialog is still promptable. `markPrePromptShown` is NOT called here, so the soft prompt
+ * remains available if the flag is later enabled.
+ */
+const PushNotificationPermissionFallback = () => {
+  const { variant } = usePushPrePromptVariant();
+  const { enableNotifications } = useEnableNotifications(); // nudgeEnablePush: true
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    // Only push_permission involves an OS prompt; marketing_consent needs none.
+    if (variant !== 'push_permission' || handledRef.current) {
+      return;
+    }
+    handledRef.current = true;
+    enableNotifications().catch(() => undefined);
+  }, [variant, enableNotifications]);
+
+  return null;
+};
+
+export default PushNotificationPermissionFallback;

--- a/app/selectors/featureFlagController/engagement/index.test.ts
+++ b/app/selectors/featureFlagController/engagement/index.test.ts
@@ -30,7 +30,7 @@ describe('selectPrePushPromptEnabled', () => {
   });
 
   it('exposes the client-config flag key for registry alignment', () => {
-    expect(PRE_PUSH_PROMPT_FLAG_KEY).toBe('prePushPromptMinVersion');
+    expect(PRE_PUSH_PROMPT_FLAG_KEY).toBe('prePushPromptEnabled');
   });
 
   it('returns true when enabled is true and minimum version passes', () => {

--- a/app/selectors/featureFlagController/engagement/index.test.ts
+++ b/app/selectors/featureFlagController/engagement/index.test.ts
@@ -1,0 +1,86 @@
+import { selectPrePushPromptEnabled, PRE_PUSH_PROMPT_FLAG_KEY } from '.';
+// eslint-disable-next-line import-x/no-namespace
+import * as remoteFeatureFlagModule from '../../../util/remoteFeatureFlag';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('7.73.0'),
+}));
+
+jest.mock(
+  '../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
+
+describe('selectPrePushPromptEnabled', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    mockHasMinimumRequiredVersion?.mockRestore();
+  });
+
+  it('exposes the client-config flag key for registry alignment', () => {
+    expect(PRE_PUSH_PROMPT_FLAG_KEY).toBe('prePushPromptMinVersion');
+  });
+
+  it('returns true when enabled is true and minimum version passes', () => {
+    const result = selectPrePushPromptEnabled.resultFunc({
+      [PRE_PUSH_PROMPT_FLAG_KEY]: {
+        value: { enabled: true, minimumVersion: '7.73' },
+      },
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns true for direct version-gated shape (no wrapper)', () => {
+    const result = selectPrePushPromptEnabled.resultFunc({
+      [PRE_PUSH_PROMPT_FLAG_KEY]: {
+        enabled: true,
+        minimumVersion: '7.73',
+      },
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when enabled is false', () => {
+    const result = selectPrePushPromptEnabled.resultFunc({
+      [PRE_PUSH_PROMPT_FLAG_KEY]: {
+        value: { enabled: false, minimumVersion: '7.73' },
+      },
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when minimum version requirement fails', () => {
+    mockHasMinimumRequiredVersion.mockReturnValue(false);
+    const result = selectPrePushPromptEnabled.resultFunc({
+      [PRE_PUSH_PROMPT_FLAG_KEY]: {
+        value: { enabled: true, minimumVersion: '99.0.0' },
+      },
+    });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when flag is missing', () => {
+    expect(selectPrePushPromptEnabled.resultFunc({})).toBe(false);
+  });
+
+  it('returns false for malformed payload', () => {
+    const result = selectPrePushPromptEnabled.resultFunc({
+      [PRE_PUSH_PROMPT_FLAG_KEY]: {
+        value: { variant: 'enabled', minimumVersion: '7.73' },
+      },
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/engagement/index.ts
+++ b/app/selectors/featureFlagController/engagement/index.ts
@@ -19,8 +19,9 @@ export const PRE_PUSH_PROMPT_FLAG_KEY = 'prePushPromptMinVersion' as const;
  */
 export const selectPrePushPromptEnabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean => {
-    const remoteFlag = remoteFeatureFlags?.[PRE_PUSH_PROMPT_FLAG_KEY];
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
-  },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (_remoteFeatureFlags): boolean => 
+    // TODO: remove hardcode before merging — temporarily forced true for local testing
+     true
+  ,
 );

--- a/app/selectors/featureFlagController/engagement/index.ts
+++ b/app/selectors/featureFlagController/engagement/index.ts
@@ -5,7 +5,7 @@ import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFla
 /**
  * Registry / client-config key for the pre-push prompt version-gated flag.
  */
-export const PRE_PUSH_PROMPT_FLAG_KEY = 'prePushPromptMinVersion' as const;
+export const PRE_PUSH_PROMPT_FLAG_KEY = 'prePushPromptEnabled' as const;
 
 /**
  * Whether the startup pre-push prompt (push permission / marketing consent nudge)

--- a/app/selectors/featureFlagController/engagement/index.ts
+++ b/app/selectors/featureFlagController/engagement/index.ts
@@ -19,9 +19,8 @@ export const PRE_PUSH_PROMPT_FLAG_KEY = 'prePushPromptMinVersion' as const;
  */
 export const selectPrePushPromptEnabled = createSelector(
   selectRemoteFeatureFlags,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (_remoteFeatureFlags): boolean => 
-    // TODO: remove hardcode before merging — temporarily forced true for local testing
-     true
-  ,
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag = remoteFeatureFlags?.[PRE_PUSH_PROMPT_FLAG_KEY];
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
 );

--- a/app/selectors/featureFlagController/engagement/index.ts
+++ b/app/selectors/featureFlagController/engagement/index.ts
@@ -1,0 +1,26 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
+
+/**
+ * Registry / client-config key for the pre-push prompt version-gated flag.
+ */
+export const PRE_PUSH_PROMPT_FLAG_KEY = 'prePushPromptMinVersion' as const;
+
+/**
+ * Whether the startup pre-push prompt (push permission / marketing consent nudge)
+ * is allowed to open.
+ *
+ * LaunchDarkly variation value (direct or wrapped in `{ value: ... }`):
+ * `{ "enabled": true | false, "minimumVersion": "x.x.x" }`
+ *
+ * Returns `true` only when `enabled` is true and the app version satisfies
+ * `minimumVersion`. Otherwise `false`, including invalid or missing payloads.
+ */
+export const selectPrePushPromptEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag = remoteFeatureFlags?.[PRE_PUSH_PROMPT_FLAG_KEY];
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5367,8 +5367,8 @@
     "push_onboarding": {
       "new_user": {
         "title": "Never miss a move",
-        "body": "Get real-time alerts when prices hit your targets, your trades confirm, and your portfolio moves. Plus product updates and rewards along the way. We'll share updates based on your interactions with MetaMask.",
-        "button_yes": "Yes",
+        "body": "Get real-time alerts on price moves, trade confirmations, portfolio activity, and rewards based on how you use MetaMask.",
+        "button_yes": "Enable notifications",
         "button_not_now": "Not now",
         "preview_card_1": {
           "time": "now",
@@ -5393,7 +5393,7 @@
       },
       "existing_user": {
         "title": "Introducing personalized alerts",
-        "body": "Get notifications that match how you trade. Update anytime.",
+        "body": "Get notifications that match how you trade, based on how you use MetaMask.",
         "card_title": "What you'll get",
         "card_description": "Personalized alerts and updates tailored to your trading activity.",
         "button_confirm": "Confirm",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5367,17 +5367,15 @@
     "push_onboarding": {
       "new_user": {
         "title": "Never miss a move",
-        "body": "Get real-time alerts when prices hit your targets, your trades confirm, and your portfolio moves. Plus product updates and rewards along the way. We'll share updates based on your interactions with MetaMask.",
-        "button_yes": "Yes",
+        "body": "Get real-time alerts on price moves, trade confirmations, portfolio activity, and rewards based on how you use MetaMask.",
+        "button_yes": "Enable notifications",
         "button_not_now": "Not now",
         "preview_card_1": {
-          "eyebrow": "METAMASK",
           "time": "now",
           "title": "ETH is up 4.2% today",
           "message": "Now at $2,668.51 — above your price alert"
         },
         "preview_card_2": {
-          "eyebrow": "METAMASK",
           "time": "1h ago",
           "title": "Received 0.25 ETH",
           "message": "From 0x9a21…4f8c · $640.29"
@@ -5395,7 +5393,7 @@
       },
       "existing_user": {
         "title": "Introducing personalized alerts",
-        "body": "Get notifications that match how you trade. Update anytime.",
+        "body": "Get notifications that match how you trade, based on how you use MetaMask.",
         "card_title": "What you'll get",
         "card_description": "Personalized alerts and updates tailored to your trading activity.",
         "button_confirm": "Confirm",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5367,8 +5367,8 @@
     "push_onboarding": {
       "new_user": {
         "title": "Never miss a move",
-        "body": "Get real-time alerts on price moves, trade confirmations, portfolio activity, and rewards based on how you use MetaMask.",
-        "button_yes": "Enable notifications",
+        "body": "Get real-time alerts when prices hit your targets, your trades confirm, and your portfolio moves. Plus product updates and rewards along the way. We'll share updates based on your interactions with MetaMask.",
+        "button_yes": "Yes",
         "button_not_now": "Not now",
         "preview_card_1": {
           "time": "now",
@@ -5393,7 +5393,7 @@
       },
       "existing_user": {
         "title": "Introducing personalized alerts",
-        "body": "Get notifications that match how you trade, based on how you use MetaMask.",
+        "body": "Get notifications that match how you trade. Update anytime.",
         "card_title": "What you'll get",
         "card_description": "Personalized alerts and updates tailored to your trading activity.",
         "button_confirm": "Confirm",

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4836,8 +4836,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  prePushPromptMinVersion: {
-    name: 'prePushPromptMinVersion',
+  prePushPromptEnabled: {
+    name: 'prePushPromptEnabled',
     type: FeatureFlagType.Remote,
     inProd: false,
     productionDefault: {

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4835,6 +4835,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: ['.infura.io', '.binance.org'],
     status: FeatureFlagStatus.Active,
   },
+
+  prePushPromptMinVersion: {
+    name: 'prePushPromptMinVersion',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '7.99.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
 };
 
 // ============================================================================


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Revises the push notification onboarding UI (NewUserSheet, ExistingUserSheet) to match updated Figma specs — adjusting typography, spacing, icon alignment, and close button positioning. Gates the pre-push prompt behind the `prePushPromptEnabled` remote feature flag, which enables/disables the sheet based on a minimum app version. Registers the flag in the feature flag registry and wires the selector to read from it.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update push notification onboarding sheets with revised designs and wire pre-push prompt behind a remote feature flag

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

IOS
<img width="400" height="852" alt="Screenshot 2026-06-02 at 11 37 52 PM" src="https://github.com/user-attachments/assets/9a21dac6-8cee-4105-b246-c76ad519a9f4" />

<img width="407" height="856" alt="Screenshot 2026-06-02 at 11 26 19 PM" src="https://github.com/user-attachments/assets/07511dff-5e10-4044-84ec-863294270ea7" />


ANDROID
<img width="1080" height="2400" alt="screenshot-push" src="https://github.com/user-attachments/assets/b045c684-34db-42f0-b364-6d411fafe992" />

<img width="1080" height="2400" alt="screenshot-market" src="https://github.com/user-attachments/assets/7148edc6-157a-4169-a783-7a41ab523838" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
