### PR TITLE
fix(agentic): harden preflight launch and fixture setup

### DIFF
--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -16,12 +16,60 @@ import type {
   NavigationContainerRef,
   ParamListBase,
 } from '@react-navigation/native';
+import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 
 const mockCreateWallet = jest.fn().mockResolvedValue(undefined);
 const mockCreateAccountGroups = jest.fn().mockResolvedValue([]);
 const mockImportAccount = jest.fn().mockResolvedValue(undefined);
 const mockIsUnlocked = jest.fn(() => true);
 const mockSubmitPassword = jest.fn().mockResolvedValue(undefined);
+const FIXTURE_WALLET_ID = 'entropy:keyring-1' as const;
+
+function mockEvmAccount(id: string, address: string, name: string) {
+  return {
+    id,
+    address,
+    type: 'eip155:eoa' as const,
+    options: {},
+    scopes: ['eip155:1' as const],
+    methods: [],
+    metadata: {
+      name,
+      importTime: 0,
+      keyring: { type: 'HD Key Tree' },
+    },
+  };
+}
+
+function mockEntropyGroup(
+  groupIndex: number,
+  accountIds: [string, ...string[]],
+  name: string,
+): {
+  type: AccountGroupType.MultichainAccount;
+  id: `${typeof FIXTURE_WALLET_ID}/${number}`;
+  accounts: [string, ...string[]];
+  metadata: {
+    name: string;
+    pinned: boolean;
+    hidden: boolean;
+    lastSelected: number;
+    entropy: { groupIndex: number };
+  };
+} {
+  return {
+    type: AccountGroupType.MultichainAccount,
+    id: `${FIXTURE_WALLET_ID}/${groupIndex}` as const,
+    accounts: accountIds,
+    metadata: {
+      name,
+      pinned: false,
+      hidden: false,
+      lastSelected: 0,
+      entropy: { groupIndex },
+    },
+  };
+}
 
 jest.mock('../Engine', () => ({
   context: {
@@ -56,8 +104,8 @@ jest.mock('../Engine', () => ({
       init: jest.fn().mockResolvedValue(undefined),
     },
     KeyringController: {
-      isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
-      submitPassword: (...args: unknown[]) => mockSubmitPassword(...args),
+      isUnlocked: () => mockIsUnlocked(),
+      submitPassword: (password: string) => mockSubmitPassword(password),
       importAccountWithStrategy: (...args: unknown[]) =>
         mockImportAccount(...(args as [string, string[]])),
     },
@@ -229,11 +277,7 @@ function installFiberHook(rootFiber: FiberNode) {
 
 function resetMockAccountState() {
   Engine.context.AccountsController.state.internalAccounts.accounts = {
-    a1: {
-      id: 'a1',
-      address: '0xABC',
-      metadata: { name: 'Account 1' },
-    },
+    a1: mockEvmAccount('a1', '0xABC', 'Account 1'),
   };
   Engine.context.AccountTreeController.state.accountTree = { wallets: {} };
 }
@@ -846,22 +890,23 @@ describe('AgenticService.install', () => {
     it('creates missing fixture HD accounts with a batched account-group range', async () => {
       const mnemonic =
         'test test test test test test test test test test test junk';
+      const group0Id = `${FIXTURE_WALLET_ID}/0` as const;
       Engine.context.AccountsController.state.internalAccounts.accounts = {
-        a1: {
-          id: 'a1',
-          address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-          metadata: { name: 'dev1' },
-        },
+        a1: mockEvmAccount(
+          'a1',
+          '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+          'dev1',
+        ),
       };
       Engine.context.AccountTreeController.state.accountTree = {
         wallets: {
-          wallet1: {
-            metadata: { entropy: { id: 'keyring-1' } },
+          [FIXTURE_WALLET_ID]: {
+            type: AccountWalletType.Entropy,
+            id: FIXTURE_WALLET_ID,
+            status: 'ready',
+            metadata: { name: 'Fixture Wallet', entropy: { id: 'keyring-1' } },
             groups: {
-              group0: {
-                accounts: ['a1'],
-                metadata: { entropy: { groupIndex: 0 } },
-              },
+              [group0Id]: mockEntropyGroup(0, ['a1'], 'dev1'),
             },
           },
         },
@@ -869,29 +914,31 @@ describe('AgenticService.install', () => {
       mockCreateAccountGroups.mockImplementationOnce(async () => {
         Engine.context.AccountsController.state.internalAccounts.accounts = {
           ...Engine.context.AccountsController.state.internalAccounts.accounts,
-          a2: {
-            id: 'a2',
-            address: '0x0000000000000000000000000000000000000002',
-            metadata: { name: 'dev2' },
-          },
-          a3: {
-            id: 'a3',
-            address: '0x0000000000000000000000000000000000000003',
-            metadata: { name: 'dev3' },
-          },
+          a2: mockEvmAccount(
+            'a2',
+            '0x0000000000000000000000000000000000000002',
+            'dev2',
+          ),
+          a3: mockEvmAccount(
+            'a3',
+            '0x0000000000000000000000000000000000000003',
+            'dev3',
+          ),
         };
         const wallet = Engine.context.AccountTreeController.state.accountTree
-          .wallets.wallet1 as {
+          .wallets[FIXTURE_WALLET_ID] as {
           groups: Record<string, unknown>;
         };
-        wallet.groups.group1 = {
-          accounts: ['a2'],
-          metadata: { entropy: { groupIndex: 1 } },
-        };
-        wallet.groups.group2 = {
-          accounts: ['a3'],
-          metadata: { entropy: { groupIndex: 2 } },
-        };
+        wallet.groups[`${FIXTURE_WALLET_ID}/1`] = mockEntropyGroup(
+          1,
+          ['a2'],
+          'dev2',
+        );
+        wallet.groups[`${FIXTURE_WALLET_ID}/2`] = mockEntropyGroup(
+          2,
+          ['a3'],
+          'dev3',
+        );
         return [];
       });
 
@@ -915,7 +962,7 @@ describe('AgenticService.install', () => {
       });
       expect(
         Engine.context.AccountTreeController.setAccountGroupName,
-      ).toHaveBeenCalledWith('group2', 'dev3');
+      ).toHaveBeenCalledWith(`${FIXTURE_WALLET_ID}/2`, 'dev3');
     });
 
     it('opts out of metametrics when specified', async () => {

--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -18,6 +18,7 @@ import type {
 } from '@react-navigation/native';
 
 const mockCreateWallet = jest.fn().mockResolvedValue(undefined);
+const mockCreateAccountGroups = jest.fn().mockResolvedValue([]);
 const mockImportAccount = jest.fn().mockResolvedValue(undefined);
 const mockIsUnlocked = jest.fn(() => true);
 const mockSubmitPassword = jest.fn().mockResolvedValue(undefined);
@@ -50,6 +51,8 @@ jest.mock('../Engine', () => ({
     MultichainAccountService: {
       createMultichainAccountWallet: (...args: unknown[]) =>
         mockCreateWallet(...args),
+      createMultichainAccountGroups: (...args: unknown[]) =>
+        mockCreateAccountGroups(...args),
       init: jest.fn().mockResolvedValue(undefined),
     },
     KeyringController: {
@@ -222,6 +225,17 @@ function installFiberHook(rootFiber: FiberNode) {
     renderers: new Map([[1, {}]]),
     getFiberRoots: () => new Set([{ current: rootFiber }]),
   };
+}
+
+function resetMockAccountState() {
+  Engine.context.AccountsController.state.internalAccounts.accounts = {
+    a1: {
+      id: 'a1',
+      address: '0xABC',
+      metadata: { name: 'Account 1' },
+    },
+  };
+  Engine.context.AccountTreeController.state.accountTree = { wallets: {} };
 }
 
 // ─── Fiber tree helper tests ────────────────────────────────────────────────
@@ -770,11 +784,17 @@ describe('AgenticService.install', () => {
   describe('setupWallet', () => {
     beforeEach(() => {
       mockCreateWallet.mockClear();
+      mockCreateAccountGroups.mockReset();
+      mockCreateAccountGroups.mockResolvedValue([]);
       mockImportAccount.mockClear();
       mockDispatch.mockClear();
       mockIsUnlocked.mockReset();
       mockIsUnlocked.mockReturnValue(true);
       mockSubmitPassword.mockClear();
+      (
+        Engine.context.AccountTreeController.setAccountGroupName as jest.Mock
+      ).mockClear();
+      resetMockAccountState();
     });
 
     it('dispatches all onboarding flags', async () => {
@@ -821,6 +841,81 @@ describe('AgenticService.install', () => {
       });
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'SET_EXISTING_USER' });
       expect(mockDispatch).toHaveBeenCalledWith({ type: 'LOG_IN' });
+    });
+
+    it('creates missing fixture HD accounts with a batched account-group range', async () => {
+      const mnemonic =
+        'test test test test test test test test test test test junk';
+      Engine.context.AccountsController.state.internalAccounts.accounts = {
+        a1: {
+          id: 'a1',
+          address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+          metadata: { name: 'dev1' },
+        },
+      };
+      Engine.context.AccountTreeController.state.accountTree = {
+        wallets: {
+          wallet1: {
+            metadata: { entropy: { id: 'keyring-1' } },
+            groups: {
+              group0: {
+                accounts: ['a1'],
+                metadata: { entropy: { groupIndex: 0 } },
+              },
+            },
+          },
+        },
+      };
+      mockCreateAccountGroups.mockImplementationOnce(async () => {
+        Engine.context.AccountsController.state.internalAccounts.accounts = {
+          ...Engine.context.AccountsController.state.internalAccounts.accounts,
+          a2: {
+            id: 'a2',
+            address: '0x0000000000000000000000000000000000000002',
+            metadata: { name: 'dev2' },
+          },
+          a3: {
+            id: 'a3',
+            address: '0x0000000000000000000000000000000000000003',
+            metadata: { name: 'dev3' },
+          },
+        };
+        const wallet = Engine.context.AccountTreeController.state.accountTree
+          .wallets.wallet1 as {
+          groups: Record<string, unknown>;
+        };
+        wallet.groups.group1 = {
+          accounts: ['a2'],
+          metadata: { entropy: { groupIndex: 1 } },
+        };
+        wallet.groups.group2 = {
+          accounts: ['a3'],
+          metadata: { entropy: { groupIndex: 2 } },
+        };
+        return [];
+      });
+
+      const result = await bridge().setupWallet({
+        password: 'test123',
+        accounts: [
+          {
+            type: 'mnemonic',
+            value: mnemonic,
+            count: 3,
+            names: ['dev1', 'dev2', 'dev3'],
+          },
+        ],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockCreateAccountGroups).toHaveBeenCalledWith({
+        fromGroupIndex: 1,
+        toGroupIndex: 2,
+        entropySource: 'keyring-1',
+      });
+      expect(
+        Engine.context.AccountTreeController.setAccountGroupName,
+      ).toHaveBeenCalledWith('group2', 'dev3');
     });
 
     it('opts out of metametrics when specified', async () => {

--- a/app/core/AgenticService/AgenticService.test.ts
+++ b/app/core/AgenticService/AgenticService.test.ts
@@ -19,6 +19,8 @@ import type {
 
 const mockCreateWallet = jest.fn().mockResolvedValue(undefined);
 const mockImportAccount = jest.fn().mockResolvedValue(undefined);
+const mockIsUnlocked = jest.fn(() => true);
+const mockSubmitPassword = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../Engine', () => ({
   context: {
@@ -51,6 +53,8 @@ jest.mock('../Engine', () => ({
       init: jest.fn().mockResolvedValue(undefined),
     },
     KeyringController: {
+      isUnlocked: (...args: unknown[]) => mockIsUnlocked(...args),
+      submitPassword: (...args: unknown[]) => mockSubmitPassword(...args),
       importAccountWithStrategy: (...args: unknown[]) =>
         mockImportAccount(...(args as [string, string[]])),
     },
@@ -768,6 +772,9 @@ describe('AgenticService.install', () => {
       mockCreateWallet.mockClear();
       mockImportAccount.mockClear();
       mockDispatch.mockClear();
+      mockIsUnlocked.mockReset();
+      mockIsUnlocked.mockReturnValue(true);
+      mockSubmitPassword.mockClear();
     });
 
     it('dispatches all onboarding flags', async () => {
@@ -790,6 +797,30 @@ describe('AgenticService.install', () => {
       });
       expect(result.ok).toBe(false);
       expect(result.error).toBe('boom');
+    });
+
+    it('recovers an existing fixture vault when auth leaves the keyring locked', async () => {
+      mockIsUnlocked
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false)
+        .mockReturnValue(true);
+
+      const result = await bridge().applyWalletFixture({
+        password: 'test123',
+        accounts: [],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockSubmitPassword).toHaveBeenCalledWith('test123');
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'PASSWORD_SET' });
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SEED_PHRASE_BACKED_UP',
+      });
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_COMPLETED_ONBOARDING',
+      });
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'SET_EXISTING_USER' });
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'LOG_IN' });
     });
 
     it('opts out of metametrics when specified', async () => {

--- a/app/core/AgenticService/AgenticService.ts
+++ b/app/core/AgenticService/AgenticService.ts
@@ -224,6 +224,95 @@ interface AgenticBridge {
 
 type WalletFixture = Parameters<AgenticBridge['setupWallet']>[0];
 
+interface FixtureKeyringController {
+  isUnlocked: () => boolean;
+  submitPassword: (password: string) => Promise<void>;
+}
+
+function logFixtureStep(step: string, detail?: Record<string, unknown>) {
+  DevLogger.log(`[AgenticService] fixture ${step}`, detail);
+}
+
+async function withFixtureTimeout<T>(
+  label: string,
+  work: Promise<T>,
+  timeoutMs = 30_000,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Fixture step timed out: ${label}`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForFixtureCondition(
+  label: string,
+  condition: () => boolean,
+  timeoutMs = 90_000,
+  intervalMs = 500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Fixture step timed out: ${label}`);
+}
+
+async function createFixtureHdAccount(
+  label: string,
+  createAccount: () => Promise<unknown>,
+  accountExists: () => boolean,
+): Promise<void> {
+  const createResult = createAccount().then(
+    () => ({ ok: true as const }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+  const observedResult = waitForFixtureCondition(label, accountExists).then(
+    () => ({ observed: true as const }),
+    (error: unknown) => ({ observed: false as const, error }),
+  );
+
+  const firstResult = await Promise.race([createResult, observedResult]);
+  if ('ok' in firstResult) {
+    if (!firstResult.ok) {
+      throw firstResult.error;
+    }
+    await waitForFixtureCondition(label, accountExists, 30_000);
+    return;
+  }
+
+  if (!firstResult.observed) {
+    throw firstResult.error;
+  }
+
+  void createResult.then((result) => {
+    if (!result.ok) {
+      Logger.log(
+        `[AgenticService] Fixture HD account promise failed after account appeared: ${String(
+          (result.error as Error).message || result.error,
+        )}`,
+      );
+    }
+  });
+}
+
 declare global {
   // eslint-disable-next-line no-var
   var __AGENTIC__: AgenticBridge | undefined;
@@ -392,6 +481,39 @@ async function initializeFixtureAccountTree(
   }
 }
 
+async function unlockFixtureVault(
+  fixture: WalletFixture,
+  keyringController: FixtureKeyringController,
+) {
+  if (keyringController.isUnlocked()) {
+    return;
+  }
+
+  logFixtureStep('unlock-via-authentication');
+  await Authentication.unlockWallet({ password: fixture.password });
+  if (keyringController.isUnlocked()) {
+    return;
+  }
+
+  // A previous interrupted fixture setup can leave a vault present while Redux
+  // still marks the user as new. Authentication.unlockWallet then navigates to
+  // onboarding without submitting the password. Recover that dev-only partial
+  // state before materializing accounts.
+  logFixtureStep('unlock-via-keyring-fallback');
+  await keyringController.submitPassword(fixture.password);
+  if (!keyringController.isUnlocked()) {
+    throw new Error('Fixture vault remained locked after password submit');
+  }
+
+  const store = ReduxService.store;
+  store.dispatch(passwordSet());
+  store.dispatch(seedphraseBackedUp());
+  store.dispatch(setCompletedOnboarding(true));
+  store.dispatch(setExistingUser(true));
+  store.dispatch(logIn());
+  store.dispatch(setMultichainAccountsIntroModalSeen(true));
+}
+
 function getMnemonicFirstAddress(value: string) {
   return EthersWallet.fromMnemonic(
     value,
@@ -482,6 +604,7 @@ async function ensureFixtureMnemonicAccounts(
 
   let wallet = findWallet();
   if (!wallet) {
+    logFixtureStep('import-mnemonic', { mnemonicIndex });
     await importNewSecretRecoveryPhrase(mnemonicAccount.value, {
       shouldSelectAccount: false,
     });
@@ -501,18 +624,32 @@ async function ensureFixtureMnemonicAccounts(
     );
   }
   const { MultichainAccountService } = Engine.context;
-  for (
-    let accountIndex = wallet.accounts.length;
-    accountIndex < count;
-    accountIndex += 1
-  ) {
-    await MultichainAccountService.createNextMultichainAccountGroup({
-      entropySource: wallet.keyringId as string,
+  if (wallet.accounts.length < count) {
+    const fromGroupIndex = wallet.accounts.length;
+    const toGroupIndex = count - 1;
+    const entropySource = wallet.keyringId as string;
+    logFixtureStep('create-hd-accounts', {
+      mnemonicIndex,
+      fromGroupIndex,
+      toGroupIndex,
+      count,
     });
+    await createFixtureHdAccount(
+      `create HD accounts ${fromGroupIndex + 1}-${count} for mnemonic ${
+        mnemonicIndex + 1
+      }`,
+      () =>
+        MultichainAccountService.createMultichainAccountGroups({
+          fromGroupIndex,
+          toGroupIndex,
+          entropySource,
+        }),
+      () => (findWallet()?.accounts.length ?? 0) >= count,
+    );
     wallet = findWallet();
     if (!wallet) {
       throw new Error(
-        `No HD wallet found after adding fixture account ${accountIndex + 1}`,
+        `No HD wallet found after adding fixture accounts ${fromGroupIndex + 1}-${count}`,
       );
     }
   }
@@ -617,9 +754,13 @@ async function materializeFixtureAccounts(
     ).find((evmAccount) => evmAccount.address.toLowerCase() === address);
 
     if (!imported) {
-      await KeyringController.importAccountWithStrategy(
-        AccountImportStrategy.privateKey,
-        [`0x${normalizePrivateKey(account.value)}`],
+      logFixtureStep('import-private-key', { address });
+      await withFixtureTimeout(
+        `import private key ${address}`,
+        KeyringController.importAccountWithStrategy(
+          AccountImportStrategy.privateKey,
+          [`0x${normalizePrivateKey(account.value)}`],
+        ),
       );
       imported = findEvmAccounts(
         AccountsController.state.internalAccounts.accounts,
@@ -1248,6 +1389,7 @@ const AgenticService = {
       applyWalletFixture: async (fixture) => {
         try {
           const {
+            MultichainAccountService,
             KeyringController,
             AccountsController,
             AccountTreeController,
@@ -1260,9 +1402,7 @@ const AgenticService = {
           // post-login) rather than a bare KeyringController.submitPassword, so
           // multichain services and Redux/auth state are consistent before we
           // mutate accounts.
-          if (!KeyringController.isUnlocked()) {
-            await Authentication.unlockWallet({ password: fixture.password });
-          }
+          await unlockFixtureVault(fixture, KeyringController);
           // Existing replay vaults can have the same historical multichain
           // account-tree init gap as fresh legacy setup. Only the known legacy
           // init errors are tolerated by this option; unexpected errors still
@@ -1271,6 +1411,20 @@ const AgenticService = {
             allowLegacyAccountTreeInitFailure: true,
           };
           await initializeFixtureAccountTree(legacyAccountTreeInitOptions);
+          try {
+            await withFixtureTimeout(
+              'initialize multichain account service',
+              MultichainAccountService.init(),
+              60_000,
+            );
+          } catch (error) {
+            if (!isExpectedLegacyAccountTreeInitError(error)) {
+              throw error;
+            }
+            Logger.log(
+              '[AgenticService] Skipping multichain account service initialization for historical replay fixture apply',
+            );
+          }
           await materializeFixtureAccounts(
             fixture,
             {
@@ -1315,11 +1469,16 @@ const AgenticService = {
           if (mnemonicAccount) {
             const mnemonic = mnemonicPhraseToBytes(mnemonicAccount.value);
             try {
-              await MultichainAccountService.createMultichainAccountWallet({
-                type: 'restore',
-                password: fixture.password,
-                mnemonic,
-              });
+              logFixtureStep('create-wallet-restore');
+              await withFixtureTimeout(
+                'create multichain wallet from fixture mnemonic',
+                MultichainAccountService.createMultichainAccountWallet({
+                  type: 'restore',
+                  password: fixture.password,
+                  mnemonic,
+                }),
+                60_000,
+              );
             } catch (error) {
               if (!isExpectedLegacyAccountTreeInitError(error)) {
                 throw error;
@@ -1335,10 +1494,15 @@ const AgenticService = {
             }
           } else {
             try {
-              await MultichainAccountService.createMultichainAccountWallet({
-                type: 'create',
-                password: fixture.password,
-              });
+              logFixtureStep('create-wallet-empty');
+              await withFixtureTimeout(
+                'create multichain wallet',
+                MultichainAccountService.createMultichainAccountWallet({
+                  type: 'create',
+                  password: fixture.password,
+                }),
+                60_000,
+              );
             } catch (error) {
               if (!isExpectedLegacyAccountTreeInitError(error)) {
                 throw error;
@@ -1488,8 +1652,11 @@ const AgenticService = {
     try {
       (globalThis as { store?: unknown }).store = ReduxService.store;
       (globalThis as { persistor?: unknown }).persistor = persistor;
-    } catch {
-      // ReduxService.store may not be initialized yet; skip.
+    } catch (error) {
+      Logger.log(
+        String((error as Error).message || error),
+        'AgenticService.install.exposeReduxGlobals',
+      );
     }
     (globalThis as { Engine?: unknown }).Engine = Engine;
   },

--- a/app/core/AgenticService/AgenticService.ts
+++ b/app/core/AgenticService/AgenticService.ts
@@ -280,37 +280,8 @@ async function createFixtureHdAccount(
   createAccount: () => Promise<unknown>,
   accountExists: () => boolean,
 ): Promise<void> {
-  const createResult = createAccount().then(
-    () => ({ ok: true as const }),
-    (error: unknown) => ({ ok: false as const, error }),
-  );
-  const observedResult = waitForFixtureCondition(label, accountExists).then(
-    () => ({ observed: true as const }),
-    (error: unknown) => ({ observed: false as const, error }),
-  );
-
-  const firstResult = await Promise.race([createResult, observedResult]);
-  if ('ok' in firstResult) {
-    if (!firstResult.ok) {
-      throw firstResult.error;
-    }
-    await waitForFixtureCondition(label, accountExists, 30_000);
-    return;
-  }
-
-  if (!firstResult.observed) {
-    throw firstResult.error;
-  }
-
-  void createResult.then((result) => {
-    if (!result.ok) {
-      Logger.log(
-        `[AgenticService] Fixture HD account promise failed after account appeared: ${String(
-          (result.error as Error).message || result.error,
-        )}`,
-      );
-    }
-  });
+  await withFixtureTimeout(label, createAccount(), 90_000);
+  await waitForFixtureCondition(label, accountExists, 30_000);
 }
 
 declare global {

--- a/package.json
+++ b/package.json
@@ -160,10 +160,10 @@
     "a:status": "scripts/perps/agentic/app-state.sh status",
     "a:reload": "scripts/perps/agentic/reload-metro.sh",
     "a:navigate": "scripts/perps/agentic/app-navigate.sh",
-    "a:ios": "yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --platform ios --mode auto --wallet-setup",
-    "a:android": "yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --platform android --mode auto --wallet-setup",
-    "a:setup:ios": "yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --platform ios --mode clean --wallet-setup",
-    "a:setup:android": "yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --platform android --mode clean --wallet-setup"
+    "a:ios": "yarn ts-node --transpile-only --project scripts/perps/agentic/preflight/tsconfig.json scripts/perps/agentic/preflight/preflight.ts --platform ios --mode auto --wallet-setup",
+    "a:android": "yarn ts-node --transpile-only --project scripts/perps/agentic/preflight/tsconfig.json scripts/perps/agentic/preflight/preflight.ts --platform android --mode auto --wallet-setup",
+    "a:setup:ios": "yarn ts-node --transpile-only --project scripts/perps/agentic/preflight/tsconfig.json scripts/perps/agentic/preflight/preflight.ts --platform ios --mode clean --wallet-setup",
+    "a:setup:android": "yarn ts-node --transpile-only --project scripts/perps/agentic/preflight/tsconfig.json scripts/perps/agentic/preflight/preflight.ts --platform android --mode clean --wallet-setup"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/perps/agentic/lib/test-build-cache.sh
+++ b/scripts/perps/agentic/lib/test-build-cache.sh
@@ -42,6 +42,11 @@ FAILED=0
 pass() { printf "  \033[32mPASS\033[0m %s\n" "$1"; }
 fail() { printf "  \033[31mFAIL\033[0m %s\n" "$1"; FAILED=1; }
 hdr()  { printf "\n\033[1m== %s ==\033[0m\n" "$1"; }
+PREFLIGHT_TS=(
+  yarn ts-node --transpile-only
+  --project scripts/perps/agentic/preflight/tsconfig.json
+  scripts/perps/agentic/preflight/preflight.ts
+)
 
 # Portable bounded capture: runs the command and captures combined stdout+stderr,
 # killing it if it exceeds $1 seconds. Avoids the GNU `timeout` binary which is
@@ -165,24 +170,24 @@ done
 
 # ─── 10. Preflight --mode plumbing ──────────────────────────────────
 hdr "preflight --mode arg parsing"
-out=$(yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode invalid --check-only 2>&1 || true)
+out=$("${PREFLIGHT_TS[@]}" --mode invalid --check-only 2>&1 || true)
 echo "$out" | grep -q "unknown --mode 'invalid'" && pass "unknown --mode rejected" || fail "unknown mode not rejected: $out"
 
-out=$(_capture_for 10 yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode fast --check-only 2>&1 | head -20 || true)
+out=$(_capture_for 10 "${PREFLIGHT_TS[@]}" --mode fast --check-only 2>&1 | head -20 || true)
 echo "$out" | grep -qE "Mode:.*fast.*no build" && pass "fast mode header rendered" || fail "fast mode header missing"
 
-out=$(_capture_for 10 yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode auto --check-only 2>&1 | head -20 || true)
+out=$(_capture_for 10 "${PREFLIGHT_TS[@]}" --mode auto --check-only 2>&1 | head -20 || true)
 echo "$out" | grep -qE "Mode:.*auto.*fingerprint-gated" && pass "auto mode header rendered" || fail "auto mode header missing"
 
-out=$(_capture_for 10 yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode rebuild-native --check-only 2>&1 | head -20 || true)
+out=$(_capture_for 10 "${PREFLIGHT_TS[@]}" --mode rebuild-native --check-only 2>&1 | head -20 || true)
 echo "$out" | grep -qE "Mode:.*rebuild-native" && pass "rebuild-native mode header rendered" || fail "rebuild-native mode header missing"
 
-out=$(_capture_for 10 yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode clean --check-only 2>&1 | head -20 || true)
-echo "$out" | grep -qE "Mode:.*clean.*yarn setup" && pass "clean mode header rendered" || fail "clean mode header missing"
+out=$(_capture_for 10 "${PREFLIGHT_TS[@]}" --mode clean --check-only 2>&1 | head -20 || true)
+echo "$out" | grep -q -- "--check-only conflicts with --clean / --mode clean" && pass "clean mode check-only conflict rejected" || fail "clean mode conflict missing"
 
 # Legacy --clean still maps to clean mode (back-compat)
-out=$(_capture_for 10 yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --clean --check-only 2>&1 | head -20 || true)
-echo "$out" | grep -qE "Mode:.*clean.*yarn setup" && pass "legacy --clean still maps to clean" || fail "legacy --clean broken"
+out=$(_capture_for 10 "${PREFLIGHT_TS[@]}" --clean --check-only 2>&1 | head -20 || true)
+echo "$out" | grep -q -- "--check-only conflicts with --clean / --mode clean" && pass "legacy --clean check-only conflict rejected" || fail "legacy --clean conflict missing"
 
 # ─── 10b. Agentic fp respects the safe/unsafe ignorePath boundary ──
 # compute-cache-fp.js ignores per-worktree build outputs but MUST keep

--- a/scripts/perps/agentic/lib/test-build-cache.sh
+++ b/scripts/perps/agentic/lib/test-build-cache.sh
@@ -301,7 +301,7 @@ trap '
   restore_fp
 ' EXIT
 
-out=$(_capture_for 20 yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode fast --platform ios --no-launch 2>&1 || true)
+out=$(_capture_for 20 "${PREFLIGHT_TS[@]}" --mode fast --platform ios --no-launch 2>&1 || true)
 restore_fp
 echo "$out" | grep -q "Mode 'fast': could not compute fingerprint" \
   && pass "--mode fast fails loud when fingerprint cannot be computed" \

--- a/scripts/perps/agentic/lib/test-preflight-cache-e2e.sh
+++ b/scripts/perps/agentic/lib/test-preflight-cache-e2e.sh
@@ -68,6 +68,11 @@ echo "Current fingerprint: ${FP:0:16}..."
 FAILED=0
 pass() { printf "  \033[32mPASS\033[0m %s\n" "$1"; }
 fail() { printf "  \033[31mFAIL\033[0m %s\n" "$1"; FAILED=1; }
+PREFLIGHT_TS=(
+  yarn ts-node --transpile-only
+  --project scripts/perps/agentic/preflight/tsconfig.json
+  scripts/perps/agentic/preflight/preflight.ts
+)
 
 printf "\n\033[1m== Path 1: installed.json matches current fingerprint ==\033[0m\n"
 mkdir -p .agent/build-cache/ios
@@ -78,7 +83,7 @@ set +e
 # Run preflight in the background; watchdog below kills it after 45s OR as
 # soon as the cache-decision marker appears. Avoids the GNU `timeout` binary
 # which is not in base macOS.
-yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts --mode auto --platform ios --no-launch > "$LOG" 2>&1 &
+"${PREFLIGHT_TS[@]}" --mode auto --platform ios --no-launch > "$LOG" 2>&1 &
 PID=$!
 ( sleep 45 && kill "$PID" 2>/dev/null ) &
 WATCHDOG=$!
@@ -115,9 +120,53 @@ else
 fi
 rm -f "$LOG"
 
+printf "\n\033[1m== Path 2: wallet setup cache hit wipes warm app data ==\033[0m\n"
+APP_BUNDLE=$(xcrun simctl get_app_container "$BOOTED_UDID" io.metamask.MetaMask app 2>/dev/null || true)
+if [ -z "$APP_BUNDLE" ] || [ ! -d "$APP_BUNDLE" ]; then
+  fail "could not locate installed MetaMask .app bundle for cache artifact"
+else
+  rm -rf .agent/build-cache "$MM_BUILD_CACHE_DIR"
+  mkdir -p .agent/build-cache/ios "$MM_BUILD_CACHE_DIR"
+  bc_store_artifact ios "$FP" "$APP_BUNDLE"
+  bc_record_install ios "$FP" "$BOOTED_UDID"
+  FIXTURE="/tmp/mm-bc-e2e-fixture-$$.json"
+  cat > "$FIXTURE" <<'JSON'
+{"password":"test123","accounts":[]}
+JSON
+  LOG="/tmp/mm-bc-e2e-wallet-log-$$"
+  set +e
+  "${PREFLIGHT_TS[@]}" --mode auto --platform ios --wallet-setup --wallet-fixture "$FIXTURE" --no-launch > "$LOG" 2>&1 &
+  PID=$!
+  ( sleep 60 && kill "$PID" 2>/dev/null ) &
+  WATCHDOG=$!
+  for _ in $(seq 1 60); do
+    if grep -q "Wiping app data (uninstall + reinstall from cache)" "$LOG" 2>/dev/null; then break; fi
+    if ! kill -0 "$PID" 2>/dev/null; then break; fi
+    sleep 1
+  done
+  kill "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+  kill "$WATCHDOG" 2>/dev/null || true
+  wait "$WATCHDOG" 2>/dev/null || true
+  set -e
+
+  if grep -q "Wiping app data (uninstall + reinstall from cache)" "$LOG"; then
+    pass "wallet-setup cache hit wiped app data via cached reinstall"
+  else
+    fail "expected wallet-setup cache reinstall marker in log:"
+    tail -50 "$LOG" | sed 's/^/      /'
+  fi
+  if grep -qE "Cache: installed app matches fingerprint .* no native action needed" "$LOG"; then
+    fail "wallet-setup cache hit incorrectly returned early without wiping"
+  else
+    pass "wallet-setup did not take the no-op cache-hit branch"
+  fi
+  rm -f "$LOG" "$FIXTURE"
+fi
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
-  printf "\033[1;32m=== E2E PATH 1 TEST PASSED ===\033[0m\n"
+  printf "\033[1;32m=== E2E CACHE TEST PASSED ===\033[0m\n"
   exit 0
 else
   printf "\033[1;31m=== E2E TEST FAILED ===\033[0m\n"

--- a/scripts/perps/agentic/preflight.sh
+++ b/scripts/perps/agentic/preflight.sh
@@ -11,4 +11,4 @@
 set -euo pipefail
 cd "$(dirname "$0")/../../.."
 echo "[preflight.sh] compatibility shim → preflight.ts (this wrapper will be removed)" >&2
-exec yarn ts-node --transpile-only scripts/perps/agentic/preflight/preflight.ts "$@"
+exec yarn ts-node --transpile-only --project scripts/perps/agentic/preflight/tsconfig.json scripts/perps/agentic/preflight/preflight.ts "$@"

--- a/scripts/perps/agentic/preflight/modules/android.ts
+++ b/scripts/perps/agentic/preflight/modules/android.ts
@@ -92,6 +92,34 @@ function adbInstall(ctx: Ctx, apk: string): boolean {
   }
 }
 
+function uninstallApp(ctx: Ctx): void {
+  try {
+    adb(ctx, ['uninstall', ctx.packageId], { stdio: 'ignore' });
+  } catch {
+    // not installed
+  }
+}
+
+function installCachedArtifact(
+  ctx: Ctx,
+  logger: Logger,
+  cache: BuildCache,
+  fp: string,
+  deviceId: string,
+): boolean {
+  const art = cache.artifactPath('android', fp);
+  if (ctx.flags.walletSetup) {
+    logger.plain('  Wiping app data (uninstall + reinstall from cache)...');
+    uninstallApp(ctx);
+  }
+  if (adbInstall(ctx, art)) {
+    cache.recordInstall('android', fp, deviceId);
+    logger.ok(`Installed from cache: ${art}`);
+    return true;
+  }
+  return false;
+}
+
 async function buildApk(ctx: Ctx, logger: Logger): Promise<string> {
   logger.plain();
   logger.plain('  Building + installing app');
@@ -145,8 +173,18 @@ export async function runAndroid(ctx: Ctx, logger: Logger): Promise<void> {
       if (fp) {
         const installedFp = cache.installedFp('android');
         if (installed && installedFp === fp && cache.installedTarget('android') === deviceId && !ctx.doRebuild) {
-          logger.ok(`Cache: installed app matches fingerprint ${fp.slice(0, 12)} on ${deviceId} — no native action needed`);
-          return;
+          if (!ctx.flags.walletSetup) {
+            logger.ok(`Cache: installed app matches fingerprint ${fp.slice(0, 12)} on ${deviceId} — no native action needed`);
+            return;
+          }
+          if (ctx.checkOnly) {
+            logger.fail('Installed app matches fingerprint, but --wallet-setup requires a data wipe and --check-only forbids reinstall');
+          }
+          if (cache.hasArtifact('android', fp) && installCachedArtifact(ctx, logger, cache, fp, deviceId)) {
+            return;
+          }
+          logger.warn('Installed app matches fingerprint, but wallet setup requires a data wipe and no cached artifact is available — rebuilding');
+          installed = false;
         }
         lock = await cache.acquireLock('android', fp);
         if (lock) {
@@ -155,11 +193,8 @@ export async function runAndroid(ctx: Ctx, logger: Logger): Promise<void> {
               logger.fail(`App not at fingerprint ${fp.slice(0, 12)} — cache hit available, but --check-only forbids install`);
             }
             logger.plain(`  Cache hit: fp=${fp.slice(0, 12)} — installing from shared cache`);
-            const art = cache.artifactPath('android', fp);
-            if (adbInstall(ctx, art)) {
-              cache.recordInstall('android', fp, deviceId);
+            if (installCachedArtifact(ctx, logger, cache, fp, deviceId)) {
               installed = true;
-              logger.ok(`Installed from cache: ${art}`);
             } else if (ctx.mode === 'fast') {
               logger.fail(`Mode 'fast': cached artifact install failed for fp ${fp.slice(0, 12)}`);
             } else {
@@ -194,11 +229,7 @@ export async function runAndroid(ctx: Ctx, logger: Logger): Promise<void> {
 
     if ((ctx.doClean || ctx.flags.walletSetup) && appInstalled(ctx)) {
       logger.plain('  Uninstalling previous app...');
-      try {
-        adb(ctx, ['uninstall', ctx.packageId], { stdio: 'ignore' });
-      } catch {
-        // not installed
-      }
+      uninstallApp(ctx);
     }
 
     const apk = await buildApk(ctx, logger);

--- a/scripts/perps/agentic/preflight/modules/ios.ts
+++ b/scripts/perps/agentic/preflight/modules/ios.ts
@@ -98,12 +98,13 @@ function uninstallApp(ctx: Ctx): void {
   }
 }
 
-function installCachedArtifact(ctx: Ctx, logger: Logger, cache: BuildCache, fp: string): boolean {
+async function installCachedArtifact(ctx: Ctx, logger: Logger, cache: BuildCache, fp: string): Promise<boolean> {
   const art = cache.artifactPath('ios', fp);
   if (ctx.flags.walletSetup) {
     logger.plain('  Wiping app data (uninstall + reinstall from cache)...');
     uninstallApp(ctx);
   }
+  await ensureSigned(art, logger);
   if (tryInstall(ctx, art)) {
     cache.recordInstall('ios', fp, ctx.simTarget);
     logger.ok(`Installed from cache: ${art}`);
@@ -284,7 +285,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
             logger.ok(`Cache: installed app matches fingerprint ${fp.slice(0, 12)} on ${ctx.simTarget} — no native action needed`);
             return;
           }
-          if (cache.hasArtifact('ios', fp) && installCachedArtifact(ctx, logger, cache, fp)) {
+          if (cache.hasArtifact('ios', fp) && (await installCachedArtifact(ctx, logger, cache, fp))) {
             return;
           }
           logger.warn('Installed app matches fingerprint, but wallet setup requires a data wipe and no cached artifact is available — rebuilding');
@@ -297,7 +298,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
               logger.fail(`App not at fingerprint ${fp.slice(0, 12)} — cache hit available, but --check-only forbids install`);
             }
             logger.plain(`  Cache hit: fp=${fp.slice(0, 12)} — installing from shared cache`);
-            if (installCachedArtifact(ctx, logger, cache, fp)) {
+            if (await installCachedArtifact(ctx, logger, cache, fp)) {
               installed = true;
             } else if (ctx.mode === 'fast') {
               logger.fail(`Mode 'fast': cached artifact install failed for fp ${fp.slice(0, 12)}`);
@@ -354,7 +355,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
           if (cache.hasArtifact('ios', postFp)) {
             logger.plain(`  Cache hit after pod install: fp=${postFp.slice(0, 12)} — installing from shared cache`);
             const art = cache.artifactPath('ios', postFp);
-            if (installCachedArtifact(ctx, logger, cache, postFp) && appInstalled(ctx)) {
+            if ((await installCachedArtifact(ctx, logger, cache, postFp)) && appInstalled(ctx)) {
               // Release the materialized-fp lock before storing the source alias.
               await lock.release();
               lock = null;
@@ -373,7 +374,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
         } else if (ctx.mode === 'fast') {
           logger.fail(`Mode 'fast': could not acquire build-cache lock for post-pod fp ${postFp.slice(0, 12)}`);
         } else {
-          logger.warn(`Could not acquirØe post-pod build-cache lock for fp ${postFp.slice(0, 12)} — proceeding without lock`);
+          logger.warn(`Could not acquire post-pod build-cache lock for fp ${postFp.slice(0, 12)} — proceeding without lock`);
         }
       } else if (ctx.mode === 'fast') {
         logger.fail("Mode 'fast': could not compute post-pod fingerprint");

--- a/scripts/perps/agentic/preflight/modules/ios.ts
+++ b/scripts/perps/agentic/preflight/modules/ios.ts
@@ -14,6 +14,35 @@ import type { Ctx } from './types';
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 const now = (): number => Math.floor(Date.now() / 1000);
 
+function isSigned(app: string): boolean {
+  try {
+    execFileSync('codesign', ['--verify', '--no-strict', app], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// `expo run:ios` logs "Build Succeeded" and we grab the .app from DerivedData, but
+// xcodebuild's CodeSign phase can still be in flight — installing in that window
+// yields an UNSIGNED bundle. Recent simulator runtimes (iOS 26+) refuse to launch
+// unsigned apps ("denied by service delegate (SBMainWorkspace)" with no crash
+// report). Wait briefly for the build's signature to land, then ad-hoc sign as a
+// fallback so the install is always launchable.
+async function ensureSigned(app: string, logger: Logger): Promise<void> {
+  if (isSigned(app)) return;
+  for (let i = 0; i < 30; i += 1) {
+    await sleep(1000);
+    if (isSigned(app)) return;
+  }
+  try {
+    execFileSync('codesign', ['--force', '--deep', '--sign', '-', app], { stdio: 'ignore' });
+    logger.warn(`Build was unsigned at install time — ad-hoc signed ${app}`);
+  } catch {
+    logger.warn(`Could not ad-hoc sign ${app} — simulator launch may fail`);
+  }
+}
+
 function simBooted(label: string): boolean {
   try {
     const out = execFileSync('xcrun', ['simctl', 'list', 'devices'], { encoding: 'utf8' });
@@ -331,6 +360,8 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
         // not installed
       }
     }
+    // Guard the codesign race: never install a .app before its signature lands.
+    await ensureSigned(app, logger);
     logger.plain('  Installing app on simulator...');
     if (!tryInstall(ctx, app)) {
       logger.fail(`simctl install failed for ${app}`);

--- a/scripts/perps/agentic/preflight/modules/ios.ts
+++ b/scripts/perps/agentic/preflight/modules/ios.ts
@@ -285,6 +285,9 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
             logger.ok(`Cache: installed app matches fingerprint ${fp.slice(0, 12)} on ${ctx.simTarget} — no native action needed`);
             return;
           }
+          if (ctx.checkOnly) {
+            logger.fail('Installed app matches fingerprint, but --wallet-setup requires a data wipe and --check-only forbids reinstall');
+          }
           if (cache.hasArtifact('ios', fp) && (await installCachedArtifact(ctx, logger, cache, fp))) {
             return;
           }

--- a/scripts/perps/agentic/preflight/modules/ios.ts
+++ b/scripts/perps/agentic/preflight/modules/ios.ts
@@ -8,7 +8,7 @@ import { BuildCache, type CacheLock, reportDrift } from './cache';
 import { podsCleanStale, podsSaveMarker } from './deps';
 import { restoreMainNoise } from './git';
 import { initStageLog, type Logger } from './log';
-import { killTree, metroAlive } from './proc';
+import { holderCmd, isMetroLikeProcess, killTree, listenHolderPid, metroAlive } from './proc';
 import type { Ctx } from './types';
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -88,6 +88,30 @@ function appInstalled(ctx: Ctx): boolean {
   }
 }
 
+function uninstallApp(ctx: Ctx): void {
+  try {
+    execFileSync('xcrun', ['simctl', 'uninstall', ctx.simTarget, ctx.bundleId], {
+      stdio: 'ignore',
+    });
+  } catch {
+    // not installed
+  }
+}
+
+function installCachedArtifact(ctx: Ctx, logger: Logger, cache: BuildCache, fp: string): boolean {
+  const art = cache.artifactPath('ios', fp);
+  if (ctx.flags.walletSetup) {
+    logger.plain('  Wiping app data (uninstall + reinstall from cache)...');
+    uninstallApp(ctx);
+  }
+  if (tryInstall(ctx, art)) {
+    cache.recordInstall('ios', fp, ctx.simTarget);
+    logger.ok(`Installed from cache: ${art}`);
+    return true;
+  }
+  return false;
+}
+
 // Run `pod install` (via bundler), retrying once with --repo-update on failure
 // in non-clean modes.
 async function podInstall(ctx: Ctx, logger: Logger): Promise<void> {
@@ -103,7 +127,6 @@ async function podInstall(ctx: Ctx, logger: Logger): Promise<void> {
   if ((await logger.runWithLiveLog(ctx.podInstallLog, cmd, ctx.root)) === 0) {
     podsSaveMarker(ctx.root);
     logger.ok('pod install complete');
-    restoreMainNoise(ctx.root, ['tsconfig.json'], logger);
     return;
   }
   if (ctx.doClean) {
@@ -116,7 +139,6 @@ async function podInstall(ctx: Ctx, logger: Logger): Promise<void> {
   if ((await logger.runWithLiveLog(ctx.podInstallLog, retry, ctx.root)) === 0) {
     podsSaveMarker(ctx.root);
     logger.ok('pod install complete (after --repo-update retry)');
-    restoreMainNoise(ctx.root, ['tsconfig.json'], logger);
   } else {
     logger.warn(`pod install had issues — see ${ctx.podInstallLog}`);
   }
@@ -227,9 +249,16 @@ async function waitPortReleased(ctx: Ctx, logger: Logger): Promise<void> {
     }
     await sleep(1000);
   }
-  if (held() && !metroAlive(ctx.port)) {
-    logger.fail(`Port ${ctx.port} still held after expo teardown — aborting to avoid CDP misrouting`);
+  const pid = listenHolderPid(ctx.port);
+  if (pid == null || metroAlive(ctx.port)) return;
+
+  const cmd = holderCmd(pid);
+  if (isMetroLikeProcess(cmd)) {
+    logger.warn(`Port ${ctx.port} still held by stale Expo/Metro after expo teardown (PID ${pid}) — start-metro will restart it`);
+    logger.dim(cmd.slice(0, 100));
+    return;
   }
+  logger.fail(`Port ${ctx.port} still held after expo teardown by foreign process (PID ${pid}): ${cmd.slice(0, 80)}`);
 }
 
 export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
@@ -251,8 +280,15 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
       if (fp) {
         const installedFp = cache.installedFp('ios');
         if (installed && installedFp === fp && cache.installedTarget('ios') === ctx.simTarget && !ctx.doRebuild) {
-          logger.ok(`Cache: installed app matches fingerprint ${fp.slice(0, 12)} on ${ctx.simTarget} — no native action needed`);
-          return;
+          if (!ctx.flags.walletSetup) {
+            logger.ok(`Cache: installed app matches fingerprint ${fp.slice(0, 12)} on ${ctx.simTarget} — no native action needed`);
+            return;
+          }
+          if (cache.hasArtifact('ios', fp) && installCachedArtifact(ctx, logger, cache, fp)) {
+            return;
+          }
+          logger.warn('Installed app matches fingerprint, but wallet setup requires a data wipe and no cached artifact is available — rebuilding');
+          installed = false;
         }
         lock = await cache.acquireLock('ios', fp);
         if (lock) {
@@ -261,11 +297,8 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
               logger.fail(`App not at fingerprint ${fp.slice(0, 12)} — cache hit available, but --check-only forbids install`);
             }
             logger.plain(`  Cache hit: fp=${fp.slice(0, 12)} — installing from shared cache`);
-            const art = cache.artifactPath('ios', fp);
-            if (tryInstall(ctx, art)) {
-              cache.recordInstall('ios', fp, ctx.simTarget);
+            if (installCachedArtifact(ctx, logger, cache, fp)) {
               installed = true;
-              logger.ok(`Installed from cache: ${art}`);
             } else if (ctx.mode === 'fast') {
               logger.fail(`Mode 'fast': cached artifact install failed for fp ${fp.slice(0, 12)}`);
             } else {
@@ -321,7 +354,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
           if (cache.hasArtifact('ios', postFp)) {
             logger.plain(`  Cache hit after pod install: fp=${postFp.slice(0, 12)} — installing from shared cache`);
             const art = cache.artifactPath('ios', postFp);
-            if (tryInstall(ctx, art) && appInstalled(ctx)) {
+            if (installCachedArtifact(ctx, logger, cache, postFp) && appInstalled(ctx)) {
               // Release the materialized-fp lock before storing the source alias.
               await lock.release();
               lock = null;
@@ -340,7 +373,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
         } else if (ctx.mode === 'fast') {
           logger.fail(`Mode 'fast': could not acquire build-cache lock for post-pod fp ${postFp.slice(0, 12)}`);
         } else {
-          logger.warn(`Could not acquire post-pod build-cache lock for fp ${postFp.slice(0, 12)} — proceeding without lock`);
+          logger.warn(`Could not acquirØe post-pod build-cache lock for fp ${postFp.slice(0, 12)} — proceeding without lock`);
         }
       } else if (ctx.mode === 'fast') {
         logger.fail("Mode 'fast': could not compute post-pod fingerprint");
@@ -354,11 +387,7 @@ export async function runIos(ctx: Ctx, logger: Logger): Promise<void> {
 
     if (ctx.doClean || ctx.flags.walletSetup) {
       logger.plain('  Wiping app data (uninstall + reinstall)...');
-      try {
-        execFileSync('xcrun', ['simctl', 'uninstall', ctx.simTarget, ctx.bundleId], { stdio: 'ignore' });
-      } catch {
-        // not installed
-      }
+      uninstallApp(ctx);
     }
     // Guard the codesign race: never install a .app before its signature lands.
     await ensureSigned(app, logger);

--- a/scripts/perps/agentic/preflight/modules/ios.ts
+++ b/scripts/perps/agentic/preflight/modules/ios.ts
@@ -6,7 +6,6 @@ import { appendFileSync, existsSync, readFileSync, statSync, writeFileSync } fro
 import { join } from 'path';
 import { BuildCache, type CacheLock, reportDrift } from './cache';
 import { podsCleanStale, podsSaveMarker } from './deps';
-import { restoreMainNoise } from './git';
 import { initStageLog, type Logger } from './log';
 import { holderCmd, isMetroLikeProcess, killTree, listenHolderPid, metroAlive } from './proc';
 import type { Ctx } from './types';

--- a/scripts/perps/agentic/preflight/modules/proc.ts
+++ b/scripts/perps/agentic/preflight/modules/proc.ts
@@ -60,7 +60,7 @@ export async function killTree(root: number): Promise<void> {
   for (const p of pids) signal(p, 'SIGKILL');
 }
 
-function listenHolderPid(port: number): number | null {
+export function listenHolderPid(port: number): number | null {
   try {
     const out = execFileSync(
       'lsof',
@@ -80,16 +80,20 @@ export function metroAlive(port: number, maxMs = 1000): boolean {
   const r = spawnSync(
     'curl',
     ['-sf', '--max-time', String(Math.ceil(maxMs / 1000)), `http://localhost:${port}/status`],
-    { stdio: 'ignore' },
+    { encoding: 'utf8' },
   );
-  return r.status === 0;
+  return (r.stdout ?? '').includes('packager-status:running');
 }
 
-function holderCmd(pid: number): string {
+export function holderCmd(pid: number): string {
   const r = spawnSync('ps', ['-p', String(pid), '-o', 'command='], {
     encoding: 'utf8',
   });
   return (r.stdout ?? '').trim() || 'unknown';
+}
+
+export function isMetroLikeProcess(cmd: string): boolean {
+  return /\b(expo|react-native|metro)\b/i.test(cmd);
 }
 
 // Detect + clean orphaned expo/metro processes on `port`. Reuses a healthy
@@ -109,7 +113,7 @@ export async function sweepPort(
   }
 
   const cmd = holderCmd(pid);
-  if (/expo (run|start)|react-native|metro/.test(cmd)) {
+  if (isMetroLikeProcess(cmd)) {
     if (checkOnly) {
       logger.fail(
         `Port ${port} (${label}) held by stale ${cmd} (PID ${pid}) — run without --check-only to sweep`,

--- a/scripts/perps/agentic/preflight/modules/runtime.ts
+++ b/scripts/perps/agentic/preflight/modules/runtime.ts
@@ -1,8 +1,8 @@
 // Metro start, CDP connect, wallet setup — shells out to start-metro.sh /
 // cdp-bridge.js / setup-wallet.sh; owns the sequencing, Metro health, and CDP wait.
 
-import { execFileSync, spawnSync } from 'child_process';
-import { existsSync } from 'fs';
+import { execFileSync, spawn, spawnSync } from 'child_process';
+import { appendFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { initStageLog, type Logger } from './log';
 import { killTree } from './proc';
@@ -29,10 +29,16 @@ async function metroRespondsWithin(port: number, seconds: number): Promise<boole
   return false;
 }
 
-function runStartMetro(ctx: Ctx, launch: boolean): void {
+function runStartMetro(ctx: Ctx, launch: boolean, logger: Logger): void {
   const args = [join(ctx.scripts, 'start-metro.sh'), '--platform', ctx.plat];
   if (launch) args.push('--launch');
-  spawnSync('bash', args, { cwd: ctx.root, stdio: 'inherit' });
+  const r = spawnSync('bash', args, { cwd: ctx.root, stdio: 'inherit' });
+  if (r.error) {
+    logger.fail(`start-metro.sh failed: ${r.error.message}`);
+  }
+  if (r.status !== 0) {
+    logger.fail(`start-metro.sh failed with exit code ${r.status ?? 'unknown'}`);
+  }
 }
 
 // Kill whatever holds the Metro port so a hung instance can be replaced.
@@ -54,7 +60,7 @@ async function freeMetroPort(port: number): Promise<void> {
 export async function startMetro(ctx: Ctx, logger: Logger): Promise<void> {
   logger.step('Starting Metro', `Bundler on port ${ctx.port} → logs at ${ctx.logFile}`);
   logger.stageLog(ctx.logFile);
-  runStartMetro(ctx, ctx.doLaunch);
+  runStartMetro(ctx, ctx.doLaunch, logger);
   if (await metroRespondsWithin(ctx.port, 10)) {
     logger.ok(`Metro running on port ${ctx.port}`);
     return;
@@ -62,7 +68,7 @@ export async function startMetro(ctx: Ctx, logger: Logger): Promise<void> {
   logger.warn(`Metro on ${ctx.port} is bound but not answering /status — restarting`);
   logger.tail(ctx.logFile, 15);
   await freeMetroPort(ctx.port);
-  runStartMetro(ctx, ctx.doLaunch);
+  runStartMetro(ctx, ctx.doLaunch, logger);
   if (!(await metroRespondsWithin(ctx.port, 15))) {
     logger.tail(ctx.logFile, 25);
     logger.fail(`Metro on ${ctx.port} not responding after restart — see ${ctx.logFile}`);
@@ -119,7 +125,7 @@ export async function connectCdp(ctx: Ctx, logger: Logger): Promise<void> {
       logger.warn('Metro stopped responding while the app loaded its bundle — restarting + relaunching');
       logger.tail(ctx.logFile, 15);
       await freeMetroPort(ctx.port);
-      runStartMetro(ctx, true);
+      runStartMetro(ctx, true, logger);
       metroRestarts += 1;
       start = Date.now();
       retry = 0;
@@ -159,22 +165,51 @@ export async function connectCdp(ctx: Ctx, logger: Logger): Promise<void> {
   await sleep(2000);
 }
 
-export function setupWallet(ctx: Ctx, logger: Logger): void {
+async function runWalletSetup(ctx: Ctx, args: string[]): Promise<number> {
+  const child = spawn('bash', [join(ctx.scripts, 'setup-wallet.sh'), ...args], {
+    cwd: ctx.root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const onData = (buf: Buffer, stream: NodeJS.WriteStream): void => {
+    appendFileSync(ctx.walletLog, buf);
+    stream.write(buf);
+  };
+  child.stdout.on('data', (buf: Buffer) => onData(buf, process.stdout));
+  child.stderr.on('data', (buf: Buffer) => onData(buf, process.stderr));
+
+  return await new Promise<number>((resolve) => {
+    child.on('close', (code) => resolve(code ?? 1));
+    child.on('error', (error) => {
+      const message = `setup-wallet.sh spawn failed: ${error.message}\n`;
+      appendFileSync(ctx.walletLog, message);
+      process.stderr.write(message);
+      resolve(1);
+    });
+  });
+}
+
+export async function setupWallet(ctx: Ctx, logger: Logger): Promise<void> {
   if (ctx.flags.walletSetup) {
     logger.step('Setting up wallet', `Configuring from ${ctx.flags.walletFixture}`);
+    logger.stageLog(ctx.walletLog);
     const fixtureFlag =
       ctx.flags.walletFixture !== '.agent/wallet-fixture.json'
         ? ['--fixture', ctx.flags.walletFixture]
         : [];
     if (existsSync(join(ctx.root, ctx.flags.walletFixture)) || fixtureFlag.length) {
-      const r = spawnSync('bash', [join(ctx.scripts, 'setup-wallet.sh'), ...fixtureFlag], {
-        cwd: ctx.root,
-        stdio: 'inherit',
-      });
-      if (r.status === 0) logger.ok('Wallet configured');
-      else logger.warn('Wallet setup failed');
+      initStageLog(
+        ctx.walletLog,
+        `$ bash ${ctx.scripts}/setup-wallet.sh ${fixtureFlag.join(' ')}`.trim(),
+      );
+      const status = await runWalletSetup(ctx, fixtureFlag);
+      if (status === 0) {
+        logger.ok('Wallet configured');
+      } else {
+        logger.tail(ctx.walletLog, 30);
+        logger.fail(`Wallet setup failed — see ${ctx.walletLog}`);
+      }
     } else {
-      logger.warn(`No fixture at ${ctx.flags.walletFixture}`);
+      logger.fail(`No fixture at ${ctx.flags.walletFixture}`);
     }
   } else if (ctx.flags.walletPw) {
     logger.step('Unlocking wallet', 'Using provided password');

--- a/scripts/perps/agentic/preflight/modules/runtime.ts
+++ b/scripts/perps/agentic/preflight/modules/runtime.ts
@@ -29,16 +29,14 @@ async function metroRespondsWithin(port: number, seconds: number): Promise<boole
   return false;
 }
 
-function runStartMetro(ctx: Ctx, launch: boolean, logger: Logger): void {
+function runStartMetro(ctx: Ctx, launch: boolean, logger: Logger): boolean {
   const args = [join(ctx.scripts, 'start-metro.sh'), '--platform', ctx.plat];
   if (launch) args.push('--launch');
   const r = spawnSync('bash', args, { cwd: ctx.root, stdio: 'inherit' });
   if (r.error) {
     logger.fail(`start-metro.sh failed: ${r.error.message}`);
   }
-  if (r.status !== 0) {
-    logger.fail(`start-metro.sh failed with exit code ${r.status ?? 'unknown'}`);
-  }
+  return r.status === 0;
 }
 
 // Kill whatever holds the Metro port so a hung instance can be replaced.
@@ -60,15 +58,26 @@ async function freeMetroPort(port: number): Promise<void> {
 export async function startMetro(ctx: Ctx, logger: Logger): Promise<void> {
   logger.step('Starting Metro', `Bundler on port ${ctx.port} → logs at ${ctx.logFile}`);
   logger.stageLog(ctx.logFile);
-  runStartMetro(ctx, ctx.doLaunch, logger);
-  if (await metroRespondsWithin(ctx.port, 10)) {
+  const firstStartOk = runStartMetro(ctx, ctx.doLaunch, logger);
+  if (firstStartOk && (await metroRespondsWithin(ctx.port, 10))) {
     logger.ok(`Metro running on port ${ctx.port}`);
     return;
   }
-  logger.warn(`Metro on ${ctx.port} is bound but not answering /status — restarting`);
-  logger.tail(ctx.logFile, 15);
-  await freeMetroPort(ctx.port);
-  runStartMetro(ctx, ctx.doLaunch, logger);
+
+  const metroRespondingAfterFailure = await metroRespondsWithin(ctx.port, 3);
+  if (firstStartOk || !metroRespondingAfterFailure) {
+    logger.warn(`Metro on ${ctx.port} is bound but not answering /status — restarting`);
+    logger.tail(ctx.logFile, 15);
+    await freeMetroPort(ctx.port);
+  } else {
+    logger.warn('start-metro.sh failed after Metro became healthy — retrying launch/start once');
+  }
+
+  const secondStartOk = runStartMetro(ctx, ctx.doLaunch, logger);
+  if (!secondStartOk) {
+    logger.tail(ctx.logFile, 25);
+    logger.fail('start-metro.sh failed after retry');
+  }
   if (!(await metroRespondsWithin(ctx.port, 15))) {
     logger.tail(ctx.logFile, 25);
     logger.fail(`Metro on ${ctx.port} not responding after restart — see ${ctx.logFile}`);

--- a/scripts/perps/agentic/preflight/modules/runtime.ts
+++ b/scripts/perps/agentic/preflight/modules/runtime.ts
@@ -65,12 +65,16 @@ export async function startMetro(ctx: Ctx, logger: Logger): Promise<void> {
   }
 
   const metroRespondingAfterFailure = await metroRespondsWithin(ctx.port, 3);
-  if (firstStartOk || !metroRespondingAfterFailure) {
+  if (metroRespondingAfterFailure) {
+    if (firstStartOk) {
+      logger.ok(`Metro running on port ${ctx.port}`);
+      return;
+    }
+    logger.warn('start-metro.sh failed after Metro became healthy — retrying launch/start once');
+  } else {
     logger.warn(`Metro on ${ctx.port} is bound but not answering /status — restarting`);
     logger.tail(ctx.logFile, 15);
     await freeMetroPort(ctx.port);
-  } else {
-    logger.warn('start-metro.sh failed after Metro became healthy — retrying launch/start once');
   }
 
   const secondStartOk = runStartMetro(ctx, ctx.doLaunch, logger);

--- a/scripts/perps/agentic/preflight/preflight.ts
+++ b/scripts/perps/agentic/preflight/preflight.ts
@@ -1,7 +1,7 @@
 // Orchestrator. Prepares a ready-to-code worktree: deps reconciled, app
 // built/installed, Metro + CDP up, wallet configured. See ./README.md.
 
-import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { buildCtx, modeLine, resolvePath } from './modules/env';
 import { decideDeps, reconcile, runCleanSetup } from './modules/deps';
@@ -43,15 +43,26 @@ async function main(): Promise<void> {
   const root = resolve(dirname(process.argv[1] ?? ''), '../../../..');
   const ctx = buildCtx(root, process.argv.slice(2));
   const logger = new Logger();
+  const rootTsconfigPath = resolvePath(ctx.root, 'tsconfig.json');
+  const rootTsconfigBefore = existsSync(rootTsconfigPath)
+    ? readFileSync(rootTsconfigPath, 'utf8')
+    : null;
 
   // Restore setup-noise on every exit — success, thrown failure, or Ctrl-C.
-  // `expo run:ios` rewrites tsconfig.json ("extends": "expo/tsconfig.base") and
-  // pod install bumps Podfile.lock; neither should be committed. Critically, a
-  // polluted tsconfig.json bricks the NEXT ts-node run (TS5098), so a run that
-  // failed before this point (e.g. CDP timeout) used to leave the tool unable to
-  // start. No-op off main. Idempotent. See modules/git.ts.
-  const restoreNoise = (): void =>
-    restoreMainNoise(ctx.root, ['tsconfig.json', 'ios/Podfile.lock'], logger);
+  // `expo run:ios` rewrites root tsconfig.json ("extends":
+  // "expo/tsconfig.base"). Restore the exact startup contents, not HEAD, so
+  // intentional local tsconfig edits are preserved while Expo noise is removed.
+  const restoreNoise = (): void => {
+    if (
+      rootTsconfigBefore !== null &&
+      existsSync(rootTsconfigPath) &&
+      readFileSync(rootTsconfigPath, 'utf8') !== rootTsconfigBefore
+    ) {
+      writeFileSync(rootTsconfigPath, rootTsconfigBefore);
+      logger.ok('Restored root tsconfig.json (preflight setup noise)');
+    }
+    restoreMainNoise(ctx.root, ['ios/Podfile.lock'], logger);
+  };
   const onSignal = (sig: NodeJS.Signals): void => {
     restoreNoise();
     process.exit(sig === 'SIGINT' ? 130 : 143);
@@ -96,7 +107,7 @@ async function main(): Promise<void> {
 
     await startMetro(ctx, logger);
     await connectCdp(ctx, logger);
-    setupWallet(ctx, logger);
+    await setupWallet(ctx, logger);
 
     logger.plain();
     logger.plain('=== Preflight complete ===');

--- a/scripts/perps/agentic/preflight/preflight.ts
+++ b/scripts/perps/agentic/preflight/preflight.ts
@@ -44,54 +44,71 @@ async function main(): Promise<void> {
   const ctx = buildCtx(root, process.argv.slice(2));
   const logger = new Logger();
 
-  if (ctx.doClean && ctx.checkOnly) {
-    logger.fail('--check-only conflicts with --clean / --mode clean (would mutate node_modules + build artifacts)');
-  }
-  if (ctx.flags.walletSetup) validateFixture(ctx, logger);
+  // Restore setup-noise on every exit — success, thrown failure, or Ctrl-C.
+  // `expo run:ios` rewrites tsconfig.json ("extends": "expo/tsconfig.base") and
+  // pod install bumps Podfile.lock; neither should be committed. Critically, a
+  // polluted tsconfig.json bricks the NEXT ts-node run (TS5098), so a run that
+  // failed before this point (e.g. CDP timeout) used to leave the tool unable to
+  // start. No-op off main. Idempotent. See modules/git.ts.
+  const restoreNoise = (): void =>
+    restoreMainNoise(ctx.root, ['tsconfig.json', 'ios/Podfile.lock'], logger);
+  const onSignal = (sig: NodeJS.Signals): void => {
+    restoreNoise();
+    process.exit(sig === 'SIGINT' ? 130 : 143);
+  };
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
 
-  mkdirSync(ctx.logDir, { recursive: true });
+  try {
+    if (ctx.doClean && ctx.checkOnly) {
+      logger.fail('--check-only conflicts with --clean / --mode clean (would mutate node_modules + build artifacts)');
+    }
+    if (ctx.flags.walletSetup) validateFixture(ctx, logger);
 
-  const decision = decideDeps(ctx, logger);
+    mkdirSync(ctx.logDir, { recursive: true });
 
-  let total = 4; // device + app + metro + cdp
-  if (ctx.doClean) total += 1;
-  if (decision.jsDepsStale || decision.setupStale) total += 1;
-  if (ctx.flags.walletSetup || ctx.flags.walletPw) total += 1;
-  logger.setTotalSteps(total);
+    const decision = decideDeps(ctx, logger);
 
-  logger.header(ctx.port, ctx.plat, modeLine(ctx.mode, ctx.checkOnly));
+    let total = 4; // device + app + metro + cdp
+    if (ctx.doClean) total += 1;
+    if (decision.jsDepsStale || decision.setupStale) total += 1;
+    if (ctx.flags.walletSetup || ctx.flags.walletPw) total += 1;
+    logger.setTotalSteps(total);
 
-  await sweepPort(ctx.port, 'worktree Metro', logger, ctx.checkOnly);
-  if (ctx.port !== 8081) await sweepPort(8081, 'expo default', logger, ctx.checkOnly);
+    logger.header(ctx.port, ctx.plat, modeLine(ctx.mode, ctx.checkOnly));
 
-  if (ctx.doClean) await runCleanSetup(ctx, logger);
-  else await reconcile(ctx, logger, decision);
+    await sweepPort(ctx.port, 'worktree Metro', logger, ctx.checkOnly);
+    if (ctx.port !== 8081) await sweepPort(8081, 'expo default', logger, ctx.checkOnly);
 
-  if (ctx.plat === 'ios') await runIos(ctx, logger);
-  else await runAndroid(ctx, logger);
+    if (ctx.doClean) await runCleanSetup(ctx, logger);
+    else await reconcile(ctx, logger, decision);
 
-  // --check-only is read-only: the probes above fail loud on mismatch; never run
-  // the state-changing Metro/CDP/wallet steps.
-  if (ctx.checkOnly) {
+    if (ctx.plat === 'ios') await runIos(ctx, logger);
+    else await runAndroid(ctx, logger);
+
+    // --check-only is read-only: the probes above fail loud on mismatch; never run
+    // the state-changing Metro/CDP/wallet steps.
+    if (ctx.checkOnly) {
+      logger.plain();
+      logger.plain(`=== Preflight check-only passed === (platform ${ctx.plat})`);
+      return;
+    }
+
+    await startMetro(ctx, logger);
+    await connectCdp(ctx, logger);
+    setupWallet(ctx, logger);
+
     logger.plain();
-    logger.plain(`=== Preflight check-only passed === (platform ${ctx.plat})`);
-    return;
-  }
-
-  await startMetro(ctx, logger);
-  await connectCdp(ctx, logger);
-  setupWallet(ctx, logger);
-
-  restoreMainNoise(ctx.root, ['tsconfig.json', 'ios/Podfile.lock'], logger);
-
-  logger.plain();
-  logger.plain('=== Preflight complete ===');
-  logger.plain(`  Platform   ${ctx.plat}`);
-  logger.plain(`  Metro      http://localhost:${ctx.port}/status`);
-  logger.plain(`  Logs       tail -f ${ctx.logFile}`);
-  logger.plain(`  CDP        node ${ctx.scripts}/cdp-bridge.js status`);
-  for (const { name, seconds } of logger.finishTimings()) {
-    logger.plain(`  ${name}: ${seconds}s`);
+    logger.plain('=== Preflight complete ===');
+    logger.plain(`  Platform   ${ctx.plat}`);
+    logger.plain(`  Metro      http://localhost:${ctx.port}/status`);
+    logger.plain(`  Logs       tail -f ${ctx.logFile}`);
+    logger.plain(`  CDP        node ${ctx.scripts}/cdp-bridge.js status`);
+    for (const { name, seconds } of logger.finishTimings()) {
+      logger.plain(`  ${name}: ${seconds}s`);
+    }
+  } finally {
+    restoreNoise();
   }
 }
 

--- a/scripts/perps/agentic/preflight/preflight.ts
+++ b/scripts/perps/agentic/preflight/preflight.ts
@@ -61,7 +61,9 @@ async function main(): Promise<void> {
       writeFileSync(rootTsconfigPath, rootTsconfigBefore);
       logger.ok('Restored root tsconfig.json (preflight setup noise)');
     }
-    restoreMainNoise(ctx.root, ['ios/Podfile.lock'], logger);
+    if (!ctx.checkOnly) {
+      restoreMainNoise(ctx.root, ['ios/Podfile.lock'], logger);
+    }
   };
   const onSignal = (sig: NodeJS.Signals): void => {
     restoreNoise();

--- a/scripts/perps/agentic/preflight/preflight.ts
+++ b/scripts/perps/agentic/preflight/preflight.ts
@@ -1,7 +1,16 @@
 // Orchestrator. Prepares a ready-to-code worktree: deps reconciled, app
 // built/installed, Metro + CDP up, wallet configured. See ./README.md.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  ftruncateSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from 'fs';
 import { dirname, resolve } from 'path';
 import { buildCtx, modeLine, resolvePath } from './modules/env';
 import { decideDeps, reconcile, runCleanSetup } from './modules/deps';
@@ -12,6 +21,52 @@ import { runIos } from './modules/ios';
 import { runAndroid } from './modules/android';
 import { connectCdp, setupWallet, startMetro } from './modules/runtime';
 import type { Ctx } from './modules/types';
+
+interface FileSnapshot {
+  contents: string;
+  dev: number;
+  ino: number;
+}
+
+function readSnapshot(path: string): FileSnapshot | null {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r');
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) return null;
+    return {
+      contents: readFileSync(fd, 'utf8'),
+      dev: stat.dev,
+      ino: stat.ino,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function restoreSnapshot(path: string, snapshot: FileSnapshot): boolean {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, 'r+');
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.dev !== snapshot.dev || stat.ino !== snapshot.ino) {
+      return false;
+    }
+    const current = readFileSync(fd, 'utf8');
+    if (current === snapshot.contents) {
+      return false;
+    }
+    ftruncateSync(fd, 0);
+    writeSync(fd, snapshot.contents, 0, 'utf8');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
 
 function validateFixture(ctx: Ctx, logger: Logger): void {
   const path = resolvePath(ctx.root, ctx.flags.walletFixture);
@@ -44,21 +99,14 @@ async function main(): Promise<void> {
   const ctx = buildCtx(root, process.argv.slice(2));
   const logger = new Logger();
   const rootTsconfigPath = resolvePath(ctx.root, 'tsconfig.json');
-  const rootTsconfigBefore = existsSync(rootTsconfigPath)
-    ? readFileSync(rootTsconfigPath, 'utf8')
-    : null;
+  const rootTsconfigBefore = readSnapshot(rootTsconfigPath);
 
   // Restore setup-noise on every exit — success, thrown failure, or Ctrl-C.
   // `expo run:ios` rewrites root tsconfig.json ("extends":
   // "expo/tsconfig.base"). Restore the exact startup contents, not HEAD, so
   // intentional local tsconfig edits are preserved while Expo noise is removed.
   const restoreNoise = (): void => {
-    if (
-      rootTsconfigBefore !== null &&
-      existsSync(rootTsconfigPath) &&
-      readFileSync(rootTsconfigPath, 'utf8') !== rootTsconfigBefore
-    ) {
-      writeFileSync(rootTsconfigPath, rootTsconfigBefore);
+    if (rootTsconfigBefore && restoreSnapshot(rootTsconfigPath, rootTsconfigBefore)) {
       logger.ok('Restored root tsconfig.json (preflight setup noise)');
     }
     if (!ctx.checkOnly) {

--- a/scripts/perps/agentic/preflight/tsconfig.json
+++ b/scripts/perps/agentic/preflight/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "//": "Dedicated ts-node config for the agentic preflight. Self-contained (no `extends`) on purpose: `expo run:ios` rewrites the repo-root tsconfig.json to `extends: expo/tsconfig.base`, whose `customConditions` is illegal with `module: commonjs` and makes ts-node abort with TS5098. Pointing ts-node here (via --project in the a:* scripts) keeps the preflight runnable regardless of root-tsconfig pollution.",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "esnext",
+    "lib": ["esnext"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["preflight.ts", "modules/*.ts"]
+}

--- a/scripts/perps/agentic/setup-wallet.sh
+++ b/scripts/perps/agentic/setup-wallet.sh
@@ -164,7 +164,14 @@ else
   # -- Call AgenticService.setupWallet() on fresh app only --
   echo "Calling __AGENTIC__.setupWallet()..."
 
+  set +e
   SETUP_RESULT=$(cdp_eval_async "(function(){ var fixture = JSON.parse($ESCAPED_FIXTURE); if (!globalThis.__AGENTIC__ || typeof globalThis.__AGENTIC__.setupWallet !== 'function') { return JSON.stringify({ok:false, error:'__AGENTIC__.setupWallet is not installed'}); } return globalThis.__AGENTIC__.setupWallet(fixture).then(function(r){ return JSON.stringify(r); }).catch(function(e){ return JSON.stringify({ok:false, error: e.message || String(e)}); }); })()")
+  SETUP_RC=$?
+  set -e
+  if [ "$SETUP_RC" -ne 0 ] || [ -z "$SETUP_RESULT" ]; then
+    echo "ERROR: setupWallet eval failed or timed out (rc=$SETUP_RC) — raise CDP_TIMEOUT for large fixtures (current ${CDP_TIMEOUT}ms)."
+    exit 1
+  fi
 
   SETUP_OK=$(echo "$SETUP_RESULT" | jq -r '.ok')
   if [ "$SETUP_OK" != "true" ]; then

--- a/scripts/perps/agentic/setup-wallet.sh
+++ b/scripts/perps/agentic/setup-wallet.sh
@@ -37,6 +37,7 @@ SCRIPTS="$SCRIPT_DIR"
 # a delay, so a high default is harmless for the fast evals. Override via env.
 export CDP_TIMEOUT="${CDP_TIMEOUT:-120000}"
 export CDP_DISCOVERY_RETRIES="${CDP_DISCOVERY_RETRIES:-3}"
+WALLET_SETUP_SETTLE_TIMEOUT="${WALLET_SETUP_SETTLE_TIMEOUT:-180}"
 CDP="node $SCRIPTS/cdp-bridge.js"
 FIXTURE_PATH=""
 
@@ -125,89 +126,6 @@ echo "Vault backup guard intent: $DISABLE_BACKUP"
 # Read fixture JSON and escape it for safe embedding in a JS string literal.
 FIXTURE_JSON=$(jq -c '.' "$FIXTURE_PATH")
 ESCAPED_FIXTURE=$(node -p "JSON.stringify(JSON.stringify(JSON.parse(process.argv[1])))" "$FIXTURE_JSON")
-
-# -- Check vault state --
-VAULT_STATE=$(cdp_eval "(function(){ var v = Engine.context.KeyringController.state; return JSON.stringify({hasVault: v.vault !== undefined && v.vault !== null, isUnlocked: Engine.context.KeyringController.isUnlocked()}); })()")
-HAS_VAULT=$(echo "$VAULT_STATE" | jq -r '.hasVault')
-IS_UNLOCKED=$(echo "$VAULT_STATE" | jq -r '.isUnlocked')
-echo "Vault state: hasVault=$HAS_VAULT, isUnlocked=$IS_UNLOCKED"
-
-if [ "$HAS_VAULT" = "true" ]; then
-  # Do NOT unlock here with a bare KeyringController.submitPassword(): that
-  # bypasses the real auth flow (multichain init + dispatchLogin/password state)
-  # and can leave Redux/auth state stale. applyWalletFixture tries the real
-  # Authentication.unlockWallet() path first, then recovers interrupted fixture
-  # state with a keyring fallback inside AgenticService.
-  if [ "$IS_UNLOCKED" = "true" ]; then
-    echo "Vault already unlocked."
-  else
-    echo "Vault locked — applyWalletFixture will unlock via auth flow with fixture recovery fallback."
-  fi
-
-  echo "Applying fixture accounts/names to existing vault..."
-  set +e
-  APPLY_RESULT=$(cdp_eval_async "(function(){ var fixture = JSON.parse($ESCAPED_FIXTURE); if (!globalThis.__AGENTIC__ || typeof globalThis.__AGENTIC__.applyWalletFixture !== 'function') { return JSON.stringify({ok:false, error:'__AGENTIC__.applyWalletFixture is not installed; reload the app from Metro'}); } return globalThis.__AGENTIC__.applyWalletFixture(fixture).then(function(r){ return JSON.stringify(r); }).catch(function(e){ return JSON.stringify({ok:false, error: e.message || String(e)}); }); })()")
-  APPLY_RC=$?
-  set -e
-  if [ "$APPLY_RC" -ne 0 ] || [ -z "$APPLY_RESULT" ]; then
-    echo "ERROR: applyWalletFixture eval failed or timed out (rc=$APPLY_RC) — raise CDP_TIMEOUT for large fixtures (current ${CDP_TIMEOUT}ms)."
-    exit 1
-  fi
-  APPLY_OK=$(echo "$APPLY_RESULT" | jq -r '.ok')
-  if [ "$APPLY_OK" != "true" ]; then
-    APPLY_ERR=$(echo "$APPLY_RESULT" | jq -r '.error // "unknown error"')
-    echo "ERROR: applyWalletFixture failed — $APPLY_ERR"
-    exit 1
-  fi
-  echo "Wallet fixture apply result:"
-  echo "$APPLY_RESULT" | jq -r '.accounts[]? | "  \(.name): \(.address)"'
-else
-  # -- Call AgenticService.setupWallet() on fresh app only --
-  echo "Calling __AGENTIC__.setupWallet()..."
-
-  set +e
-  SETUP_RESULT=$(cdp_eval_async "(function(){ var fixture = JSON.parse($ESCAPED_FIXTURE); if (!globalThis.__AGENTIC__ || typeof globalThis.__AGENTIC__.setupWallet !== 'function') { return JSON.stringify({ok:false, error:'__AGENTIC__.setupWallet is not installed'}); } return globalThis.__AGENTIC__.setupWallet(fixture).then(function(r){ return JSON.stringify(r); }).catch(function(e){ return JSON.stringify({ok:false, error: e.message || String(e)}); }); })()")
-  SETUP_RC=$?
-  set -e
-  if [ "$SETUP_RC" -ne 0 ] || [ -z "$SETUP_RESULT" ]; then
-    echo "ERROR: setupWallet eval failed or timed out (rc=$SETUP_RC) — raise CDP_TIMEOUT for large fixtures (current ${CDP_TIMEOUT}ms)."
-    exit 1
-  fi
-
-  SETUP_OK=$(echo "$SETUP_RESULT" | jq -r '.ok')
-  if [ "$SETUP_OK" != "true" ]; then
-    SETUP_ERR=$(echo "$SETUP_RESULT" | jq -r '.error // "unknown error"')
-    SETUP_STEP=$(echo "$SETUP_RESULT" | jq -r '.step // "unknown-step"')
-    echo "ERROR: setupWallet failed at ${SETUP_STEP} — $SETUP_ERR"
-    exit 1
-  fi
-
-  echo "Wallet setup result:"
-  echo "$SETUP_RESULT" | jq -r '.accounts[]? | "  \(.name): \(.address)"'
-  sleep 2
-fi
-
-# -- Ask the app to leave auth/onboarding after unlock.
-# HomeNav matches the product auth reset path, but some warm/onboarding states
-# land on intermediate post-onboarding screens. Follow with WalletView so the
-# harness proves the user-visible unlocked wallet, not just a populated vault.
-$CDP navigate HomeNav >/dev/null 2>&1 || true
-sleep 1
-$CDP navigate WalletView >/dev/null 2>&1 || true
-sleep 1
-
-# -- Summary + hard validation --
-ACCOUNTS=$(cdp_eval "(function(){ try { var ctx = Engine && Engine.context ? Engine.context : {}; var accountsController = ctx.AccountsController || {}; var keyringController = ctx.KeyringController || {}; var state = accountsController.state || {}; var internalAccounts = state.internalAccounts || {}; var accountsById = internalAccounts.accounts || {}; var accs = Object.values(accountsById); var eth = accs.filter(function(a){ return String(a && a.address || '').indexOf('0x') === 0; }); var route = globalThis.__AGENTIC__ && globalThis.__AGENTIC__.getRoute ? globalThis.__AGENTIC__.getRoute() : null; var selected = null; if (typeof accountsController.getSelectedAccount === 'function') { selected = accountsController.getSelectedAccount(); } else if (internalAccounts.selectedAccount && accountsById[internalAccounts.selectedAccount]) { selected = accountsById[internalAccounts.selectedAccount]; } return JSON.stringify({ok:true, unlocked: typeof keyringController.isUnlocked === 'function' ? keyringController.isUnlocked() : null, routeName: route && route.name, selected: selected ? {name: selected.metadata && selected.metadata.name, address: selected.address} : null, total: accs.length, ethAccounts: eth.length, accounts: eth.map(function(a){ return {name: a && a.metadata && a.metadata.name, address: a && a.address}; }), first3: eth.slice(0,3).map(function(a){ return {name: a && a.metadata && a.metadata.name, address: a && a.address}; })}); } catch (e) { return JSON.stringify({ok:false, error: e && (e.stack || e.message) || String(e)}); } })()")
-ACCOUNTS_OK=$(echo "$ACCOUNTS" | jq -r '.ok // false')
-if [ "$ACCOUNTS_OK" != "true" ]; then
-  echo "ERROR: Unable to read wallet state after setupWallet"
-  echo "$ACCOUNTS" | jq .
-  exit 1
-fi
-TOTAL=$(echo "$ACCOUNTS" | jq -r '.total')
-ETH_COUNT=$(echo "$ACCOUNTS" | jq -r '.ethAccounts')
-UNLOCKED=$(echo "$ACCOUNTS" | jq -r '.unlocked')
-ROUTE_NAME=$(echo "$ACCOUNTS" | jq -r '.routeName // empty')
 EXPECTED_ADDRESSES=$(node - "$FIXTURE_PATH" <<'NODE'
 const fs = require('fs');
 const { Wallet } = require('ethers');
@@ -235,14 +153,175 @@ for (const account of fixture.accounts || []) {
 console.log(JSON.stringify(addresses));
 NODE
 )
-MISSING_ADDRESSES=$(ACCOUNTS_JSON="$ACCOUNTS" EXPECTED_JSON="$EXPECTED_ADDRESSES" node <<'NODE'
+
+read_wallet_state() {
+  cdp_eval "(function(){ try { var ctx = Engine && Engine.context ? Engine.context : {}; var accountsController = ctx.AccountsController || {}; var keyringController = ctx.KeyringController || {}; var state = accountsController.state || {}; var internalAccounts = state.internalAccounts || {}; var accountsById = internalAccounts.accounts || {}; var accs = Object.values(accountsById); var eth = accs.filter(function(a){ return String(a && a.address || '').indexOf('0x') === 0; }); var route = globalThis.__AGENTIC__ && globalThis.__AGENTIC__.getRoute ? globalThis.__AGENTIC__.getRoute() : null; var selected = null; if (typeof accountsController.getSelectedAccount === 'function') { selected = accountsController.getSelectedAccount(); } else if (internalAccounts.selectedAccount && accountsById[internalAccounts.selectedAccount]) { selected = accountsById[internalAccounts.selectedAccount]; } return JSON.stringify({ok:true, unlocked: typeof keyringController.isUnlocked === 'function' ? keyringController.isUnlocked() : null, routeName: route && route.name, selected: selected ? {name: selected.metadata && selected.metadata.name, address: selected.address} : null, total: accs.length, ethAccounts: eth.length, accounts: eth.map(function(a){ return {name: a && a.metadata && a.metadata.name, address: a && a.address}; }), first3: eth.slice(0,3).map(function(a){ return {name: a && a.metadata && a.metadata.name, address: a && a.address}; })}); } catch (e) { return JSON.stringify({ok:false, error: e && (e.stack || e.message) || String(e)}); } })()"
+}
+
+missing_fixture_addresses() {
+  ACCOUNTS_JSON="$1" EXPECTED_JSON="$EXPECTED_ADDRESSES" node <<'NODE'
 const accounts = JSON.parse(process.env.ACCOUNTS_JSON);
 const expected = JSON.parse(process.env.EXPECTED_JSON);
 const actual = new Set((accounts.accounts || accounts.first3 || []).map((a) => String(a.address || '').toLowerCase()));
 const missing = expected.filter((address) => !actual.has(address));
 console.log(JSON.stringify(missing));
 NODE
-)
+}
+
+wallet_state_issue() {
+  local accounts_json="$1"
+  if [ -z "$accounts_json" ]; then
+    echo "wallet state unavailable"
+    return
+  fi
+
+  local ok unlocked eth_count missing_count
+  ok=$(echo "$accounts_json" | jq -r '.ok // false' 2>/dev/null || echo false)
+  if [ "$ok" != "true" ]; then
+    echo "$(echo "$accounts_json" | jq -r '.error // "wallet state read failed"' 2>/dev/null || echo "wallet state read failed")"
+    return
+  fi
+
+  unlocked=$(echo "$accounts_json" | jq -r '.unlocked')
+  eth_count=$(echo "$accounts_json" | jq -r '.ethAccounts')
+  if [ "$unlocked" != "true" ]; then
+    echo "vault still locked"
+    return
+  fi
+  if [ "$eth_count" -lt "$EXPECTED_ETH_TOTAL" ]; then
+    echo "$eth_count ETH account(s), expected at least $EXPECTED_ETH_TOTAL"
+    return
+  fi
+
+  missing_count=$(missing_fixture_addresses "$accounts_json" | jq -r 'length')
+  if [ "$missing_count" != "0" ]; then
+    echo "$missing_count expected fixture address(es) missing"
+    return
+  fi
+
+  echo "ready"
+}
+
+wallet_state_ready() {
+  [ "$(wallet_state_issue "$1")" = "ready" ]
+}
+
+wait_for_wallet_state_after_eval_timeout() {
+  local label="$1"
+  local rc="$2"
+  local elapsed=0
+  local interval=5
+  local last_accounts=""
+  local issue=""
+
+  echo "WARN: ${label} eval did not return (rc=$rc) before ${CDP_TIMEOUT}ms; validating app wallet state for up to ${WALLET_SETUP_SETTLE_TIMEOUT}s."
+  while [ "$elapsed" -le "$WALLET_SETUP_SETTLE_TIMEOUT" ]; do
+    last_accounts=$(read_wallet_state 2>/dev/null || true)
+    if wallet_state_ready "$last_accounts"; then
+      echo "Wallet state validated after ${label} eval timeout."
+      return 0
+    fi
+
+    issue=$(wallet_state_issue "$last_accounts")
+    [ "$elapsed" -eq 0 ] && echo "  Still waiting for fixture completion: $issue"
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+
+  echo "ERROR: ${label} eval failed or timed out (rc=$rc), and wallet state did not validate after ${WALLET_SETUP_SETTLE_TIMEOUT}s."
+  echo "Last observed state:"
+  if [ -n "$last_accounts" ]; then
+    echo "$last_accounts" | jq .
+  else
+    echo "  unavailable"
+  fi
+  return 1
+}
+
+# -- Check vault state --
+VAULT_STATE=$(cdp_eval "(function(){ var v = Engine.context.KeyringController.state; return JSON.stringify({hasVault: v.vault !== undefined && v.vault !== null, isUnlocked: Engine.context.KeyringController.isUnlocked()}); })()")
+HAS_VAULT=$(echo "$VAULT_STATE" | jq -r '.hasVault')
+IS_UNLOCKED=$(echo "$VAULT_STATE" | jq -r '.isUnlocked')
+echo "Vault state: hasVault=$HAS_VAULT, isUnlocked=$IS_UNLOCKED"
+
+if [ "$HAS_VAULT" = "true" ]; then
+  # Do NOT unlock here with a bare KeyringController.submitPassword(): that
+  # bypasses the real auth flow (multichain init + dispatchLogin/password state)
+  # and can leave Redux/auth state stale. applyWalletFixture tries the real
+  # Authentication.unlockWallet() path first, then recovers interrupted fixture
+  # state with a keyring fallback inside AgenticService.
+  if [ "$IS_UNLOCKED" = "true" ]; then
+    echo "Vault already unlocked."
+  else
+    echo "Vault locked — applyWalletFixture will unlock via auth flow with fixture recovery fallback."
+  fi
+
+  echo "Applying fixture accounts/names to existing vault..."
+  set +e
+  APPLY_RESULT=$(cdp_eval_async "(function(){ var fixture = JSON.parse($ESCAPED_FIXTURE); if (!globalThis.__AGENTIC__ || typeof globalThis.__AGENTIC__.applyWalletFixture !== 'function') { return JSON.stringify({ok:false, error:'__AGENTIC__.applyWalletFixture is not installed; reload the app from Metro'}); } return globalThis.__AGENTIC__.applyWalletFixture(fixture).then(function(r){ return JSON.stringify(r); }).catch(function(e){ return JSON.stringify({ok:false, error: e.message || String(e)}); }); })()")
+  APPLY_RC=$?
+  set -e
+  if [ "$APPLY_RC" -ne 0 ] || [ -z "$APPLY_RESULT" ]; then
+    wait_for_wallet_state_after_eval_timeout "applyWalletFixture" "$APPLY_RC" || exit 1
+    echo "Wallet fixture apply result recovered from validated wallet state."
+  else
+    APPLY_OK=$(echo "$APPLY_RESULT" | jq -r '.ok')
+    if [ "$APPLY_OK" != "true" ]; then
+      APPLY_ERR=$(echo "$APPLY_RESULT" | jq -r '.error // "unknown error"')
+      echo "ERROR: applyWalletFixture failed — $APPLY_ERR"
+      exit 1
+    fi
+    echo "Wallet fixture apply result:"
+    echo "$APPLY_RESULT" | jq -r '.accounts[]? | "  \(.name): \(.address)"'
+  fi
+else
+  # -- Call AgenticService.setupWallet() on fresh app only --
+  echo "Calling __AGENTIC__.setupWallet()..."
+
+  set +e
+  SETUP_RESULT=$(cdp_eval_async "(function(){ var fixture = JSON.parse($ESCAPED_FIXTURE); if (!globalThis.__AGENTIC__ || typeof globalThis.__AGENTIC__.setupWallet !== 'function') { return JSON.stringify({ok:false, error:'__AGENTIC__.setupWallet is not installed'}); } return globalThis.__AGENTIC__.setupWallet(fixture).then(function(r){ return JSON.stringify(r); }).catch(function(e){ return JSON.stringify({ok:false, error: e.message || String(e)}); }); })()")
+  SETUP_RC=$?
+  set -e
+  if [ "$SETUP_RC" -ne 0 ] || [ -z "$SETUP_RESULT" ]; then
+    wait_for_wallet_state_after_eval_timeout "setupWallet" "$SETUP_RC" || exit 1
+    echo "Wallet setup result recovered from validated wallet state."
+  else
+    SETUP_OK=$(echo "$SETUP_RESULT" | jq -r '.ok')
+    if [ "$SETUP_OK" != "true" ]; then
+      SETUP_ERR=$(echo "$SETUP_RESULT" | jq -r '.error // "unknown error"')
+      SETUP_STEP=$(echo "$SETUP_RESULT" | jq -r '.step // "unknown-step"')
+      echo "ERROR: setupWallet failed at ${SETUP_STEP} — $SETUP_ERR"
+      exit 1
+    fi
+
+    echo "Wallet setup result:"
+    echo "$SETUP_RESULT" | jq -r '.accounts[]? | "  \(.name): \(.address)"'
+  fi
+  sleep 2
+fi
+
+# -- Ask the app to leave auth/onboarding after unlock.
+# HomeNav matches the product auth reset path, but some warm/onboarding states
+# land on intermediate post-onboarding screens. Follow with WalletView so the
+# harness proves the user-visible unlocked wallet, not just a populated vault.
+$CDP navigate HomeNav >/dev/null 2>&1 || true
+sleep 1
+$CDP navigate WalletView >/dev/null 2>&1 || true
+sleep 1
+
+# -- Summary + hard validation --
+ACCOUNTS=$(read_wallet_state)
+ACCOUNTS_OK=$(echo "$ACCOUNTS" | jq -r '.ok // false')
+if [ "$ACCOUNTS_OK" != "true" ]; then
+  echo "ERROR: Unable to read wallet state after setupWallet"
+  echo "$ACCOUNTS" | jq .
+  exit 1
+fi
+TOTAL=$(echo "$ACCOUNTS" | jq -r '.total')
+ETH_COUNT=$(echo "$ACCOUNTS" | jq -r '.ethAccounts')
+UNLOCKED=$(echo "$ACCOUNTS" | jq -r '.unlocked')
+ROUTE_NAME=$(echo "$ACCOUNTS" | jq -r '.routeName // empty')
+MISSING_ADDRESSES=$(missing_fixture_addresses "$ACCOUNTS")
 if [ "$UNLOCKED" != "true" ]; then
   echo "ERROR: Wallet setup did not unlock the vault"
   echo "$ACCOUNTS" | jq .

--- a/scripts/perps/agentic/setup-wallet.sh
+++ b/scripts/perps/agentic/setup-wallet.sh
@@ -135,12 +135,13 @@ echo "Vault state: hasVault=$HAS_VAULT, isUnlocked=$IS_UNLOCKED"
 if [ "$HAS_VAULT" = "true" ]; then
   # Do NOT unlock here with a bare KeyringController.submitPassword(): that
   # bypasses the real auth flow (multichain init + dispatchLogin/password state)
-  # and can leave Redux/auth state stale. applyWalletFixture unlocks via
-  # Authentication.unlockWallet() when the vault is locked.
+  # and can leave Redux/auth state stale. applyWalletFixture tries the real
+  # Authentication.unlockWallet() path first, then recovers interrupted fixture
+  # state with a keyring fallback inside AgenticService.
   if [ "$IS_UNLOCKED" = "true" ]; then
     echo "Vault already unlocked."
   else
-    echo "Vault locked — applyWalletFixture will unlock via Authentication.unlockWallet() (real post-login flow)."
+    echo "Vault locked — applyWalletFixture will unlock via auth flow with fixture recovery fallback."
   fi
 
   echo "Applying fixture accounts/names to existing vault..."

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -34,6 +34,8 @@ fi
 PORT="${WATCHER_PORT:-8081}"
 LOGFILE=".agent/metro.log"
 PIDFILE=".agent/metro.pid"
+APP_LAUNCH_LOG=".agent/ios-app-launch.log"
+APP_LAUNCH_PIDFILE=".agent/ios-app-launch.pid"
 TIMEOUT=60
 LAUNCH_APP=false
 
@@ -94,23 +96,110 @@ suppress_expo_dev_menu_android() {
   $ADB_CMD shell "mkdir -p $PREFS_DIR && echo '<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?><map><boolean name=\"isOnboardingFinished\" value=\"true\" /></map>' > $PREFS_DIR/$PREFS_FILE" 2>/dev/null || true
 }
 
+ios_app_running() {
+  xcrun simctl spawn "$SIM_TARGET" launchctl list 2>/dev/null | grep -q "$BUNDLE_ID"
+}
+
+open_dev_client_ios() {
+  local output
+  if output=$(xcrun simctl openurl "$SIM_TARGET" "$DEV_CLIENT_URL" 2>&1); then
+    return 0
+  fi
+  echo "WARN: simctl openurl failed: ${output:-no output}"
+  return 1
+}
+
+launch_direct_ios() {
+  local output
+  if output=$(xcrun simctl launch "$SIM_TARGET" "$BUNDLE_ID" 2>&1); then
+    [ -n "$output" ] && echo "$output"
+    return 0
+  fi
+  echo "WARN: simctl launch failed: ${output:-no output}"
+  return 1
+}
+
+launch_console_ios() {
+  local pid
+  pid=$(node - "$SIM_TARGET" "$BUNDLE_ID" "$APP_LAUNCH_LOG" "$APP_LAUNCH_PIDFILE" <<'NODE'
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+const [, , simTarget, bundleId, logFile, pidFile] = process.argv;
+const logFd = fs.openSync(logFile, 'a');
+const child = spawn('xcrun', ['simctl', 'launch', '--console', simTarget, bundleId], {
+  detached: true,
+  stdio: ['ignore', logFd, logFd],
+});
+fs.writeFileSync(pidFile, String(child.pid));
+child.unref();
+process.stdout.write(String(child.pid));
+NODE
+)
+  echo "simctl launch --console PID: $pid, logging to $APP_LAUNCH_LOG"
+}
+
+stop_previous_ios_console() {
+  if [ -f "$APP_LAUNCH_PIDFILE" ]; then
+    local old_pid
+    old_pid=$(cat "$APP_LAUNCH_PIDFILE" 2>/dev/null || true)
+    if [ -n "$old_pid" ]; then
+      kill "$old_pid" 2>/dev/null || true
+    fi
+    rm -f "$APP_LAUNCH_PIDFILE"
+  fi
+}
+
 launch_app_ios() {
+  stop_previous_ios_console
   suppress_expo_dev_menu_ios
   xcrun simctl terminate "$SIM_TARGET" "$BUNDLE_ID" 2>/dev/null || true
   sleep 1
 
   ENCODED_URL=$(python3 -c "import urllib.parse; print(urllib.parse.quote('http://localhost:${PORT}?disableOnboarding=1', safe=''))")
   DEV_CLIENT_URL="expo-metamask://expo-development-client/?url=${ENCODED_URL}"
-  xcrun simctl openurl "$SIM_TARGET" "$DEV_CLIENT_URL" 2>/dev/null || \
-    echo "WARN: Could not launch app — is it installed on this simulator?"
 
-  # First launch after a rebuild sometimes crashes — retry once
-  sleep 5
-  if ! xcrun simctl spawn "$SIM_TARGET" launchctl list 2>/dev/null | grep -q "$BUNDLE_ID"; then
-    echo "App exited after launch — retrying..."
-    sleep 2
-    xcrun simctl openurl "$SIM_TARGET" "$DEV_CLIENT_URL" 2>/dev/null || true
+  echo "Launching iOS app with console log capture..."
+  > "$APP_LAUNCH_LOG"
+  launch_console_ios
+  sleep 15
+  if ios_app_running; then
+    echo "Opening iOS dev-client URL..."
+    open_dev_client_ios || true
+    sleep 5
   fi
+  if ios_app_running; then
+    echo "iOS app running: $BUNDLE_ID"
+    return 0
+  fi
+
+  echo "iOS app is not running after console launch/dev-client URL; trying direct launch."
+  launch_direct_ios || true
+  sleep 8
+  if ios_app_running; then
+    echo "iOS app running: $BUNDLE_ID"
+    return 0
+  fi
+
+  echo "iOS app is not running after direct launch; trying dev-client URL."
+  for attempt in 1 2; do
+    echo "Opening iOS dev client (attempt ${attempt})..."
+    open_dev_client_ios || true
+    sleep 5
+    if ios_app_running; then
+      echo "iOS app running: $BUNDLE_ID"
+      return 0
+    fi
+
+    echo "iOS app is not running after openurl."
+  done
+
+  echo "ERROR: iOS app did not stay running after launch."
+  echo "       Simulator: $SIM_TARGET"
+  echo "       Bundle ID: $BUNDLE_ID"
+  echo "       Last 20 lines of $APP_LAUNCH_LOG:"
+  tail -20 "$APP_LAUNCH_LOG" 2>/dev/null || true
+  return 1
 }
 
 launch_app_android() {
@@ -142,8 +231,12 @@ launch_app() {
 
 mkdir -p .agent
 
+metro_responds() {
+  curl -sf --max-time 3 "http://localhost:${PORT}/status" 2>/dev/null | grep -q 'packager-status:running'
+}
+
 # --- Detect a running Metro via HTTP probe ---
-if curl -sf "http://localhost:${PORT}/status" >/dev/null 2>&1; then
+if metro_responds; then
   echo "Metro already running on port $PORT."
   echo ""
   echo "To follow live logs:  tail -f $LOGFILE"
@@ -186,15 +279,29 @@ else
 fi
 
 echo "Starting Metro on port $PORT..."
-EXPO_NO_TYPESCRIPT_SETUP=1 yarn expo start --port "$PORT" >> "$LOGFILE" 2>&1 &
-METRO_PID=$!
-echo "$METRO_PID" > "$PIDFILE"
+METRO_PID=$(node - "$LOGFILE" "$PIDFILE" "$PORT" <<'NODE'
+const { spawn } = require('child_process');
+const fs = require('fs');
+
+const [, , logFile, pidFile, port] = process.argv;
+const logFd = fs.openSync(logFile, 'a');
+const child = spawn('yarn', ['expo', 'start', '--port', port], {
+  cwd: process.cwd(),
+  detached: true,
+  env: { ...process.env, EXPO_NO_TYPESCRIPT_SETUP: '1' },
+  stdio: ['ignore', logFd, logFd],
+});
+fs.writeFileSync(pidFile, String(child.pid));
+child.unref();
+process.stdout.write(String(child.pid));
+NODE
+)
 echo "Metro PID: $METRO_PID, logging to $LOGFILE"
 
 # Wait for ready signal
 ELAPSED=0
 while [ $ELAPSED -lt $TIMEOUT ]; do
-  if grep -q "Waiting on http://localhost:${PORT}" "$LOGFILE" 2>/dev/null; then
+  if metro_responds; then
     echo "Metro ready after ${ELAPSED}s."
     echo ""
     echo "To follow live logs:  tail -f $LOGFILE"

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -34,8 +34,6 @@ fi
 PORT="${WATCHER_PORT:-8081}"
 LOGFILE=".agent/metro.log"
 PIDFILE=".agent/metro.pid"
-APP_LAUNCH_LOG=".agent/ios-app-launch.log"
-APP_LAUNCH_PIDFILE=".agent/ios-app-launch.pid"
 TIMEOUT=60
 LAUNCH_APP=false
 
@@ -100,6 +98,19 @@ ios_app_running() {
   xcrun simctl spawn "$SIM_TARGET" launchctl list 2>/dev/null | grep -q "$BUNDLE_ID"
 }
 
+wait_ios_app_running() {
+  local elapsed=0
+  local timeout="${1:-30}"
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if ios_app_running; then
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  return 1
+}
+
 open_dev_client_ios() {
   local output
   if output=$(xcrun simctl openurl "$SIM_TARGET" "$DEV_CLIENT_URL" 2>&1); then
@@ -109,84 +120,18 @@ open_dev_client_ios() {
   return 1
 }
 
-launch_direct_ios() {
-  local output
-  if output=$(xcrun simctl launch "$SIM_TARGET" "$BUNDLE_ID" 2>&1); then
-    [ -n "$output" ] && echo "$output"
-    return 0
-  fi
-  echo "WARN: simctl launch failed: ${output:-no output}"
-  return 1
-}
-
-launch_console_ios() {
-  local pid
-  pid=$(node - "$SIM_TARGET" "$BUNDLE_ID" "$APP_LAUNCH_LOG" "$APP_LAUNCH_PIDFILE" <<'NODE'
-const { spawn } = require('child_process');
-const fs = require('fs');
-
-const [, , simTarget, bundleId, logFile, pidFile] = process.argv;
-const logFd = fs.openSync(logFile, 'a');
-const child = spawn('xcrun', ['simctl', 'launch', '--console', simTarget, bundleId], {
-  detached: true,
-  stdio: ['ignore', logFd, logFd],
-});
-fs.writeFileSync(pidFile, String(child.pid));
-child.unref();
-process.stdout.write(String(child.pid));
-NODE
-)
-  echo "simctl launch --console PID: $pid, logging to $APP_LAUNCH_LOG"
-}
-
-stop_previous_ios_console() {
-  if [ -f "$APP_LAUNCH_PIDFILE" ]; then
-    local old_pid
-    old_pid=$(cat "$APP_LAUNCH_PIDFILE" 2>/dev/null || true)
-    if [ -n "$old_pid" ]; then
-      kill "$old_pid" 2>/dev/null || true
-    fi
-    rm -f "$APP_LAUNCH_PIDFILE"
-  fi
-}
-
 launch_app_ios() {
-  stop_previous_ios_console
   suppress_expo_dev_menu_ios
-  xcrun simctl terminate "$SIM_TARGET" "$BUNDLE_ID" 2>/dev/null || true
-  sleep 1
 
   ENCODED_URL=$(python3 -c "import urllib.parse; print(urllib.parse.quote('http://localhost:${PORT}?disableOnboarding=1', safe=''))")
   DEV_CLIENT_URL="expo-metamask://expo-development-client/?url=${ENCODED_URL}"
 
-  echo "Launching iOS app with console log capture..."
-  > "$APP_LAUNCH_LOG"
-  launch_console_ios
-  sleep 15
-  if ios_app_running; then
-    echo "Opening iOS dev-client URL..."
-    open_dev_client_ios || true
-    sleep 5
-  fi
-  if ios_app_running; then
-    echo "iOS app running: $BUNDLE_ID"
-    return 0
-  fi
-
-  echo "iOS app is not running after console launch/dev-client URL; trying direct launch."
-  launch_direct_ios || true
-  sleep 8
-  if ios_app_running; then
-    echo "iOS app running: $BUNDLE_ID"
-    return 0
-  fi
-
-  echo "iOS app is not running after direct launch; trying dev-client URL."
   for attempt in 1 2; do
+    xcrun simctl terminate "$SIM_TARGET" "$BUNDLE_ID" 2>/dev/null || true
+    sleep 1
     echo "Opening iOS dev client (attempt ${attempt})..."
     open_dev_client_ios || true
-    sleep 5
-    if ios_app_running; then
+    if wait_ios_app_running 30; then
       echo "iOS app running: $BUNDLE_ID"
       return 0
     fi
@@ -197,8 +142,6 @@ launch_app_ios() {
   echo "ERROR: iOS app did not stay running after launch."
   echo "       Simulator: $SIM_TARGET"
   echo "       Bundle ID: $BUNDLE_ID"
-  echo "       Last 20 lines of $APP_LAUNCH_LOG:"
-  tail -20 "$APP_LAUNCH_LOG" 2>/dev/null || true
   return 1
 }
 

--- a/scripts/perps/agentic/start-metro.sh
+++ b/scripts/perps/agentic/start-metro.sh
@@ -187,7 +187,7 @@ if metro_responds; then
   echo "To stop Metro:        ./scripts/perps/agentic/stop-metro.sh"
   if $LAUNCH_APP; then
     echo "Launching app..."
-    launch_app
+    launch_app || exit 1
   fi
   exit 0
 fi
@@ -252,7 +252,7 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
     echo "To stop Metro:        ./scripts/perps/agentic/stop-metro.sh"
     if $LAUNCH_APP; then
       echo "Launching app..."
-      launch_app
+      launch_app || exit 1
     fi
     exit 0
   fi


### PR DESCRIPTION
## **Description**

Fixes regressions in the TypeScript agentic preflight flow after #30988 where `yarn a:ios` could reuse a broken Metro process, fail to keep the iOS app launched, or stall during wallet fixture import.

The preflight now uses a dedicated ts-node config, preserves the root `tsconfig.json`, requires Metro `/status` to report `packager-status:running`, retries stale Metro launches, wipes/reinstalls cached apps before fixture setup, and fails immediately when launch/setup subprocesses fail instead of drifting into CDP timeouts.

The wallet fixture path was also hardened so HD fixture accounts are created through deterministic batched multichain account groups instead of the all-provider account creation path.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A - dev-only agentic tooling regression from #30988.

## **Manual testing steps**

```gherkin
Feature: agentic preflight launches iOS and imports wallet fixtures

  Scenario: clean iOS preflight reuses a healthy Metro and imports fixtures
    Given simulator mm-2 is booted
    And the cached iOS app artifact exists
    When I run yarn a:ios
    Then Metro is verified through /status
    And the app launches and exposes CDP on port 8062
    And wallet fixture setup reaches "=== Wallet Ready ==="
    And the run reaches "=== Preflight complete ==="

  Scenario: repo setup noise is not left behind
    When preflight runs through yarn a:ios
    Then root tsconfig.json has no diff
```

Validation evidence:

- `yarn a:ios` passed end to end
- Final CDP status: `WalletView`, platform `ios`, selected account `dev1`
- Root `tsconfig.json`: no diff
- `yarn tsc --noEmit --project scripts/perps/agentic/preflight/tsconfig.json`
- `yarn tsc --noEmit --pretty false --skipLibCheck`
- `bash -n scripts/perps/agentic/start-metro.sh scripts/perps/agentic/preflight.sh scripts/perps/agentic/setup-wallet.sh`
- `yarn prettier --check` on touched app/preflight files
- `yarn jest --runTestsByPath app/core/AgenticService/AgenticService.test.ts -t "setupWallet"`

## **Screenshots/Recordings**

### **Before**

N/A - internal CLI tooling, no UI surface.

### **After**

N/A - internal CLI tooling, no UI surface.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch vault unlock fallbacks and multichain account creation in __DEV__ AgenticService, but they are confined to agentic tooling and test harness paths, not production user flows.
> 
> **Overview**
> This PR hardens **dev-only** agentic preflight and wallet fixture flows after regressions from the TypeScript preflight migration.
> 
> **Preflight / Metro / install:** `yarn a:*` now runs preflight through a **dedicated `tsconfig.json`** so `expo run:ios` rewriting the repo-root `tsconfig` no longer breaks `ts-node`. Preflight **snapshots and restores** root `tsconfig.json` on exit (including signals). Metro health checks require **`packager-status:running`** on `/status`, with **retries** when `start-metro.sh` fails or the bundler is bound but hung. iOS installs wait for **codesign** (with ad-hoc fallback) and treat stale Expo/Metro port holders more gracefully than hard-failing. With **`--wallet-setup`**, a fingerprint cache hit **uninstalls and reinstalls** from the cached artifact so app data is wiped instead of skipping native work.
> 
> **Wallet fixtures (`AgenticService` + `setup-wallet.sh`):** Fixture apply adds **`unlockFixtureVault`** (real `Authentication.unlockWallet`, then keyring + onboarding Redux recovery when auth leaves the vault locked). Missing HD accounts are created in one **`createMultichainAccountGroups`** batch (not per-account loops), with **timeouts and polling** until accounts exist. CDP setup can **validate wallet state after eval timeouts** instead of failing immediately on slow large fixtures.
> 
> **Tests / scripts:** New unit coverage for vault recovery and batched HD groups; shell tests updated for the preflight tsconfig and wallet-setup cache wipe path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d06d450076ae4ea9e50bef12e4674bbf5c87488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->