### PR TITLE
feat(predict): add Ethereum accent color to crypto up/down markets cp-7.81.0

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
@@ -184,10 +184,10 @@ jest.mock('../PredictCryptoUpDownChart', () => {
   const { TouchableOpacity } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: jest.fn(({ market, targetPrice, onCurrentPriceChange }) => (
+    default: jest.fn(({ market, targetPrice, color, onCurrentPriceChange }) => (
       <TouchableOpacity
         testID="mock-predict-crypto-up-down-chart"
-        accessibilityLabel={`market:${market.id};target:${targetPrice ?? 'none'}`}
+        accessibilityLabel={`market:${market.id};target:${targetPrice ?? 'none'};color:${color ?? 'none'}`}
         onPress={() => {
           if (typeof mockChartCurrentPrice === 'number') {
             onCurrentPriceChange?.(mockChartCurrentPrice);
@@ -289,7 +289,13 @@ const getChartMarketId = () => {
 const getChartTargetPrice = () => {
   const chart = screen.getByTestId('mock-predict-crypto-up-down-chart');
   const label = chart.props.accessibilityLabel as string | undefined;
-  return label?.match(/;target:(.+)$/)?.[1];
+  return label?.match(/;target:([^;]+)/)?.[1];
+};
+
+const getChartColor = () => {
+  const chart = screen.getByTestId('mock-predict-crypto-up-down-chart');
+  const label = chart.props.accessibilityLabel as string | undefined;
+  return label?.match(/;color:(.+)$/)?.[1];
 };
 
 const getSelectedTimeSlotMarketId = () => {
@@ -495,6 +501,49 @@ describe('PredictCryptoUpDownDetails', () => {
     expect(
       screen.getByTestId('mock-predict-crypto-up-down-chart'),
     ).toBeOnTheScreen();
+  });
+
+  it('uses the Bitcoin accent color for BTC markets', () => {
+    const market = createMockMarket({
+      slug: 'btc-up-or-down-5m',
+      tags: ['crypto', 'up-or-down', 'bitcoin'],
+    });
+    mockUsePredictSeries.mockReturnValue({ data: [market] });
+
+    render(<PredictCryptoUpDownDetails market={market} onBack={mockOnBack} />);
+
+    expect(getChartColor()).toBe('rgb(247, 147, 26)');
+  });
+
+  it('uses the Ethereum accent color for ETH markets', () => {
+    const ethSeries: PredictSeries = {
+      id: 's-eth',
+      slug: 'eth-up-or-down-5m',
+      title: 'ETH Up or Down - 5 Minutes',
+      recurrence: '5m',
+    };
+    const market = createMockMarket({
+      slug: 'eth-up-or-down-5m',
+      tags: ['crypto', 'up-or-down', 'ethereum'],
+      series: ethSeries,
+    });
+    mockUsePredictSeries.mockReturnValue({ data: [market] });
+
+    render(<PredictCryptoUpDownDetails market={market} onBack={mockOnBack} />);
+
+    expect(getChartColor()).toBe('rgb(94, 109, 183)');
+  });
+
+  it('falls back to the default accent color for unmapped crypto symbols', () => {
+    const market = createMockMarket({
+      slug: 'unknown-up-or-down-5m',
+      tags: ['crypto', 'up-or-down'],
+    });
+    mockUsePredictSeries.mockReturnValue({ data: [market] });
+
+    render(<PredictCryptoUpDownDetails market={market} onBack={mockOnBack} />);
+
+    expect(getChartColor()).toBe('rgb(245, 158, 11)');
   });
 
   it('renders claim action without a buy callback when positive pnl is available', () => {

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
@@ -67,6 +67,7 @@ const NOOP = () => undefined;
 const DEFAULT_CRYPTO_ACCENT_COLOR = 'rgb(245, 158, 11)';
 const CRYPTO_SYMBOL_TO_ACCENT_COLOR: Record<string, string> = {
   BTC: 'rgb(247, 147, 26)',
+  ETH: 'rgb(94, 109, 183)', // #5E6DB7
 };
 
 const splitCurrency = (

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -127,6 +127,7 @@ const PROGRESS_RING_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RING_RADIUS;
 const CRYPTO_ACCENT_DEFAULT = 'rgb(245, 158, 11)';
 const CRYPTO_ACCENT_BY_SYMBOL: Record<string, string> = {
   BTC: 'rgb(247, 147, 26)',
+  ETH: 'rgb(94, 109, 183)', // #5E6DB7
 };
 const AnimatedPath = Animated.createAnimatedComponent(Path);
 const AnimatedLine = Animated.createAnimatedComponent(SvgLine);


### PR DESCRIPTION
## **Description**

Maps the `ETH` symbol to `#5E6DB7` in both the series card (`PredictCryptoUpDownMarketCard`) and the details screen (`PredictCryptoUpDownDetails`) so Ethereum up/down markets render with a distinct accent — chart line, sparkline, badge, and current-price text — instead of falling back to the default amber.

Symbol resolution was already in place via `getCryptoSymbol()` (`ethereum` tag + `eth-` slug prefix), so only the two color lookup tables (`CRYPTO_SYMBOL_TO_ACCENT_COLOR` on the details screen, `CRYPTO_ACCENT_BY_SYMBOL` on the card) needed extending. BTC keeps its orange accent and any unmapped symbol continues to fall back to the default amber.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: PRED-941

## **Manual testing steps**

```gherkin
Feature: Predict Ethereum up/down accent color

  Scenario: user views an Ethereum up/down market card on the feed
    Given the predict up/down feature flag is enabled
    And an Ethereum up/down market is available in the feed

    When the user scrolls to the Ethereum market card
    Then the card's sparkline and accent elements render in the Ethereum accent (#5E6DB7)
    And BTC up/down cards continue to render in the BTC orange accent
    And any unmapped crypto up/down card falls back to the default amber accent

  Scenario: user opens the Ethereum up/down details screen
    Given the predict up/down feature flag is enabled
    And an Ethereum up/down market is available

    When the user taps the Ethereum market card and opens the details screen
    Then the chart line, "Current price" label, and current price value render in the Ethereum accent (#5E6DB7)
    And opening a BTC up/down market still renders in the BTC orange accent
```

## **Screenshots/Recordings**

### **Before**

<!-- Not provided — Ethereum up/down markets previously fell back to the default amber accent (`rgb(245, 158, 11)`), identical to any unmapped symbol. -->

### **After**

<img width="370" height="308" alt="Screenshot 2026-06-03 at 8 42 17 PM" src="https://github.com/user-attachments/assets/20ccd606-46d2-4b46-9ade-e3314f4dc6a7" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable; static color constant addition only.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static UI color constants and unit tests only; no auth, data, or trading logic changes.
> 
> **Overview**
> Adds **Ethereum** (`rgb(94, 109, 183)` / `#5E6DB7`) to the crypto up/down accent color maps on the **feed card** (`CRYPTO_ACCENT_BY_SYMBOL`) and **details screen** (`CRYPTO_SYMBOL_TO_ACCENT_COLOR`), so ETH markets use a distinct purple accent instead of the default amber. **BTC** orange and the **default** fallback are unchanged.
> 
> Details tests now assert the chart receives the correct `color` for BTC, ETH, and unmapped symbols (mock chart exposes `color` in `accessibilityLabel`; target-price parsing was adjusted for the extra label segment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2290913c973ee6886273b8467a951f07a4426ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->