### PR TITLE
perf(simulation): memoize useSimulationMetrics params + dependency key

### DIFF
--- a/app/components/UI/SimulationDetails/useSimulationMetrics.test.ts
+++ b/app/components/UI/SimulationDetails/useSimulationMetrics.test.ts
@@ -37,6 +37,10 @@ jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useEffect: jest.fn(),
   useState: jest.fn(),
+  // Passthrough so the hook can be called directly in these tests (which stub
+  // useEffect/useState) without a React render context. Memoization itself is
+  // not under test here; the dispatch payload assertions are the safety net.
+  useMemo: (fn: () => unknown) => fn(),
 }));
 
 jest.mock('./useLoadingTime');

--- a/app/components/UI/SimulationDetails/useSimulationMetrics.ts
+++ b/app/components/UI/SimulationDetails/useSimulationMetrics.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   SimulationData,
@@ -74,27 +74,34 @@ export function useSimulationMetrics({
 
   useIncompleteAssetEvent(balanceChanges, displayNamesByAddress);
 
-  const receivingAssets = balanceChanges.filter(
-    (change) => !change.amount.isNegative(),
+  const receivingAssets = useMemo(
+    () => balanceChanges.filter((change) => !change.amount.isNegative()),
+    [balanceChanges],
   );
 
-  const sendingAssets = balanceChanges.filter((change) =>
-    change.amount.isNegative(),
+  const sendingAssets = useMemo(
+    () => balanceChanges.filter((change) => change.amount.isNegative()),
+    [balanceChanges],
   );
 
   const simulationResponse = getSimulationResponseType(simulationData);
   const simulationLatency = loadingTime;
 
-  const properties = {
-    simulation_response: simulationResponse,
-    simulation_latency: simulationLatency,
-    ...getProperties(receivingAssets, 'simulation_receiving_assets_'),
-    ...getProperties(sendingAssets, 'simulation_sending_assets_'),
-    ...getTotalValueProperty(receivingAssets, 'simulation_receiving_assets_'),
-    ...getTotalValueProperty(sendingAssets, 'simulation_sending_assets_'),
-  };
+  // Memoize the metrics properties (and `params` below) so they only change
+  // when the underlying inputs do, instead of being rebuilt every render.
+  const properties = useMemo(
+    () => ({
+      simulation_response: simulationResponse,
+      simulation_latency: simulationLatency,
+      ...getProperties(receivingAssets, 'simulation_receiving_assets_'),
+      ...getProperties(sendingAssets, 'simulation_sending_assets_'),
+      ...getTotalValueProperty(receivingAssets, 'simulation_receiving_assets_'),
+      ...getTotalValueProperty(sendingAssets, 'simulation_sending_assets_'),
+    }),
+    [simulationResponse, simulationLatency, receivingAssets, sendingAssets],
+  );
 
-  const params = { properties };
+  const params = useMemo(() => ({ properties }), [properties]);
 
   const shouldSkipMetrics =
     !enableMetrics ||
@@ -103,6 +110,12 @@ export function useSimulationMetrics({
       SimulationErrorCode.Disabled,
     ].includes(simulationData?.error?.code as SimulationErrorCode);
 
+  // Derive the effect dependency from the (now memoized) params. When params is
+  // referentially stable this skips JSON.stringify entirely; otherwise it still
+  // produces the same string value, so the effect fires only on a real content
+  // change — matching the previous behavior without over-firing.
+  const paramsKey = useMemo(() => JSON.stringify(params), [params]);
+
   useEffect(() => {
     if (shouldSkipMetrics) {
       return;
@@ -110,7 +123,7 @@ export function useSimulationMetrics({
 
     dispatch(updateConfirmationMetric({ id: transactionId, params }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldSkipMetrics, transactionId, JSON.stringify(params), dispatch]);
+  }, [shouldSkipMetrics, transactionId, paramsKey, dispatch]);
 }
 
 function useIncompleteAssetEvent(


### PR DESCRIPTION
## **Description**

### What

`useSimulationMetrics`' metrics-dispatch effect used `JSON.stringify(params)` as its dependency, where `params` / `properties` (and the `receivingAssets` / `sendingAssets` filters that feed them) were rebuilt **inline on every render** of the confirmation screen.

### Changes

- Memoize `receivingAssets` / `sendingAssets` (on `balanceChanges`), `properties` (on `simulationResponse` / `simulationLatency` / `receivingAssets` / `sendingAssets`), and `params` (on `properties`).
- Derive the effect dependency as `paramsKey = useMemo(() => JSON.stringify(params), [params])` and depend on `paramsKey`.

### Why keep a `JSON.stringify` content key (not just depend on the `params` reference)?

The audit suggested depending on the memoized `params` reference directly, but `balanceChanges` comes from `useBalanceChanges`, which (on `main`) returns a fresh array each render. A pure reference dependency would then make the effect fire **every render** → extra `updateConfirmationMetric` dispatches (a regression). Keeping `paramsKey` as a memoized content hash means:
- inputs stable → the `JSON.stringify` is skipped entirely (the win);
- inputs unstable but content identical → `paramsKey` resolves to the same string value, so the effect fires on exactly the same content changes as before — **no over-firing**.

**Behavior and dispatch payload are unchanged** (`{ id, params: { properties } }`).

### Risk

Low — memoization + a content-equality dependency key that preserves the exact firing behavior. From the internal performance audit (`hook-deps`, `fix_risk: Simple`, `test_safety_net: Covered`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31299
Fixes: #31380

## **Manual testing steps**

> **Validation status:** behavior-preserving refactor validated by the unit test(s) below; not yet manually profiled on Android / a power-user device, and no new Sentry traces added — the underlying audit finding is still `status: UNVALIDATED`. The Performance-checks boxes are intentionally left **unchecked** until that profiling is done.

## **Screenshots/Recordings**

N/A — internal performance refactor; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted memoization in confirmation metrics only; dispatch payload and firing semantics are intended to match prior behavior, with tests covering payloads.
> 
> **Overview**
> Reduces unnecessary **`updateConfirmationMetric`** dispatches on the confirmation simulation UI by stabilizing what feeds the metrics effect in **`useSimulationMetrics`**.
> 
> **`receivingAssets`**, **`sendingAssets`**, the analytics **`properties`** object, and **`params`** are now built with **`useMemo`** so they are not recreated every render. The effect no longer depends on **`JSON.stringify(params)`** inline; it uses a memoized **`paramsKey`** so stringify runs only when **`params`** changes, while still firing on **content** changes (not just reference) when **`balanceChanges`** from **`useBalanceChanges`** is a new array each render with the same data.
> 
> The unit test React mock adds **`useMemo`** as a passthrough so existing direct-hook tests keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f390bc5cbd432834b2cb6f2a4b530a742523e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->