### PR TITLE
fix(money): uniform onboarding card image padding (MUSD-889)

### DIFF
--- a/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
@@ -1,6 +1,8 @@
 // Third party dependencies.
 import React from 'react';
+import { Image } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // Internal dependencies.
 import StepperCard from './StepperCard';
@@ -71,6 +73,38 @@ describe('StepperCard', () => {
         />,
       );
       expect(getByTestId('card-title')).toHaveTextContent('Step 2');
+    });
+  });
+
+  describe('step image', () => {
+    it('sizes the image to its intrinsic aspect ratio so padding stays uniform', () => {
+      const resolveSpy = jest
+        .spyOn(Image, 'resolveAssetSource')
+        .mockReturnValue({ width: 987, height: 555, scale: 1, uri: 'card' });
+      const tw = useTailwind();
+
+      render(
+        <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
+      );
+
+      expect(tw.style).toHaveBeenCalledWith('w-full', {
+        aspectRatio: 987 / 555,
+      });
+      resolveSpy.mockRestore();
+    });
+
+    it('falls back to a fixed height when the image has no intrinsic size', () => {
+      const resolveSpy = jest
+        .spyOn(Image, 'resolveAssetSource')
+        .mockReturnValue({ width: 0, height: 0, scale: 1, uri: 'card' });
+      const tw = useTailwind();
+
+      render(
+        <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
+      );
+
+      expect(tw.style).toHaveBeenCalledWith('w-full', { height: 215 });
+      resolveSpy.mockRestore();
     });
   });
 

--- a/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
@@ -74,19 +74,6 @@ describe('StepperCard', () => {
     });
   });
 
-  describe('step image', () => {
-    it('sizes the image box to a 16:9 aspect ratio so padding stays uniform', () => {
-      const { getByTestId } = render(
-        <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
-      );
-
-      expect(getByTestId('card-step-image')).toHaveStyle({
-        width: '100%',
-        aspectRatio: 16 / 9,
-      });
-    });
-  });
-
   describe('completion bounds guard', () => {
     it('returns null when currentStep equals steps.length', () => {
       const { toJSON } = render(

--- a/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { Image } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // Internal dependencies.
 import StepperCard from './StepperCard';
@@ -77,17 +76,17 @@ describe('StepperCard', () => {
   });
 
   describe('step image', () => {
-    it('sizes the image to its intrinsic aspect ratio so padding stays uniform', () => {
+    it('sizes the image box to its intrinsic aspect ratio so padding stays uniform', () => {
       const resolveSpy = jest
         .spyOn(Image, 'resolveAssetSource')
         .mockReturnValue({ width: 987, height: 555, scale: 1, uri: 'card' });
-      const tw = useTailwind();
 
-      render(
+      const { getByTestId } = render(
         <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
       );
 
-      expect(tw.style).toHaveBeenCalledWith('w-full', {
+      expect(getByTestId('card-step-image')).toHaveStyle({
+        width: '100%',
         aspectRatio: 987 / 555,
       });
       resolveSpy.mockRestore();
@@ -97,13 +96,15 @@ describe('StepperCard', () => {
       const resolveSpy = jest
         .spyOn(Image, 'resolveAssetSource')
         .mockReturnValue({ width: 0, height: 0, scale: 1, uri: 'card' });
-      const tw = useTailwind();
 
-      render(
+      const { getByTestId } = render(
         <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
       );
 
-      expect(tw.style).toHaveBeenCalledWith('w-full', { height: 215 });
+      expect(getByTestId('card-step-image')).toHaveStyle({
+        width: '100%',
+        height: 215,
+      });
       resolveSpy.mockRestore();
     });
   });

--- a/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
@@ -1,6 +1,5 @@
 // Third party dependencies.
 import React from 'react';
-import { Image } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 
 // Internal dependencies.
@@ -76,36 +75,15 @@ describe('StepperCard', () => {
   });
 
   describe('step image', () => {
-    it('sizes the image box to its intrinsic aspect ratio so padding stays uniform', () => {
-      const resolveSpy = jest
-        .spyOn(Image, 'resolveAssetSource')
-        .mockReturnValue({ width: 987, height: 555, scale: 1, uri: 'card' });
-
+    it('sizes the image box to a 16:9 aspect ratio so padding stays uniform', () => {
       const { getByTestId } = render(
         <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
       );
 
       expect(getByTestId('card-step-image')).toHaveStyle({
         width: '100%',
-        aspectRatio: 987 / 555,
+        aspectRatio: 16 / 9,
       });
-      resolveSpy.mockRestore();
-    });
-
-    it('falls back to a fixed height when the image has no intrinsic size', () => {
-      const resolveSpy = jest
-        .spyOn(Image, 'resolveAssetSource')
-        .mockReturnValue({ width: 0, height: 0, scale: 1, uri: 'card' });
-
-      const { getByTestId } = render(
-        <StepperCard steps={[makeStep()]} currentStep={0} testID="card" />,
-      );
-
-      expect(getByTestId('card-step-image')).toHaveStyle({
-        width: '100%',
-        height: 215,
-      });
-      resolveSpy.mockRestore();
     });
   });
 

--- a/app/component-library/components-temp/StepperCard/StepperCard.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useRef } from 'react';
-import { Image, TouchableOpacity } from 'react-native';
+import { Image, TouchableOpacity, View, ViewStyle } from 'react-native';
 import {
   Box,
-  BoxAlignItems,
   Button,
   ButtonSize,
   ButtonVariant,
@@ -55,6 +54,9 @@ const StepperCard = ({
     resolvedImage?.width && resolvedImage?.height
       ? resolvedImage.width / resolvedImage.height
       : undefined;
+  const imageWrapperStyle: ViewStyle = imageAspectRatio
+    ? { width: '100%', aspectRatio: imageAspectRatio }
+    : { width: '100%', height: 215 };
 
   return (
     <Box
@@ -62,21 +64,14 @@ const StepperCard = ({
       testID={getTestId('container')}
     >
       {/* Image */}
-      <Box
-        alignItems={BoxAlignItems.Center}
-        testID={getTestId('step-image')}
-        twClassName="p-4"
-      >
-        <Image
-          source={step.image}
-          style={tw.style(
-            'w-full',
-            imageAspectRatio
-              ? { aspectRatio: imageAspectRatio }
-              : { height: 215 },
-          )}
-          resizeMode="contain"
-        />
+      <Box twClassName="p-4">
+        <View testID={getTestId('step-image')} style={imageWrapperStyle}>
+          <Image
+            source={step.image}
+            style={tw.style('w-full h-full')}
+            resizeMode="contain"
+          />
+        </View>
       </Box>
 
       {/* Content */}

--- a/app/component-library/components-temp/StepperCard/StepperCard.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.tsx
@@ -49,14 +49,7 @@ const StepperCard = ({
 
   const step = steps[currentStep];
 
-  const resolvedImage = Image.resolveAssetSource(step.image);
-  const imageAspectRatio =
-    resolvedImage?.width && resolvedImage?.height
-      ? resolvedImage.width / resolvedImage.height
-      : undefined;
-  const imageWrapperStyle: ViewStyle = imageAspectRatio
-    ? { width: '100%', aspectRatio: imageAspectRatio }
-    : { width: '100%', height: 215 };
+  const imageWrapperStyle: ViewStyle = { width: '100%', aspectRatio: 16 / 9 };
 
   return (
     <Box

--- a/app/component-library/components-temp/StepperCard/StepperCard.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.tsx
@@ -50,6 +50,12 @@ const StepperCard = ({
 
   const step = steps[currentStep];
 
+  const resolvedImage = Image.resolveAssetSource(step.image);
+  const imageAspectRatio =
+    resolvedImage?.width && resolvedImage?.height
+      ? resolvedImage.width / resolvedImage.height
+      : undefined;
+
   return (
     <Box
       twClassName="rounded-2xl bg-muted overflow-hidden"
@@ -59,11 +65,16 @@ const StepperCard = ({
       <Box
         alignItems={BoxAlignItems.Center}
         testID={getTestId('step-image')}
-        twClassName="px-4 pt-4 h-[215px]"
+        twClassName="p-4"
       >
         <Image
           source={step.image}
-          style={tw.style('w-full h-full')}
+          style={tw.style(
+            'w-full',
+            imageAspectRatio
+              ? { aspectRatio: imageAspectRatio }
+              : { height: 215 },
+          )}
           resizeMode="contain"
         />
       </Box>

--- a/app/component-library/components-temp/StepperCard/StepperCard.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Image, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { Image, TouchableOpacity } from 'react-native';
 import {
   Box,
   Button,
@@ -49,8 +49,6 @@ const StepperCard = ({
 
   const step = steps[currentStep];
 
-  const imageWrapperStyle: ViewStyle = { width: '100%', aspectRatio: 16 / 9 };
-
   return (
     <Box
       twClassName="rounded-2xl bg-muted overflow-hidden"
@@ -58,13 +56,13 @@ const StepperCard = ({
     >
       {/* Image */}
       <Box twClassName="p-4">
-        <View testID={getTestId('step-image')} style={imageWrapperStyle}>
+        <Box testID={getTestId('step-image')} twClassName="w-full aspect-video">
           <Image
             source={step.image}
             style={tw.style('w-full h-full')}
             resizeMode="contain"
           />
-        </View>
+        </Box>
       </Box>
 
       {/* Content */}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Money home screen the onboarding card's image had more padding on top than on its sides. The `StepperCard` rendered the image in a fixed-height box (`px-4 pt-4 h-[215px]`) with `resizeMode="contain"`, so the 16:9 artwork was letterboxed inside the 215px area and the top gap ended up larger than the 16px left/right padding.

This replaces the fixed height with a 16:9 (`aspect-video`) frame and applies a uniform `p-4` (16px) padding on every side, so the spacing around the image is consistent. The artwork itself is unchanged.

`StepperCard` is only consumed by the Money onboarding card, so the change is scoped to that surface.

Figma link: https://www.figma.com/design/XKZ8hRqSn2iTiuzmlQLuYQ/Money-account?node-id=8027-14779&m=dev
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [MUSD-889](https://consensyssoftware.atlassian.net/browse/MUSD-889)

## **Manual testing steps**

```gherkin
Feature: Onboarding card image padding

  Scenario: Image padding is uniform on the onboarding card
    Given I am on the Money home screen with the onboarding card visible
    Then the gap above the card image matches the gap on its left and right sides
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/073472af-fc44-4b4e-8ecc-4c4563443bb7" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-889]: https://consensyssoftware.atlassian.net/browse/MUSD-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational layout-only change in a single shared card component used for Money onboarding; no auth, data, or business logic.
> 
> **Overview**
> **`StepperCard`** image layout is updated so the step image uses **uniform 16px padding** on all sides and a **16:9 (`aspect-video`)** frame instead of a **fixed 215px** height with asymmetric `px-4` / `pt-4`.
> 
> That removes extra top letterboxing from `resizeMode="contain"` inside the old box, which showed up on the **Money onboarding card** as uneven spacing above the artwork. Copy, CTAs, and step logic are unchanged; only the image container structure and Tailwind classes differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4761aa6bd988d7948f233abf19b193cc8beea67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

