### PR TITLE
fix: refresh unified assets balances from real-time websocket pushes

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -44,6 +44,7 @@ import { isTestNet } from '../../util/networks';
 import { deprecatedGetNetworkId } from '../../util/networks/engineNetworkUtils';
 import AppConstants from '../AppConstants';
 import { store } from '../../store';
+import { selectIsAssetsUnifyStateEnabled } from '../../selectors/featureFlagController/assetsUnifyState';
 import {
   renderFromTokenMinimalUnit,
   balanceToFiatNumber,
@@ -52,6 +53,10 @@ import {
   hexToBN,
   renderFromWei,
 } from '../../util/number';
+import {
+  buildAssetsBalanceUpdateFromPush,
+  type BalanceUpdatedPushPayload,
+} from './utils/buildAssetsBalanceUpdateFromPush';
 import NotificationManager from '../NotificationManager';
 import Logger from '../../util/Logger';
 import { isZero } from '../../util/lodash';
@@ -759,6 +764,57 @@ export class Engine {
         } catch (error) {
           console.error(
             'Error handling BridgeStatusController:destinationTransactionCompleted event:',
+            error,
+          );
+        }
+      },
+    );
+
+    // Forward real-time websocket balance pushes into the AssetsController.
+    // When `assetsUnifyState` is enabled the UI reads balances from
+    // `AssetsController.assetsBalance`. Both `AccountActivityService` and the
+    // controller's internal `BackendWebsocketDataSource` open a separate
+    // websocket subscription to the same account-activity channel, but the
+    // backend routes each notification to a single subscriptionId, so the data
+    // source's subscription is starved and `assetsBalance` is not refreshed
+    // until the 30s poll. `AccountActivityService` reliably receives the push,
+    // so we bridge it into the controller's own public merge entrypoint.
+    this.controllerMessenger.subscribe(
+      'AccountActivityService:balanceUpdated',
+      (payload: BalanceUpdatedPushPayload) => {
+        try {
+          if (!selectIsAssetsUnifyStateEnabled(store.getState())) {
+            return;
+          }
+          const account = this.context.AccountsController.getAccountByAddress(
+            payload.address,
+          );
+          const accountId = account?.id;
+          if (!accountId) {
+            return;
+          }
+
+          const response = buildAssetsBalanceUpdateFromPush(payload, accountId);
+          if (!response) {
+            return;
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          Promise.resolve(
+            (
+              this.context.AssetsController as unknown as {
+                handleAssetsUpdate: (
+                  response: unknown,
+                  sourceId: string,
+                ) => Promise<void>;
+              }
+            ).handleAssetsUpdate(response, 'BackendWebsocketDataSource'),
+          ).catch(() => {
+            // Best-effort real-time refresh; the periodic poll remains a fallback.
+          });
+        } catch (error) {
+          console.error(
+            'Error forwarding AccountActivityService:balanceUpdated to AssetsController:',
             error,
           );
         }

--- a/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.test.ts
+++ b/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.test.ts
@@ -1,0 +1,173 @@
+import {
+  buildAssetsBalanceUpdateFromPush,
+  type BalanceUpdatedPushPayload,
+} from './buildAssetsBalanceUpdateFromPush';
+
+const ACCOUNT_ID = 'account-1';
+const USDC_BASE =
+  'eip155:8453/erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const ETH_BASE = 'eip155:8453/slip44:60';
+
+const createPayload = (
+  updates: BalanceUpdatedPushPayload['updates'],
+): BalanceUpdatedPushPayload => ({
+  address: '0xabc',
+  chain: 'eip155:8453',
+  updates,
+});
+
+describe('buildAssetsBalanceUpdateFromPush', () => {
+  it('converts a hex minimal-unit amount to a human-readable decimal', () => {
+    const payload = createPayload([
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '0xf4240' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsBalance[ACCOUNT_ID][USDC_BASE]).toEqual({
+      amount: '1',
+    });
+  });
+
+  it('converts a decimal minimal-unit string to a human-readable decimal', () => {
+    const payload = createPayload([
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '2552549' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsBalance[ACCOUNT_ID][USDC_BASE]).toEqual({
+      amount: '2.552549',
+    });
+  });
+
+  it('marks slip44 assets as native and erc20 assets accordingly', () => {
+    const payload = createPayload([
+      {
+        asset: { type: ETH_BASE, unit: 'ETH', decimals: 18 },
+        postBalance: { amount: '0xde0b6b3a7640000' },
+      },
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '1500000' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsInfo[ETH_BASE].type).toBe('native');
+    expect(result?.assetsInfo[USDC_BASE].type).toBe('erc20');
+  });
+
+  it('uses the asset unit for symbol and name', () => {
+    const payload = createPayload([
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '1000000' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsInfo[USDC_BASE]).toEqual({
+      type: 'erc20',
+      symbol: 'USDC',
+      name: 'USDC',
+      decimals: 6,
+    });
+  });
+
+  it('defaults symbol and name to an empty string when the unit is missing', () => {
+    const payload = createPayload([
+      {
+        asset: { type: USDC_BASE, decimals: 6 },
+        postBalance: { amount: '1000000' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsInfo[USDC_BASE].symbol).toBe('');
+    expect(result?.assetsInfo[USDC_BASE].name).toBe('');
+  });
+
+  it('merges multiple updates under the same account id', () => {
+    const payload = createPayload([
+      {
+        asset: { type: ETH_BASE, unit: 'ETH', decimals: 18 },
+        postBalance: { amount: '0xde0b6b3a7640000' },
+      },
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '2552549' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result).toEqual({
+      updateMode: 'merge',
+      assetsBalance: {
+        [ACCOUNT_ID]: {
+          [ETH_BASE]: { amount: '1' },
+          [USDC_BASE]: { amount: '2.552549' },
+        },
+      },
+      assetsInfo: {
+        [ETH_BASE]: {
+          type: 'native',
+          symbol: 'ETH',
+          name: 'ETH',
+          decimals: 18,
+        },
+        [USDC_BASE]: {
+          type: 'erc20',
+          symbol: 'USDC',
+          name: 'USDC',
+          decimals: 6,
+        },
+      },
+    });
+  });
+
+  it('skips updates missing an asset id, decimals, or amount', () => {
+    const payload = createPayload([
+      { asset: { unit: 'USDC', decimals: 6 }, postBalance: { amount: '1' } },
+      {
+        asset: { type: USDC_BASE, unit: 'USDC' },
+        postBalance: { amount: '1' },
+      },
+      { asset: { type: ETH_BASE, unit: 'ETH', decimals: 18 }, postBalance: {} },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when updates is not an array', () => {
+    const payload = {
+      address: '0xabc',
+      chain: 'eip155:8453',
+      updates: undefined,
+    } as unknown as BalanceUpdatedPushPayload;
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no applicable updates remain', () => {
+    const payload = createPayload([]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result).toBeNull();
+  });
+});

--- a/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.test.ts
+++ b/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.test.ts
@@ -151,6 +151,63 @@ describe('buildAssetsBalanceUpdateFromPush', () => {
     expect(result).toBeNull();
   });
 
+  it('skips an entry with null decimals while keeping valid entries in the same push', () => {
+    const payload = createPayload([
+      {
+        asset: {
+          type: ETH_BASE,
+          unit: 'ETH',
+          decimals: null as unknown as number,
+        },
+        postBalance: { amount: '0xde0b6b3a7640000' },
+      },
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '2552549' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsBalance[ACCOUNT_ID]).toEqual({
+      [USDC_BASE]: { amount: '2.552549' },
+    });
+    expect(result?.assetsInfo).not.toHaveProperty(ETH_BASE);
+  });
+
+  it('skips an entry whose amount cannot be converted while keeping valid entries', () => {
+    const payload = createPayload([
+      {
+        asset: { type: ETH_BASE, unit: 'ETH', decimals: 18 },
+        postBalance: { amount: 'not-a-number' },
+      },
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: '1000000' },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result?.assetsBalance[ACCOUNT_ID]).toEqual({
+      [USDC_BASE]: { amount: '1' },
+    });
+    expect(result?.assetsInfo).not.toHaveProperty(ETH_BASE);
+  });
+
+  it('skips entries with a non-string amount', () => {
+    const payload = createPayload([
+      {
+        asset: { type: USDC_BASE, unit: 'USDC', decimals: 6 },
+        postBalance: { amount: 1000000 as unknown as string },
+      },
+    ]);
+
+    const result = buildAssetsBalanceUpdateFromPush(payload, ACCOUNT_ID);
+
+    expect(result).toBeNull();
+  });
+
   it('returns null when updates is not an array', () => {
     const payload = {
       address: '0xabc',

--- a/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.ts
+++ b/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.ts
@@ -1,0 +1,90 @@
+import { fromTokenMinimalUnitString } from '../../../util/number/bigint';
+
+/**
+ * A single balance update entry inside an
+ * `AccountActivityService:balanceUpdated` push notification.
+ */
+export interface BalanceUpdatePushEntry {
+  asset?: { type?: string; unit?: string; decimals?: number };
+  postBalance?: { amount?: string };
+}
+
+/**
+ * Payload emitted by `AccountActivityService:balanceUpdated`.
+ */
+export interface BalanceUpdatedPushPayload {
+  address: string;
+  chain: string;
+  updates: BalanceUpdatePushEntry[];
+}
+
+/**
+ * Merge payload accepted by `AssetsController.handleAssetsUpdate`.
+ */
+export interface AssetsBalanceMergeUpdate {
+  updateMode: 'merge';
+  assetsBalance: Record<string, Record<string, { amount: string }>>;
+  assetsInfo: Record<
+    string,
+    {
+      type: 'native' | 'erc20';
+      symbol: string;
+      name: string;
+      decimals: number;
+    }
+  >;
+}
+
+/**
+ * Builds the `AssetsController.handleAssetsUpdate` merge payload from a
+ * real-time `AccountActivityService:balanceUpdated` websocket push.
+ *
+ * Raw on-chain amounts (hex like `0x26f0e5` or a decimal minimal-unit string)
+ * are converted to the human-readable decimal form stored in `assetsBalance`,
+ * mirroring the controller's own `BackendWebsocketDataSource`. Updates missing
+ * an asset id, decimals, or amount are skipped.
+ *
+ * @param payload - The balance push payload.
+ * @param accountId - The resolved internal account id for `payload.address`.
+ * @returns The merge payload, or `null` when there are no applicable updates.
+ */
+export function buildAssetsBalanceUpdateFromPush(
+  payload: BalanceUpdatedPushPayload,
+  accountId: string,
+): AssetsBalanceMergeUpdate | null {
+  const { updates } = payload;
+  if (!Array.isArray(updates)) {
+    return null;
+  }
+
+  const assetsBalance: AssetsBalanceMergeUpdate['assetsBalance'] = {
+    [accountId]: {},
+  };
+  const assetsInfo: AssetsBalanceMergeUpdate['assetsInfo'] = {};
+
+  for (const update of updates) {
+    const assetId = update.asset?.type;
+    const decimals = update.asset?.decimals;
+    const rawAmount = update.postBalance?.amount;
+    if (!assetId || decimals === undefined || rawAmount === undefined) {
+      continue;
+    }
+    assetsBalance[accountId][assetId] = {
+      amount: fromTokenMinimalUnitString(rawAmount, decimals),
+    };
+    const isNative = assetId.includes('/slip44:');
+    const unit = update.asset?.unit ?? '';
+    assetsInfo[assetId] = {
+      type: isNative ? 'native' : 'erc20',
+      symbol: unit,
+      name: unit,
+      decimals,
+    };
+  }
+
+  if (Object.keys(assetsBalance[accountId]).length === 0) {
+    return null;
+  }
+
+  return { updateMode: 'merge', assetsBalance, assetsInfo };
+}

--- a/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.ts
+++ b/app/core/Engine/utils/buildAssetsBalanceUpdateFromPush.ts
@@ -66,12 +66,29 @@ export function buildAssetsBalanceUpdateFromPush(
     const assetId = update.asset?.type;
     const decimals = update.asset?.decimals;
     const rawAmount = update.postBalance?.amount;
-    if (!assetId || decimals === undefined || rawAmount === undefined) {
+    // Strict guards: the payload is untyped at runtime, so `null`, `NaN`,
+    // negative or fractional decimals, and non-string amounts can all reach
+    // here despite the declared types.
+    if (
+      !assetId ||
+      typeof decimals !== 'number' ||
+      !Number.isInteger(decimals) ||
+      decimals < 0 ||
+      typeof rawAmount !== 'string'
+    ) {
       continue;
     }
-    assetsBalance[accountId][assetId] = {
-      amount: fromTokenMinimalUnitString(rawAmount, decimals),
-    };
+
+    let amount: string;
+    try {
+      amount = fromTokenMinimalUnitString(rawAmount, decimals);
+    } catch {
+      // A single malformed amount must not abort the whole push; skip this
+      // row so the remaining valid balances still merge.
+      continue;
+    }
+
+    assetsBalance[accountId][assetId] = { amount };
     const isNative = assetId.includes('/slip44:');
     const unit = update.asset?.unit ?? '';
     assetsInfo[assetId] = {


### PR DESCRIPTION
## **Description**

When the `assetsUnifyState` feature flag is enabled, the UI reads token balances from `AssetsController.assetsBalance` instead of `TokenBalancesController`. After a swap (e.g. QuickBuy), balances did not update in the simulator until the 30s poll, even though the real-time websocket push arrived almost immediately.

**Root cause:** both `AccountActivityService` and the controller's internal `BackendWebsocketDataSource` open a separate websocket subscription to the same `account-activity` channel. The backend routes each notification to a single `subscriptionId`, so only one subscriber receives the push. `AccountActivityService` wins that race, starving the data source's subscription — so `AssetsController.assetsBalance` is never merged with the fresh balance until the periodic poll.

**Solution:** bridge the `AccountActivityService:balanceUpdated` event (which reliably receives the push) into the controller's own public `handleAssetsUpdate` merge entrypoint. The push payload is transformed into the merge shape by a pure, unit-tested helper (`buildAssetsBalanceUpdateFromPush`) that mirrors the data source's own raw-amount → human-readable-decimal conversion, skipping malformed rows so a single bad entry can't drop the whole push. The bridge is gated behind `assetsUnifyState`, and the 30s poll remains as a fallback.

### Why it wasn't noticeable before (and surfaced via QuickBuy)

This bug affects every balance update under `assetsUnifyState`, not just QuickBuy — which is why the fix lives at the controller-bridge layer rather than in QuickBuy. It was surfaced by the QuickBuy because of how each flow ends:

- **Regular Swaps (Bridge):** on completion the confirm flow navigates to `Routes.TRANSACTIONS_VIEW` (`useBridgeConfirm`). Navigating away and back re-mounts the wallet token list, which under unify force-refreshes `AssetsController.getAssets({ forceUpdate: true })` (`useRefreshTokens`). That forced read masked the starved websocket path, so balances looked instant.
- **QuickBuy:** by design it stays on `TraderPositionView` and only shows lifecycle toasts — no navigation, no re-mount, no forced refresh. With nothing to mask it, the starved real-time path was exposed and balances only updated on the 30s poll (consistent with "pull-to-refresh fixes it" and "waiting eventually updates").

Both flows submit through the same `BridgeStatusController.submitTx`; the difference is purely the post-submit navigation side effect. This fix repairs the real-time path itself, so balances update live for all flows without relying on navigation or pull-to-refresh.

## **Changelog**

CHANGELOG entry: Fixed token balances not updating immediately after a swap when the unified assets state is enabled.

## **Related issues**

Fixes:

## **Manual testing steps**

\`\`\`gherkin
Feature: Real-time balance refresh after swap

  Scenario: user completes a swap with unified assets state enabled
    Given the assetsUnifyState feature flag is enabled
    And the user is on a screen displaying their token balances

    When the user completes a swap (e.g. via QuickBuy)
    Then the source and destination token balances update within a couple of seconds
    And the user does not need to pull-to-refresh or wait for the 30s poll
\`\`\`

## **Screenshots/Recordings**

### **Before**

<!-- Balance stays stale until the 30s poll / pull-to-refresh. -->

### **After**

<!-- Balance updates in real time after the swap completes. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.