### PR TITLE
fix(engagement): gate marketing-consent sheet on MetaMetrics cp-7.80.0

### DIFF
--- a/app/util/notifications/hooks/useEnableMarketingConsent.test.ts
+++ b/app/util/notifications/hooks/useEnableMarketingConsent.test.ts
@@ -6,10 +6,6 @@ import { AccountType } from '../../../constants/onboarding';
 import { UserProfileProperty } from '../../metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 import { renderHookWithProvider } from '../../test/renderWithProvider';
 import { analytics } from '../../analytics/analytics';
-import generateDeviceAnalyticsMetaData, {
-  UserSettingsAnalyticsMetaData as generateUserSettingsAnalyticsMetaData,
-} from '../../metrics';
-import { updateCachedConsent } from '../../trace';
 import Logger from '../../Logger';
 import { useEnableMarketingConsent } from './useEnableMarketingConsent';
 
@@ -22,16 +18,6 @@ jest.mock('../../analytics/analytics', () => ({
   },
 }));
 
-jest.mock('../../metrics', () => ({
-  __esModule: true,
-  default: jest.fn(),
-  UserSettingsAnalyticsMetaData: jest.fn(),
-}));
-
-jest.mock('../../trace', () => ({
-  updateCachedConsent: jest.fn(),
-}));
-
 jest.mock('../../../core/OAuthService/OAuthService', () => ({
   __esModule: true,
   default: {
@@ -42,9 +28,6 @@ jest.mock('../../../core/OAuthService/OAuthService', () => ({
 jest.mock('../../Logger', () => ({
   error: jest.fn(),
 }));
-
-const deviceTraits = { device_trait: 'device' };
-const userSettingsTraits = { user_settings_trait: 'settings' };
 
 const renderUseEnableMarketingConsent = ({
   accountType = AccountType.MetamaskGoogle,
@@ -84,64 +67,27 @@ describe('useEnableMarketingConsent', () => {
     jest.clearAllMocks();
     jest.mocked(analytics.isEnabled).mockReturnValue(false);
     jest.mocked(analytics.optIn).mockResolvedValue(undefined);
-    jest.mocked(generateDeviceAnalyticsMetaData).mockReturnValue(deviceTraits);
-    jest
-      .mocked(generateUserSettingsAnalyticsMetaData)
-      .mockReturnValue(userSettingsTraits);
     jest
       .mocked(OAuthService.updateMarketingOptInStatus)
       .mockResolvedValue(undefined);
   });
 
-  it('opts into metrics, dispatches marketing consent, and identifies consent when analytics is disabled', async () => {
+  it('does nothing when MetaMetrics is off — never enables metrics or data collection', async () => {
+    // analytics.isEnabled returns false (set in beforeEach)
     const { result, store } = renderUseEnableMarketingConsent();
 
     await act(async () => {
       await result.current.enableMarketingConsent();
     });
 
-    expect(analytics.optIn).toHaveBeenCalledTimes(1);
-    expect(updateCachedConsent).toHaveBeenCalledWith(true);
-    expect(analytics.identify).toHaveBeenCalledWith({
-      ...deviceTraits,
-      ...userSettingsTraits,
-      [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
-    });
-    expect(analytics.identify).toHaveBeenCalledTimes(1);
-    expect(
-      jest.mocked(analytics.identify).mock.invocationCallOrder[0],
-    ).toBeLessThan(
-      jest.mocked(analytics.trackEvent).mock.invocationCallOrder[0],
-    );
-    expect(analytics.trackEvent).toHaveBeenCalledTimes(2);
-    expect(analytics.trackEvent).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        name: MetaMetricsEvents.METRICS_OPT_IN.category,
-        properties: expect.objectContaining({
-          account_type: AccountType.MetamaskGoogle,
-          location: 'push_pre_prompt',
-          updated_after_onboarding: true,
-        }),
-      }),
-    );
-    expect(analytics.trackEvent).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
-        properties: expect.objectContaining({
-          [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
-          is_metrics_opted_in: true,
-          account_type: AccountType.MetamaskGoogle,
-          location: 'push_pre_prompt',
-          updated_after_onboarding: true,
-        }),
-      }),
-    );
-    expect(store.getState().security.dataCollectionForMarketing).toBe(true);
+    expect(analytics.optIn).not.toHaveBeenCalled();
+    expect(analytics.identify).not.toHaveBeenCalled();
+    expect(analytics.trackEvent).not.toHaveBeenCalled();
+    expect(OAuthService.updateMarketingOptInStatus).not.toHaveBeenCalled();
+    expect(store.getState().security.dataCollectionForMarketing).toBe(false);
   });
 
-  it('dispatches and identifies marketing consent without metrics opt-in when analytics is already enabled', async () => {
+  it('dispatches and identifies marketing consent when MetaMetrics is already enabled', async () => {
     jest.mocked(analytics.isEnabled).mockReturnValue(true);
     const { result, store } = renderUseEnableMarketingConsent();
 
@@ -150,7 +96,6 @@ describe('useEnableMarketingConsent', () => {
     });
 
     expect(analytics.optIn).not.toHaveBeenCalled();
-    expect(updateCachedConsent).not.toHaveBeenCalled();
     expect(analytics.identify).toHaveBeenCalledWith({
       [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
     });
@@ -165,14 +110,36 @@ describe('useEnableMarketingConsent', () => {
         name: MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED.category,
         properties: expect.objectContaining({
           [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
-          is_metrics_opted_in: true,
           account_type: AccountType.MetamaskGoogle,
           location: 'push_pre_prompt',
           updated_after_onboarding: true,
         }),
       }),
     );
+    // is_metrics_opted_in must NOT be present — this flow never touches metrics.
+    expect(analytics.trackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.not.objectContaining({
+          is_metrics_opted_in: expect.anything(),
+        }),
+      }),
+    );
     expect(store.getState().security.dataCollectionForMarketing).toBe(true);
+  });
+
+  it('does nothing when marketing consent is already enabled', async () => {
+    jest.mocked(analytics.isEnabled).mockReturnValue(true);
+    const { result } = renderUseEnableMarketingConsent({
+      hasMarketingConsent: true,
+    });
+
+    await act(async () => {
+      await result.current.enableMarketingConsent();
+    });
+
+    expect(analytics.identify).not.toHaveBeenCalled();
+    expect(analytics.trackEvent).not.toHaveBeenCalled();
+    expect(OAuthService.updateMarketingOptInStatus).not.toHaveBeenCalled();
   });
 
   it('syncs marketing consent to OAuth for seedless users', async () => {
@@ -206,21 +173,5 @@ describe('useEnableMarketingConsent', () => {
       expect(store.getState().security.dataCollectionForMarketing).toBe(false);
     });
     expect(Logger.error).toHaveBeenCalled();
-  });
-
-  it('does nothing when marketing consent is already enabled', async () => {
-    const { result } = renderUseEnableMarketingConsent({
-      hasMarketingConsent: true,
-    });
-
-    await act(async () => {
-      await result.current.enableMarketingConsent();
-    });
-
-    expect(analytics.optIn).not.toHaveBeenCalled();
-    expect(updateCachedConsent).not.toHaveBeenCalled();
-    expect(analytics.identify).not.toHaveBeenCalled();
-    expect(analytics.trackEvent).not.toHaveBeenCalled();
-    expect(OAuthService.updateMarketingOptInStatus).not.toHaveBeenCalled();
   });
 });

--- a/app/util/notifications/hooks/useEnableMarketingConsent.ts
+++ b/app/util/notifications/hooks/useEnableMarketingConsent.ts
@@ -9,10 +9,6 @@ import { MetaMetricsEvents } from '../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../analytics/AnalyticsEventBuilder';
 import { analytics } from '../../analytics/analytics';
 import { UserProfileProperty } from '../../metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
-import generateDeviceAnalyticsMetaData, {
-  UserSettingsAnalyticsMetaData as generateUserSettingsAnalyticsMetaData,
-} from '../../metrics';
-import { updateCachedConsent } from '../../trace';
 import Logger from '../../Logger';
 
 interface UseEnableMarketingConsentOptions {
@@ -36,45 +32,24 @@ export function useEnableMarketingConsent({
       [UserProfileProperty.HAS_MARKETING_CONSENT]: true,
     };
 
+    // Never toggle MetaMetrics from the push onboarding sheets. If metrics is
+    // off, leave both metrics and data collection off.
+    if (!analytics.isEnabled()) {
+      return;
+    }
+
     if (hasMarketingConsent) {
       return;
     }
 
-    const shouldOptInToMetrics = !analytics.isEnabled();
-
-    if (shouldOptInToMetrics) {
-      await analytics.optIn();
-      updateCachedConsent(true);
-    }
-
     dispatch(setDataCollectionForMarketing(true));
-    if (shouldOptInToMetrics) {
-      analytics.identify({
-        ...generateDeviceAnalyticsMetaData(),
-        ...generateUserSettingsAnalyticsMetaData(),
-        ...marketingConsentTraits,
-      });
-      analytics.trackEvent(
-        AnalyticsEventBuilder.createEventBuilder(
-          MetaMetricsEvents.METRICS_OPT_IN,
-        )
-          .addProperties({
-            updated_after_onboarding: true,
-            location: metricsOptInLocation,
-            ...(accountType && { account_type: accountType }),
-          })
-          .build(),
-      );
-    } else {
-      analytics.identify(marketingConsentTraits);
-    }
+    analytics.identify(marketingConsentTraits);
     analytics.trackEvent(
       AnalyticsEventBuilder.createEventBuilder(
         MetaMetricsEvents.ANALYTICS_PREFERENCE_SELECTED,
       )
         .addProperties({
           ...marketingConsentTraits,
-          is_metrics_opted_in: true,
           updated_after_onboarding: true,
           location: metricsOptInLocation,
           ...(accountType && { account_type: accountType }),

--- a/app/util/notifications/hooks/usePushPrePromptVariant.test.ts
+++ b/app/util/notifications/hooks/usePushPrePromptVariant.test.ts
@@ -1,5 +1,7 @@
 import { act, waitFor } from '@testing-library/react-native';
 // eslint-disable-next-line import-x/no-namespace
+import * as AnalyticsControllerSelectors from '../../../selectors/analyticsController';
+// eslint-disable-next-line import-x/no-namespace
 import * as NotificationSelectors from '../../../selectors/notifications';
 // eslint-disable-next-line import-x/no-namespace
 import * as OnboardingSelectors from '../../../selectors/onboarding';
@@ -62,10 +64,12 @@ const arrangeSelectors = ({
   completedOnboarding = true,
   isFeatureFlagOn = true,
   isBasicFunctionalityEnabled = true,
+  isMetaMetricsEnabled = true,
 }: {
   completedOnboarding?: boolean;
   isFeatureFlagOn?: boolean;
   isBasicFunctionalityEnabled?: boolean;
+  isMetaMetricsEnabled?: boolean;
 } = {}) => {
   jest
     .spyOn(OnboardingSelectors, 'selectCompletedOnboarding')
@@ -79,6 +83,9 @@ const arrangeSelectors = ({
   jest
     .spyOn(SettingsSelectors, 'selectBasicFunctionalityEnabled')
     .mockReturnValue(isBasicFunctionalityEnabled);
+  jest
+    .spyOn(AnalyticsControllerSelectors, 'selectAnalyticsEnabled')
+    .mockReturnValue(isMetaMetricsEnabled);
 };
 
 const renderUsePushPrePromptVariant = ({
@@ -441,6 +448,67 @@ describe('usePushPrePromptVariant', () => {
     });
     expect(result.current.variant).toBeNull();
     expect(result.current.nativeOsPermissionEnabled).toBeNull();
+  });
+
+  it('does not return the marketing consent prompt when MetaMetrics is off', async () => {
+    // OS push is granted, no marketing consent, but MetaMetrics is off —
+    // the marketing-consent sheet must never appear in this state.
+    arrangeSelectors({ isMetaMetricsEnabled: false });
+
+    const { result } = renderUsePushPrePromptVariant();
+
+    await waitFor(() => {
+      expect(result.current.isResolving).toBe(false);
+    });
+    expect(result.current.variant).toBeNull();
+    expect(result.current.nativeOsPermissionEnabled).toBe(true);
+  });
+
+  it('still returns the push permission prompt when MetaMetrics is off', async () => {
+    // MetaMetrics being off must not block the push-permission sheet.
+    arrangeSelectors({ isMetaMetricsEnabled: false });
+    mockNativePushPermissionStatus({
+      nativeOsPermissionEnabled: false,
+      nativeOsPermissionPromptable: true,
+    });
+
+    const { result } = renderUsePushPrePromptVariant();
+
+    await waitFor(() => {
+      expect(result.current.variant).toBe('push_permission');
+    });
+    expect(result.current.nativeOsPermissionEnabled).toBe(false);
+  });
+
+  it('does not return a prompt when OS push is on, MetaMetrics is off, and marketing consent is already on', async () => {
+    // dc=on gates before the mm check — variant must be null regardless of mm state.
+    arrangeSelectors({ isMetaMetricsEnabled: false });
+    const { result } = renderUsePushPrePromptVariant({
+      hasMarketingConsent: true,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isResolving).toBe(false);
+    });
+    expect(result.current.variant).toBeNull();
+    expect(result.current.nativeOsPermissionEnabled).toBe(true);
+  });
+
+  it('still returns the push permission prompt when MetaMetrics is off and marketing consent is on', async () => {
+    // push=off gates before dc and mm — push_permission must still appear.
+    arrangeSelectors({ isMetaMetricsEnabled: false });
+    mockNativePushPermissionStatus({
+      nativeOsPermissionEnabled: false,
+      nativeOsPermissionPromptable: true,
+    });
+    const { result } = renderUsePushPrePromptVariant({
+      hasMarketingConsent: true,
+    });
+
+    await waitFor(() => {
+      expect(result.current.variant).toBe('push_permission');
+    });
+    expect(result.current.nativeOsPermissionEnabled).toBe(false);
   });
 
   it('marks the prompt as shown without hiding it until dismissed', async () => {

--- a/app/util/notifications/hooks/usePushPrePromptVariant.ts
+++ b/app/util/notifications/hooks/usePushPrePromptVariant.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../selectors/onboarding';
 import { selectDataCollectionForMarketingEnabled } from '../../../selectors/engagement';
 import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
+import { selectAnalyticsEnabled } from '../../../selectors/analyticsController';
 import Logger from '../../Logger';
 import {
   hasPushPrePromptBeenShown,
@@ -32,6 +33,7 @@ interface PushPrePromptEligibility {
   hasPrePromptBeenShown: boolean;
   hasMarketingConsent: boolean;
   isMarketingConsentResolutionPending: boolean;
+  isMetaMetricsEnabled: boolean;
   pendingSocialLoginMarketingConsentBackfill: string | null;
 }
 
@@ -40,6 +42,7 @@ const getResolutionKey = ({
   hasPrePromptBeenShown,
   hasMarketingConsent,
   isMarketingConsentResolutionPending,
+  isMetaMetricsEnabled,
   pendingSocialLoginMarketingConsentBackfill,
 }: PushPrePromptEligibility) =>
   [
@@ -47,6 +50,7 @@ const getResolutionKey = ({
     `hasPrePromptBeenShown:${hasPrePromptBeenShown}`,
     `hasMarketingConsent:${hasMarketingConsent}`,
     `isMarketingConsentResolutionPending:${isMarketingConsentResolutionPending}`,
+    `isMetaMetricsEnabled:${isMetaMetricsEnabled}`,
     `pendingSocialLoginMarketingConsentBackfill:${
       pendingSocialLoginMarketingConsentBackfill ?? 'null'
     }`,
@@ -93,6 +97,17 @@ const resolvePrePromptVariant = async (
   }
 
   if (eligibility.hasMarketingConsent) {
+    return {
+      nativeOsPermissionEnabled,
+      variant: null,
+    };
+  }
+
+  // The marketing-consent sheet must never appear when MetaMetrics is off —
+  // confirming it would call enableMarketingConsent(), which is a no-op when
+  // metrics is off, so the sheet would achieve nothing. More importantly, we
+  // never want these sheets to be a backdoor to toggling MetaMetrics.
+  if (!eligibility.isMetaMetricsEnabled) {
     return {
       nativeOsPermissionEnabled,
       variant: null,
@@ -151,6 +166,7 @@ export function usePushPrePromptVariant(): {
   const hasMarketingConsent = useSelector(
     selectDataCollectionForMarketingEnabled,
   );
+  const isMetaMetricsEnabled = Boolean(useSelector(selectAnalyticsEnabled));
   const pendingSocialLoginMarketingConsentBackfill = useSelector(
     selectPendingSocialLoginMarketingConsentBackfill,
   );
@@ -199,12 +215,14 @@ export function usePushPrePromptVariant(): {
       hasPrePromptBeenShown,
       hasMarketingConsent: startupHasMarketingConsent,
       isMarketingConsentResolutionPending,
+      isMetaMetricsEnabled,
       pendingSocialLoginMarketingConsentBackfill,
     }),
     [
       canShowPrePrompt,
       hasPrePromptBeenShown,
       isMarketingConsentResolutionPending,
+      isMetaMetricsEnabled,
       startupHasMarketingConsent,
       pendingSocialLoginMarketingConsentBackfill,
     ],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Previously, the push onboarding sheets could trigger analytics.optIn() when MetaMetrics was off, effectively using the marketing-consent flow to enable MetaMetrics in a less than clear way. This is not desired. This PR simplifies the action taken after accepting the push pre-prompt. It reduces the risk of the existing code.

  This PR:
  - Adds a isMetaMetricsEnabled gate in usePushPrePromptVariant so the marketing_consent variant is never returned when MetaMetrics is off (the push_permission variant is unaffected)
  - Strips analytics.optIn(), updateCachedConsent(), and the device/user-settings trait generation from useEnableMarketingConsent — the hook now only operates when MetaMetrics is already on
  - Removes is_metrics_opted_in from the ANALYTICS_PREFERENCE_SELECTED event property, since this flow no longer touches metrics opt-in state
  - Adds test coverage for the missing push×MetaMetrics×dataCollection combinations

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Remove the ability for the push onboarding flow to toggle MetaMetrics opt-in state.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
