### PR TITLE
fix(money): preserve trailing decimal on max conversion (MUSD-894)

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -350,6 +350,17 @@ describe('useTransactionCustomAmount', () => {
     expect(result.current.amountFiat).toBe('567.89');
   });
 
+  it('pads targetAmount.usd to two decimals when isMaxAmount is true', async () => {
+    useTransactionPayIsMaxAmountMock.mockReturnValue(true);
+    useTransactionPayTotalsMock.mockReturnValue({
+      targetAmount: { usd: '3.4' },
+    } as TransactionPayTotals);
+
+    const { result } = runHook();
+
+    expect(result.current.amountFiat).toBe('3.40');
+  });
+
   it.each([
     TransactionType.perpsWithdraw,
     TransactionType.predictWithdraw,
@@ -833,7 +844,7 @@ describe('useTransactionCustomAmount', () => {
         result.current.updatePendingAmountPercentage(100);
       });
 
-      expect(result.current.amountFiat).toBe('750.5');
+      expect(result.current.amountFiat).toBe('750.50');
     });
 
     it('returns 0 when payment override is MoneyAccount but totalFiatRaw is undefined', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -37,6 +37,10 @@ import { useConfirmationMetricEvents } from '../metrics/useConfirmationMetricEve
 export const MAX_LENGTH = 28;
 const DEBOUNCE_DELAY = 500;
 
+function formatFiatAmount(value: BigNumber): string {
+  return value.isInteger() ? value.toString(10) : value.toFixed(2);
+}
+
 export function useTransactionCustomAmount({
   currency,
 }: { currency?: string } = {}) {
@@ -98,9 +102,12 @@ export function useTransactionCustomAmount({
       targetAmountUsd &&
       targetAmountUsd !== '0'
     ) {
-      return new BigNumber(targetAmountUsd)
-        .decimalPlaces(2, BigNumber.ROUND_HALF_UP)
-        .toString(10);
+      return formatFiatAmount(
+        new BigNumber(targetAmountUsd).decimalPlaces(
+          2,
+          BigNumber.ROUND_HALF_UP,
+        ),
+      );
     }
 
     return amountFiatState;
@@ -170,11 +177,12 @@ export function useTransactionCustomAmount({
         return;
       }
 
-      const newAmount = new BigNumber(percentage)
-        .dividedBy(100)
-        .multipliedBy(balanceUsd)
-        .decimalPlaces(2, BigNumber.ROUND_DOWN)
-        .toString(10);
+      const newAmount = formatFiatAmount(
+        new BigNumber(percentage)
+          .dividedBy(100)
+          .multipliedBy(balanceUsd)
+          .decimalPlaces(2, BigNumber.ROUND_DOWN),
+      );
 
       setConfirmationMetric({
         properties: {


### PR DESCRIPTION
## **Description**

On the Money Account *Add funds* / max-conversion screen, selecting **Max** dropped the last digit of the displayed amount: a `$3.40` balance rendered as `$3.4` while the rest of the screen correctly showed `US$3.40`.

The fiat amount string was built with `BigNumber.toString(10)`, which normalizes away trailing zeros from a two-decimal currency value. This happened in two paths of `useTransactionCustomAmount`: the `isMaxAmount` branch of the `amountFiat` memo (the value shown once the quote resolves) and `updatePendingAmountPercentage` (the value the instant a percentage/Max is tapped).

A small `formatFiatAmount` helper now pads fractional amounts to exactly two decimals (`3.4` → `3.40`) while leaving whole numbers untouched (`0` → `0`, `500` → `500`), so round-number display in the shared perps/predict/pay flows is unchanged.

## **Changelog**

CHANGELOG entry: Fixed the amount on the Money Account max conversion screen dropping its last decimal digit (e.g. showing $3.4 instead of $3.40).

## **Related issues**

Fixes: MUSD-894

## **Manual testing steps**

```gherkin
Feature: Money Account max conversion amount

  Scenario: user selects Max with a balance ending in a trailing zero
    Given the user is on the Add funds screen with an mUSD balance of US$3.40

    When the user taps Max
    Then the displayed amount shows $3.40 (not $3.4)
    And whole-number balances (e.g. $500) still display without forced decimals
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-string formatting in the confirmation amount hook with existing rounding rules; tests updated, no auth or payment logic changes.
> 
> **Overview**
> Fixes **Money Account max conversion** (and related pay flows) showing fiat amounts like `$3.4` instead of `$3.40` when the last decimal digit is zero.
> 
> Adds **`formatFiatAmount`** in `useTransactionCustomAmount`: fractional values use **`toFixed(2)`** after rounding/truncation; whole numbers stay unpadded (e.g. `500`, `0`). That helper now formats **`amountFiat`** when **Max** uses quoted `targetAmount.usd`, and **`updatePendingAmountPercentage`** when the user taps a percentage or Max.
> 
> Tests cover padded max-quote display (`3.4` → `3.40`) and Money Account **100%** balance display (`750.50`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f91608b655d04a8f7f999138966d4006288241e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->