### PR TITLE
perf(useTokenLogo): stable empty-set defaults + memoized image handlers

### DIFF
--- a/app/components/hooks/useTokenLogo/useTokenLogo.test.ts
+++ b/app/components/hooks/useTokenLogo/useTokenLogo.test.ts
@@ -101,6 +101,27 @@ describe('useTokenLogo', () => {
     });
   });
 
+  describe('referential stability', () => {
+    it('returns stable styles and handlers across re-renders when bg sets are omitted', () => {
+      const { result, rerender } = renderHook(
+        ({ symbol }) => useTokenLogo({ symbol, size: 44 }),
+        { initialProps: { symbol: 'USDC' } },
+      );
+
+      const first = result.current;
+
+      // Re-render with identical inputs (and omitted bg sets, which previously
+      // defaulted to a fresh Set each render and busted the style memos).
+      rerender({ symbol: 'USDC' });
+
+      expect(result.current.containerStyle).toBe(first.containerStyle);
+      expect(result.current.imageStyle).toBe(first.imageStyle);
+      expect(result.current.handleLoadStart).toBe(first.handleLoadStart);
+      expect(result.current.handleLoadEnd).toBe(first.handleLoadEnd);
+      expect(result.current.handleError).toBe(first.handleError);
+    });
+  });
+
   describe('State reset on symbol change', () => {
     it('should reset loading and error states when symbol changes', () => {
       const { result, rerender } = renderHook(

--- a/app/components/hooks/useTokenLogo/useTokenLogo.ts
+++ b/app/components/hooks/useTokenLogo/useTokenLogo.ts
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ImageStyle, ViewStyle } from 'react-native';
 import { useTheme } from '../../../util/theme';
+
+// Stable default so omitting the bg sets doesn't create a fresh Set each render
+// (which would bust the background/style memoization below).
+const EMPTY_SET = new Set<string>();
 
 export interface UseTokenLogoConfig {
   symbol: string;
@@ -35,8 +39,8 @@ export interface UseTokenLogoReturn {
 export const useTokenLogo = ({
   symbol,
   size = 44,
-  assetsRequiringLightBg = new Set<string>(),
-  assetsRequiringDarkBg = new Set<string>(),
+  assetsRequiringLightBg = EMPTY_SET,
+  assetsRequiringDarkBg = EMPTY_SET,
 }: UseTokenLogoConfig): UseTokenLogoReturn => {
   const { colors, themeAppearance } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
@@ -108,19 +112,21 @@ export const useTokenLogo = ({
     [size, colors.text.default],
   );
 
-  const handleLoadStart = () => {
+  // Stable handler identities so memoized children (e.g. <Image>) don't
+  // re-render from new onLoadStart/onLoadEnd/onError props each render.
+  const handleLoadStart = useCallback(() => {
     setIsLoading(true);
     setHasError(false);
-  };
+  }, []);
 
-  const handleLoadEnd = () => {
+  const handleLoadEnd = useCallback(() => {
     setIsLoading(false);
-  };
+  }, []);
 
-  const handleError = () => {
+  const handleError = useCallback(() => {
     setIsLoading(false);
     setHasError(true);
-  };
+  }, []);
 
   return {
     isLoading,


### PR DESCRIPTION
## **Description**

### What

`useTokenLogo` backs `TrendingTokenLogo`, which renders one logo **per row in trending-token lists** — a hot, virtualized path. Two issues defeated the style memoization the hook already had:

1. The `assetsRequiringLightBg` / `assetsRequiringDarkBg` parameter defaults were `new Set<string>()`, creating a **fresh Set every render** whenever omitted (which every current consumer does). Those Sets are dependencies of the `needsLightBg`/`needsDarkBg` `useMemo`, so it recomputed every render — and that feeds the `containerStyle` `useMemo`, so the container style was rebuilt every render too.
2. The `handleLoadStart` / `handleLoadEnd` / `handleError` handlers were inline, getting a **new identity each render** and re-binding the `<Image>` `onLoadStart`/`onLoadEnd`/`onError` props, defeating image-prop stability.

### Changes

- Hoist the empty-Set default to a shared module-level `const EMPTY_SET = new Set<string>()` (read-only — only ever queried via `.has(...)`).
- Wrap the three handlers in `useCallback(..., [])` — they only call the stable `useState` setters.

**Behavior is unchanged.** (The returned object is intentionally *not* wrapped in `useMemo`: `isLoading`/`hasError` change on load events and consumers destructure individual members, so the per-member memoization is what matters.)

### Risk

Low — stable default + handler memoization; no behavior change. From the internal performance audit (`unstable-hook`, `fix_risk: Simple`, `test_safety_net: Covered`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31382

## **Manual testing steps**

> **Validation status:** behavior-preserving refactor validated by the unit test(s) below; not yet manually profiled on Android / a power-user device, and no new Sentry traces added — the underlying audit finding is still `status: UNVALIDATED`. The Performance-checks boxes are intentionally left **unchecked** until that profiling is done.

## **Screenshots/Recordings**

N/A — internal performance refactor; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only memoization with existing tests plus a referential-stability case; no API or behavior changes.
> 
> **Overview**
> **`useTokenLogo`** is tuned so trending list rows stop invalidating memoized styles and image callbacks on every parent re-render.
> 
> When callers omit the light/dark background asset sets (as **`TrendingTokenLogo`** does), defaults now use a shared **`EMPTY_SET`** instead of **`new Set()`** each render, so background checks and **`containerStyle`** stay memoized. **`handleLoadStart`**, **`handleLoadEnd`**, and **`handleError`** are wrapped in **`useCallback`** so **`Image`** load props keep stable references. A test asserts style/handler referential equality across identical re-renders; runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3cee46994777f3b9cdf9eabebb47ed67d89f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->