### PR TITLE
fix(rewards): avoid misleading zero PnL display for sub-cent values

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignLeaderboard.tsx
@@ -38,7 +38,8 @@ export interface CampaignLeaderboardEntryRowProps<
   /** When true, hides the pending tag for the current user’s row (campaign ended). */
   isCampaignComplete?: boolean;
   formatPrimaryMetric: (entry: T) => string;
-  isPositivePrimaryMetric: (entry: T) => boolean;
+  /** Return true for positive, false for negative, null for neutral (no colour). */
+  isPositivePrimaryMetric: (entry: T) => boolean | null;
 }
 
 export function CampaignLeaderboardEntryRow<
@@ -53,17 +54,21 @@ export function CampaignLeaderboardEntryRow<
 }: CampaignLeaderboardEntryRowProps<T>) {
   const isPositive = isPositivePrimaryMetric(entry);
   const textColor = isCurrentUser
-    ? isPositive
+    ? isPositive === true
       ? TextColor.SuccessDefault
-      : TextColor.ErrorDefault
+      : isPositive === false
+        ? TextColor.ErrorDefault
+        : TextColor.TextDefault
     : TextColor.TextDefault;
   const isPending = !entry.qualified;
   const rowBg = isCurrentUser
     ? isPending
       ? 'bg-muted'
-      : isPositive
+      : isPositive === true
         ? 'bg-success-muted'
-        : 'bg-error-muted'
+        : isPositive === false
+          ? 'bg-error-muted'
+          : 'bg-muted'
     : '';
 
   const showPendingTag = isCurrentUser && isPending && !isCampaignComplete;

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.test.tsx
@@ -118,6 +118,41 @@ describe('PerpsCampaignStatsSummary', () => {
     expect(pnlCell.props.color).toBe(TextColor.ErrorDefault);
   });
 
+  it('uses default color and near-zero label for a tiny positive pnl', () => {
+    const { getByTestId, getByText } = render(
+      <PerpsCampaignStatsSummary
+        leaderboardPosition={{ ...basePosition, pnl: 0.003 }}
+        leaderboard={mockLeaderboard}
+      />,
+    );
+    const pnlCell = getByTestId(TEST_IDS.PNL);
+    expect(pnlCell.props.color).toBe(TextColor.TextDefault);
+    expect(getByText('< $0.01')).toBeDefined();
+  });
+
+  it('uses default color and near-zero label for a tiny negative pnl', () => {
+    const { getByTestId, getByText } = render(
+      <PerpsCampaignStatsSummary
+        leaderboardPosition={{ ...basePosition, pnl: -0.003 }}
+        leaderboard={mockLeaderboard}
+      />,
+    );
+    const pnlCell = getByTestId(TEST_IDS.PNL);
+    expect(pnlCell.props.color).toBe(TextColor.TextDefault);
+    expect(getByText('> -$0.01')).toBeDefined();
+  });
+
+  it('uses default color for exactly zero pnl', () => {
+    const { getByTestId } = render(
+      <PerpsCampaignStatsSummary
+        leaderboardPosition={{ ...basePosition, pnl: 0 }}
+        leaderboard={mockLeaderboard}
+      />,
+    );
+    const pnlCell = getByTestId(TEST_IDS.PNL);
+    expect(pnlCell.props.color).toBe(TextColor.TextDefault);
+  });
+
   it('renders em dashes when position is null', () => {
     const { getAllByText } = render(
       <PerpsCampaignStatsSummary

--- a/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsCampaignStatsSummary.tsx
@@ -18,7 +18,11 @@ import type {
   PerpsTradingCampaignLeaderboardPositionDto,
 } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../../locales/i18n';
-import { formatSignedUsd, formatUsd } from '../../utils/formatUtils';
+import {
+  formatPnlDisplay,
+  formatUsd,
+  isPnlNearZero,
+} from '../../utils/formatUtils';
 import { PERPS_QUALIFICATION_NOTIONAL_USD } from '../../utils/perpsCampaignConstants';
 import { PendingTag, StatCell } from './OndoCampaignStatsSummary';
 import { CampaignOutcomeBanner } from './CampaignOutcomeBanners';
@@ -72,11 +76,11 @@ const PerpsCampaignStatsSummary: React.FC<PerpsCampaignStatsSummaryProps> = ({
 
   const rankDisplay = rank != null ? String(rank).padStart(2, '0') : '—';
 
-  const pnlDisplay = pnl != null ? formatSignedUsd(pnl) : '—';
+  const pnlDisplay = pnl != null ? formatPnlDisplay(pnl) : '—';
 
   const pnlColor =
-    pnl != null
-      ? pnl >= 0
+    pnl != null && !isPnlNearZero(pnl)
+      ? pnl > 0
         ? TextColor.SuccessDefault
         : TextColor.ErrorDefault
       : TextColor.TextDefault;

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.test.tsx
@@ -23,7 +23,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('../../utils/formatUtils', () => ({
-  formatSignedUsd: (value: number) => `$${value.toFixed(2)}`,
+  formatPnlDisplay: (value: number) => `$${value.toFixed(2)}`,
+  isPnlNearZero: (value: number) => Math.abs(value) < 0.005,
 }));
 
 jest.mock('../RewardsErrorBanner', () => {

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignLeaderboard.tsx
@@ -10,7 +10,7 @@ import {
 import type { PerpsTradingCampaignLeaderboardEntry } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../../locales/i18n';
 import RewardsErrorBanner from '../RewardsErrorBanner';
-import { formatSignedUsd } from '../../utils/formatUtils';
+import { formatPnlDisplay, isPnlNearZero } from '../../utils/formatUtils';
 import {
   CampaignLeaderboardEntryRow,
   CampaignLeaderboardNeighborSeparator,
@@ -201,8 +201,10 @@ const PerpsTradingCampaignLeaderboard: React.FC<
             isCurrentUser={isCurrentUser(entry)}
             showCrown={!isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS}
             isCampaignComplete={isCampaignComplete}
-            formatPrimaryMetric={(e) => formatSignedUsd(e.pnl)}
-            isPositivePrimaryMetric={(e) => e.pnl >= 0}
+            formatPrimaryMetric={(e) => formatPnlDisplay(e.pnl)}
+            isPositivePrimaryMetric={(e) =>
+              isPnlNearZero(e.pnl) ? null : e.pnl > 0
+            }
           />
         ))}
         {showSplitView && userPosition && (
@@ -217,8 +219,10 @@ const PerpsTradingCampaignLeaderboard: React.FC<
                   !isPreview && entry.rank <= PERPS_TRADING_MAX_WINNERS
                 }
                 isCampaignComplete={isCampaignComplete}
-                formatPrimaryMetric={(e) => formatSignedUsd(e.pnl)}
-                isPositivePrimaryMetric={(e) => e.pnl >= 0}
+                formatPrimaryMetric={(e) => formatPnlDisplay(e.pnl)}
+                isPositivePrimaryMetric={(e) =>
+                  isPnlNearZero(e.pnl) ? null : e.pnl > 0
+                }
               />
             ))}
           </>

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -416,6 +416,33 @@ export const formatSignedUsd = (value: string | number | null): string => {
   return `${sign}${formatUsd(value)}`;
 };
 
+// Values whose absolute amount is below this threshold round to $0.00 at 2dp.
+const PNL_NEAR_ZERO_THRESHOLD = 0.005;
+
+/**
+ * Returns true when a PnL value is too small to display as a non-zero dollar
+ * amount at 2 decimal places (i.e. |pnl| < $0.005).
+ */
+export const isPnlNearZero = (pnl: number): boolean =>
+  Math.abs(pnl) < PNL_NEAR_ZERO_THRESHOLD;
+
+/**
+ * Formats a PnL number for display.  Very small non-zero values that would
+ * round to "$0.00" are shown as "< $0.01" / "> -$0.01" instead of misleading
+ * zeroes.  Exactly-zero values are formatted normally via formatSignedUsd.
+ *
+ * @example formatPnlDisplay(0.003)   // '< $0.01'
+ * @example formatPnlDisplay(-0.003)  // '> -$0.01'
+ * @example formatPnlDisplay(0)       // '$0.00'
+ * @example formatPnlDisplay(5000)    // '+$5,000.00'
+ */
+export const formatPnlDisplay = (pnl: number): string => {
+  if (pnl !== 0 && isPnlNearZero(pnl)) {
+    return pnl > 0 ? '< $0.01' : '> -$0.01';
+  }
+  return formatSignedUsd(pnl);
+};
+
 // ── Percent / rate formatting ───────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- Adds `formatPnlDisplay()` / `isPnlNearZero()` to `formatUtils.ts`: values where `|pnl| < $0.005` (which round to `$0.00` at 2dp) are shown as `< $0.01` or `> -$0.01` instead of a misleading zero
- `CampaignLeaderboardEntryRow` now accepts `boolean | null` for `isPositivePrimaryMetric`; `null` renders with neutral (default) colour and background — near-zero PnL no longer highlights the current-user row red or green
- Both the stats summary card and the leaderboard rows use the new helpers

## Changelog

CHANGELOG entry: null

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only rewards UI changes with unit tests; no auth, payments, or data pipeline impact.
> 
> **Overview**
> Fixes misleading **sub-cent PnL** in the Perps trading campaign UI: values with `|pnl| < $0.005` no longer show as `$0.00` or get red/green styling.
> 
> Adds **`formatPnlDisplay`** and **`isPnlNearZero`** in `formatUtils` so tiny non-zero amounts render as `< $0.01` / `> -$0.01`, while true zero still uses normal signed USD formatting. **`PerpsCampaignStatsSummary`** and **`PerpsTradingCampaignLeaderboard`** switch to these helpers; PnL color only applies when the amount is meaningfully positive or negative.
> 
> **`CampaignLeaderboardEntryRow`** now treats **`isPositivePrimaryMetric`** as `boolean | null`: `null` uses neutral text and muted background for the current user’s row instead of success/error highlights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a3e4ec46131f3ca472d9b8b658358731551808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->