### PR TITLE
fix: keep QuickBuy CTA live during background quote refresh

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyAmount.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyAmount.tsx
@@ -17,7 +17,7 @@ const QuickBuyAmount: React.FC = () => {
     sourceToken,
     estimatedReceiveAmount,
     destToken,
-    isQuoteLoading,
+    isBlockingQuoteLoad,
     hiddenInputRef,
     handleAmountAreaPress,
     handleAmountChange,
@@ -42,7 +42,7 @@ const QuickBuyAmount: React.FC = () => {
       usdAmount={usdAmount}
       destSymbol={cryptoSymbol}
       estimatedReceiveAmount={displayedCryptoAmount}
-      isQuoteLoading={isQuoteLoading}
+      isQuoteLoading={isBlockingQuoteLoad}
       isUnpricedSource={isUnpricedSource}
       sourceCryptoAmount={sourceAmountTokens}
       sourceSymbol={sourceToken?.symbol ?? target.tokenSymbol}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyContext.test.tsx
@@ -70,6 +70,7 @@ const buildController = (
   formattedRate: undefined,
   totalAmountUsd: '$0',
   isQuoteLoading: false,
+  isBlockingQuoteLoad: false,
   isSubmittingTx: false,
   isTotalLoading: false,
   sortedQuotes: [],

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -165,6 +165,7 @@ const buildHookResult = (
   formattedRate: undefined,
   totalAmountUsd: '$0',
   isQuoteLoading: false,
+  isBlockingQuoteLoad: false,
   isSubmittingTx: false,
   isTotalLoading: false,
   sortedQuotes: [],

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
@@ -202,6 +202,7 @@ const buildHookResult = (
   formattedRate: undefined,
   totalAmountUsd: '$0',
   isQuoteLoading: false,
+  isBlockingQuoteLoad: false,
   isSubmittingTx: false,
   isTotalLoading: false,
   sortedQuotes: [],

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -452,6 +452,7 @@ export function useQuickBuyController(
     isNoQuotesAvailable,
     quoteFetchError,
     isActiveQuoteForCurrentTokenPair,
+    isQuoteRequestStale,
     quotesLastFetchedAt,
     refreshCount,
     quoteRefreshRateMs,
@@ -1079,14 +1080,18 @@ export function useQuickBuyController(
     Boolean(activeQuote) && !isActiveQuoteForCurrentTokenPair;
 
   // A usable quote for exactly what's displayed: present, for the current token
-  // pair, for the current (committed) amount, and not mid-drag. When this holds,
-  // an in-flight fetch is a benign background refresh — the displayed quote stays
-  // valid and submittable and is swapped in place when the new one lands.
+  // pair, for the current (committed) amount, not mid-drag, and for the current
+  // request-only inputs (slippage, destination address, gas settings). When this
+  // holds, an in-flight fetch is a benign background refresh — the displayed
+  // quote stays valid and submittable and is swapped in place when the new one
+  // lands. When a request input changes, the displayed quote no longer matches
+  // the request being fetched, so it is not usable until the new quote arrives.
   const hasUsableQuoteOnScreen =
     Boolean(activeQuote) &&
     isActiveQuoteForCurrentTokenPair &&
     !isPendingQuoteRefresh &&
-    !isAmountUncommitted;
+    !isAmountUncommitted &&
+    !isQuoteRequestStale;
 
   // Loading that should block the UI: first load or an input change with no
   // usable quote yet. A plain background refresh is excluded so the CTA and the
@@ -1103,6 +1108,7 @@ export function useQuickBuyController(
     !activeQuote ||
     hasQuoteMismatch ||
     isPendingQuoteRefresh ||
+    isQuoteRequestStale ||
     isBlockingQuoteLoad ||
     hasInsufficientBalance ||
     isNetworkFeeUnavailable ||
@@ -1113,7 +1119,8 @@ export function useQuickBuyController(
     !walletAddress;
 
   const isTotalLoading =
-    hasValidAmount && (isBlockingQuoteLoad || isPendingQuoteRefresh);
+    hasValidAmount &&
+    (isBlockingQuoteLoad || isPendingQuoteRefresh || isQuoteRequestStale);
 
   const isConfirmLoading = isSubmittingTx;
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -153,6 +153,12 @@ export interface UseQuickBuyControllerResult {
   totalAmountUsd: string;
   // quote state
   isQuoteLoading: boolean;
+  /**
+   * True only when a quote load should block the UI (first load or an input
+   * change with no usable quote yet). False during benign background refreshes,
+   * so the CTA stays enabled and the receive estimate stays visible.
+   */
+  isBlockingQuoteLoad: boolean;
   isSubmittingTx: boolean;
   isTotalLoading: boolean;
   // all quotes for the select-quote screen
@@ -1072,6 +1078,21 @@ export function useQuickBuyController(
   const hasQuoteMismatch =
     Boolean(activeQuote) && !isActiveQuoteForCurrentTokenPair;
 
+  // A usable quote for exactly what's displayed: present, for the current token
+  // pair, for the current (committed) amount, and not mid-drag. When this holds,
+  // an in-flight fetch is a benign background refresh — the displayed quote stays
+  // valid and submittable and is swapped in place when the new one lands.
+  const hasUsableQuoteOnScreen =
+    Boolean(activeQuote) &&
+    isActiveQuoteForCurrentTokenPair &&
+    !isPendingQuoteRefresh &&
+    !isAmountUncommitted;
+
+  // Loading that should block the UI: first load or an input change with no
+  // usable quote yet. A plain background refresh is excluded so the CTA and the
+  // receive estimate are not blanked every refresh tick.
+  const isBlockingQuoteLoad = isQuoteLoading && !hasUsableQuoteOnScreen;
+
   const isConfirmDisabled =
     !hasValidAmount ||
     isAmountUncommitted ||
@@ -1082,7 +1103,7 @@ export function useQuickBuyController(
     !activeQuote ||
     hasQuoteMismatch ||
     isPendingQuoteRefresh ||
-    isQuoteLoading ||
+    isBlockingQuoteLoad ||
     hasInsufficientBalance ||
     isNetworkFeeUnavailable ||
     hasInsufficientGas ||
@@ -1092,7 +1113,7 @@ export function useQuickBuyController(
     !walletAddress;
 
   const isTotalLoading =
-    hasValidAmount && (isQuoteLoading || isPendingQuoteRefresh);
+    hasValidAmount && (isBlockingQuoteLoad || isPendingQuoteRefresh);
 
   const isConfirmLoading = isSubmittingTx;
 
@@ -1160,6 +1181,7 @@ export function useQuickBuyController(
     formattedRate,
     totalAmountUsd,
     isQuoteLoading,
+    isBlockingQuoteLoad,
     isSubmittingTx,
     isTotalLoading,
     sortedQuotes,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyQuotes.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyQuotes.ts
@@ -73,6 +73,13 @@ export interface UseQuickBuyQuotesResult {
   quoteFetchError: string | null;
   isNoQuotesAvailable: boolean;
   isActiveQuoteForCurrentTokenPair: boolean;
+  /**
+   * True when request-only inputs the consumer cannot observe (slippage,
+   * destination address, gas settings) have changed since the currently
+   * displayed quotes were fetched. While true, the displayed quotes no longer
+   * match the active request and must not be treated as submittable.
+   */
+  isQuoteRequestStale: boolean;
   /** Number of quotes returned by the most recent successful request. */
   quoteCount: number;
   /** Timestamp (ms) of the last successful quotes fetch. */
@@ -190,6 +197,24 @@ export function useQuickBuyQuotes({
   // Tracks request timing so the received-event can report latency.
   const requestStartedAtRef = useRef<number | null>(null);
 
+  // Signature of the request-only inputs (slippage, destination address, gas
+  // settings) that the consumer of this hook cannot observe. Used to detect when
+  // the displayed quotes were fetched for a different request than the current
+  // one so the CTA is not left enabled with a stale quote.
+  const requestParamsKey = useMemo(
+    () =>
+      JSON.stringify({
+        slippage: slippage ?? null,
+        destAddress: destAddress ?? null,
+        gasIncluded,
+        gasIncluded7702,
+      }),
+    [slippage, destAddress, gasIncluded, gasIncluded7702],
+  );
+  // The request-params signature the most recently settled quotes were fetched
+  // for. Null until the first fetch settles (or after quotes are reset).
+  const settledRequestParamsKeyRef = useRef<string | null>(null);
+
   const resetQuotesIdle = useCallback(() => {
     setRawQuotes([]);
     setIsQuoteLoading(false);
@@ -198,6 +223,7 @@ export function useQuickBuyQuotes({
     setQuotesLastFetchedAt(null);
     setQuotesLastAttemptAt(null);
     setRefreshCount(0);
+    settledRequestParamsKeyRef.current = null;
   }, []);
 
   const fetchQuotes = useCallback(async () => {
@@ -229,6 +255,15 @@ export function useQuickBuyQuotes({
       resetQuotesIdle();
       return;
     }
+
+    // Snapshot of the request-only inputs this fetch is for, recorded as settled
+    // once the result (or error) lands so later input changes register as stale.
+    const fetchedRequestParamsKey = JSON.stringify({
+      slippage: slippage ?? null,
+      destAddress: destAddress ?? null,
+      gasIncluded,
+      gasIncluded7702,
+    });
 
     const controller = new AbortController();
     abortControllerRef.current = controller;
@@ -285,6 +320,7 @@ export function useQuickBuyQuotes({
         return;
       }
 
+      settledRequestParamsKeyRef.current = fetchedRequestParamsKey;
       setRawQuotes(result);
       setIsNoQuotesAvailable(result.length === 0);
       setIsQuoteLoading(false);
@@ -311,6 +347,7 @@ export function useQuickBuyQuotes({
           },
         }),
       );
+      settledRequestParamsKeyRef.current = fetchedRequestParamsKey;
       setQuoteFetchError(message);
       setRawQuotes([]);
       setIsNoQuotesAvailable(false);
@@ -472,6 +509,13 @@ export function useQuickBuyQuotes({
         )
       : undefined;
 
+  // The displayed quotes were fetched for a settled request; if the current
+  // request-only inputs no longer match it, the quotes are stale. Before the
+  // first settle (ref null) there is nothing displayed to be stale against.
+  const isQuoteRequestStale =
+    settledRequestParamsKeyRef.current !== null &&
+    settledRequestParamsKeyRef.current !== requestParamsKey;
+
   return {
     activeQuote,
     sortedQuotes,
@@ -480,6 +524,7 @@ export function useQuickBuyQuotes({
     quoteFetchError,
     isNoQuotesAvailable,
     isActiveQuoteForCurrentTokenPair,
+    isQuoteRequestStale,
     quoteCount: sortedQuotes.length,
     quotesLastFetchedAt,
     refreshCount,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -975,6 +975,91 @@ describe('useQuickBuyController', () => {
       // QuickBuyContext.handleBuy which routes to priceImpactConfirm instead.
       expect(result.current.isConfirmDisabled).toBe(false);
     });
+
+    it('keeps the CTA enabled during a background refresh of a usable quote', () => {
+      const quoteState: UseQuickBuyQuotesResult = {
+        activeQuote: undefined,
+        destTokenAmount: undefined,
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        sortedQuotes: [],
+        quoteCount: 0,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      };
+      (useQuickBuyQuotes as jest.Mock).mockImplementation(() => quoteState);
+
+      const props = {
+        target: createTarget(),
+        onClose: jest.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ target, onClose }) => useQuickBuyController(target, onClose),
+        { initialProps: props },
+      );
+
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+      quoteState.isQuoteLoading = true;
+      rerender(props);
+      quoteState.isQuoteLoading = false;
+      quoteState.activeQuote = createActiveQuote();
+      rerender(props);
+      rerender(props);
+
+      expect(result.current.isConfirmDisabled).toBe(false);
+
+      quoteState.isQuoteLoading = true;
+      rerender(props);
+
+      expect(result.current.isBlockingQuoteLoad).toBe(false);
+      expect(result.current.isConfirmDisabled).toBe(false);
+      expect(result.current.isTotalLoading).toBe(false);
+    });
+
+    it('blocks the CTA on the initial load when no usable quote exists yet', () => {
+      const quoteState: UseQuickBuyQuotesResult = {
+        activeQuote: undefined,
+        destTokenAmount: undefined,
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        sortedQuotes: [],
+        quoteCount: 0,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      };
+      (useQuickBuyQuotes as jest.Mock).mockImplementation(() => quoteState);
+
+      const props = {
+        target: createTarget(),
+        onClose: jest.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ target, onClose }) => useQuickBuyController(target, onClose),
+        { initialProps: props },
+      );
+
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+      quoteState.isQuoteLoading = true;
+      rerender(props);
+
+      expect(result.current.isBlockingQuoteLoad).toBe(true);
+      expect(result.current.isConfirmDisabled).toBe(true);
+      expect(result.current.isTotalLoading).toBe(true);
+    });
   });
 
   describe('source token auto-selection', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -326,6 +326,7 @@ const setupDefaultMocks = () => {
     isNoQuotesAvailable: false,
     quoteFetchError: null,
     isActiveQuoteForCurrentTokenPair: true,
+    isQuoteRequestStale: false,
     quoteCount: 0,
     quotesLastFetchedAt: null,
     refreshCount: 0,
@@ -627,6 +628,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -672,6 +674,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -724,6 +727,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -754,6 +758,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -783,6 +788,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -828,6 +834,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -878,6 +885,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -935,6 +943,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -984,6 +993,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -1031,6 +1041,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -1057,6 +1068,57 @@ describe('useQuickBuyController', () => {
       rerender(props);
 
       expect(result.current.isBlockingQuoteLoad).toBe(true);
+      expect(result.current.isConfirmDisabled).toBe(true);
+      expect(result.current.isTotalLoading).toBe(true);
+    });
+
+    it('blocks the CTA when a request input change makes the displayed quote stale', () => {
+      const quoteState: UseQuickBuyQuotesResult = {
+        activeQuote: undefined,
+        destTokenAmount: undefined,
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
+        sortedQuotes: [],
+        quoteCount: 0,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      };
+      (useQuickBuyQuotes as jest.Mock).mockImplementation(() => quoteState);
+
+      const props = {
+        target: createTarget(),
+        onClose: jest.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ target, onClose }) => useQuickBuyController(target, onClose),
+        { initialProps: props },
+      );
+
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+      quoteState.isQuoteLoading = true;
+      rerender(props);
+      quoteState.isQuoteLoading = false;
+      quoteState.activeQuote = createActiveQuote();
+      rerender(props);
+      rerender(props);
+
+      expect(result.current.isConfirmDisabled).toBe(false);
+
+      // Slippage/destination address/gas settings changed: the quotes hook keeps
+      // the prior activeQuote but flags the request as stale. The CTA must
+      // disable even before a new fetch starts (no blocking load reported yet).
+      quoteState.isQuoteRequestStale = true;
+      rerender(props);
+
+      expect(result.current.isBlockingQuoteLoad).toBe(false);
       expect(result.current.isConfirmDisabled).toBe(true);
       expect(result.current.isTotalLoading).toBe(true);
     });
@@ -1536,6 +1598,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         quoteCount: sortedQuotes.length,
         quotesLastFetchedAt: Date.now(),
         refreshCount: 1,
@@ -1594,6 +1657,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -1632,6 +1696,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -1667,6 +1732,7 @@ describe('useQuickBuyController', () => {
         isNoQuotesAvailable: false,
         quoteFetchError: null,
         isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
         sortedQuotes: [],
         quoteCount: 0,
         quotesLastFetchedAt: null,
@@ -1709,6 +1775,7 @@ describe('useQuickBuyController', () => {
           isNoQuotesAvailable: false,
           quoteFetchError: null,
           isActiveQuoteForCurrentTokenPair: true,
+          isQuoteRequestStale: false,
           sortedQuotes: [],
           quoteCount: 0,
           quotesLastFetchedAt: null,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyQuotes.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyQuotes.test.ts
@@ -520,4 +520,56 @@ describe('useQuickBuyQuotes', () => {
     const lastCallFields = mockSelectBridgeQuotesBase.mock.calls.at(-1)?.[0];
     expect(lastCallFields.quotes).toEqual([fetched]);
   });
+
+  it('flags isQuoteRequestStale when slippage changes after quotes settle, then clears once refetched', async () => {
+    fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
+
+    const { result, rerender } = renderHook(() =>
+      useQuickBuyQuotes({
+        sourceToken: createSourceToken(),
+        destToken: createDestToken(),
+        sourceTokenAmount: '0.001',
+      }),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(QUICK_BUY_QUOTE_DEBOUNCE_MS);
+    });
+    await waitFor(() => expect(fetchQuotesMock).toHaveBeenCalledTimes(1));
+    expect(result.current.isQuoteRequestStale).toBe(false);
+
+    (selectSlippage as unknown as jest.Mock).mockReturnValue('1');
+    rerender({});
+
+    expect(result.current.isQuoteRequestStale).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(QUICK_BUY_QUOTE_DEBOUNCE_MS);
+    });
+
+    await waitFor(() => expect(result.current.isQuoteRequestStale).toBe(false));
+  });
+
+  it('flags isQuoteRequestStale when the destination address changes', async () => {
+    fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
+
+    const { result, rerender } = renderHook(() =>
+      useQuickBuyQuotes({
+        sourceToken: createSourceToken(),
+        destToken: createDestToken(),
+        sourceTokenAmount: '0.001',
+      }),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(QUICK_BUY_QUOTE_DEBOUNCE_MS);
+    });
+    await waitFor(() => expect(fetchQuotesMock).toHaveBeenCalledTimes(1));
+    expect(result.current.isQuoteRequestStale).toBe(false);
+
+    (selectDestAddress as unknown as jest.Mock).mockReturnValue('0xRECIPIENT');
+    rerender({});
+
+    expect(result.current.isQuoteRequestStale).toBe(true);
+  });
 });


### PR DESCRIPTION
## **Description**



https://github.com/user-attachments/assets/8d03658d-f20d-4a4e-8e62-d6d49dd520a8




In QuickBuy, quotes auto-refresh on a fixed interval. The data layer already keeps the displayed quote live during a refresh (`useQuickBuyQuotes` only flips `isQuoteLoading = true` and atomically swaps `rawQuotes` on success — it never clears the existing quote). However, the controller wired the raw `isQuoteLoading` flag into the CTA disable gate and the amount-section spinner.

As a result, on every refresh tick the Buy/Sell button greyed out and the receive estimate was replaced by a spinner, even though the on-screen quote stayed valid and submittable the entire time. This produced a visible, recurring flicker.

This PR introduces `isBlockingQuoteLoad` — loading that has no usable on-screen quote yet (first load, or an input change where the current quote no longer matches). A plain background refresh is excluded, so the CTA stays enabled and the receive estimate stays visible, then updates in place when the new quote arrives.

The genuine "no usable quote for what's displayed" cases remain blocked via the existing, more precise guards:
- mid-drag -> `isAmountUncommitted`
- amount changed, quote is for old amount -> `isPendingQuoteRefresh`
- token pair changed -> `hasQuoteMismatch`
- no quote / error -> `!activeQuote`, `hasError`

The all-quotes select screen keeps consuming raw `isQuoteLoading`, where reflecting refresh activity is desirable.

### Key changes
- `useQuickBuyController.ts`: derive `hasUsableQuoteOnScreen` + `isBlockingQuoteLoad`; use the latter in `isConfirmDisabled` and `isTotalLoading`; expose it on the result type.
- `QuickBuyAmount.tsx`: feed `isBlockingQuoteLoad` to the amount section so the receive estimate persists during refresh.
- Added controller tests for the background-refresh (enabled) and initial-load (blocked) cases; updated typed context mocks.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: QuickBuy non-blocking quote refresh

  Scenario: user keeps the CTA usable while quotes auto-refresh
    Given the user has opened QuickBuy and selected a valid amount with a quote shown

    When the periodic quote refresh runs in the background
    Then the Buy/Sell button stays enabled
    And the receive estimate stays visible (no spinner) and updates in place when the new quote lands

  Scenario: user changes the amount
    Given the user has a quote on screen

    When the user changes the amount or token
    Then the CTA is disabled and the loading state is shown until a matching quote arrives
```

## **Screenshots/Recordings**

### **Before**

<!-- CTA greys out + receive estimate replaced by spinner on every refresh tick -->

### **After**

<!-- CTA stays enabled, estimate stays visible and updates in place -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote gating and submit-disable logic for trades; incorrect stale/usable detection could allow or block submission at the wrong time, though new flags and tests target those cases.
> 
> **Overview**
> QuickBuy was treating every quote fetch as a full UI block: the Buy/Sell CTA and receive estimate reacted to raw `isQuoteLoading`, so periodic auto-refresh caused flicker even when the on-screen quote stayed valid.
> 
> The controller now derives **`isBlockingQuoteLoad`** (loading only when there is no **usable** quote for the current amount, token pair, and committed inputs) and wires that into confirm disable, total loading, and the amount section spinner. **`useQuickBuyQuotes`** adds **`isQuoteRequestStale`** when hidden request inputs (slippage, destination address, gas flags) change after the last settled fetch, so the CTA cannot stay enabled on a quote that no longer matches the active request.
> 
> Initial load and real input changes still block as before; benign background refreshes keep the CTA enabled and the estimate visible until the new quote lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc095abe82e8ce0e4dc59fc76dadda628b477676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->