### PR TITLE
perf(usePolling): reuse a single input hash and drop the O(n²) stop scan

### DIFF
--- a/app/components/hooks/usePolling.test.ts
+++ b/app/components/hooks/usePolling.test.ts
@@ -37,4 +37,29 @@ describe('usePolling', () => {
       );
     }
   });
+
+  it('does not start or stop polling when re-rendered with unchanged inputs', () => {
+    const inputs = ['foo', 'bar'];
+    const mockStartPolling = jest
+      .fn()
+      .mockImplementation((input) => `${input}_token`);
+    const mockStopPollingByPollingToken = jest.fn();
+
+    const { rerender } = renderHook(() =>
+      usePolling({
+        startPolling: mockStartPolling,
+        stopPollingByPollingToken: mockStopPollingByPollingToken,
+        input: inputs,
+      }),
+    );
+
+    expect(mockStartPolling).toHaveBeenCalledTimes(2);
+
+    // Same input contents -> the deep-equality dependency is unchanged, so the
+    // effect must not re-run and no polls should be (re)started or stopped.
+    rerender({ input: inputs });
+
+    expect(mockStartPolling).toHaveBeenCalledTimes(2);
+    expect(mockStopPollingByPollingToken).not.toHaveBeenCalled();
+  });
 });

--- a/app/components/hooks/usePolling.ts
+++ b/app/components/hooks/usePolling.ts
@@ -14,39 +14,50 @@ const usePolling = <PollingInput>(
 ) => {
   const pollingTokens = useRef<Map<string, string>>(new Map());
 
+  const { input, startPolling, stopPollingByPollingToken } = usePollingOptions;
+
+  // Deep-equality hash of `input`, recomputed each render so the effect still
+  // re-runs when the array changes by content (callers may mutate the array in
+  // place or pass a new reference). Computed once here and reused as both the
+  // effect dependency and below, instead of stringifying repeatedly.
+  const inputKey = input && JSON.stringify(input);
+
   useEffect(
     () => {
+      const tokens = pollingTokens.current;
+
+      // Stringify each input once and reuse for both loops. Previously the stop
+      // loop re-stringified every input for every existing token (O(n^2)).
+      const inputKeys = input.map((i) => JSON.stringify(i));
+      const currentKeys = new Set(inputKeys);
+
       // start new polls
-      for (const input of usePollingOptions.input) {
-        const key = JSON.stringify(input);
-        if (!pollingTokens.current.has(key)) {
-          const token = usePollingOptions.startPolling(input);
-          pollingTokens.current.set(key, token);
+      input.forEach((i, index) => {
+        const key = inputKeys[index];
+        if (!tokens.has(key)) {
+          tokens.set(key, startPolling(i));
         }
-      }
+      });
 
-      // stop existing polls
-      for (const [inputKey, token] of pollingTokens.current.entries()) {
-        const exists = usePollingOptions.input.some(
-          (i) => inputKey === JSON.stringify(i),
-        );
-
-        if (!exists) {
-          usePollingOptions.stopPollingByPollingToken(token);
-          pollingTokens.current.delete(inputKey);
+      // stop existing polls that are no longer present in the input
+      for (const [key, token] of tokens.entries()) {
+        if (!currentKeys.has(key)) {
+          stopPollingByPollingToken(token);
+          tokens.delete(key);
         }
       }
     },
-    // stringified for deep equality
+    // `inputKey` is the deep-equality hash above; `startPolling` /
+    // `stopPollingByPollingToken` are caller-provided callbacks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [usePollingOptions.input && JSON.stringify(usePollingOptions.input)],
+    [inputKey],
   );
 
   // stop all polling on dismount
   useEffect(
     () => () => {
       for (const token of pollingTokens.current.values()) {
-        usePollingOptions.stopPollingByPollingToken(token);
+        stopPollingByPollingToken(token);
       }
     },
     // Intentionally empty to trigger on dismount


### PR DESCRIPTION
## **Description**

### What

`usePolling` is a shared hook used by many polling controllers (balances, prices, gas, etc.). On every render it serialized its whole `input` array to derive the effect dependency, and inside the effect it re-stringified every input for **every existing polling token** via `input.some((i) => key === JSON.stringify(i))` — an **O(n²)** scan.

### Changes

- Compute the deep-equality input hash once per render (`inputKey = input && JSON.stringify(input)`) and reuse it as the effect dependency.
- Inside the effect, stringify each input once into an array + a `Set`, and use `Set.has(key)` for the stop loop — replacing the O(n²) `.some(JSON.stringify)` scan with O(n).

### Why not `useMemo(() => JSON.stringify(input), [input])`?

That was the audit's suggestion, but it would **change behavior**: the hash must be recomputed every render so a caller that **mutates the `input` array in place** (same reference, changed contents) still triggers a poll restart — memoizing on the array reference would miss that. The existing test exercises exactly this in-place-mutation case. So the hash stays per-render; only the redundant per-element / O(n²) serialization inside the effect is removed.

**Observable behavior is unchanged** (same start/stop semantics, deep-equality on content).

### Risk

Low — pure internal optimization; public API and observable behavior unchanged. Consumers all pass fresh input arrays and are unaffected. From the internal performance audit (`hook-deps`, `fix_risk: Simple`, `test_safety_net: Covered`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31297

## **Manual testing steps**

> **Validation status:** behavior-preserving refactor validated by the unit test(s) below; not yet manually profiled on Android / a power-user device, and no new Sentry traces added — the underlying audit finding is still `status: UNVALIDATED`. The Performance-checks boxes are intentionally left **unchecked** until that profiling is done.

## **Screenshots/Recordings**

N/A — internal performance refactor; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal serialization and loop optimization only; start/stop semantics and hook API are unchanged, with added test coverage.
> 
> **Overview**
> Optimizes the shared **`usePolling`** hook so it does less repeated `JSON.stringify` work on each render and inside its sync effect, without changing when polls start or stop.
> 
> The effect dependency is now a single per-render **`inputKey`** (`input && JSON.stringify(input)`), still recomputed every render so in-place array mutations keep working. Inside the effect, each input is stringified once into a **`Set`** for membership checks when stopping stale polls, replacing the previous **O(n²)** scan that re-stringified inputs for every token.
> 
> A new unit test asserts that re-rendering with the same input contents does not start or stop polling again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eaf58cf7c3ed4c7473e968290603022011e40d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->