### PR TITLE
feat: add exclusive lock mode to `Toast` component

### DIFF
--- a/app/component-library/components/Toast/Toast.stories.tsx
+++ b/app/component-library/components/Toast/Toast.stories.tsx
@@ -45,6 +45,76 @@ export default {
   },
 } as Meta;
 
+export const ExclusiveLock = {
+  render: function Render() {
+    const { toastRef } = useContext(ToastContext);
+    const tw = useTailwind();
+
+    const showExclusive = () => {
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Plain,
+        labelOptions: [
+          { label: 'Transaction pending...', isBold: true },
+          { label: ' This toast cannot be replaced.' },
+        ],
+        hasNoTimeout: true,
+        exclusive: true,
+      });
+    };
+
+    const showNormal = () => {
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Plain,
+        labelOptions: [{ label: 'Normal toast — will be blocked.' }],
+        hasNoTimeout: false,
+      });
+    };
+
+    const showForceOverride = () => {
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Plain,
+        labelOptions: [
+          { label: 'Transaction confirmed!', isBold: true },
+          { label: ' Forced through the lock.' },
+        ],
+        hasNoTimeout: true,
+        exclusive: true,
+        force: true,
+      });
+    };
+
+    const dismiss = () => {
+      toastRef?.current?.closeToast();
+    };
+
+    return (
+      <View style={tw.style('min-h-[300px] relative gap-y-2')}>
+        <Button
+          variant={ButtonVariants.Primary}
+          label="1. Show Exclusive Toast"
+          onPress={showExclusive}
+        />
+        <Button
+          variant={ButtonVariants.Secondary}
+          label="2. Try Normal Toast (blocked)"
+          onPress={showNormal}
+        />
+        <Button
+          variant={ButtonVariants.Secondary}
+          label="3. Force Override (exclusive → exclusive)"
+          onPress={showForceOverride}
+        />
+        <Button
+          variant={ButtonVariants.Secondary}
+          label="4. Dismiss Toast (release lock)"
+          onPress={dismiss}
+        />
+        <ToastComponent ref={toastRef} />
+      </View>
+    );
+  },
+};
+
 export const Default = {
   args: {
     variant: ToastVariants.Plain,

--- a/app/component-library/components/Toast/Toast.test.tsx
+++ b/app/component-library/components/Toast/Toast.test.tsx
@@ -166,6 +166,145 @@ describe('Toast', () => {
     expect(screen.getByText('Success')).toBeOnTheScreen();
   });
 
+  describe('exclusive toast lock', () => {
+    const exclusiveOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [{ label: 'Exclusive Toast' }],
+      hasNoTimeout: true,
+      exclusive: true,
+    };
+
+    const normalOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [{ label: 'Normal Toast' }],
+      hasNoTimeout: false,
+    };
+
+    const forcedOptions: ToastOptions = {
+      variant: ToastVariants.Plain,
+      labelOptions: [{ label: 'Forced Toast' }],
+      hasNoTimeout: true,
+      force: true,
+    };
+
+    it('blocks non-force toasts while exclusive toast is active', async () => {
+      render(<Toast ref={toastRef} />);
+
+      await act(async () => {
+        toastRef.current?.showToast(exclusiveOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Exclusive Toast')).toBeOnTheScreen();
+
+      await act(async () => {
+        toastRef.current?.showToast(normalOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Exclusive Toast')).toBeOnTheScreen();
+      expect(screen.queryByText('Normal Toast')).toBeNull();
+    });
+
+    it('allows force toast to override exclusive toast', async () => {
+      render(<Toast ref={toastRef} />);
+
+      await act(async () => {
+        toastRef.current?.showToast(exclusiveOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Exclusive Toast')).toBeOnTheScreen();
+
+      await act(async () => {
+        toastRef.current?.showToast(forcedOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('Exclusive Toast')).toBeNull();
+      expect(screen.getByText('Forced Toast')).toBeOnTheScreen();
+    });
+
+    it('releases lock when closeToast is called', async () => {
+      render(<Toast ref={toastRef} />);
+
+      await act(async () => {
+        toastRef.current?.showToast(exclusiveOptions);
+        jest.runAllTimers();
+      });
+
+      await act(async () => {
+        toastRef.current?.closeToast();
+        jest.runAllTimers();
+      });
+
+      await act(async () => {
+        toastRef.current?.showToast(normalOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Normal Toast')).toBeOnTheScreen();
+    });
+
+    it('supports back-to-back exclusive toasts with force', async () => {
+      const secondExclusive: ToastOptions = {
+        variant: ToastVariants.Plain,
+        labelOptions: [{ label: 'Second Exclusive' }],
+        hasNoTimeout: true,
+        exclusive: true,
+        force: true,
+      };
+
+      render(<Toast ref={toastRef} />);
+
+      await act(async () => {
+        toastRef.current?.showToast(exclusiveOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Exclusive Toast')).toBeOnTheScreen();
+
+      await act(async () => {
+        toastRef.current?.showToast(secondExclusive);
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('Exclusive Toast')).toBeNull();
+      expect(screen.getByText('Second Exclusive')).toBeOnTheScreen();
+
+      await act(async () => {
+        toastRef.current?.showToast(normalOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Second Exclusive')).toBeOnTheScreen();
+      expect(screen.queryByText('Normal Toast')).toBeNull();
+    });
+
+    it('does not lock when exclusive is not set', async () => {
+      render(<Toast ref={toastRef} />);
+
+      const firstOptions: ToastOptions = {
+        variant: ToastVariants.Plain,
+        labelOptions: [{ label: 'First' }],
+        hasNoTimeout: true,
+      };
+
+      await act(async () => {
+        toastRef.current?.showToast(firstOptions);
+        jest.runAllTimers();
+      });
+
+      await act(async () => {
+        toastRef.current?.showToast(normalOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('First')).toBeNull();
+      expect(screen.getByText('Normal Toast')).toBeOnTheScreen();
+    });
+  });
+
   it('uses flex-start justifyContent on labels container by default', async () => {
     const toastOptions: ToastOptions = {
       variant: ToastVariants.Plain,

--- a/app/component-library/components/Toast/Toast.test.tsx
+++ b/app/component-library/components/Toast/Toast.test.tsx
@@ -303,6 +303,32 @@ describe('Toast', () => {
       expect(screen.queryByText('First')).toBeNull();
       expect(screen.getByText('Normal Toast')).toBeOnTheScreen();
     });
+
+    it('closeToast cancels a pending deferred toast', async () => {
+      render(<Toast ref={toastRef} />);
+
+      await act(async () => {
+        toastRef.current?.showToast(exclusiveOptions);
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Exclusive Toast')).toBeOnTheScreen();
+
+      act(() => {
+        toastRef.current?.showToast({
+          ...exclusiveOptions,
+          labelOptions: [{ label: 'Deferred Exclusive' }],
+          force: true,
+        });
+      });
+
+      await act(async () => {
+        toastRef.current?.closeToast();
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('Deferred Exclusive')).toBeNull();
+    });
   });
 
   it('uses flex-start justifyContent on labels container by default', async () => {

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -66,6 +66,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   const { bottom: bottomNotchSpacing } = useSafeAreaInsets();
   const translateYProgress = useSharedValue(screenHeight);
   const pendingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exclusiveRef = useRef(false);
   const customOffset = toastOptions?.customBottomOffset ?? 0;
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
@@ -77,13 +78,22 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
     [styles.base, animatedStyle],
   );
 
-  const resetState = () => setToastOptions(undefined);
+  const resetState = () => {
+    exclusiveRef.current = false;
+    setToastOptions(undefined);
+  };
 
   const showToast = (options: ToastOptions) => {
+    if (exclusiveRef.current && !options.force) {
+      return;
+    }
+
     if (pendingTimeoutRef.current !== null) {
       clearTimeout(pendingTimeoutRef.current);
       pendingTimeoutRef.current = null;
     }
+
+    exclusiveRef.current = !!options.exclusive;
 
     let timeoutDuration = 0;
     if (toastOptions) {
@@ -101,6 +111,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   };
 
   const closeToast = () => {
+    exclusiveRef.current = false;
     translateYProgress.value = withTiming(
       screenHeight,
       { duration: animationDuration },

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -93,8 +93,6 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
       pendingTimeoutRef.current = null;
     }
 
-    exclusiveRef.current = !!options.exclusive;
-
     let timeoutDuration = 0;
     if (toastOptions) {
       if (!options.hasNoTimeout) {
@@ -106,6 +104,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
     }
     pendingTimeoutRef.current = setTimeout(() => {
       pendingTimeoutRef.current = null;
+      exclusiveRef.current = !!options.exclusive;
       setToastOptions(options);
     }, timeoutDuration);
   };

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -95,9 +95,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
 
     let timeoutDuration = 0;
     if (toastOptions) {
-      if (!options.hasNoTimeout) {
-        cancelAnimation(translateYProgress);
-      }
+      cancelAnimation(translateYProgress);
       timeoutDuration = 100;
       // Clear existing toast state to prevent animation conflicts when showing rapid successive toasts
       setToastOptions(undefined);

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -110,6 +110,10 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   };
 
   const closeToast = () => {
+    if (pendingTimeoutRef.current !== null) {
+      clearTimeout(pendingTimeoutRef.current);
+      pendingTimeoutRef.current = null;
+    }
     exclusiveRef.current = false;
     translateYProgress.value = withTiming(
       screenHeight,

--- a/app/component-library/components/Toast/Toast.types.ts
+++ b/app/component-library/components/Toast/Toast.types.ts
@@ -53,6 +53,16 @@ interface BaseToastVariants {
   closeButtonOptions?: ToastCloseButtonOptions;
   startAccessory?: ReactElement;
   customBottomOffset?: number;
+  /**
+   * When true, prevents other toasts from replacing this one until it is
+   * dismissed (via timeout or explicit `closeToast()`).
+   */
+  exclusive?: boolean;
+  /**
+   * When true, overrides an active exclusive toast. Use together with
+   * `exclusive` to chain back-to-back exclusive toasts.
+   */
+  force?: boolean;
 }
 
 export type ToastCloseButtonOptions =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Currently any `showToast` call unconditionally replaces whatever toast is on screen. When multiple features fire toasts in quick succession (e.g. a transaction-in-progress toast stomped by a network-change toast), the user loses important feedback.

This PR adds two new optional fields to `ToastOptions`:

- **`exclusive?: boolean`** – when `true`, the toast "locks" the slot. All subsequent `showToast` calls are silently dropped until the toast is dismissed (via timeout or explicit `closeToast()`).
- **`force?: boolean`** – when `true`, overrides an active exclusive toast. Combine with `exclusive: true` to chain back-to-back exclusive toasts (e.g. "pending…" → "confirmed!") without releasing the lock.

Both default to `undefined`/`false`, so **all existing callers are unaffected**.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes part of: https://consensyssoftware.atlassian.net/browse/CONF-1493

## **Manual testing steps**

```gherkin
Feature: Exclusive Toast Lock

  Scenario: exclusive toast blocks normal toasts
    Given the app is running

    When a toast is shown with exclusive: true
    And another toast is triggered without force: true
    Then the second toast is silently dropped
    And the exclusive toast remains visible

  Scenario: force overrides exclusive toast
    Given an exclusive toast is currently showing

    When a toast is shown with force: true
    Then the new toast replaces the exclusive one

  Scenario: closeToast releases the lock
    Given an exclusive toast is currently showing

    When closeToast() is called
    And a normal toast is triggered
    Then the normal toast appears as expected

  Scenario: back-to-back exclusive toasts
    Given an exclusive toast is currently showing

    When a toast is shown with force: true and exclusive: true
    Then the new toast replaces the old one
    And subsequent normal toasts are still blocked
```

Use the **ExclusiveLock** Storybook story (`Component Library / Toast`) to
exercise all four scenarios via dedicated buttons.

## **Screenshots/Recordings**

### **Before**

Any toast call replaces the current toast unconditionally.

### **After**

Normal Toast gets blocked:

https://github.com/user-attachments/assets/0679bb81-4145-4520-9ca5-cb9b4fd4d547

Normal Toast removed when exclusive toast is asked:


https://github.com/user-attachments/assets/d875d898-4413-4043-b613-53cc0f45eec0




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the deprecated component-library Toast with opt-in flags defaulting off; behavior change for rapid toast replacement is limited to always canceling animation when swapping toasts.
> 
> **Overview**
> Adds an **exclusive toast lock** to the component-library `Toast`: optional `exclusive` and `force` on `ToastOptions`, with behavior implemented in `showToast` / `closeToast` via an internal ref.
> 
> While an exclusive toast is showing, later `showToast` calls are **no-ops** unless `force: true`. **`force`** replaces the current toast (including another exclusive one) so flows like pending → confirmed can chain without releasing the lock. **`closeToast`** clears pending deferred shows, drops the lock, and allows normal toasts again. Replacing an existing toast now always **`cancelAnimation`** on the slide animation (not only when the incoming toast has a timeout).
> 
> Coverage includes a Storybook **ExclusiveLock** demo and unit tests for block, force override, dismiss, chained exclusive, and canceling a pending forced toast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728474ccc13394d5a4cae58fe6c48dd1a95b70c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->