### PR TITLE
fix(money): gate onboarding stepper animation behind feature flag (MUSD-865)

### DIFF
--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.test.tsx
@@ -6,9 +6,11 @@ import MoneyOnboardingView, {
 import { RiveOnboardingStepperTestIds } from '../../../RiveOnboardingStepper/RiveOnboardingStepper.testIds';
 import { __clearLastMockedMethods } from '../../../../../__mocks__/rive-react-native';
 import Routes from '../../../../../constants/navigation/Routes';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 
 const mockNavigate = jest.fn();
 const mockDispatch = jest.fn();
+const mockUseSelector = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
@@ -16,7 +18,7 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
-  useSelector: jest.fn().mockReturnValue(false),
+  useSelector: (selector: unknown) => mockUseSelector(selector),
 }));
 
 jest.mock('../../hooks/useMoneyAccountBalance', () => ({
@@ -43,6 +45,11 @@ describe('MoneyOnboardingView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     __clearLastMockedMethods();
+    // Stepper animation (Rive) enabled by default; every other selector is irrelevant here.
+    mockUseSelector.mockImplementation(
+      (selector: unknown) =>
+        selector === selectMoneyOnboardingStepperAnimationEnabled,
+    );
   });
 
   describe('Rendering', () => {
@@ -110,6 +117,30 @@ describe('MoneyOnboardingView', () => {
       const { getByText } = render(<MoneyOnboardingView />);
       expect(
         getByText('APY is variable and not guaranteed.'),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('when the onboarding stepper flag is disabled', () => {
+    beforeEach(() => {
+      mockUseSelector.mockImplementation(() => false);
+    });
+
+    it('does not render the Rive animation', () => {
+      const { queryByTestId } = render(<MoneyOnboardingView />);
+      expect(
+        queryByTestId(RiveOnboardingStepperTestIds.RIVE_ANIMATION),
+      ).toBeNull();
+    });
+
+    it('still renders the onboarding content (container, title, footer button)', () => {
+      const { getByTestId, getByText } = render(<MoneyOnboardingView />);
+      expect(
+        getByTestId(RiveOnboardingStepperTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+      expect(getByText('Money accounts are here')).toBeOnTheScreen();
+      expect(
+        getByTestId(RiveOnboardingStepperTestIds.FOOTER_BUTTON),
       ).toBeOnTheScreen();
     });
   });

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import LinearGradient from 'react-native-linear-gradient';
 import { useNavigation } from '@react-navigation/native';
 import { type StackNavigationProp } from '@react-navigation/stack';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   ButtonVariant,
   IconColor,
@@ -15,6 +15,7 @@ import RiveOnboardingStepper, {
   type RiveConfig,
 } from '../../../RiveOnboardingStepper';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 import { useTheme } from '../../../../../util/theme';
 import { setMoneyOnboardingSeen } from '../../../../../actions/user';
 import { AppThemeKey } from '../../../../../util/theme/models';
@@ -53,6 +54,10 @@ const MoneyOnboardingView = () => {
   const dispatch = useDispatch();
 
   const { colors, themeAppearance } = useTheme();
+
+  const isStepperAnimationEnabled = useSelector(
+    selectMoneyOnboardingStepperAnimationEnabled,
+  );
 
   const tw = useTailwind();
 
@@ -157,6 +162,7 @@ const MoneyOnboardingView = () => {
       onClose={handleComplete}
       onComplete={handleComplete}
       autoCompleteOnLastStep
+      enableRiveAnimation={isStepperAnimationEnabled}
     />
   );
 };

--- a/app/components/UI/RiveOnboardingStepper/RiveOnboardingStepper.test.tsx
+++ b/app/components/UI/RiveOnboardingStepper/RiveOnboardingStepper.test.tsx
@@ -181,6 +181,43 @@ describe('RiveOnboardingStepper', () => {
     });
   });
 
+  describe('When Rive animation is disabled', () => {
+    it('does not mount the Rive animation', () => {
+      const { queryByTestId } = render(
+        <RiveOnboardingStepper {...defaultProps} enableRiveAnimation={false} />,
+      );
+      expect(
+        queryByTestId(RiveOnboardingStepperTestIds.RIVE_ANIMATION),
+      ).toBeNull();
+    });
+
+    it('reveals content without waiting for Rive onPlay', () => {
+      const { getByTestId } = render(
+        <RiveOnboardingStepper {...defaultProps} enableRiveAnimation={false} />,
+      );
+      // The content is gated behind onPlay when Rive is on; with it off the
+      // footer button must be visible (not opacity-0) immediately.
+      expect(getByTestId(RiveOnboardingStepperTestIds.TITLE)).toBeOnTheScreen();
+      expect(
+        getByTestId(RiveOnboardingStepperTestIds.FOOTER_BUTTON),
+      ).toBeVisible();
+    });
+
+    it('advances steps on Continue without firing a Rive trigger', () => {
+      const onStepChange = jest.fn();
+      const { getByTestId } = render(
+        <RiveOnboardingStepper
+          {...defaultProps}
+          enableRiveAnimation={false}
+          onStepChange={onStepChange}
+        />,
+      );
+      fireEvent.press(getByTestId(RiveOnboardingStepperTestIds.FOOTER_BUTTON));
+      expect(onStepChange).toHaveBeenCalledWith(1);
+      expect(__mockRiveFireState).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Close button', () => {
     it('does not render close button when onClose is not provided', () => {
       const { queryByTestId } = render(

--- a/app/components/UI/RiveOnboardingStepper/RiveOnboardingStepper.tsx
+++ b/app/components/UI/RiveOnboardingStepper/RiveOnboardingStepper.tsx
@@ -54,11 +54,14 @@ const RiveOnboardingStepper = ({
   onStepChange,
   onComplete,
   autoCompleteOnLastStep = false,
+  enableRiveAnimation = true,
 }: RiveOnboardingStepperProps) => {
   const tw = useTailwind();
   const riveRef = useRef<RiveRef>(null);
   const hasCompletedRef = useRef(false);
-  const [isRiveReady, setIsRiveReady] = useState(false);
+  // When Rive is disabled it never fires `onPlay`, so start ready to avoid the
+  // content staying hidden behind the `opacity-0` gate.
+  const [isRiveReady, setIsRiveReady] = useState(!enableRiveAnimation);
 
   const {
     currentStepIndex,
@@ -151,19 +154,21 @@ const RiveOnboardingStepper = ({
         </Box>
 
         {/* Rive animation fills remaining space — intentionally edge-to-edge, no horizontal padding */}
-        <Box twClassName="absolute inset-0">
-          <Rive
-            ref={riveRef}
-            style={riveStyle}
-            source={riveConfig.source}
-            stateMachineName={riveConfig.stateMachineName}
-            fit={riveConfig.fit ?? Fit.FitWidth}
-            alignment={riveConfig.alignment ?? Alignment.Center}
-            autoplay
-            testID={RiveOnboardingStepperTestIds.RIVE_ANIMATION}
-            onPlay={handleRivePlay}
-          />
-        </Box>
+        {enableRiveAnimation && (
+          <Box twClassName="absolute inset-0">
+            <Rive
+              ref={riveRef}
+              style={riveStyle}
+              source={riveConfig.source}
+              stateMachineName={riveConfig.stateMachineName}
+              fit={riveConfig.fit ?? Fit.FitWidth}
+              alignment={riveConfig.alignment ?? Alignment.Center}
+              autoplay
+              testID={RiveOnboardingStepperTestIds.RIVE_ANIMATION}
+              onPlay={handleRivePlay}
+            />
+          </Box>
+        )}
       </Box>
       <Box
         twClassName={`pb-4${!isRiveReady || !currentStep?.footerText ? ' opacity-0' : ''}`}

--- a/app/components/UI/RiveOnboardingStepper/RiveOnboardingStepper.types.ts
+++ b/app/components/UI/RiveOnboardingStepper/RiveOnboardingStepper.types.ts
@@ -88,4 +88,10 @@ export interface RiveOnboardingStepperProps {
    * `durationMs` elapses, without requiring a button tap.
    */
   autoCompleteOnLastStep?: boolean;
+  /**
+   * When false, the Rive animation is not mounted at all and the stepper renders
+   * only its background and text content. Use to disable the native Rive renderer
+   * on builds/platforms where it is unstable. Defaults to true.
+   */
+  enableRiveAnimation?: boolean;
 }

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -7,6 +7,17 @@ import {
   DEV_VAULT_CONFIG,
 } from './index';
 
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('99.0.0'),
+}));
+
+jest.mock(
+  '../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
+
 describe('Money Account feature flag selectors', () => {
   describe('selectMoneyAccountDepositEnabledFlag', () => {
     it('returns true when moneyAccountDepositEnabled is true', () => {
@@ -83,17 +94,40 @@ describe('Money Account feature flag selectors', () => {
   });
 
   describe('selectMoneyOnboardingStepperAnimationEnabled', () => {
-    it('returns true when the flag is enabled', () => {
+    it('exposes the client-config flag key for registry alignment', () => {
+      expect(MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY).toBe(
+        'moneyEnableOnboardingStepperAnimation',
+      );
+    });
+
+    it('returns true when enabled and the minimum version passes', () => {
       const result = selectMoneyOnboardingStepperAnimationEnabled.resultFunc({
-        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: true,
+        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: {
+          enabled: true,
+          minimumVersion: '0.0.0',
+        },
       });
 
       expect(result).toBe(true);
     });
 
-    it('returns false when the flag is disabled', () => {
+    it('returns false when enabled is false', () => {
       const result = selectMoneyOnboardingStepperAnimationEnabled.resultFunc({
-        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: false,
+        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: {
+          enabled: false,
+          minimumVersion: '0.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the minimum version requirement fails', () => {
+      const result = selectMoneyOnboardingStepperAnimationEnabled.resultFunc({
+        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: {
+          enabled: true,
+          minimumVersion: '999.0.0',
+        },
       });
 
       expect(result).toBe(false);

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -2,6 +2,8 @@ import {
   selectMoneyAccountDepositEnabledFlag,
   selectMoneyAccountWithdrawEnabledFlag,
   selectMoneyAccountVaultConfig,
+  selectMoneyOnboardingStepperAnimationEnabled,
+  MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY,
   DEV_VAULT_CONFIG,
 } from './index';
 
@@ -75,6 +77,32 @@ describe('Money Account feature flag selectors', () => {
       const result = selectMoneyAccountWithdrawEnabledFlag.resultFunc({
         moneyAccount: {},
       });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectMoneyOnboardingStepperAnimationEnabled', () => {
+    it('returns true when the flag is enabled', () => {
+      const result = selectMoneyOnboardingStepperAnimationEnabled.resultFunc({
+        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: true,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the flag is disabled', () => {
+      const result = selectMoneyOnboardingStepperAnimationEnabled.resultFunc({
+        [MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY]: false,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the flag is absent (safe default)', () => {
+      const result = selectMoneyOnboardingStepperAnimationEnabled.resultFunc(
+        {},
+      );
 
       expect(result).toBe(false);
     });

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -24,6 +24,17 @@ export const selectMoneyAccountWithdrawEnabledFlag = createSelector(
   },
 );
 
+export const MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY =
+  'money-enable-onboarding-stepper-animation' as const;
+
+export const selectMoneyOnboardingStepperAnimationEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean =>
+    Boolean(
+      remoteFeatureFlags?.[MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY],
+    ),
+);
+
 export interface MoneyAccountVaultConfig {
   chainId: string;
   boringVault: string;

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
 
 interface MoneyAccountFeatureFlag {
   moneyAccountDepositEnabled?: boolean;
@@ -25,14 +26,15 @@ export const selectMoneyAccountWithdrawEnabledFlag = createSelector(
 );
 
 export const MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY =
-  'money-enable-onboarding-stepper-animation' as const;
+  'moneyEnableOnboardingStepperAnimation' as const;
 
 export const selectMoneyOnboardingStepperAnimationEnabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean =>
-    Boolean(
-      remoteFeatureFlags?.[MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY],
-    ),
+  (remoteFeatureFlags): boolean => {
+    const remoteFlag =
+      remoteFeatureFlags?.[MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY];
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
 );
 
 export interface MoneyAccountVaultConfig {

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3408,6 +3408,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  moneyEnableOnboardingStepperAnimation: {
+    name: 'moneyEnableOnboardingStepperAnimation',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      minimumVersion: '0.0.0',
+      enabled: false,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   nonZeroUnusedApprovals: {
     name: 'nonZeroUnusedApprovals',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
## **Description**

The Rive animation on the money account onboarding screen crashes the app on Android. The native Rive `SurfaceView` is released during the navigation transition while its render thread is still drawing, producing a fatal `SIGSEGV` (`Surface has already been released`).

This gates the animation behind the `money-enable-onboarding-stepper-animation` remote feature flag, which is **off by default**. When the flag is disabled the stepper no longer mounts the Rive view and renders its gradient background and per-step content (progress bar, titles, body, footer, buttons) only. Not mounting the native view removes the crash path entirely while keeping the onboarding flow intact.

`RiveOnboardingStepper` gains a generic `enableRiveAnimation` prop (defaults to `true`, so existing behaviour is unchanged); `MoneyOnboardingView` wires it to the flag.

## **Changelog**

CHANGELOG entry: Fixed a crash that could occur on the money account onboarding screen.

## **Related issues**

Fixes: [MUSD-865](https://consensyssoftware.atlassian.net/browse/MUSD-865)

## **Manual testing steps**

```gherkin
Feature: Money onboarding stepper animation flag

  Scenario: Animation disabled (flag off, default)
    Given the money-enable-onboarding-stepper-animation flag is off
    When the user opens the money account onboarding screen
    Then the onboarding steps and text render without the animation
    And the app does not crash

  Scenario: Animation enabled (flag on)
    Given the money-enable-onboarding-stepper-animation flag is on
    When the user opens the money account onboarding screen
    Then the Rive animation plays as before
```

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/5cb53d73-02ff-4db0-80a9-9277c856bf20


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-865]: https://consensyssoftware.atlassian.net/browse/MUSD-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI/native-renderer change with safe default (flag off) and broad test coverage; no auth, payments, or data-handling changes.
> 
> **Overview**
> Gates the **money account onboarding** Rive stepper behind the remote flag `moneyEnableOnboardingStepperAnimation` (registered with **enabled: false** by default), so production avoids mounting the native Rive view that was crashing on Android during navigation.
> 
> **`RiveOnboardingStepper`** now accepts **`enableRiveAnimation`** (default `true`). When it is `false`, the Rive component is not mounted, **`isRiveReady`** starts `true` so UI is not stuck behind the `onPlay` opacity gate, and step advances without firing Rive triggers. **`MoneyOnboardingView`** reads **`selectMoneyOnboardingStepperAnimationEnabled`** and passes that into the stepper.
> 
> Adds selector/tests and E2E registry entry for the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0017ee4bec04d23dc4a1715a41f1efe16c6d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->