### PR TITLE
test(e2e): stabilize TestSnaps date/time picker taps

### DIFF
--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -368,9 +368,15 @@ class TestSnaps {
       },
     );
 
-    await Gestures.waitAndTap(this.dateTimePickerTouchable);
+    await Gestures.waitAndTap(this.dateTimePickerTouchable, {
+      checkStability: true,
+      elemDescription: 'open date-time picker',
+    });
 
-    await Gestures.waitAndTap(this.dateTimePickerOkButton);
+    await Gestures.waitAndTap(this.dateTimePickerOkButton, {
+      checkStability: true,
+      elemDescription: 'date-time picker OK',
+    });
 
     // Android date and time picker is a two-step process, so we need to tap OK again
     if (device.getPlatform() === 'android') {
@@ -379,15 +385,27 @@ class TestSnaps {
   }
 
   async selectDateInDatePicker() {
-    await Gestures.waitAndTap(this.datePickerTouchable);
+    await Gestures.waitAndTap(this.datePickerTouchable, {
+      checkStability: true,
+      elemDescription: 'open date picker',
+    });
 
-    await Gestures.waitAndTap(this.dateTimePickerOkButton);
+    await Gestures.waitAndTap(this.dateTimePickerOkButton, {
+      checkStability: true,
+      elemDescription: 'date picker OK',
+    });
   }
 
   async selectTimeInTimePicker() {
-    await Gestures.waitAndTap(this.timePickerTouchable);
+    await Gestures.waitAndTap(this.timePickerTouchable, {
+      checkStability: true,
+      elemDescription: 'open time picker',
+    });
 
-    await Gestures.waitAndTap(this.dateTimePickerOkButton);
+    await Gestures.waitAndTap(this.dateTimePickerOkButton, {
+      checkStability: true,
+      elemDescription: 'time picker OK',
+    });
   }
 
   async installSnap(


### PR DESCRIPTION
## **Description**

Adds `checkStability` and `elemDescription` options to the `Gestures.waitAndTap` calls inside the date, time, and date-time picker helpers in the `TestSnaps` page object. Stability checks prevent taps from firing on an element while it is still animating, and the descriptions surface clearer messages when a tap fails. No production code is affected.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: TestSnaps date/time picker E2E helpers

  Scenario: e2e suite drives the date-time picker via TestSnaps page object
    Given the test-snaps dapp is loaded on a device

    When the suite invokes selectDateInDateTimePicker / selectDateInDatePicker / selectTimeInTimePicker
    Then each tap waits for element stability before firing
    And failures report a human-readable element description
```

## **Screenshots/Recordings**

### **Before**

N/A — test-only change.

### **After**

N/A — test-only change.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.