### PR TITLE
perf(watch-asset): drop pointless isEqual on getActiveTabUrl (a string)

### DIFF
--- a/app/components/Views/confirmations/legacy/components/WatchAssetRequest/index.js
+++ b/app/components/Views/confirmations/legacy/components/WatchAssetRequest/index.js
@@ -17,7 +17,6 @@ import NotificationManager from '../../../../../../core/NotificationManager';
 import { selectEvmChainId } from '../../../../../../selectors/networkController';
 import ApproveTransactionHeader from '../ApproveTransactionHeader';
 import { getActiveTabUrl } from '../../../../../../util/transactions';
-import { isEqual } from 'lodash';
 import { AssetWatcherSelectorsIDs } from './AssetWatcher.testIds';
 import { getDecimalChainId } from '../../../../../../util/networks';
 import { useAnalytics } from '../../../../../../components/hooks/useAnalytics/useAnalytics';
@@ -120,7 +119,9 @@ const WatchAssetRequest = ({
     ? strings('transaction.failed')
     : `${renderFromTokenMinimalUnit(balance, asset.decimals)} ${asset.symbol}`;
 
-  const activeTabUrl = useSelector(getActiveTabUrl, isEqual);
+  // getActiveTabUrl returns a string, so the default referential (===)
+  // equality already compares it correctly; lodash.isEqual was needless work.
+  const activeTabUrl = useSelector(getActiveTabUrl);
 
   const getTokenAddedAnalyticsParams = () => {
     try {


### PR DESCRIPTION
## **Description**

### What

`WatchAssetRequest` did `useSelector(getActiveTabUrl, isEqual)`. `getActiveTabUrl` returns a plain **string** (the active tab URL), so `useSelector`'s default referential (`===`) equality already compares it correctly. `lodash.isEqual` is heavier than `===` and provides **zero** benefit for a primitive — it ran on every Redux dispatch while this screen is mounted, and it misleadingly implies the value is a complex object.

### Changes

- Drop the `isEqual` second argument: `const activeTabUrl = useSelector(getActiveTabUrl);`
- Remove the now-unused `import { isEqual } from 'lodash'`.

### Note on the audit target

The performance audit originally flagged this exact anti-pattern in `app/components/Views/AccountPermissions/AccountPermissions.tsx`, but that component has since been **removed as dead code** (#30348). `WatchAssetRequest/index.js` is the **only remaining occurrence** of `useSelector(getActiveTabUrl, ...)` in the app, so the equivalent fix is applied here.

**Behavior is identical** (`===` and `isEqual` are equivalent for a string/`undefined`; no change to `useSelector` re-render behavior).

### Risk

Very low — removes redundant work; no behavior change. From the internal performance audit (`redux`, `fix_risk: Simple`, `test_safety_net: Covered`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31330

## **Manual testing steps**

> **Validation status:** behavior-preserving refactor validated by the unit test(s) below; not yet manually profiled on Android / a power-user device, and no new Sentry traces added — the underlying audit finding is still `status: UNVALIDATED`. The Performance-checks boxes are intentionally left **unchecked** until that profiling is done.

## **Screenshots/Recordings**

N/A — internal performance refactor; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes redundant selector comparison only; re-render behavior for the URL string is unchanged.
> 
> **Overview**
> In **`WatchAssetRequest`**, the active tab URL is now read with default `useSelector` equality instead of **`lodash.isEqual`**, and the unused lodash import is removed.
> 
> **`getActiveTabUrl`** yields a string (or `null`/`undefined`), so **`===`** already matches prior deep-equality behavior for this value while avoiding extra work on each Redux update while the watch-asset screen is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8aebe07c65014505dd097d65402342786b08f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->