### PR TITLE
test: fix ff default value

### DIFF
--- a/tests/api-mocking/helpers/remoteFeatureFlagsHelper.test.ts
+++ b/tests/api-mocking/helpers/remoteFeatureFlagsHelper.test.ts
@@ -255,6 +255,26 @@ describe('Remote Feature Flags Helper', () => {
         arrayFlag: { replaced: 'with object' },
       });
     });
+
+    it('pins homepage trending sections A/B test to control by default', () => {
+      const result = createRemoteFeatureFlagsMock();
+
+      const response = result.response as Record<string, unknown>[];
+      expect(response).toContainEqual({
+        homeTMCU470AbtestTrendingSections: 'control',
+      });
+    });
+
+    it('allows homepage trending sections A/B test override', () => {
+      const result = createRemoteFeatureFlagsMock({
+        homeTMCU470AbtestTrendingSections: 'trendingSections',
+      });
+
+      const response = result.response as Record<string, unknown>[];
+      expect(response).toContainEqual({
+        homeTMCU470AbtestTrendingSections: 'trendingSections',
+      });
+    });
   });
 
   describe('setupRemoteFeatureFlagsMock', () => {

--- a/tests/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/tests/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -63,6 +63,9 @@ const E2E_SAFE_DEFAULTS: Record<string, unknown> = {
   mobileMinimumVersions: {
     appMinimumBuild: 1,
   },
+  // Production uses a percentage rollout for this A/B test. Pin E2E to control
+  // so homepage section labels do not depend on the generated analytics ID.
+  homeTMCU470AbtestTrendingSections: 'control',
 };
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

This PR makes the E2E remote feature-flag mock deterministic for the homepage
trending-sections A/B test.

The flaky behavior came from `setupRemoteFeatureFlagsMock(mockServer, {})`
serving the production registry defaults. For
`homeTMCU470AbtestTrendingSections`, the production default is a percentage
rollout array, not a fixed `control` value. `RemoteFeatureFlagController`
resolves that rollout at runtime using a deterministic threshold based on:

```text
sha256(analyticsId + flagName)
```

That means the same build and the same mocked feature-flag endpoint can still
render different homepage UI if the runtime analytics ID differs:

- `control` renders the regular `Perpetuals` section.
- `trendingSections` renders the separate `Trending perpetuals` section.

The fix pins `homeTMCU470AbtestTrendingSections` to `control` in the shared
E2E-safe mock defaults. Individual tests can still explicitly opt into
`trendingSections` by passing an override to `createRemoteFeatureFlagsMock` or
`setupRemoteFeatureFlagsMock`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: E2E remote feature flag defaults

  Scenario: homepage trending sections A/B test is deterministic in E2E mocks
    Given the E2E remote feature flag mock is created with default overrides
    When the mock response is generated
    Then homeTMCU470AbtestTrendingSections resolves to control

  Scenario: a test intentionally opts into the treatment
    Given the E2E remote feature flag mock is created with a trendingSections override
    When the mock response is generated
    Then homeTMCU470AbtestTrendingSections resolves to trendingSections
```

Verified with:

```sh
NODE_OPTIONS=--max-old-space-size=8192 yarn jest tests/api-mocking/helpers/remoteFeatureFlagsHelper.test.ts --runInBand --watchman=false --forceExit
```

Result: `1` test suite passed, `23` tests passed.

## **Screenshots/Recordings**

Not applicable. Test-only change.

### **Before**

E2E default feature-flag mocks could return the production rollout array for
`homeTMCU470AbtestTrendingSections`, allowing runtime analytics ID bucketing to
choose either homepage variant.

### **After**

E2E default feature-flag mocks pin `homeTMCU470AbtestTrendingSections` to
`control`, so existing specs continue to see the `Perpetuals` section unless a
spec explicitly overrides the variant.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to API-mocking defaults; no production app or auth logic.
>
> **Overview**
> E2E remote feature-flag mocks now **pin** `homeTMCU470AbtestTrendingSections` to **`control`** in `E2E_SAFE_DEFAULTS`, alongside existing safe defaults like `mobileMinimumVersions`. Production’s percentage rollout made homepage section labels depend on the generated analytics ID; pinning keeps API-mocked E2E runs deterministic.
>
> Two unit tests assert the default mock includes `control` and that `createRemoteFeatureFlagsMock({ homeTMCU470AbtestTrendingSections: 'trendingSections' })` still overrides the pin.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d4df1ba7d59d83471b07c169fb99340db3dc7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
