### PR TITLE
feat(predict): support series ids in predictMarketHighlights cp-7.81.0

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx
@@ -348,6 +348,7 @@ describe('PredictCryptoUpDownMarketCard', () => {
       expect.objectContaining({ id: 'market-live' }),
       69000,
       {
+        enabled: true,
         liveUpdatesEnabled: false,
         historicalWindow: {
           startDate: expect.any(String),
@@ -711,5 +712,74 @@ describe('PredictCryptoUpDownMarketCard', () => {
     const secondResolved = mockUseCryptoUpDownChartData.mock.calls.at(-1)?.[0];
     expect(secondResolved).not.toBe(firstResolved);
     expect(secondResolved?.id).toBe('market-next');
+  });
+
+  describe('compact (isCarousel) variant', () => {
+    it('hides the sparkline and target labels but keeps title, buttons, live badge, and reset copy', () => {
+      renderCard(createMarket(), { isCarousel: true });
+
+      expect(screen.getByText('BTC Up or Down - 5 Minutes')).toBeOnTheScreen();
+      expect(screen.getByText('Up · 40¢')).toBeOnTheScreen();
+      expect(screen.getByText('Down · 60¢')).toBeOnTheScreen();
+      expect(screen.getByText(/Resets every 5 min/)).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(
+          PredictCryptoUpDownMarketCardSelectorsIDs.LIVE_BADGE,
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(
+          PredictCryptoUpDownMarketCardSelectorsIDs.SPARKLINE,
+        ),
+      ).toBeNull();
+      expect(screen.queryByText('Target')).toBeNull();
+    });
+
+    it('gates chart-data and target-price queries so they do not run in the carousel', () => {
+      renderCard(createMarket(), { isCarousel: true });
+
+      const chartCall = mockUseCryptoUpDownChartData.mock.calls.at(-1);
+      expect(chartCall?.[2]).toEqual(
+        expect.objectContaining({ enabled: false }),
+      );
+
+      const targetCall = mockUseCryptoTargetPrice.mock.calls.at(-1);
+      expect(targetCall?.[0]).toEqual(
+        expect.objectContaining({ enabled: false }),
+      );
+    });
+
+    it('renders the compact skeleton (no chart placeholder) while the series window is loading', () => {
+      mockUsePredictSeries.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      });
+
+      renderCard(createMarket(), { isCarousel: true });
+
+      expect(
+        screen.getByTestId(PredictCryptoUpDownMarketCardSelectorsIDs.SKELETON),
+      ).toBeOnTheScreen();
+    });
+
+    it('still opens the buy sheet for the Up and Down outcomes in the carousel', () => {
+      const liveMarket = createMarket();
+      mockUsePredictSeries.mockReturnValue({
+        data: [liveMarket],
+        isLoading: false,
+      });
+
+      renderCard(liveMarket, { isCarousel: true });
+
+      fireEvent.press(
+        screen.getByTestId(PredictCryptoUpDownMarketCardSelectorsIDs.UP_BUTTON),
+      );
+      expect(mockOpenBuySheet).toHaveBeenCalledWith({
+        market: liveMarket,
+        outcome: liveMarket.outcomes[0],
+        outcomeToken: liveMarket.outcomes[0].tokens[0],
+        entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+      });
+    });
   });
 });

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -128,6 +128,12 @@ const CRYPTO_ACCENT_DEFAULT = 'rgb(245, 158, 11)';
 const CRYPTO_ACCENT_BY_SYMBOL: Record<string, string> = {
   BTC: 'rgb(247, 147, 26)',
 };
+
+const FULL_CARD_HEIGHT = 319;
+const FULL_PROGRESS_LOGO_TOP = 112;
+const FULL_LIVE_BADGE_TOP = 171;
+const FULL_TITLE_TOP = 197;
+const FULL_OUTCOME_BUTTONS_TOP = 235;
 const AnimatedPath = Animated.createAnimatedComponent(Path);
 const AnimatedLine = Animated.createAnimatedComponent(SvgLine);
 const CLOCK_UPDATE_OFFSET_MS = 50;
@@ -165,10 +171,12 @@ interface PredictCryptoUpDownMarketCardProps {
   testID?: string;
   entryPoint?: PredictEntryPoint;
   /**
-   * Forwarded by the parent `PredictMarket` router for parity with sibling
-   * cards (`PredictMarketSingle`, `PredictMarketMultiple`). The crypto up/down
-   * card does not yet implement a carousel sizing variant — accepting the
-   * prop keeps the variant-card contract stable.
+   * When true, renders the compact carousel variant: the sparkline and target
+   * line/label treatment are dropped, and the card uses a `height: 100%` flex
+   * layout (matching `PredictMarketSingle` / `PredictMarketMultiple`) so it
+   * sits flush with its neighbours in the Explore TrendingView carousel.
+   * Chart-data and target-price queries are skipped in this mode since their
+   * output isn't displayed.
    */
   isCarousel?: boolean;
   /** Called synchronously before the card's navigation press fires. */
@@ -867,6 +875,17 @@ const ProgressLogo = React.memo(
 );
 ProgressLogo.displayName = 'ProgressLogo';
 
+type LiveStatusProps = {
+  endDate?: string;
+  durationMs: number;
+  imageUrl?: string;
+  accentColor: string;
+  trackColor: string;
+} & (
+  | { compact: true; progressLogoTop?: never; liveBadgeTop?: never }
+  | { compact?: false; progressLogoTop: number; liveBadgeTop: number }
+);
+
 const LiveStatus = React.memo(
   ({
     endDate,
@@ -874,13 +893,10 @@ const LiveStatus = React.memo(
     imageUrl,
     accentColor,
     trackColor,
-  }: {
-    endDate?: string;
-    durationMs: number;
-    imageUrl?: string;
-    accentColor: string;
-    trackColor: string;
-  }) => {
+    compact,
+    progressLogoTop,
+    liveBadgeTop,
+  }: LiveStatusProps) => {
     const tw = useTailwind();
     const nowMs = useSharedNowMs();
     const countdown = formatSeriesMarketCountdown(endDate, nowMs);
@@ -890,41 +906,73 @@ const LiveStatus = React.memo(
       nowMs,
     );
 
+    const logo = (
+      <ProgressLogo
+        imageUrl={imageUrl}
+        progress={progressRemaining}
+        color={accentColor}
+        trackColor={trackColor}
+      />
+    );
+
+    const badge = (
+      <Box
+        testID={PredictCryptoUpDownMarketCardSelectorsIDs.LIVE_BADGE}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+      >
+        <Box
+          twClassName="mr-1.5 h-2 w-2 rounded-full"
+          style={tw.style({ backgroundColor: accentColor })}
+        />
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          style={tw.style({ color: accentColor })}
+        >
+          LIVE · {countdown}
+        </Text>
+      </Box>
+    );
+
+    if (compact) {
+      return (
+        <Box twClassName="items-center gap-2">
+          {logo}
+          {badge}
+        </Box>
+      );
+    }
+
     return (
       <>
-        <Box twClassName="absolute left-0 right-0 top-[112px] items-center px-4">
-          <ProgressLogo
-            imageUrl={imageUrl}
-            progress={progressRemaining}
-            color={accentColor}
-            trackColor={trackColor}
-          />
-        </Box>
-
         <Box
-          testID={PredictCryptoUpDownMarketCardSelectorsIDs.LIVE_BADGE}
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          justifyContent={BoxJustifyContent.Center}
-          twClassName="absolute left-0 right-0 top-[171px]"
+          twClassName="absolute left-0 right-0 items-center px-4"
+          style={tw.style({ top: progressLogoTop })}
         >
-          <Box
-            twClassName="mr-1.5 h-2 w-2 rounded-full"
-            style={tw.style({ backgroundColor: accentColor })}
-          />
-          <Text
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            style={tw.style({ color: accentColor })}
-          >
-            LIVE · {countdown}
-          </Text>
+          {logo}
+        </Box>
+        <Box
+          twClassName="absolute left-0 right-0 items-center"
+          style={tw.style({ top: liveBadgeTop })}
+        >
+          {badge}
         </Box>
       </>
     );
   },
 );
 LiveStatus.displayName = 'LiveStatus';
+
+type OutcomeButtonsProps = {
+  upToken?: PredictOutcomeToken;
+  downToken?: PredictOutcomeToken;
+  marketId?: string;
+  outcomeId?: string;
+  marketStatus: PredictMarketStatus;
+  onBuyPress: (token?: PredictOutcomeToken) => void;
+} & ({ compact: true; top?: never } | { compact?: false; top: number });
 
 const OutcomeButtons = React.memo(
   ({
@@ -934,14 +982,10 @@ const OutcomeButtons = React.memo(
     outcomeId,
     marketStatus,
     onBuyPress,
-  }: {
-    upToken?: PredictOutcomeToken;
-    downToken?: PredictOutcomeToken;
-    marketId?: string;
-    outcomeId?: string;
-    marketStatus: PredictMarketStatus;
-    onBuyPress: (token?: PredictOutcomeToken) => void;
-  }) => {
+    compact,
+    top,
+  }: OutcomeButtonsProps) => {
+    const tw = useTailwind();
     const tokenIds = useMemo(
       () =>
         [upToken?.id, downToken?.id].filter((id): id is string => Boolean(id)),
@@ -977,11 +1021,8 @@ const OutcomeButtons = React.memo(
       restPrices,
     );
 
-    return (
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        twClassName="absolute left-4 right-4 top-[235px] z-10 gap-2"
-      >
+    const buttons = (
+      <>
         <ButtonBase
           testID={PredictCryptoUpDownMarketCardSelectorsIDs.UP_BUTTON}
           onPress={() => onBuyPress(upToken)}
@@ -1010,6 +1051,24 @@ const OutcomeButtons = React.memo(
             Down · {formatCents(downPrice)}
           </Text>
         </ButtonBase>
+      </>
+    );
+
+    if (compact) {
+      return (
+        <Box flexDirection={BoxFlexDirection.Row} twClassName="w-full gap-2">
+          {buttons}
+        </Box>
+      );
+    }
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        twClassName="absolute left-4 right-4 z-10 gap-2"
+        style={tw.style({ top })}
+      >
+        {buttons}
       </Box>
     );
   },
@@ -1018,20 +1077,31 @@ OutcomeButtons.displayName = 'OutcomeButtons';
 
 const PredictCryptoUpDownMarketCardSkeleton = ({
   testID,
+  compact,
 }: {
   testID?: string;
+  compact?: boolean;
 }) => {
   const tw = useTailwind();
 
   return (
-    <Box testID={testID} twClassName="my-2 rounded-xl bg-section p-4">
+    <Box
+      testID={testID}
+      twClassName={
+        compact
+          ? 'h-full rounded-xl bg-section p-4 justify-between'
+          : 'my-2 rounded-xl bg-section p-4'
+      }
+    >
       <Box
         testID={PredictCryptoUpDownMarketCardSelectorsIDs.SKELETON}
         twClassName="items-center gap-3"
       >
         <Skeleton width={40} height={40} style={tw.style('rounded-full')} />
         <Skeleton width="70%" height={18} style={tw.style('rounded-md')} />
-        <Skeleton width="100%" height={120} style={tw.style('rounded-xl')} />
+        {!compact && (
+          <Skeleton width="100%" height={120} style={tw.style('rounded-xl')} />
+        )}
         <Box flexDirection={BoxFlexDirection.Row} twClassName="w-full gap-2">
           <Skeleton width="48%" height={40} style={tw.style('rounded-lg')} />
           <Skeleton width="48%" height={40} style={tw.style('rounded-lg')} />
@@ -1047,12 +1117,14 @@ const PredictCryptoUpDownMarketCard: React.FC<
   market,
   testID,
   entryPoint: propEntryPoint,
+  isCarousel = false,
   onCardPress,
   onBuyButtonPress,
   predictFeedTab,
   predictScreen,
   transactionActiveAbTests,
 }) => {
+  const isCompact = isCarousel;
   const tw = useTailwind();
   const { colors } = useTheme();
   const navigation =
@@ -1123,6 +1195,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
     variant: getVariant(selectedMarket.series.recurrence),
     endDate: selectedMarket.endDate ?? '',
     enabled:
+      !isCompact &&
       Boolean(symbol) &&
       Boolean(targetPriceEventStartTime) &&
       Boolean(selectedMarket.endDate),
@@ -1134,7 +1207,11 @@ const PredictCryptoUpDownMarketCard: React.FC<
   const chartData = useCryptoUpDownChartData(
     selectedMarket,
     validatedTargetPrice,
-    { liveUpdatesEnabled: false, historicalWindow: chartHistoryWindow },
+    {
+      enabled: !isCompact,
+      liveUpdatesEnabled: false,
+      historicalWindow: chartHistoryWindow,
+    },
   );
   const sparklinePoints = useMemo(() => chartData.data, [chartData.data]);
   const latestPrice =
@@ -1243,11 +1320,71 @@ const PredictCryptoUpDownMarketCard: React.FC<
   );
 
   if (isSeriesLoading && !seriesMarkets) {
-    return <PredictCryptoUpDownMarketCardSkeleton testID={testID} />;
+    return (
+      <PredictCryptoUpDownMarketCardSkeleton
+        testID={testID}
+        compact={isCompact}
+      />
+    );
+  }
+
+  if (isCompact) {
+    return (
+      <Pressable
+        testID={testID ?? PredictCryptoUpDownMarketCardSelectorsIDs.CARD}
+        onPress={handleCardPress}
+        accessibilityLabel={cardTitle}
+        accessibilityRole="button"
+        style={tw.style('h-full rounded-xl bg-muted overflow-hidden')}
+      >
+        <Box twClassName="flex-1 p-4 items-center justify-between">
+          <Box twClassName="items-center gap-2">
+            <LiveStatus
+              compact
+              endDate={selectedMarket.endDate}
+              durationMs={durationMs}
+              imageUrl={imageUrl}
+              accentColor={accentColor}
+              trackColor={colors.border.muted}
+            />
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+              numberOfLines={1}
+              twClassName="text-center"
+            >
+              {cardTitle}
+            </Text>
+          </Box>
+
+          <Box twClassName="w-full items-center gap-3">
+            <OutcomeButtons
+              compact
+              upToken={upToken}
+              downToken={downToken}
+              marketId={selectedMarket.id}
+              outcomeId={selectedOutcome?.id}
+              marketStatus={selectedMarket.status as PredictMarketStatus}
+              onBuyPress={handleBuyPress}
+            />
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              Resets every {resetDuration}
+            </Text>
+          </Box>
+        </Box>
+      </Pressable>
+    );
   }
 
   return (
-    <Box twClassName="my-2 h-[319px] rounded-xl bg-muted overflow-hidden">
+    <Box
+      twClassName="my-2 rounded-xl bg-muted overflow-hidden"
+      style={tw.style({ height: FULL_CARD_HEIGHT })}
+    >
       <Pressable
         testID={testID ?? PredictCryptoUpDownMarketCardSelectorsIDs.CARD}
         onPress={handleCardPress}
@@ -1318,6 +1455,8 @@ const PredictCryptoUpDownMarketCard: React.FC<
           imageUrl={imageUrl}
           accentColor={accentColor}
           trackColor={colors.border.muted}
+          progressLogoTop={FULL_PROGRESS_LOGO_TOP}
+          liveBadgeTop={FULL_LIVE_BADGE_TOP}
         />
 
         <Text
@@ -1325,7 +1464,8 @@ const PredictCryptoUpDownMarketCard: React.FC<
           fontWeight={FontWeight.Medium}
           color={TextColor.TextDefault}
           numberOfLines={1}
-          twClassName="absolute left-4 right-4 top-[197px] text-center"
+          twClassName="absolute left-4 right-4 text-center"
+          style={tw.style({ top: FULL_TITLE_TOP })}
         >
           {cardTitle}
         </Text>
@@ -1338,6 +1478,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
         outcomeId={selectedOutcome?.id}
         marketStatus={selectedMarket.status as PredictMarketStatus}
         onBuyPress={handleBuyPress}
+        top={FULL_OUTCOME_BUTTONS_TOP}
       />
       <Box
         flexDirection={BoxFlexDirection.Row}

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -1316,7 +1316,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
         style={tw.style('h-full rounded-xl bg-muted overflow-hidden')}
       >
         <Box twClassName="flex-1 p-4 items-center justify-between">
-          <Box twClassName="items-center gap-2">
+          <Box twClassName="items-center">
             <LiveStatus
               compact
               endDate={selectedMarket.endDate}
@@ -1336,7 +1336,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
             </Text>
           </Box>
 
-          <Box twClassName="w-full items-center gap-3">
+          <Box twClassName="w-full items-center gap-2">
             <OutcomeButtons
               compact
               upToken={upToken}

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -128,12 +128,6 @@ const CRYPTO_ACCENT_DEFAULT = 'rgb(245, 158, 11)';
 const CRYPTO_ACCENT_BY_SYMBOL: Record<string, string> = {
   BTC: 'rgb(247, 147, 26)',
 };
-
-const FULL_CARD_HEIGHT = 319;
-const FULL_PROGRESS_LOGO_TOP = 112;
-const FULL_LIVE_BADGE_TOP = 171;
-const FULL_TITLE_TOP = 197;
-const FULL_OUTCOME_BUTTONS_TOP = 235;
 const AnimatedPath = Animated.createAnimatedComponent(Path);
 const AnimatedLine = Animated.createAnimatedComponent(SvgLine);
 const CLOCK_UPDATE_OFFSET_MS = 50;
@@ -875,17 +869,6 @@ const ProgressLogo = React.memo(
 );
 ProgressLogo.displayName = 'ProgressLogo';
 
-type LiveStatusProps = {
-  endDate?: string;
-  durationMs: number;
-  imageUrl?: string;
-  accentColor: string;
-  trackColor: string;
-} & (
-  | { compact: true; progressLogoTop?: never; liveBadgeTop?: never }
-  | { compact?: false; progressLogoTop: number; liveBadgeTop: number }
-);
-
 const LiveStatus = React.memo(
   ({
     endDate,
@@ -894,9 +877,14 @@ const LiveStatus = React.memo(
     accentColor,
     trackColor,
     compact,
-    progressLogoTop,
-    liveBadgeTop,
-  }: LiveStatusProps) => {
+  }: {
+    endDate?: string;
+    durationMs: number;
+    imageUrl?: string;
+    accentColor: string;
+    trackColor: string;
+    compact?: boolean;
+  }) => {
     const tw = useTailwind();
     const nowMs = useSharedNowMs();
     const countdown = formatSeriesMarketCountdown(endDate, nowMs);
@@ -947,16 +935,10 @@ const LiveStatus = React.memo(
 
     return (
       <>
-        <Box
-          twClassName="absolute left-0 right-0 items-center px-4"
-          style={tw.style({ top: progressLogoTop })}
-        >
+        <Box twClassName="absolute left-0 right-0 top-[112px] items-center px-4">
           {logo}
         </Box>
-        <Box
-          twClassName="absolute left-0 right-0 items-center"
-          style={tw.style({ top: liveBadgeTop })}
-        >
+        <Box twClassName="absolute left-0 right-0 top-[171px] items-center">
           {badge}
         </Box>
       </>
@@ -964,15 +946,6 @@ const LiveStatus = React.memo(
   },
 );
 LiveStatus.displayName = 'LiveStatus';
-
-type OutcomeButtonsProps = {
-  upToken?: PredictOutcomeToken;
-  downToken?: PredictOutcomeToken;
-  marketId?: string;
-  outcomeId?: string;
-  marketStatus: PredictMarketStatus;
-  onBuyPress: (token?: PredictOutcomeToken) => void;
-} & ({ compact: true; top?: never } | { compact?: false; top: number });
 
 const OutcomeButtons = React.memo(
   ({
@@ -983,9 +956,15 @@ const OutcomeButtons = React.memo(
     marketStatus,
     onBuyPress,
     compact,
-    top,
-  }: OutcomeButtonsProps) => {
-    const tw = useTailwind();
+  }: {
+    upToken?: PredictOutcomeToken;
+    downToken?: PredictOutcomeToken;
+    marketId?: string;
+    outcomeId?: string;
+    marketStatus: PredictMarketStatus;
+    onBuyPress: (token?: PredictOutcomeToken) => void;
+    compact?: boolean;
+  }) => {
     const tokenIds = useMemo(
       () =>
         [upToken?.id, downToken?.id].filter((id): id is string => Boolean(id)),
@@ -1065,8 +1044,7 @@ const OutcomeButtons = React.memo(
     return (
       <Box
         flexDirection={BoxFlexDirection.Row}
-        twClassName="absolute left-4 right-4 z-10 gap-2"
-        style={tw.style({ top })}
+        twClassName="absolute left-4 right-4 top-[235px] z-10 gap-2"
       >
         {buttons}
       </Box>
@@ -1381,10 +1359,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
   }
 
   return (
-    <Box
-      twClassName="my-2 rounded-xl bg-muted overflow-hidden"
-      style={tw.style({ height: FULL_CARD_HEIGHT })}
-    >
+    <Box twClassName="my-2 h-[319px] rounded-xl bg-muted overflow-hidden">
       <Pressable
         testID={testID ?? PredictCryptoUpDownMarketCardSelectorsIDs.CARD}
         onPress={handleCardPress}
@@ -1455,8 +1430,6 @@ const PredictCryptoUpDownMarketCard: React.FC<
           imageUrl={imageUrl}
           accentColor={accentColor}
           trackColor={colors.border.muted}
-          progressLogoTop={FULL_PROGRESS_LOGO_TOP}
-          liveBadgeTop={FULL_LIVE_BADGE_TOP}
         />
 
         <Text
@@ -1464,8 +1437,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
           fontWeight={FontWeight.Medium}
           color={TextColor.TextDefault}
           numberOfLines={1}
-          twClassName="absolute left-4 right-4 text-center"
-          style={tw.style({ top: FULL_TITLE_TOP })}
+          twClassName="absolute left-4 right-4 top-[197px] text-center"
         >
           {cardTitle}
         </Text>
@@ -1478,7 +1450,6 @@ const PredictCryptoUpDownMarketCard: React.FC<
         outcomeId={selectedOutcome?.id}
         marketStatus={selectedMarket.status as PredictMarketStatus}
         onBuyPress={handleBuyPress}
-        top={FULL_OUTCOME_BUTTONS_TOP}
       />
       <Box
         flexDirection={BoxFlexDirection.Row}

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -313,6 +313,7 @@ describe('PredictController', () => {
       searchMarkets: jest.fn(),
       getCarouselMarkets: jest.fn(),
       getMarketsByIds: jest.fn(),
+      getMarketSeries: jest.fn(),
       getPositions: jest.fn(),
       getMarketDetails: jest.fn(),
       getActivity: jest.fn(),
@@ -2477,7 +2478,8 @@ describe('PredictController', () => {
       minimumVersion?: string;
       highlights: {
         category: string;
-        markets: string[];
+        markets?: string[];
+        series?: string[];
       }[];
     }) => ({
       remoteFeatureFlags: {
@@ -2757,7 +2759,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('handles getMarketsByIds failure gracefully', async () => {
+    it('handles an empty getMarketsByIds result gracefully', async () => {
       const regularMarkets = [createMockMarket('regular-1')];
 
       await withController(
@@ -2774,6 +2776,38 @@ describe('PredictController', () => {
 
           expect(result.markets).toHaveLength(1);
           expect(result.markets[0].id).toBe('regular-1');
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [
+                  { category: 'trending', markets: ['highlight-1'] },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('propagates getMarketsByIds rejections so the caller sees the failure', async () => {
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: regularMarkets as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketsByIds.mockRejectedValue(
+            new Error('market-ids provider failed'),
+          );
+
+          await expect(
+            controller.getMarkets({ category: 'trending' }),
+          ).rejects.toBeDefined();
         },
         {
           mocks: {
@@ -3120,6 +3154,387 @@ describe('PredictController', () => {
                   {
                     category: 'trending',
                     markets: ['highlight-1'],
+                  },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('resolves a series highlight to its currently live market and prepends it', async () => {
+      const expiredMarket = {
+        ...createMockMarket('series-expired'),
+        endDate: new Date(Date.now() - 60_000).toISOString(),
+      };
+      const liveMarket = {
+        ...createMockMarket('series-live'),
+        endDate: new Date(Date.now() + 60_000).toISOString(),
+      };
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: regularMarkets as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([
+            expiredMarket,
+            liveMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(2);
+          expect(result.markets[0].id).toBe('series-live');
+          expect(result.markets[0].isHighlighted).toBe(true);
+          expect(result.markets[1].id).toBe('regular-1');
+          expect(result.markets[1].isHighlighted).toBeUndefined();
+          expect(mockPolymarketProvider.getMarketSeries).toHaveBeenCalledWith(
+            expect.objectContaining({
+              seriesId: 'series-abc',
+              endDateMin: expect.any(String),
+              endDateMax: expect.any(String),
+              limit: 50,
+            }),
+          );
+          expect(mockPolymarketProvider.getMarketsByIds).not.toHaveBeenCalled();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [{ category: 'crypto', series: ['series-abc'] }],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('prepends market-id highlights before series-resolved highlights when both are configured', async () => {
+      const directMarket = createMockMarket('direct-1');
+      const liveSeriesMarket = {
+        ...createMockMarket('series-live'),
+        endDate: new Date(Date.now() + 60_000).toISOString(),
+      };
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: regularMarkets as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketsByIds.mockResolvedValue([
+            directMarket,
+          ] as any);
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([
+            liveSeriesMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(3);
+          expect(result.markets.map((m) => m.id)).toEqual([
+            'direct-1',
+            'series-live',
+            'regular-1',
+          ]);
+          expect(result.markets[0].isHighlighted).toBe(true);
+          expect(result.markets[1].isHighlighted).toBe(true);
+          expect(result.markets[2].isHighlighted).toBeUndefined();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [
+                  {
+                    category: 'crypto',
+                    markets: ['direct-1'],
+                    series: ['series-abc'],
+                  },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('falls back to the nearest market when no future market exists in the series window', async () => {
+      const expiredMarket = {
+        ...createMockMarket('series-expired'),
+        endDate: new Date(Date.now() - 60_000).toISOString(),
+      };
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: [],
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([
+            expiredMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(1);
+          expect(result.markets[0].id).toBe('series-expired');
+          expect(result.markets[0].isHighlighted).toBe(true);
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [{ category: 'crypto', series: ['series-abc'] }],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('skips a series highlight when the series returns no markets', async () => {
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: regularMarkets as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([]);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(1);
+          expect(result.markets[0].id).toBe('regular-1');
+          expect(result.markets[0].isHighlighted).toBeUndefined();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [{ category: 'crypto', series: ['series-empty'] }],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('filters out series-resolved markets that are not open', async () => {
+      const closedSeriesMarket = {
+        ...createMockMarket('series-closed'),
+        endDate: new Date(Date.now() + 60_000).toISOString(),
+        status: 'closed',
+      };
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: regularMarkets as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([
+            closedSeriesMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(1);
+          expect(result.markets[0].id).toBe('regular-1');
+          expect(
+            result.markets.find((m) => m.id === 'series-closed'),
+          ).toBeUndefined();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [{ category: 'crypto', series: ['series-abc'] }],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('silently skips a series highlight when getMarketSeries throws', async () => {
+      const regularMarkets = [createMockMarket('regular-1')];
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: regularMarkets as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries.mockRejectedValue(
+            new Error('series provider failed'),
+          );
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(1);
+          expect(result.markets[0].id).toBe('regular-1');
+          expect(result.markets[0].isHighlighted).toBeUndefined();
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [{ category: 'crypto', series: ['series-abc'] }],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('still resolves remaining series highlights when one entry in the batch throws', async () => {
+      const liveMarket = {
+        ...createMockMarket('series-live'),
+        endDate: new Date(Date.now() + 60_000).toISOString(),
+      };
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: [createMockMarket('regular-1')] as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries
+            .mockImplementationOnce(() =>
+              Promise.reject(new Error('first series failed')),
+            )
+            .mockImplementationOnce(() => Promise.resolve([liveMarket] as any));
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(2);
+          expect(result.markets[0].id).toBe('series-live');
+          expect(result.markets[0].isHighlighted).toBe(true);
+          expect(result.markets[1].id).toBe('regular-1');
+          expect(mockPolymarketProvider.getMarketSeries).toHaveBeenCalledTimes(
+            2,
+          );
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [
+                  {
+                    category: 'crypto',
+                    series: ['series-failing', 'series-healthy'],
+                  },
+                ],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('picks the live market even when the series returns many earlier-ending events first', async () => {
+      // Regression guard for the endDate-ASC + limit interaction.
+      // For a 5m series, the provider's default pagination places ~12 past
+      // events ahead of the live slot. The fetch limit must be high enough
+      // (SERIES_MAX_EVENTS) that the live market is included in the response.
+      const now = Date.now();
+      const pastMarkets = Array.from({ length: 12 }, (_, i) => ({
+        ...createMockMarket(`series-past-${i}`),
+        endDate: new Date(now - (12 - i) * 5 * 60_000).toISOString(),
+      }));
+      const liveMarket = {
+        ...createMockMarket('series-live'),
+        endDate: new Date(now + 60_000).toISOString(),
+      };
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: [createMockMarket('regular-1')] as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([
+            ...pastMarkets,
+            liveMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets[0].id).toBe('series-live');
+          expect(result.markets[0].isHighlighted).toBe(true);
+          expect(mockPolymarketProvider.getMarketSeries).toHaveBeenCalledWith(
+            expect.objectContaining({ limit: 50 }),
+          );
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [{ category: 'crypto', series: ['series-abc'] }],
+              }),
+            ),
+          },
+        },
+      );
+    });
+
+    it('deduplicates when the same market is referenced both as a market id and via a series', async () => {
+      const sharedMarket = {
+        ...createMockMarket('shared'),
+        endDate: new Date(Date.now() + 60_000).toISOString(),
+      };
+
+      await withController(
+        async ({ controller }) => {
+          mockPolymarketProvider.getMarkets.mockResolvedValue({
+            markets: [createMockMarket('regular-1')] as any,
+            nextCursor: null,
+          });
+          mockPolymarketProvider.getMarketsByIds.mockResolvedValue([
+            sharedMarket,
+          ] as any);
+          mockPolymarketProvider.getMarketSeries.mockResolvedValue([
+            sharedMarket,
+          ] as any);
+
+          const result = await controller.getMarkets({ category: 'crypto' });
+
+          expect(result.markets).toHaveLength(2);
+          expect(result.markets[0].id).toBe('shared');
+          expect(result.markets[0].isHighlighted).toBe(true);
+          expect(result.markets[1].id).toBe('regular-1');
+          expect(result.markets.filter((m) => m.id === 'shared')).toHaveLength(
+            1,
+          );
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest.fn().mockReturnValue(
+              createFlagState({
+                enabled: true,
+                highlights: [
+                  {
+                    category: 'crypto',
+                    markets: ['shared'],
+                    series: ['series-abc'],
                   },
                 ],
               }),

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -113,6 +113,11 @@ import { resolveCryptoTargetPrice } from '../utils/cryptoUpDown';
 import { validateMarketBettable } from '../utils/marketState';
 import { ensureError } from '../utils/predictErrorHandler';
 import { resolvePredictFeatureFlags } from '../utils/resolvePredictFeatureFlags';
+import {
+  findLiveMarket,
+  findNearestMarket,
+  SERIES_MAX_EVENTS,
+} from '../utils/series';
 import { validateDepositTransactions } from '../utils/validateTransactions';
 import { PredictAnalytics } from './PredictAnalytics';
 import type { PredictControllerMethodActions } from './PredictController-method-action-types';
@@ -407,6 +412,19 @@ const MESSENGER_EXPOSED_METHODS = [
 const ERC20_TRANSFER_FUNCTION_SELECTOR = '0xa9059cbb';
 
 /**
+ * Window applied when fetching series markets for highlight resolution.
+ * The future bound must be wide enough to contain the currently-live market
+ * for any supported recurrence (5m / 15m / 1h / 4h / daily). The past bound
+ * exists only so `findNearestMarket` can pin a recently-expired market when
+ * no future market is in range — `findLiveMarket` itself ignores past data.
+ * Limit reuses the canonical `SERIES_MAX_EVENTS` so the provider's default
+ * `endDate ASC` ordering can't truncate the live slot for fast recurrences
+ * (a 5m series produces ~12 past events inside the past buffer alone).
+ */
+const HIGHLIGHT_SERIES_PAST_WINDOW_MS = 60 * 60 * 1000;
+const HIGHLIGHT_SERIES_FUTURE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
  * PredictController - Protocol-agnostic prediction markets trading controller
  *
  * Provides a unified interface for prediction markets trading across multiple protocols.
@@ -621,14 +639,25 @@ export class PredictController extends BaseController<
           highlights.length > 0 && isFirstPage && params.category;
 
         if (shouldFetchHighlights) {
-          const highlightedMarketIds =
-            highlights.find((h) => h.category === params.category)?.markets ??
-            [];
+          const entry = highlights.find((h) => h.category === params.category);
+          const highlightedMarketIds = entry?.markets ?? [];
+          const highlightedSeriesIds = entry?.series ?? [];
 
-          if (highlightedMarketIds.length > 0) {
-            const fetchedHighlightedMarkets =
-              (await this.provider.getMarketsByIds?.(highlightedMarketIds)) ??
-              [];
+          if (
+            highlightedMarketIds.length > 0 ||
+            highlightedSeriesIds.length > 0
+          ) {
+            const [fromMarketIds, fromSeriesIds] = await Promise.all([
+              highlightedMarketIds.length > 0 && this.provider.getMarketsByIds
+                ? this.provider.getMarketsByIds(highlightedMarketIds)
+                : Promise.resolve<PredictMarket[]>([]),
+              this.resolveSeriesHighlights(highlightedSeriesIds),
+            ]);
+
+            const fetchedHighlightedMarkets = [
+              ...fromMarketIds,
+              ...fromSeriesIds,
+            ];
 
             const highlightedMarkets = fetchedHighlightedMarkets
               .filter((market) => market.status === 'open')
@@ -637,19 +666,70 @@ export class PredictController extends BaseController<
                 isHighlighted: true,
               }));
 
-            const highlightedIdSet = new Set(
-              highlightedMarkets.map((m) => m.id),
-            );
+            const highlightedIdSet = new Set<string>();
+            const uniqueHighlighted = highlightedMarkets.filter((market) => {
+              if (highlightedIdSet.has(market.id)) {
+                return false;
+              }
+              highlightedIdSet.add(market.id);
+              return true;
+            });
             markets = markets.filter(
               (market) => !highlightedIdSet.has(market.id),
             );
 
-            markets = [...highlightedMarkets, ...markets];
+            markets = [...uniqueHighlighted, ...markets];
           }
         }
 
         return { markets, nextCursor };
       },
+    );
+  }
+
+  private async resolveSeriesHighlights(
+    seriesIds: string[],
+  ): Promise<PredictMarket[]> {
+    if (seriesIds.length === 0 || !this.provider.getMarketSeries) {
+      return [];
+    }
+
+    const nowMs = Date.now();
+    const endDateMin = new Date(
+      nowMs - HIGHLIGHT_SERIES_PAST_WINDOW_MS,
+    ).toISOString();
+    const endDateMax = new Date(
+      nowMs + HIGHLIGHT_SERIES_FUTURE_WINDOW_MS,
+    ).toISOString();
+
+    const resolved = await Promise.all(
+      seriesIds.map(async (seriesId) => {
+        try {
+          const seriesMarkets =
+            (await this.provider.getMarketSeries?.({
+              seriesId,
+              endDateMin,
+              endDateMax,
+              limit: SERIES_MAX_EVENTS,
+            })) ?? [];
+          return (
+            findLiveMarket(seriesMarkets) ?? findNearestMarket(seriesMarkets)
+          );
+        } catch (error) {
+          DevLogger.log(
+            'PredictController: failed to resolve series highlight',
+            {
+              seriesId,
+              error: error instanceof Error ? error.message : 'Unknown error',
+            },
+          );
+          return undefined;
+        }
+      }),
+    );
+
+    return resolved.filter(
+      (market): market is PredictMarket => market !== undefined,
     );
   }
 

--- a/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
@@ -21,7 +21,11 @@ export const mockPredictMarketHighlightsFlag: PredictMarketHighlightsFlag = {
       category: 'trending',
       markets: ['market-highlight-1', 'market-highlight-2'],
     },
-    { category: 'crypto', markets: ['market-highlight-3'] },
+    {
+      category: 'crypto',
+      markets: ['market-highlight-3'],
+      series: ['series-highlight-1'],
+    },
     {
       category: 'sports',
       markets: ['market-highlight-4', 'market-highlight-5'],

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -11,7 +11,8 @@ export interface PredictLiveSportsFlag {
 
 export interface PredictMarketHighlight {
   category: string;
-  markets: string[];
+  markets?: string[];
+  series?: string[];
 }
 
 export interface PredictMarketHighlightsFlag extends VersionGatedFeatureFlag {

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -105,6 +105,31 @@ describe('resolvePredictFeatureFlags', () => {
     expect(result.marketHighlightsFlag).toEqual(marketHighlights);
   });
 
+  it('passes through series ids on market highlights entries unchanged', () => {
+    mockValidatedVersionGatedFeatureFlag.mockImplementationOnce(() => true);
+
+    const marketHighlights = {
+      enabled: true,
+      minimumVersion: '1.0.0',
+      highlights: [
+        {
+          category: 'crypto',
+          markets: ['direct-1'],
+          series: ['series-1', 'series-2'],
+        },
+        { category: 'sports', series: ['series-3'] },
+      ],
+    };
+
+    const result = resolvePredictFeatureFlags({
+      remoteFeatureFlags: {
+        predictMarketHighlights: marketHighlights,
+      },
+    });
+
+    expect(result.marketHighlightsFlag).toEqual(marketHighlights);
+  });
+
   it('falls back to default market highlights flag when validation returns false', () => {
     mockValidatedVersionGatedFeatureFlag.mockImplementationOnce(() => false);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Extends the `predictMarketHighlights` remote feature flag to accept series IDs in addition to market IDs, and renders series-resolved crypto up/down highlights in horizontally-scrolling carousels via a new compact card variant.

**Why**

Recurring crypto up/down markets (e.g. "BTC Up or Down — 5 Minutes") expose a new market every N minutes. A market-ID pin in `predictMarketHighlights` therefore goes stale within a single time slot — once the market resolves, the pin disappears, and there is no way to express "always pin the currently-live BTC Up/Down 5m market." Resolving from a series at request time fixes this: the pin automatically rotates to whatever slot is live when the feed is fetched.

**Schema change (additive, backward compatible)**

```ts
export interface PredictMarketHighlight {
  category: string;
  markets?: string[]; // was required, now optional
  series?: string[];  // NEW
}
```

- Existing LD flag values that only use `markets` continue to work unchanged. Both fields are now optional; entries with neither are skipped.
- The controller's highlight block fetches `getMarketsByIds(markets)` and `getMarketSeries(seriesId)` in parallel via `Promise.all`, then resolves each series response to its currently-live market via the existing `findLiveMarket()` (with `findNearestMarket()` as a fallback when no future market is in the fetch window).
- Resolved series markets pass through the same `status === 'open'` filter and are marked with `isHighlighted: true`, identical to the market-ID path.
- Order: market-ID highlights are prepended first, then series-resolved highlights, then the regular feed. Existing flag values that only use `markets` keep their original ordering. Dedupe is unified across both paths so a market reachable via both `markets` and `series` appears exactly once.

**Compact carousel variant**

`PredictCryptoUpDownMarketCard` now has two render variants, keyed off the existing `isCarousel` prop that `PredictMarket` forwards to its sibling cards (`PredictMarketSingle`, `PredictMarketMultiple`, `PredictMarketSportCard`):

- **Full** (`isCarousel=false`, the default) — the existing sparkline + target-line / target-price treatment used on `PredictFeed`, `PredictHome`, the wallet home carousel, and search.
- **Compact** (`isCarousel=true`) — drops the sparkline and target labels and switches to a `height: 100%` + flex-column + `justifyContent: 'space-between'` layout that mirrors `PredictMarketSingle` / `PredictMarketMultiple` so the card sits flush with its neighbours in `HorizontalCarousel`. This is the variant the 5 TrendingView carousel tabs (Now, Macro, RWAs, Crypto, Sports) render for series-resolved highlights.

The compact path also gates `useCryptoUpDownChartData` and `useCryptoTargetPrice` with `enabled: !isCompact`, so the chart historical fetch and live-price websocket subscription don't run for cards that never display them.

**Resilience**

- Per-series fetch failures are caught locally with a `DevLogger.log`, so one unhealthy series entry can't take down a healthy batch.
- The series fetch reuses the canonical `SERIES_MAX_EVENTS` (50) for `limit`. The provider returns markets in `endDate ASC` order, and a fast recurrence (5m) can produce ~12 past events inside the past buffer alone — too low a limit would clip the live slot.
- `getMarketsByIds` keeps its existing fail-hard contract; the previously misleading test `"handles getMarketsByIds failure gracefully"` (which actually only tested an empty-array result) was renamed accordingly, and a real rejection-propagation test was added.

**Test coverage**

- 8 new tests in `PredictController.test.ts` (live-market resolution, mixed markets+series ordering, nearest-market fallback, empty-series skip, closed-market status filter, throw-silent on single series, partial-batch failure, dedupe across paths)
- 1 shape-passthrough test in `resolvePredictFeatureFlags.test.ts`
- 4 new tests in `PredictCryptoUpDownMarketCard.test.tsx` covering the compact variant (sparkline not rendered, both chart queries gated with `enabled: false`, compact skeleton renders, buy sheet still opens)
- All tests in the touched suites pass.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for pinning the currently-live market of a recurring series (e.g. BTC Up/Down 5m) via the `predictMarketHighlights` remote feature flag.

## **Related issues**

Fixes: PRED-950

## **Manual testing steps**

Both scenarios assume the `predictMarketHighlights` LaunchDarkly variation is updated to the new shape. The series ID `10684` corresponds to the Polymarket Gamma `BTC Up/Down 5m` series (also hardcoded as `BTC_UP_DOWN_5M_SERIES_ID` in `app/components/UI/Predict/constants/btcUpDown5mSeries.ts`).

```gherkin
Feature: Series-id highlights in predictMarketHighlights

  Scenario: A series-id highlight resolves to the currently-live market on PredictFeed
    Given the predictMarketHighlights flag is set to
      """
      {
        "enabled": true,
        "minimumVersion": "7.63.0",
        "highlights": [
          { "category": "crypto", "series": ["10684"] }
        ]
      }
      """
    When the user opens the Predict tab and switches to the "Crypto" feed tab
    Then the currently-live BTC Up/Down 5m market is pinned at the top of the feed
    And the pin auto-rotates to the next live slot when the current one resolves
    And the card renders in the full variant (with sparkline + target labels)

  Scenario: A series-id highlight renders the compact variant in TrendingView carousels
    Given the same flag configuration as above
    When the user opens the Explore page and views the "Crypto" or "Now" tab carousel
    Then the BTC Up/Down series card IS pinned in the Explore carousel
    And it renders as the compact variant (no sparkline, same height as its neighbours)
    And no chart-history fetch or live-price websocket subscription is opened for that card

  Scenario: Existing market-id highlights are unaffected
    Given the predictMarketHighlights flag is set to
      """
      {
        "enabled": true,
        "highlights": [
          { "category": "trending", "markets": ["451614"] }
        ]
      }
      """
    When the user opens PredictFeed → Trending and Explore → Now
    Then market 451614 is pinned at the top on both surfaces (market-id path is unchanged)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

<!-- [screenshots/recordings] -->

### **After**

N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feed ordering and highlight resolution now depend on series API behavior and remote flag shape; carousel gating changes which data loads on Explore surfaces.
> 
> **Overview**
> Adds optional **`series`** IDs to **`predictMarketHighlights`** so recurring crypto up/down pins resolve to the **currently live** market via **`getMarketSeries`** + **`findLiveMarket`** / **`findNearestMarket`**, merged with existing market-ID highlights (parallel fetch, dedupe, open-only, market IDs first).
> 
> **`PredictCryptoUpDownMarketCard`** now honors **`isCarousel`**: a **compact** layout (no sparkline/target UI, full-height flex) and **`enabled: false`** on chart/target hooks to avoid unused network work in Explore carousels; full feed cards unchanged with **`enabled: true`** on chart data.
> 
> Controller tests cover series resolution edge cases; **`getMarketsByIds`** failures now **reject** instead of being mislabeled as graceful handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f5c7558c7a4a6ea70ec52e607b3b73535cfdda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->