### PR TITLE
Fix MM Pay fiat ramp provider filtering

### DIFF
--- a/app/components/UI/Ramp/utils/determinePreferredProvider.test.ts
+++ b/app/components/UI/Ramp/utils/determinePreferredProvider.test.ts
@@ -60,6 +60,11 @@ const mockTransakProvider: Provider = {
   },
 };
 
+const mockTransakNativeProvider: Provider = {
+  ...mockTransakProvider,
+  id: '/providers/transak-native',
+};
+
 const makeFiatOrder = (
   overrides: Partial<FiatOrder> & { provider: string },
 ): FiatOrder => ({
@@ -221,6 +226,21 @@ describe('determinePreferredProvider', () => {
       });
     });
 
+    it('prefers Transak Native over Transak aggregator', () => {
+      const providers = [
+        mockProvider1,
+        mockTransakProvider,
+        mockTransakNativeProvider,
+      ];
+
+      const result = determinePreferredProvider([], providers);
+
+      expect(result).toEqual({
+        provider: mockTransakNativeProvider,
+        autoSelected: false,
+      });
+    });
+
     it('returns null if Transak is not available (no preselection without signal)', () => {
       const providers = [mockProvider1, mockProvider2];
 
@@ -269,6 +289,18 @@ describe('determinePreferredProvider', () => {
 
       expect(result).toEqual({
         provider: transakVariant,
+        autoSelected: false,
+      });
+    });
+
+    it('prefers Transak Native when legacy history ambiguously maps to Transak by name', () => {
+      const completedOrders = [{ providerId: 'TRANSAK', completedAt: 1000 }];
+      const providers = [mockTransakProvider, mockTransakNativeProvider];
+
+      const result = determinePreferredProvider(completedOrders, providers);
+
+      expect(result).toEqual({
+        provider: mockTransakNativeProvider,
         autoSelected: false,
       });
     });

--- a/app/components/UI/Ramp/utils/determinePreferredProvider.ts
+++ b/app/components/UI/Ramp/utils/determinePreferredProvider.ts
@@ -71,12 +71,24 @@ export interface PreferredProviderResult {
   autoSelected: boolean;
 }
 
+function isTransakNativeProvider(provider: Provider): boolean {
+  return provider.id?.toLowerCase().includes('transak-native') ?? false;
+}
+
+function isTransakProvider(provider: Provider): boolean {
+  return (
+    provider.id?.toLowerCase().includes('transak') ||
+    provider.name?.toLowerCase().includes('transak') ||
+    false
+  );
+}
+
 /**
  * Determines the preferred provider based on user's completed order history.
  *
  * Fallback order:
  * 1. Provider from most recent completed order (autoSelected: false)
- * 2. Transak (autoSelected: false)
+ * 2. Transak Native, then any Transak provider (autoSelected: false)
  * 3. null — no preselection; wait for the user to pick a token, then
  * choose the first provider that supports it.
  *
@@ -98,22 +110,22 @@ export function determinePreferredProvider(
       (a, b) => b.completedAt - a.completedAt,
     );
 
-    const foundProvider = availableProviders.find(
+    const matchingProviders = availableProviders.filter(
       (provider) =>
         provider.id?.toLowerCase() === mostRecent.providerId.toLowerCase() ||
         provider.name?.toLowerCase() === mostRecent.providerId.toLowerCase(),
     );
+    const foundProvider =
+      matchingProviders.find(isTransakNativeProvider) ?? matchingProviders[0];
 
     if (foundProvider) {
       return { provider: foundProvider, autoSelected: false };
     }
   }
 
-  const transakProvider = availableProviders.find(
-    (provider) =>
-      provider.id?.toLowerCase().includes('transak') ||
-      provider.name?.toLowerCase().includes('transak'),
-  );
+  const transakProvider =
+    availableProviders.find(isTransakNativeProvider) ??
+    availableProviders.find(isTransakProvider);
 
   if (transakProvider) {
     return { provider: transakProvider, autoSelected: false };

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts
@@ -3,18 +3,31 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useRampsProviders } from '../../../../UI/Ramp/hooks/useRampsProviders';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 
 jest.mock('./useMMPayFiatConfig');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+jest.mock('../../../../UI/Ramp/hooks/useRampsProviders');
 jest.mock('../transactions/useTransactionMetadataRequest');
 
 describe('useIsFiatPaymentAvailable', () => {
   const useMMPayFiatConfigMock = jest.mocked(useMMPayFiatConfig);
   const useRampsPaymentMethodsMock = jest.mocked(useRampsPaymentMethods);
+  const useRampsProvidersMock = jest.mocked(useRampsProviders);
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
+
+  const transakNativeProvider = {
+    id: '/providers/transak-native',
+    name: 'Transak',
+  };
+
+  const transakAggregatorProvider = {
+    id: '/providers/transak',
+    name: 'Transak',
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -27,6 +40,11 @@ describe('useIsFiatPaymentAvailable', () => {
     useRampsPaymentMethodsMock.mockReturnValue({
       paymentMethods: [{ id: 'apple-pay' }],
     } as unknown as ReturnType<typeof useRampsPaymentMethods>);
+
+    useRampsProvidersMock.mockReturnValue({
+      providers: [transakNativeProvider],
+      selectedProvider: transakNativeProvider,
+    } as unknown as ReturnType<typeof useRampsProviders>);
 
     useTransactionMetadataRequestMock.mockReturnValue({
       type: TransactionType.perpsDeposit,
@@ -68,6 +86,26 @@ describe('useIsFiatPaymentAvailable', () => {
 
   it('returns false when transaction metadata is undefined', () => {
     useTransactionMetadataRequestMock.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when payment methods are for Transak aggregator only', () => {
+    useRampsProvidersMock.mockReturnValue({
+      providers: [transakAggregatorProvider],
+      selectedProvider: transakAggregatorProvider,
+    } as unknown as ReturnType<typeof useRampsProviders>);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when selected Transak Native provider is stale for the current region', () => {
+    useRampsProvidersMock.mockReturnValue({
+      providers: [transakAggregatorProvider],
+      selectedProvider: transakNativeProvider,
+    } as unknown as ReturnType<typeof useRampsProviders>);
 
     const { result } = renderHook(() => useIsFiatPaymentAvailable());
     expect(result.current).toBe(false);

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
@@ -1,20 +1,39 @@
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useRampsProviders } from '../../../../UI/Ramp/hooks/useRampsProviders';
 import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 
+const TRANSAK_NATIVE_PROVIDER_ID_FRAGMENT = 'transak-native';
+
+function isTransakNativeProvider(
+  provider: { id?: string } | null | undefined,
+): boolean {
+  return (
+    provider?.id?.toLowerCase().includes(TRANSAK_NATIVE_PROVIDER_ID_FRAGMENT) ??
+    false
+  );
+}
+
 /**
  * Returns whether fiat payment is available for the current transaction.
  * True when the transaction type is fiat-enabled via remote feature flags
- * AND at least one Ramps payment method exists.
+ * AND the current region exposes Transak Native payment methods.
  */
 export function useIsFiatPaymentAvailable(): boolean {
   const transactionMeta = useTransactionMetadataRequest();
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const { paymentMethods } = useRampsPaymentMethods();
+  const { providers, selectedProvider } = useRampsProviders();
+
+  const isSelectedProviderAvailableInRegion = providers.some(
+    (provider) => provider.id === selectedProvider?.id,
+  );
 
   return (
     hasTransactionType(transactionMeta, enabledTransactionTypes) &&
+    isSelectedProviderAvailableInRegion &&
+    isTransakNativeProvider(selectedProvider) &&
     paymentMethods.length > 0
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Require MM Pay fiat availability to use the current-region Transak Native provider, not any ramps payment method.
- Prefer Transak Native over the Transak aggregator when ramps auto-selects a Transak fallback.
- Add regression coverage for aggregator-only and stale-provider availability cases.

## Testing
- `yarn jest app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts app/components/UI/Ramp/utils/determinePreferredProvider.test.ts` printed PASS for both suites, then Node hit a heap OOM during Jest teardown.
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest --runInBand --forceExit app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts app/components/UI/Ramp/utils/determinePreferredProvider.test.ts` printed PASS for both suites, then hung during teardown and was stopped.
- `NODE_OPTIONS='--max-old-space-size=12288' yarn eslint app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts app/components/UI/Ramp/utils/determinePreferredProvider.ts app/components/UI/Ramp/utils/determinePreferredProvider.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0AK3NXRM7W/p1780512193447679?thread_ts=1780512193.447679&cid=C0AK3NXRM7W)

<div><a href="https://cursor.com/agents/bc-29024a0b-9b7f-50d9-a690-e81ffa30ce0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29024a0b-9b7f-50d9-a690-e81ffa30ce0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

