### PR TITLE
fix(e2e-selector): handle test-only file changes in smart E2E selector

### DIFF
--- a/tests/tools/e2e-ai-analyzer/ai-tools/handlers/related-files.ts
+++ b/tests/tools/e2e-ai-analyzer/ai-tools/handlers/related-files.ts
@@ -154,7 +154,7 @@ function findImporters(
     const pattern = `from ['\\\"].*${fileNameSafe}`; // from ['\"].*fileName
 
     const importers = execSync(
-      `grep -r -l --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" -E "${pattern}" app/ 2>/dev/null | grep -v "${filePath}" | head -${maxResults} || true`,
+      `grep -r -l --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" -E "${pattern}" app/ tests/ 2>/dev/null | grep -v "${filePath}" | head -${maxResults} || true`,
       { encoding: 'utf-8', cwd: baseDir },
     )
       .trim()

--- a/tests/tools/e2e-ai-analyzer/config.ts
+++ b/tests/tools/e2e-ai-analyzer/config.ts
@@ -16,7 +16,7 @@ export const MODEL_PRICING: Record<
 > = {
   'gpt-5.2-chat-latest': { inputPerM: 1.75, outputPerM: 14.0 },
   'claude-sonnet-4-6': { inputPerM: 3.0, outputPerM: 15.0 },
-  'gemini-2.0-flash': { inputPerM: 0.1, outputPerM: 0.4 },
+  'gemini-2.5-flash': { inputPerM: 0.1, outputPerM: 0.4 },
 };
 
 /**
@@ -45,7 +45,7 @@ export const LLM_CONFIG = {
       envKey: 'E2E_OPENAI_API_KEY',
     } as ProviderConfig,
     google: {
-      model: 'gemini-2.0-flash',
+      model: 'gemini-2.5-flash',
       envKey: 'E2E_GEMINI_API_KEY',
     } as ProviderConfig,
   },

--- a/tests/tools/e2e-ai-analyzer/index.ts
+++ b/tests/tools/e2e-ai-analyzer/index.ts
@@ -407,19 +407,28 @@ async function main() {
   }[] = [];
 
   for (const providerType of providerOrder) {
-    const provider = createProvider(providerType);
-    console.log(`   Checking ${provider.displayName}...`);
+    try {
+      const provider = createProvider(providerType);
+      console.log(`   Checking ${provider.displayName}...`);
 
-    if (await provider.isAvailable()) {
-      console.log(`   ✅ ${provider.displayName} is available`);
-      availableProviders.push({ type: providerType, provider });
-    } else {
-      const envKey = LLM_CONFIG.providers[providerType].envKey;
-      const hasKey = !!process.env[envKey];
-      const reason = hasKey
-        ? 'API call failed (see warning above)'
-        : `missing ${envKey}`;
-      console.log(`   ❌ ${provider.displayName} is not available — ${reason}`);
+      if (await provider.isAvailable()) {
+        console.log(`   ✅ ${provider.displayName} is available`);
+        availableProviders.push({ type: providerType, provider });
+      } else {
+        const envKey = LLM_CONFIG.providers[providerType].envKey;
+        const hasKey = !!process.env[envKey];
+        const reason = hasKey
+          ? 'API call failed (see warning above)'
+          : `missing ${envKey}`;
+        console.log(
+          `   ❌ ${provider.displayName} is not available — ${reason}`,
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `   ⚠️  Skipping ${providerType} — unexpected error during availability check: ${message}`,
+      );
     }
   }
 

--- a/tests/tools/e2e-ai-analyzer/index.ts
+++ b/tests/tools/e2e-ai-analyzer/index.ts
@@ -384,6 +384,17 @@ async function main() {
     console.log(`🔗 PR #${options.prNumber} - using gh CLI for diffs`);
   }
 
+  // Check hard rules before provider availability — hard rules are deterministic
+  // and require no AI, so we can skip all API calls if one fires.
+  const { checkHardRules } = MODES[mode];
+  if (checkHardRules) {
+    const hardRuleResult = checkHardRules(allChangedFiles, analysisContext);
+    if (hardRuleResult) {
+      (MODES[mode].outputAnalysis as (a: unknown) => void)(hardRuleResult);
+      return;
+    }
+  }
+
   // Get provider order (forced provider or priority from config)
   const providerOrder = getProviderOrder(forcedProvider);
   console.log(`📋 Provider failover order: ${providerOrder.join(' → ')}`);

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -383,7 +383,7 @@ const HARD_RULES: HardRule[] = [
           selectedTags: [],
           riskLevel: 'low',
           confidence: 90,
-          reasoning: `Hard rule (test-shared-infra-impact): ${infraFiles.join(', ')} changed but no smoke/regression specs import them. No Detox tags needed.`,
+          reasoning: `Shared test infra changed (${infraFiles.join(', ')}) but no smoke/regression specs import them. No Detox tags needed.`,
           performanceTests: {
             selectedTags: [],
             reasoning: 'No performance impact detected',
@@ -396,7 +396,7 @@ const HARD_RULES: HardRule[] = [
         selectedTags,
         riskLevel: 'medium',
         confidence: 92,
-        reasoning: `Hard rule (test-shared-infra-impact): ${infraFiles.join(', ')} changed. Impacted specs: ${affectedSpecFiles.join(', ')}. Running tags: ${selectedTags.join(', ')}`,
+        reasoning: `Shared test infra changed (${infraFiles.join(', ')}). Found ${affectedSpecFiles.length} affected spec file(s). Running tags: ${selectedTags.join(', ')}`,
         performanceTests: {
           selectedTags: [],
           reasoning: 'No performance impact from shared test infra changes',
@@ -462,7 +462,6 @@ export function checkHardRules(
     const result = rule.check(changedFiles, context);
     if (result) {
       console.log(`🚨 Hard rule triggered: ${rule.name}`);
-      console.log(`   ${result.reasoning}`);
       return result;
     }
   }

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -2,7 +2,8 @@
  * Mode-specific logic for processing analysis results and creating fallbacks
  */
 
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   SelectTagsAnalysis,
   PerformanceTestSelection,
@@ -13,6 +14,10 @@ import { getFileDiff, getPRFileDiff } from '../../utils/git-utils';
 import { smokeTags, flaskTags } from '../../../../tags';
 import { performanceTags } from '../../../../tags.performance';
 import { getGlobalInfrastructureHardRuleReason } from './global-infrastructure-paths';
+import {
+  getFrameworkInfraChanges,
+  getChangedSpecFiles,
+} from './test-infrastructure-paths';
 
 /**
  * Derive AI config from smokeTags and flaskTags
@@ -168,6 +173,50 @@ function getPackageJsonDiffLines(
  *
  * To add a new hard rule, append an entry to this array.
  */
+/**
+ * Wraps a reason string into a conservative (run-all) SelectTagsAnalysis.
+ */
+function makeConservativeResult(
+  ruleName: string,
+  reason: string,
+): SelectTagsAnalysis {
+  const result = createConservativeResult();
+  const fullReason = `Hard rule (${ruleName}): ${reason}. Running all tests.`;
+  result.reasoning = fullReason;
+  result.confidence = 100;
+  result.performanceTests.reasoning = fullReason;
+  return result;
+}
+
+/**
+ * Extracts Detox tag names imported in a spec file.
+ * Tags are imported as named exports from the tags module.
+ */
+function extractTagsFromSpecFile(
+  filePath: string,
+  baseDir: string,
+  validTags: Set<string>,
+): string[] {
+  try {
+    const content = readFileSync(join(baseDir, filePath), 'utf-8');
+    const matches = content.matchAll(
+      /import\s*\{([^}]+)\}\s*from\s*['"][^'"]*\/tags['"]/g,
+    );
+    const found: string[] = [];
+    for (const match of matches) {
+      const names = match[1].split(',').map((n) => n.trim());
+      for (const name of names) {
+        if (validTags.has(name)) {
+          found.push(name);
+        }
+      }
+    }
+    return found;
+  } catch {
+    return [];
+  }
+}
+
 const HARD_RULES: HardRule[] = [
   {
     name: 'controller-version-update',
@@ -195,38 +244,91 @@ const HARD_RULES: HardRule[] = [
       console.log(`   Updated controllers (${updatedControllers.length}):`);
       updatedControllers.forEach((pkg) => console.log(`     - ${pkg}`));
 
-      return `@metamask controller package version updated in package.json: ${updatedControllers.join(', ')}`;
+      const reason = `@metamask controller package version updated in package.json: ${updatedControllers.join(', ')}`;
+      return makeConservativeResult('controller-version-update', reason);
     },
   },
   {
     name: 'global-infrastructure-change',
     description:
       'Changes to globally-mounted hooks, contexts, Redux store, or Engine wiring',
-    check: (changedFiles) =>
-      getGlobalInfrastructureHardRuleReason(changedFiles),
+    check: (changedFiles) => {
+      const reason = getGlobalInfrastructureHardRuleReason(changedFiles);
+      return reason
+        ? makeConservativeResult('global-infrastructure-change', reason)
+        : null;
+    },
+  },
+  {
+    name: 'test-framework-infra-change',
+    description:
+      'Changes to tests/framework/ shared utilities (Assertions, Gestures, Matchers, etc.) used by virtually all specs',
+    check: (changedFiles) => {
+      const infraFiles = getFrameworkInfraChanges(changedFiles);
+      if (infraFiles.length === 0) return null;
+      const reason = `Test framework infrastructure changed: ${infraFiles.join(', ')}`;
+      return makeConservativeResult('test-framework-infra-change', reason);
+    },
+  },
+  {
+    name: 'test-spec-tag-extraction',
+    description:
+      'Spec files in tests/smoke/ or tests/regression/ changed — extract their tags and run directly',
+    check: (changedFiles, context) => {
+      const specFiles = getChangedSpecFiles(changedFiles);
+      if (specFiles.length === 0) return null;
+
+      // If any non-test files changed, let AI handle the full picture
+      const hasNonTestChanges = changedFiles.some(
+        (f) => !f.startsWith('tests/'),
+      );
+      if (hasNonTestChanges) return null;
+
+      const validTags = new Set(SELECT_TAGS_CONFIG.map((c) => c.tag));
+      const selectedTags = Array.from(
+        new Set(
+          specFiles.flatMap((f) =>
+            extractTagsFromSpecFile(f, context.baseDir, validTags),
+          ),
+        ),
+      );
+
+      if (selectedTags.length === 0) {
+        // Tags couldn't be extracted — fall through to AI
+        return null;
+      }
+
+      console.log(`   Changed spec files (${specFiles.length}):`);
+      specFiles.forEach((f) => console.log(`     - ${f}`));
+      console.log(`   Extracted tags: ${selectedTags.join(', ')}`);
+
+      return {
+        selectedTags,
+        riskLevel: 'medium',
+        confidence: 95,
+        reasoning: `Hard rule (test-spec-tag-extraction): Spec files changed directly. Running their associated tags: ${selectedTags.join(', ')}`,
+        performanceTests: {
+          selectedTags: [],
+          reasoning: 'No performance impact from spec-only changes',
+        },
+      };
+    },
   },
 ];
 
 /**
  * Evaluates all hard rules for the select-tags mode.
- * Returns a conservative result (all tests) on the first triggered rule, or null to proceed with AI.
+ * Returns the first non-null result, skipping AI analysis entirely.
  */
 export function checkHardRules(
   changedFiles: string[],
   context: AnalysisContext,
 ): SelectTagsAnalysis | null {
   for (const rule of HARD_RULES) {
-    const reason = rule.check(changedFiles, context);
-    if (reason) {
+    const result = rule.check(changedFiles, context);
+    if (result) {
       console.log(`🚨 Hard rule triggered: ${rule.name}`);
-      console.log(`   ${reason}`);
-      console.log('   Running all tests.');
-
-      const result = createConservativeResult();
-      const hardRuleReason = `Hard rule (${rule.name}): ${reason}. Running all tests.`;
-      result.reasoning = hardRuleReason;
-      result.confidence = 100;
-      result.performanceTests.reasoning = hardRuleReason;
+      console.log(`   ${result.reasoning}`);
       return result;
     }
   }

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -193,11 +193,22 @@ function makeConservativeResult(
 }
 
 /**
+ * Intermediate test directories — page-objects, flows, selectors, locators.
+ * Changes here can chain through to spec files via one-hop imports.
+ */
+const INTERMEDIATE_TEST_DIRS = [
+  'tests/page-objects/',
+  'tests/flows/',
+  'tests/selectors/',
+  'tests/locators/',
+] as const;
+
+/**
  * Finds smoke/regression spec files that import a given file, resolving up to
- * one level of indirection through intermediate utility/flow files.
+ * one level of indirection through intermediate utility/flow/page-object files.
  *
  * Example: wallet.flow.ts → imported by 30 spec files (direct)
- * Example: ExperienceEnhancerBottomSheet.ts → imported by utils.ts → imported by seedless specs
+ * Example: TokenSelectors.ts → imported by TokenPage.ts → imported by token specs
  *
  * Uses execFileSync with an argument array (no shell) to avoid command injection.
  * Uses -F (fixed-string) so file stem is matched literally, not as a regex.
@@ -213,7 +224,7 @@ function findSpecFilesImporting(
       ?.replace(/\.(ts|tsx|js|jsx)$/, '') ?? '';
   if (!stem) return [];
 
-  const grepImporters = (name: string): string[] => {
+  const grepInDirs = (name: string, dirs: readonly string[]): string[] => {
     try {
       return execFileSync(
         'grep',
@@ -226,7 +237,7 @@ function findSpecFilesImporting(
           '--include=*.js',
           '--include=*.jsx',
           name,
-          ...SPEC_PATH_PREFIXES,
+          ...dirs,
         ],
         { encoding: 'utf-8', cwd: baseDir },
       )
@@ -239,12 +250,16 @@ function findSpecFilesImporting(
     }
   };
 
-  // Step 1: find direct importers within smoke/regression
-  const directImporters = grepImporters(stem);
+  // Step 1: find importers in spec dirs AND intermediate dirs (page-objects, flows, etc.)
+  const allTestDirs = [
+    ...SPEC_PATH_PREFIXES,
+    ...INTERMEDIATE_TEST_DIRS,
+  ] as const;
+  const directImporters = grepInDirs(stem, allTestDirs);
   const specFiles = directImporters.filter(isSpecFile);
   const utilImporters = directImporters.filter((f) => !isSpecFile(f));
 
-  // Step 2: one hop — find spec files that import the intermediate utility files
+  // Step 2: one hop — find spec files that import the intermediate files
   for (const util of utilImporters) {
     const utilStem =
       util
@@ -252,7 +267,9 @@ function findSpecFilesImporting(
         .pop()
         ?.replace(/\.(ts|tsx|js|jsx)$/, '') ?? '';
     if (!utilStem) continue;
-    const indirect = grepImporters(utilStem).filter(isSpecFile);
+    const indirect = grepInDirs(utilStem, SPEC_PATH_PREFIXES).filter(
+      isSpecFile,
+    );
     specFiles.push(...indirect);
   }
 
@@ -271,7 +288,7 @@ function extractTagsFromSpecFile(
   try {
     const content = readFileSync(join(baseDir, filePath), 'utf-8');
     const matches = content.matchAll(
-      /import\s*\{([^}]+)\}\s*from\s*['"][^'"]*\/tags['"]/g,
+      /import\s*\{([^}]+)\}\s*from\s*['"][^'"]*\/tags(?:\.js)?['"]/g,
     );
     const found: string[] = [];
     for (const match of matches) {
@@ -356,15 +373,24 @@ const HARD_RULES: HardRule[] = [
       if (hasNonTestChanges) return null;
 
       const validTags = new Set(SELECT_TAGS_CONFIG.map((c) => c.tag));
+
+      // Find spec files transitively affected by the infra changes
       const affectedSpecFiles = Array.from(
         new Set(
           infraFiles.flatMap((f) => findSpecFilesImporting(f, context.baseDir)),
         ),
       );
 
+      // Also include any spec files that were directly changed in the same PR
+      const directlyChangedSpecFiles = getChangedSpecFiles(changedFiles);
+
+      const allSpecFiles = Array.from(
+        new Set([...affectedSpecFiles, ...directlyChangedSpecFiles]),
+      );
+
       const selectedTags = Array.from(
         new Set(
-          affectedSpecFiles.flatMap((f) =>
+          allSpecFiles.flatMap((f) =>
             extractTagsFromSpecFile(f, context.baseDir, validTags),
           ),
         ),
@@ -377,18 +403,10 @@ const HARD_RULES: HardRule[] = [
 
       if (selectedTags.length === 0) {
         console.log(
-          '   No Detox spec files import these files — no tags needed.',
+          '   No Detox spec files import these files — falling through to next rule.',
         );
-        return {
-          selectedTags: [],
-          riskLevel: 'low',
-          confidence: 90,
-          reasoning: `Shared test infra changed (${infraFiles.join(', ')}) but no smoke/regression specs import them. No Detox tags needed.`,
-          performanceTests: {
-            selectedTags: [],
-            reasoning: 'No performance impact detected',
-          },
-        };
+        // Bug 4 fix: return null so test-spec-tag-extraction can handle directly-changed specs
+        return null;
       }
 
       console.log(`   Extracted tags: ${selectedTags.join(', ')}`);

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -224,7 +224,11 @@ function findSpecFilesImporting(
       ?.replace(/\.(ts|tsx|js|jsx)$/, '') ?? '';
   if (!stem) return [];
 
-  const grepInDirs = (name: string, dirs: readonly string[]): string[] => {
+  // Prefix with '/' so we match import paths (e.g. from './TokenSelectors')
+  // rather than arbitrary occurrences of the stem in comments or variable names.
+  const importPattern = `/${stem}`;
+
+  const grepInDirs = (pattern: string, dirs: readonly string[]): string[] => {
     try {
       return execFileSync(
         'grep',
@@ -236,7 +240,7 @@ function findSpecFilesImporting(
           '--include=*.tsx',
           '--include=*.js',
           '--include=*.jsx',
-          name,
+          pattern,
           ...dirs,
         ],
         { encoding: 'utf-8', cwd: baseDir },
@@ -255,7 +259,7 @@ function findSpecFilesImporting(
     ...SPEC_PATH_PREFIXES,
     ...INTERMEDIATE_TEST_DIRS,
   ] as const;
-  const directImporters = grepInDirs(stem, allTestDirs);
+  const directImporters = grepInDirs(importPattern, allTestDirs);
   const specFiles = directImporters.filter(isSpecFile);
   const utilImporters = directImporters.filter((f) => !isSpecFile(f));
 
@@ -267,7 +271,7 @@ function findSpecFilesImporting(
         .pop()
         ?.replace(/\.(ts|tsx|js|jsx)$/, '') ?? '';
     if (!utilStem) continue;
-    const indirect = grepInDirs(utilStem, SPEC_PATH_PREFIXES).filter(
+    const indirect = grepInDirs(`/${utilStem}`, SPEC_PATH_PREFIXES).filter(
       isSpecFile,
     );
     specFiles.push(...indirect);

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -2,6 +2,7 @@
  * Mode-specific logic for processing analysis results and creating fallbacks
  */
 
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -17,6 +18,9 @@ import { getGlobalInfrastructureHardRuleReason } from './global-infrastructure-p
 import {
   getFrameworkInfraChanges,
   getChangedSpecFiles,
+  getChangedSharedInfraFiles,
+  isSpecFile,
+  SPEC_PATH_PREFIXES,
 } from './test-infrastructure-paths';
 
 /**
@@ -189,6 +193,73 @@ function makeConservativeResult(
 }
 
 /**
+ * Finds smoke/regression spec files that import a given file, resolving up to
+ * one level of indirection through intermediate utility/flow files.
+ *
+ * Example: wallet.flow.ts → imported by 30 spec files (direct)
+ * Example: ExperienceEnhancerBottomSheet.ts → imported by utils.ts → imported by seedless specs
+ *
+ * Uses execFileSync with an argument array (no shell) to avoid command injection.
+ * Uses -F (fixed-string) so file stem is matched literally, not as a regex.
+ */
+function findSpecFilesImporting(
+  changedFile: string,
+  baseDir: string,
+): string[] {
+  const stem =
+    changedFile
+      .split('/')
+      .pop()
+      ?.replace(/\.(ts|tsx|js|jsx)$/, '') ?? '';
+  if (!stem) return [];
+
+  const grepImporters = (name: string): string[] => {
+    try {
+      return execFileSync(
+        'grep',
+        [
+          '-r',
+          '-l',
+          '-F',
+          '--include=*.ts',
+          '--include=*.tsx',
+          '--include=*.js',
+          '--include=*.jsx',
+          name,
+          ...SPEC_PATH_PREFIXES,
+        ],
+        { encoding: 'utf-8', cwd: baseDir },
+      )
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+    } catch {
+      // grep exits non-zero when no matches found
+      return [];
+    }
+  };
+
+  // Step 1: find direct importers within smoke/regression
+  const directImporters = grepImporters(stem);
+  const specFiles = directImporters.filter(isSpecFile);
+  const utilImporters = directImporters.filter((f) => !isSpecFile(f));
+
+  // Step 2: one hop — find spec files that import the intermediate utility files
+  for (const util of utilImporters) {
+    const utilStem =
+      util
+        .split('/')
+        .pop()
+        ?.replace(/\.(ts|tsx|js|jsx)$/, '') ?? '';
+    if (!utilStem) continue;
+    const indirect = grepImporters(utilStem).filter(isSpecFile);
+    specFiles.push(...indirect);
+  }
+
+  return Array.from(new Set(specFiles));
+}
+
+/**
  * Extracts Detox tag names imported in a spec file.
  * Tags are imported as named exports from the tags module.
  */
@@ -268,6 +339,69 @@ const HARD_RULES: HardRule[] = [
       if (infraFiles.length === 0) return null;
       const reason = `Test framework infrastructure changed: ${infraFiles.join(', ')}`;
       return makeConservativeResult('test-framework-infra-change', reason);
+    },
+  },
+  {
+    name: 'test-shared-infra-impact',
+    description:
+      'Changes to flows, page-objects, selectors, or locators — find impacted smoke/regression specs and run their tags',
+    check: (changedFiles, context) => {
+      const infraFiles = getChangedSharedInfraFiles(changedFiles);
+      if (infraFiles.length === 0) return null;
+
+      // Only apply when all changes are within tests/ — app changes go to AI
+      const hasNonTestChanges = changedFiles.some(
+        (f) => !f.startsWith('tests/'),
+      );
+      if (hasNonTestChanges) return null;
+
+      const validTags = new Set(SELECT_TAGS_CONFIG.map((c) => c.tag));
+      const affectedSpecFiles = Array.from(
+        new Set(
+          infraFiles.flatMap((f) => findSpecFilesImporting(f, context.baseDir)),
+        ),
+      );
+
+      const selectedTags = Array.from(
+        new Set(
+          affectedSpecFiles.flatMap((f) =>
+            extractTagsFromSpecFile(f, context.baseDir, validTags),
+          ),
+        ),
+      );
+
+      console.log(`   Changed shared infra files (${infraFiles.length}):`);
+      infraFiles.forEach((f) => console.log(`     - ${f}`));
+      console.log(`   Affected spec files (${affectedSpecFiles.length}):`);
+      affectedSpecFiles.forEach((f) => console.log(`     - ${f}`));
+
+      if (selectedTags.length === 0) {
+        console.log(
+          '   No Detox spec files import these files — no tags needed.',
+        );
+        return {
+          selectedTags: [],
+          riskLevel: 'low',
+          confidence: 90,
+          reasoning: `Hard rule (test-shared-infra-impact): ${infraFiles.join(', ')} changed but no smoke/regression specs import them. No Detox tags needed.`,
+          performanceTests: {
+            selectedTags: [],
+            reasoning: 'No performance impact detected',
+          },
+        };
+      }
+
+      console.log(`   Extracted tags: ${selectedTags.join(', ')}`);
+      return {
+        selectedTags,
+        riskLevel: 'medium',
+        confidence: 92,
+        reasoning: `Hard rule (test-shared-infra-impact): ${infraFiles.join(', ')} changed. Impacted specs: ${affectedSpecFiles.join(', ')}. Running tags: ${selectedTags.join(', ')}`,
+        performanceTests: {
+          selectedTags: [],
+          reasoning: 'No performance impact from shared test infra changes',
+        },
+      };
     },
   },
   {

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/prompt.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/prompt.ts
@@ -38,6 +38,7 @@ ${availableSkills
   const guidanceSection = `GUIDANCE:
 Use your judgment - selecting all tags is acceptable (recommended as conservative approach for risky changes), as well as selecting none of them if the changes are unrisky.
 Changes to wdio/ or tests/performance directories (separate test frameworks) do not require Detox tags - select none unless app code is also changed.
+Changes to tests/selectors/, tests/flows/, tests/locators/, or tests/page-objects/ DO affect Detox tests - use find_related_files to identify which spec files import the changed file and select the appropriate tags.
 Critical files (marked in file list) typically warrant wide testing. Use tools to investigate the impact of the changes.
 For E2E test infrastructure related changes, consider running the necessary tests or all of them in case the changes are wide-ranging.
 Balance thoroughness with efficiency, and be conservative in your risk assessment. When in doubt, err on the side of running more test tags to ensure adequate coverage.

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts
@@ -1,0 +1,83 @@
+/**
+ * Core Detox test infrastructure whose changes affect virtually all E2E specs.
+ *
+ * Files are split into two categories:
+ * - Exact files: specific high-impact files imported by nearly every spec
+ * - Directory prefixes: subdirectories whose entire contents are high-impact
+ *
+ * Excluded from the hard rule:
+ * - Playwright*.ts — separate framework (system/visual tests, not Detox)
+ * - logger.ts, types.ts, TimerHelper.ts, TimerStore.ts — low/no runtime impact on test outcomes
+ * - DappServer.ts, DeepLink.ts, PortManager.ts — targeted impact on specific test subsets
+ * - *.test.ts files — test files themselves, handled by the spec-tag-extraction rule
+ */
+const FRAMEWORK_INFRA_EXACT_FILES = new Set([
+  'tests/framework/Assertions.ts',
+  'tests/framework/EncapsulatedElement.ts',
+  'tests/framework/encapsulatedAction.ts',
+  'tests/framework/Gestures.ts',
+  'tests/framework/GestureStrategy.ts',
+  'tests/framework/UnifiedGestures.ts',
+  'tests/framework/Matchers.ts',
+  'tests/framework/Utilities.ts',
+  'tests/framework/index.ts',
+  'tests/framework/SoftAssert.ts',
+  'tests/framework/PlatformLocator.ts',
+  'tests/framework/FrameworkDetector.ts',
+]);
+
+/**
+ * Subdirectories where all non-test files are high-impact.
+ * fixtures/ is used by nearly every spec via FixtureBuilder/FixtureHelper.
+ * config/ contains global Detox setup that runs before all tests.
+ */
+const FRAMEWORK_INFRA_DIR_PREFIXES = [
+  'tests/framework/fixtures/',
+  'tests/framework/config/',
+] as const;
+
+const TEST_FILE_PATTERN = /\.test\.(ts|tsx|js|jsx)$/;
+
+function normalizeChangedFilePath(file: string): string {
+  return file.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function isFrameworkInfraFile(file: string): boolean {
+  if (TEST_FILE_PATTERN.test(file)) {
+    return false;
+  }
+  if (FRAMEWORK_INFRA_EXACT_FILES.has(file)) {
+    return true;
+  }
+  return FRAMEWORK_INFRA_DIR_PREFIXES.some((prefix) => file.startsWith(prefix));
+}
+
+/**
+ * Returns changed files that are core Detox infrastructure, or an empty array if none match.
+ */
+export function getFrameworkInfraChanges(changedFiles: string[]): string[] {
+  return changedFiles
+    .map(normalizeChangedFilePath)
+    .filter(isFrameworkInfraFile);
+}
+
+/**
+ * Spec file path prefixes for Detox smoke and regression tests.
+ * Changes to these files are directly runnable by extracting their embedded tags.
+ */
+const SPEC_PATH_PREFIXES = ['tests/smoke/', 'tests/regression/'] as const;
+
+const SPEC_FILE_PATTERN = /\.spec\./;
+
+/**
+ * Returns changed files that are Detox spec files.
+ */
+export function getChangedSpecFiles(changedFiles: string[]): string[] {
+  return changedFiles
+    .map(normalizeChangedFilePath)
+    .filter(
+      (f) =>
+        SPEC_PATH_PREFIXES.some((prefix) => f.startsWith(prefix)) &&
+        SPEC_FILE_PATTERN.test(f),
+    );
+}

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts
@@ -65,7 +65,10 @@ export function getFrameworkInfraChanges(changedFiles: string[]): string[] {
  * Spec file path prefixes for Detox smoke and regression tests.
  * Changes to these files are directly runnable by extracting their embedded tags.
  */
-const SPEC_PATH_PREFIXES = ['tests/smoke/', 'tests/regression/'] as const;
+export const SPEC_PATH_PREFIXES = [
+  'tests/smoke/',
+  'tests/regression/',
+] as const;
 
 const SPEC_FILE_PATTERN = /\.spec\./;
 
@@ -80,4 +83,42 @@ export function getChangedSpecFiles(changedFiles: string[]): string[] {
         SPEC_PATH_PREFIXES.some((prefix) => f.startsWith(prefix)) &&
         SPEC_FILE_PATTERN.test(f),
     );
+}
+
+/**
+ * Shared test infrastructure whose changes can affect any smoke/regression spec
+ * that imports them — directly or through one intermediate utility file.
+ *
+ * Unlike tests/framework/ (hard "run all"), these files have targeted impact:
+ * only specs that actually import the changed file need to run.
+ */
+const SHARED_TEST_INFRA_PREFIXES = [
+  'tests/flows/',
+  'tests/page-objects/',
+  'tests/selectors/',
+  'tests/locators/',
+] as const;
+
+/**
+ * Returns changed files that are shared test infrastructure (flows, page objects,
+ * selectors, locators) — but not spec files themselves.
+ */
+export function getChangedSharedInfraFiles(changedFiles: string[]): string[] {
+  return changedFiles
+    .map(normalizeChangedFilePath)
+    .filter(
+      (f) =>
+        SHARED_TEST_INFRA_PREFIXES.some((prefix) => f.startsWith(prefix)) &&
+        !SPEC_FILE_PATTERN.test(f),
+    );
+}
+
+/**
+ * Returns true if the file is a Detox spec file.
+ */
+export function isSpecFile(file: string): boolean {
+  return (
+    SPEC_PATH_PREFIXES.some((prefix) => file.startsWith(prefix)) &&
+    SPEC_FILE_PATTERN.test(file)
+  );
 }

--- a/tests/tools/e2e-ai-analyzer/types/index.ts
+++ b/tests/tools/e2e-ai-analyzer/types/index.ts
@@ -233,13 +233,17 @@ export interface AnalysisContext {
 }
 
 /**
- * A hard rule that overrides AI analysis and forces all tests to run.
- * If `check` returns a non-null string, it becomes the reason for running all tests.
+ * A hard rule that overrides AI analysis and returns a deterministic result.
+ * If `check` returns non-null, AI analysis is skipped and the result is used directly.
+ * Rules may return all tests (conservative) or a targeted subset.
  */
 export interface HardRule {
   name: string;
   description: string;
-  check: (changedFiles: string[], context: AnalysisContext) => string | null;
+  check: (
+    changedFiles: string[],
+    context: AnalysisContext,
+  ) => SelectTagsAnalysis | null;
 }
 
 export interface ParsedArgs {


### PR DESCRIPTION
## **Description**

The smart E2E test selector was returning no tags when a PR changed only test files (spec files, selectors, framework utilities, flows). This meant zero E2E tests ran for test-only PRs, defeating the purpose of having a selector.

**Root causes identified:**
1. `findImporters` only searched `app/` — so when the AI investigated a changed selector/flow file it found no dependents and concluded no tests were needed
2. The system prompt implied that changes under `tests/` don't require Detox tags (a sentence scoped to `wdio/` and `tests/performance/` was being over-generalised)
3. No hard rule existed for test infrastructure changes

**What changed:**

Two new deterministic hard rules (no AI needed):
- `test-framework-infra-change`: changes to core Detox primitives (`Assertions.ts`, `Gestures.ts`, `Matchers.ts`, `Utilities.ts`, `EncapsulatedElement.ts`, `fixtures/`, `config/`, etc.) → run all tests
- `test-spec-tag-extraction`: only spec files changed (`tests/smoke/*.spec.*`, `tests/regression/*.spec.*`) with no app code changes → extract the tag name directly from each spec's import line and run only those tags (targeted, deterministic)

AI tooling improvement:
- `findImporters` now searches `tests/` in addition to `app/`, so the AI can find which spec files import a changed selector, locator, or flow file

Prompt fix:
- Clarified that `tests/selectors/`, `tests/flows/`, `tests/locators/`, `tests/page-objects/` changes DO require Detox tags; only `wdio/` and `tests/performance/` are exempt

The `HardRule` interface was updated so rules return `SelectTagsAnalysis | null` directly, allowing targeted rules to return a partial tag list rather than always running everything.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Smart E2E selector handles test-only file changes

  Scenario: Only spec files changed
    Given a PR that only modifies tests/smoke/accounts/someTest.spec.ts
    When the smart E2E selector runs
    Then it extracts the tag (e.g. SmokeAccounts) from the spec file
    And runs only that tag without invoking the AI

  Scenario: Core framework infra changed
    Given a PR that modifies tests/framework/Assertions.ts
    When the smart E2E selector runs
    Then it triggers the test-framework-infra-change hard rule
    And runs all test tags

  Scenario: Selector file changed (targeted via AI)
    Given a PR that only modifies tests/selectors/Wallet/WalletView.selectors.ts
    When the smart E2E selector runs
    Then find_related_files returns the spec files that import the selector
    And the AI selects the appropriate tags for those specs

  Scenario: App code + spec files changed
    Given a PR that modifies both app/components/Foo.tsx and tests/smoke/foo.spec.ts
    When the smart E2E selector runs
    Then the spec-tag-extraction rule does not fire (non-test files present)
    And the AI runs and analyses both app and test changes
```

## **Screenshots/Recordings**

### **Before**

PRs changing only test files → selector returns no tags → no E2E tests run

### **After**

- Spec-only PRs → targeted tag extraction (deterministic)
- Framework infra PRs → run all tests (deterministic)
- Selector/flow PRs → AI finds importers in tests/ and selects correct tags

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test-selection logic; mis-tagged runs could under- or over-test PRs, but scope is limited to the e2e-ai-analyzer tool, not app runtime.
> 
> **Overview**
> Fixes the smart E2E tag selector so **test-only PRs** no longer end up with **zero Detox tags** by adding deterministic **hard rules** and tightening how test changes are discovered.
> 
> **Deterministic select-tags rules** now run **before any LLM calls** (`checkHardRules` moved earlier in `index.ts`). `HardRule` returns a full `SelectTagsAnalysis` (run-all or targeted tags) instead of only a reason string. New/expanded behavior includes: **core `tests/framework/`** changes → run all tags; **spec-only** smoke/regression changes → parse tag imports from specs; **shared infra** (flows, page-objects, selectors, locators) on test-only PRs → grep importers (up to one hop) and run only those specs’ tags.
> 
> **AI/tooling**: `find_related_files` / importers grep now includes **`tests/`** as well as `app/`. Prompt guidance clarifies that Detox-relevant paths under `tests/` need tags (only `wdio/` and `tests/performance` stay exempt). Provider checks are wrapped in **try/catch**; default Google model is **`gemini-2.5-flash`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1784003e65cf8125b261128a3d3568c5ead14b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->