### PR TITLE
fix(predict): update sports moneyline detail actions cp-7.80.0

### DIFF
--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -270,6 +270,18 @@ describe('PredictGameDetailsContent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (useGameDetailsTabs as jest.Mock).mockReturnValue({
+      enabled: false,
+      showTabBar: false,
+      tabs: [],
+      activeTab: 0,
+      handleTabPress: jest.fn(),
+      chips: [],
+      groupMap: new Map(),
+      activeChipKey: '',
+      handleChipSelect: jest.fn(),
+      showChips: false,
+    });
   });
 
   describe('Header Rendering', () => {
@@ -423,6 +435,68 @@ describe('PredictGameDetailsContent', () => {
       const infoButton = getByTestId('mock-info-button');
 
       expect(infoButton).toBeOnTheScreen();
+    });
+
+    it('hides the prediction footer when extended sports markets are enabled', () => {
+      (useGameDetailsTabs as jest.Mock).mockReturnValue({
+        enabled: true,
+        showTabBar: false,
+        tabs: [{ label: 'Outcomes', key: 'outcomes' }],
+        activeTab: 0,
+        handleTabPress: jest.fn(),
+        chips: [],
+        groupMap: new Map([
+          ['game_lines', { key: 'game_lines', outcomes: [] }],
+        ]),
+        activeChipKey: 'game_lines',
+        handleChipSelect: jest.fn(),
+        showChips: false,
+      });
+      const market = createMockMarket();
+
+      const { queryByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      expect(queryByTestId('predict-game-details-footer')).toBeNull();
+    });
+
+    it('keeps the footer for claimable winnings when extended sports markets are enabled', () => {
+      (useGameDetailsTabs as jest.Mock).mockReturnValue({
+        enabled: true,
+        showTabBar: false,
+        tabs: [{ label: 'Outcomes', key: 'outcomes' }],
+        activeTab: 0,
+        handleTabPress: jest.fn(),
+        chips: [],
+        groupMap: new Map([
+          ['game_lines', { key: 'game_lines', outcomes: [] }],
+        ]),
+        activeChipKey: 'game_lines',
+        handleChipSelect: jest.fn(),
+        showChips: false,
+      });
+      const market = createMockMarket();
+
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          onClaimPress={jest.fn()}
+          claimableAmount={1}
+          refreshing={false}
+        />,
+      );
+
+      expect(getByTestId('predict-game-details-footer')).toBeOnTheScreen();
     });
   });
 
@@ -685,6 +759,11 @@ describe('PredictGameDetailsContent', () => {
         ],
         activeTab: 0,
         handleTabPress: jest.fn(),
+        chips: [],
+        groupMap: new Map(),
+        activeChipKey: '',
+        handleChipSelect: jest.fn(),
+        showChips: false,
       });
 
       const market = createMockMarket();
@@ -709,6 +788,11 @@ describe('PredictGameDetailsContent', () => {
         tabs: [],
         activeTab: 0,
         handleTabPress: jest.fn(),
+        chips: [],
+        groupMap: new Map(),
+        activeChipKey: '',
+        handleChipSelect: jest.fn(),
+        showChips: false,
       });
 
       const market = createMockMarket();

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -146,6 +146,9 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
   }, [activeChipKey, stickyHeaderY]);
 
   const showStickyHeader = showTabBar || showChips;
+  const hasExtendedOutcomes = tabsEnabled && groupMap.size > 0;
+  const showFooter =
+    !hasExtendedOutcomes || (claimableAmount > 0 && Boolean(onClaimPress));
   const stickyHeaderIndices = useMemo(
     () => (showStickyHeader ? [CHIPS_STICKY_INDEX] : undefined),
     [showStickyHeader],
@@ -258,16 +261,18 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
         </Box>
       </ScrollView>
 
-      <PredictGameDetailsFooter
-        market={market}
-        outcome={outcome}
-        onBetPress={onBetPress}
-        onClaimPress={onClaimPress}
-        onInfoPress={handleInfoPress}
-        claimableAmount={claimableAmount}
-        isLoading={isLoading}
-        isClaimPending={isClaimPending}
-      />
+      {showFooter && (
+        <PredictGameDetailsFooter
+          market={market}
+          outcome={outcome}
+          onBetPress={onBetPress}
+          onClaimPress={onClaimPress}
+          onInfoPress={handleInfoPress}
+          claimableAmount={claimableAmount}
+          isLoading={isLoading}
+          isClaimPending={isClaimPending}
+        />
+      )}
 
       {isVisible && (
         <PredictGameAboutSheet

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -45,6 +45,14 @@ jest.mock('../../../../../util/Logger', () => ({
   default: { error: jest.fn() },
 }));
 
+const mockGetLivePrice = jest.fn();
+
+jest.mock('../../hooks/useLiveMarketPrices', () => ({
+  useLiveMarketPrices: jest.fn(() => ({
+    getPrice: mockGetLivePrice,
+  })),
+}));
+
 const mockOnBuyPress = jest.fn();
 
 interface CapturedCard {
@@ -206,6 +214,7 @@ const mockGame: PredictMarketGame = {
 describe('PredictGameOutcomesTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetLivePrice.mockReturnValue(undefined);
     mockCapturedCards = [];
   });
 
@@ -1059,7 +1068,7 @@ describe('PredictGameOutcomesTab', () => {
   });
 
   describe('moneyline subgroup rendering', () => {
-    it('renders stacked card for moneyline subgroup with multiple outcomes sorted by threshold', () => {
+    it('renders inline-spaced card for moneyline subgroup with multiple outcomes sorted by threshold', () => {
       const outcomes = [
         createOutcome({
           id: 'ml-2',
@@ -1100,7 +1109,7 @@ describe('PredictGameOutcomesTab', () => {
       );
 
       expect(mockCapturedCards).toHaveLength(1);
-      expect(mockCapturedCards[0].buttonLayout).toBe('stacked');
+      expect(mockCapturedCards[0].buttonLayout).toBe('inlineNoSeparator');
       expect(mockCapturedCards[0].buttons[0].label).toBe('HOM');
       expect(mockCapturedCards[0].buttons[1].label).toBe('Draw');
       expect(mockCapturedCards[0].buttons[2].label).toBe('AWY');
@@ -1183,6 +1192,44 @@ describe('PredictGameOutcomesTab', () => {
       expect(mockCapturedCards[0].buttons[1].variant).toBe('draw');
       expect(mockCapturedCards[0].buttons[2].price).toBe(25);
       expect(mockCapturedCards[0].buttons[2].variant).toBe('no');
+    });
+
+    it('uses live best ask prices for moneyline buttons', () => {
+      mockGetLivePrice.mockImplementation((tokenId: string) => ({
+        tokenId,
+        price: 0,
+        bestBid: 0,
+        bestAsk: tokenId === 'tok-a' ? 0.76 : 0.24,
+      }));
+
+      const outcomes = [
+        createOutcome({
+          id: 'ml-a',
+          tokens: [createToken({ id: 'tok-a', shortTitle: 'TA', price: 0.45 })],
+        }),
+        createOutcome({
+          id: 'ml-b',
+          tokens: [createToken({ id: 'tok-b', shortTitle: 'TB', price: 0.55 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons[0].price).toBe(76);
+      expect(mockCapturedCards[0].buttons[1].price).toBe(24);
     });
 
     it('calls onBuyPress with correct outcome and token for moneyline button', () => {
@@ -1386,7 +1433,7 @@ describe('PredictGameOutcomesTab', () => {
   });
 
   describe('flat outcomes moneyline rendering', () => {
-    it('renders single stacked card for moneyline-like group without subgroups', () => {
+    it('renders single inline-spaced card for moneyline-like group without subgroups', () => {
       const outcomes = [
         createOutcome({
           id: 'hr-1',
@@ -1422,7 +1469,7 @@ describe('PredictGameOutcomesTab', () => {
       );
 
       expect(mockCapturedCards).toHaveLength(1);
-      expect(mockCapturedCards[0].buttonLayout).toBe('stacked');
+      expect(mockCapturedCards[0].buttonLayout).toBe('inlineNoSeparator');
       expect(mockCapturedCards[0].testID).toBe('halftime-moneyline');
       expect(mockCapturedCards[0].subtitle).toBe('$15k Vol');
     });

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx
@@ -1232,6 +1232,39 @@ describe('PredictGameOutcomesTab', () => {
       expect(mockCapturedCards[0].buttons[1].price).toBe(24);
     });
 
+    it('falls back to static token price when live best ask is zero', () => {
+      mockGetLivePrice.mockReturnValue({
+        tokenId: 'tok-a',
+        price: 0,
+        bestBid: 0,
+        bestAsk: 0,
+      });
+
+      const outcomes = [
+        createOutcome({
+          id: 'ml-a',
+          tokens: [createToken({ id: 'tok-a', shortTitle: 'TA', price: 0.45 })],
+        }),
+      ];
+      const subgroups: PredictOutcomeGroup[] = [
+        createGroup({ key: 'moneyline', outcomes }),
+      ];
+      const groups = [
+        createGroup({ key: 'game_lines', outcomes: [], subgroups }),
+      ];
+
+      render(
+        <PredictGameOutcomesTab
+          groupMap={toGroupMap(groups)}
+          game={mockGame}
+          activeChipKey="game_lines"
+          onBuyPress={mockOnBuyPress}
+        />,
+      );
+
+      expect(mockCapturedCards[0].buttons[0].price).toBe(45);
+    });
+
     it('calls onBuyPress with correct outcome and token for moneyline button', () => {
       const tokenA = createToken({ id: 'tok-a', shortTitle: 'TA', price: 0.6 });
       const tokenB = createToken({ id: 'tok-b', shortTitle: 'TB', price: 0.4 });

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -12,6 +12,7 @@ import PredictSportOutcomeCard, {
   type PredictSportOutcomeButton,
 } from '../PredictSportOutcomeCard';
 import { formatVolume } from '../../utils/format';
+import { isValidPrice } from '../../utils/prices';
 import { isMoneylineLikeMarketType } from '../../constants/sports';
 import { strings } from '../../../../../../locales/i18n';
 import Logger from '../../../../../util/Logger';
@@ -289,7 +290,8 @@ const buildMoneylineButtons = (
 
   return sortedWithTokens.map((outcome, i) => {
     const yesToken = outcome.tokens[0];
-    const price = getPrice?.(yesToken.id)?.bestAsk ?? yesToken.price;
+    const liveBestAsk = getPrice?.(yesToken.id)?.bestAsk;
+    const price = isValidPrice(liveBestAsk) ? liveBestAsk : yesToken.price;
 
     return {
       label: yesToken.shortTitle ?? yesToken.title,

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.tsx
@@ -6,6 +6,7 @@ import type {
   PredictOutcomeGroup,
   PredictOutcomeToken,
 } from '../../types';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 import type { PredictBetButtonVariant } from '../PredictActionButtons/PredictActionButtons.types';
 import PredictSportOutcomeCard, {
   type PredictSportOutcomeButton,
@@ -280,6 +281,7 @@ const buildMoneylineButtons = (
   outcomes: PredictOutcome[],
   onBuyPress: BuyHandler,
   game?: PredictMarketGame,
+  getPrice?: ReturnType<typeof useLiveMarketPrices>['getPrice'],
 ): PredictSportOutcomeButton[] => {
   const sortedWithTokens = sortMoneylineOutcomes(outcomes, game).filter(
     (outcome) => outcome.tokens[0] !== undefined,
@@ -287,10 +289,11 @@ const buildMoneylineButtons = (
 
   return sortedWithTokens.map((outcome, i) => {
     const yesToken = outcome.tokens[0];
+    const price = getPrice?.(yesToken.id)?.bestAsk ?? yesToken.price;
 
     return {
       label: yesToken.shortTitle ?? yesToken.title,
-      price: Math.round(yesToken.price * 100),
+      price: Math.round(price * 100),
       onPress: () => onBuyPress(outcome, yesToken),
       variant: getButtonVariant(i, sortedWithTokens.length, true),
       teamColor: getTeamColor(yesToken.shortTitle ?? yesToken.title, game),
@@ -321,9 +324,17 @@ const MoneylineCard = memo(
       () => buildMoneylineSubtitle(outcomes),
       [outcomes],
     );
+    const tokenIds = useMemo(
+      () =>
+        sortMoneylineOutcomes(outcomes, game)
+          .map((outcome) => outcome.tokens[0]?.id)
+          .filter((id): id is string => Boolean(id)),
+      [outcomes, game],
+    );
+    const { getPrice } = useLiveMarketPrices(tokenIds);
     const buttons = useMemo(
-      () => buildMoneylineButtons(outcomes, onBuyPress, game),
-      [outcomes, onBuyPress, game],
+      () => buildMoneylineButtons(outcomes, onBuyPress, game, getPrice),
+      [outcomes, onBuyPress, game, getPrice],
     );
 
     return (
@@ -331,7 +342,7 @@ const MoneylineCard = memo(
         title={title}
         subtitle={subtitle}
         buttons={buttons}
-        buttonLayout="stacked"
+        buttonLayout="inlineNoSeparator"
         testID={testID}
       />
     );

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
@@ -29,7 +29,7 @@ interface PredictSportOutcomeCardProps {
   selectedLine?: number;
   selectedIndex?: number;
   onSelectLine?: (line: number, index: number) => void;
-  buttonLayout?: 'inline' | 'stacked';
+  buttonLayout?: 'inline' | 'inlineNoSeparator' | 'stacked';
   disabled?: boolean;
   testID?: string;
 }

--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -180,7 +180,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
-        twClassName={compact ? 'w-full gap-2' : 'w-full gap-3'}
+        twClassName="w-full"
       >
         {renderTeamLogo(leftTeam, leftLogoTestID)}
 
@@ -189,7 +189,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             variant={TextVariant.DisplayMd}
             color={TextColor.TextDefault}
             fontWeight={FontWeight.Bold}
-            twClassName={scoreWidthClass}
+            twClassName={`${scoreWidthClass} ${compact ? 'pl-2' : 'pl-3'}`}
             numberOfLines={1}
           >
             {leftScore}
@@ -267,7 +267,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             variant={TextVariant.DisplayMd}
             color={TextColor.TextDefault}
             fontWeight={FontWeight.Bold}
-            twClassName={`${scoreWidthClass} text-right`}
+            twClassName={`${scoreWidthClass} ${compact ? 'pr-2' : 'pr-3'} text-right`}
             numberOfLines={1}
           >
             {rightScore}

--- a/app/components/UI/Predict/utils/prices.ts
+++ b/app/components/UI/Predict/utils/prices.ts
@@ -4,7 +4,7 @@ import type {
   PriceUpdate,
 } from '../types';
 
-const isValidPrice = (price: number | undefined): price is number =>
+export const isValidPrice = (price: number | undefined): price is number =>
   typeof price === 'number' && Number.isFinite(price) && price > 0;
 
 export const getPredictBuyPrice = (


### PR DESCRIPTION
## **Description**

Fixes Predict detail screens for sports markets with extended sports markets enabled:

- Adds proper spacing between moneyline button labels and prices.
- Uses live market prices for moneyline buttons in the Game Lines/Halftime outcome cards.
- Hides the redundant static prediction footer when extended outcome cards are available, while preserving claim actions for claimable winnings.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: PRED-949

## **Manual testing steps**

```gherkin
Feature: Predict sports market detail actions

  Scenario: user views an extended sports market detail screen
    Given predictExtendedSportsMarkets is enabled for the sports league
    And the user opens a sports market detail screen with moneyline outcomes

    When live prices update for the Game Lines moneyline outcomes
    Then the moneyline buttons show labels and prices with spacing
    And the moneyline button prices match the live prices
    And the static prediction footer is not shown
```

## **Screenshots/Recordings**

### **Before**

<img width="350"  alt="Simulator Screenshot - mm-blue - 2026-06-03 at 11 11 49" src="https://github.com/user-attachments/assets/0d21aea1-18e6-4344-beb5-6dbad614076f" />

### **After**

<img width="350"  alt="simulator_screenshot_B8780C21-F06F-49C9-A690-B778D96AFCF0" src="https://github.com/user-attachments/assets/25a797c7-a2ef-4788-8c8f-099d022d1ee7" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable; UI rendering/state wiring change only.

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Predict sports detail changes with tests; live price wiring reuses existing hooks and the same validity rules as other buy flows.
> 
> **Overview**
> Improves **extended sports** game detail screens: moneyline outcome cards now show **live best-ask** prices (with static token price fallback), use an **inline** button layout for clearer label/price spacing, and the **static prediction footer** is hidden when extended outcome groups are shown—**claim** actions still show when there are claimable winnings.
> 
> Also tightens **scoreboard** horizontal spacing (score padding; row gap cleanup) and exports **`isValidPrice`** for reuse in outcome pricing. Tests cover footer visibility, live pricing, and layout expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0843991759c014b0271ce04379c010de09362f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->