### PR TITLE
fix: Revert  enhance useTransakRouting to resolve wallet address from headless

### DIFF
--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -22,13 +22,6 @@ jest.mock('../headless/sessionRegistry', () => ({
   failSession: jest.fn(),
 }));
 
-jest.mock('../headless', () => ({
-  getChainIdFromAssetId: (assetId: string) => {
-    const slashIndex = assetId.indexOf('/');
-    return slashIndex <= 0 ? null : assetId.slice(0, slashIndex);
-  },
-}));
-
 const MOCK_WALLET_ADDRESS = '0xabcdef1234567890';
 
 jest.mock('react-redux', () => ({
@@ -40,13 +33,9 @@ jest.mock('react-redux', () => ({
   })),
 }));
 
-const mockUseRampAccountAddress = jest.fn(
-  (_chainId?: unknown): string | null => MOCK_WALLET_ADDRESS,
-);
-
 jest.mock('./useRampAccountAddress', () => ({
   __esModule: true,
-  default: (chainId: unknown) => mockUseRampAccountAddress(chainId),
+  default: () => MOCK_WALLET_ADDRESS,
 }));
 
 jest.mock('../../../../util/theme', () => {
@@ -406,69 +395,6 @@ describe('useTransakRouting', () => {
           ],
         }),
       );
-    });
-
-    it('resolves the wallet address from the headless session assetId, not the async-seeded selectedToken (TRAM-3598)', async () => {
-      const mockGetSession = jest.requireMock('../headless/sessionRegistry')
-        .getSession as jest.Mock;
-      mockGetSession.mockReturnValue({
-        id: 'hs-1',
-        params: { assetId: 'eip155:42161/slip44:60' },
-        callbacks: {
-          onOrderCreated: jest.fn(),
-          onClose: jest.fn(),
-          onError: jest.fn(),
-        },
-      });
-      mockGetUserDetails.mockResolvedValue({
-        firstName: 'John',
-        lastName: 'Doe',
-        mobileNumber: '+1',
-        dob: '1990-01-01',
-        address: {},
-      });
-      mockGetKycRequirement.mockResolvedValue({
-        status: 'APPROVED',
-        kycType: 'SIMPLE',
-      });
-      mockGetUserLimits.mockResolvedValue({
-        remaining: { '1': 10000, '30': 50000, '365': 200000 },
-      });
-      mockRequestOtt.mockResolvedValue({ ott: 'test-ott' });
-      mockGeneratePaymentWidgetUrl.mockReturnValue(
-        'https://payment.example.com',
-      );
-
-      const { result } = renderHook(() =>
-        useTransakRouting({
-          baseRoute: 'RampHeadlessHost',
-          baseRouteParams: { headlessSessionId: 'hs-1' },
-        }),
-      );
-      await act(async () => {
-        await result.current.routeAfterAuthentication(
-          mockQuote as never,
-          mockQuote.fiatAmount,
-        );
-      });
-
-      expect(mockUseRampAccountAddress).toHaveBeenCalledWith('eip155:42161');
-      expect(mockGeneratePaymentWidgetUrl).toHaveBeenCalledWith(
-        'test-ott',
-        mockQuote,
-        MOCK_WALLET_ADDRESS,
-        { theme: 'light' },
-      );
-    });
-
-    it('falls back to the selectedToken chain when there is no headless session', () => {
-      const mockGetSession = jest.requireMock('../headless/sessionRegistry')
-        .getSession as jest.Mock;
-      mockGetSession.mockReturnValue(undefined);
-
-      renderHook(() => useTransakRouting());
-
-      expect(mockUseRampAccountAddress).toHaveBeenCalledWith('eip155:1');
     });
 
     it('navigates to bank details for manual bank transfer when KYC is APPROVED', async () => {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -34,7 +34,6 @@ import {
   getSession,
 } from '../headless/sessionRegistry';
 import { dismissHeadlessFlow } from '../headless/headlessEntryNavigation';
-import { getChainIdFromAssetId } from '../headless';
 
 interface RampStackParamList {
   /** `baseRouteParams` (e.g. `headlessSessionId`) are merged onto this route in resets — see `navigateToVerifyIdentityCallback`. */
@@ -168,11 +167,9 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const { selectedPaymentMethod } = useRampsPaymentMethods();
 
   const { selected: selectedToken } = useSelector(selectTokens);
-  const headlessAssetId = getSession(headlessSessionId)?.params?.assetId;
-  const walletAddressChainId =
-    (headlessAssetId ? getChainIdFromAssetId(headlessAssetId) : null) ??
-    (selectedToken?.chainId as CaipChainId | undefined);
-  const walletAddress = useRampAccountAddress(walletAddressChainId);
+  const walletAddress = useRampAccountAddress(
+    selectedToken?.chainId as CaipChainId,
+  );
 
   const fiatCurrency = userRegion?.country?.currency || '';
   const regionIsoCode = userRegion?.regionCode || '';


### PR DESCRIPTION
## **Description**

This reverts #31021 (commit 81c088f6f6).

**Why:** <!-- REQUIRED: state what broke. e.g. "The change caused a regression
where <X>; <crash/wrong behavior> was observed in <flow>." -->

The original PR fixed the Headless Ramps "Add funds" wallet-address seeding race
(TRAM-3598) by deriving the wallet-address chain from the headless session
`assetId`. We are reverting because <reason>, and will re-land a corrected fix
under TRAM-3598.

## **Changelog**

CHANGELOG entry: null

<!--
The reverted change was not yet in a shipped release (labeled release-7.81.0),
so no user-facing changelog is needed. If it HAD shipped, instead write:
`CHANGELOG entry: Reverted the "Add funds" wallet-address resolution change.`
-->

## **Related issues**

Re-opens: https://consensyssoftware.atlassian.net/browse/TRAM-3598

<!--
Intentionally NOT using "Fixes:" — this revert re-introduces the bug, so the
Jira ticket should be re-opened, not closed.
-->

## **Manual testing steps**

```gherkin
Feature: Revert Headless Ramps wallet-address routing change

  Scenario: App behavior matches the state prior to #31021
    Given the revert is applied
    When I run the headless "Add funds" flow
    Then behavior matches main as of before #31021 was merged
```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — straight revert -->

### **After**

<!-- N/A — straight revert -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Headless Transak buys may again use the wrong chain’s wallet address when selectedToken lags the session asset (the bug TRAM-3598 fixed).
> 
> **Overview**
> This **reverts** the TRAM-3598 change that derived the Transak wallet address from the headless session’s `assetId` (via `getChainIdFromAssetId`) with a fallback to the Redux `selectedToken` chain.
> 
> `useTransakRouting` again calls `useRampAccountAddress` with only **`selectedToken?.chainId`**, so payment widget URLs, order creation, and checkout redirects use whatever chain the ramps token selector has—not necessarily the headless buy asset’s chain. Related unit tests and mocks for that behavior are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8aa4d1d0d4da18b906d556c85f1c0108713b6f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->