### PR TITLE
fix: speed up and cancel for qr wallets. cp-7.80.0

### DIFF
--- a/app/components/UI/QRHardware/QRSigningTransactionModal.test.tsx
+++ b/app/components/UI/QRHardware/QRSigningTransactionModal.test.tsx
@@ -161,8 +161,15 @@ describe('QRSigningTransactionModal', () => {
     jest
       .spyOn(InteractionManager, 'runAfterInteractions')
       .mockImplementation((task) => {
-        task();
-        return { cancel: jest.fn() };
+        if (typeof task === 'function') {
+          task();
+        }
+        return {
+          then: (onfulfilled?: () => void) => Promise.resolve(onfulfilled?.()),
+          done: (onfulfilled?: () => void, onrejected?: () => void) =>
+            Promise.resolve().then(onfulfilled, onrejected),
+          cancel: jest.fn(),
+        };
       });
   });
 

--- a/app/components/UI/QRHardware/QRSigningTransactionModal.test.tsx
+++ b/app/components/UI/QRHardware/QRSigningTransactionModal.test.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { ViewProps, StyleSheet } from 'react-native';
+import { ViewProps, StyleSheet, InteractionManager } from 'react-native';
+import { waitFor } from '@testing-library/react-native';
 import {
   renderScreen,
   DeepPartial,
 } from '../../../util/test/renderWithProvider';
-import QRSigningTransactionModal from './QRSigningTransactionModal';
+import QRSigningTransactionModal, {
+  QRSignMode,
+} from './QRSigningTransactionModal';
 import Engine from '../../../core/Engine';
 import { useParams } from '../../../util/navigation/navUtils';
+import { speedUpTransaction as speedUpTx } from '../../../util/transaction-controller';
+import ToastService from '../../../core/ToastService/ToastService';
+import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 import {
   type QrScanRequest,
   QrScanRequestType,
@@ -15,6 +21,18 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { RootState } from '../../../reducers';
 
 jest.mock('../../../core/Engine');
+
+jest.mock('../../../util/transaction-controller', () => ({
+  speedUpTransaction: jest.fn(),
+}));
+
+jest.mock('../../../core/ToastService/ToastService', () => ({
+  showToast: jest.fn(),
+}));
+
+jest.mock('../../../util/confirmation/transactions', () => ({
+  getTransactionUpdateErrorToastOptions: jest.fn(),
+}));
 
 jest.mock('./QRSigningDetails', () => {
   const { View: MockView } = jest.requireActual('react-native');
@@ -55,6 +73,10 @@ jest.mock('react-native', () => {
 });
 
 const mockUseParams = useParams as jest.Mock;
+const mockSpeedUpTx = speedUpTx as jest.Mock;
+const mockShowToast = ToastService.showToast as jest.Mock;
+const mockGetTransactionUpdateErrorToastOptions =
+  getTransactionUpdateErrorToastOptions as jest.Mock;
 
 describe('QRSigningTransactionModal', () => {
   const mockTransactionId = 'tx-123';
@@ -117,10 +139,31 @@ describe('QRSigningTransactionModal', () => {
     (
       Engine.context as unknown as {
         ApprovalController: { acceptRequest: jest.Mock };
+        TransactionController: { stopTransaction: jest.Mock };
       }
     ).ApprovalController = {
       acceptRequest: jest.fn().mockResolvedValue(undefined),
     };
+    (
+      Engine.context as unknown as {
+        TransactionController: { stopTransaction: jest.Mock };
+      }
+    ).TransactionController = {
+      stopTransaction: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockSpeedUpTx.mockResolvedValue(undefined);
+    mockGetTransactionUpdateErrorToastOptions.mockImplementation(
+      (error: unknown) => ({
+        descriptionOptions: { description: String(error) },
+      }),
+    );
+    jest
+      .spyOn(InteractionManager, 'runAfterInteractions')
+      .mockImplementation((task) => {
+        task();
+        return { cancel: jest.fn() };
+      });
   });
 
   afterEach(() => {
@@ -269,5 +312,80 @@ describe('QRSigningTransactionModal', () => {
     const qrSigningDetailsElement = getByTestId('QRSigningDetails');
 
     expect(qrSigningDetailsElement.props.fromAddress).toBe('');
+  });
+
+  it('shows transaction update error toast when speed-up fails', async () => {
+    const speedUpError = new Error('speed up failed');
+    mockSpeedUpTx.mockRejectedValueOnce(speedUpError);
+    mockUseParams.mockReturnValue({
+      transactionId: mockTransactionId,
+      onConfirmationComplete: mockOnConfirmationComplete,
+      signMode: QRSignMode.SpeedUp,
+      gasValues: { gasPrice: '0x1' },
+    });
+
+    renderScreen(
+      QRSigningTransactionModal,
+      { name: 'QRSigningTransactionModal' },
+      { state: createInitialState(null) },
+    );
+
+    await waitFor(() => {
+      expect(mockGetTransactionUpdateErrorToastOptions).toHaveBeenCalledWith(
+        speedUpError,
+      );
+      expect(mockShowToast).toHaveBeenCalledWith({
+        descriptionOptions: { description: 'Error: speed up failed' },
+      });
+      expect(mockOnConfirmationComplete).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('shows transaction update error toast when cancel fails', async () => {
+    const cancelError = new Error('cancel failed');
+    (
+      Engine.context.TransactionController.stopTransaction as jest.Mock
+    ).mockRejectedValueOnce(cancelError);
+    mockUseParams.mockReturnValue({
+      transactionId: mockTransactionId,
+      onConfirmationComplete: mockOnConfirmationComplete,
+      signMode: QRSignMode.Cancel,
+      gasValues: { gasPrice: '0x1' },
+    });
+
+    renderScreen(
+      QRSigningTransactionModal,
+      { name: 'QRSigningTransactionModal' },
+      { state: createInitialState(null) },
+    );
+
+    await waitFor(() => {
+      expect(mockGetTransactionUpdateErrorToastOptions).toHaveBeenCalledWith(
+        cancelError,
+      );
+      expect(mockShowToast).toHaveBeenCalledWith({
+        descriptionOptions: { description: 'Error: cancel failed' },
+      });
+      expect(mockOnConfirmationComplete).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('does not show transaction update error toast when approval fails', async () => {
+    const approvalError = new Error('approval failed');
+    (
+      Engine.context.ApprovalController.acceptRequest as jest.Mock
+    ).mockRejectedValueOnce(approvalError);
+
+    renderScreen(
+      QRSigningTransactionModal,
+      { name: 'QRSigningTransactionModal' },
+      { state: createInitialState(null) },
+    );
+
+    await waitFor(() => {
+      expect(mockOnConfirmationComplete).toHaveBeenCalledWith(false);
+    });
+
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/QRHardware/QRSigningTransactionModal.tsx
+++ b/app/components/UI/QRHardware/QRSigningTransactionModal.tsx
@@ -14,17 +14,31 @@ import { useAppThemeFromContext, mockTheme } from '../../../util/theme';
 import { useSelector } from 'react-redux';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import { RootState } from '../../../reducers';
+import {
+  type FeeMarketEIP1559Values,
+  type GasPriceValue,
+} from '@metamask/transaction-controller';
+import { speedUpTransaction as speedUpTx } from '../../../util/transaction-controller';
 
-export const createQRSigningTransactionModalNavDetails =
-  createNavigationDetails<QRSigningTransactionModalParams>(
-    Routes.QR_SIGNING_TRANSACTION_MODAL,
-  );
+export const QRSignMode = {
+  SpeedUp: 'speedup',
+  Cancel: 'cancel',
+} as const;
+
+export type QRSignMode = (typeof QRSignMode)[keyof typeof QRSignMode];
 
 export interface QRSigningTransactionModalParams {
   onConfirmationComplete: (confirmed: boolean) => void;
   transactionId: string;
   deviceId?: string;
+  signMode?: QRSignMode;
+  gasValues?: GasPriceValue | FeeMarketEIP1559Values;
 }
+
+export const createQRSigningTransactionModalNavDetails =
+  createNavigationDetails<QRSigningTransactionModalParams>(
+    Routes.QR_SIGNING_TRANSACTION_MODAL,
+  );
 
 const QRSigningTransactionModal = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
@@ -35,7 +49,7 @@ const QRSigningTransactionModal = () => {
 
   const [signingStarted, setSigningStarted] = useState(false);
 
-  const { transactionId, onConfirmationComplete } =
+  const { transactionId, onConfirmationComplete, signMode, gasValues } =
     useParams<QRSigningTransactionModalParams>();
 
   const pendingScanRequest = useSelector(
@@ -53,17 +67,24 @@ const QRSigningTransactionModal = () => {
     dismissModal();
   }, [onConfirmationComplete, dismissModal]);
 
-  // Start the signing flow when modal mounts
   useEffect(() => {
     if (signingStarted) return;
 
     const startSigning = async () => {
       setSigningStarted(true);
       try {
-        // This triggers the QR keyring which populates pendingScanRequest
-        await ApprovalController.acceptRequest(transactionId, undefined, {
-          waitForResult: true,
-        });
+        if (signMode === QRSignMode.SpeedUp) {
+          await speedUpTx(transactionId, gasValues);
+        } else if (signMode === QRSignMode.Cancel) {
+          await Engine.context.TransactionController.stopTransaction(
+            transactionId,
+            gasValues,
+          );
+        } else {
+          await ApprovalController.acceptRequest(transactionId, undefined, {
+            waitForResult: true,
+          });
+        }
         onConfirmationComplete(true);
         dismissModal();
       } catch (error) {

--- a/app/components/UI/QRHardware/QRSigningTransactionModal.tsx
+++ b/app/components/UI/QRHardware/QRSigningTransactionModal.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useRef, useEffect, useState } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import {
+  View,
+  ActivityIndicator,
+  StyleSheet,
+  InteractionManager,
+} from 'react-native';
 import Engine from '../../../core/Engine';
 import QRSigningDetails from './QRSigningDetails';
 import BottomSheet, {
@@ -19,6 +24,8 @@ import {
   type GasPriceValue,
 } from '@metamask/transaction-controller';
 import { speedUpTransaction as speedUpTx } from '../../../util/transaction-controller';
+import ToastService from '../../../core/ToastService/ToastService';
+import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 
 export const QRSignMode = {
   SpeedUp: 'speedup',
@@ -88,6 +95,13 @@ const QRSigningTransactionModal = () => {
         onConfirmationComplete(true);
         dismissModal();
       } catch (error) {
+        if (signMode === QRSignMode.SpeedUp || signMode === QRSignMode.Cancel) {
+          InteractionManager.runAfterInteractions(() => {
+            ToastService.showToast(
+              getTransactionUpdateErrorToastOptions(error),
+            );
+          });
+        }
         onConfirmationComplete(false);
         dismissModal();
       }

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -638,19 +638,16 @@ class Transactions extends PureComponent {
       }
 
       if (isQRHardwareAccount) {
-        this.closeSpeedUpCancelModal();
+        const transactionId = this.speedUpTxId;
         this.props.navigation.navigate(
           ...createQRSigningTransactionModalNavDetails({
-            transactionId: this.speedUpTxId,
+            transactionId,
             signMode: QRSignMode.SpeedUp,
             gasValues: params,
-            onConfirmationComplete: (confirmed) => {
-              if (confirmed) {
-                this.closeSpeedUpCancelModal();
-              }
-            },
+            onConfirmationComplete: () => undefined,
           }),
         );
+        this.closeSpeedUpCancelModal();
         return;
       }
 
@@ -776,19 +773,16 @@ class Transactions extends PureComponent {
       }
 
       if (isQRHardwareAccount) {
-        this.closeSpeedUpCancelModal();
+        const transactionId = this.cancelTxId;
         this.props.navigation.navigate(
           ...createQRSigningTransactionModalNavDetails({
-            transactionId: this.cancelTxId,
+            transactionId,
             signMode: QRSignMode.Cancel,
             gasValues: params,
-            onConfirmationComplete: (confirmed) => {
-              if (confirmed) {
-                this.closeSpeedUpCancelModal();
-              }
-            },
+            onConfirmationComplete: () => undefined,
           }),
         );
+        this.closeSpeedUpCancelModal();
         return;
       }
 

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -60,7 +60,10 @@ import {
   normalizeReplacementGasFeeParams,
 } from '../../../util/confirmation/gas';
 import { validateTransactionActionBalance } from '../../../util/transactions';
-import { createQRSigningTransactionModalNavDetails } from '../../UI/QRHardware/QRSigningTransactionModal';
+import {
+  createQRSigningTransactionModalNavDetails,
+  QRSignMode,
+} from '../../UI/QRHardware/QRSigningTransactionModal';
 import { CancelSpeedupModal } from '../../Views/confirmations/components/modals/cancel-speedup-modal';
 import PriceChartContext, {
   PriceChartProvider,
@@ -607,6 +610,11 @@ class Transactions extends PureComponent {
         ExtendedKeyringTypes.ledger,
       ]);
 
+      const isQRHardwareAccount = isHardwareAccount(
+        this.props.selectedAddress,
+        [ExtendedKeyringTypes.qr],
+      );
+
       const rawParams = this.getParamsToSend(transactionObject);
       const params = getGasValuesForReplacement(
         rawParams,
@@ -626,6 +634,23 @@ class Transactions extends PureComponent {
         });
         // The shared hardware-wallet flow closes the modal itself on success
         // or rejection.
+        return;
+      }
+
+      if (isQRHardwareAccount) {
+        this.closeSpeedUpCancelModal();
+        this.props.navigation.navigate(
+          ...createQRSigningTransactionModalNavDetails({
+            transactionId: this.speedUpTxId,
+            signMode: QRSignMode.SpeedUp,
+            gasValues: params,
+            onConfirmationComplete: (confirmed) => {
+              if (confirmed) {
+                this.closeSpeedUpCancelModal();
+              }
+            },
+          }),
+        );
         return;
       }
 
@@ -723,6 +748,11 @@ class Transactions extends PureComponent {
         ExtendedKeyringTypes.ledger,
       ]);
 
+      const isQRHardwareAccount = isHardwareAccount(
+        this.props.selectedAddress,
+        [ExtendedKeyringTypes.qr],
+      );
+
       const rawParams = this.getParamsToSend(transactionObject);
       const params = getGasValuesForReplacement(
         rawParams,
@@ -742,6 +772,23 @@ class Transactions extends PureComponent {
         });
         // The shared hardware-wallet flow closes the modal itself on success
         // or rejection.
+        return;
+      }
+
+      if (isQRHardwareAccount) {
+        this.closeSpeedUpCancelModal();
+        this.props.navigation.navigate(
+          ...createQRSigningTransactionModalNavDetails({
+            transactionId: this.cancelTxId,
+            signMode: QRSignMode.Cancel,
+            gasValues: params,
+            onConfirmationComplete: (confirmed) => {
+              if (confirmed) {
+                this.closeSpeedUpCancelModal();
+              }
+            },
+          }),
+        );
         return;
       }
 

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
@@ -63,6 +63,10 @@ jest.mock('../../UI/QRHardware/QRSigningTransactionModal', () => ({
   createQRSigningTransactionModalNavDetails: jest
     .fn()
     .mockReturnValue(['QRSigningModal', {}]),
+  QRSignMode: {
+    SpeedUp: 'speedup',
+    Cancel: 'cancel',
+  },
 }));
 
 jest.mock('@metamask/rpc-errors', () => ({

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
@@ -27,7 +27,11 @@ import {
   type GasFeeEstimates,
 } from '@metamask/transaction-controller';
 import { LedgerReplacementTxTypes } from '../../UI/LedgerModals/LedgerTransactionModal';
-import { createQRSigningTransactionModalNavDetails } from '../../UI/QRHardware/QRSigningTransactionModal';
+import {
+  createQRSigningTransactionModalNavDetails,
+  QRSignMode,
+} from '../../UI/QRHardware/QRSigningTransactionModal';
+import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 
 const mockNavigate = jest.fn();
 
@@ -1004,6 +1008,73 @@ describe('useUnifiedTxActions', () => {
           expect(result.current.cancelIsOpen).toBe(false);
           expect(result.current.cancelTxId).toBeNull();
           expect(result.current.existingTx).toBeNull();
+        });
+      });
+
+      describe('QR hardware account transactions', () => {
+        beforeEach(() => {
+          (isHardwareAccount as jest.Mock).mockImplementation(
+            (_address: string, keyringTypes?: string[]) =>
+              Boolean(keyringTypes?.includes(ExtendedKeyringTypes.qr)),
+          );
+        });
+
+        afterEach(() => {
+          (isHardwareAccount as jest.Mock).mockReturnValue(false);
+        });
+
+        it('passes speed-up transaction id to QR signing modal and closes gas modal', async () => {
+          const { result } = renderUnifiedTxActions();
+          const tx = { id: 'qr-speedup-1' } as unknown as TransactionMeta;
+
+          act(() => result.current.onSpeedUpAction(true, tx));
+          await act(async () => {
+            await result.current.speedUpTransaction({
+              maxFeePerGas: '0xaa',
+              maxPriorityFeePerGas: '0xbb',
+            });
+          });
+
+          expect(
+            createQRSigningTransactionModalNavDetails,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              transactionId: 'qr-speedup-1',
+              signMode: QRSignMode.SpeedUp,
+            }),
+          );
+          expect(mockNavigate).toHaveBeenCalledWith('QRSigningModal', {});
+          expect(result.current.speedUpIsOpen).toBe(false);
+          expect(result.current.speedUpTxId).toBeNull();
+          expect(speedUpTx).not.toHaveBeenCalled();
+        });
+
+        it('passes cancel transaction id to QR signing modal and closes gas modal', async () => {
+          const { result } = renderUnifiedTxActions();
+          const tx = { id: 'qr-cancel-1' } as unknown as TransactionMeta;
+
+          act(() => result.current.onCancelAction(true, tx));
+          await act(async () => {
+            await result.current.cancelTransaction({
+              maxFeePerGas: '0x11',
+              maxPriorityFeePerGas: '0x22',
+            });
+          });
+
+          expect(
+            createQRSigningTransactionModalNavDetails,
+          ).toHaveBeenCalledWith(
+            expect.objectContaining({
+              transactionId: 'qr-cancel-1',
+              signMode: QRSignMode.Cancel,
+            }),
+          );
+          expect(mockNavigate).toHaveBeenCalledWith('QRSigningModal', {});
+          expect(result.current.cancelIsOpen).toBe(false);
+          expect(result.current.cancelTxId).toBeNull();
+          expect(
+            engineContext.TransactionController.stopTransaction,
+          ).not.toHaveBeenCalled();
         });
       });
     });

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
@@ -28,7 +28,10 @@ import {
 import { validateTransactionActionBalance } from '../../../util/transactions';
 import { LedgerReplacementTxTypes } from '../../UI/LedgerModals/LedgerTransactionModal';
 import { type ReplacementTxParams } from '../../../core/HardwareWallet/transactionReplacementParams';
-import { createQRSigningTransactionModalNavDetails } from '../../UI/QRHardware/QRSigningTransactionModal';
+import {
+  createQRSigningTransactionModalNavDetails,
+  QRSignMode,
+} from '../../UI/QRHardware/QRSigningTransactionModal';
 import {
   useHardwareWallet,
   executeHardwareWalletOperation,
@@ -99,6 +102,10 @@ export function useUnifiedTxActions() {
 
   const isLedgerAccount = isHardwareAccount(selectedAddress ?? '', [
     ExtendedKeyringTypes.ledger,
+  ]);
+
+  const isQRHardwareAccount = isHardwareAccount(selectedAddress ?? '', [
+    ExtendedKeyringTypes.qr,
   ]);
 
   const showTransactionUpdateErrorToast = useCallback(
@@ -295,6 +302,23 @@ export function useUnifiedTxActions() {
         return;
       }
 
+      if (isQRHardwareAccount) {
+        closeSpeedUpCancelModal();
+        navigation.navigate(
+          ...createQRSigningTransactionModalNavDetails({
+            transactionId: speedUpTxId,
+            signMode: QRSignMode.SpeedUp,
+            gasValues,
+            onConfirmationComplete: (confirmed: boolean) => {
+              if (confirmed) {
+                onSpeedUpCancelCompleted();
+              }
+            },
+          }),
+        );
+        return;
+      }
+
       await speedUpTx(speedUpTxId, gasValues);
       onSpeedUpCancelCompleted();
     } catch (error: unknown) {
@@ -331,6 +355,23 @@ export function useUnifiedTxActions() {
               : { legacyGasFee: gasValues }),
           },
         });
+        return;
+      }
+
+      if (isQRHardwareAccount) {
+        closeSpeedUpCancelModal();
+        navigation.navigate(
+          ...createQRSigningTransactionModalNavDetails({
+            transactionId: cancelTxId,
+            signMode: QRSignMode.Cancel,
+            gasValues,
+            onConfirmationComplete: (confirmed: boolean) => {
+              if (confirmed) {
+                onSpeedUpCancelCompleted();
+              }
+            },
+          }),
+        );
         return;
       }
 

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
@@ -303,19 +303,16 @@ export function useUnifiedTxActions() {
       }
 
       if (isQRHardwareAccount) {
-        closeSpeedUpCancelModal();
+        const transactionId = speedUpTxId;
         navigation.navigate(
           ...createQRSigningTransactionModalNavDetails({
-            transactionId: speedUpTxId,
+            transactionId,
             signMode: QRSignMode.SpeedUp,
             gasValues,
-            onConfirmationComplete: (confirmed: boolean) => {
-              if (confirmed) {
-                onSpeedUpCancelCompleted();
-              }
-            },
+            onConfirmationComplete: () => undefined,
           }),
         );
+        onSpeedUpCancelCompleted();
         return;
       }
 
@@ -359,19 +356,16 @@ export function useUnifiedTxActions() {
       }
 
       if (isQRHardwareAccount) {
-        closeSpeedUpCancelModal();
+        const transactionId = cancelTxId;
         navigation.navigate(
           ...createQRSigningTransactionModalNavDetails({
-            transactionId: cancelTxId,
+            transactionId,
             signMode: QRSignMode.Cancel,
             gasValues,
-            onConfirmationComplete: (confirmed: boolean) => {
-              if (confirmed) {
-                onSpeedUpCancelCompleted();
-              }
-            },
+            onConfirmationComplete: () => undefined,
           }),
         );
+        onSpeedUpCancelCompleted();
         return;
       }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR fixes the speed up and cancel for qr wallets. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix speedup and cancel for qr wallets. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/30939

## **Manual testing steps**

```gherkin
Feature: Speed up and cancel transactions for QR hardware wallet accounts

  Background:
    Given a local Ganache network is running with:
      | Command | npx ganache --wallet.mnemonic 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about' --miner.blockTime 1200 |
    And the Ganache RPC is available at http://localhost:8545
    And Ganache accounts are funded with ETH
    And the MetaMask mobile app is connected to the local Ganache network via custom network configuration
    And a QR hardware wallet (Keystone) account is imported and selected in MetaMask

  Scenario: user speeds up a pending transaction from a QR hardware wallet account
    Given the user has submitted a transaction from their QR hardware wallet account
    And the transaction is in "submitted" status (not yet mined)
    And the user is viewing the transaction details in the transactions list

    When user taps "Speed up" on the pending transaction
    And user confirms the suggested gas fee values in the speed up modal
    Then the QR signing modal is displayed showing a QR code
    And the user scans the QR code with their Keystone hardware device
    And the Keystone device signs the speed-up replacement transaction
    And the user presents the signed result back to MetaMask
    Then the original transaction is replaced with a new transaction with higher gas
    And the speed-up transaction is broadcast to the network
    And the transaction status changes to "submitted" for the replacement transaction

  Scenario: user cancels a pending transaction from a QR hardware wallet account
    Given the user has submitted a transaction from their QR hardware wallet account
    And the transaction is in "submitted" status (not yet mined)
    And the user is viewing the transaction details in the transactions list

    When user taps "Cancel" on the pending transaction
    And user confirms the suggested gas fee values in the cancel modal
    Then the QR signing modal is displayed showing a QR code
    And the user scans the QR code with their Keystone hardware device
    And the Keystone device signs the cancel replacement transaction
    And the user presents the signed result back to MetaMask
    Then a cancel transaction (0 ETH to self with higher gas) is broadcast to the network
    And the original transaction is replaced by the cancel transaction
    And the transaction status changes to "submitted" for the cancel transaction

  Scenario: user rejects the QR signature during speed up
    Given the user has submitted a transaction from their QR hardware wallet account
    And the transaction is in "submitted" status

    When user taps "Speed up" on the pending transaction
    And user confirms the gas fee values in the speed up modal
    And the QR signing modal is displayed
    And user taps "Cancel" on the QR signing modal
    Then the QR signing modal is dismissed
    And no replacement transaction is created
    And the original transaction remains in "submitted" status
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/55e7279b-19ec-40d6-94e1-3dcb7cc10c84


https://github.com/user-attachments/assets/31d2a7c4-4fdc-4fde-86c3-4523bed6fb42



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pending-transaction replacement and gas submission for QR hardware accounts; behavior is aligned with existing Ledger paths and covered by new tests, but mistakes could affect broadcast or user funds timing.
> 
> **Overview**
> QR hardware wallets can **speed up** and **cancel** pending transactions the same way Ledger accounts do: after gas confirmation, the app opens the QR signing modal instead of calling the transaction controller directly.
> 
> `QRSigningTransactionModal` now accepts optional `signMode` (`speedup` / `cancel`) and `gasValues`. On open it runs `speedUpTransaction` or `stopTransaction` for those modes, and still uses `ApprovalController.acceptRequest` for normal QR signing. Speed-up/cancel failures show the shared transaction-update error toast; approval failures do not.
> 
> The legacy **Transactions** list and **UnifiedTransactionsView** (`useUnifiedTxActions`) branch on QR keyring accounts and navigate with the new params, then close the gas modal without invoking in-app speed-up/cancel. Tests cover modal error handling and both entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b18b8a25684dd4699b3c21fedc2a36b64a5fa15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->