### PR TITLE
fix(ramp): headless getQuotes surfaces provider rejections

### DIFF
--- a/app/components/UI/Ramp/headless/useHeadlessBuy.test.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessBuy.test.ts
@@ -312,6 +312,274 @@ describe('useHeadlessBuy', () => {
       ).rejects.toThrow(/could not resolve wallet address/);
       expect(mockGetQuotesRaw).not.toHaveBeenCalled();
     });
+
+    const assetId = 'eip155:59144/erc20:0xabc';
+    const cardPaymentMethod = '/payments/debit-credit-card';
+    const transakProvider = '/providers/transak-native';
+    const baseQuotesParams = {
+      assetId,
+      amount: 5,
+      walletAddress: '0xWALLET',
+      paymentMethodIds: [cardPaymentMethod],
+      providerIds: [transakProvider],
+    };
+    const emptyQuotesResponse = {
+      success: [],
+      sorted: [],
+      error: [],
+      customActions: [],
+    };
+    const quoteResponse = (overrides = {}) => ({
+      ...emptyQuotesResponse,
+      ...overrides,
+    });
+    const seedQuote = {
+      provider: transakProvider,
+      quote: {
+        amountIn: 5,
+        amountOut: 0.001,
+        paymentMethod: cardPaymentMethod,
+      },
+      providerInfo: {
+        id: transakProvider,
+        name: 'Transak',
+        type: 'native' as const,
+      },
+    } as unknown as Parameters<
+      ReturnType<typeof useHeadlessBuy>['startHeadlessBuy']
+    >[0]['quote'];
+    const startParams = { quote: seedQuote, assetId, amount: 5 };
+    const startActiveSession = () => {
+      const { result } = renderHook(() => useHeadlessBuy());
+      const callbacks = {
+        onOrderCreated: jest.fn(),
+        onError: jest.fn(),
+        onClose: jest.fn(),
+      };
+      let sessionId: string | undefined;
+      act(() => {
+        sessionId = result.current.startHeadlessBuy(
+          startParams,
+          callbacks,
+        ).sessionId;
+      });
+      return { callbacks, result, sessionId };
+    };
+
+    describe('provider rejection inspection (Fix #2)', () => {
+      it('rejects with LIMIT_EXCEEDED and routes through the active session', async () => {
+        mockGetQuotesRaw.mockResolvedValueOnce(
+          quoteResponse({
+            error: [{ provider: 'transak', error: 'Below minimum buy amount' }],
+          }),
+        );
+        const { callbacks, result, sessionId } = startActiveSession();
+
+        await expect(
+          act(async () => {
+            await result.current.getQuotes(baseQuotesParams);
+          }),
+        ).rejects.toMatchObject({
+          headlessBuyErrorCode: 'LIMIT_EXCEEDED',
+        });
+        expect(callbacks.onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            code: 'LIMIT_EXCEEDED',
+            details: expect.objectContaining({
+              providerErrors: [
+                expect.objectContaining({
+                  provider: 'transak',
+                  message: 'Below minimum buy amount',
+                }),
+              ],
+              successCount: 0,
+              errorCount: 1,
+              source: 'network-reject',
+            }),
+          }),
+        );
+        expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
+        expect(sessionId).toBeDefined();
+        expect(getSession(sessionId)).toBeUndefined();
+      });
+
+      it('rejects with the structured error when no session is active', async () => {
+        mockGetQuotesRaw.mockResolvedValueOnce(
+          quoteResponse({
+            error: [{ provider: 'transak', error: 'Below minimum buy amount' }],
+          }),
+        );
+        const { result } = renderHook(() => useHeadlessBuy());
+        await expect(
+          result.current.getQuotes(baseQuotesParams),
+        ).rejects.toMatchObject({
+          headlessBuyErrorCode: 'LIMIT_EXCEEDED',
+          details: expect.objectContaining({ errorCount: 1, successCount: 0 }),
+        });
+      });
+
+      it.each([
+        [
+          'non-limit messages',
+          [{ provider: 'transak', error: 'Payment provider unavailable' }],
+          'QUOTE_FAILED',
+        ],
+        [
+          'rate-limit messages',
+          [{ provider: 'transak', error: 'Rate limit exceeded' }],
+          'QUOTE_FAILED',
+        ],
+        [
+          'SDK limit codes over message parsing',
+          [
+            {
+              provider: 'transak',
+              error: 'Some unrelated message',
+              code: 'AMOUNT_LIMIT_EXCEEDED',
+            },
+          ],
+          'LIMIT_EXCEEDED',
+        ],
+        [
+          'mixed provider SDK codes',
+          [
+            {
+              provider: 'transak',
+              error: 'Below minimum buy amount',
+              code: 'AMOUNT_LIMIT_EXCEEDED',
+            },
+            {
+              provider: 'moonpay',
+              error: 'Provider throttled - try again later',
+              code: 'RATE_LIMIT_EXCEEDED',
+            },
+          ],
+          'LIMIT_EXCEEDED',
+        ],
+      ])('classifies %s as %s', async (_name, error, headlessBuyErrorCode) => {
+        mockGetQuotesRaw.mockResolvedValueOnce(quoteResponse({ error }));
+        const { result } = renderHook(() => useHeadlessBuy());
+        await expect(
+          result.current.getQuotes(baseQuotesParams),
+        ).rejects.toMatchObject({ headlessBuyErrorCode });
+      });
+
+      it.each([
+        ['empty success and error', quoteResponse()],
+        [
+          'non-empty success',
+          quoteResponse({
+            success: [{ provider: 'transak', amountOut: 0.01 }],
+            sorted: [{ provider: 'transak', amountOut: 0.01 }],
+          }),
+        ],
+      ])('returns the response unchanged when %s', async (_name, response) => {
+        mockGetQuotesRaw.mockResolvedValueOnce(response);
+        const { result } = renderHook(() => useHeadlessBuy());
+        await expect(result.current.getQuotes(baseQuotesParams)).resolves.toBe(
+          response,
+        );
+      });
+
+      it('returns an undefined quote response unchanged', async () => {
+        mockGetQuotesRaw.mockResolvedValueOnce(undefined);
+        const { result } = renderHook(() => useHeadlessBuy());
+        await expect(result.current.getQuotes(baseQuotesParams)).resolves.toBe(
+          undefined,
+        );
+      });
+
+      it('fails the session captured at getQuotes() entry, not whatever is active after the await', async () => {
+        // Regression: a concurrent startHeadlessBuy() must not cause the
+        // in-flight getQuotes() error to terminate the *new* session.
+        let resolveQuotes: (value: unknown) => void = () => undefined;
+        mockGetQuotesRaw.mockReturnValueOnce(
+          new Promise((resolve) => {
+            resolveQuotes = resolve;
+          }),
+        );
+
+        const { result } = renderHook(() => useHeadlessBuy());
+        const firstCallbacks = {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        };
+        let firstSessionId: string | undefined;
+        act(() => {
+          firstSessionId = result.current.startHeadlessBuy(
+            startParams,
+            firstCallbacks,
+          ).sessionId;
+        });
+
+        // Kick off getQuotes against session A; it will await resolveQuotes.
+        const quotesPromise = result.current
+          .getQuotes(baseQuotesParams)
+          .catch(() => undefined);
+
+        // Swap to session B while session A's await is pending.
+        const secondCallbacks = {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        };
+        let secondSessionId: string | undefined;
+        act(() => {
+          secondSessionId = result.current.startHeadlessBuy(
+            startParams,
+            secondCallbacks,
+          ).sessionId;
+        });
+        expect(secondSessionId).not.toBe(firstSessionId);
+
+        await act(async () => {
+          resolveQuotes(
+            quoteResponse({
+              error: [
+                { provider: 'transak', error: 'Below minimum buy amount' },
+              ],
+            }),
+          );
+          await quotesPromise;
+        });
+
+        // Session B must remain alive and unfailed; session A's onClose
+        // already fired (with consumer_cancelled) when B was started.
+        expect(secondCallbacks.onError).not.toHaveBeenCalled();
+        expect(secondCallbacks.onClose).not.toHaveBeenCalled();
+        expect(getSession(secondSessionId as string)).toBeDefined();
+        expect(firstCallbacks.onClose).toHaveBeenCalledWith({
+          reason: 'consumer_cancelled',
+        });
+        expect(firstCallbacks.onError).not.toHaveBeenCalled();
+      });
+
+      it('normalizes malformed provider rejections to unknown/no-message details', async () => {
+        mockGetQuotesRaw.mockResolvedValueOnce(
+          quoteResponse({
+            error: [{ provider: { id: 'not-a-string' } }],
+          }),
+        );
+        const { result } = renderHook(() => useHeadlessBuy());
+
+        await expect(
+          result.current.getQuotes(baseQuotesParams),
+        ).rejects.toMatchObject({
+          message: 'unknown: (no message)',
+          headlessBuyErrorCode: 'QUOTE_FAILED',
+          details: expect.objectContaining({
+            providerErrors: [
+              {
+                provider: 'unknown',
+                message: undefined,
+                code: undefined,
+              },
+            ],
+          }),
+        });
+      });
+    });
   });
 
   describe('startHeadlessBuy', () => {

--- a/app/components/UI/Ramp/headless/useHeadlessBuy.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessBuy.ts
@@ -12,10 +12,12 @@ import useRampsController from '../hooks/useRampsController';
 import {
   closeSession,
   createSession,
+  failSession,
   getActiveSessionId,
 } from './sessionRegistry';
 import type {
   HeadlessBuyCallbacks,
+  HeadlessBuyErrorCode,
   HeadlessBuyParams,
   HeadlessBuyResult,
   HeadlessGetQuotesParams,
@@ -102,7 +104,15 @@ export function useHeadlessBuy(): HeadlessBuyResult {
           `useHeadlessBuy: could not resolve wallet address for assetId="${params.assetId}". Pass walletAddress explicitly or ensure an account is selected for chain ${chainId ?? 'unknown'}.`,
         );
       }
-      return getQuotesRaw({
+
+      // Capture the session id at function entry. If a concurrent
+      // startHeadlessBuy() swaps the active session while we're awaiting
+      // getQuotesRaw below, calling getActiveSessionId() post-await would
+      // return the *new* session's id, and failSession would terminate the
+      // wrong session with this call's error.
+      const sessionIdAtStart = getActiveSessionId();
+
+      const quotesResponse = await getQuotesRaw({
         assetId: params.assetId,
         amount: params.amount,
         walletAddress,
@@ -111,6 +121,65 @@ export function useHeadlessBuy(): HeadlessBuyResult {
         redirectUrl: params.redirectUrl ?? getRampCallbackBaseUrl(),
         forceRefresh: params.forceRefresh,
       });
+
+      // UB2 surfaces empty-success provider rejections; headless must too.
+      // Previously an all-reject response returned an empty success list with
+      // no error, leaving the consumer stuck awaiting a result that never came.
+      const errorEntries = (quotesResponse?.error ?? []) as readonly Record<
+        string,
+        unknown
+      >[];
+      const successCount = quotesResponse?.success?.length ?? 0;
+      if (successCount === 0 && errorEntries.length > 0) {
+        const providerErrors = errorEntries.map((entry) => ({
+          provider:
+            typeof entry.provider === 'string' ? entry.provider : 'unknown',
+          message: typeof entry.error === 'string' ? entry.error : undefined,
+          code: typeof entry.code === 'string' ? entry.code : undefined,
+        }));
+        const combinedMessage = providerErrors
+          .map((p) => `${p.provider}: ${p.message ?? '(no message)'}`)
+          .join('; ');
+
+        // Classify per provider so a rate-limit signal cannot veto another
+        // provider's buy-limit signal.
+        const limitWord = /\b(minimum|maximum|limit)\b/i;
+        const rateRequestWord = /\b(rate|request)\b/i;
+        const limitCodePattern = /limit/i;
+        const rateRequestCodePattern = /rate|request/i;
+        const isLimitExceeded = providerErrors.some((p) => {
+          if (p.code !== undefined) {
+            return (
+              limitCodePattern.test(p.code) &&
+              !rateRequestCodePattern.test(p.code)
+            );
+          }
+          const message = p.message ?? '';
+          return limitWord.test(message) && !rateRequestWord.test(message);
+        });
+        const code: HeadlessBuyErrorCode = isLimitExceeded
+          ? 'LIMIT_EXCEEDED'
+          : 'QUOTE_FAILED';
+
+        const error = new Error(combinedMessage) as Error & {
+          headlessBuyErrorCode: HeadlessBuyErrorCode;
+          details: Record<string, unknown>;
+        };
+        error.headlessBuyErrorCode = code;
+        error.details = {
+          providerErrors,
+          successCount,
+          errorCount: errorEntries.length,
+          source: 'network-reject',
+        };
+
+        if (sessionIdAtStart) {
+          failSession(sessionIdAtStart, error, code);
+        }
+        throw error;
+      }
+
+      return quotesResponse;
     },
     [getQuotesRaw],
   );


### PR DESCRIPTION
## **Description**

Extracted from #30317 (Fix #2 only) — independent of the other fixes in that PR (onOrderCreated snapshot, JSDoc, pre-quote static bounds), based directly on `main`.

`getQuotes` no longer silently eats provider rejections. A 5 EUR amount under the provider's minimum used to return an empty success list and no error, so the consumer was stuck awaiting a result that never arrived.

Now `getQuotes`:
- **Throws a typed `HeadlessBuyError`** when the quote response has zero successes and at least one provider error.
- **Fires `onError` + `onClose`** on the active headless session (via the existing `failSession`), which removes the session from the registry.
- **Classifies per provider** so a rate-limit signal from one provider cannot veto another provider's buy-limit signal:
  - `LIMIT_EXCEEDED` for limit / minimum / maximum messages (or SDK `*_LIMIT` codes).
  - `QUOTE_FAILED` for everything else — **rate-limit messages are NOT mis-classified as limit-exceeded**.
- **Captures the active session id at call entry**, so a concurrent `startHeadlessBuy()` swap can't terminate the wrong session with this call's error.

When no session is active, the structured error still rejects the `await getQuotes(...)` so the direct caller sees it.

## **Changelog**

CHANGELOG entry: null

(internal API change — no end-user-facing change in this PR.)

## **Related issues**

Relates to https://consensyssoftware.atlassian.net/browse/TRAM-3582
Slack — Goktug's May 12 testing thread: https://consensys.slack.com/archives/C0AK3NXRM7W/p1778577403631269

## **Manual testing steps**

```gherkin
Feature: Headless buy getQuotes surfaces provider rejections

  Scenario: 5 EUR provider rejection surfaces to the consumer
    Given an active headless session via `startHeadlessBuy`
    When the consumer calls `getQuotes` with a fiat amount below the provider's minimum
    Then `onError` fires with `{ code: 'LIMIT_EXCEEDED', details: { providerErrors: [...], source: 'network-reject' } }`
    And `onClose` fires with `{ reason: 'unknown' }`
    And the session is removed from the registry
    And the consumer's `await getQuotes(...)` catch also receives the same structured error

  Scenario: Rate-limit messages are not mis-classified
    Given a provider rejection whose message/code indicates a rate limit
    When `getQuotes` surfaces it
    Then the error code is `QUOTE_FAILED`, not `LIMIT_EXCEEDED`
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (`team-money-movement`)

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes headless buy quote/session error handling (internal API) with session lifecycle side effects; well-covered by tests but affects money-movement integration flows.
> 
> **Overview**
> **Headless `getQuotes`** now treats “all providers rejected, zero successes” as a hard failure instead of returning an empty success list. It builds a structured rejection (`headlessBuyErrorCode`, `details.providerErrors`, `source: 'network-reject'`), classifies **`LIMIT_EXCEEDED`** vs **`QUOTE_FAILED`** per provider (SDK limit codes vs messages; rate-limit signals stay **`QUOTE_FAILED`**), and **`failSession`** on the session id captured **at call entry** so a concurrent **`startHeadlessBuy`** does not get the wrong session torn down.
> 
> With an active session, consumers get **`onError`** + **`onClose`** and the promise still rejects; without a session, the same structured error rejects **`await getQuotes`**. Successful or empty error responses are unchanged.
> 
> Tests in **`useHeadlessBuy.test.ts`** cover classification, session routing, the concurrent-session regression, and malformed provider payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2368bb369bfd0a07e5926a1a582b078faf754bb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->