### PR TITLE
perf(useExistingAddress): flatten address book in O(n) instead of O(n²)

### DIFF
--- a/app/components/hooks/useExistingAddress.test.ts
+++ b/app/components/hooks/useExistingAddress.test.ts
@@ -9,6 +9,7 @@ import { RootState } from '../../reducers';
 
 const MOCK_ADDRESS_1 = '0x0';
 const MOCK_ADDRESS_2 = '0x1';
+const MOCK_ADDRESS_3 = '0x3';
 
 const MOCK_ACCOUNTS_CONTROLLER_STATE = createMockAccountsControllerState([
   MOCK_ADDRESS_1,
@@ -26,6 +27,14 @@ const mockInitialState: DeepPartial<RootState> = {
             [MOCK_ADDRESS_2]: {
               address: MOCK_ADDRESS_2,
               name: 'Account 2',
+            },
+          },
+          // A second network's address book, to exercise flattening/merging
+          // entries across multiple networks.
+          [MOCK_ADDRESS_3]: {
+            [MOCK_ADDRESS_3]: {
+              address: MOCK_ADDRESS_3,
+              name: 'Account 3',
             },
           },
         },
@@ -60,6 +69,15 @@ describe('useExistingAddress', () => {
       },
     );
     expect(result?.current?.name).toEqual('Account 2');
+  });
+  it('returns existing address from a second network address book', async () => {
+    const { result } = renderHookWithProvider(
+      () => useExistingAddress(MOCK_ADDRESS_3),
+      {
+        state: mockInitialState,
+      },
+    );
+    expect(result?.current?.name).toEqual('Account 3');
   });
   it('returns undefined address not in identities or address book', async () => {
     const { result } = renderHookWithProvider(() => useExistingAddress('0x2'), {

--- a/app/components/hooks/useExistingAddress.ts
+++ b/app/components/hooks/useExistingAddress.ts
@@ -17,11 +17,11 @@ const useExistingAddress = (address?: string): AccountInfo | undefined => {
 
   const filteredAddressBook = useMemo(
     () =>
+      // Flatten the per-network address book into a single map. Mutating one
+      // accumulator with Object.assign is O(n); spreading `...acc` on every
+      // iteration was O(n^2) in the total number of entries.
       Object.values(addressBook).reduce(
-        (acc, networkAddressBook) => ({
-          ...acc,
-          ...networkAddressBook,
-        }),
+        (acc, networkAddressBook) => Object.assign(acc, networkAddressBook),
         {},
       ),
     [addressBook],


### PR DESCRIPTION
## **Description**

### What

`useExistingAddress` flattened the per-network address book with:

```ts
Object.values(addressBook).reduce((acc, n) => ({ ...acc, ...n }), {})
```

Spreading `...acc` on every iteration reallocates and recopies the entire accumulator each step, making the flatten **O(n²)** in the total number of address-book entries — which grows with the user's saved contacts across networks.

### Changes

Mutate a single fresh accumulator with `Object.assign` instead — **O(n)**, producing the same flattened map and the same key-collision semantics (later networks override earlier):

```ts
Object.values(addressBook).reduce((acc, n) => Object.assign(acc, n), {})
```

The `useMemo` and its `[addressBook]` dependency are unchanged; only a fresh accumulator is mutated (no external state is touched). **Behavior is unchanged.**

### Risk

Very low — equivalent output, lower complexity. From the internal performance audit (`unstable-hook`, `fix_risk: Simple`, `test_safety_net: Covered`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31378

## **Manual testing steps**

> **Validation status:** behavior-preserving refactor validated by the unit test(s) below; not yet manually profiled on Android / a power-user device, and no new Sentry traces added — the underlying audit finding is still `status: UNVALIDATED`. The Performance-checks boxes are intentionally left **unchecked** until that profiling is done.

## **Screenshots/Recordings**

N/A — internal performance refactor; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Equivalent flattened map and collision rules; only internal memoization changes, with hook tests extended for multi-network address books.
> 
> **Overview**
> **`useExistingAddress`** now flattens the per-network address book in **O(n)** by merging each network map with `Object.assign` on one accumulator, instead of spreading the accumulator on every `reduce` step (which was **O(n²)** as contacts grow across networks). Lookup behavior and merge semantics (later networks win on key clashes) stay the same.
> 
> Tests add a **second network** address-book entry and assert a lookup resolves to that contact, so multi-network flattening stays covered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e143c497ac077ed64405896d15840ca3e4664026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->