### PR TITLE
fix(ramps): forward quote payment method in headless buy

### DIFF
--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
@@ -316,6 +316,28 @@ describe('HeadlessHost', () => {
       expect(ctx.currency).toBe('USD');
     });
 
+    it('falls back to the quote payment method when it is absent from the loaded catalog and no override is given', async () => {
+      // Catalog only has debit-credit-card and bank-transfer; the quote was
+      // priced with sepa-bank-transfer. The membership check misses, so the
+      // resolver must forward the quote's own payment method rather than
+      // sending an empty one (which Transak rejects with HTTP 400).
+      const quote = buildNativeQuote({
+        quote: {
+          amountIn: SAMPLE_AMOUNT,
+          amountOut: 0.011,
+          paymentMethod: '/payments/sepa-bank-transfer',
+          cryptoTranslation: { symbol: 'mUSD' },
+        },
+      } as unknown as Partial<Quote>);
+      const session = seedSession(quote);
+      renderHost({ headlessSessionId: session.id });
+      await waitFor(() =>
+        expect(mockContinueWithQuote).toHaveBeenCalledTimes(1),
+      );
+      const [, ctx] = mockContinueWithQuote.mock.calls[0];
+      expect(ctx.paymentMethodId).toBe('/payments/sepa-bank-transfer');
+    });
+
     it('falls back to userRegion currency when the session does not pin one', async () => {
       const quote = buildAggregatorQuote();
       const session = seedSession(quote);

--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
@@ -191,14 +191,17 @@ function HeadlessHost() {
     const { quote, amount, assetId, currency, paymentMethodId } =
       currentSession.params;
     // Caller override wins. Otherwise `find` is a membership check on the
-    // loaded catalog, not a remap: when it matches, `?.id` equals
-    // `quote.quote.paymentMethod`; when the quote id is absent from
-    // `paymentMethods` (stale quote, filters, load race), we omit
-    // `ctx.paymentMethodId` instead of forwarding an unverified id, and
-    // `useContinueWithQuote` falls back to controller-selected payment method.
+    // loaded catalog: when it matches, `?.id` equals
+    // `quote.quote.paymentMethod`. When the quote id is absent from
+    // `paymentMethods` (stale quote, filters, load race), fall back to the
+    // quote's own `paymentMethod` — it's the method the quote was priced
+    // with, and the native Transak flow requires a payment method on the
+    // quote fetch. Omitting it sends an empty `paymentMethod` to Transak,
+    // which rejects the request with HTTP 400.
     const resolvedPaymentMethodId =
       paymentMethodId ??
-      paymentMethods?.find((pm) => pm.id === quote.quote.paymentMethod)?.id;
+      paymentMethods?.find((pm) => pm.id === quote.quote.paymentMethod)?.id ??
+      quote.quote.paymentMethod;
 
     const ctx: ContinueWithQuoteContext = {
       amount,

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
@@ -209,7 +209,7 @@ async function invoke(
     typeof renderHook<ReturnType<typeof useContinueWithQuote>, unknown>
   >['result'],
   quote: unknown,
-  ctx: { amount: number; assetId: string } = CTX,
+  ctx: { amount: number; assetId: string; headlessSessionId?: string } = CTX,
 ): Promise<Error | undefined> {
   let caught: Error | undefined;
   await act(async () => {
@@ -323,7 +323,7 @@ describe('useContinueWithQuote', () => {
       );
     });
 
-    it('throws before fetching the quote when no payment method resolves', async () => {
+    it('throws before fetching the quote when no payment method resolves (headless)', async () => {
       mockUseRampsController.mockReturnValue(
         buildController({
           selectedProvider: NATIVE_PROVIDER,
@@ -334,7 +334,12 @@ describe('useContinueWithQuote', () => {
 
       const { result } = renderHook(() => useContinueWithQuote());
 
-      const caught = await invoke(result, NATIVE_PROVIDER_QUOTE);
+      // The missing-payment-method guard is scoped to the headless flow, so
+      // it only fires when `ctx.headlessSessionId` is set.
+      const caught = await invoke(result, NATIVE_PROVIDER_QUOTE, {
+        ...CTX,
+        headlessSessionId: 'session-1',
+      });
 
       expect(caught).toBeInstanceOf(Error);
       expect(mockCheckExistingToken).not.toHaveBeenCalled();
@@ -343,6 +348,41 @@ describe('useContinueWithQuote', () => {
         expect.any(Error),
         { message: 'Missing payment method for native provider flow' },
         'deposit.buildQuote.unexpectedError',
+      );
+    });
+
+    it('does not throw at the missing-payment-method guard for the non-headless (UB2) path', async () => {
+      // UB2 (BuildQuote -> continueWithQuote -> continueNative) never sets
+      // `ctx.headlessSessionId`, so even with no resolvable payment method the
+      // guard must stay dormant and the flow proceeds unchanged.
+      mockUseRampsController.mockReturnValue(
+        buildController({
+          selectedProvider: NATIVE_PROVIDER,
+          selectedPaymentMethod: null,
+        }),
+      );
+      mockCheckExistingToken.mockResolvedValue(false);
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, NATIVE_PROVIDER_QUOTE);
+
+      // It got past the guard (checkExistingToken ran) and did not report the
+      // headless-only missing-payment-method error.
+      expect(caught).toBeUndefined();
+      expect(mockCheckExistingToken).toHaveBeenCalled();
+      expect(mockReportRampsError).not.toHaveBeenCalledWith(
+        expect.any(Error),
+        { message: 'Missing payment method for native provider flow' },
+        'deposit.buildQuote.unexpectedError',
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.RAMP.VERIFY_IDENTITY,
+        expect.objectContaining({
+          amount: '100',
+          currency: 'USD',
+          assetId: 'eip155:1/slip44:60',
+        }),
       );
     });
 

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
@@ -323,6 +323,29 @@ describe('useContinueWithQuote', () => {
       );
     });
 
+    it('throws before fetching the quote when no payment method resolves', async () => {
+      mockUseRampsController.mockReturnValue(
+        buildController({
+          selectedProvider: NATIVE_PROVIDER,
+          selectedPaymentMethod: null,
+        }),
+      );
+      mockCheckExistingToken.mockResolvedValue(true);
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, NATIVE_PROVIDER_QUOTE);
+
+      expect(caught).toBeInstanceOf(Error);
+      expect(mockCheckExistingToken).not.toHaveBeenCalled();
+      expect(mockGetBuyQuote).not.toHaveBeenCalled();
+      expect(mockReportRampsError).toHaveBeenCalledWith(
+        expect.any(Error),
+        { message: 'Missing payment method for native provider flow' },
+        'deposit.buildQuote.unexpectedError',
+      );
+    });
+
     it('throws when transakGetBuyQuote returns null', async () => {
       mockCheckExistingToken.mockResolvedValue(true);
       mockGetBuyQuote.mockResolvedValue(null);

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -150,6 +150,19 @@ export function useContinueWithQuote(
       const effectiveChainId = ctx.chainId ?? selectedToken?.chainId ?? '';
       const effectivePaymentMethodId =
         ctx.paymentMethodId ?? selectedPaymentMethod?.id ?? '';
+      // The native Transak quote fetch requires a payment method. An empty
+      // value gets dropped from the request query and Transak rejects it with
+      // HTTP 400, so fail fast with a reported error instead of issuing a
+      // request that can never succeed.
+      if (!effectivePaymentMethodId) {
+        throw new Error(
+          reportRampsError(
+            new Error('Native provider flow requires a payment method'),
+            { message: 'Missing payment method for native provider flow' },
+            strings('deposit.buildQuote.unexpectedError'),
+          ),
+        );
+      }
       try {
         const hasToken = await transakCheckExistingToken();
 

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -154,7 +154,12 @@ export function useContinueWithQuote(
       // value gets dropped from the request query and Transak rejects it with
       // HTTP 400, so fail fast with a reported error instead of issuing a
       // request that can never succeed.
-      if (!effectivePaymentMethodId) {
+      //
+      // Gate on `ctx.headlessSessionId` so this guard is scoped to the
+      // headless buy flow. The shared UB2 path (BuildQuote ->
+      // continueWithQuote -> continueNative) never sets `headlessSessionId`,
+      // so its behavior is provably unchanged.
+      if (!effectivePaymentMethodId && ctx.headlessSessionId) {
         throw new Error(
           reportRampsError(
             new Error('Native provider flow requires a payment method'),


### PR DESCRIPTION
## **Description**

The headless Transak buy flow could issue a quote request with no `paymentMethod`. Transak's `/api/v2/lookup/quotes` endpoint requires the parameter and rejects the request with HTTP 400 (`"paymentMethod is required parameter"`).

The root cause is the payment-method resolution chain degrading to an empty string when the quote's payment method isn't found in the loaded catalog and no explicit `paymentMethodId` override is passed:

1. `HeadlessHost` resolved `paymentMethodId ?? catalog.find(...)?.id` — `undefined` on a catalog miss.
2. `useContinueWithQuote.continueNative` then computed `ctx.paymentMethodId ?? selectedPaymentMethod?.id ?? ''` — `''` because the headless flow never seeds `selectedPaymentMethod` when the lookup misses.
3. `TransakService.getBuyQuote` silently drops `paymentMethod` from the query when it's falsy → 400.

### Solution

- **Forward the quote's own payment method** (`HeadlessHost.tsx`): when the catalog membership check misses, fall back to `quote.quote.paymentMethod` — the method the quote was actually priced with. Transak normalizes the `/payments/...` id.
- **Fail fast** (`useContinueWithQuote.ts`): if no payment method resolves, throw a reported error instead of issuing a request that can never succeed, so this can't silently regress.

## **Changelog**

CHANGELOG entry: null

<!-- Developer-only headless buy flow; not end-user-facing yet. -->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3631

## **Manual testing steps**

```gherkin
Feature: Headless buy quote fetch

  Scenario: user starts a headless Transak buy without an explicit paymentMethodId
    Given a quote whose paymentMethod is not in the loaded payment-method catalog
    When the headless buy flow fetches the Transak quote
    Then the request includes the quote's paymentMethod
    And Transak returns a quote instead of HTTP 400
```

## **Screenshots/Recordings**

Walkthrough from Amitabh's integrated `test-money-account` TestFlight build, which stacks the headless PRs (#31045, #31046, #31109) plus the money-account deposit layer and exercises this change end-to-end:

- Part I → https://www.loom.com/share/3af06e801b57484d92e3bb9565e2d932
- Part II → https://www.loom.com/share/da47c43b3c544e2f85d2538fc5426443

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — this is a headless payment-method resolution fix (network request only) with no performance-sensitive rendering, data loading, or production instrumentation paths. The checklist below was consciously assessed as not applicable for this PR.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native Transak quote request inputs in the headless buy flow; behavior is gated on `headlessSessionId` with new tests, but incorrect resolution could still break headless deposits.
> 
> **Overview**
> Fixes the headless Transak buy path sending quote requests **without** `paymentMethod`, which Transak rejects with HTTP 400.
> 
> **`HeadlessHost`** now resolves payment method as: session override → catalog membership → **`quote.quote.paymentMethod`** when the quote’s method isn’t in the loaded catalog (stale quote, filters, or load race). Previously a catalog miss left `paymentMethodId` unset and the native flow degraded to an empty value on the wire.
> 
> **`useContinueWithQuote.continueNative`** adds a **headless-only** fail-fast: when `ctx.headlessSessionId` is set and no payment method resolves, it reports and throws before `getBuyQuote`, instead of issuing a doomed request. The standard BuildQuote (UB2) path is unchanged because it never sets `headlessSessionId`.
> 
> Tests cover catalog-miss fallback, the headless guard, and that UB2 still proceeds without the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34492f202d9076417b5187f2576cad04f0beeec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
