### PR TITLE
perf(display-name): stabilize the useDisplayName hook family

### DIFF
--- a/app/components/hooks/DisplayName/useAccountNames.test.ts
+++ b/app/components/hooks/DisplayName/useAccountNames.test.ts
@@ -173,4 +173,31 @@ describe('useAccountNames', () => {
 
     expect(result.current).toEqual(['Group 1']);
   });
+
+  it('returns a stable reference across re-renders with identical inputs', () => {
+    const requests: UseDisplayNameRequest[] = [
+      {
+        type: NameType.EthereumAddress,
+        value: '0x1234567890123456789012345678901234567890',
+        variation: 'normal',
+      },
+    ];
+
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectInternalAccountsById) {
+        return mockInternalAccountsById;
+      }
+      if (selector === selectAccountGroups) {
+        return mockAccountGroups;
+      }
+      return undefined;
+    });
+
+    const { result, rerender } = renderHook(() => useAccountNames(requests));
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
 });

--- a/app/components/hooks/DisplayName/useAccountNames.ts
+++ b/app/components/hooks/DisplayName/useAccountNames.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectInternalAccountsById } from '../../../selectors/accountsController';
@@ -8,19 +9,29 @@ export function useAccountNames(requests: UseDisplayNameRequest[]) {
   const internalAccountsById = useSelector(selectInternalAccountsById);
   const accountGroups = useSelector(selectAccountGroups);
 
-  const accountGroupNames = accountGroups.reduce(
-    (acc, group) => {
-      group.accounts.forEach((accountId) => {
-        const account = internalAccountsById[accountId];
-        acc[account.address.toLowerCase()] = group.metadata.name;
-      });
-      return acc;
-    },
-    {} as Record<string, string>,
+  // Build the address -> group-name map only when the underlying account data
+  // changes, instead of rebuilding it on every render.
+  const accountGroupNames = useMemo(
+    () =>
+      accountGroups.reduce(
+        (acc, group) => {
+          group.accounts.forEach((accountId) => {
+            const account = internalAccountsById[accountId];
+            acc[account.address.toLowerCase()] = group.metadata.name;
+          });
+          return acc;
+        },
+        {} as Record<string, string>,
+      ),
+    [accountGroups, internalAccountsById],
   );
 
-  return requests.map((request) => {
-    const { value } = request;
-    return accountGroupNames[value.toLowerCase()];
-  });
+  return useMemo(
+    () =>
+      requests.map((request) => {
+        const { value } = request;
+        return accountGroupNames[value.toLowerCase()];
+      }),
+    [requests, accountGroupNames],
+  );
 }

--- a/app/components/hooks/DisplayName/useAccountWalletNames.test.ts
+++ b/app/components/hooks/DisplayName/useAccountWalletNames.test.ts
@@ -299,4 +299,36 @@ describe('useAccountWalletNames', () => {
 
     expect(result.current).toEqual(['Wallet 1', undefined, 'Wallet 2']);
   });
+
+  it('returns a stable reference across re-renders with identical inputs', () => {
+    const requests: UseDisplayNameRequest[] = [
+      {
+        type: NameType.EthereumAddress,
+        value: '0x1234567890123456789012345678901234567890',
+        variation: 'normal',
+      },
+    ];
+
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectInternalAccountsById) {
+        return mockInternalAccountsById;
+      }
+      if (selector === selectAccountToWalletMap) {
+        return mockAccountToWalletMap;
+      }
+      if (selector === selectWalletsMap) {
+        return mockWalletsMap;
+      }
+      return undefined;
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useAccountWalletNames(requests),
+    );
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
 });

--- a/app/components/hooks/DisplayName/useAccountWalletNames.ts
+++ b/app/components/hooks/DisplayName/useAccountWalletNames.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectInternalAccountsById } from '../../../selectors/accountsController';
@@ -7,13 +8,24 @@ import {
 } from '../../../selectors/multichainAccounts/accountTreeController';
 import { UseDisplayNameRequest } from './useDisplayName';
 
+// Stable reference returned when there is only a single wallet (no subtitles).
+const EMPTY_WALLET_NAMES: (string | undefined)[] = [];
+
 export function useAccountWalletNames(requests: UseDisplayNameRequest[]) {
   const internalAccountsById = useSelector(selectInternalAccountsById);
   const accountToWalletMap = useSelector(selectAccountToWalletMap);
-  const walletsMap = useSelector(selectWalletsMap) || {};
-  const haveMoreThanOneWallet = Object.keys(walletsMap).length > 1;
+  const walletsMapResult = useSelector(selectWalletsMap);
 
-  if (haveMoreThanOneWallet) {
+  // Memoize so the wallet-name map and per-request lookup are only rebuilt when
+  // the underlying data (or requests) change, and consumers get a stable array.
+  return useMemo(() => {
+    const walletsMap = walletsMapResult || {};
+    const haveMoreThanOneWallet = Object.keys(walletsMap).length > 1;
+
+    if (!haveMoreThanOneWallet) {
+      return EMPTY_WALLET_NAMES;
+    }
+
     const accountWalletNames = Object.entries(accountToWalletMap).reduce(
       (acc, [accountId, walletId]) => {
         const account = internalAccountsById[accountId];
@@ -30,7 +42,5 @@ export function useAccountWalletNames(requests: UseDisplayNameRequest[]) {
       const { value } = request;
       return accountWalletNames[value.toLowerCase()];
     });
-  }
-
-  return [];
+  }, [requests, accountToWalletMap, internalAccountsById, walletsMapResult]);
 }

--- a/app/components/hooks/DisplayName/useDisplayName.test.ts
+++ b/app/components/hooks/DisplayName/useDisplayName.test.ts
@@ -1,4 +1,5 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { renderHook } from '@testing-library/react-native';
 
 import { NameType } from '../../UI/Name/Name.types';
 import useDisplayName, {
@@ -85,11 +86,13 @@ describe('useDisplayName', () => {
 
   describe('unknown address', () => {
     it('should not return a name', () => {
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: UNKNOWN_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: UNKNOWN_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual({
         variant: DisplayNameVariant.Unknown,
@@ -111,11 +114,13 @@ describe('useDisplayName', () => {
         KNOWN_FIRST_PARTY_CONTRACT_NAME,
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual({
         variant: DisplayNameVariant.Recognized,
@@ -133,11 +138,13 @@ describe('useDisplayName', () => {
     it('returns watched NFT name', () => {
       mockUseWatchedNFTNames.mockReturnValue([KNOWN_NFT_NAME_MOCK]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(mockUseFirstPartyContractNames).toHaveBeenCalledWith([
         {
@@ -166,11 +173,13 @@ describe('useDisplayName', () => {
         { name: KNOWN_TOKEN_LIST_NAME, image: '' },
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(mockUseFirstPartyContractNames).toHaveBeenCalledWith([
         {
@@ -192,11 +201,13 @@ describe('useDisplayName', () => {
     it('returns internal account name', () => {
       mockUseAccountNames.mockReturnValue([KNOWN_ACCOUNT_NAME]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -209,11 +220,13 @@ describe('useDisplayName', () => {
     it('returns account wallet name', () => {
       mockUseAccountWalletNames.mockReturnValue([KNOWN_ACCOUNT_WALLET_NAME]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -227,11 +240,13 @@ describe('useDisplayName', () => {
         getResolvedENSName: jest.fn().mockReturnValue('ensname.eth'),
       } as unknown as ReturnType<typeof useSendFlowEnsResolutions>);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -248,11 +263,13 @@ describe('useDisplayName', () => {
       ]);
       mockUseAccountNames.mockReturnValue([KNOWN_ACCOUNT_NAME]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -268,11 +285,13 @@ describe('useDisplayName', () => {
       ]);
       mockUseAccountNames.mockReturnValue([KNOWN_ACCOUNT_NAME]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -288,11 +307,13 @@ describe('useDisplayName', () => {
         { state: TrustSignalDisplayState.Warning, label: null },
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: UNKNOWN_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: UNKNOWN_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -309,11 +330,13 @@ describe('useDisplayName', () => {
         KNOWN_FIRST_PARTY_CONTRACT_NAME,
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -328,11 +351,13 @@ describe('useDisplayName', () => {
         { state: TrustSignalDisplayState.Verified, label: 'Verified Label' },
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: UNKNOWN_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: UNKNOWN_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -347,11 +372,13 @@ describe('useDisplayName', () => {
         { state: TrustSignalDisplayState.Unknown, label: null },
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: UNKNOWN_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: UNKNOWN_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -366,11 +393,13 @@ describe('useDisplayName', () => {
         { state: TrustSignalDisplayState.Unknown, label: 'Scan Label' },
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: UNKNOWN_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: UNKNOWN_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -387,11 +416,13 @@ describe('useDisplayName', () => {
         KNOWN_FIRST_PARTY_CONTRACT_NAME,
       ]);
 
-      const displayName = useDisplayName({
-        type: NameType.EthereumAddress,
-        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
-        variation: CHAIN_IDS.MAINNET,
-      });
+      const displayName = renderHook(() =>
+        useDisplayName({
+          type: NameType.EthereumAddress,
+          value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+          variation: CHAIN_IDS.MAINNET,
+        }),
+      ).result.current;
 
       expect(displayName).toEqual(
         expect.objectContaining({
@@ -399,6 +430,31 @@ describe('useDisplayName', () => {
           displayState: TrustSignalDisplayState.Recognized,
         }),
       );
+    });
+  });
+
+  describe('referential stability', () => {
+    it('returns a stable reference across re-renders with identical input', () => {
+      mockUseFirstPartyContractNames.mockReturnValue([
+        KNOWN_FIRST_PARTY_CONTRACT_NAME,
+      ]);
+      const request = {
+        type: NameType.EthereumAddress,
+        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+        variation: CHAIN_IDS.MAINNET,
+      };
+
+      const { result, rerender } = renderHook(
+        (r: Parameters<typeof useDisplayName>[0]) => useDisplayName(r),
+        { initialProps: request },
+      );
+      const first = result.current;
+
+      // Re-render with an identical request; the memoized result should keep
+      // the same reference (pre-change this returned a new object each render).
+      rerender({ ...request });
+
+      expect(result.current).toBe(first);
     });
   });
 });

--- a/app/components/hooks/DisplayName/useDisplayName.ts
+++ b/app/components/hooks/DisplayName/useDisplayName.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { NameType } from '../../UI/Name/Name.types';
 import { useFirstPartyContractNames } from './useFirstPartyContractNames';
 import { useWatchedNFTNames } from './useWatchedNFTNames';
@@ -132,7 +133,15 @@ function getDisplayState(
 export function useDisplayName(
   request: UseDisplayNameRequest,
 ): UseDisplayNameResponse {
-  return useDisplayNames([request])[0];
+  const { type, value, variation, preferContractSymbol } = request;
+  // Memoize the single-element request array on the primitive fields so the
+  // sub-hooks (and the memoized result below) see a stable `requests`
+  // reference instead of a fresh `[request]` literal on every render.
+  const requests = useMemo(
+    () => [{ type, value, variation, preferContractSymbol }],
+    [type, value, variation, preferContractSymbol],
+  );
+  return useDisplayNames(requests)[0];
 }
 
 export function useDisplayNames(
@@ -145,60 +154,81 @@ export function useDisplayNames(
   const accountWalletNames = useAccountWalletNames(requests);
   const { getResolvedENSName } = useSendFlowEnsResolutions();
 
-  const trustSignalRequests = requests.map(({ value, variation }) => ({
-    address: value,
-    chainId: variation,
-  }));
+  const trustSignalRequests = useMemo(
+    () =>
+      requests.map(({ value, variation }) => ({
+        address: value,
+        chainId: variation,
+      })),
+    [requests],
+  );
   const trustSignals = useAddressTrustSignals(trustSignalRequests);
 
-  return requests.map(({ value, variation }, index) => {
-    const watchedNftName = watchedNftNames[index];
-    const firstPartyContractName = firstPartyContractNames[index];
-    const erc20Token = erc20Tokens[index];
-    const accountName = accountNames[index];
-    const subtitle = accountWalletNames[index];
-    const ensName = getResolvedENSName(variation, value);
-    const trustSignal = trustSignals[index];
+  // Memoize the mapped result so consumers receive a referentially stable
+  // array (and stable per-row objects) across renders with identical inputs,
+  // instead of a brand-new array of new objects on every render.
+  return useMemo(
+    () =>
+      requests.map(({ value, variation }, index) => {
+        const watchedNftName = watchedNftNames[index];
+        const firstPartyContractName = firstPartyContractNames[index];
+        const erc20Token = erc20Tokens[index];
+        const accountName = accountNames[index];
+        const subtitle = accountWalletNames[index];
+        const ensName = getResolvedENSName(variation, value);
+        const trustSignal = trustSignals[index];
 
-    let name =
-      accountName ||
-      ensName ||
-      firstPartyContractName ||
-      watchedNftName ||
-      erc20Token?.name;
+        let name =
+          accountName ||
+          ensName ||
+          firstPartyContractName ||
+          watchedNftName ||
+          erc20Token?.name;
 
-    const hasPetname = Boolean(accountName);
+        const hasPetname = Boolean(accountName);
 
-    const displayState = getDisplayState(
-      trustSignal?.state,
-      hasPetname,
-      name || null,
-    );
+        const displayState = getDisplayState(
+          trustSignal?.state,
+          hasPetname,
+          name || null,
+        );
 
-    // Applied after displayState to avoid the label triggering Recognized state
-    if (!name && trustSignal?.label) {
-      name = trustSignal.label;
-    }
+        // Applied after displayState to avoid the label triggering Recognized state
+        if (!name && trustSignal?.label) {
+          name = trustSignal.label;
+        }
 
-    const image = erc20Token?.image;
+        const image = erc20Token?.image;
 
-    const isFirstPartyContractName =
-      firstPartyContractName !== undefined && firstPartyContractName !== null;
+        const isFirstPartyContractName =
+          firstPartyContractName !== undefined &&
+          firstPartyContractName !== null;
 
-    const icon = getTrustSignalIcon(displayState);
+        const icon = getTrustSignalIcon(displayState);
 
-    return {
-      contractDisplayName: erc20Token?.name,
-      image,
-      isFirstPartyContractName,
-      name,
-      subtitle,
-      variant: getVariant({ name, accountName }),
-      displayState,
-      icon,
-      isAccount: Boolean(accountName),
-    };
-  });
+        return {
+          contractDisplayName: erc20Token?.name,
+          image,
+          isFirstPartyContractName,
+          name,
+          subtitle,
+          variant: getVariant({ name, accountName }),
+          displayState,
+          icon,
+          isAccount: Boolean(accountName),
+        };
+      }),
+    [
+      requests,
+      firstPartyContractNames,
+      watchedNftNames,
+      erc20Tokens,
+      accountNames,
+      accountWalletNames,
+      getResolvedENSName,
+      trustSignals,
+    ],
+  );
 }
 
 export default useDisplayName;

--- a/app/components/hooks/DisplayName/useERC20Tokens.test.ts
+++ b/app/components/hooks/DisplayName/useERC20Tokens.test.ts
@@ -109,4 +109,19 @@ describe('useERC20Tokens', () => {
 
     expect(result.current[0]?.name).toBe(TOKEN_NAME_MOCK);
   });
+
+  it('returns a stable reference across re-renders with identical inputs', () => {
+    const { result, rerender } = renderHook([
+      {
+        type: NameType.EthereumAddress,
+        value: TOKEN_ADDRESS_MOCK,
+        variation: CHAIN_ID_MOCK,
+      },
+    ]);
+    const first = result.current;
+
+    rerender({});
+
+    expect(result.current).toBe(first);
+  });
 });

--- a/app/components/hooks/DisplayName/useERC20Tokens.ts
+++ b/app/components/hooks/DisplayName/useERC20Tokens.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { NameType } from '../../UI/Name/Name.types';
 import { UseDisplayNameRequest } from './useDisplayName';
 import { Hex } from '@metamask/utils';
@@ -5,24 +6,34 @@ import { useTokensData } from '../useTokensData/useTokensData';
 import { buildEvmCaip19AssetId } from '../../../util/multichain/buildEvmCaip19AssetId';
 
 export function useERC20Tokens(requests: UseDisplayNameRequest[]) {
-  const assetIds = requests
-    .filter(({ type, value }) => type === NameType.EthereumAddress && value)
-    .map(({ value, variation }) =>
-      buildEvmCaip19AssetId(value as string, variation as Hex),
-    );
+  const assetIds = useMemo(
+    () =>
+      requests
+        .filter(({ type, value }) => type === NameType.EthereumAddress && value)
+        .map(({ value, variation }) =>
+          buildEvmCaip19AssetId(value as string, variation as Hex),
+        ),
+    [requests],
+  );
 
   const tokensByAssetId = useTokensData(assetIds);
 
-  return requests.map(({ preferContractSymbol, type, value, variation }) => {
-    if (type !== NameType.EthereumAddress || !value) {
-      return undefined;
-    }
+  return useMemo(
+    () =>
+      requests.map(({ preferContractSymbol, type, value, variation }) => {
+        if (type !== NameType.EthereumAddress || !value) {
+          return undefined;
+        }
 
-    const token =
-      tokensByAssetId[buildEvmCaip19AssetId(value as string, variation as Hex)];
-    const name =
-      preferContractSymbol && token?.symbol ? token.symbol : token?.name;
+        const token =
+          tokensByAssetId[
+            buildEvmCaip19AssetId(value as string, variation as Hex)
+          ];
+        const name =
+          preferContractSymbol && token?.symbol ? token.symbol : token?.name;
 
-    return { name, image: token?.iconUrl };
-  });
+        return { name, image: token?.iconUrl };
+      }),
+    [requests, tokensByAssetId],
+  );
 }

--- a/app/components/hooks/DisplayName/useFirstPartyContractNames.test.ts
+++ b/app/components/hooks/DisplayName/useFirstPartyContractNames.test.ts
@@ -1,6 +1,9 @@
+import { renderHook } from '@testing-library/react-native';
+
 import { NETWORKS_CHAIN_ID } from '../../../constants/network';
 import { useFirstPartyContractNames } from './useFirstPartyContractNames';
 import { NameType } from '../../UI/Name/Name.types';
+import { UseDisplayNameRequest } from './useDisplayName';
 
 const BRIDGE_NAME_MOCK = 'Bridge';
 const BRIDGE_MAINNET_ADDRESS_MOCK =
@@ -9,38 +12,63 @@ const UNKNOWN_ADDRESS_MOCK = '0xabc123';
 
 describe('useFirstPartyContractNames', () => {
   it('returns null if no name found', () => {
-    const name = useFirstPartyContractNames([
-      {
-        type: NameType.EthereumAddress,
-        value: UNKNOWN_ADDRESS_MOCK,
-        variation: NETWORKS_CHAIN_ID.MAINNET,
-      },
-    ])[0];
+    const { result } = renderHook(() =>
+      useFirstPartyContractNames([
+        {
+          type: NameType.EthereumAddress,
+          value: UNKNOWN_ADDRESS_MOCK,
+          variation: NETWORKS_CHAIN_ID.MAINNET,
+        },
+      ]),
+    );
 
-    expect(name).toBe(null);
+    expect(result.current[0]).toBe(null);
   });
 
   it('returns name if found', () => {
-    const name = useFirstPartyContractNames([
+    const { result } = renderHook(() =>
+      useFirstPartyContractNames([
+        {
+          type: NameType.EthereumAddress,
+          value: BRIDGE_MAINNET_ADDRESS_MOCK,
+          variation: NETWORKS_CHAIN_ID.MAINNET,
+        },
+      ]),
+    );
+
+    expect(result.current[0]).toBe(BRIDGE_NAME_MOCK);
+  });
+
+  it('normalizes addresses to lowercase', () => {
+    const { result } = renderHook(() =>
+      useFirstPartyContractNames([
+        {
+          type: NameType.EthereumAddress,
+          value: BRIDGE_MAINNET_ADDRESS_MOCK.toUpperCase(),
+          variation: NETWORKS_CHAIN_ID.MAINNET,
+        },
+      ]),
+    );
+
+    expect(result.current[0]).toBe(BRIDGE_NAME_MOCK);
+  });
+
+  it('returns a stable reference across re-renders with identical input', () => {
+    const requests: UseDisplayNameRequest[] = [
       {
         type: NameType.EthereumAddress,
         value: BRIDGE_MAINNET_ADDRESS_MOCK,
         variation: NETWORKS_CHAIN_ID.MAINNET,
       },
-    ])[0];
+    ];
 
-    expect(name).toBe(BRIDGE_NAME_MOCK);
-  });
+    const { result, rerender } = renderHook(() =>
+      useFirstPartyContractNames(requests),
+    );
+    const first = result.current;
 
-  it('normalizes addresses to lowercase', () => {
-    const name = useFirstPartyContractNames([
-      {
-        type: NameType.EthereumAddress,
-        value: BRIDGE_MAINNET_ADDRESS_MOCK.toUpperCase(),
-        variation: NETWORKS_CHAIN_ID.MAINNET,
-      },
-    ])[0];
+    rerender({});
 
-    expect(name).toBe(BRIDGE_NAME_MOCK);
+    expect(result.current).toBe(first);
   });
 });

--- a/app/components/hooks/DisplayName/useFirstPartyContractNames.ts
+++ b/app/components/hooks/DisplayName/useFirstPartyContractNames.ts
@@ -1,28 +1,37 @@
+import { useMemo } from 'react';
 import { type Hex } from '@metamask/utils';
 import FIRST_PARTY_CONTRACT_NAMES from '../../../constants/first-party-contracts';
 import { UseDisplayNameRequest } from './useDisplayName';
 import { NameType } from '../../UI/Name/Name.types';
 
+// The set of known first-party contracts is a static import, so compute the
+// key list once at module load instead of on every lookup.
+const CONTRACT_NAMES = Object.keys(FIRST_PARTY_CONTRACT_NAMES);
+
 export function useFirstPartyContractNames(
   requests: UseDisplayNameRequest[],
 ): (string | null)[] {
-  return requests.map((request) => {
-    const { type, variation } = request;
+  return useMemo(
+    () =>
+      requests.map((request) => {
+        const { type, variation } = request;
 
-    if (type !== NameType.EthereumAddress) {
-      return null;
-    }
+        if (type !== NameType.EthereumAddress) {
+          return null;
+        }
 
-    const chainId = variation as Hex;
-    const normalizedValue = request.value.toLowerCase();
-    const contractNames = Object.keys(FIRST_PARTY_CONTRACT_NAMES);
+        const chainId = variation as Hex;
+        const normalizedValue = request.value.toLowerCase();
 
-    const name = contractNames.find(
-      (contractName) =>
-        FIRST_PARTY_CONTRACT_NAMES[contractName]?.[chainId]?.toLowerCase() ===
-        normalizedValue,
-    );
+        const name = CONTRACT_NAMES.find(
+          (contractName) =>
+            FIRST_PARTY_CONTRACT_NAMES[contractName]?.[
+              chainId
+            ]?.toLowerCase() === normalizedValue,
+        );
 
-    return name ?? null;
-  });
+        return name ?? null;
+      }),
+    [requests],
+  );
 }

--- a/app/components/hooks/DisplayName/useWatchedNFTNames.test.ts
+++ b/app/components/hooks/DisplayName/useWatchedNFTNames.test.ts
@@ -99,4 +99,23 @@ describe('useWatchedNFTNames', () => {
 
     expect(current[0]).toBe(KNOWN_NFT_NAME_MOCK);
   });
+
+  it('returns a stable reference across re-renders with identical inputs', () => {
+    const requests = [
+      {
+        type: NameType.EthereumAddress,
+        value: KNOWN_NFT_ADDRESS_CHECKSUMMED,
+        variation: CHAIN_IDS.MAINNET,
+      },
+    ];
+    const { result, rerender } = renderHookWithProvider(
+      () => useWatchedNFTNames(requests),
+      { state: STATE_MOCK },
+    );
+    const first = result.current;
+
+    rerender({});
+
+    expect(result.current).toBe(first);
+  });
 });

--- a/app/components/hooks/DisplayName/useWatchedNFTNames.ts
+++ b/app/components/hooks/DisplayName/useWatchedNFTNames.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { UseDisplayNameRequest } from './useDisplayName';
 import { selectAllNftContracts } from '../../../selectors/nftController';
@@ -9,23 +10,29 @@ export const useWatchedNFTNames = (
 ): (string | null)[] => {
   const nftContractsByChainIdByAccount = useSelector(selectAllNftContracts);
 
-  return requests.map(({ type, value, variation }) => {
-    if (type !== NameType.EthereumAddress || !value) {
-      return null;
-    }
-
-    const contractAddress = value.toLowerCase();
-    const chainId = variation as Hex;
+  // Memoize the per-request NFT lookup so the O(accounts × nfts) scan only runs
+  // when the requests or the watched-NFT contracts change. The account list is
+  // request-independent, so compute it once per memo run rather than per request.
+  return useMemo(() => {
     const accounts = Object.keys(nftContractsByChainIdByAccount);
 
-    const chainNfts = accounts.flatMap(
-      (account) => nftContractsByChainIdByAccount[account]?.[chainId] ?? [],
-    );
+    return requests.map(({ type, value, variation }) => {
+      if (type !== NameType.EthereumAddress || !value) {
+        return null;
+      }
 
-    const watchedNft = chainNfts.find(
-      (nft) => nft.address.toLowerCase() === contractAddress,
-    );
+      const contractAddress = value.toLowerCase();
+      const chainId = variation as Hex;
 
-    return watchedNft?.name ?? null;
-  });
+      const chainNfts = accounts.flatMap(
+        (account) => nftContractsByChainIdByAccount[account]?.[chainId] ?? [],
+      );
+
+      const watchedNft = chainNfts.find(
+        (nft) => nft.address.toLowerCase() === contractAddress,
+      );
+
+      return watchedNft?.name ?? null;
+    });
+  }, [requests, nftContractsByChainIdByAccount]);
 };


### PR DESCRIPTION
## **Description**

### What

`useDisplayName` / `useDisplayNames` is used broadly across confirmation screens, simulation rows, `Name` components, and transaction lists — frequently **per-row inside lists**. It built a **brand-new array of brand-new objects on every render**, and each of its sub-hooks also returned a fresh array every render. So every consumer that takes a display-name object/array as a prop or dependency re-rendered/recomputed on every parent render, defeating `React.memo` / `useMemo` / dependency-array memoization downstream.

### Why these are combined into one PR

The audit flagged these as separate findings, but they are **one interdependent optimization** — the top-level `useDisplayNames` memo depends on its sub-hooks' results, so it only becomes referentially stable once the whole family is memoized. Shipping the top-level memo alone would be a no-op in production. The individual findings addressed here:

| Finding | Hook | Change |
| --- | --- | --- |
| #2 (High) | `useDisplayName` / `useDisplayNames` | Memoize the `requests.map(...)` return; memoize the single-element request array (on primitive fields) and the `trustSignalRequests` array. |
| #6 (Med) | `useAccountNames` | Memoize the address → group-name map build and the returned array. |
| #7 (Med) | `useERC20Tokens` | Memoize the `assetIds` input and the returned array. |
| #8 (Med) | `useFirstPartyContractNames` | Hoist the static contract-name key list to module scope; memoize the returned array. |
| #10 (Med) | `useWatchedNFTNames` | Memoize the O(accounts × nfts) lookup; hoist the request-independent account list out of the per-request loop. |
| (not in batch, required) | `useAccountWalletNames` | Memoize the wallet-name map build + per-request lookup; stable empty array for the single-wallet case. |

### End-to-end stability

After these changes the `useDisplayNames` return memo's dependencies are all stable given stable inputs:
- `requests` — memoized on primitive fields in `useDisplayName`.
- The 5 sub-hooks — now each memoized (selector-backed inputs are reselect-stable; `useERC20Tokens` reads `useTokensData`, whose value is a `useState` ref that's stable across renders until data changes).
- `getResolvedENSName` — already a stable `useCallback` ref.
- `trustSignals` — `useAddressTrustSignals` is internally memoized on a `createDeepEqualSelector` result; feeding it a memoized `trustSignalRequests` keeps that stable.

**Behavior is unchanged** — same values, same semantics.

### Risk

Low — pure memoization/dependency-stabilization; no output or control-flow changes. From the internal performance audit (`unstable-hook`, `fix_risk: Simple`, `test_safety_net: Covered`). Note: a pre-existing unguarded access (`internalAccountsById[accountId].address` in `useAccountNames`) is preserved as-is and intentionally out of scope for this perf change.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31372
Fixes: #31375
Fixes: #31377
Fixes: #31379
Fixes: #31383

## **Manual testing steps**

> **Validation status:** behavior-preserving refactor validated by the unit test(s) below; not yet manually profiled on Android / a power-user device, and no new Sentry traces added — the underlying audit finding is still `status: UNVALIDATED`. The Performance-checks boxes are intentionally left **unchecked** until that profiling is done.

`yarn jest app/components/hooks/DisplayName/` → **47/47 pass across 6 suites.**
- Added a `returns a stable reference across re-renders with identical inputs` test to **each** of the 6 hooks. Each is **discriminating** — it fails on the pre-change (un-memoized) code.
- Migrated `useDisplayName.test.ts` and `useFirstPartyContractNames.test.ts` from direct hook calls to `renderHook`, now that those hooks contain a real React hook (a direct call would throw "Invalid hook call").

ESLint clean (incl. `react-hooks/exhaustive-deps`); changed files are `tsc`-clean.

## **Screenshots/Recordings**

N/A — internal performance refactor; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure memoization and test updates; no change to name resolution logic or trust-signal priority.
> 
> **Overview**
> The **DisplayName** hook family (`useDisplayName`, `useDisplayNames`, and their sub-hooks) no longer allocates fresh arrays/objects on every render. **`useMemo`** now guards mapped results, derived inputs (`assetIds`, `trustSignalRequests`, single-item `requests`), and expensive builds (account group / wallet maps, NFT scans). **`useFirstPartyContractNames`** hoists static contract keys to module scope; **`useAccountWalletNames`** returns a shared empty array when there is only one wallet.
> 
> **Tests** move to **`renderHook`** where hooks are required, and each hook gains a **referential-stability** test so memoization regressions fail in CI. Display semantics are unchanged; the goal is stable references for list rows and **`React.memo`** / dependency arrays downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafcbe120b93dfd2f6aea3a8852c9392062730ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->