### PR TITLE
fix: resolve native token icons in QuickBuy Pay with list

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.test.tsx
@@ -80,6 +80,8 @@ jest.mock(
 jest.mock('@metamask/bridge-controller', () => ({
   formatChainIdToHex: () => '0x1',
   isNonEvmChainId: () => false,
+  isNativeAddress: () => false,
+  getNativeAssetForChainId: () => undefined,
 }));
 
 describe('QuickBuyPayWithScreen', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/getBridgeTokenImageSource.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/getBridgeTokenImageSource.test.ts
@@ -1,14 +1,32 @@
-import { getBridgeTokenImageSource } from './getBridgeTokenImageSource';
+import {
+  getNativeAssetForChainId,
+  isNativeAddress,
+} from '@metamask/bridge-controller';
 import { getAssetImageUrl } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
+import { getBridgeTokenImageSource } from './getBridgeTokenImageSource';
 
 jest.mock('../../../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
   getAssetImageUrl: jest.fn(),
 }));
 
+jest.mock('@metamask/bridge-controller', () => ({
+  getNativeAssetForChainId: jest.fn(),
+  isNativeAddress: jest.fn(),
+}));
+
 const mockGetAssetImageUrl = getAssetImageUrl as jest.MockedFunction<
   typeof getAssetImageUrl
 >;
+const mockGetNativeAssetForChainId =
+  getNativeAssetForChainId as jest.MockedFunction<
+    typeof getNativeAssetForChainId
+  >;
+const mockIsNativeAddress = isNativeAddress as jest.MockedFunction<
+  typeof isNativeAddress
+>;
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const baseToken: BridgeToken = {
   address: '0xabc',
@@ -21,6 +39,7 @@ const baseToken: BridgeToken = {
 describe('getBridgeTokenImageSource', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsNativeAddress.mockReturnValue(false);
   });
 
   it('returns the token image URI when token.image is set', () => {
@@ -31,7 +50,7 @@ describe('getBridgeTokenImageSource', () => {
     expect(mockGetAssetImageUrl).not.toHaveBeenCalled();
   });
 
-  it('returns the CDN fallback URI when token.image is absent but getAssetImageUrl resolves', () => {
+  it('returns the CDN fallback URI for an ERC-20 using its own address', () => {
     const token = { ...baseToken };
     mockGetAssetImageUrl.mockReturnValue('https://cdn.example.com/0xabc.png');
 
@@ -42,6 +61,45 @@ describe('getBridgeTokenImageSource', () => {
       token.address,
       token.chainId,
     );
+  });
+
+  it('resolves native tokens through their SLIP-44 asset id', () => {
+    const token: BridgeToken = {
+      ...baseToken,
+      address: ZERO_ADDRESS,
+      chainId: '0xe708',
+    };
+    mockIsNativeAddress.mockReturnValue(true);
+    mockGetNativeAssetForChainId.mockReturnValue({
+      assetId: 'eip155:59144/slip44:60',
+    } as unknown as ReturnType<typeof getNativeAssetForChainId>);
+    mockGetAssetImageUrl.mockReturnValue('https://cdn.example.com/slip44.png');
+
+    expect(getBridgeTokenImageSource(token)).toEqual({
+      uri: 'https://cdn.example.com/slip44.png',
+    });
+    expect(mockGetAssetImageUrl).toHaveBeenCalledWith(
+      'eip155:59144/slip44:60',
+      '0xe708',
+    );
+  });
+
+  it('falls back to the token address when getNativeAssetForChainId throws', () => {
+    const token: BridgeToken = {
+      ...baseToken,
+      address: ZERO_ADDRESS,
+      chainId: '0xe708',
+    };
+    mockIsNativeAddress.mockReturnValue(true);
+    mockGetNativeAssetForChainId.mockImplementation(() => {
+      throw new Error('unsupported chain');
+    });
+    mockGetAssetImageUrl.mockReturnValue('https://cdn.example.com/zero.png');
+
+    expect(getBridgeTokenImageSource(token)).toEqual({
+      uri: 'https://cdn.example.com/zero.png',
+    });
+    expect(mockGetAssetImageUrl).toHaveBeenCalledWith(ZERO_ADDRESS, '0xe708');
   });
 
   it('returns undefined when token.image is absent and getAssetImageUrl returns null', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/getBridgeTokenImageSource.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/getBridgeTokenImageSource.ts
@@ -1,4 +1,8 @@
 import type { ImageURISource } from 'react-native';
+import {
+  getNativeAssetForChainId,
+  isNativeAddress,
+} from '@metamask/bridge-controller';
 import { getAssetImageUrl } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 
@@ -7,9 +11,10 @@ import type { BridgeToken } from '../../../../../UI/Bridge/types';
  *
  * Order of preference:
  * 1. The token's own `image` URL (set for stablecoins and most ERC-20s).
- * 2. The MetaMask static token-icon CDN URL derived from the token address +
- * chain (covers native tokens — ETH, BNB, POL, etc. — whose `image` field
- * from `getNativeSourceToken` is often empty).
+ * 2. The MetaMask static token-icon CDN URL derived from the asset id + chain.
+ * Native tokens (ETH, BNB, POL, SOL, etc.) resolve through their canonical
+ * SLIP-44 asset id (e.g. `eip155:59144/slip44:60`) — the zero-address
+ * `erc20:0x0…0` path only serves a real icon on a handful of chains.
  * 3. `undefined`, in which case `AvatarToken` renders the symbol monogram.
  */
 export const getBridgeTokenImageSource = (
@@ -18,6 +23,17 @@ export const getBridgeTokenImageSource = (
   if (token.image) {
     return { uri: token.image };
   }
-  const fallback = getAssetImageUrl(token.address, token.chainId);
+
+  let assetId: string = token.address;
+  if (isNativeAddress(token.address)) {
+    try {
+      assetId =
+        getNativeAssetForChainId(token.chainId)?.assetId ?? token.address;
+    } catch {
+      assetId = token.address;
+    }
+  }
+
+  const fallback = getAssetImageUrl(assetId, token.chainId);
   return fallback ? { uri: fallback } : undefined;
 };


### PR DESCRIPTION
## **Description**


Native EVM tokens (ETH on Linea, Optimism, Arbitrum, and mainnet) were rendering without their token icon in the QuickBuy "Pay with" list, falling back to the network badge / symbol monogram only.

**Reason for the change:** Native tokens come from `getNativeSourceToken` with an empty `image` and the zero address. The icon helper `getBridgeTokenImageSource` then fell back to `getAssetImageUrl(token.address, token.chainId)`, which builds an `erc20:0x0000…0000` CAIP asset id for the zero address. The MetaMask icon CDN (`static.cx.metamask.io`) only serves a real image at that `erc20:0x0` path on a handful of chains (e.g. Base, 9396 B); for Linea/Optimism/Arbitrum/mainnet it returns a ~675 B placeholder, so no icon shows. The canonical SLIP-44 path (`slip44/60`) serves the real 7930 B ETH icon on every chain.

**Solution:** In `getBridgeTokenImageSource`, when the token is native, resolve its asset id via the bridge-controller's `getNativeAssetForChainId(chainId).assetId` (e.g. `eip155:59144/slip44:60`) before building the CDN URL, with a `try/catch` fallback to the raw address for unsupported chains. ERC-20s and the `token.image` short-circuit are untouched, and `isNativeAddress` keeps Solana/non-EVM natives working. The fix is intentionally contained to this QuickBuy helper, leaving the shared `getAssetImageUrl`/`toAssetId` untouched to avoid app-wide regressions.

## **Changelog**

CHANGELOG entry: Fixed missing native token icons (e.g. Linea ETH) in the QuickBuy "Pay with" list.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: QuickBuy Pay with native token icons

  Scenario: user opens the Pay with sheet with native balances on multiple chains
    Given a wallet holding native ETH on Linea (and other non-Base EVM chains)

    When the user opens QuickBuy and taps the "Pay with" selector
    Then each native token row shows its proper token icon (no blank/monogram placeholder)
```

## **Screenshots/Recordings**

### **Before**

<img width="585" height="1266" alt="IMG_0029" src="https://github.com/user-attachments/assets/9be7a66f-8420-4272-854e-6f4b5431865a" />

### **After**

<img width="433" height="878" alt="image" src="https://github.com/user-attachments/assets/b5166f48-2dbe-4951-9b3f-4b359e5e0305" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI helper change with try/catch fallback; no auth, payments, or shared bridge URL logic changes.
> 
> **Overview**
> Fixes missing native token icons in the QuickBuy **Pay with** list (and related picker rows) when `token.image` is empty.
> 
> **`getBridgeTokenImageSource`** now uses `@metamask/bridge-controller`’s `isNativeAddress` and `getNativeAssetForChainId` so CDN fallback URLs use the canonical **SLIP-44** asset id instead of the zero address—addressing placeholder icons on Linea, Optimism, Arbitrum, mainnet, etc. ERC-20 behavior and the `token.image` shortcut are unchanged; unsupported chains still fall back to the raw address inside a `try/catch`.
> 
> Tests cover native SLIP-44 resolution and error fallback; **`QuickBuyPayWithScreen`** mocks were extended for the new bridge-controller helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da99cba0fd3b7d162cad35fb9081f089f953e038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->