### PR TITLE
fix: NFT/token/DeFi full view headers and NFT grid layout

### DIFF
--- a/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
@@ -82,6 +82,9 @@ const styleSheet = (params: {
     imageFallBackShowText: {
       alignSelf: 'center',
     },
+    noFlex: {
+      flex: 0,
+    },
   });
 };
 

--- a/app/components/UI/CollectibleMedia/CollectibleMedia.tsx
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.tsx
@@ -138,6 +138,7 @@ const CollectibleMedia: React.FC<CollectibleMediaProps> = ({
           <View
             style={[
               styles.textContainer,
+              styles.noFlex,
               style,
               tiny && styles.tinyImage,
               small && styles.smallImage,

--- a/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.test.tsx
@@ -53,13 +53,12 @@ describe('DeFiFullView', () => {
   });
 
   it('renders header with title and back button', () => {
-    const { getByTestId } = renderScreen(DeFiFullView, {
+    const { getByTestId, getByText } = renderScreen(DeFiFullView, {
       name: 'DeFiFullView',
     });
 
-    expect(getByTestId('header')).toBeOnTheScreen();
-    expect(getByTestId('header-title')).toBeOnTheScreen();
     expect(getByTestId('back-button')).toBeOnTheScreen();
+    expect(getByText('DeFi')).toBeOnTheScreen();
   });
 
   it('renders DeFi positions list', () => {

--- a/app/components/Views/DeFiFullView/DeFiFullView.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.tsx
@@ -1,14 +1,19 @@
 import React, { useCallback } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import HeaderBase from '../../../component-library/components/HeaderBase';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../component-library/components/Buttons/ButtonIcon';
-import { IconName } from '../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../locales/i18n';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import DeFiPositionsList from '../../UI/DeFiPositions/DeFiPositionsList';
 import Engine from '../../../core/Engine';
 import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
@@ -16,6 +21,7 @@ import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
 const DeFiFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const insets = useSafeAreaInsets();
 
   useFocusEffect(
     useCallback(
@@ -33,21 +39,26 @@ const DeFiFullView = () => {
   }, [navigation]);
 
   return (
-    <SafeAreaView style={tw`flex-1 bg-default pb-4`}>
-      <HeaderBase
-        startAccessory={
-          <ButtonIcon
-            size={ButtonIconSizes.Lg}
-            onPress={handleBackPress}
-            iconName={IconName.ArrowLeft}
-            testID="back-button"
-          />
-        }
-        style={tw`p-4`}
-        twClassName="h-auto"
-      >
-        {strings('homepage.sections.defi')}
-      </HeaderBase>
+    <SafeAreaView
+      style={tw.style('flex-1 bg-default pb-4', { paddingTop: insets.top })}
+      edges={['left', 'right', 'bottom']}
+    >
+      <Box twClassName="flex-row items-center h-14 px-2">
+        <ButtonIcon
+          size={ButtonIconSize.Md}
+          iconName={IconName.ArrowLeft}
+          onPress={handleBackPress}
+          testID="back-button"
+        />
+        <Box
+          twClassName="absolute inset-0 items-center justify-center"
+          pointerEvents="none"
+        >
+          <Text variant={TextVariant.HeadingSm}>
+            {strings('homepage.sections.defi')}
+          </Text>
+        </Box>
+      </Box>
       <Box twClassName="flex-1 px-4">
         <DeFiPositionsList
           tabLabel={strings('homepage.sections.defi')}

--- a/app/components/Views/NftDetails/NftDetails.styles.ts
+++ b/app/components/Views/NftDetails/NftDetails.styles.ts
@@ -14,8 +14,8 @@ const styleSheet = (params: { theme: Theme }) => {
       alignItems: 'baseline',
     },
     collectibleMediaWrapper: {
-      paddingTop: 16,
-      paddingBottom: 40,
+      paddingTop: 4,
+      paddingBottom: 16,
       flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
@@ -70,7 +70,6 @@ const styleSheet = (params: { theme: Theme }) => {
     wrapper: {
       flex: 1,
       backgroundColor: colors.background.default,
-      padding: 16,
     },
     buttonSendWrapper: {
       flexDirection: 'row',

--- a/app/components/Views/NftFullView/NftFullView.test.tsx
+++ b/app/components/Views/NftFullView/NftFullView.test.tsx
@@ -15,27 +15,6 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('../../UI/NftGrid/NftGrid', () => 'NftGrid');
 
-jest.mock(
-  '../../../component-library/components/BottomSheets/BottomSheetHeader',
-  () => {
-    const { TouchableOpacity, View, Text } = jest.requireActual('react-native');
-    return ({
-      children,
-      onBack,
-    }: {
-      children: React.ReactNode;
-      onBack: () => void;
-    }) => (
-      <View testID="bottom-sheet-header">
-        <TouchableOpacity testID="header-back-button" onPress={onBack}>
-          <Text>Back</Text>
-        </TouchableOpacity>
-        <Text testID="header-title">{children}</Text>
-      </View>
-    );
-  },
-);
-
 describe('NftFullView', () => {
   const initialState = {
     engine: {
@@ -72,7 +51,7 @@ describe('NftFullView', () => {
     });
 
     // Act
-    const backButton = getByTestId('header-back-button');
+    const backButton = getByTestId('back-button');
     fireEvent.press(backButton);
 
     // Assert
@@ -81,11 +60,11 @@ describe('NftFullView', () => {
 
   it('displays NFTs header title', () => {
     // Arrange & Act
-    const { getByTestId } = renderWithProvider(<NftFullView />, {
+    const { getByText } = renderWithProvider(<NftFullView />, {
       state: initialState,
     });
 
     // Assert
-    expect(getByTestId('header-title')).toBeOnTheScreen();
+    expect(getByText('NFTs')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/NftFullView/NftFullView.tsx
+++ b/app/components/Views/NftFullView/NftFullView.tsx
@@ -1,25 +1,50 @@
 import React, { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import BottomSheetHeader from '../../../component-library/components/BottomSheets/BottomSheetHeader';
 import { strings } from '../../../../locales/i18n';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import NftGrid from '../../UI/NftGrid/NftGrid';
 
 const NftFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const insets = useSafeAreaInsets();
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
   return (
-    <SafeAreaView style={tw`flex-1 bg-default pb-4`}>
-      <BottomSheetHeader onBack={handleBackPress}>
-        {strings('wallet.collectibles')}
-      </BottomSheetHeader>
+    <SafeAreaView
+      style={tw.style('flex-1 bg-default pb-4', { paddingTop: insets.top })}
+      edges={['left', 'right', 'bottom']}
+    >
+      <Box twClassName="flex-row items-center h-14 px-2">
+        <ButtonIcon
+          size={ButtonIconSize.Md}
+          iconName={IconName.ArrowLeft}
+          onPress={handleBackPress}
+        />
+        <Box
+          twClassName="absolute inset-0 items-center justify-center"
+          pointerEvents="none"
+        >
+          <Text variant={TextVariant.HeadingSm}>
+            {strings('wallet.collectibles')}
+          </Text>
+        </Box>
+      </Box>
       <Box twClassName="flex-1">
         <NftGrid isFullView />
       </Box>

--- a/app/components/Views/NftFullView/NftFullView.tsx
+++ b/app/components/Views/NftFullView/NftFullView.tsx
@@ -35,6 +35,7 @@ const NftFullView = () => {
           size={ButtonIconSize.Md}
           iconName={IconName.ArrowLeft}
           onPress={handleBackPress}
+          testID="back-button"
         />
         <Box
           twClassName="absolute inset-0 items-center justify-center"

--- a/app/components/Views/TokensFullView/TokensFullView.test.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.test.tsx
@@ -67,13 +67,13 @@ describe('TokensFullView', () => {
 
   it('renders header with title and back button', () => {
     // Arrange
-    const { getByTestId } = renderScreen(TokensFullView, {
+    const { getByTestId, getByText } = renderScreen(TokensFullView, {
       name: 'TokensFullView',
     });
 
     // Act & Assert
-    expect(getByTestId('header')).toBeOnTheScreen();
-    expect(getByTestId('header-title')).toBeOnTheScreen();
+    expect(getByTestId('back-button')).toBeOnTheScreen();
+    expect(getByText('Tokens')).toBeOnTheScreen();
     expect(getByTestId('tokens-component')).toBeOnTheScreen();
   });
 

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,12 +1,18 @@
 import React, { useCallback, useEffect } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import HeaderBase from '../../../component-library/components/HeaderBase';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../component-library/components/Buttons/ButtonIcon';
-import { IconName } from '../../../component-library/components/Icons/Icon';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import Tokens from '../../UI/Tokens';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
@@ -16,6 +22,7 @@ import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
 const TokensFullView = () => {
   const navigation = useNavigation();
   const tw = useTailwind();
+  const insets = useSafeAreaInsets();
 
   useEffect(
     () => () => {
@@ -33,21 +40,26 @@ const TokensFullView = () => {
   return (
     <>
       <AssetPollingProvider />
-      <SafeAreaView style={tw`flex-1 bg-default pb-4`}>
-        <HeaderBase
-          startAccessory={
-            <ButtonIcon
-              size={ButtonIconSizes.Md}
-              onPress={handleBackPress}
-              iconName={IconName.ArrowLeft}
-              testID="back-button"
-            />
-          }
-          style={tw`p-4`}
-          twClassName="h-auto"
-        >
-          {strings('wallet.tokens')}
-        </HeaderBase>
+      <SafeAreaView
+        style={tw.style('flex-1 bg-default pb-4', { paddingTop: insets.top })}
+        edges={['left', 'right', 'bottom']}
+      >
+        <Box twClassName="flex-row items-center h-14 px-2">
+          <ButtonIcon
+            size={ButtonIconSize.Md}
+            iconName={IconName.ArrowLeft}
+            onPress={handleBackPress}
+            testID="back-button"
+          />
+          <Box
+            twClassName="absolute inset-0 items-center justify-center"
+            pointerEvents="none"
+          >
+            <Text variant={TextVariant.HeadingSm}>
+              {strings('wallet.tokens')}
+            </Text>
+          </Box>
+        </Box>
         <Tokens isFullView />
       </SafeAreaView>
     </>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

  - Fix NftDetails screen having extra padding around the entire screen due to padding: 16 on the SafeAreaView wrapper, and
  reduce excess spacing between the header, image, and title
  - Fix NftFullView header using BottomSheetHeader (a modal-only component) — replace with a standard header row using
  absolute-positioned title and correct safe area handling
  - Fix TokensFullView and DeFiFullView headers using deprecated local HeaderBase + ButtonIcon — align with DS components and
  correct safe area handling
  - Fix header title shifting left mid-animation on TokensFullView, NftFullView, and DeFiFullView by applying top inset via
  useSafeAreaInsets at the container level and using an absolutely-positioned title, which is immune to HeaderBase's
  onLayout-based centering re-render
  - Fix NFT grid items with no image collapsing to zero height (causing the network badge to overflow) by overriding flex: 1
  from textContainer with flex: 0 so aspectRatio can correctly determine the placeholder size
  - Fix NFT detail screen showing a portrait-shaped placeholder instead of a square when there is no image
  
  

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix NFT/token/DeFi full view headers and NFT grid layout


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3318

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and header refactors with updated unit tests; no auth, data, or payment logic touched.
> 
> **Overview**
> **Tokens**, **NFT**, and **DeFi** full-view screens now share the same header pattern: design-system `ButtonIcon` + centered `Text`, top inset from `useSafeAreaInsets`, and `SafeAreaView` edges that exclude the top so titles stay centered during navigation animations. **NftFullView** drops modal-only `BottomSheetHeader`; **Tokens** and **DeFi** drop legacy `HeaderBase`.
> 
> **NftDetails** loses extra wrapper padding and tightens media section vertical spacing so the header, image, and title sit closer together.
> 
> **CollectibleMedia** applies `noFlex` (`flex: 0`) on token-ID fallbacks so grid cells without images keep square dimensions instead of collapsing and overflowing the chain badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5d782caee00c0583923d7ae4448ac7b3a0ce27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->