### PR TITLE
refactor(MainNavigator): migrate RewardsHome to native stack

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -81,7 +81,10 @@ import { SnapSettings } from '../../Views/Snaps/SnapSettings';
 import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../constants/snaps';
 ///: END:ONLY_INCLUDE_IF
 import Routes from '../../../constants/navigation/Routes';
-import { clearStackNavigatorOptionsWithTransitionAnimation } from '../../../constants/navigation/clearStackNavigatorOptions';
+import {
+  clearStackNavigatorOptionsWithTransitionAnimation,
+  transparentModalScreenOptions,
+} from '../../../constants/navigation/clearStackNavigatorOptions';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { TabBarIconKey } from '../../../component-library/components/Navigation/TabBar/TabBar.types';
 import { selectProviderConfig } from '../../../selectors/networkController';
@@ -321,56 +324,48 @@ const TransactionsHome = () => {
 
 const RewardsHome = () => {
   const { colors } = useTheme();
+  const rewardsModalScreenOptions = {
+    ...transparentModalScreenOptions,
+    contentStyle: { backgroundColor: 'transparent' },
+  };
   return (
-    <Stack.Navigator
+    <NativeStack.Navigator
       screenOptions={{
-        ...clearStackNavigatorOptionsWithTransitionAnimation,
-        cardStyle: { backgroundColor: colors.background.default },
+        headerShown: false,
+        animation: 'none',
+        contentStyle: { backgroundColor: colors.background.default },
       }}
     >
-      <Stack.Screen name={Routes.REWARDS_VIEW} component={RewardsNavigator} />
-      <Stack.Screen
+      <NativeStack.Screen
+        name={Routes.REWARDS_VIEW}
+        component={RewardsNavigator}
+      />
+      <NativeStack.Screen
         name={Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL}
         component={RewardsBottomSheetModal}
-        options={{
-          presentation: 'transparentModal',
-          cardStyle: { backgroundColor: 'transparent' },
-        }}
+        options={rewardsModalScreenOptions}
       />
-      <Stack.Screen
+      <NativeStack.Screen
         name={Routes.MODAL.REWARDS_CLAIM_BOTTOM_SHEET_MODAL}
         component={RewardsClaimBottomSheetModal}
-        options={{
-          presentation: 'transparentModal',
-          cardStyle: { backgroundColor: 'transparent' },
-        }}
+        options={rewardsModalScreenOptions}
       />
-      <Stack.Screen
+      <NativeStack.Screen
         name={Routes.MODAL.REWARDS_OPTIN_ACCOUNT_GROUP_MODAL}
         component={RewardOptInAccountGroupModal}
-        options={{
-          headerShown: false,
-          presentation: 'transparentModal',
-          cardStyle: { backgroundColor: 'transparent' },
-        }}
+        options={rewardsModalScreenOptions}
       />
-      <Stack.Screen
+      <NativeStack.Screen
         name={Routes.MODAL.REWARDS_END_OF_SEASON_CLAIM_BOTTOM_SHEET}
         component={EndOfSeasonClaimBottomSheet}
-        options={{
-          presentation: 'transparentModal',
-          cardStyle: { backgroundColor: 'transparent' },
-        }}
+        options={rewardsModalScreenOptions}
       />
-      <Stack.Screen
+      <NativeStack.Screen
         name={Routes.MODAL.REWARDS_SELECT_SHEET}
         component={RewardsSelectSheet}
-        options={{
-          presentation: 'transparentModal',
-          cardStyle: { backgroundColor: 'transparent' },
-        }}
+        options={rewardsModalScreenOptions}
       />
-    </Stack.Navigator>
+    </NativeStack.Navigator>
   );
 };
 

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
@@ -74,7 +74,7 @@ const RewardsSettingsView: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="RewardsSettingsView">
       <SafeAreaView
-        edges={{ top: 'additive' }}
+        edges={{ bottom: 'additive' }}
         style={tw.style('flex-1 bg-default')}
         testID={REWARDS_SETTINGS_SAFE_AREA_TEST_ID}
       >
@@ -82,6 +82,7 @@ const RewardsSettingsView: React.FC = () => {
           title={strings('rewards.settings.title')}
           onBack={() => navigation.goBack()}
           backButtonProps={{ testID: 'header-back-button' }}
+          includesTopInset
         />
         <Box twClassName="py-4 flex-1 gap-4">
           {offDeviceAccounts.length > 0 && (

--- a/app/components/Views/NavigationDevPanel/NavigationDevPanel.mockParams.ts
+++ b/app/components/Views/NavigationDevPanel/NavigationDevPanel.mockParams.ts
@@ -1,5 +1,8 @@
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import type { Nft } from '@metamask/assets-controllers';
+import { IconName } from '@metamask/design-system-react-native';
+import { SeasonRewardType } from '../../../core/Engine/controllers/rewards-controller/types';
+import type { CaipChainId } from '@metamask/utils';
 import { StatusTypes } from '@metamask/bridge-controller';
 import {
   DepositOrderType,
@@ -124,6 +127,70 @@ export const MOCK_SET_PASSWORD_FLOW_PARAMS = {
 
 export const MOCK_PR4A_PARAMS = {
   REVEAL_PRIVATE_CREDENTIAL: { shouldUpdateNav: true },
+};
+
+/** Static params so RewardsHome stack screens render from the dev panel. */
+export const MOCK_REWARDS_HOME_PARAMS = {
+  REWARDS_BOTTOM_SHEET_MODAL: {
+    title: 'Dev panel confirmation',
+    description: 'Mock rewards bottom sheet for navigation testing.',
+    confirmAction: {
+      label: 'Confirm',
+      onPress: () => {
+        // Dev panel noop — real flow runs confirmAction from rewards UI.
+      },
+    },
+    showCancelButton: true,
+    cancelLabel: 'Cancel',
+  },
+  REWARDS_CLAIM_BOTTOM_SHEET_MODAL: {
+    title: 'Dev panel claim reward',
+    description: 'Mock claim sheet for navigation testing.',
+    rewardId: 'dev-panel-reward-id',
+    seasonRewardId: 'dev-panel-season-reward-id',
+    rewardType: SeasonRewardType.GENERIC,
+    isLocked: false,
+    hasClaimed: false,
+    icon: IconName.Lock,
+  },
+  REWARDS_OPTIN_ACCOUNT_GROUP_MODAL: {
+    accountGroupId: 'keyring:wallet-1/ethereum',
+    addressData: [
+      {
+        address: '0x1234567890123456789012345678901234567890',
+        hasOptedIn: true,
+        scopes: ['eip155:1' as CaipChainId],
+        isSupported: true,
+      },
+      {
+        address: '0x0987654321098765432109876543210987654321',
+        hasOptedIn: false,
+        scopes: ['eip155:1' as CaipChainId],
+        isSupported: true,
+      },
+    ],
+  },
+  REWARDS_END_OF_SEASON_CLAIM_BOTTOM_SHEET: {
+    rewardId: 'dev-panel-end-of-season-reward-id',
+    seasonRewardId: 'dev-panel-end-of-season-season-reward-id',
+    title: 'Dev panel end-of-season reward',
+    description: 'Mock end-of-season claim sheet for navigation testing.',
+    rewardType: SeasonRewardType.METAL_CARD,
+    showEmail: 'required' as const,
+    showTelegram: 'optional' as const,
+  },
+  REWARDS_SELECT_SHEET: {
+    title: 'Select tier',
+    options: [
+      { key: 'bronze', label: 'Bronze', value: 'STARTER' },
+      { key: 'silver', label: 'Silver', value: 'MID' },
+      { key: 'platinum', label: 'Platinum', value: 'UPPER' },
+    ],
+    selectedValue: 'MID',
+    onSelect: (_value: string) => {
+      // Dev panel noop — real flow persists selection in rewards UI.
+    },
+  },
 };
 
 // --- PR4a TransactionsHome: dev order IDs & seed payloads ---

--- a/app/components/Views/NavigationDevPanel/NavigationDevPanel.tsx
+++ b/app/components/Views/NavigationDevPanel/NavigationDevPanel.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { Alert, TouchableOpacity } from 'react-native';
-import { useDispatch, useSelector } from 'react-redux';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
   Text,
@@ -28,6 +28,7 @@ import {
   MOCK_NFT_FULL_IMAGE_PARAMS,
   MOCK_OFFLINE_MODE_PARAMS,
   MOCK_PR4A_PARAMS,
+  MOCK_REWARDS_HOME_PARAMS,
   MOCK_SET_PASSWORD_FLOW_PARAMS,
   MOCK_WEBVIEW_PARAMS,
   resolvePr4aTransactionsHomeParams,
@@ -36,6 +37,7 @@ import {
   seedDevPanelDepositOrder,
   seedDevPanelRampsOrder,
   seedDevPanelSellOrder,
+  type Pr4aTransactionsHomeContext,
 } from './NavigationDevPanel.mockParams';
 
 /**
@@ -58,6 +60,8 @@ interface RouteEntry {
   needsParams?: boolean;
   /** Resolves params from wallet state (with dev fallbacks) and opens via Activity tab. */
   pr4aTransactionsHome?: boolean;
+  /** Opens via Rewards tab stack (RewardsHome). */
+  rewardsHome?: boolean;
 }
 
 interface RouteGroup {
@@ -66,7 +70,8 @@ interface RouteGroup {
 }
 
 // NOTE: Scoped to in-progress native-stack migration PRs. PR2 = single-screen
-// wrappers; PR3 = multi-screen leaf flows; PR4a = wallet + activity tab stacks.
+// wrappers; PR3 = multi-screen leaf flows; PR4a = wallet + activity tab stacks;
+// PR4b = rewards tab stack.
 // Uncomment groups below as each subsequent PR lands so the panel reflects
 // what is currently being migrated.
 const ROUTE_GROUPS: RouteGroup[] = [
@@ -196,6 +201,47 @@ const ROUTE_GROUPS: RouteGroup[] = [
         name: Routes.BRIDGE.BRIDGE_TRANSACTION_DETAILS,
         label: 'BridgeTransactionDetails',
         pr4aTransactionsHome: true,
+      },
+    ],
+  },
+  {
+    title: 'PR4b — RewardsHome',
+    routes: [
+      {
+        name: Routes.REWARDS_VIEW,
+        label: 'RewardsNavigator (stack root)',
+        rewardsHome: true,
+      },
+      {
+        name: Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
+        label: 'RewardsBottomSheetModal',
+        params: MOCK_REWARDS_HOME_PARAMS.REWARDS_BOTTOM_SHEET_MODAL,
+        rewardsHome: true,
+      },
+      {
+        name: Routes.MODAL.REWARDS_CLAIM_BOTTOM_SHEET_MODAL,
+        label: 'RewardsClaimBottomSheetModal',
+        params: MOCK_REWARDS_HOME_PARAMS.REWARDS_CLAIM_BOTTOM_SHEET_MODAL,
+        rewardsHome: true,
+      },
+      {
+        name: Routes.MODAL.REWARDS_OPTIN_ACCOUNT_GROUP_MODAL,
+        label: 'RewardOptInAccountGroupModal',
+        params: MOCK_REWARDS_HOME_PARAMS.REWARDS_OPTIN_ACCOUNT_GROUP_MODAL,
+        rewardsHome: true,
+      },
+      {
+        name: Routes.MODAL.REWARDS_END_OF_SEASON_CLAIM_BOTTOM_SHEET,
+        label: 'EndOfSeasonClaimBottomSheet',
+        params:
+          MOCK_REWARDS_HOME_PARAMS.REWARDS_END_OF_SEASON_CLAIM_BOTTOM_SHEET,
+        rewardsHome: true,
+      },
+      {
+        name: Routes.MODAL.REWARDS_SELECT_SHEET,
+        label: 'RewardsSelectSheet',
+        params: MOCK_REWARDS_HOME_PARAMS.REWARDS_SELECT_SHEET,
+        rewardsHome: true,
       },
     ],
   },
@@ -362,7 +408,7 @@ const NavigationDevPanel = () => {
   const transactions = useSelector(selectTransactions);
   const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
 
-  const pr4aTransactionsHomeContext = useMemo(
+  const pr4aTransactionsHomeContext = useMemo<Pr4aTransactionsHomeContext>(
     () => ({
       rampsOrders,
       fiatOrders,
@@ -372,18 +418,8 @@ const NavigationDevPanel = () => {
     [rampsOrders, fiatOrders, transactions, bridgeHistory],
   );
 
-  useLayoutEffect(() => {
-    navigation.setOptions(
-      getNavigationOptionsTitle(
-        'Navigation Dev Panel',
-        navigation,
-        false,
-        colors,
-        null,
-      ),
-    );
-  }, [navigation, colors]);
-
+  // Dev tool navigates to arbitrary registered routes, so the param list can't
+  // be statically typed here.
   const navigateUntyped = useCallback(
     (name: string, params?: Record<string, unknown>) => {
       (
@@ -397,6 +433,18 @@ const NavigationDevPanel = () => {
     },
     [navigation],
   );
+
+  useLayoutEffect(() => {
+    navigation.setOptions(
+      getNavigationOptionsTitle(
+        'Navigation Dev Panel',
+        navigation,
+        false,
+        colors,
+        null,
+      ),
+    );
+  }, [navigation, colors]);
 
   const navigateToTransactionsHomeScreen = useCallback(
     (screenName: string, screenParams: Record<string, unknown>) => {
@@ -420,8 +468,34 @@ const NavigationDevPanel = () => {
     [isMoneyAccountEnabled, navigateUntyped],
   );
 
+  const navigateToRewardsHomeScreen = useCallback(
+    (screenName?: string, screenParams?: Record<string, unknown>) => {
+      if (!screenName) {
+        navigateUntyped('Home', { screen: Routes.REWARDS_VIEW });
+        return;
+      }
+
+      navigateUntyped('Home', {
+        screen: Routes.REWARDS_VIEW,
+        params: {
+          screen: screenName,
+          params: screenParams,
+        },
+      });
+    },
+    [navigateUntyped],
+  );
+
   const handleNavigate = useCallback(
     (entry: RouteEntry) => {
+      if (entry.rewardsHome) {
+        navigateToRewardsHomeScreen(
+          entry.name === Routes.REWARDS_VIEW ? undefined : entry.name,
+          entry.params,
+        );
+        return;
+      }
+
       if (entry.pr4aTransactionsHome) {
         let screenParams: Record<string, unknown> | null = null;
 
@@ -484,6 +558,7 @@ const NavigationDevPanel = () => {
       bridgeHistory,
       dispatch,
       fiatOrders,
+      navigateToRewardsHomeScreen,
       navigateToTransactionsHomeScreen,
       navigateUntyped,
       pr4aTransactionsHomeContext,


### PR DESCRIPTION
## **Description**
This PR continues the MainNavigator native-stack migration by converting the Rewards tab outer stack (RewardsHome) from @react-navigation/stack to @react-navigation/native-stack.

RewardsHome hosts RewardsNavigator plus five transparent modal routes (bottom sheets) that overlay the full Rewards tab. All modal screens already render their own in-component headers (BottomSheetHeader / HeaderStandard), so no nav-header → HeaderStandard migration was needed in this PR.

Also extends the Navigation Dev Panel with a PR4b — RewardsHome route group (and supporting mock params / navigation helpers) so each Rewards stack screen can be opened directly for manual QA. These 2 files will be delete after migration is done so no review is needed here. 

Bugfix: I also fixed the layout shift from rewards screen to rewards settings

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-585

## **Manual testing steps**

```gherkin
Feature: RewardsHome transparent modals
  Scenario Outline: Rewards modal opens and dismisses
    Given I am on the Rewards tab
    When I open "<modal>"
    Then the "<modal>" should appear over Rewards content
    And I should be able to dismiss it
    Examples:
      | modal                          |
      | RewardsBottomSheetModal        |
      | RewardsClaimBottomSheetModal   |
      | RewardOptInAccountGroupModal   |
      | EndOfSeasonClaimBottomSheet    |
      | RewardsSelectSheet             |
```

## **Screenshots/Recordings**
|BEFORE|AFTER|
|---|---|
|<img width="368" height="762" alt="Rewards 1 before" src="https://github.com/user-attachments/assets/07910c31-fce7-4d3d-b8a1-e0e6ae9fae05" />|<img width="368" height="762" alt="Rewards 1 after" src="https://github.com/user-attachments/assets/c29b990f-218b-43ea-a100-dec4e5ed3f5d" />|

|BEFORE|AFTER|
|---|---|
|<img width="368" height="762" alt="Rewards 2 before" src="https://github.com/user-attachments/assets/249a4504-4b30-4271-9450-9a487cfc2fb4" />|<img width="368" height="762" alt="rewards 2 after" src="https://github.com/user-attachments/assets/2eb08286-1c78-4d56-99b5-9d8af2f36445" />|

Rewards settings layout shifts 
|BEFORE|AFTER|
|---|---|
|<img width="368" height="762" alt="rewards before" src="https://github.com/user-attachments/assets/8dcfd7b5-e1ce-4a9e-9c26-521168b07761" />|<img width="368" height="762" alt="rewards after" src="https://github.com/user-attachments/assets/db360c70-6049-4cf1-9e88-1cc713239047" />|

Android build: https://github.com/MetaMask/metamask-mobile/actions/runs/26920604761
Android video: https://github.com/user-attachments/assets/58ca59ad-5595-4366-b31e-51a26a1dbd06

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation presentation and safe-area tweaks on the Rewards tab and settings screen; no auth, payments, or core wallet logic changes.
> 
> **Overview**
> Migrates the **Rewards tab outer stack** (`RewardsHome`) from `@react-navigation/stack` to **`@react-navigation/native-stack`**, matching other migrated tab stacks. The stack still hosts `RewardsNavigator` plus five **transparent modal** routes (rewards bottom sheets); per-screen options now use shared **`transparentModalScreenOptions`** with transparent `contentStyle` instead of JS-stack `presentation: 'transparentModal'` + `cardStyle`.
> 
> **Rewards settings** layout is adjusted so the header owns the top inset (`HeaderStandard` with `includesTopInset`, `SafeAreaView` bottom-only edges), fixing a visible shift when navigating from Rewards into settings.
> 
> The **Navigation Dev Panel** gains a **PR4b — RewardsHome** group with mock params and nested navigation via the Rewards tab for manual QA of the migrated stack (dev-only; intended to be removed after migration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be53ca9c3b3d3e57abad71497a96bc269c7a511e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->