### PR TITLE
feat: add Quick Buy button to Market Insights and related analytics

### DIFF
--- a/app/components/UI/MarketInsights/MarketInsights.testIds.ts
+++ b/app/components/UI/MarketInsights/MarketInsights.testIds.ts
@@ -15,6 +15,7 @@ export enum MarketInsightsSelectorsIDs {
   SHORT_BUTTON = 'market-insights-short-button',
   SWAP_BUTTON = 'market-insights-swap-button',
   BUY_BUTTON = 'market-insights-buy-button',
+  QUICK_BUY_BUTTON = 'market-insights-quick-buy-button',
   FEEDBACK_BOTTOM_SHEET = 'market-insights-feedback-bottom-sheet',
   FEEDBACK_OPTION_NOT_RELEVANT = 'market-insights-feedback-option-not-relevant',
   FEEDBACK_OPTION_NOT_ACCURATE = 'market-insights-feedback-option-not-accurate',

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.test.tsx
@@ -242,23 +242,50 @@ jest.mock('../../../TokenDetails/components/TokenDetailsStickyFooter', () => {
     default: ({
       onSwapPress,
       onBuyPress,
+      onQuickBuyPress,
       swapTestID,
       buyTestID,
+      quickBuyTestID,
     }: {
       onSwapPress?: () => void;
       onBuyPress?: () => void;
+      onQuickBuyPress?: () => void;
       swapTestID?: string;
       buyTestID?: string;
+      quickBuyTestID?: string;
     }) => (
       <MockView testID="token-details-sticky-footer">
         {swapTestID && (
           <MockPressable testID={swapTestID} onPress={onSwapPress} />
         )}
         {buyTestID && <MockPressable testID={buyTestID} onPress={onBuyPress} />}
+        {onQuickBuyPress && quickBuyTestID && (
+          <MockPressable testID={quickBuyTestID} onPress={onQuickBuyPress} />
+        )}
       </MockView>
     ),
   };
 });
+
+const mockAssetDetailsQuickBuy = jest.fn((_props: unknown) => null);
+jest.mock('../../../TokenDetails/components/AssetDetailsQuickBuy', () => ({
+  __esModule: true,
+  default: (props: unknown) => mockAssetDetailsQuickBuy(props),
+}));
+
+let mockIsQuickBuyEnabled = false;
+jest.mock(
+  '../../../../../selectors/featureFlagController/socialAiAssetDetailsQuickBuy',
+  () => ({
+    selectSocialAiAssetDetailsQuickBuyEnabled: () => mockIsQuickBuyEnabled,
+  }),
+);
+
+const mockPlayImpact = jest.fn();
+jest.mock('../../../../../util/haptics', () => ({
+  playImpact: (...args: unknown[]) => mockPlayImpact(...args),
+  ImpactMoment: { PrimaryCTA: 'PrimaryCTA' },
+}));
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -292,6 +319,7 @@ describe('MarketInsightsView', () => {
     jest.clearAllMocks();
     resetFeedbackCache();
     mockIsEligible = true;
+    mockIsQuickBuyEnabled = false;
     mockRouteParams = {
       assetSymbol: 'ETH',
       assetIdentifier: 'eip155:1/erc20:0x123',
@@ -898,6 +926,76 @@ describe('MarketInsightsView', () => {
     expect(queryByTestId(MarketInsightsSelectorsIDs.LONG_BUTTON)).toBeNull();
     expect(queryByTestId(MarketInsightsSelectorsIDs.SHORT_BUTTON)).toBeNull();
     expect(getByTestId('token-details-sticky-footer')).toBeOnTheScreen();
+  });
+
+  it('does not render the quick buy button or mount AssetDetailsQuickBuy when the flag is disabled', () => {
+    mockIsQuickBuyEnabled = false;
+    mockUseMarketInsights.mockReturnValue({
+      report: buildMockReport(),
+      isLoading: false,
+      error: null,
+      timeAgo: '1m ago',
+    });
+
+    const { queryByTestId } = renderWithProvider(<MarketInsightsView />);
+
+    expect(
+      queryByTestId(MarketInsightsSelectorsIDs.QUICK_BUY_BUTTON),
+    ).toBeNull();
+    expect(mockAssetDetailsQuickBuy).not.toHaveBeenCalled();
+  });
+
+  it('renders the quick buy button and mounts AssetDetailsQuickBuy hidden when the flag is enabled', () => {
+    mockIsQuickBuyEnabled = true;
+    mockUseMarketInsights.mockReturnValue({
+      report: buildMockReport(),
+      isLoading: false,
+      error: null,
+      timeAgo: '1m ago',
+    });
+
+    const { getByTestId } = renderWithProvider(<MarketInsightsView />);
+
+    expect(
+      getByTestId(MarketInsightsSelectorsIDs.QUICK_BUY_BUTTON),
+    ).toBeOnTheScreen();
+    expect(mockAssetDetailsQuickBuy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isVisible: false,
+        source: 'market_insights',
+        token: expect.objectContaining({ address: '0x123', symbol: 'ETH' }),
+      }),
+    );
+  });
+
+  it('opens AssetDetailsQuickBuy and tracks a quick_buy interaction when the quick buy button is pressed', async () => {
+    mockIsQuickBuyEnabled = true;
+    mockUseMarketInsights.mockReturnValue({
+      report: buildMockReport({ digestId: 'digest-123' }),
+      isLoading: false,
+      error: null,
+      timeAgo: '1m ago',
+    });
+
+    const { getByTestId } = renderWithProvider(<MarketInsightsView />);
+
+    await act(async () => {
+      fireEvent.press(getByTestId(MarketInsightsSelectorsIDs.QUICK_BUY_BUTTON));
+    });
+
+    expect(mockPlayImpact).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
+        properties: expect.objectContaining({
+          interaction_type: 'quick_buy',
+          source: 'unknown',
+        }),
+      }),
+    );
+    expect(mockAssetDetailsQuickBuy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isVisible: true, source: 'market_insights' }),
+    );
   });
 
   it('sends perps_market analytics property (not caip19) in perps context', async () => {

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -86,7 +86,10 @@ import {
 } from '@metamask/perps-controller';
 import { usePerpsEventTracking } from '../../../Perps/hooks/usePerpsEventTracking';
 import TokenDetailsStickyFooter from '../../../TokenDetails/components/TokenDetailsStickyFooter';
+import AssetDetailsQuickBuy from '../../../TokenDetails/components/AssetDetailsQuickBuy';
 import type { TokenDetailsRouteParams } from '../../../TokenDetails/constants/constants';
+import { selectSocialAiAssetDetailsQuickBuyEnabled } from '../../../../../selectors/featureFlagController/socialAiAssetDetailsQuickBuy';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 
 const feedbackByDigest = new Map<string, 'up' | 'down'>();
 
@@ -217,8 +220,12 @@ const MarketInsightsView: React.FC = () => {
   );
 
   const isEligible = useSelector(selectPerpsEligibility);
+  const isQuickBuyEnabled = useSelector(
+    selectSocialAiAssetDetailsQuickBuyEnabled,
+  );
   const [isEligibilityModalVisible, setIsEligibilityModalVisible] =
     useState(false);
+  const [isQuickBuyVisible, setIsQuickBuyVisible] = useState(false);
   const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
   const { gate } = useComplianceGate(selectedAddress ?? '');
   const { track } = usePerpsEventTracking();
@@ -389,6 +396,32 @@ const MarketInsightsView: React.FC = () => {
     assetSymbolProperty,
     routeSource,
   ]);
+
+  const handleStickyQuickBuyPress = useCallback(() => {
+    playImpact(ImpactMoment.PrimaryCTA);
+    const event = createEventBuilder(
+      MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
+    )
+      .addProperties({
+        ...assetIdProperty,
+        ...assetSymbolProperty,
+        interaction_type: 'quick_buy',
+        source: routeSource,
+      })
+      .build();
+    trackEvent(event);
+    setIsQuickBuyVisible(true);
+  }, [
+    trackEvent,
+    createEventBuilder,
+    assetIdProperty,
+    assetSymbolProperty,
+    routeSource,
+  ]);
+
+  const handleQuickBuyClose = useCallback(() => {
+    setIsQuickBuyVisible(false);
+  }, []);
 
   const handleTrendPress = useCallback((trend: MarketInsightsTrend) => {
     const hasArticles = trend.articles.length > 0;
@@ -677,6 +710,17 @@ const MarketInsightsView: React.FC = () => {
           </Box>
         </AnimatedSection>
 
+        {!isPerps && Boolean(stickyFooterToken) && (
+          <Box alignItems={BoxAlignItems.Center} twClassName="px-4 pb-6">
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {strings('market_insights.footer_disclaimer')}
+            </Text>
+          </Box>
+        )}
+
         {/* "What's being said" section */}
         {allTweets.length > 0 && (
           <AnimatedSection delay={SECTION_ANIMATION_DELAYS_MS.whatsBeingSaid}>
@@ -828,18 +872,14 @@ const MarketInsightsView: React.FC = () => {
               buyTestID={MarketInsightsSelectorsIDs.BUY_BUTTON}
               onSwapPress={handleStickySwapPress}
               onBuyPress={handleStickyBuyPress}
+              onQuickBuyPress={
+                isQuickBuyEnabled ? handleStickyQuickBuyPress : undefined
+              }
+              quickBuyTestID={MarketInsightsSelectorsIDs.QUICK_BUY_BUTTON}
               sourcePage="MarketInsightsView"
               isPricePositive={isPricePositive}
               useAmbientColor={useAmbientColor}
             />
-            <Box alignItems={BoxAlignItems.Center}>
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('market_insights.footer_disclaimer')}
-              </Text>
-            </Box>
           </Box>
         ) : null)}
 
@@ -860,6 +900,15 @@ const MarketInsightsView: React.FC = () => {
           onSubmit={handleFeedbackSubmit}
         />
       ) : null}
+
+      {isQuickBuyEnabled && stickyFooterToken && (
+        <AssetDetailsQuickBuy
+          isVisible={isQuickBuyVisible}
+          token={stickyFooterToken}
+          onClose={handleQuickBuyClose}
+          source="market_insights"
+        />
+      )}
 
       {isEligibilityModalVisible && (
         // Android Compatibility: Wrap the <Modal> in a plain <View> component to prevent rendering issues and freezing.

--- a/app/components/UI/TokenDetails/components/AssetDetailsQuickBuy.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetDetailsQuickBuy.test.tsx
@@ -204,7 +204,7 @@ describe('AssetDetailsQuickBuy', () => {
     );
   });
 
-  it('sets analytics source to "asset_details"', () => {
+  it('defaults analytics source to "asset_details" when no source prop is provided', () => {
     render(
       <AssetDetailsQuickBuy isVisible token={mockToken} onClose={jest.fn()} />,
     );
@@ -212,6 +212,23 @@ describe('AssetDetailsQuickBuy', () => {
     expect(mockQuickBuyRoot).toHaveBeenCalledWith(
       expect.objectContaining({
         analyticsContext: { source: 'asset_details' },
+      }),
+    );
+  });
+
+  it('forwards an explicit source prop into the analytics context', () => {
+    render(
+      <AssetDetailsQuickBuy
+        isVisible
+        token={mockToken}
+        onClose={jest.fn()}
+        source="market_insights"
+      />,
+    );
+
+    expect(mockQuickBuyRoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        analyticsContext: { source: 'market_insights' },
       }),
     );
   });

--- a/app/components/UI/TokenDetails/components/AssetDetailsQuickBuy.tsx
+++ b/app/components/UI/TokenDetails/components/AssetDetailsQuickBuy.tsx
@@ -3,6 +3,7 @@ import type { CaipChainId, Hex } from '@metamask/utils';
 import React, { useMemo } from 'react';
 import { TOP_TRADERS_QUICK_BUY_FEATURES } from '../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/features';
 import { QuickBuy } from '../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuy';
+import type { QuickBuySheetSource } from '../../../Views/SocialLeaderboard/analytics';
 import type {
   QuickBuyAnalyticsContext,
   QuickBuyTarget,
@@ -13,9 +14,9 @@ export interface AssetDetailsQuickBuyProps {
   isVisible: boolean;
   token: TokenDetailsRouteParams | null;
   onClose: () => void;
+  /** Analytics surface reported as the QuickBuy `source`. Defaults to `'asset_details'`. */
+  source?: QuickBuySheetSource;
 }
-
-const ANALYTICS_CONTEXT: QuickBuyAnalyticsContext = { source: 'asset_details' };
 
 /**
  * Asset Details host adapter for QuickBuy. Maps `TokenI.chainId` (hex or CAIP)
@@ -27,6 +28,7 @@ const AssetDetailsQuickBuy: React.FC<AssetDetailsQuickBuyProps> = ({
   isVisible,
   token,
   onClose,
+  source = 'asset_details',
 }) => {
   // Read only the primitive fields the target depends on, so unrelated
   // `TokenDetailsRouteParams` changes (balance, price, etc.) don't produce a
@@ -55,13 +57,15 @@ const AssetDetailsQuickBuy: React.FC<AssetDetailsQuickBuyProps> = ({
     };
   }, [chainId, tokenAddress, tokenSymbol, tokenName]);
 
+  const analyticsContext: QuickBuyAnalyticsContext = { source };
+
   return (
     <QuickBuy.Root
       isVisible={isVisible}
       target={target}
       onClose={onClose}
       features={TOP_TRADERS_QUICK_BUY_FEATURES}
-      analyticsContext={ANALYTICS_CONTEXT}
+      analyticsContext={analyticsContext}
     />
   );
 };

--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
@@ -843,5 +843,19 @@ describe('TokenDetailsStickyFooter', () => {
 
       expect(onQuickBuyPress).not.toHaveBeenCalled();
     });
+
+    it('hides the quick buy button when the account has no eligible swap source', () => {
+      mockHasEligibleSwapTokens = false;
+      const onQuickBuyPress = jest.fn();
+      const { queryByTestId } = render(
+        <TokenDetailsStickyFooter
+          {...defaultProps}
+          onQuickBuyPress={onQuickBuyPress}
+          quickBuyTestID={quickBuyTestID}
+        />,
+      );
+
+      expect(queryByTestId(quickBuyTestID)).toBeNull();
+    });
   });
 });

--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
@@ -182,6 +182,7 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
   const showSwapButton = hasEligibleSwapTokens;
   const showBuyButton = isBuyable || !hasEligibleSwapTokens;
   const showBothButtons = showSwapButton && showBuyButton;
+  const showQuickBuyButton = Boolean(onQuickBuyPress) && hasEligibleSwapTokens;
 
   const tradingOpen = isTokenTradingOpen(token as BridgeToken);
   useEffect(() => {
@@ -345,13 +346,14 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
             {strings('asset_overview.buy_button')}
           </Button>
         )}
-        {onQuickBuyPress && (
+        {showQuickBuyButton && (
           <ButtonAnimated
             testID={quickBuyTestID}
             accessibilityRole="button"
             accessibilityLabel={strings('asset_overview.buy_button')}
             style={[styles.quickBuyButton, { borderColor: successColorHex }]}
             onPress={() => {
+              if (!onQuickBuyPress) return;
               trackStickyFooterTapped({
                 ctaType: 'quick_buy',
                 balanceFiatUsd,

--- a/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
+++ b/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
@@ -84,7 +84,8 @@ export type SocialLeaderboardSource =
   | 'leaderboard'
   | 'trader_profile'
   | 'profile_position'
-  | 'asset_details';
+  | 'asset_details'
+  | 'market_insights';
 
 export type LeaderboardScreenViewedSource = Extract<
   SocialLeaderboardSource,
@@ -113,5 +114,9 @@ export type FollowTradingTokenSource = Extract<
 
 export type QuickBuySheetSource = Extract<
   SocialLeaderboardSource,
-  'notification' | 'profile_position' | 'leaderboard' | 'asset_details'
+  | 'notification'
+  | 'profile_position'
+  | 'leaderboard'
+  | 'asset_details'
+  | 'market_insights'
 >;


### PR DESCRIPTION
## **Description**

- [Companion PR adding the events in Segment](https://github.com/Consensys/segment-schema/pull/594)

https://github.com/user-attachments/assets/712b71e5-a5f7-4881-a562-2d2c285047ec


This PR adds the QuickBuy "flash" button entry point to the Market Insights view, mirroring its existing implementation in the parent Asset Details (Token Details) view.

1. **Reason for the change:** Market Insights already renders the shared `TokenDetailsStickyFooter`, but it did not expose the QuickBuy lightning button that Asset Details offers. Users reading an asset's Market Insights had no fast path to buy.
2. **Improvement/solution:** Wire the footer's existing `onQuickBuyPress`/`quickBuyTestID` slot in `MarketInsightsView`, gated behind the same `socialAiAssetDetailsQuickBuy` feature flag, and open the reused `AssetDetailsQuickBuy` sheet with the in-scope `stickyFooterToken`. The sheet reports a distinct `market_insights` analytics source (a new value added to `SocialLeaderboardSource`/`QuickBuySheetSource`), and pressing the button fires a `MARKET_INSIGHTS_INTERACTION` event with `interaction_type: 'quick_buy'`, parallel to the existing swap/buy handlers.

Note: the new analytics values (`market_insights` source, `quick_buy` interaction type) are registered in a companion `segment-schema` PR so the events pass schema validation.

## **Changelog**

CHANGELOG entry: Added a Quick Buy button to the Market Insights view for faster asset purchases.

## **Related issues**

Fixes: TSA-599

## **Manual testing steps**

```gherkin
Feature: Quick Buy from Market Insights

  Scenario: User opens Quick Buy from the Market Insights view
    Given the socialAiAssetDetailsQuickBuy feature flag is enabled
    And the user is on a token's Market Insights view (non-perps)
    When the user taps the Quick Buy (lightning) button in the sticky footer
    Then the QuickBuy bottom sheet opens for that token
    And a Market Insights interaction event is tracked with interaction_type "quick_buy"
    And the QuickBuy sheet reports analytics source "market_insights"

  Scenario: Flag disabled hides the button
    Given the socialAiAssetDetailsQuickBuy feature flag is disabled
    When the user is on a token's Market Insights view
    Then the Quick Buy button is not rendered
    And the QuickBuy sheet is not mounted
```

## **Screenshots/Recordings**

### **Before**

<!-- No Quick Buy button in the Market Insights sticky footer. -->

### **After**

<!-- Quick Buy (lightning) button shown in the Market Insights sticky footer; tapping it opens the QuickBuy sheet. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes an in-app purchase/swap path from a new screen behind a flag, but reuses existing QuickBuy and footer gating rather than new payment logic.
> 
> **Overview**
> Adds a **Quick Buy** (lightning) entry point on **Market Insights** for non-perps token views, using the same `socialAiAssetDetailsQuickBuy` flag and shared `TokenDetailsStickyFooter` / `AssetDetailsQuickBuy` flow as Asset Details.
> 
> When the flag is on, the sticky footer receives `onQuickBuyPress` and a new test ID; tapping it triggers haptics, opens the QuickBuy sheet for `stickyFooterToken`, and emits `MARKET_INSIGHTS_INTERACTION` with `interaction_type: 'quick_buy'`. QuickBuy analytics now accept an optional `source` (default `asset_details`; Market Insights passes `market_insights`), with `QuickBuySheetSource` / `SocialLeaderboardSource` extended accordingly.
> 
> `TokenDetailsStickyFooter` only shows Quick Buy when there is an eligible swap source (`hasEligibleSwapTokens`). The Market Insights **footer disclaimer** moves into the scroll content above “What’s being said” instead of sitting under the sticky footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c5789801f3c41bec25d274a265699bf4a9eb5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->