### PR TITLE
feat: add skip-pod-install input to E2E setup action and adjust timeout for iOS test-runner jobs

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -102,6 +102,13 @@ inputs:
       Per-attempt timeout (minutes) for the CocoaPods install retry step (iOS only).
     required: false
     default: '15'
+  skip-pod-install:
+    description: >-
+      Skip Ruby, bundler, and CocoaPods pod install steps (iOS only).
+      Safe to set to 'true' for test-runner jobs that use a pre-built app artifact
+      — Detox does not require the Pods directory to run tests.
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -343,19 +350,19 @@ runs:
 
     ## Ruby Setup & Cache Management
     - name: Setup Ruby
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd
       with:
         ruby-version: ${{ inputs.ruby-version }}
 
     - name: Install bundler
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: gem install bundler -v ${{ inputs.bundler-version }}
       working-directory: ios
       shell: bash
 
     - name: Restore Bundler cache
-      if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' && inputs.runner_provider != 'namespace' }}
       uses: actions/cache@v4
       with:
         path: ios/vendor/bundle
@@ -364,30 +371,30 @@ runs:
           ${{ inputs.cache-prefix }}-bundler-${{ inputs.platform }}-${{ runner.os }}-
 
     - name: Configure bundler install path
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: bundle config set path 'vendor/bundle'
       working-directory: ios
       shell: bash
 
     - name: Install Ruby gems via bundler
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: bundle install
       working-directory: ios
       shell: bash
 
     - name: Generate binstubs for CocoaPods
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: bundle binstubs cocoapods --force --path=vendor/bundle/bin
       working-directory: ios
       shell: bash
 
     - name: Add binstubs to PATH
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: echo "$(pwd)/ios/vendor/bundle/bin" >> "$GITHUB_PATH"
       shell: bash
 
     - name: Verify CocoaPods
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: |
         bundle show cocoapods || (echo "❌ CocoaPods not installed from ios/Gemfile" && exit 1)
         bundle exec pod --version
@@ -395,7 +402,7 @@ runs:
       shell: bash
 
     - name: Verify CocoaPods BinStub
-      if: ${{ inputs.platform == 'ios' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       run: |
         bundle show cocoapods || (echo "❌ CocoaPods not installed from ios/Gemfile" && exit 1)
         pod --version
@@ -412,7 +419,7 @@ runs:
       shell: bash
 
     - name: Restore CocoaPods specs cache
-      if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' && inputs.runner_provider != 'namespace' }}
       id: cocoapods-specs-cache
       uses: actions/cache@v4
       with:
@@ -423,7 +430,7 @@ runs:
       continue-on-error: true
 
     - name: Install CocoaPods via bundler
-      if: ${{ inputs.platform == 'ios'}}
+      if: ${{ inputs.platform == 'ios' && inputs.skip-pod-install != 'true' }}
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
       with:
         timeout_minutes: ${{ fromJSON(inputs.pod-install-timeout-minutes) }}

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -149,7 +149,7 @@ jobs:
         # headroom than the composite default (see INFRA-3596 / run 25755790077 timeouts).
         # pod-install is skipped for iOS test-runner jobs: the app is pre-built and Detox
         # does not require the Pods directory to run tests.
-        timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && 20 || 25 }}
+        timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && 30 || 25 }}
         uses: ./.github/actions/setup-e2e-env
         with:
           platform: ${{ inputs.platform }}
@@ -162,17 +162,11 @@ jobs:
           pod-install-timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && '22' || '15' }}
           skip-pod-install: ${{ inputs.platform == 'ios' && 'true' || 'false' }}
 
-      - name: Restore Detox framework cache
-        if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Detox
-          key: detox-framework-${{ runner.os }}-${{ hashFiles('node_modules/detox/package.json') }}
-
       - name: Build Detox framework cache (iOS)
         if: ${{ inputs.platform == 'ios' }}
         run: |
           echo "Building Detox framework cache for iOS..."
+          yarn detox clean-framework-cache
           yarn detox build-framework-cache
 
       - name: Determine android target paths and Artifact Names

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -135,6 +135,7 @@ jobs:
             .metamask
             .yarn/cache
             ~/Library/Detox
+            node_modules
 
       - name: Restore .metamask folder
         if: ${{ inputs.runner_provider != 'namespace' }}
@@ -146,7 +147,9 @@ jobs:
       - name: Set up E2E environment
         # Namespace iOS smoke runs many matrix jobs in parallel; CocoaPods + yarn need more
         # headroom than the composite default (see INFRA-3596 / run 25755790077 timeouts).
-        timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && 45 || 25 }}
+        # pod-install is skipped for iOS test-runner jobs: the app is pre-built and Detox
+        # does not require the Pods directory to run tests.
+        timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && 20 || 25 }}
         uses: ./.github/actions/setup-e2e-env
         with:
           platform: ${{ inputs.platform }}
@@ -157,12 +160,19 @@ jobs:
           runner_provider: ${{ inputs.runner_provider }}
           js-retry-timeout-minutes: ${{ inputs.runner_provider == 'namespace' && '20' || '15' }}
           pod-install-timeout-minutes: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' && '22' || '15' }}
+          skip-pod-install: ${{ inputs.platform == 'ios' && 'true' || 'false' }}
+
+      - name: Restore Detox framework cache
+        if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Detox
+          key: detox-framework-${{ runner.os }}-${{ hashFiles('node_modules/detox/package.json') }}
 
       - name: Build Detox framework cache (iOS)
         if: ${{ inputs.platform == 'ios' }}
         run: |
           echo "Building Detox framework cache for iOS..."
-          yarn detox clean-framework-cache
           yarn detox build-framework-cache
 
       - name: Determine android target paths and Artifact Names


### PR DESCRIPTION
## **Description**

iOS E2E test-runner jobs were spending ~8m48s (Cirrus) and ~5m48s (Namespace) on environment setup, with the majority of that time consumed by the Ruby → Bundler → CocoaPods → `pod install` chain. Since iOS test-runner jobs use a **pre-built `.app` artifact**, the Pods directory is not needed — Detox 20.x does not integrate via CocoaPods and does not require `ios/Pods/` to run tests.

This PR introduces a `skip-pod-install` input to the `setup-e2e-env` composite action that skips the entire Ruby/Bundler/CocoaPods chain for jobs that do not need it. The `run-e2e-workflow.yml` enables this for all iOS test-runner shards.

**Measured impact (27 shards, Cirrus runners):**
- Setup time: **8m48s → 2m00s** average (−6m48s per shard)
- Total job time: **17m44s → 11m38s** average
- Across 27 parallel shards: ~**176 minutes of compute eliminated per run**

Additional changes:
- `node_modules` added to the Namespace iOS cache path (mirrors existing Android config)
- iOS Namespace setup step timeout reduced from 45 → 30 minutes (pod install no longer runs)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

CI-only change — no app behaviour is modified. Verification is observing the `Set up E2E environment` step duration in the iOS smoke test shards drop from ~8–9 minutes to ~2 minutes.

## **Screenshots/Recordings**

### **Before**

Average iOS shard setup: **8m48s** (Cirrus), **5m48s** (Namespace)

### **After**

Average iOS shard setup: **2m00s** (Cirrus) — measured across 27 shards on run [26952185912](https://github.com/MetaMask/metamask-mobile/actions/runs/26952185912)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.