### PR TITLE
feat: batch sell hide RWAs

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenLoadErrorState.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenLoadErrorState.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import emptyStateDefiLight from '../../../../../images/empty-state-defi-light.png';
+import { BatchSellTokenSelectSelectorsIDs } from './BatchSellTokenSelect.testIds';
+
+export function BatchSellTokenLoadErrorState() {
+  const tw = useTailwind();
+
+  return (
+    <Box
+      testID={BatchSellTokenSelectSelectorsIDs.ERROR_STATE}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      gap={3}
+      twClassName="flex-1 px-4 py-4"
+    >
+      <Image
+        source={emptyStateDefiLight}
+        resizeMode="contain"
+        style={tw.style('h-[72px] w-[72px]')}
+      />
+      <Box alignItems={BoxAlignItems.Center} gap={2} twClassName="px-4">
+        <Text
+          variant={TextVariant.HeadingSm}
+          color={TextColor.TextDefault}
+          twClassName="w-[240px] text-center"
+        >
+          {strings('bridge.batch_sell_token_load_error_title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="w-[240px] text-center"
+        >
+          {strings('bridge.batch_sell_token_load_error_description')}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -18,6 +18,7 @@ import {
 import Routes from '../../../../../constants/navigation/Routes';
 import { BridgeTokenMetadata } from '../../constants/tokens';
 import { DEFAULT_BATCH_SELL_SLIPPAGE } from '../../components/SlippageModal/utils';
+import { isRwaChecked } from '../../../../hooks/useTokensData/useTokensData';
 import {
   TextColor as ComponentLibraryTextColor,
   TextVariant as ComponentLibraryTextVariant,
@@ -26,6 +27,7 @@ import {
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
 const mockUseTokensWithBalance = jest.fn();
+const mockIsRwaChecked = isRwaChecked as jest.Mock;
 let mockDestinationStablecoins: BridgeToken[] = [];
 let mockDestinationStablecoinsByChain: Partial<
   Record<CaipChainId, BridgeToken[]>
@@ -87,8 +89,12 @@ jest.mock('@metamask/design-system-react-native', () => {
 jest.mock('../../hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: (
     params?: { chainIds?: CaipChainId[] },
-    options?: { shouldFetchTokenData?: boolean },
+    options?: { shouldFetchExtraTokenData?: boolean },
   ) => mockUseTokensWithBalance(params, options),
+}));
+
+jest.mock('../../../../hooks/useTokensData/useTokensData', () => ({
+  isRwaChecked: jest.fn(),
 }));
 
 jest.mock('../../../Tokens/hooks/useTokenPricePercentageChange', () => ({
@@ -424,6 +430,7 @@ describe('BatchSellTokenSelect', () => {
     mockWalletTokens = [
       createToken({ symbol: 'ETHA', name: 'Ethereum A', tokenFiatAmount: 10 }),
     ];
+    mockIsRwaChecked.mockReturnValue(true);
     mockUseTokensWithBalance.mockImplementation(
       (params?: { chainIds?: CaipChainId[] }) => {
         const tokens = !params?.chainIds
@@ -433,7 +440,7 @@ describe('BatchSellTokenSelect', () => {
                 formatChainIdToCaip(token.chainId) as CaipChainId,
               ),
             );
-        return { tokens, isRwaDataLoading: false };
+        return { tokens, isExtraTokenDataLoading: false };
       },
     );
   });
@@ -534,7 +541,7 @@ describe('BatchSellTokenSelect', () => {
       {
         chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
       },
-      { shouldFetchTokenData: true },
+      { shouldFetchExtraTokenData: true },
     );
     expect(
       getByTestId(getNetworkPillTestId('eip155:1' as CaipChainId)),
@@ -733,9 +740,10 @@ describe('BatchSellTokenSelect', () => {
   });
 
   it('shows loading skeletons and not the empty state while RWA data loads', () => {
+    mockIsRwaChecked.mockReturnValue(false);
     mockUseTokensWithBalance.mockReturnValue({
       tokens: mockWalletTokens,
-      isRwaDataLoading: true,
+      isExtraTokenDataLoading: true,
     });
 
     const { getByTestId, queryByTestId } = render(<BatchSellTokenSelect />);

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -10,6 +10,7 @@ import {
   buildBatchSellEligibleChains,
   getBatchSellDestinationToken,
   removeStablecoinsFromSourceTokens,
+  removeRwaTokens,
   MAX_BATCH_SELL_SOURCE_TOKENS,
   SUPPORTED_BATCH_SELL_CHAIN_IDS,
   sortBatchSellTokens,
@@ -84,8 +85,10 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 jest.mock('../../hooks/useTokensWithBalance', () => ({
-  useTokensWithBalance: (options?: { chainIds?: CaipChainId[] }) =>
-    mockUseTokensWithBalance(options),
+  useTokensWithBalance: (
+    params?: { chainIds?: CaipChainId[] },
+    options?: { shouldFetchTokenData?: boolean },
+  ) => mockUseTokensWithBalance(params, options),
 }));
 
 jest.mock('../../../Tokens/hooks/useTokenPricePercentageChange', () => ({
@@ -227,6 +230,48 @@ describe('filterBatchSellDestinationStablecoins', () => {
     });
 
     expect(result.map((token) => token.symbol)).toEqual(['LOW', 'HIGH']);
+  });
+});
+
+describe('removeRwaTokens', () => {
+  it('filters out tokens that have rwaData', () => {
+    const normalToken = createToken({
+      symbol: 'ETH',
+      address: '0x1111111111111111111111111111111111111111',
+    });
+    const stockRwa = createToken({
+      symbol: 'AAPL',
+      address: '0x2222222222222222222222222222222222222222',
+      rwaData: { instrumentType: 'stock' } as BridgeToken['rwaData'],
+    });
+    const bondRwa = createToken({
+      symbol: 'TBOND',
+      address: '0x3333333333333333333333333333333333333333',
+      rwaData: { instrumentType: 'bond' } as BridgeToken['rwaData'],
+    });
+
+    const result = removeRwaTokens([normalToken, stockRwa, bondRwa]);
+
+    expect(result.map((t) => t.symbol)).toEqual(['ETH']);
+  });
+
+  it('keeps tokens without rwaData', () => {
+    const tokenA = createToken({
+      symbol: 'ETH',
+      address: '0x1111111111111111111111111111111111111111',
+    });
+    const tokenB = createToken({
+      symbol: 'LINK',
+      address: '0x2222222222222222222222222222222222222222',
+    });
+
+    const result = removeRwaTokens([tokenA, tokenB]);
+
+    expect(result.map((t) => t.symbol)).toEqual(['ETH', 'LINK']);
+  });
+
+  it('returns an empty array when given an empty array', () => {
+    expect(removeRwaTokens([])).toEqual([]);
   });
 });
 
@@ -380,16 +425,15 @@ describe('BatchSellTokenSelect', () => {
       createToken({ symbol: 'ETHA', name: 'Ethereum A', tokenFiatAmount: 10 }),
     ];
     mockUseTokensWithBalance.mockImplementation(
-      (options?: { chainIds?: CaipChainId[] }) => {
-        if (!options?.chainIds) {
-          return mockWalletTokens;
-        }
-
-        return mockWalletTokens.filter((token) =>
-          options.chainIds?.includes(
-            formatChainIdToCaip(token.chainId) as CaipChainId,
-          ),
-        );
+      (params?: { chainIds?: CaipChainId[] }) => {
+        const tokens = !params?.chainIds
+          ? mockWalletTokens
+          : mockWalletTokens.filter((token) =>
+              params.chainIds?.includes(
+                formatChainIdToCaip(token.chainId) as CaipChainId,
+              ),
+            );
+        return { tokens, isRwaDataLoading: false };
       },
     );
   });
@@ -486,9 +530,12 @@ describe('BatchSellTokenSelect', () => {
       <BatchSellTokenSelect />,
     );
 
-    expect(mockUseTokensWithBalance).toHaveBeenCalledWith({
-      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
-    });
+    expect(mockUseTokensWithBalance).toHaveBeenCalledWith(
+      {
+        chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+      },
+      { shouldFetchTokenData: true },
+    );
     expect(
       getByTestId(getNetworkPillTestId('eip155:1' as CaipChainId)),
     ).toBeOnTheScreen();
@@ -682,6 +729,26 @@ describe('BatchSellTokenSelect', () => {
     ).toBeOnTheScreen();
     expect(
       queryByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('shows loading skeletons and not the empty state while RWA data loads', () => {
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: mockWalletTokens,
+      isRwaDataLoading: true,
+    });
+
+    const { getByTestId, queryByTestId } = render(<BatchSellTokenSelect />);
+
+    expect(
+      getByTestId(BatchSellTokenSelectSelectorsIDs.TOKEN_LIST),
+    ).toBeOnTheScreen();
+    // The empty state must not flash while RWA status is still unknown.
+    expect(
+      queryByTestId(BatchSellTokenSelectSelectorsIDs.EMPTY_STATE),
+    ).not.toBeOnTheScreen();
+    expect(
+      queryByTestId(`${BatchSellTokenSelectSelectorsIDs.TOKEN_ROW}-ETHA`),
     ).not.toBeOnTheScreen();
   });
 

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -440,7 +440,11 @@ describe('BatchSellTokenSelect', () => {
                 formatChainIdToCaip(token.chainId) as CaipChainId,
               ),
             );
-        return { tokens, isExtraTokenDataLoading: false };
+        return {
+          tokens,
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        };
       },
     );
   });
@@ -744,6 +748,7 @@ describe('BatchSellTokenSelect', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: mockWalletTokens,
       isExtraTokenDataLoading: true,
+      hasExtraTokenDataError: false,
     });
 
     const { getByTestId, queryByTestId } = render(<BatchSellTokenSelect />);
@@ -756,7 +761,41 @@ describe('BatchSellTokenSelect', () => {
       queryByTestId(BatchSellTokenSelectSelectorsIDs.EMPTY_STATE),
     ).not.toBeOnTheScreen();
     expect(
+      queryByTestId(BatchSellTokenSelectSelectorsIDs.ERROR_STATE),
+    ).not.toBeOnTheScreen();
+    expect(
       queryByTestId(`${BatchSellTokenSelectSelectorsIDs.TOKEN_ROW}-ETHA`),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('shows a generic token load error state when extra token data fails', () => {
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: mockWalletTokens,
+      isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: true,
+    });
+
+    const { getByTestId, getByText, queryByTestId } = render(
+      <BatchSellTokenSelect />,
+    );
+
+    expect(
+      getByTestId(BatchSellTokenSelectSelectorsIDs.ERROR_STATE),
+    ).toBeOnTheScreen();
+    expect(getByText('Unable to load tokens')).toBeOnTheScreen();
+    expect(
+      getByText(
+        "We couldn't load your eligible tokens. Check your connection and try again.",
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(BatchSellTokenSelectSelectorsIDs.EMPTY_STATE),
+    ).not.toBeOnTheScreen();
+    expect(
+      queryByTestId(BatchSellTokenSelectSelectorsIDs.TOKEN_LIST),
+    ).not.toBeOnTheScreen();
+    expect(
+      queryByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON),
     ).not.toBeOnTheScreen();
   });
 

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.testIds.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.testIds.ts
@@ -4,6 +4,7 @@ export const BatchSellTokenSelectSelectorsIDs = {
   NETWORK_PILL: 'batch-sell-token-select-network-pill',
   NEXT_BUTTON: 'batch-sell-token-select-next-button',
   EMPTY_STATE: 'batch-sell-token-select-empty-state',
+  ERROR_STATE: 'batch-sell-token-select-error-state',
   EXPLORE_TOKENS_BUTTON: 'batch-sell-token-select-explore-tokens-button',
   BALANCE_SORT_BUTTON: 'batch-sell-token-select-balance-sort-button',
 };

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -111,8 +111,11 @@ export function BatchSellTokenSelect() {
   const tw = useTailwind();
   const [tokenSortDirection, setTokenSortDirection] =
     useState<BatchSellTokenSortDirection>('desc');
-  const { eligibleSourceTokens, isRwaDataLoading, sortedEligibleChains } =
-    useBatchSellTokens(tokenSortDirection);
+  const {
+    eligibleSourceTokens,
+    isExtraTokenDataLoading,
+    sortedEligibleChains,
+  } = useBatchSellTokens(tokenSortDirection);
   const [selectedChainId, setSelectedChainId] = useState<
     CaipChainId | undefined
   >(() => sortedEligibleChains[0]?.chainId);
@@ -158,10 +161,10 @@ export function BatchSellTokenSelect() {
   );
   const tokenListData = useMemo(
     () =>
-      isRwaDataLoading
+      isExtraTokenDataLoading
         ? Array.from({ length: BATCH_SELL_LOADING_SKELETON_COUNT }, () => null)
         : selectedChainTokens,
-    [isRwaDataLoading, selectedChainTokens],
+    [isExtraTokenDataLoading, selectedChainTokens],
   );
   const selectedTokenKeys = useMemo(
     () => new Set(selectedTokens.map(getTokenKey)),
@@ -375,7 +378,7 @@ export function BatchSellTokenSelect() {
     >
       <Box twClassName="flex-1">
         <HeaderStandard title="" onBack={handleBackPress} includesTopInset />
-        {sortedEligibleChains.length === 0 ? (
+        {!isExtraTokenDataLoading && sortedEligibleChains.length === 0 ? (
           <BatchSellEmptyState
             onExploreTokensPress={handleExploreTokensPress}
           />

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -37,7 +37,6 @@ import Routes from '../../../../../constants/navigation/Routes';
 import {
   resetBridgeState,
   selectBatchSellDestStablecoins,
-  selectBatchSellDestStablecoinsByChain,
   setBatchSellDestToken,
   setBatchSellSourceTokenAmounts,
   setBatchSellSourceTokens,
@@ -45,25 +44,20 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { RootState } from '../../../../../reducers';
 import { BridgeToken } from '../../types';
-import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
 import ButtonToggle from '../../../../../component-library/components-temp/Buttons/ButtonToggle';
 import { ButtonSize as ButtonToggleSize } from '../../../../../component-library/components/Buttons/Button';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import {
-  buildBatchSellEligibleChains,
-  removeStablecoinsFromSourceTokens,
-  removeRwaTokens,
   getBatchSellDestinationToken,
   MAX_BATCH_SELL_SOURCE_TOKENS,
   BatchSellTokenSortDirection,
-  sortBatchSellTokens,
-  SUPPORTED_BATCH_SELL_CHAIN_IDS,
 } from './BatchSellTokenSelect.utils';
 import { BatchSellTokenSelectSelectorsIDs } from './BatchSellTokenSelect.testIds';
 import { BatchSellTokenRow } from './BatchSellTokenRow';
 import { BatchSellEmptyState } from './BatchSellEmptyState';
 import { SkeletonItem } from '../../components/SkeletonItem';
 import { DEFAULT_BATCH_SELL_SLIPPAGE } from '../../components/SlippageModal/utils';
+import { useBatchSellTokens } from './useBatchSellTokens';
 
 const getTokenKey = (token: BridgeToken) =>
   `${formatChainIdToCaip(token.chainId)}:${token.address}`;
@@ -115,27 +109,10 @@ export function BatchSellTokenSelect() {
   const navigation = useNavigation();
   const dispatch = useDispatch();
   const tw = useTailwind();
-  const { tokens: allWalletTokens, isRwaDataLoading } = useTokensWithBalance(
-    {
-      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
-    },
-    { shouldFetchTokenData: true },
-  );
-  const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
   const [tokenSortDirection, setTokenSortDirection] =
     useState<BatchSellTokenSortDirection>('desc');
-  const eligibleSourceTokens = useMemo(() => {
-    const withoutStablecoins = removeStablecoinsFromSourceTokens({
-      tokens: allWalletTokens,
-      stablecoinsByChain,
-    });
-    const withoutRwas = removeRwaTokens(withoutStablecoins);
-    return sortBatchSellTokens(withoutRwas, tokenSortDirection);
-  }, [allWalletTokens, stablecoinsByChain, tokenSortDirection]);
-  const sortedEligibleChains = useMemo(
-    () => buildBatchSellEligibleChains(eligibleSourceTokens),
-    [eligibleSourceTokens],
-  );
+  const { eligibleSourceTokens, isRwaDataLoading, sortedEligibleChains } =
+    useBatchSellTokens(tokenSortDirection);
   const [selectedChainId, setSelectedChainId] = useState<
     CaipChainId | undefined
   >(() => sortedEligibleChains[0]?.chainId);

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -55,6 +55,7 @@ import {
 import { BatchSellTokenSelectSelectorsIDs } from './BatchSellTokenSelect.testIds';
 import { BatchSellTokenRow } from './BatchSellTokenRow';
 import { BatchSellEmptyState } from './BatchSellEmptyState';
+import { BatchSellTokenLoadErrorState } from './BatchSellTokenLoadErrorState';
 import { SkeletonItem } from '../../components/SkeletonItem';
 import { DEFAULT_BATCH_SELL_SLIPPAGE } from '../../components/SlippageModal/utils';
 import { useBatchSellTokens } from './useBatchSellTokens';
@@ -114,6 +115,7 @@ export function BatchSellTokenSelect() {
   const {
     eligibleSourceTokens,
     isExtraTokenDataLoading,
+    hasExtraTokenDataError,
     sortedEligibleChains,
   } = useBatchSellTokens(tokenSortDirection);
   const [selectedChainId, setSelectedChainId] = useState<
@@ -191,6 +193,14 @@ export function BatchSellTokenSelect() {
 
     return strings('bridge.next');
   }, [selectedTokenCount]);
+  const shouldShowTokenLoadError =
+    !isExtraTokenDataLoading && hasExtraTokenDataError;
+  const shouldShowEmptyState =
+    !isExtraTokenDataLoading &&
+    !hasExtraTokenDataError &&
+    sortedEligibleChains.length === 0;
+  const shouldShowTokenList =
+    !shouldShowTokenLoadError && !shouldShowEmptyState;
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
@@ -378,11 +388,13 @@ export function BatchSellTokenSelect() {
     >
       <Box twClassName="flex-1">
         <HeaderStandard title="" onBack={handleBackPress} includesTopInset />
-        {!isExtraTokenDataLoading && sortedEligibleChains.length === 0 ? (
+        {shouldShowTokenLoadError && <BatchSellTokenLoadErrorState />}
+        {shouldShowEmptyState && (
           <BatchSellEmptyState
             onExploreTokensPress={handleExploreTokensPress}
           />
-        ) : (
+        )}
+        {shouldShowTokenList && (
           <>
             <Box twClassName="px-4 pt-2">
               <Text

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -52,6 +52,7 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import {
   buildBatchSellEligibleChains,
   removeStablecoinsFromSourceTokens,
+  removeRwaTokens,
   getBatchSellDestinationToken,
   MAX_BATCH_SELL_SOURCE_TOKENS,
   BatchSellTokenSortDirection,
@@ -61,10 +62,14 @@ import {
 import { BatchSellTokenSelectSelectorsIDs } from './BatchSellTokenSelect.testIds';
 import { BatchSellTokenRow } from './BatchSellTokenRow';
 import { BatchSellEmptyState } from './BatchSellEmptyState';
+import { SkeletonItem } from '../../components/SkeletonItem';
 import { DEFAULT_BATCH_SELL_SLIPPAGE } from '../../components/SlippageModal/utils';
 
 const getTokenKey = (token: BridgeToken) =>
   `${formatChainIdToCaip(token.chainId)}:${token.address}`;
+
+// Number of skeleton rows shown while RWA status is being resolved.
+const BATCH_SELL_LOADING_SKELETON_COUNT = 6;
 
 function getBatchSellSourceTokenAmount(token: BridgeToken, percent: number) {
   if (percent <= 0) return '0';
@@ -110,19 +115,22 @@ export function BatchSellTokenSelect() {
   const navigation = useNavigation();
   const dispatch = useDispatch();
   const tw = useTailwind();
-  const allWalletTokens = useTokensWithBalance({
-    chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
-  });
+  const { tokens: allWalletTokens, isRwaDataLoading } = useTokensWithBalance(
+    {
+      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+    },
+    { shouldFetchTokenData: true },
+  );
   const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
   const [tokenSortDirection, setTokenSortDirection] =
     useState<BatchSellTokenSortDirection>('desc');
   const eligibleSourceTokens = useMemo(() => {
-    const sourceTokens = removeStablecoinsFromSourceTokens({
+    const withoutStablecoins = removeStablecoinsFromSourceTokens({
       tokens: allWalletTokens,
       stablecoinsByChain,
     });
-
-    return sortBatchSellTokens(sourceTokens, tokenSortDirection);
+    const withoutRwas = removeRwaTokens(withoutStablecoins);
+    return sortBatchSellTokens(withoutRwas, tokenSortDirection);
   }, [allWalletTokens, stablecoinsByChain, tokenSortDirection]);
   const sortedEligibleChains = useMemo(
     () => buildBatchSellEligibleChains(eligibleSourceTokens),
@@ -170,6 +178,13 @@ export function BatchSellTokenSelect() {
           )
         : eligibleSourceTokens,
     [activeChainId, eligibleSourceTokens],
+  );
+  const tokenListData = useMemo(
+    () =>
+      isRwaDataLoading
+        ? Array.from({ length: BATCH_SELL_LOADING_SKELETON_COUNT }, () => null)
+        : selectedChainTokens,
+    [isRwaDataLoading, selectedChainTokens],
   );
   const selectedTokenKeys = useMemo(
     () => new Set(selectedTokens.map(getTokenKey)),
@@ -342,7 +357,9 @@ export function BatchSellTokenSelect() {
   );
 
   const renderToken = useCallback(
-    ({ item: token }: ListRenderItemInfo<BridgeToken>) => {
+    ({ item: token }: ListRenderItemInfo<BridgeToken | null>) => {
+      if (!token) return <SkeletonItem />;
+
       const tokenKey = getTokenKey(token);
       const isSelected = selectedTokenKeys.has(tokenKey);
 
@@ -366,6 +383,12 @@ export function BatchSellTokenSelect() {
       );
     },
     [handleTokenPress, selectedTokenKeys, sortedEligibleChains],
+  );
+
+  const getTokenListKey = useCallback(
+    (token: BridgeToken | null, index: number) =>
+      token ? getTokenKey(token) : `batch-sell-skeleton-${index}`,
+    [],
   );
 
   return (
@@ -448,9 +471,9 @@ export function BatchSellTokenSelect() {
             </Box>
             <FlatList
               testID={BatchSellTokenSelectSelectorsIDs.TOKEN_LIST}
-              data={selectedChainTokens}
+              data={tokenListData}
               renderItem={renderToken}
-              keyExtractor={getTokenKey}
+              keyExtractor={getTokenListKey}
               showsVerticalScrollIndicator={false}
               contentContainerStyle={tw.style('pb-4')}
             />

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.utils.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.utils.ts
@@ -81,6 +81,10 @@ export function removeStablecoinsFromSourceTokens({
   });
 }
 
+export function removeRwaTokens(tokens: BridgeToken[]): BridgeToken[] {
+  return tokens.filter((token) => !token.rwaData);
+}
+
 export function sortBatchSellTokens(
   tokens: BridgeToken[],
   sortDirection: BatchSellTokenSortDirection = 'desc',

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react-native';
+import { CaipChainId, Hex } from '@metamask/utils';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+
+import { BridgeToken } from '../../types';
+import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
+import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
+import { useBatchSellTokens } from './useBatchSellTokens';
+import {
+  SUPPORTED_BATCH_SELL_CHAIN_IDS,
+  BatchSellTokenSortDirection,
+} from './BatchSellTokenSelect.utils';
+
+const mockUseSelector = jest.fn();
+const mockUseTokensWithBalance = useTokensWithBalance as jest.Mock;
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) =>
+    mockUseSelector(selector),
+}));
+
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  selectBatchSellDestStablecoinsByChain: jest.fn(),
+}));
+
+jest.mock('../../hooks/useTokensWithBalance', () => ({
+  useTokensWithBalance: jest.fn(),
+}));
+
+const createToken = (overrides: Partial<BridgeToken>): BridgeToken => ({
+  address: '0x1111111111111111111111111111111111111111',
+  chainId: '0x1' as Hex,
+  decimals: 18,
+  symbol: 'TST',
+  name: 'Test Token',
+  balance: '1',
+  balanceFiat: '$1.00',
+  tokenFiatAmount: 1,
+  ...overrides,
+});
+
+function renderUseBatchSellTokens(
+  sortDirection: BatchSellTokenSortDirection = 'desc',
+) {
+  return renderHook(() => useBatchSellTokens(sortDirection));
+}
+
+describe('useBatchSellTokens', () => {
+  let stablecoinsByChain: Partial<Record<CaipChainId, BridgeToken[]>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stablecoinsByChain = {};
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectBatchSellDestStablecoinsByChain) {
+        return stablecoinsByChain;
+      }
+      return undefined;
+    });
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [],
+      isRwaDataLoading: false,
+    });
+  });
+
+  it('opts into fetching token data for supported batch sell chains', () => {
+    renderUseBatchSellTokens();
+
+    expect(mockUseTokensWithBalance).toHaveBeenCalledWith(
+      {
+        chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+      },
+      { shouldFetchTokenData: true },
+    );
+  });
+
+  it('filters destination stablecoins and RWA tokens, then sorts by descending fiat balance', () => {
+    const stablecoin = createToken({
+      symbol: 'USDC',
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      tokenFiatAmount: 100,
+    });
+    const stockRwa = createToken({
+      symbol: 'AAPL',
+      address: '0x2222222222222222222222222222222222222222',
+      tokenFiatAmount: 50,
+      rwaData: { instrumentType: 'stock' } as BridgeToken['rwaData'],
+    });
+    const lowValueToken = createToken({
+      symbol: 'LOW',
+      address: '0x3333333333333333333333333333333333333333',
+      tokenFiatAmount: 10,
+    });
+    const highValueToken = createToken({
+      symbol: 'HIGH',
+      address: '0x4444444444444444444444444444444444444444',
+      tokenFiatAmount: 25,
+    });
+
+    stablecoinsByChain = {
+      [formatChainIdToCaip(stablecoin.chainId)]: [stablecoin],
+    };
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [stablecoin, stockRwa, lowValueToken, highValueToken],
+      isRwaDataLoading: false,
+    });
+
+    const { result } = renderUseBatchSellTokens();
+
+    expect(
+      result.current.eligibleSourceTokens.map((token) => token.symbol),
+    ).toEqual(['HIGH', 'LOW']);
+  });
+
+  it('sorts eligible tokens by ascending fiat balance when requested', () => {
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [
+        createToken({
+          symbol: 'HIGH',
+          address: '0x4444444444444444444444444444444444444444',
+          tokenFiatAmount: 25,
+        }),
+        createToken({
+          symbol: 'LOW',
+          address: '0x3333333333333333333333333333333333333333',
+          tokenFiatAmount: 10,
+        }),
+      ],
+      isRwaDataLoading: false,
+    });
+
+    const { result } = renderUseBatchSellTokens('asc');
+
+    expect(
+      result.current.eligibleSourceTokens.map((token) => token.symbol),
+    ).toEqual(['LOW', 'HIGH']);
+  });
+
+  it('builds eligible chains from filtered source tokens', () => {
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [
+        createToken({
+          symbol: 'ETHA',
+          address: '0x1111111111111111111111111111111111111111',
+          chainId: '0x1' as Hex,
+          tokenFiatAmount: 10,
+        }),
+        createToken({
+          symbol: 'BSCA',
+          address: '0x2222222222222222222222222222222222222222',
+          chainId: '0x38' as Hex,
+          tokenFiatAmount: 25,
+        }),
+      ],
+      isRwaDataLoading: false,
+    });
+
+    const { result } = renderUseBatchSellTokens();
+
+    expect(
+      result.current.sortedEligibleChains.map((chain) => chain.chainId),
+    ).toEqual(['eip155:56', 'eip155:1']);
+  });
+
+  it('passes through the RWA data loading state', () => {
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [createToken({ symbol: 'ETHA' })],
+      isRwaDataLoading: true,
+    });
+
+    const { result } = renderUseBatchSellTokens();
+
+    expect(result.current.isRwaDataLoading).toBe(true);
+  });
+});

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -3,6 +3,7 @@ import { CaipChainId, Hex } from '@metamask/utils';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 
 import { BridgeToken } from '../../types';
+import { isRwaChecked } from '../../../../hooks/useTokensData/useTokensData';
 import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
 import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
 import { useBatchSellTokens } from './useBatchSellTokens';
@@ -13,6 +14,7 @@ import {
 
 const mockUseSelector = jest.fn();
 const mockUseTokensWithBalance = useTokensWithBalance as jest.Mock;
+const mockIsRwaChecked = isRwaChecked as jest.Mock;
 
 jest.mock('react-redux', () => ({
   useSelector: (selector: (state: unknown) => unknown) =>
@@ -25,6 +27,10 @@ jest.mock('../../../../../core/redux/slices/bridge', () => ({
 
 jest.mock('../../hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useTokensData/useTokensData', () => ({
+  isRwaChecked: jest.fn(),
 }));
 
 const createToken = (overrides: Partial<BridgeToken>): BridgeToken => ({
@@ -61,6 +67,7 @@ describe('useBatchSellTokens', () => {
       tokens: [],
       isRwaDataLoading: false,
     });
+    mockIsRwaChecked.mockReturnValue(true);
   });
 
   it('opts into fetching token data for supported batch sell chains', () => {
@@ -110,6 +117,32 @@ describe('useBatchSellTokens', () => {
     expect(
       result.current.eligibleSourceTokens.map((token) => token.symbol),
     ).toEqual(['HIGH', 'LOW']);
+  });
+
+  it('excludes tokens whose RWA status has not been checked', () => {
+    const checkedToken = createToken({
+      symbol: 'CHECKED',
+      address: '0x1111111111111111111111111111111111111111',
+      tokenFiatAmount: 25,
+    });
+    const uncheckedToken = createToken({
+      symbol: 'UNKNOWN',
+      address: '0x2222222222222222222222222222222222222222',
+      tokenFiatAmount: 50,
+    });
+    mockIsRwaChecked.mockImplementation(
+      (assetId: string) => !assetId.includes(uncheckedToken.address),
+    );
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [checkedToken, uncheckedToken],
+      isRwaDataLoading: false,
+    });
+
+    const { result } = renderUseBatchSellTokens();
+
+    expect(
+      result.current.eligibleSourceTokens.map((token) => token.symbol),
+    ).toEqual(['CHECKED']);
   });
 
   it('sorts eligible tokens by ascending fiat balance when requested', () => {

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -66,6 +66,7 @@ describe('useBatchSellTokens', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
     mockIsRwaChecked.mockReturnValue(true);
   });
@@ -110,6 +111,7 @@ describe('useBatchSellTokens', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [stablecoin, stockRwa, lowValueToken, highValueToken],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
 
     const { result } = renderUseBatchSellTokens();
@@ -136,6 +138,7 @@ describe('useBatchSellTokens', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [checkedToken, uncheckedToken],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
 
     const { result } = renderUseBatchSellTokens();
@@ -160,6 +163,7 @@ describe('useBatchSellTokens', () => {
         }),
       ],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
 
     const { result } = renderUseBatchSellTokens('asc');
@@ -186,6 +190,7 @@ describe('useBatchSellTokens', () => {
         }),
       ],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
 
     const { result } = renderUseBatchSellTokens();
@@ -195,14 +200,27 @@ describe('useBatchSellTokens', () => {
     ).toEqual(['eip155:56', 'eip155:1']);
   });
 
-  it('passes through the RWA data loading state', () => {
+  it('passes through the extra token data loading state', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [createToken({ symbol: 'ETHA' })],
       isExtraTokenDataLoading: true,
+      hasExtraTokenDataError: false,
     });
 
     const { result } = renderUseBatchSellTokens();
 
     expect(result.current.isExtraTokenDataLoading).toBe(true);
+  });
+
+  it('passes through the extra token data error state', () => {
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [createToken({ symbol: 'ETHA' })],
+      isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: true,
+    });
+
+    const { result } = renderUseBatchSellTokens();
+
+    expect(result.current.hasExtraTokenDataError).toBe(true);
   });
 });

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -65,7 +65,7 @@ describe('useBatchSellTokens', () => {
     });
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
     mockIsRwaChecked.mockReturnValue(true);
   });
@@ -77,7 +77,7 @@ describe('useBatchSellTokens', () => {
       {
         chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
       },
-      { shouldFetchTokenData: true },
+      { shouldFetchExtraTokenData: true },
     );
   });
 
@@ -109,7 +109,7 @@ describe('useBatchSellTokens', () => {
     };
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [stablecoin, stockRwa, lowValueToken, highValueToken],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
 
     const { result } = renderUseBatchSellTokens();
@@ -135,7 +135,7 @@ describe('useBatchSellTokens', () => {
     );
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [checkedToken, uncheckedToken],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
 
     const { result } = renderUseBatchSellTokens();
@@ -159,7 +159,7 @@ describe('useBatchSellTokens', () => {
           tokenFiatAmount: 10,
         }),
       ],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
 
     const { result } = renderUseBatchSellTokens('asc');
@@ -185,7 +185,7 @@ describe('useBatchSellTokens', () => {
           tokenFiatAmount: 25,
         }),
       ],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
 
     const { result } = renderUseBatchSellTokens();
@@ -198,11 +198,11 @@ describe('useBatchSellTokens', () => {
   it('passes through the RWA data loading state', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [createToken({ symbol: 'ETHA' })],
-      isRwaDataLoading: true,
+      isExtraTokenDataLoading: true,
     });
 
     const { result } = renderUseBatchSellTokens();
 
-    expect(result.current.isRwaDataLoading).toBe(true);
+    expect(result.current.isExtraTokenDataLoading).toBe(true);
   });
 });

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -17,13 +17,16 @@ import {
 export function useBatchSellTokens(
   tokenSortDirection: BatchSellTokenSortDirection,
 ) {
-  const { tokens: allWalletTokens, isExtraTokenDataLoading } =
-    useTokensWithBalance(
-      {
-        chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
-      },
-      { shouldFetchExtraTokenData: true },
-    );
+  const {
+    tokens: allWalletTokens,
+    isExtraTokenDataLoading,
+    hasExtraTokenDataError,
+  } = useTokensWithBalance(
+    {
+      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+    },
+    { shouldFetchExtraTokenData: true },
+  );
   const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
 
   const eligibleSourceTokens = useMemo(() => {
@@ -51,6 +54,7 @@ export function useBatchSellTokens(
   return {
     eligibleSourceTokens,
     isExtraTokenDataLoading,
+    hasExtraTokenDataError,
     sortedEligibleChains,
   };
 }

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { formatAddressToAssetId } from '@metamask/bridge-controller';
 
+import { isRwaChecked } from '../../../../hooks/useTokensData/useTokensData';
 import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
 import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
 import {
@@ -29,7 +31,15 @@ export function useBatchSellTokens(
       stablecoinsByChain,
     });
     const withoutRwas = removeRwaTokens(withoutStablecoins);
-    return sortBatchSellTokens(withoutRwas, tokenSortDirection);
+    const confirmedNonRwas = withoutRwas.filter((token) => {
+      try {
+        const assetId = formatAddressToAssetId(token.address, token.chainId);
+        return assetId ? isRwaChecked(assetId.toLowerCase()) : false;
+      } catch {
+        return false;
+      }
+    });
+    return sortBatchSellTokens(confirmedNonRwas, tokenSortDirection);
   }, [allWalletTokens, stablecoinsByChain, tokenSortDirection]);
 
   const sortedEligibleChains = useMemo(

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -17,12 +17,13 @@ import {
 export function useBatchSellTokens(
   tokenSortDirection: BatchSellTokenSortDirection,
 ) {
-  const { tokens: allWalletTokens, isRwaDataLoading } = useTokensWithBalance(
-    {
-      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
-    },
-    { shouldFetchTokenData: true },
-  );
+  const { tokens: allWalletTokens, isExtraTokenDataLoading } =
+    useTokensWithBalance(
+      {
+        chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+      },
+      { shouldFetchExtraTokenData: true },
+    );
   const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
 
   const eligibleSourceTokens = useMemo(() => {
@@ -49,7 +50,7 @@ export function useBatchSellTokens(
 
   return {
     eligibleSourceTokens,
-    isRwaDataLoading,
+    isExtraTokenDataLoading,
     sortedEligibleChains,
   };
 }

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
+import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
+import {
+  BatchSellTokenSortDirection,
+  buildBatchSellEligibleChains,
+  removeRwaTokens,
+  removeStablecoinsFromSourceTokens,
+  sortBatchSellTokens,
+  SUPPORTED_BATCH_SELL_CHAIN_IDS,
+} from './BatchSellTokenSelect.utils';
+
+export function useBatchSellTokens(
+  tokenSortDirection: BatchSellTokenSortDirection,
+) {
+  const { tokens: allWalletTokens, isRwaDataLoading } = useTokensWithBalance(
+    {
+      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+    },
+    { shouldFetchTokenData: true },
+  );
+  const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
+
+  const eligibleSourceTokens = useMemo(() => {
+    const withoutStablecoins = removeStablecoinsFromSourceTokens({
+      tokens: allWalletTokens,
+      stablecoinsByChain,
+    });
+    const withoutRwas = removeRwaTokens(withoutStablecoins);
+    return sortBatchSellTokens(withoutRwas, tokenSortDirection);
+  }, [allWalletTokens, stablecoinsByChain, tokenSortDirection]);
+
+  const sortedEligibleChains = useMemo(
+    () => buildBatchSellEligibleChains(eligibleSourceTokens),
+    [eligibleSourceTokens],
+  );
+
+  return {
+    eligibleSourceTokens,
+    isRwaDataLoading,
+    sortedEligibleChains,
+  };
+}

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -214,8 +214,8 @@ jest.mock('../../hooks/useBalancesByAssetId', () => ({
   useBalancesByAssetId: (params: unknown) => mockUseBalancesByAssetId(params),
 }));
 
-jest.mock('../../hooks/useTokensWithBalances', () => ({
-  useTokensWithBalances: (tokens: Record<string, unknown>[]) =>
+jest.mock('../../hooks/useMergeApiTokensWithBalances', () => ({
+  useMergeApiTokensWithBalances: (tokens: Record<string, unknown>[]) =>
     tokens.map((token) => {
       const { iconUrl, ...tokenWithoutIconUrl } = token as { iconUrl?: string };
       return {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -56,7 +56,7 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { type BridgeToken, TokenSelectorType } from '../../types';
 import { usePopularTokens } from '../../hooks/usePopularTokens';
 import { useSearchTokens } from '../../hooks/useSearchTokens';
-import { useTokensWithBalances } from '../../hooks/useTokensWithBalances';
+import { useMergeApiTokensWithBalances } from '../../hooks/useMergeApiTokensWithBalances';
 import { useTokenSelection } from '../../hooks/useTokenSelection';
 import { createStyles } from './BridgeTokenSelector.styles';
 import Engine from '../../../../../core/Engine';
@@ -214,11 +214,11 @@ export const BridgeTokenSelector: React.FC = () => {
   }, [selectedChainId, debouncedSearch, resetSearch, isValidSearch]);
 
   // Use custom hook for merging balances
-  const popularTokensWithBalance = useTokensWithBalances(
+  const popularTokensWithBalance = useMergeApiTokensWithBalances(
     popularTokens,
     balancesByAssetId,
   );
-  const searchResultsWithBalance = useTokensWithBalances(
+  const searchResultsWithBalance = useMergeApiTokensWithBalances(
     searchResults,
     balancesByAssetId,
   );

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
@@ -21,7 +21,10 @@ describe('useBalancesByAssetId', () => {
 
   describe('basic functionality', () => {
     it('returns empty balancesByAssetId when no tokens have balances', () => {
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -48,7 +51,10 @@ describe('useBalancesByAssetId', () => {
           tokenFiatAmount: 100,
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -72,6 +78,33 @@ describe('useBalancesByAssetId', () => {
       });
     });
 
+    it('preserves rwaData in the balance lookup map', () => {
+      const rwaData = { instrumentType: 'stock' };
+      const mockTokens = [
+        createMockTokenWithBalance({
+          address: '0x1111111111111111111111111111111111111111',
+          balance: '50.0',
+          rwaData,
+        }),
+      ];
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
+
+      const { result } = renderHook(() =>
+        useBalancesByAssetId({
+          chainIds: [MOCK_CHAIN_IDS_HEX.ethereum as Hex],
+        }),
+      );
+
+      expect(
+        result.current.balancesByAssetId[
+          'eip155:1/erc20:0x1111111111111111111111111111111111111111' as CaipAssetType
+        ]?.rwaData,
+      ).toEqual(rwaData);
+    });
+
     it('maps EVM token balances to canonical and lowercase assetId keys', () => {
       const mockTokens = [
         createMockTokenWithBalance({
@@ -80,7 +113,10 @@ describe('useBalancesByAssetId', () => {
           balanceFiat: '$50',
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -119,7 +155,10 @@ describe('useBalancesByAssetId', () => {
           balanceFiat: '$50',
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -145,7 +184,10 @@ describe('useBalancesByAssetId', () => {
         createMockTokenWithBalance({ address: '0xtoken1' }),
         createMockTokenWithBalance({ address: '0xtoken2' }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -169,7 +211,10 @@ describe('useBalancesByAssetId', () => {
           balance: undefined,
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -205,7 +250,10 @@ describe('useBalancesByAssetId', () => {
           balance: '20.0',
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -233,7 +281,10 @@ describe('useBalancesByAssetId', () => {
           balance: '100.0',
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({ chainIds: ['eip155:1' as CaipChainId] }),
@@ -249,7 +300,10 @@ describe('useBalancesByAssetId', () => {
 
   describe('parameter handling', () => {
     it('passes chainIds to useTokensWithBalance', () => {
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
       const chainIds = [MOCK_CHAIN_IDS_HEX.ethereum as Hex, '0xa' as Hex];
 
       renderHook(() => useBalancesByAssetId({ chainIds }));
@@ -258,7 +312,10 @@ describe('useBalancesByAssetId', () => {
     });
 
     it('handles undefined chainIds', () => {
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({ chainIds: undefined }),
@@ -280,7 +337,10 @@ describe('useBalancesByAssetId', () => {
           currencyExchangeRate: undefined,
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({
@@ -311,7 +371,10 @@ describe('useBalancesByAssetId', () => {
           accountType: BtcAccountType.P2wpkh,
         }),
       ];
-      mockUseTokensWithBalance.mockReturnValue(mockTokens);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: mockTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useBalancesByAssetId({

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
@@ -23,7 +23,7 @@ describe('useBalancesByAssetId', () => {
     it('returns empty balancesByAssetId when no tokens have balances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -53,7 +53,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -89,7 +89,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -115,7 +115,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -157,7 +157,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -186,7 +186,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -213,7 +213,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -252,7 +252,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -283,7 +283,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -302,7 +302,7 @@ describe('useBalancesByAssetId', () => {
     it('passes chainIds to useTokensWithBalance', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
       const chainIds = [MOCK_CHAIN_IDS_HEX.ethereum as Hex, '0xa' as Hex];
 
@@ -314,7 +314,7 @@ describe('useBalancesByAssetId', () => {
     it('handles undefined chainIds', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -339,7 +339,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -373,7 +373,7 @@ describe('useBalancesByAssetId', () => {
       ];
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.test.ts
@@ -24,6 +24,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -54,6 +55,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -90,6 +92,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -116,6 +119,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -158,6 +162,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -187,6 +192,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -214,6 +220,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -253,6 +260,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -284,6 +292,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -303,6 +312,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
       const chainIds = [MOCK_CHAIN_IDS_HEX.ethereum as Hex, '0xa' as Hex];
 
@@ -315,6 +325,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -340,6 +351,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -374,6 +386,7 @@ describe('useBalancesByAssetId', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: mockTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>

--- a/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
+++ b/app/components/UI/Bridge/hooks/useBalancesByAssetId/index.ts
@@ -16,6 +16,7 @@ export interface BalanceData {
   tokenFiatAmount?: number;
   currencyExchangeRate?: number;
   accountType?: BridgeToken['accountType'];
+  rwaData?: BridgeToken['rwaData'];
 }
 
 /**
@@ -34,10 +35,10 @@ export const useBalancesByAssetId = ({
 }: {
   chainIds: (Hex | CaipChainId)[] | undefined;
 }): {
-  tokensWithBalance: ReturnType<typeof useTokensWithBalance>;
+  tokensWithBalance: ReturnType<typeof useTokensWithBalance>['tokens'];
   balancesByAssetId: BalancesByAssetId;
 } => {
-  const tokensWithBalance = useTokensWithBalance({ chainIds });
+  const { tokens: tokensWithBalance } = useTokensWithBalance({ chainIds });
 
   const balancesByAssetId = useMemo(() => {
     const balancesMap: BalancesByAssetId = {};
@@ -51,6 +52,7 @@ export const useBalancesByAssetId = ({
           tokenFiatAmount: token.tokenFiatAmount,
           currencyExchangeRate: token.currencyExchangeRate,
           accountType: token.accountType,
+          ...(token.rwaData ? { rwaData: token.rwaData } : {}),
         };
 
         // Store the canonical bridge-controller key for checksummed lookups for EVM.

--- a/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.test.ts
+++ b/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.test.ts
@@ -107,6 +107,48 @@ describe('useMergeApiTokensWithBalances', () => {
       });
     });
 
+    it('merges rwaData from balance data when API token does not include it', () => {
+      const assetId =
+        'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
+      const mockToken = createMockPopularToken({ assetId });
+      const rwaData = { instrumentType: 'stock' };
+      const balancesByAssetId: BalancesByAssetId = {
+        [assetId]: createMockBalanceData({
+          balance: '500.0',
+          rwaData,
+        }),
+      };
+
+      const { result } = renderHook(() =>
+        useMergeApiTokensWithBalances([mockToken], balancesByAssetId),
+      );
+
+      expect(result.current[0].rwaData).toEqual(rwaData);
+    });
+
+    it('preserves API token rwaData over balance data rwaData', () => {
+      const assetId =
+        'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
+      const apiRwaData = { instrumentType: 'bond' };
+      const balanceRwaData = { instrumentType: 'stock' };
+      const mockToken = {
+        ...createMockPopularToken({ assetId }),
+        rwaData: apiRwaData,
+      };
+      const balancesByAssetId: BalancesByAssetId = {
+        [assetId]: createMockBalanceData({
+          balance: '500.0',
+          rwaData: balanceRwaData,
+        }),
+      };
+
+      const { result } = renderHook(() =>
+        useMergeApiTokensWithBalances([mockToken], balancesByAssetId),
+      );
+
+      expect(result.current[0].rwaData).toEqual(apiRwaData);
+    });
+
     it('preserves token properties when no balance data exists', () => {
       const mockToken = createMockPopularToken({
         name: 'Preserved Token',

--- a/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.test.ts
+++ b/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.test.ts
@@ -2,14 +2,14 @@ import { renderHook } from '@testing-library/react-native';
 import { CaipAssetType } from '@metamask/utils';
 import { constants } from 'ethers';
 import { BtcAccountType } from '@metamask/keyring-api';
-import { useTokensWithBalances } from './useTokensWithBalances';
+import { useMergeApiTokensWithBalances } from './useMergeApiTokensWithBalances';
 import {
   createMockPopularToken,
   createMockBalanceData,
 } from '../testUtils/fixtures';
 import { BalancesByAssetId } from './useBalancesByAssetId';
 
-describe('useTokensWithBalances', () => {
+describe('useMergeApiTokensWithBalances', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -52,7 +52,7 @@ describe('useTokensWithBalances', () => {
       'converts %s with correct address and chainId',
       (_, mockToken, expected) => {
         const { result } = renderHook(() =>
-          useTokensWithBalances([mockToken], {}),
+          useMergeApiTokensWithBalances([mockToken], {}),
         );
 
         expect(result.current[0]).toMatchObject(expected);
@@ -73,7 +73,9 @@ describe('useTokensWithBalances', () => {
         }),
       ];
 
-      const { result } = renderHook(() => useTokensWithBalances(tokens, {}));
+      const { result } = renderHook(() =>
+        useMergeApiTokensWithBalances(tokens, {}),
+      );
 
       expect(result.current[0].chainId).toBe('0x89');
       expect(result.current[1].chainId).toBe('0xa');
@@ -94,7 +96,7 @@ describe('useTokensWithBalances', () => {
       const balancesByAssetId: BalancesByAssetId = { [assetId]: balanceData };
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], balancesByAssetId),
+        useMergeApiTokensWithBalances([mockToken], balancesByAssetId),
       );
 
       expect(result.current[0]).toMatchObject({
@@ -113,7 +115,7 @@ describe('useTokensWithBalances', () => {
       });
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], {}),
+        useMergeApiTokensWithBalances([mockToken], {}),
       );
 
       expect(result.current[0]).toMatchObject({
@@ -125,13 +127,17 @@ describe('useTokensWithBalances', () => {
     });
 
     it('handles empty token array', () => {
-      const { result } = renderHook(() => useTokensWithBalances([], {}));
+      const { result } = renderHook(() =>
+        useMergeApiTokensWithBalances([], {}),
+      );
 
       expect(result.current).toEqual([]);
     });
 
     it('handles undefined token arrays', () => {
-      const { result } = renderHook(() => useTokensWithBalances(undefined, {}));
+      const { result } = renderHook(() =>
+        useMergeApiTokensWithBalances(undefined, {}),
+      );
 
       expect(result.current).toEqual([]);
     });
@@ -152,7 +158,7 @@ describe('useTokensWithBalances', () => {
       };
 
       const { result } = renderHook(() =>
-        useTokensWithBalances(tokens, balancesByAssetId),
+        useMergeApiTokensWithBalances(tokens, balancesByAssetId),
       );
 
       expect(result.current[0].balance).toBe('100.0');
@@ -167,7 +173,7 @@ describe('useTokensWithBalances', () => {
       });
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], {}),
+        useMergeApiTokensWithBalances([mockToken], {}),
       );
 
       expect(result.current[0].noFee).toEqual({
@@ -182,7 +188,7 @@ describe('useTokensWithBalances', () => {
       });
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], {}),
+        useMergeApiTokensWithBalances([mockToken], {}),
       );
 
       expect(result.current[0].isVerified).toBe(true);
@@ -202,7 +208,7 @@ describe('useTokensWithBalances', () => {
       const balancesByAssetId: BalancesByAssetId = { [assetId]: balanceData };
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], balancesByAssetId),
+        useMergeApiTokensWithBalances([mockToken], balancesByAssetId),
       );
 
       expect(result.current[0].accountType).toBe(BtcAccountType.P2wpkh);
@@ -219,7 +225,7 @@ describe('useTokensWithBalances', () => {
       const balancesByAssetId: BalancesByAssetId = { [assetId]: balanceData };
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], balancesByAssetId),
+        useMergeApiTokensWithBalances([mockToken], balancesByAssetId),
       );
 
       expect(result.current[0].accountType).toBeUndefined();
@@ -231,7 +237,7 @@ describe('useTokensWithBalances', () => {
       });
 
       const { result } = renderHook(() =>
-        useTokensWithBalances([mockToken], {}),
+        useMergeApiTokensWithBalances([mockToken], {}),
       );
 
       expect(result.current[0].accountType).toBeUndefined();

--- a/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.ts
+++ b/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.ts
@@ -55,7 +55,7 @@ const convertAPITokensToBridgeTokens = (
  * @param balancesByAssetId - Balance data indexed by assetId
  * @returns Tokens with merged balance information
  */
-export const useTokensWithBalances = (
+export const useMergeApiTokensWithBalances = (
   apiTokens: (PopularToken | IncludeAsset)[] | null | undefined,
   balancesByAssetId: BalancesByAssetId,
 ): BridgeToken[] =>

--- a/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.ts
+++ b/app/components/UI/Bridge/hooks/useMergeApiTokensWithBalances.ts
@@ -76,6 +76,7 @@ export const useMergeApiTokensWithBalances = (
           tokenFiatAmount: balanceData.tokenFiatAmount,
           currencyExchangeRate: balanceData.currencyExchangeRate,
           accountType: balanceData.accountType,
+          rwaData: token.rwaData ?? balanceData.rwaData,
         };
       }
       return token;

--- a/app/components/UI/Bridge/hooks/useSortedSourceNetworks/useSortedSourceNetworks.ts
+++ b/app/components/UI/Bridge/hooks/useSortedSourceNetworks/useSortedSourceNetworks.ts
@@ -52,7 +52,7 @@ export const useSortedSourceNetworks = () => {
   );
 
   // Calculate total fiat value for Solana (native + tokens)
-  const solTokensWithBalance = useTokensWithBalance({
+  const { tokens: solTokensWithBalance } = useTokensWithBalance({
     chainIds: [SolScope.Mainnet],
   });
   const solFiatTotal = solTokensWithBalance.reduce(
@@ -60,7 +60,7 @@ export const useSortedSourceNetworks = () => {
     0,
   );
 
-  const btcTokensWithBalance = useTokensWithBalance({
+  const { tokens: btcTokensWithBalance } = useTokensWithBalance({
     chainIds: [BtcScope.Mainnet],
   });
   const btcFiatTotal = btcTokensWithBalance.reduce(
@@ -69,7 +69,7 @@ export const useSortedSourceNetworks = () => {
   );
 
   // Calculate total fiat value for Tron (native + tokens)
-  const trxTokensWithBalance = useTokensWithBalance({
+  const { tokens: trxTokensWithBalance } = useTokensWithBalance({
     chainIds: [TrxScope.Mainnet],
   });
   const trxFiatTotal = trxTokensWithBalance.reduce(

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -157,8 +157,8 @@ export const calculateEvmBalances = ({
  * @param {Object} params - The parameters object
  * @param {Hex[]} params.chainIds - Array of chain IDs to filter by
  * @param {Object} options - Optional hook configuration
- * @param {boolean} options.shouldFetchTokenData - Whether to fetch and merge token metadata
- * @returns tokens with sortable fiat balances and RWA loading state.
+ * @param {boolean} options.shouldFetchExtraTokenData - Whether to fetch and merge token metadata
+ * @returns tokens with sortable fiat balances and extra token data loading state.
  */
 export const useTokensWithBalance = (
   {
@@ -167,10 +167,10 @@ export const useTokensWithBalance = (
     chainIds: (Hex | CaipChainId)[] | undefined;
   },
   options: {
-    shouldFetchTokenData?: boolean;
+    shouldFetchExtraTokenData?: boolean;
   } = {},
-): { tokens: BridgeToken[]; isRwaDataLoading: boolean } => {
-  const { shouldFetchTokenData = false } = options;
+): { tokens: BridgeToken[]; isExtraTokenDataLoading: boolean } => {
+  const { shouldFetchExtraTokenData = false } = options;
   const tokenSortConfig = useSelector(selectTokenSortConfig);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const networkConfigurationsByChainId = useSelector(
@@ -327,7 +327,7 @@ export const useTokensWithBalance = (
   // cache hits and never trigger a re-fetch.
   const missingRwaAssetIds = useMemo(
     () =>
-      shouldFetchTokenData
+      shouldFetchExtraTokenData
         ? sortedTokens
             .filter((token) => !token.rwaData)
             .map((token) => {
@@ -346,7 +346,7 @@ export const useTokensWithBalance = (
                 assetId !== null && !isRwaChecked(assetId),
             )
         : [],
-    [shouldFetchTokenData, sortedTokens],
+    [shouldFetchExtraTokenData, sortedTokens],
   );
 
   // apiTokenData is consumed only as a memo trigger: it changes identity when a
@@ -356,14 +356,12 @@ export const useTokensWithBalance = (
   // lose their rwaData on remount.
   // TODO: Migrate away from calling the token API directly once the Assets team
   // persists rwaData in controller state.
-  const { tokens: apiTokenData, isLoading: isRwaDataLoading } = useTokensData(
-    missingRwaAssetIds,
-    { includeRwaData: true },
-  );
+  const { tokens: apiTokenData, isLoading: isExtraTokenDataLoading } =
+    useTokensData(missingRwaAssetIds, { includeRwaData: true });
 
   return useMemo(
     () => ({
-      tokens: shouldFetchTokenData
+      tokens: shouldFetchExtraTokenData
         ? sortedTokens.map((token) => {
             if (token.rwaData) return token;
             try {
@@ -384,8 +382,15 @@ export const useTokensWithBalance = (
             }
           })
         : sortedTokens,
-      isRwaDataLoading: shouldFetchTokenData ? isRwaDataLoading : false,
+      isExtraTokenDataLoading: shouldFetchExtraTokenData
+        ? isExtraTokenDataLoading
+        : false,
     }),
-    [shouldFetchTokenData, sortedTokens, apiTokenData, isRwaDataLoading],
+    [
+      shouldFetchExtraTokenData,
+      sortedTokens,
+      apiTokenData,
+      isExtraTokenDataLoading,
+    ],
   );
 };

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -158,7 +158,7 @@ export const calculateEvmBalances = ({
  * @param {Hex[]} params.chainIds - Array of chain IDs to filter by
  * @param {Object} options - Optional hook configuration
  * @param {boolean} options.shouldFetchExtraTokenData - Whether to fetch and merge token metadata
- * @returns tokens with sortable fiat balances and extra token data loading state.
+ * @returns tokens with sortable fiat balances and extra token data request state.
  */
 export const useTokensWithBalance = (
   {
@@ -169,7 +169,11 @@ export const useTokensWithBalance = (
   options: {
     shouldFetchExtraTokenData?: boolean;
   } = {},
-): { tokens: BridgeToken[]; isExtraTokenDataLoading: boolean } => {
+): {
+  tokens: BridgeToken[];
+  isExtraTokenDataLoading: boolean;
+  hasExtraTokenDataError: boolean;
+} => {
   const { shouldFetchExtraTokenData = false } = options;
   const tokenSortConfig = useSelector(selectTokenSortConfig);
   const currentCurrency = useSelector(selectCurrentCurrency);
@@ -356,8 +360,11 @@ export const useTokensWithBalance = (
   // lose their rwaData on remount.
   // TODO: Migrate away from calling the token API directly once the Assets team
   // persists rwaData in controller state.
-  const { tokens: apiTokenData, isLoading: isExtraTokenDataLoading } =
-    useTokensData(missingRwaAssetIds, { includeRwaData: true });
+  const {
+    tokens: apiTokenData,
+    isLoading: isExtraTokenDataLoading,
+    hasError: hasExtraTokenDataError,
+  } = useTokensData(missingRwaAssetIds, { includeRwaData: true });
 
   return useMemo(
     () => ({
@@ -385,12 +392,16 @@ export const useTokensWithBalance = (
       isExtraTokenDataLoading: shouldFetchExtraTokenData
         ? isExtraTokenDataLoading
         : false,
+      hasExtraTokenDataError: shouldFetchExtraTokenData
+        ? hasExtraTokenDataError
+        : false,
     }),
     [
       shouldFetchExtraTokenData,
       sortedTokens,
       apiTokenData,
       isExtraTokenDataLoading,
+      hasExtraTokenDataError,
     ],
   );
 };

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -40,6 +40,11 @@ import {
 } from '@metamask/bridge-controller';
 import { isTradableToken } from '../../utils/isTradableToken';
 import { normalizeTokenAddress } from '../../utils/tokenUtils';
+import {
+  useTokensData,
+  isRwaChecked,
+  getCheckedRwaData,
+} from '../../../../hooks/useTokensData/useTokensData';
 
 interface CalculateFiatBalancesParams {
   assets: TokenI[];
@@ -151,13 +156,21 @@ export const calculateEvmBalances = ({
  * TODO refactor to use selectAssetsBySelectedAccountGroup or selectSortedAssetsBySelectedAccountGroup (BIP44 only and it does pretty much everything for you, fiat value, etc) and also use Asset type
  * @param {Object} params - The parameters object
  * @param {Hex[]} params.chainIds - Array of chain IDs to filter by
- * @returns {BridgeToken[]} Array of tokens (native and non-native) with sortable fiat balances
+ * @param {Object} options - Optional hook configuration
+ * @param {boolean} options.shouldFetchTokenData - Whether to fetch and merge token metadata
+ * @returns tokens with sortable fiat balances and RWA loading state.
  */
-export const useTokensWithBalance: ({
-  chainIds,
-}: {
-  chainIds: (Hex | CaipChainId)[] | undefined;
-}) => BridgeToken[] = ({ chainIds }) => {
+export const useTokensWithBalance = (
+  {
+    chainIds,
+  }: {
+    chainIds: (Hex | CaipChainId)[] | undefined;
+  },
+  options: {
+    shouldFetchTokenData?: boolean;
+  } = {},
+): { tokens: BridgeToken[]; isRwaDataLoading: boolean } => {
+  const { shouldFetchTokenData = false } = options;
   const tokenSortConfig = useSelector(selectTokenSortConfig);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const networkConfigurationsByChainId = useSelector(
@@ -302,5 +315,77 @@ export const useTokensWithBalance: ({
     nonEvmTokens,
   ]);
 
-  return sortedTokens;
+  // Tokens without rwaData from Redux that haven't been confirmed via the API
+  // cache yet. isRwaChecked reads the module-level tokenCache, so confirmed
+  // tokens are excluded on each recomputation when sortedTokens changes.
+  //
+  // Deps are intentionally [sortedTokens] only (not apiTokenData). apiTokenData
+  // is a forward reference here, and depending on it would create a cycle.
+  // It is not needed: isRwaChecked reads the cache directly, so confirmed IDs
+  // drop out on the next sortedTokens change. The list may not shrink to []
+  // within a stable sortedTokens, but that is harmless — the excluded IDs are
+  // cache hits and never trigger a re-fetch.
+  const missingRwaAssetIds = useMemo(
+    () =>
+      shouldFetchTokenData
+        ? sortedTokens
+            .filter((token) => !token.rwaData)
+            .map((token) => {
+              try {
+                const assetId = formatAddressToAssetId(
+                  token.address,
+                  token.chainId,
+                );
+                return assetId ? assetId.toLowerCase() : null;
+              } catch {
+                return null;
+              }
+            })
+            .filter(
+              (assetId): assetId is string =>
+                assetId !== null && !isRwaChecked(assetId),
+            )
+        : [],
+    [shouldFetchTokenData, sortedTokens],
+  );
+
+  // apiTokenData is consumed only as a memo trigger: it changes identity when a
+  // fetch resolves, forcing the merge below to re-run. rwaData itself is read
+  // from the persistent module-level cache (getCheckedRwaData), not from this
+  // per-instance map — otherwise confirmed RWAs excluded from the fetch would
+  // lose their rwaData on remount.
+  // TODO: Migrate away from calling the token API directly once the Assets team
+  // persists rwaData in controller state.
+  const { tokens: apiTokenData, isLoading: isRwaDataLoading } = useTokensData(
+    missingRwaAssetIds,
+    { includeRwaData: true },
+  );
+
+  return useMemo(
+    () => ({
+      tokens: shouldFetchTokenData
+        ? sortedTokens.map((token) => {
+            if (token.rwaData) return token;
+            try {
+              const assetId = formatAddressToAssetId(
+                token.address,
+                token.chainId,
+              );
+              const normalizedAssetId = assetId?.toLowerCase();
+              const cachedRwaData = normalizedAssetId
+                ? (apiTokenData[normalizedAssetId]?.rwaData ??
+                  getCheckedRwaData(normalizedAssetId))
+                : undefined;
+              return cachedRwaData
+                ? { ...token, rwaData: cachedRwaData }
+                : token;
+            } catch {
+              return token;
+            }
+          })
+        : sortedTokens,
+      isRwaDataLoading: shouldFetchTokenData ? isRwaDataLoading : false,
+    }),
+    [shouldFetchTokenData, sortedTokens, apiTokenData, isRwaDataLoading],
+  );
 };

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
@@ -3,6 +3,7 @@ import { renderHookWithProvider } from '../../../../../util/test/renderWithProvi
 import { useTokensWithBalance } from '.';
 import { constants } from 'ethers';
 import { waitFor } from '@testing-library/react-native';
+import { handleFetch } from '@metamask/controller-utils';
 import { Hex } from '@metamask/utils';
 import { SolScope } from '@metamask/keyring-api';
 
@@ -10,6 +11,13 @@ jest.mock('../../../Tokens/util', () => ({
   ...jest.requireActual('../../../Tokens/util'),
   sortAssets: jest.fn().mockImplementation((assets) => assets),
 }));
+
+jest.mock('@metamask/controller-utils', () => ({
+  ...jest.requireActual('@metamask/controller-utils'),
+  handleFetch: jest.fn().mockResolvedValue([]),
+}));
+
+const mockHandleFetch = handleFetch as jest.Mock;
 
 describe('useTokensWithBalance', () => {
   const mockAddress = '0x1234567890123456789012345678901234567890' as Hex;
@@ -22,6 +30,7 @@ describe('useTokensWithBalance', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHandleFetch.mockResolvedValue([]);
   });
 
   it('should include native token with correct properties', async () => {
@@ -36,7 +45,7 @@ describe('useTokensWithBalance', () => {
     );
 
     await waitFor(() => {
-      const nativeToken = result.current.find(
+      const nativeToken = result.current.tokens.find(
         (token) =>
           token.address === constants.AddressZero &&
           token.chainId === mockChainId,
@@ -54,6 +63,25 @@ describe('useTokensWithBalance', () => {
     });
   });
 
+  it('does not fetch RWA data by default', async () => {
+    const { result } = renderHookWithProvider(
+      () =>
+        useTokensWithBalance({
+          chainIds: [mockChainId],
+        }),
+      {
+        state: initialState,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tokens.length).toBeGreaterThan(0);
+    });
+
+    expect(result.current.isRwaDataLoading).toBe(false);
+    expect(mockHandleFetch).not.toHaveBeenCalled();
+  });
+
   it('should show correct balances and fiat values for tokens', async () => {
     const { result } = renderHookWithProvider(
       () =>
@@ -67,10 +95,10 @@ describe('useTokensWithBalance', () => {
 
     await waitFor(() => {
       // Ethereum chain tokens
-      const token1 = result.current.find(
+      const token1 = result.current.tokens.find(
         (t) => t.address === token1Address && t.chainId === mockChainId,
       );
-      const token2 = result.current.find(
+      const token2 = result.current.tokens.find(
         (t) => t.address === token2Address && t.chainId === mockChainId,
       );
 
@@ -87,7 +115,7 @@ describe('useTokensWithBalance', () => {
       });
 
       // Optimism chain tokens
-      const optimismNative = result.current.find(
+      const optimismNative = result.current.tokens.find(
         (token) =>
           token.address === constants.AddressZero &&
           token.chainId === optimismChainId,
@@ -101,7 +129,9 @@ describe('useTokensWithBalance', () => {
         tokenFiatAmount: 40000,
       });
 
-      const token3 = result.current.find((t) => t.address === token3Address);
+      const token3 = result.current.tokens.find(
+        (t) => t.address === token3Address,
+      );
       expect(token3).toMatchObject({
         address: token3Address,
         symbol: 'FOO',
@@ -127,31 +157,37 @@ describe('useTokensWithBalance', () => {
 
     await waitFor(() => {
       // Ethereum tokens should be present
-      const ethereumNative = result.current.find(
+      const ethereumNative = result.current.tokens.find(
         (token) =>
           token.address === constants.AddressZero &&
           token.chainId === mockChainId,
       );
-      const token1 = result.current.find((t) => t.address === token1Address);
-      const token2 = result.current.find((t) => t.address === token2Address);
+      const token1 = result.current.tokens.find(
+        (t) => t.address === token1Address,
+      );
+      const token2 = result.current.tokens.find(
+        (t) => t.address === token2Address,
+      );
 
       expect(ethereumNative).toBeTruthy();
       expect(token1).toBeTruthy();
       expect(token2).toBeTruthy();
 
       // Optimism tokens should not be present
-      const optimismNative = result.current.find(
+      const optimismNative = result.current.tokens.find(
         (token) =>
           token.address === constants.AddressZero &&
           token.chainId === optimismChainId,
       );
-      const token3 = result.current.find((t) => t.address === token3Address);
+      const token3 = result.current.tokens.find(
+        (t) => t.address === token3Address,
+      );
 
       expect(optimismNative).toBeUndefined();
       expect(token3).toBeUndefined();
 
       // Verify the total number of tokens is correct (should only have Ethereum tokens)
-      expect(result.current.length).toBe(3); // ETH native + TOKEN1 + TOKEN2
+      expect(result.current.tokens.length).toBe(3); // ETH native + TOKEN1 + TOKEN2
     });
   });
 
@@ -198,20 +234,24 @@ describe('useTokensWithBalance', () => {
     );
 
     await waitFor(() => {
-      const ethereumNative = result.current.find(
+      const ethereumNative = result.current.tokens.find(
         (token) =>
           token.address === constants.AddressZero &&
           token.chainId === mockChainId,
       );
-      const token1 = result.current.find((t) => t.address === token1Address);
-      const token2 = result.current.find((t) => t.address === token2Address);
+      const token1 = result.current.tokens.find(
+        (t) => t.address === token1Address,
+      );
+      const token2 = result.current.tokens.find(
+        (t) => t.address === token2Address,
+      );
 
       expect(ethereumNative).toBeUndefined();
       expect(token1).toMatchObject({
         balance: '1.0',
       });
       expect(token2).toBeUndefined();
-      expect(result.current.length).toBe(1);
+      expect(result.current.tokens.length).toBe(1);
     });
   });
 
@@ -249,11 +289,106 @@ describe('useTokensWithBalance', () => {
     );
 
     await waitFor(() => {
-      const token1 = result.current.find((t) => t.address === token1Address);
+      const token1 = result.current.tokens.find(
+        (t) => t.address === token1Address,
+      );
       expect(token1?.balanceFiat).toBe('$0.00');
 
-      const token3 = result.current.find((t) => t.address === token3Address);
+      const token3 = result.current.tokens.find(
+        (t) => t.address === token3Address,
+      );
       expect(token3?.balanceFiat).toBe('$0.00');
+    });
+  });
+
+  describe('rwaData enrichment', () => {
+    // token1 on Ethereum, lowercased CAIP-19 asset ID as built by the hook.
+    const token1AssetId = `eip155:1/erc20:${token1Address}`.toLowerCase();
+    const rwaData = { instrumentType: 'stock' };
+
+    it('enriches tokens with rwaData fetched from the API', async () => {
+      mockHandleFetch.mockResolvedValue([
+        {
+          assetId: token1AssetId,
+          name: 'Token 1',
+          symbol: 'T1',
+          iconUrl: '',
+          rwaData,
+        },
+      ]);
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useTokensWithBalance(
+            {
+              chainIds: [mockChainId],
+            },
+            { shouldFetchTokenData: true },
+          ),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        const token1 = result.current.tokens.find(
+          (t) => t.address === token1Address,
+        );
+        expect(token1?.rwaData).toEqual(rwaData);
+      });
+    });
+
+    it('keeps rwaData on remount when the asset is excluded from re-fetch', async () => {
+      // First mount confirms token1 as an RWA and populates the module-level cache.
+      mockHandleFetch.mockResolvedValue([
+        {
+          assetId: token1AssetId,
+          name: 'Token 1',
+          symbol: 'T1',
+          iconUrl: '',
+          rwaData,
+        },
+      ]);
+
+      const first = renderHookWithProvider(
+        () =>
+          useTokensWithBalance(
+            {
+              chainIds: [mockChainId],
+            },
+            { shouldFetchTokenData: true },
+          ),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        const token1 = first.result.current.tokens.find(
+          (t) => t.address === token1Address,
+        );
+        expect(token1?.rwaData).toEqual(rwaData);
+      });
+
+      first.unmount();
+
+      // On remount token1 is cache-confirmed, so it is excluded from the fetch
+      // (which now returns nothing). rwaData must still resolve from the cache.
+      mockHandleFetch.mockResolvedValue([]);
+
+      const second = renderHookWithProvider(
+        () =>
+          useTokensWithBalance(
+            {
+              chainIds: [mockChainId],
+            },
+            { shouldFetchTokenData: true },
+          ),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        const token1 = second.result.current.tokens.find(
+          (t) => t.address === token1Address,
+        );
+        expect(token1?.rwaData).toEqual(rwaData);
+      });
     });
   });
 });

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
@@ -79,6 +79,7 @@ describe('useTokensWithBalance', () => {
     });
 
     expect(result.current.isExtraTokenDataLoading).toBe(false);
+    expect(result.current.hasExtraTokenDataError).toBe(false);
     expect(mockHandleFetch).not.toHaveBeenCalled();
   });
 
@@ -305,6 +306,26 @@ describe('useTokensWithBalance', () => {
     // token1 on Ethereum, lowercased CAIP-19 asset ID as built by the hook.
     const token1AssetId = `eip155:1/erc20:${token1Address}`.toLowerCase();
     const rwaData = { instrumentType: 'stock' };
+
+    it('sets hasExtraTokenDataError when extra token data fetch fails', async () => {
+      mockHandleFetch.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useTokensWithBalance(
+            {
+              chainIds: [mockChainId],
+            },
+            { shouldFetchExtraTokenData: true },
+          ),
+        { state: initialState },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isExtraTokenDataLoading).toBe(false);
+        expect(result.current.hasExtraTokenDataError).toBe(true);
+      });
+    });
 
     it('enriches tokens with rwaData fetched from the API', async () => {
       mockHandleFetch.mockResolvedValue([

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/useTokensWithBalance.test.ts
@@ -78,7 +78,7 @@ describe('useTokensWithBalance', () => {
       expect(result.current.tokens.length).toBeGreaterThan(0);
     });
 
-    expect(result.current.isRwaDataLoading).toBe(false);
+    expect(result.current.isExtraTokenDataLoading).toBe(false);
     expect(mockHandleFetch).not.toHaveBeenCalled();
   });
 
@@ -323,7 +323,7 @@ describe('useTokensWithBalance', () => {
             {
               chainIds: [mockChainId],
             },
-            { shouldFetchTokenData: true },
+            { shouldFetchExtraTokenData: true },
           ),
         { state: initialState },
       );
@@ -354,7 +354,7 @@ describe('useTokensWithBalance', () => {
             {
               chainIds: [mockChainId],
             },
-            { shouldFetchTokenData: true },
+            { shouldFetchExtraTokenData: true },
           ),
         { state: initialState },
       );
@@ -378,7 +378,7 @@ describe('useTokensWithBalance', () => {
             {
               chainIds: [mockChainId],
             },
-            { shouldFetchTokenData: true },
+            { shouldFetchExtraTokenData: true },
           ),
         { state: initialState },
       );

--- a/app/components/UI/Card/hooks/useAssetBalances.test.ts
+++ b/app/components/UI/Card/hooks/useAssetBalances.test.ts
@@ -25,7 +25,10 @@ jest.mock('../../../../selectors/assets/assets-list', () => ({
   selectAsset: jest.fn(),
 }));
 jest.mock('../../Bridge/hooks/useTokensWithBalance', () => ({
-  useTokensWithBalance: jest.fn(() => []),
+  useTokensWithBalance: jest.fn(() => ({
+    tokens: [],
+    isRwaDataLoading: false,
+  })),
 }));
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
@@ -163,7 +166,10 @@ describe('useAssetBalances', () => {
     });
 
     mockSelectAsset.mockReturnValue(undefined);
-    mockUseTokensWithBalance.mockReturnValue([]);
+    mockUseTokensWithBalance.mockReturnValue({
+      tokens: [],
+      isRwaDataLoading: false,
+    });
     mockDeriveBalanceFromAssetMarketDetails.mockReturnValue({
       balanceFiat: '$1,000.00',
       balanceValueFormatted: '1.0 USDC',
@@ -333,16 +339,19 @@ describe('useAssetBalances', () => {
           },
       };
 
-      mockUseTokensWithBalance.mockReturnValue([
-        {
-          address: mockNotEnabledToken.address?.toLowerCase() || '',
-          chainId: mockNotEnabledToken.caipChainId,
-          balance: '100.0',
-          balanceFiat: '$100.00',
-          symbol: 'DAI',
-          decimals: 18,
-        } as any,
-      ]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [
+          {
+            address: mockNotEnabledToken.address?.toLowerCase() || '',
+            chainId: mockNotEnabledToken.caipChainId,
+            balance: '100.0',
+            balanceFiat: '$100.00',
+            symbol: 'DAI',
+            decimals: 18,
+          } as any,
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => useAssetBalances(tokens));
 
@@ -397,16 +406,19 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([
-        {
-          address: mockEvmToken.address?.toLowerCase() || '',
-          chainId: '0xe708', // Use hex format, not CAIP format
-          balance: '250.75',
-          balanceFiat: '$250.75',
-          symbol: 'USDC',
-          decimals: 18,
-        } as any,
-      ]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [
+          {
+            address: mockEvmToken.address?.toLowerCase() || '',
+            chainId: '0xe708', // Use hex format, not CAIP format
+            balance: '250.75',
+            balanceFiat: '$250.75',
+            symbol: 'USDC',
+            decimals: 18,
+          } as any,
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => useAssetBalances([enabledToken]));
 
@@ -423,7 +435,10 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const walletAsset = {
         address: mockEvmToken.address,
@@ -485,7 +500,10 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
       mockSelectAsset.mockReturnValue(undefined);
 
       const { result } = renderHook(() => useAssetBalances([enabledToken]));
@@ -497,16 +515,19 @@ describe('useAssetBalances', () => {
     });
 
     it('uses filteredToken balance for non-enabled tokens', () => {
-      mockUseTokensWithBalance.mockReturnValue([
-        {
-          address: mockNotEnabledToken.address?.toLowerCase() || '',
-          chainId: '0xe708', // Use hex format, not CAIP format
-          balance: '200.75',
-          balanceFiat: '$200.75',
-          symbol: 'DAI',
-          decimals: 18,
-        } as any,
-      ]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [
+          {
+            address: mockNotEnabledToken.address?.toLowerCase() || '',
+            chainId: '0xe708', // Use hex format, not CAIP format
+            balance: '200.75',
+            balanceFiat: '$200.75',
+            symbol: 'DAI',
+            decimals: 18,
+          } as any,
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useAssetBalances([mockNotEnabledToken]),
@@ -519,7 +540,10 @@ describe('useAssetBalances', () => {
     });
 
     it('uses walletAsset balance when non-enabled token has no filteredToken', () => {
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const walletAsset = {
         address: mockNotEnabledToken.address,
@@ -603,7 +627,10 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
       mockSelectAsset.mockReturnValue(undefined);
 
       const { result } = renderHook(() =>
@@ -640,16 +667,19 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([
-        {
-          address: mockEvmToken.address?.toLowerCase() || '',
-          chainId: '0xe708', // Use hex format, not CAIP format
-          balance: '125.50',
-          balanceFiat: '$125.50',
-          symbol: 'USDC',
-          decimals: 18,
-        } as any,
-      ]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [
+          {
+            address: mockEvmToken.address?.toLowerCase() || '',
+            chainId: '0xe708', // Use hex format, not CAIP format
+            balance: '125.50',
+            balanceFiat: '$125.50',
+            symbol: 'USDC',
+            decimals: 18,
+          } as any,
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => useAssetBalances([limitedToken]));
 
@@ -666,7 +696,10 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const walletAsset = {
         address: mockEvmToken.address,
@@ -728,7 +761,10 @@ describe('useAssetBalances', () => {
         spendableBalance: '',
       };
 
-      mockUseTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
       mockSelectAsset.mockReturnValue(undefined);
 
       const { result } = renderHook(() => useAssetBalances([limitedToken]));
@@ -1602,16 +1638,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '0',
-            balanceFiat: 'tokenRateUndefined',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '0',
+              balanceFiat: 'tokenRateUndefined',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         mockFormatWithThreshold.mockReturnValue('$0.00');
 
@@ -1633,16 +1672,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '100.5',
-            balanceFiat: 'tokenRateUndefined',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '100.5',
+              balanceFiat: 'tokenRateUndefined',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         const { result } = renderHook(() =>
           useAssetBalances([notEnabledToken]),
@@ -1664,16 +1706,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '0',
-            balanceFiat: 'tokenBalanceLoading',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '0',
+              balanceFiat: 'tokenBalanceLoading',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         mockFormatWithThreshold.mockReturnValue('$0.00');
 
@@ -1695,16 +1740,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '250.75',
-            balanceFiat: 'tokenBalanceLoading',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '250.75',
+              balanceFiat: 'tokenBalanceLoading',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         const { result } = renderHook(() =>
           useAssetBalances([notEnabledToken]),
@@ -1726,16 +1774,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '100.5',
-            balanceFiat: '55.61632 usd',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '100.5',
+              balanceFiat: '55.61632 usd',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         mockFormatWithThreshold.mockReturnValue('$55.62');
 
@@ -1766,16 +1817,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '1000',
-            balanceFiat: '1,234.56 usd',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '1000',
+              balanceFiat: '1,234.56 usd',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         mockFormatWithThreshold.mockReturnValue('$1,234.56');
 
@@ -1797,16 +1851,19 @@ describe('useAssetBalances', () => {
           spendableBalance: '',
         };
 
-        mockUseTokensWithBalance.mockReturnValue([
-          {
-            address: notEnabledToken.address?.toLowerCase() || '',
-            chainId: '0xe708',
-            balance: '100.5',
-            balanceFiat: '55.61632 brl',
-            symbol: 'USDC',
-            decimals: 18,
-          } as any,
-        ]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [
+            {
+              address: notEnabledToken.address?.toLowerCase() || '',
+              chainId: '0xe708',
+              balance: '100.5',
+              balanceFiat: '55.61632 brl',
+              symbol: 'USDC',
+              decimals: 18,
+            } as any,
+          ],
+          isRwaDataLoading: false,
+        });
 
         mockFormatWithThreshold.mockReturnValue('R$ 55,62');
 
@@ -1884,7 +1941,10 @@ describe('useAssetBalances', () => {
           return 'USD';
         });
 
-        mockUseTokensWithBalance.mockReturnValue([]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [],
+          isRwaDataLoading: false,
+        });
         mockFormatWithThreshold.mockReturnValue('$0.00');
 
         const { result } = renderHook(() =>
@@ -1950,7 +2010,10 @@ describe('useAssetBalances', () => {
           return 'USD';
         });
 
-        mockUseTokensWithBalance.mockReturnValue([]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [],
+          isRwaDataLoading: false,
+        });
 
         const { result } = renderHook(() =>
           useAssetBalances([notEnabledToken]),
@@ -2017,7 +2080,10 @@ describe('useAssetBalances', () => {
           return 'USD';
         });
 
-        mockUseTokensWithBalance.mockReturnValue([]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [],
+          isRwaDataLoading: false,
+        });
         mockFormatWithThreshold.mockReturnValue('$15.62');
 
         const { result } = renderHook(() =>
@@ -2083,7 +2149,10 @@ describe('useAssetBalances', () => {
           return 'USD';
         });
 
-        mockUseTokensWithBalance.mockReturnValue([]);
+        mockUseTokensWithBalance.mockReturnValue({
+          tokens: [],
+          isRwaDataLoading: false,
+        });
         mockFormatWithThreshold.mockReturnValue('R$ 15,62');
 
         const { result } = renderHook(() =>

--- a/app/components/UI/Card/hooks/useAssetBalances.test.ts
+++ b/app/components/UI/Card/hooks/useAssetBalances.test.ts
@@ -28,6 +28,7 @@ jest.mock('../../Bridge/hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: jest.fn(() => ({
     tokens: [],
     isExtraTokenDataLoading: false,
+    hasExtraTokenDataError: false,
   })),
 }));
 jest.mock('../../../../../locales/i18n', () => ({
@@ -169,6 +170,7 @@ describe('useAssetBalances', () => {
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
     mockDeriveBalanceFromAssetMarketDetails.mockReturnValue({
       balanceFiat: '$1,000.00',
@@ -351,6 +353,7 @@ describe('useAssetBalances', () => {
           } as any,
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => useAssetBalances(tokens));
@@ -418,6 +421,7 @@ describe('useAssetBalances', () => {
           } as any,
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => useAssetBalances([enabledToken]));
@@ -438,6 +442,7 @@ describe('useAssetBalances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const walletAsset = {
@@ -503,6 +508,7 @@ describe('useAssetBalances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
       mockSelectAsset.mockReturnValue(undefined);
 
@@ -527,6 +533,7 @@ describe('useAssetBalances', () => {
           } as any,
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -543,6 +550,7 @@ describe('useAssetBalances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const walletAsset = {
@@ -630,6 +638,7 @@ describe('useAssetBalances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
       mockSelectAsset.mockReturnValue(undefined);
 
@@ -679,6 +688,7 @@ describe('useAssetBalances', () => {
           } as any,
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => useAssetBalances([limitedToken]));
@@ -699,6 +709,7 @@ describe('useAssetBalances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const walletAsset = {
@@ -764,6 +775,7 @@ describe('useAssetBalances', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
       mockSelectAsset.mockReturnValue(undefined);
 
@@ -1650,6 +1662,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$0.00');
@@ -1684,6 +1697,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         const { result } = renderHook(() =>
@@ -1718,6 +1732,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$0.00');
@@ -1752,6 +1767,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         const { result } = renderHook(() =>
@@ -1786,6 +1802,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$55.62');
@@ -1829,6 +1846,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$1,234.56');
@@ -1863,6 +1881,7 @@ describe('useAssetBalances', () => {
             } as any,
           ],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('R$ 55,62');
@@ -1944,6 +1963,7 @@ describe('useAssetBalances', () => {
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
         mockFormatWithThreshold.mockReturnValue('$0.00');
 
@@ -2013,6 +2033,7 @@ describe('useAssetBalances', () => {
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
         const { result } = renderHook(() =>
@@ -2083,6 +2104,7 @@ describe('useAssetBalances', () => {
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
         mockFormatWithThreshold.mockReturnValue('$15.62');
 
@@ -2152,6 +2174,7 @@ describe('useAssetBalances', () => {
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
         mockFormatWithThreshold.mockReturnValue('R$ 15,62');
 

--- a/app/components/UI/Card/hooks/useAssetBalances.test.ts
+++ b/app/components/UI/Card/hooks/useAssetBalances.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../../../selectors/assets/assets-list', () => ({
 jest.mock('../../Bridge/hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: jest.fn(() => ({
     tokens: [],
-    isRwaDataLoading: false,
+    isExtraTokenDataLoading: false,
   })),
 }));
 jest.mock('../../../../../locales/i18n', () => ({
@@ -168,7 +168,7 @@ describe('useAssetBalances', () => {
     mockSelectAsset.mockReturnValue(undefined);
     mockUseTokensWithBalance.mockReturnValue({
       tokens: [],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
     mockDeriveBalanceFromAssetMarketDetails.mockReturnValue({
       balanceFiat: '$1,000.00',
@@ -350,7 +350,7 @@ describe('useAssetBalances', () => {
             decimals: 18,
           } as any,
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => useAssetBalances(tokens));
@@ -417,7 +417,7 @@ describe('useAssetBalances', () => {
             decimals: 18,
           } as any,
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => useAssetBalances([enabledToken]));
@@ -437,7 +437,7 @@ describe('useAssetBalances', () => {
 
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const walletAsset = {
@@ -502,7 +502,7 @@ describe('useAssetBalances', () => {
 
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
       mockSelectAsset.mockReturnValue(undefined);
 
@@ -526,7 +526,7 @@ describe('useAssetBalances', () => {
             decimals: 18,
           } as any,
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -542,7 +542,7 @@ describe('useAssetBalances', () => {
     it('uses walletAsset balance when non-enabled token has no filteredToken', () => {
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const walletAsset = {
@@ -629,7 +629,7 @@ describe('useAssetBalances', () => {
 
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
       mockSelectAsset.mockReturnValue(undefined);
 
@@ -678,7 +678,7 @@ describe('useAssetBalances', () => {
             decimals: 18,
           } as any,
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => useAssetBalances([limitedToken]));
@@ -698,7 +698,7 @@ describe('useAssetBalances', () => {
 
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const walletAsset = {
@@ -763,7 +763,7 @@ describe('useAssetBalances', () => {
 
       mockUseTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
       mockSelectAsset.mockReturnValue(undefined);
 
@@ -1649,7 +1649,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$0.00');
@@ -1683,7 +1683,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         const { result } = renderHook(() =>
@@ -1717,7 +1717,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$0.00');
@@ -1751,7 +1751,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         const { result } = renderHook(() =>
@@ -1785,7 +1785,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$55.62');
@@ -1828,7 +1828,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('$1,234.56');
@@ -1862,7 +1862,7 @@ describe('useAssetBalances', () => {
               decimals: 18,
             } as any,
           ],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         mockFormatWithThreshold.mockReturnValue('R$ 55,62');
@@ -1943,7 +1943,7 @@ describe('useAssetBalances', () => {
 
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
         mockFormatWithThreshold.mockReturnValue('$0.00');
 
@@ -2012,7 +2012,7 @@ describe('useAssetBalances', () => {
 
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
 
         const { result } = renderHook(() =>
@@ -2082,7 +2082,7 @@ describe('useAssetBalances', () => {
 
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
         mockFormatWithThreshold.mockReturnValue('$15.62');
 
@@ -2151,7 +2151,7 @@ describe('useAssetBalances', () => {
 
         mockUseTokensWithBalance.mockReturnValue({
           tokens: [],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         });
         mockFormatWithThreshold.mockReturnValue('R$ 15,62');
 

--- a/app/components/UI/Card/hooks/useAssetBalances.tsx
+++ b/app/components/UI/Card/hooks/useAssetBalances.tsx
@@ -89,7 +89,7 @@ export interface AssetBalanceInfo {
 export const useAssetBalances = (
   tokens: CardFundingToken[],
 ): Map<string, AssetBalanceInfo> => {
-  const tokensWithBalance = useTokensWithBalance({
+  const { tokens: tokensWithBalance } = useTokensWithBalance({
     chainIds: CARD_CHAIN_IDS,
   });
 

--- a/app/components/UI/Card/hooks/useOpenSwaps.test.ts
+++ b/app/components/UI/Card/hooks/useOpenSwaps.test.ts
@@ -124,6 +124,7 @@ describe('useOpenSwaps', () => {
     (useTokensWithBalance as jest.Mock).mockReturnValue({
       tokens: mockTokensWithBalance,
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
 
     (useSelector as jest.Mock).mockImplementation((selector) => selector());

--- a/app/components/UI/Card/hooks/useOpenSwaps.test.ts
+++ b/app/components/UI/Card/hooks/useOpenSwaps.test.ts
@@ -123,7 +123,7 @@ describe('useOpenSwaps', () => {
     );
     (useTokensWithBalance as jest.Mock).mockReturnValue({
       tokens: mockTokensWithBalance,
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
 
     (useSelector as jest.Mock).mockImplementation((selector) => selector());

--- a/app/components/UI/Card/hooks/useOpenSwaps.test.ts
+++ b/app/components/UI/Card/hooks/useOpenSwaps.test.ts
@@ -121,7 +121,10 @@ describe('useOpenSwaps', () => {
     (selectSelectedSourceChainIds as unknown as jest.Mock).mockReturnValue(
       mockChainIds,
     );
-    (useTokensWithBalance as jest.Mock).mockReturnValue(mockTokensWithBalance);
+    (useTokensWithBalance as jest.Mock).mockReturnValue({
+      tokens: mockTokensWithBalance,
+      isRwaDataLoading: false,
+    });
 
     (useSelector as jest.Mock).mockImplementation((selector) => selector());
 

--- a/app/components/UI/Card/hooks/useOpenSwaps.ts
+++ b/app/components/UI/Card/hooks/useOpenSwaps.ts
@@ -36,7 +36,7 @@ export const useOpenSwaps = ({
 }: UseOpenSwapsOptions = {}) => {
   const dispatch = useDispatch();
   const chainIds = useSelector(selectSelectedSourceChainIds);
-  const tokensWithBalance = useTokensWithBalance({
+  const { tokens: tokensWithBalance } = useTokensWithBalance({
     chainIds,
   });
   const { trackEvent, createEventBuilder } = useAnalytics();

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -342,6 +342,7 @@ describe('useSpendingLimit', () => {
     (useTokensWithBalance as jest.Mock).mockReturnValue({
       tokens: [],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
 
     // Setup account selector navigation details mock
@@ -502,6 +503,7 @@ describe('useSpendingLimit', () => {
           { address: '0xdai', chainId: '0xe708', tokenFiatAmount: 9999 }, // Enabled — excluded
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -533,6 +535,7 @@ describe('useSpendingLimit', () => {
           { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 10 },
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -560,6 +563,7 @@ describe('useSpendingLimit', () => {
       (useTokensWithBalance as jest.Mock).mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -581,6 +585,7 @@ describe('useSpendingLimit', () => {
       (useTokensWithBalance as jest.Mock).mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -784,6 +789,7 @@ describe('useSpendingLimit', () => {
           { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 50 },
         ],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() =>
@@ -1139,8 +1145,13 @@ describe('useSpendingLimit', () => {
         .mockReturnValueOnce({
           tokens: [musdToken],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         }) // walletTokens (card)
-        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false }); // allWalletTokens
+        .mockReturnValueOnce({
+          tokens: [],
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        }); // allWalletTokens
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1151,8 +1162,16 @@ describe('useSpendingLimit', () => {
 
     it('emits musd_linea_balance of 0 when mUSD not in wallet', () => {
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false }) // walletTokens — no mUSD
-        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false });
+        .mockReturnValueOnce({
+          tokens: [],
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        }) // walletTokens — no mUSD
+        .mockReturnValueOnce({
+          tokens: [],
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        });
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1183,8 +1202,13 @@ describe('useSpendingLimit', () => {
         .mockReturnValueOnce({
           tokens: [lowToken, highToken],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         }) // walletTokens (card)
-        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false });
+        .mockReturnValueOnce({
+          tokens: [],
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        });
 
       renderHook(() => useSpendingLimit(createDefaultParams({ allTokens })));
 
@@ -1196,8 +1220,16 @@ describe('useSpendingLimit', () => {
 
     it('emits null for top_card_chain_asset when no card tokens have balance', () => {
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false }) // walletTokens — empty
-        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false });
+        .mockReturnValueOnce({
+          tokens: [],
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        }) // walletTokens — empty
+        .mockReturnValueOnce({
+          tokens: [],
+          isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
+        });
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1220,10 +1252,12 @@ describe('useSpendingLimit', () => {
         .mockReturnValueOnce({
           tokens: [nativeSol],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         }) // walletTokens
         .mockReturnValueOnce({
           tokens: [nativeSol],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         });
 
       // allTokens has a card-supported token (USDC on Linea) but NOT nativeSol
@@ -1251,10 +1285,12 @@ describe('useSpendingLimit', () => {
         .mockReturnValueOnce({
           tokens: [cardToken],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         }) // walletTokens (card)
         .mockReturnValueOnce({
           tokens: [walletToken],
           isExtraTokenDataLoading: false,
+          hasExtraTokenDataError: false,
         }); // allWalletTokens
 
       renderHook(() => useSpendingLimit(createDefaultParams()));

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -339,7 +339,10 @@ describe('useSpendingLimit', () => {
     ] as never);
 
     // Default: no balances (triggers fallback to mUSD + USDC)
-    (useTokensWithBalance as jest.Mock).mockReturnValue([]);
+    (useTokensWithBalance as jest.Mock).mockReturnValue({
+      tokens: [],
+      isRwaDataLoading: false,
+    });
 
     // Setup account selector navigation details mock
     mockCreateAccountSelectorNavDetails.mockReturnValue([
@@ -492,11 +495,14 @@ describe('useSpendingLimit', () => {
         fundingStatus: FundingStatus.Enabled,
       });
 
-      (useTokensWithBalance as jest.Mock).mockReturnValue([
-        { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 500 },
-        { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 100 },
-        { address: '0xdai', chainId: '0xe708', tokenFiatAmount: 9999 }, // Enabled — excluded
-      ]);
+      (useTokensWithBalance as jest.Mock).mockReturnValue({
+        tokens: [
+          { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 500 },
+          { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 100 },
+          { address: '0xdai', chainId: '0xe708', tokenFiatAmount: 9999 }, // Enabled — excluded
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useSpendingLimit(
@@ -521,10 +527,13 @@ describe('useSpendingLimit', () => {
         fundingStatus: FundingStatus.NotEnabled,
       });
 
-      (useTokensWithBalance as jest.Mock).mockReturnValue([
-        { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 9999 },
-        { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 10 },
-      ]);
+      (useTokensWithBalance as jest.Mock).mockReturnValue({
+        tokens: [
+          { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 9999 },
+          { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 10 },
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useSpendingLimit(
@@ -548,7 +557,10 @@ describe('useSpendingLimit', () => {
         fundingStatus: FundingStatus.NotEnabled,
       });
 
-      (useTokensWithBalance as jest.Mock).mockReturnValue([]);
+      (useTokensWithBalance as jest.Mock).mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useSpendingLimit(
@@ -566,7 +578,10 @@ describe('useSpendingLimit', () => {
         fundingStatus: FundingStatus.NotEnabled,
       });
 
-      (useTokensWithBalance as jest.Mock).mockReturnValue([]);
+      (useTokensWithBalance as jest.Mock).mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useSpendingLimit(createDefaultParams({ allTokens: [usdcToken] })),
@@ -763,10 +778,13 @@ describe('useSpendingLimit', () => {
       });
 
       // USDC has highest balance → becomes selectedToken by default
-      (useTokensWithBalance as jest.Mock).mockReturnValue([
-        { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 200 },
-        { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 50 },
-      ]);
+      (useTokensWithBalance as jest.Mock).mockReturnValue({
+        tokens: [
+          { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 200 },
+          { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 50 },
+        ],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() =>
         useSpendingLimit(
@@ -1118,8 +1136,8 @@ describe('useSpendingLimit', () => {
         tokenFiatAmount: 450,
       };
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce([musdToken]) // walletTokens (card)
-        .mockReturnValueOnce([]); // allWalletTokens
+        .mockReturnValueOnce({ tokens: [musdToken], isRwaDataLoading: false }) // walletTokens (card)
+        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false }); // allWalletTokens
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1130,8 +1148,8 @@ describe('useSpendingLimit', () => {
 
     it('emits musd_linea_balance of 0 when mUSD not in wallet', () => {
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce([]) // walletTokens — no mUSD
-        .mockReturnValueOnce([]);
+        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false }) // walletTokens — no mUSD
+        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false });
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1159,8 +1177,11 @@ describe('useSpendingLimit', () => {
         createMockToken({ address: '0xhigh', symbol: 'mUSD' }),
       ];
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce([lowToken, highToken]) // walletTokens (card)
-        .mockReturnValueOnce([]);
+        .mockReturnValueOnce({
+          tokens: [lowToken, highToken],
+          isRwaDataLoading: false,
+        }) // walletTokens (card)
+        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false });
 
       renderHook(() => useSpendingLimit(createDefaultParams({ allTokens })));
 
@@ -1172,8 +1193,8 @@ describe('useSpendingLimit', () => {
 
     it('emits null for top_card_chain_asset when no card tokens have balance', () => {
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce([]) // walletTokens — empty
-        .mockReturnValueOnce([]);
+        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false }) // walletTokens — empty
+        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false });
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1193,8 +1214,8 @@ describe('useSpendingLimit', () => {
         tokenFiatAmount: 1200,
       };
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce([nativeSol]) // walletTokens
-        .mockReturnValueOnce([nativeSol]);
+        .mockReturnValueOnce({ tokens: [nativeSol], isRwaDataLoading: false }) // walletTokens
+        .mockReturnValueOnce({ tokens: [nativeSol], isRwaDataLoading: false });
 
       // allTokens has a card-supported token (USDC on Linea) but NOT nativeSol
       renderHook(() => useSpendingLimit(createDefaultParams()));
@@ -1218,8 +1239,11 @@ describe('useSpendingLimit', () => {
         tokenFiatAmount: 9000,
       };
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce([cardToken]) // walletTokens (card)
-        .mockReturnValueOnce([walletToken]); // allWalletTokens
+        .mockReturnValueOnce({ tokens: [cardToken], isRwaDataLoading: false }) // walletTokens (card)
+        .mockReturnValueOnce({
+          tokens: [walletToken],
+          isRwaDataLoading: false,
+        }); // allWalletTokens
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -341,7 +341,7 @@ describe('useSpendingLimit', () => {
     // Default: no balances (triggers fallback to mUSD + USDC)
     (useTokensWithBalance as jest.Mock).mockReturnValue({
       tokens: [],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
 
     // Setup account selector navigation details mock
@@ -501,7 +501,7 @@ describe('useSpendingLimit', () => {
           { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 100 },
           { address: '0xdai', chainId: '0xe708', tokenFiatAmount: 9999 }, // Enabled — excluded
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -532,7 +532,7 @@ describe('useSpendingLimit', () => {
           { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 9999 },
           { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 10 },
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -559,7 +559,7 @@ describe('useSpendingLimit', () => {
 
       (useTokensWithBalance as jest.Mock).mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -580,7 +580,7 @@ describe('useSpendingLimit', () => {
 
       (useTokensWithBalance as jest.Mock).mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -783,7 +783,7 @@ describe('useSpendingLimit', () => {
           { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 200 },
           { address: '0xmusd', chainId: '0xe708', tokenFiatAmount: 50 },
         ],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -1136,8 +1136,11 @@ describe('useSpendingLimit', () => {
         tokenFiatAmount: 450,
       };
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [musdToken], isRwaDataLoading: false }) // walletTokens (card)
-        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false }); // allWalletTokens
+        .mockReturnValueOnce({
+          tokens: [musdToken],
+          isExtraTokenDataLoading: false,
+        }) // walletTokens (card)
+        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false }); // allWalletTokens
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1148,8 +1151,8 @@ describe('useSpendingLimit', () => {
 
     it('emits musd_linea_balance of 0 when mUSD not in wallet', () => {
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false }) // walletTokens — no mUSD
-        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false });
+        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false }) // walletTokens — no mUSD
+        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false });
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1179,9 +1182,9 @@ describe('useSpendingLimit', () => {
       (useTokensWithBalance as jest.Mock)
         .mockReturnValueOnce({
           tokens: [lowToken, highToken],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         }) // walletTokens (card)
-        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false });
+        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false });
 
       renderHook(() => useSpendingLimit(createDefaultParams({ allTokens })));
 
@@ -1193,8 +1196,8 @@ describe('useSpendingLimit', () => {
 
     it('emits null for top_card_chain_asset when no card tokens have balance', () => {
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false }) // walletTokens — empty
-        .mockReturnValueOnce({ tokens: [], isRwaDataLoading: false });
+        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false }) // walletTokens — empty
+        .mockReturnValueOnce({ tokens: [], isExtraTokenDataLoading: false });
 
       renderHook(() => useSpendingLimit(createDefaultParams()));
 
@@ -1214,8 +1217,14 @@ describe('useSpendingLimit', () => {
         tokenFiatAmount: 1200,
       };
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [nativeSol], isRwaDataLoading: false }) // walletTokens
-        .mockReturnValueOnce({ tokens: [nativeSol], isRwaDataLoading: false });
+        .mockReturnValueOnce({
+          tokens: [nativeSol],
+          isExtraTokenDataLoading: false,
+        }) // walletTokens
+        .mockReturnValueOnce({
+          tokens: [nativeSol],
+          isExtraTokenDataLoading: false,
+        });
 
       // allTokens has a card-supported token (USDC on Linea) but NOT nativeSol
       renderHook(() => useSpendingLimit(createDefaultParams()));
@@ -1239,10 +1248,13 @@ describe('useSpendingLimit', () => {
         tokenFiatAmount: 9000,
       };
       (useTokensWithBalance as jest.Mock)
-        .mockReturnValueOnce({ tokens: [cardToken], isRwaDataLoading: false }) // walletTokens (card)
+        .mockReturnValueOnce({
+          tokens: [cardToken],
+          isExtraTokenDataLoading: false,
+        }) // walletTokens (card)
         .mockReturnValueOnce({
           tokens: [walletToken],
-          isRwaDataLoading: false,
+          isExtraTokenDataLoading: false,
         }); // allWalletTokens
 
       renderHook(() => useSpendingLimit(createDefaultParams()));

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -226,7 +226,7 @@ const useSpendingLimit = ({
   // Using this (instead of useAssetBalances) ensures sorting reflects the active
   // account's real wallet balance — not the card's availableBalance or another
   // account's cached data — so account switches are reflected immediately.
-  const walletTokens = useTokensWithBalance({
+  const { tokens: walletTokens } = useTokensWithBalance({
     chainIds: CARD_CHAIN_IDS,
   });
 
@@ -243,7 +243,9 @@ const useSpendingLimit = ({
       ] as (Hex | CaipChainId)[],
     [evmNetworkConfigs],
   );
-  const allWalletTokens = useTokensWithBalance({ chainIds: allWalletChainIds });
+  const { tokens: allWalletTokens } = useTokensWithBalance({
+    chainIds: allWalletChainIds,
+  });
 
   const applySelectedToken = useCallback((token: CardFundingToken) => {
     const nextLimitState = deriveLimitStateFromToken(token);

--- a/app/components/UI/Perps/hooks/usePerpsPaymentTokens.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPaymentTokens.test.ts
@@ -99,6 +99,7 @@ describe('usePerpsPaymentTokens', () => {
     mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
       tokens: mockTokensWithBalance,
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     });
     mockUsePerpsLiveAccount.mockReturnValue({
       account: mockAccountState,
@@ -203,6 +204,7 @@ describe('usePerpsPaymentTokens', () => {
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: tokensWithHyperliquid,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -244,6 +246,7 @@ describe('usePerpsPaymentTokens', () => {
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: extraTokens,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -337,6 +340,7 @@ describe('usePerpsPaymentTokens', () => {
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: [],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -360,6 +364,7 @@ describe('usePerpsPaymentTokens', () => {
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: tokensWithMalformedFiat,
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -417,6 +422,7 @@ describe('usePerpsPaymentTokens', () => {
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: tokensWithMissingFields as BridgeToken[],
         isExtraTokenDataLoading: false,
+        hasExtraTokenDataError: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());

--- a/app/components/UI/Perps/hooks/usePerpsPaymentTokens.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPaymentTokens.test.ts
@@ -96,9 +96,10 @@ describe('usePerpsPaymentTokens', () => {
     // Set up mock return values
     mockUseSelector.mockReturnValueOnce(mockNetworkConfigurations); // selectNetworkConfigurations
 
-    mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue(
-      mockTokensWithBalance,
-    );
+    mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
+      tokens: mockTokensWithBalance,
+      isRwaDataLoading: false,
+    });
     mockUsePerpsLiveAccount.mockReturnValue({
       account: mockAccountState,
       isInitialLoading: false,
@@ -199,9 +200,10 @@ describe('usePerpsPaymentTokens', () => {
         },
       ];
 
-      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue(
-        tokensWithHyperliquid,
-      );
+      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
+        tokens: tokensWithHyperliquid,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
 
@@ -239,9 +241,10 @@ describe('usePerpsPaymentTokens', () => {
         },
       ];
 
-      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue(
-        extraTokens,
-      );
+      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
+        tokens: extraTokens,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
 
@@ -331,7 +334,10 @@ describe('usePerpsPaymentTokens', () => {
     });
 
     it('handles empty tokens with balance', () => {
-      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue([]);
+      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
+        tokens: [],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
 
@@ -351,9 +357,10 @@ describe('usePerpsPaymentTokens', () => {
         },
       ];
 
-      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue(
-        tokensWithMalformedFiat,
-      );
+      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
+        tokens: tokensWithMalformedFiat,
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
 
@@ -407,9 +414,10 @@ describe('usePerpsPaymentTokens', () => {
         },
       ];
 
-      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue(
-        tokensWithMissingFields as BridgeToken[],
-      );
+      mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
+        tokens: tokensWithMissingFields as BridgeToken[],
+        isRwaDataLoading: false,
+      });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
 

--- a/app/components/UI/Perps/hooks/usePerpsPaymentTokens.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPaymentTokens.test.ts
@@ -98,7 +98,7 @@ describe('usePerpsPaymentTokens', () => {
 
     mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
       tokens: mockTokensWithBalance,
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     });
     mockUsePerpsLiveAccount.mockReturnValue({
       account: mockAccountState,
@@ -202,7 +202,7 @@ describe('usePerpsPaymentTokens', () => {
 
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: tokensWithHyperliquid,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -243,7 +243,7 @@ describe('usePerpsPaymentTokens', () => {
 
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: extraTokens,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -336,7 +336,7 @@ describe('usePerpsPaymentTokens', () => {
     it('handles empty tokens with balance', () => {
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: [],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -359,7 +359,7 @@ describe('usePerpsPaymentTokens', () => {
 
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: tokensWithMalformedFiat,
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());
@@ -416,7 +416,7 @@ describe('usePerpsPaymentTokens', () => {
 
       mockUseTokensWithBalance.useTokensWithBalance.mockReturnValue({
         tokens: tokensWithMissingFields as BridgeToken[],
-        isRwaDataLoading: false,
+        isExtraTokenDataLoading: false,
       });
 
       const { result } = renderHook(() => usePerpsPaymentTokens());

--- a/app/components/UI/Perps/hooks/usePerpsPaymentTokens.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPaymentTokens.ts
@@ -56,7 +56,9 @@ export function usePerpsPaymentTokens(): PerpsToken[] {
   }, [networkConfigurations, currentNetwork]);
 
   // Get all tokens with balances across networks
-  const tokensWithBalance = useTokensWithBalance({ chainIds: allChainIds });
+  const { tokens: tokensWithBalance } = useTokensWithBalance({
+    chainIds: allChainIds,
+  });
 
   // Filter and enhance tokens
   const paymentTokens = useMemo(() => {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -146,6 +146,7 @@ jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance', () => ({
     ({
       tokens: [],
       isExtraTokenDataLoading: false,
+      hasExtraTokenDataError: false,
     }) as ReturnType<typeof useTokensWithBalance>,
 }));
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -145,7 +145,7 @@ jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: () =>
     ({
       tokens: [],
-      isRwaDataLoading: false,
+      isExtraTokenDataLoading: false,
     }) as ReturnType<typeof useTokensWithBalance>,
 }));
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -142,7 +142,11 @@ jest.mock('react-native-gzip', () => ({
 }));
 
 jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance', () => ({
-  useTokensWithBalance: () => [] as ReturnType<typeof useTokensWithBalance>,
+  useTokensWithBalance: () =>
+    ({
+      tokens: [],
+      isRwaDataLoading: false,
+    }) as ReturnType<typeof useTokensWithBalance>,
 }));
 
 jest.mock('../../../../../core/redux/slices/bridge', () => ({

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -143,7 +143,11 @@ describe('useAccountTokens', () => {
     mockGetIntlNumberFormatter.mockReturnValue(mockFormatter as any);
     mockFormatter.format.mockReturnValue('$100.50');
     mockIsTestNet.mockReturnValue(false);
-    mockUseTokensData.mockReturnValue({ tokens: {}, isLoading: false });
+    mockUseTokensData.mockReturnValue({
+      tokens: {},
+      isLoading: false,
+      hasError: false,
+    });
     mockBuildEvmCaip19AssetId.mockImplementation(
       (address: string, chainId: Hex) =>
         `eip155:${chainId}/erc20:${address.toLowerCase()}`,
@@ -700,6 +704,7 @@ describe('useAccountTokens', () => {
           },
         },
         isLoading: false,
+        hasError: false,
       });
 
       const { result } = renderHook(() =>
@@ -754,6 +759,7 @@ describe('useAccountTokens', () => {
           },
         },
         isLoading: false,
+        hasError: false,
       });
 
       const { result } = renderHook(() =>
@@ -779,7 +785,11 @@ describe('useAccountTokens', () => {
 
       const requests = [{ chainId: '0x1' as Hex, address: '0xunknown' }];
 
-      mockUseTokensData.mockReturnValue({ tokens: {}, isLoading: false });
+      mockUseTokensData.mockReturnValue({
+        tokens: {},
+        isLoading: false,
+        hasError: false,
+      });
 
       const { result } = renderHook(() =>
         useAccountTokens({ enrichTokenRequests: requests }),

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -143,7 +143,7 @@ describe('useAccountTokens', () => {
     mockGetIntlNumberFormatter.mockReturnValue(mockFormatter as any);
     mockFormatter.format.mockReturnValue('$100.50');
     mockIsTestNet.mockReturnValue(false);
-    mockUseTokensData.mockReturnValue({});
+    mockUseTokensData.mockReturnValue({ tokens: {}, isLoading: false });
     mockBuildEvmCaip19AssetId.mockImplementation(
       (address: string, chainId: Hex) =>
         `eip155:${chainId}/erc20:${address.toLowerCase()}`,
@@ -690,13 +690,16 @@ describe('useAccountTokens', () => {
       const requests = [{ chainId: '0x1' as Hex, address: '0xusdc' }];
 
       mockUseTokensData.mockReturnValue({
-        'eip155:0x1/erc20:0xusdc': {
-          assetId: 'eip155:0x1/erc20:0xusdc',
-          name: 'USD Coin',
-          symbol: 'USDC',
-          decimals: 6,
-          iconUrl: 'https://example.com/usdc.png',
+        tokens: {
+          'eip155:0x1/erc20:0xusdc': {
+            assetId: 'eip155:0x1/erc20:0xusdc',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+            iconUrl: 'https://example.com/usdc.png',
+          },
         },
+        isLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -741,13 +744,16 @@ describe('useAccountTokens', () => {
       const requests = [{ chainId: '0x1' as Hex, address: '0xusdc' }];
 
       mockUseTokensData.mockReturnValue({
-        'eip155:0x1/erc20:0xusdc': {
-          assetId: 'eip155:0x1/erc20:0xusdc',
-          name: 'USD Coin',
-          symbol: 'USDC',
-          decimals: 6,
-          iconUrl: 'https://example.com/usdc.png',
+        tokens: {
+          'eip155:0x1/erc20:0xusdc': {
+            assetId: 'eip155:0x1/erc20:0xusdc',
+            name: 'USD Coin',
+            symbol: 'USDC',
+            decimals: 6,
+            iconUrl: 'https://example.com/usdc.png',
+          },
         },
+        isLoading: false,
       });
 
       const { result } = renderHook(() =>
@@ -773,7 +779,7 @@ describe('useAccountTokens', () => {
 
       const requests = [{ chainId: '0x1' as Hex, address: '0xunknown' }];
 
-      mockUseTokensData.mockReturnValue({});
+      mockUseTokensData.mockReturnValue({ tokens: {}, isLoading: false });
 
       const { result } = renderHook(() =>
         useAccountTokens({ enrichTokenRequests: requests }),

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -75,7 +75,7 @@ export function useAccountTokens({
     [enrichTokenRequests],
   );
 
-  const tokensByAssetId = useTokensData(assetIds);
+  const { tokens: tokensByAssetId } = useTokensData(assetIds);
 
   return useMemo(() => {
     const flatAssets = Object.values(assets).flat();

--- a/app/components/hooks/DisplayName/useERC20Tokens.test.ts
+++ b/app/components/hooks/DisplayName/useERC20Tokens.test.ts
@@ -35,6 +35,7 @@ describe('useERC20Tokens', () => {
         },
       },
       isLoading: false,
+      hasError: false,
     });
   });
 
@@ -88,7 +89,11 @@ describe('useERC20Tokens', () => {
   });
 
   it('returns name and image as undefined when token is not found', () => {
-    mockUseTokensData.mockReturnValue({ tokens: {}, isLoading: false });
+    mockUseTokensData.mockReturnValue({
+      tokens: {},
+      isLoading: false,
+      hasError: false,
+    });
 
     const { result } = renderHook([
       {

--- a/app/components/hooks/DisplayName/useERC20Tokens.test.ts
+++ b/app/components/hooks/DisplayName/useERC20Tokens.test.ts
@@ -26,12 +26,15 @@ describe('useERC20Tokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseTokensData.mockReturnValue({
-      [ASSET_ID_MOCK]: {
-        assetId: ASSET_ID_MOCK,
-        name: TOKEN_NAME_MOCK,
-        symbol: TOKEN_SYMBOL_MOCK,
-        iconUrl: TOKEN_ICON_URL_MOCK,
+      tokens: {
+        [ASSET_ID_MOCK]: {
+          assetId: ASSET_ID_MOCK,
+          name: TOKEN_NAME_MOCK,
+          symbol: TOKEN_SYMBOL_MOCK,
+          iconUrl: TOKEN_ICON_URL_MOCK,
+        },
       },
+      isLoading: false,
     });
   });
 
@@ -85,7 +88,7 @@ describe('useERC20Tokens', () => {
   });
 
   it('returns name and image as undefined when token is not found', () => {
-    mockUseTokensData.mockReturnValue({});
+    mockUseTokensData.mockReturnValue({ tokens: {}, isLoading: false });
 
     const { result } = renderHook([
       {

--- a/app/components/hooks/DisplayName/useERC20Tokens.ts
+++ b/app/components/hooks/DisplayName/useERC20Tokens.ts
@@ -11,7 +11,7 @@ export function useERC20Tokens(requests: UseDisplayNameRequest[]) {
       buildEvmCaip19AssetId(value as string, variation as Hex),
     );
 
-  const tokensByAssetId = useTokensData(assetIds);
+  const { tokens: tokensByAssetId } = useTokensData(assetIds);
 
   return requests.map(({ preferContractSymbol, type, value, variation }) => {
     if (type !== NameType.EthereumAddress || !value) {

--- a/app/components/hooks/useTokensData/useTokensData.test.ts
+++ b/app/components/hooks/useTokensData/useTokensData.test.ts
@@ -159,6 +159,46 @@ describe('useTokensData', () => {
     expect(mockHandleFetch).not.toHaveBeenCalled();
   });
 
+  it('hydrates tokens from cache when assetIds change to an already-cached set', async () => {
+    const assetIdA = makeAssetId();
+    const assetIdB = makeAssetId();
+    // The hex address survives URL-encoding (the CAIP prefix's ":" and "/" do not),
+    // so match on it to decide which token the mocked request resolves.
+    const addressB = assetIdB.split('erc20:')[1];
+    mockHandleFetch.mockImplementation((url: string) =>
+      Promise.resolve(
+        makeTokenResponse(url.includes(addressB) ? assetIdB : assetIdA),
+      ),
+    );
+
+    // Prime the module-level cache for B in a separate instance.
+    const { result: priming } = renderHook([assetIdB]);
+    await waitFor(() => {
+      expect(priming.current.tokens[assetIdB]?.name).toBe(TOKEN_NAME_MOCK);
+    });
+
+    // This instance starts on A, then switches to the already-cached B.
+    let ids = [assetIdA];
+    const { result, rerender } = renderHookWithProvider(
+      () => useTokensData(ids),
+      { state: {} },
+    );
+    await waitFor(() => {
+      expect(result.current.tokens[assetIdA]?.name).toBe(TOKEN_NAME_MOCK);
+    });
+
+    ids = [assetIdB];
+    act(() => {
+      rerender(undefined);
+    });
+
+    await waitFor(() => {
+      expect(result.current.tokens[assetIdB]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(result.current.tokens[assetIdA]).toBeUndefined();
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
   it('looks up token by lowercase key when API returns checksummed assetId', async () => {
     const lowercaseId = makeAssetId(); // already lowercase from makeAssetId
     const checksummedId = lowercaseId.replace(/0x[0-9a-f]+/, (m) =>

--- a/app/components/hooks/useTokensData/useTokensData.test.ts
+++ b/app/components/hooks/useTokensData/useTokensData.test.ts
@@ -1,6 +1,12 @@
 import { act, waitFor } from '@testing-library/react-native';
 import { handleFetch } from '@metamask/controller-utils';
-import { useTokensData, MAX_BATCH_SIZE } from './useTokensData';
+import {
+  useTokensData,
+  isRwaChecked,
+  getCheckedRwaData,
+  MAX_BATCH_SIZE,
+  FetchTokensOptions,
+} from './useTokensData';
 import { renderHookWithProvider } from '../../../util/test/renderWithProvider';
 
 jest.mock('@metamask/controller-utils', () => ({
@@ -30,8 +36,10 @@ function makeTokenResponse(assetId: string) {
   ];
 }
 
-function renderHook(assetIds: string[]) {
-  return renderHookWithProvider(() => useTokensData(assetIds), { state: {} });
+function renderHook(assetIds: string[], options?: FetchTokensOptions) {
+  return renderHookWithProvider(() => useTokensData(assetIds, options), {
+    state: {},
+  });
 }
 
 describe('useTokensData', () => {
@@ -39,23 +47,25 @@ describe('useTokensData', () => {
     jest.clearAllMocks();
   });
 
-  it('returns empty object initially before fetch resolves', () => {
+  it('returns empty tokens and isLoading true initially before fetch resolves', () => {
     const assetId = makeAssetId();
     mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
 
     const { result } = renderHook([assetId]);
 
-    expect(result.current).toEqual({});
+    expect(result.current.tokens).toEqual({});
+    expect(result.current.isLoading).toBe(true);
   });
 
-  it('returns token data after fetch resolves', async () => {
+  it('returns token data and isLoading false after fetch resolves', async () => {
     const assetId = makeAssetId();
     mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
 
     const { result } = renderHook([assetId]);
 
     await waitFor(() => {
-      expect(result.current[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(result.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(result.current.isLoading).toBe(false);
     });
   });
 
@@ -66,12 +76,12 @@ describe('useTokensData', () => {
     const { result } = renderHook([assetId]);
 
     await waitFor(() => {
-      expect(result.current[assetId]?.symbol).toBe(TOKEN_SYMBOL_MOCK);
-      expect(result.current[assetId]?.iconUrl).toBe(TOKEN_ICON_URL_MOCK);
+      expect(result.current.tokens[assetId]?.symbol).toBe(TOKEN_SYMBOL_MOCK);
+      expect(result.current.tokens[assetId]?.iconUrl).toBe(TOKEN_ICON_URL_MOCK);
     });
   });
 
-  it('returns empty object when fetch fails', async () => {
+  it('returns empty tokens and isLoading false when fetch fails', async () => {
     mockHandleFetch.mockRejectedValue(new Error('Network error'));
 
     const { result } = renderHook([makeAssetId()]);
@@ -80,13 +90,15 @@ describe('useTokensData', () => {
       await new Promise((r) => setTimeout(r, 50));
     });
 
-    expect(result.current).toEqual({});
+    expect(result.current.tokens).toEqual({});
+    expect(result.current.isLoading).toBe(false);
   });
 
-  it('returns empty object when assetIds is empty', () => {
+  it('returns empty tokens and isLoading false when assetIds is empty', () => {
     const { result } = renderHook([]);
 
-    expect(result.current).toEqual({});
+    expect(result.current.tokens).toEqual({});
+    expect(result.current.isLoading).toBe(false);
     expect(mockHandleFetch).not.toHaveBeenCalled();
   });
 
@@ -119,9 +131,9 @@ describe('useTokensData', () => {
     const { result: r3 } = renderHook([assetId]);
 
     await waitFor(() => {
-      expect(r1.current[assetId]?.name).toBe(TOKEN_NAME_MOCK);
-      expect(r2.current[assetId]?.name).toBe(TOKEN_NAME_MOCK);
-      expect(r3.current[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(r1.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(r2.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(r3.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
     });
 
     expect(mockHandleFetch).toHaveBeenCalledTimes(1);
@@ -133,13 +145,14 @@ describe('useTokensData', () => {
 
     const { result: result1 } = renderHook([assetId]);
     await waitFor(() => {
-      expect(result1.current[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(result1.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
     });
 
     mockHandleFetch.mockClear();
     const { result: result2 } = renderHook([assetId]);
 
-    expect(result2.current[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+    expect(result2.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
+    expect(result2.current.isLoading).toBe(false);
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));
     });
@@ -166,7 +179,7 @@ describe('useTokensData', () => {
     const { result } = renderHook([lowercaseId]);
 
     await waitFor(() => {
-      expect(result.current[lowercaseId]?.name).toBe(TOKEN_NAME_MOCK);
+      expect(result.current.tokens[lowercaseId]?.name).toBe(TOKEN_NAME_MOCK);
     });
   });
 
@@ -190,7 +203,7 @@ describe('useTokensData', () => {
     const { result } = renderHook(assetIds);
 
     await waitFor(() => {
-      expect(Object.keys(result.current)).toHaveLength(assetIds.length);
+      expect(Object.keys(result.current.tokens)).toHaveLength(assetIds.length);
     });
 
     expect(mockHandleFetch).toHaveBeenCalledTimes(2);
@@ -208,5 +221,124 @@ describe('useTokensData', () => {
 
     expect(firstCallCount).toBe(MAX_BATCH_SIZE);
     expect(secondCallCount).toBe(1);
+  });
+
+  it('includes includeRwaData=true in the URL when option is set', async () => {
+    const assetId = makeAssetId();
+    mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
+
+    renderHook([assetId], { includeRwaData: true });
+
+    await waitFor(() => {
+      expect(mockHandleFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const calledUrl = mockHandleFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('includeRwaData=true');
+  });
+
+  it('does not include includeRwaData in the URL by default', async () => {
+    const assetId = makeAssetId();
+    mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
+
+    renderHook([assetId]);
+
+    await waitFor(() => {
+      expect(mockHandleFetch).toHaveBeenCalledTimes(1);
+    });
+
+    const calledUrl = mockHandleFetch.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain('includeRwaData');
+  });
+
+  it('does not share cache between requests with and without includeRwaData', async () => {
+    const assetId = makeAssetId();
+    const rwaData = { instrumentType: 'stock' };
+    mockHandleFetch
+      .mockResolvedValueOnce(makeTokenResponse(assetId))
+      .mockResolvedValueOnce([{ ...makeTokenResponse(assetId)[0], rwaData }]);
+
+    const { result: r1 } = renderHook([assetId]);
+    await waitFor(() =>
+      expect(r1.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK),
+    );
+    expect(r1.current.tokens[assetId]?.rwaData).toBeUndefined();
+
+    mockHandleFetch.mockClear();
+    const { result: r2 } = renderHook([assetId], { includeRwaData: true });
+    await waitFor(() =>
+      expect(r2.current.tokens[assetId]?.rwaData).toEqual(rwaData),
+    );
+
+    expect(mockHandleFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('isRwaChecked returns true after fetching with includeRwaData', async () => {
+    const assetId = makeAssetId();
+    mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
+
+    expect(isRwaChecked(assetId)).toBe(false);
+
+    const { result } = renderHook([assetId], { includeRwaData: true });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(isRwaChecked(assetId)).toBe(true);
+  });
+
+  it('isRwaChecked returns false for tokens fetched without includeRwaData', async () => {
+    const assetId = makeAssetId();
+    mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
+
+    const { result } = renderHook([assetId]);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(isRwaChecked(assetId)).toBe(false);
+  });
+
+  it('getCheckedRwaData returns cached rwaData after fetch with includeRwaData', async () => {
+    const assetId = makeAssetId();
+    const rwaData = { instrumentType: 'stock' };
+    mockHandleFetch.mockResolvedValue([
+      { ...makeTokenResponse(assetId)[0], rwaData },
+    ]);
+
+    expect(getCheckedRwaData(assetId)).toBeUndefined();
+
+    const { result } = renderHook([assetId], { includeRwaData: true });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getCheckedRwaData(assetId)).toEqual(rwaData);
+  });
+
+  it('getCheckedRwaData returns undefined for a confirmed non-RWA token', async () => {
+    const assetId = makeAssetId();
+    mockHandleFetch.mockResolvedValue(makeTokenResponse(assetId));
+
+    const { result } = renderHook([assetId], { includeRwaData: true });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(isRwaChecked(assetId)).toBe(true);
+    expect(getCheckedRwaData(assetId)).toBeUndefined();
+  });
+
+  it('getCheckedRwaData resolves from cache even when the asset is not in the current request', async () => {
+    const assetId = makeAssetId();
+    const otherAssetId = makeAssetId();
+    const rwaData = { instrumentType: 'bond' };
+
+    // First request confirms the RWA and populates the module-level cache.
+    mockHandleFetch.mockResolvedValue([
+      { ...makeTokenResponse(assetId)[0], rwaData },
+    ]);
+    const { result: r1 } = renderHook([assetId], { includeRwaData: true });
+    await waitFor(() => expect(r1.current.isLoading).toBe(false));
+
+    // A later request for a different asset (simulating the confirmed asset
+    // being excluded from re-fetch) must not erase access to the cached rwaData.
+    mockHandleFetch.mockResolvedValue(makeTokenResponse(otherAssetId));
+    const { result: r2 } = renderHook([otherAssetId], { includeRwaData: true });
+    await waitFor(() => expect(r2.current.isLoading).toBe(false));
+
+    expect(getCheckedRwaData(assetId)).toEqual(rwaData);
   });
 });

--- a/app/components/hooks/useTokensData/useTokensData.test.ts
+++ b/app/components/hooks/useTokensData/useTokensData.test.ts
@@ -55,6 +55,7 @@ describe('useTokensData', () => {
 
     expect(result.current.tokens).toEqual({});
     expect(result.current.isLoading).toBe(true);
+    expect(result.current.hasError).toBe(false);
   });
 
   it('returns token data and isLoading false after fetch resolves', async () => {
@@ -66,6 +67,7 @@ describe('useTokensData', () => {
     await waitFor(() => {
       expect(result.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
       expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasError).toBe(false);
     });
   });
 
@@ -92,6 +94,7 @@ describe('useTokensData', () => {
 
     expect(result.current.tokens).toEqual({});
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasError).toBe(true);
   });
 
   it('returns empty tokens and isLoading false when assetIds is empty', () => {
@@ -99,6 +102,7 @@ describe('useTokensData', () => {
 
     expect(result.current.tokens).toEqual({});
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasError).toBe(false);
     expect(mockHandleFetch).not.toHaveBeenCalled();
   });
 
@@ -153,6 +157,7 @@ describe('useTokensData', () => {
 
     expect(result2.current.tokens[assetId]?.name).toBe(TOKEN_NAME_MOCK);
     expect(result2.current.isLoading).toBe(false);
+    expect(result2.current.hasError).toBe(false);
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));
     });
@@ -196,6 +201,7 @@ describe('useTokensData', () => {
       expect(result.current.tokens[assetIdB]?.name).toBe(TOKEN_NAME_MOCK);
       expect(result.current.tokens[assetIdA]).toBeUndefined();
       expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasError).toBe(false);
     });
   });
 

--- a/app/components/hooks/useTokensData/useTokensData.ts
+++ b/app/components/hooks/useTokensData/useTokensData.ts
@@ -167,13 +167,15 @@ export function useTokensData(
   const [isLoading, setIsLoading] = useState(!allCached);
 
   useEffect(() => {
-    if (!assetIdsKey) {
-      setIsLoading(false);
-      return;
-    }
+    const ids = assetIdsKey ? assetIdsKey.split(',') : [];
 
-    const ids = assetIdsKey.split(',');
-    if (ids.every((id) => tokenCache[id + suffix])) {
+    if (allCached) {
+      // All requested IDs are already cached (or none requested). Sync state to
+      // the current IDs so direct callers (e.g. useERC20Tokens, useAccountTokens)
+      // read the cached tokens rather than a stale map from a previous render.
+      setTokensByAssetId(
+        Object.fromEntries(ids.map((id) => [id, tokenCache[id + suffix]])),
+      );
       setIsLoading(false);
       return;
     }
@@ -183,7 +185,7 @@ export function useTokensData(
 
     (async () => {
       try {
-        const data = await fetchTokenAssets(assetIdsKey.split(','), {
+        const data = await fetchTokenAssets(ids, {
           includeRwaData,
         });
         if (!cancelled) {
@@ -209,7 +211,7 @@ export function useTokensData(
     return () => {
       cancelled = true;
     };
-  }, [assetIdsKey, includeRwaData, suffix]);
+  }, [assetIdsKey, includeRwaData, suffix, allCached]);
 
   return { tokens: tokensByAssetId, isLoading };
 }

--- a/app/components/hooks/useTokensData/useTokensData.ts
+++ b/app/components/hooks/useTokensData/useTokensData.ts
@@ -4,6 +4,7 @@
 // from Redux state rather than calling the API directly.
 import { useState, useEffect } from 'react';
 import { handleFetch } from '@metamask/controller-utils';
+import type { TokenRwaData } from '@metamask/assets-controllers';
 
 export interface TokenAsset {
   assetId: string;
@@ -11,6 +12,11 @@ export interface TokenAsset {
   iconUrl: string;
   name: string;
   symbol: string;
+  rwaData?: TokenRwaData;
+}
+
+export interface FetchTokensOptions {
+  includeRwaData?: boolean;
 }
 
 const TOKEN_API_V3_BASE_URL = 'https://tokens.api.cx.metamask.io/v3';
@@ -21,25 +27,40 @@ export const MAX_BATCH_SIZE = 25;
 
 // Module-level cache and in-flight deduplication so multiple hook instances
 // share a single HTTP request for the same batch of asset IDs.
+// Per-asset cache keys include a suffix for each option flag so that results
+// fetched without a flag (e.g. without rwaData) don't satisfy requests that
+// need it.
 const tokenCache: Record<string, TokenAsset> = {};
 const inFlight = new Map<string, Promise<TokenAsset[]>>();
 
-function fetchTokenBatch(assetIds: string[]): Promise<TokenAsset[]> {
-  const key = assetIds.join(',');
+function optionsSuffix(options: FetchTokensOptions): string {
+  return options.includeRwaData ? '|rwa' : '';
+}
 
-  const existing = inFlight.get(key);
+function fetchTokenBatch(
+  assetIds: string[],
+  options: FetchTokensOptions = {},
+): Promise<TokenAsset[]> {
+  const suffix = optionsSuffix(options);
+  const inFlightKey = assetIds.join(',') + suffix;
+
+  const existing = inFlight.get(inFlightKey);
   if (existing) {
     return existing;
   }
 
-  if (assetIds.every((id) => tokenCache[id])) {
-    return Promise.resolve(assetIds.map((id) => tokenCache[id]));
+  if (assetIds.every((id) => tokenCache[id + suffix])) {
+    return Promise.resolve(assetIds.map((id) => tokenCache[id + suffix]));
   }
 
   const params = new URLSearchParams({
     assetIds: assetIds.join(','),
     includeIconUrl: 'true',
   });
+
+  if (options.includeRwaData) {
+    params.set('includeRwaData', 'true');
+  }
 
   const promise = (async () => {
     try {
@@ -51,25 +72,61 @@ function fetchTokenBatch(assetIds: string[]): Promise<TokenAsset[]> {
       // The API may return EIP-55 checksummed addresses (e.g. 0xABc…) which
       // would otherwise cause every cache lookup and state lookup to miss.
       data.forEach((t) => {
-        tokenCache[t.assetId.toLowerCase()] = t;
+        tokenCache[t.assetId.toLowerCase() + suffix] = t;
       });
       return data;
     } finally {
-      inFlight.delete(key);
+      inFlight.delete(inFlightKey);
     }
   })();
 
-  inFlight.set(key, promise);
+  inFlight.set(inFlightKey, promise);
   return promise;
 }
 
-async function fetchTokenAssets(assetIds: string[]): Promise<TokenAsset[]> {
+async function fetchTokenAssets(
+  assetIds: string[],
+  options: FetchTokensOptions = {},
+): Promise<TokenAsset[]> {
   const batches: string[][] = [];
   for (let i = 0; i < assetIds.length; i += MAX_BATCH_SIZE) {
     batches.push(assetIds.slice(i, i + MAX_BATCH_SIZE));
   }
-  const results = await Promise.all(batches.map(fetchTokenBatch));
+  const results = await Promise.all(
+    batches.map((batch) => fetchTokenBatch(batch, options)),
+  );
   return results.flat();
+}
+
+/**
+ * Returns whether an asset ID has been fetched and confirmed with the
+ * `includeRwaData` option. Reads from the module-level cache — not reactive
+ * on its own, but safe to call during renders triggered by useTokensData
+ * state updates.
+ *
+ * If this returns true and the corresponding TokenAsset has no rwaData,
+ * the token is confirmed to be a non-RWA asset.
+ */
+export function isRwaChecked(assetId: string): boolean {
+  return assetId + '|rwa' in tokenCache;
+}
+
+/**
+ * Returns the cached `rwaData` for an asset that has been fetched with the
+ * `includeRwaData` option, or `undefined` if it has not been checked or is a
+ * confirmed non-RWA. Reads from the module-level cache, which persists across
+ * component mounts — unlike the per-instance state returned by
+ * {@link useTokensData}. This is the source of truth callers should use to
+ * resolve RWA status, so that confirmed assets excluded from re-fetch (see
+ * {@link isRwaChecked}) still resolve correctly on remount.
+ */
+export function getCheckedRwaData(assetId: string): TokenRwaData | undefined {
+  return tokenCache[assetId + '|rwa']?.rwaData;
+}
+
+export interface UseTokensDataResult {
+  tokens: Record<string, TokenAsset>;
+  isLoading: boolean;
 }
 
 /**
@@ -82,27 +139,53 @@ async function fetchTokenAssets(assetIds: string[]): Promise<TokenAsset[]> {
  * simultaneous hook instances for the same assets share a single HTTP request.
  *
  * @param assetIds - Array of CAIP-19 asset identifiers (e.g. "eip155:1/erc20:0xabc…")
- * @returns A map from asset ID to {@link TokenAsset} for all resolved tokens.
+ * @param options - Optional fetch configuration
+ * @param options.includeRwaData - Whether to request RWA metadata in the response (default: false)
+ * @returns tokens map from asset ID to {@link TokenAsset}, and isLoading flag.
  */
-export function useTokensData(assetIds: string[]): Record<string, TokenAsset> {
+export function useTokensData(
+  assetIds: string[],
+  options: FetchTokensOptions = {},
+): UseTokensDataResult {
   const assetIdsKey = assetIds.join(',');
+  const { includeRwaData = false } = options;
+  const suffix = optionsSuffix(options);
+
+  const allCached =
+    assetIds.length === 0 || assetIds.every((id) => tokenCache[id + suffix]);
 
   const [tokensByAssetId, setTokensByAssetId] = useState<
     Record<string, TokenAsset>
   >(() =>
     Object.fromEntries(
-      assetIds.filter((id) => tokenCache[id]).map((id) => [id, tokenCache[id]]),
+      assetIds
+        .filter((id) => tokenCache[id + suffix])
+        .map((id) => [id, tokenCache[id + suffix]]),
     ),
   );
 
-  useEffect(() => {
-    if (!assetIdsKey) return;
+  const [isLoading, setIsLoading] = useState(!allCached);
 
+  useEffect(() => {
+    if (!assetIdsKey) {
+      setIsLoading(false);
+      return;
+    }
+
+    const ids = assetIdsKey.split(',');
+    if (ids.every((id) => tokenCache[id + suffix])) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
     let cancelled = false;
 
     (async () => {
       try {
-        const data = await fetchTokenAssets(assetIdsKey.split(','));
+        const data = await fetchTokenAssets(assetIdsKey.split(','), {
+          includeRwaData,
+        });
         if (!cancelled) {
           setTokensByAssetId((prev) => ({
             ...prev,
@@ -112,14 +195,21 @@ export function useTokensData(assetIds: string[]): Record<string, TokenAsset> {
           }));
         }
       } catch {
-        // silently ignore fetch errors
+        // Silently ignore fetch errors. On failure the cache is not populated,
+        // so isRwaChecked stays false and these IDs are retried on the next
+        // input change. Callers relying on RWA status should treat a resolved
+        // isLoading with missing data as "status unknown" (see useTokensWithBalance).
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [assetIdsKey]);
+  }, [assetIdsKey, includeRwaData, suffix]);
 
-  return tokensByAssetId;
+  return { tokens: tokensByAssetId, isLoading };
 }

--- a/app/components/hooks/useTokensData/useTokensData.ts
+++ b/app/components/hooks/useTokensData/useTokensData.ts
@@ -127,6 +127,7 @@ export function getCheckedRwaData(assetId: string): TokenRwaData | undefined {
 export interface UseTokensDataResult {
   tokens: Record<string, TokenAsset>;
   isLoading: boolean;
+  hasError: boolean;
 }
 
 /**
@@ -141,7 +142,7 @@ export interface UseTokensDataResult {
  * @param assetIds - Array of CAIP-19 asset identifiers (e.g. "eip155:1/erc20:0xabc…")
  * @param options - Optional fetch configuration
  * @param options.includeRwaData - Whether to request RWA metadata in the response (default: false)
- * @returns tokens map from asset ID to {@link TokenAsset}, and isLoading flag.
+ * @returns tokens map from asset ID to {@link TokenAsset}, loading flag, and error flag.
  */
 export function useTokensData(
   assetIds: string[],
@@ -165,6 +166,7 @@ export function useTokensData(
   );
 
   const [isLoading, setIsLoading] = useState(!allCached);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     const ids = assetIdsKey ? assetIdsKey.split(',') : [];
@@ -177,10 +179,12 @@ export function useTokensData(
         Object.fromEntries(ids.map((id) => [id, tokenCache[id + suffix]])),
       );
       setIsLoading(false);
+      setHasError(false);
       return;
     }
 
     setIsLoading(true);
+    setHasError(false);
     let cancelled = false;
 
     (async () => {
@@ -195,12 +199,16 @@ export function useTokensData(
               data.map((t) => [t.assetId.toLowerCase(), t]),
             ),
           }));
+          setHasError(false);
         }
       } catch {
         // Silently ignore fetch errors. On failure the cache is not populated,
         // so isRwaChecked stays false and these IDs are retried on the next
         // input change. Callers relying on RWA status should treat a resolved
         // isLoading with missing data as "status unknown" (see useTokensWithBalance).
+        if (!cancelled) {
+          setHasError(true);
+        }
       } finally {
         if (!cancelled) {
           setIsLoading(false);
@@ -213,5 +221,5 @@ export function useTokensData(
     };
   }, [assetIdsKey, includeRwaData, suffix, allCached]);
 
-  return { tokens: tokensByAssetId, isLoading };
+  return { tokens: tokensByAssetId, isLoading, hasError };
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7551,6 +7551,8 @@
     "batch_sell_select_subtitle": "All tokens need to be on the same network.",
     "batch_sell_empty_state_title": "No tokens. No problem.",
     "batch_sell_empty_state_description": "No tokens. No problem. Explore and buy tokens to batch sell.",
+    "batch_sell_token_load_error_title": "Unable to load tokens",
+    "batch_sell_token_load_error_description": "We couldn't load your eligible tokens. Check your connection and try again.",
     "batch_sell_continue_with_one_token": "Continue with (1) token",
     "batch_sell_continue_with_tokens": "Continue with ({{tokenCount}}) tokens",
     "batch_sell_max_tokens_allowed": "Max 5 tokens allowed",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Batch Sell should not show Real World Asset (RWA) tokens as sellable source tokens. This change enriches Batch Sell wallet tokens with optional token API metadata, including `rwaData`, then filters any token with `rwaData` from the Batch Sell token selector.

To keep the impact narrow, the additional token metadata fetch is opt-in on `useTokensWithBalance` via `shouldFetchExtraTokenData`. Batch Sell is the only caller that opts in; other callers continue to receive Redux-derived wallet tokens without an additional token API request. While RWA metadata is loading, Batch Sell keeps the selector chrome visible and shows skeleton rows only in the token list.

The token data helper now returns `{ tokens, isLoading, hasError }`, supports `includeRwaData`, and exposes cache helpers so RWA checks can avoid refetching confirmed non-RWAs while still preserving cached RWA metadata across remounts.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that allowed RWA tokens to appear in Batch Sell token selection.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Batch Sell RWA token filtering

  Scenario: Batch Sell hides RWA tokens from the source token list
    Given a wallet has Batch Sell-supported tokens including at least one token with RWA metadata
    And Batch Sell is enabled

    When user opens the Batch Sell token selector
    Then the selector shows loading skeletons in the token rows while RWA metadata is loading
    And the selector chrome, network pills, and sort header remain visible
    And tokens with RWA metadata are not shown after loading completes
    And non-RWA tokens with balances remain selectable
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/73d91194-aff0-44d9-911a-2b9f776a10fd



## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared hooks (`useTokensWithBalance`, `useTokensData`) used across Bridge, Card, Perps, and confirmations; incorrect RWA cache or filtering could hide valid sell tokens or briefly show RWAs before load completes.
> 
> **Overview**
> Batch Sell no longer lists **RWA** tokens as sellable sources. Eligibility moves into **`useBatchSellTokens`**, which opts into extra token metadata on **`useTokensWithBalance`**, drops destination stablecoins and tokens with **`rwaData`**, and hides assets until **`isRwaChecked`** confirms they are non-RWA.
> 
> The selector shows **skeleton rows** while that metadata loads (without flashing the empty state), a dedicated **load error** screen on failure, and keeps network pills/sort chrome visible during loading.
> 
> **`useTokensWithBalance`** now returns `{ tokens, isExtraTokenDataLoading, hasExtraTokenDataError }` with opt-in **`shouldFetchExtraTokenData`** (Batch Sell only). **`useTokensData`** returns the same shape plus **`includeRwaData`**, separate cache keys, and **`isRwaChecked` / `getCheckedRwaData`**. **`rwaData`** flows through balance maps and API merge (**`useMergeApiTokensWithBalances`**, renamed from **`useTokensWithBalances`**). Call sites and tests are updated for the new return shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82f251b8d94b67b5d0a158c5543768e6ad1a53a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->