### PR TITLE
feat: enhance useTransakRouting to resolve wallet address from headle…

### DIFF
--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -409,9 +409,6 @@ describe('useTransakRouting', () => {
     });
 
     it('resolves the wallet address from the headless session assetId, not the async-seeded selectedToken (TRAM-3598)', async () => {
-      // Arrange — selectedToken default chain is eip155:1, but the headless
-      // session's asset is on Arbitrum. The session asset must win so the
-      // address resolves on the first attempt (before selectedToken propagates).
       const mockGetSession = jest.requireMock('../headless/sessionRegistry')
         .getSession as jest.Mock;
       mockGetSession.mockReturnValue({
@@ -442,7 +439,6 @@ describe('useTransakRouting', () => {
         'https://payment.example.com',
       );
 
-      // Act
       const { result } = renderHook(() =>
         useTransakRouting({
           baseRoute: 'RampHeadlessHost',
@@ -456,8 +452,6 @@ describe('useTransakRouting', () => {
         );
       });
 
-      // Assert — chain derived from the session asset (Arbitrum), and the
-      // resolved address (not an empty string) is passed to Transak.
       expect(mockUseRampAccountAddress).toHaveBeenCalledWith('eip155:42161');
       expect(mockGeneratePaymentWidgetUrl).toHaveBeenCalledWith(
         'test-ott',
@@ -468,15 +462,12 @@ describe('useTransakRouting', () => {
     });
 
     it('falls back to the selectedToken chain when there is no headless session', () => {
-      // Arrange — non-headless BuildQuote flow: no session, selectedToken is eip155:1.
       const mockGetSession = jest.requireMock('../headless/sessionRegistry')
         .getSession as jest.Mock;
       mockGetSession.mockReturnValue(undefined);
 
-      // Act
       renderHook(() => useTransakRouting());
 
-      // Assert
       expect(mockUseRampAccountAddress).toHaveBeenCalledWith('eip155:1');
     });
 

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -22,6 +22,13 @@ jest.mock('../headless/sessionRegistry', () => ({
   failSession: jest.fn(),
 }));
 
+jest.mock('../headless', () => ({
+  getChainIdFromAssetId: (assetId: string) => {
+    const slashIndex = assetId.indexOf('/');
+    return slashIndex <= 0 ? null : assetId.slice(0, slashIndex);
+  },
+}));
+
 const MOCK_WALLET_ADDRESS = '0xabcdef1234567890';
 
 jest.mock('react-redux', () => ({
@@ -33,9 +40,13 @@ jest.mock('react-redux', () => ({
   })),
 }));
 
+const mockUseRampAccountAddress = jest.fn(
+  (_chainId?: unknown): string | null => MOCK_WALLET_ADDRESS,
+);
+
 jest.mock('./useRampAccountAddress', () => ({
   __esModule: true,
-  default: () => MOCK_WALLET_ADDRESS,
+  default: (chainId: unknown) => mockUseRampAccountAddress(chainId),
 }));
 
 jest.mock('../../../../util/theme', () => {
@@ -395,6 +406,78 @@ describe('useTransakRouting', () => {
           ],
         }),
       );
+    });
+
+    it('resolves the wallet address from the headless session assetId, not the async-seeded selectedToken (TRAM-3598)', async () => {
+      // Arrange — selectedToken default chain is eip155:1, but the headless
+      // session's asset is on Arbitrum. The session asset must win so the
+      // address resolves on the first attempt (before selectedToken propagates).
+      const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+        .getSession as jest.Mock;
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        params: { assetId: 'eip155:42161/slip44:60' },
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onClose: jest.fn(),
+          onError: jest.fn(),
+        },
+      });
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        mobileNumber: '+1',
+        dob: '1990-01-01',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'APPROVED',
+        kycType: 'SIMPLE',
+      });
+      mockGetUserLimits.mockResolvedValue({
+        remaining: { '1': 10000, '30': 50000, '365': 200000 },
+      });
+      mockRequestOtt.mockResolvedValue({ ott: 'test-ott' });
+      mockGeneratePaymentWidgetUrl.mockReturnValue(
+        'https://payment.example.com',
+      );
+
+      // Act
+      const { result } = renderHook(() =>
+        useTransakRouting({
+          baseRoute: 'RampHeadlessHost',
+          baseRouteParams: { headlessSessionId: 'hs-1' },
+        }),
+      );
+      await act(async () => {
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
+      });
+
+      // Assert — chain derived from the session asset (Arbitrum), and the
+      // resolved address (not an empty string) is passed to Transak.
+      expect(mockUseRampAccountAddress).toHaveBeenCalledWith('eip155:42161');
+      expect(mockGeneratePaymentWidgetUrl).toHaveBeenCalledWith(
+        'test-ott',
+        mockQuote,
+        MOCK_WALLET_ADDRESS,
+        { theme: 'light' },
+      );
+    });
+
+    it('falls back to the selectedToken chain when there is no headless session', () => {
+      // Arrange — non-headless BuildQuote flow: no session, selectedToken is eip155:1.
+      const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+        .getSession as jest.Mock;
+      mockGetSession.mockReturnValue(undefined);
+
+      // Act
+      renderHook(() => useTransakRouting());
+
+      // Assert
+      expect(mockUseRampAccountAddress).toHaveBeenCalledWith('eip155:1');
     });
 
     it('navigates to bank details for manual bank transfer when KYC is APPROVED', async () => {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -34,6 +34,7 @@ import {
   getSession,
 } from '../headless/sessionRegistry';
 import { dismissHeadlessFlow } from '../headless/headlessEntryNavigation';
+import { getChainIdFromAssetId } from '../headless';
 
 interface RampStackParamList {
   /** `baseRouteParams` (e.g. `headlessSessionId`) are merged onto this route in resets — see `navigateToVerifyIdentityCallback`. */
@@ -167,9 +168,14 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const { selectedPaymentMethod } = useRampsPaymentMethods();
 
   const { selected: selectedToken } = useSelector(selectTokens);
-  const walletAddress = useRampAccountAddress(
-    selectedToken?.chainId as CaipChainId,
-  );
+  // Headless seeds `selectedToken` async, so it can still be empty here — making
+  // Transak re-prompt for the wallet address (TRAM-3598). The session knows the
+  // assetId up front, so use it for the chain; fall back to selectedToken otherwise.
+  const headlessAssetId = getSession(headlessSessionId)?.params?.assetId;
+  const walletAddressChainId =
+    (headlessAssetId ? getChainIdFromAssetId(headlessAssetId) : null) ??
+    (selectedToken?.chainId as CaipChainId | undefined);
+  const walletAddress = useRampAccountAddress(walletAddressChainId);
 
   const fiatCurrency = userRegion?.country?.currency || '';
   const regionIsoCode = userRegion?.regionCode || '';

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -168,9 +168,6 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const { selectedPaymentMethod } = useRampsPaymentMethods();
 
   const { selected: selectedToken } = useSelector(selectTokens);
-  // Headless seeds `selectedToken` async, so it can still be empty here — making
-  // Transak re-prompt for the wallet address (TRAM-3598). The session knows the
-  // assetId up front, so use it for the chain; fall back to selectedToken otherwise.
   const headlessAssetId = getSession(headlessSessionId)?.params?.assetId;
   const walletAddressChainId =
     (headlessAssetId ? getChainIdFromAssetId(headlessAssetId) : null) ??


### PR DESCRIPTION
## **Description**

This PR fixes the Headless Ramps "Add funds" (fiat deposit) flow used by MM Pay for Perps/Money Account deposits. After OTP login the Transak checkout prompted the user to enter a wallet address instead of going straight to payment, and it "fixed itself" on a second attempt.

This is a state-propagation race. `startHeadlessBuy` seeds the selected token asynchronously via `setSelectedToken`, but `routeAfterAuthentication` derived the wallet address from `selectedToken?.chainId`, which was still undefined on the first pass — so `useRampAccountAddress` returned `null`, an empty `walletAddress=` was sent to Transak, and Transak re-prompted. The fix derives the chain for the wallet address from the headless session's `assetId` (known synchronously the moment the session is created) and falls back to `selectedToken` only for the non-headless BuildQuote flow, so the address resolves correctly on the first attempt.

The asset, environment, and feature flags were all correct throughout; this was purely a seeding race.

## **Changelog**

CHANGELOG entry: Fixed the "Add funds" fiat deposit flow (Perps/Money Account): the Transak checkout no longer prompts for a wallet address after OTP login.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3598

## **Manual testing steps**

> Verified the wallet address now resolves from the headless session `assetId` on the first attempt.

```gherkin
Feature: Add funds (fiat) for a Perps deposit via Headless Ramps + MM Pay

  Scenario: Transak skips the wallet-address prompt on the first attempt
    Given I have hard-refreshed the mobile app
    And I am logged out of Transak (fresh install)
    When I complete the email + OTP login in the Transak checkout
    Then the checkout goes straight to payment (or add-card details for a new user)
    And it does not prompt me to enter a wallet address
```

## **Screenshots/Recordings**

> **Note:** Both recordings below were captured after a **hard refresh** of the app. The hard refresh is what reliably reproduces the "Before" failure on the very first attempt — without it, stale propagated state can mask the bug and make it look like it works.

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

> Captured after a hard refresh — reproduces the wallet-address prompt after OTP on the first attempt.

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/3c92c0a4-5415-4e24-99bb-8378d45bcd8e



### **After**

> Captured after a hard refresh — with the fix, the first attempt succeeds (Transak skips straight to payment).

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/527c831c-0c25-42d4-9f10-6d91e5166f63



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
