### PR TITLE
feat: batch sell filter out RWAs

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -9,7 +9,6 @@ import { BatchSellTokenSelectSelectorsIDs } from './BatchSellTokenSelect.testIds
 import {
   buildBatchSellEligibleChains,
   getBatchSellDestinationToken,
-  removeStablecoinsFromSourceTokens,
   MAX_BATCH_SELL_SOURCE_TOKENS,
   SUPPORTED_BATCH_SELL_CHAIN_IDS,
   sortBatchSellTokens,
@@ -199,36 +198,6 @@ const createToken = (overrides: Partial<BridgeToken>): BridgeToken => ({
 
 const getNetworkPillTestId = (chainId: CaipChainId) =>
   `${BatchSellTokenSelectSelectorsIDs.NETWORK_PILL}-${chainId}`;
-
-describe('filterBatchSellDestinationStablecoins', () => {
-  it('excludes configured stablecoins', () => {
-    const stablecoinAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-    const highBalanceToken = createToken({
-      symbol: 'HIGH',
-      address: '0x2222222222222222222222222222222222222222',
-      tokenFiatAmount: 50,
-    });
-    const lowBalanceToken = createToken({
-      symbol: 'LOW',
-      address: '0x3333333333333333333333333333333333333333',
-      tokenFiatAmount: 10,
-    });
-    const stablecoinToken = createToken({
-      symbol: 'USDC',
-      address: stablecoinAddress,
-      tokenFiatAmount: 100,
-    });
-
-    const result = removeStablecoinsFromSourceTokens({
-      tokens: [lowBalanceToken, stablecoinToken, highBalanceToken],
-      stablecoinsByChain: {
-        ['eip155:1' as CaipChainId]: [BridgeTokenMetadata[usdcAssetId]],
-      },
-    });
-
-    expect(result.map((token) => token.symbol)).toEqual(['LOW', 'HIGH']);
-  });
-});
 
 describe('buildBatchSellEligibleNetworks', () => {
   it('sorts eligible networks by highest aggregate fiat value', () => {

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -37,7 +37,6 @@ import Routes from '../../../../../constants/navigation/Routes';
 import {
   resetBridgeState,
   selectBatchSellDestStablecoins,
-  selectBatchSellDestStablecoinsByChain,
   setBatchSellDestToken,
   setBatchSellSourceTokenAmounts,
   setBatchSellSourceTokens,
@@ -45,23 +44,21 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { RootState } from '../../../../../reducers';
 import { BridgeToken } from '../../types';
-import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
 import ButtonToggle from '../../../../../component-library/components-temp/Buttons/ButtonToggle';
 import { ButtonSize as ButtonToggleSize } from '../../../../../component-library/components/Buttons/Button';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import {
   buildBatchSellEligibleChains,
-  removeStablecoinsFromSourceTokens,
   getBatchSellDestinationToken,
   MAX_BATCH_SELL_SOURCE_TOKENS,
   BatchSellTokenSortDirection,
   sortBatchSellTokens,
-  SUPPORTED_BATCH_SELL_CHAIN_IDS,
 } from './BatchSellTokenSelect.utils';
 import { BatchSellTokenSelectSelectorsIDs } from './BatchSellTokenSelect.testIds';
 import { BatchSellTokenRow } from './BatchSellTokenRow';
 import { BatchSellEmptyState } from './BatchSellEmptyState';
 import { DEFAULT_BATCH_SELL_SLIPPAGE } from '../../components/SlippageModal/utils';
+import { useBatchSellTokens } from './useBatchSellTokens';
 
 const getTokenKey = (token: BridgeToken) =>
   `${formatChainIdToCaip(token.chainId)}:${token.address}`;
@@ -110,23 +107,16 @@ export function BatchSellTokenSelect() {
   const navigation = useNavigation();
   const dispatch = useDispatch();
   const tw = useTailwind();
-  const allWalletTokens = useTokensWithBalance({
-    chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
-  });
-  const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
+  const batchSellTokens = useBatchSellTokens();
   const [tokenSortDirection, setTokenSortDirection] =
     useState<BatchSellTokenSortDirection>('desc');
-  const eligibleSourceTokens = useMemo(() => {
-    const sourceTokens = removeStablecoinsFromSourceTokens({
-      tokens: allWalletTokens,
-      stablecoinsByChain,
-    });
-
-    return sortBatchSellTokens(sourceTokens, tokenSortDirection);
-  }, [allWalletTokens, stablecoinsByChain, tokenSortDirection]);
+  const sortedEligibleSourceTokens = useMemo(
+    () => sortBatchSellTokens(batchSellTokens, tokenSortDirection),
+    [batchSellTokens, tokenSortDirection],
+  );
   const sortedEligibleChains = useMemo(
-    () => buildBatchSellEligibleChains(eligibleSourceTokens),
-    [eligibleSourceTokens],
+    () => buildBatchSellEligibleChains(sortedEligibleSourceTokens),
+    [sortedEligibleSourceTokens],
   );
   const [selectedChainId, setSelectedChainId] = useState<
     CaipChainId | undefined
@@ -165,11 +155,11 @@ export function BatchSellTokenSelect() {
   const selectedChainTokens = useMemo(
     () =>
       activeChainId
-        ? eligibleSourceTokens.filter(
+        ? sortedEligibleSourceTokens.filter(
             (token) => formatChainIdToCaip(token.chainId) === activeChainId,
           )
-        : eligibleSourceTokens,
-    [activeChainId, eligibleSourceTokens],
+        : sortedEligibleSourceTokens,
+    [activeChainId, sortedEligibleSourceTokens],
   );
   const selectedTokenKeys = useMemo(
     () => new Set(selectedTokens.map(getTokenKey)),

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.utils.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.utils.ts
@@ -1,9 +1,8 @@
 import {
-  formatAddressToAssetId,
   formatChainIdToCaip,
   formatChainIdToHex,
 } from '@metamask/bridge-controller';
-import { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { CaipChainId } from '@metamask/utils';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 import { BridgeToken } from '../../types';
 
@@ -41,44 +40,6 @@ export function getBatchSellDestinationToken(
   return stablecoins.find(
     (stablecoin) => formatChainIdToCaip(stablecoin.chainId) === caipChainId,
   );
-}
-
-export function removeStablecoinsFromSourceTokens({
-  tokens,
-  stablecoinsByChain,
-}: {
-  tokens: BridgeToken[];
-  stablecoinsByChain: Partial<Record<CaipChainId, BridgeToken[]>>;
-}): BridgeToken[] {
-  const stablecoinAssetIdsByChain = new Map(
-    Object.entries(stablecoinsByChain).map(([chainId, stablecoins]) => [
-      chainId as CaipChainId,
-      new Set(
-        (stablecoins ?? [])
-          .map((stablecoin) =>
-            formatAddressToAssetId(stablecoin.address, stablecoin.chainId),
-          )
-          .filter((assetId): assetId is CaipAssetType => Boolean(assetId)),
-      ),
-    ]),
-  );
-
-  return tokens.filter((token) => {
-    const caipChainId = formatChainIdToCaip(token.chainId);
-    const stablecoinAssetIds = stablecoinAssetIdsByChain.get(caipChainId);
-
-    if (!stablecoinAssetIds) {
-      return true;
-    }
-
-    const assetId = formatAddressToAssetId(token.address, token.chainId);
-
-    if (!assetId) {
-      return true;
-    }
-
-    return !stablecoinAssetIds.has(assetId);
-  });
 }
 
 export function sortBatchSellTokens(

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -75,4 +75,26 @@ describe('useBatchSellTokens', () => {
 
     expect(result.current).toEqual([lowValueToken, highValueToken]);
   });
+
+  it('excludes Ondo Tokenized tokens', () => {
+    const sellableToken = createToken({
+      address: '0x2222222222222222222222222222222222222222',
+      name: 'Sellable Token',
+      symbol: 'SELL',
+    });
+    const ondoTokenizedToken = createToken({
+      address: '0x3333333333333333333333333333333333333333',
+      name: 'Ondo Tokenized TSLA',
+      symbol: 'TSLAon',
+    });
+
+    mockUseTokensWithBalance.mockReturnValue([
+      sellableToken,
+      ondoTokenizedToken,
+    ]);
+
+    const { result } = renderHook(() => useBatchSellTokens());
+
+    expect(result.current).toEqual([sellableToken]);
+  });
 });

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { CaipChainId, Hex } from '@metamask/utils';
+
+import { BridgeToken } from '../../types';
+import { SUPPORTED_BATCH_SELL_CHAIN_IDS } from './BatchSellTokenSelect.utils';
+import { useBatchSellTokens } from './useBatchSellTokens';
+
+const mockUseTokensWithBalance = jest.fn();
+let mockStablecoinsByChain: Partial<Record<CaipChainId, BridgeToken[]>> = {};
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  selectBatchSellDestStablecoinsByChain: jest.fn(() => mockStablecoinsByChain),
+}));
+
+jest.mock('../../hooks/useTokensWithBalance', () => ({
+  useTokensWithBalance: (options?: { chainIds?: CaipChainId[] }) =>
+    mockUseTokensWithBalance(options),
+}));
+
+const createToken = (overrides: Partial<BridgeToken>): BridgeToken => ({
+  address: '0x1111111111111111111111111111111111111111',
+  chainId: '0x1' as Hex,
+  decimals: 18,
+  name: 'Test Token',
+  symbol: 'TEST',
+  ...overrides,
+});
+
+describe('useBatchSellTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStablecoinsByChain = {};
+    mockUseTokensWithBalance.mockReturnValue([]);
+  });
+
+  it('requests wallet tokens for supported Batch Sell chains', () => {
+    renderHook(() => useBatchSellTokens());
+
+    expect(mockUseTokensWithBalance).toHaveBeenCalledWith({
+      chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+    });
+  });
+
+  it('returns unsorted wallet tokens excluding configured destination stablecoins', () => {
+    const lowValueToken = createToken({
+      address: '0x2222222222222222222222222222222222222222',
+      symbol: 'LOW',
+      tokenFiatAmount: 1,
+    });
+    const stablecoinToken = createToken({
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      symbol: 'USDC',
+      tokenFiatAmount: 100,
+    });
+    const highValueToken = createToken({
+      address: '0x3333333333333333333333333333333333333333',
+      symbol: 'HIGH',
+      tokenFiatAmount: 500,
+    });
+
+    mockUseTokensWithBalance.mockReturnValue([
+      lowValueToken,
+      stablecoinToken,
+      highValueToken,
+    ]);
+    mockStablecoinsByChain = {
+      'eip155:1': [stablecoinToken],
+    };
+
+    const { result } = renderHook(() => useBatchSellTokens());
+
+    expect(result.current).toEqual([lowValueToken, highValueToken]);
+  });
+});

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
@@ -97,4 +97,24 @@ describe('useBatchSellTokens', () => {
 
     expect(result.current).toEqual([sellableToken]);
   });
+
+  it('excludes tokens with rwaData', () => {
+    const sellableToken = createToken({
+      address: '0x2222222222222222222222222222222222222222',
+      symbol: 'SELL',
+    });
+    const rwaToken = createToken({
+      address: '0x3333333333333333333333333333333333333333',
+      symbol: 'AAPL',
+      rwaData: {
+        instrumentType: 'stock',
+      },
+    });
+
+    mockUseTokensWithBalance.mockReturnValue([sellableToken, rwaToken]);
+
+    const { result } = renderHook(() => useBatchSellTokens());
+
+    expect(result.current).toEqual([sellableToken]);
+  });
 });

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -1,12 +1,53 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import {
+  formatAddressToAssetId,
+  formatChainIdToCaip,
+} from '@metamask/bridge-controller';
+import { CaipAssetType, CaipChainId } from '@metamask/utils';
 
 import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
 import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
-import {
-  removeStablecoinsFromSourceTokens,
-  SUPPORTED_BATCH_SELL_CHAIN_IDS,
-} from './BatchSellTokenSelect.utils';
+import { BridgeToken } from '../../types';
+import { SUPPORTED_BATCH_SELL_CHAIN_IDS } from './BatchSellTokenSelect.utils';
+
+function removeStablecoinsFromSourceTokens({
+  tokens,
+  stablecoinsByChain,
+}: {
+  tokens: BridgeToken[];
+  stablecoinsByChain: Partial<Record<CaipChainId, BridgeToken[]>>;
+}): BridgeToken[] {
+  const stablecoinAssetIdsByChain = new Map(
+    Object.entries(stablecoinsByChain).map(([chainId, stablecoins]) => [
+      chainId as CaipChainId,
+      new Set(
+        (stablecoins ?? [])
+          .map((stablecoin) =>
+            formatAddressToAssetId(stablecoin.address, stablecoin.chainId),
+          )
+          .filter((assetId): assetId is CaipAssetType => Boolean(assetId)),
+      ),
+    ]),
+  );
+
+  return tokens.filter((token) => {
+    const caipChainId = formatChainIdToCaip(token.chainId);
+    const stablecoinAssetIds = stablecoinAssetIdsByChain.get(caipChainId);
+
+    if (!stablecoinAssetIds) {
+      return true;
+    }
+
+    const assetId = formatAddressToAssetId(token.address, token.chainId);
+
+    if (!assetId) {
+      return true;
+    }
+
+    return !stablecoinAssetIds.has(assetId);
+  });
+}
 
 export function useBatchSellTokens() {
   const allWalletTokens = useTokensWithBalance({

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -58,6 +58,10 @@ function removeOndoTokenizedTokens(tokens: BridgeToken[]): BridgeToken[] {
   );
 }
 
+function removeRwaTokens(tokens: BridgeToken[]): BridgeToken[] {
+  return tokens.filter((token) => !token.rwaData);
+}
+
 export function useBatchSellTokens() {
   const allWalletTokens = useTokensWithBalance({
     chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
@@ -73,6 +77,7 @@ export function useBatchSellTokens() {
             stablecoinsByChain,
           }),
         removeOndoTokenizedTokens,
+        removeRwaTokens,
       )(allWalletTokens),
     [allWalletTokens, stablecoinsByChain],
   );

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -5,11 +5,14 @@ import {
   formatChainIdToCaip,
 } from '@metamask/bridge-controller';
 import { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { flow } from 'lodash/fp';
 
 import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
 import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
 import { BridgeToken } from '../../types';
 import { SUPPORTED_BATCH_SELL_CHAIN_IDS } from './BatchSellTokenSelect.utils';
+
+const ONDO_TOKENIZED_TOKEN_NAME = 'Ondo Tokenized';
 
 function removeStablecoinsFromSourceTokens({
   tokens,
@@ -49,6 +52,12 @@ function removeStablecoinsFromSourceTokens({
   });
 }
 
+function removeOndoTokenizedTokens(tokens: BridgeToken[]): BridgeToken[] {
+  return tokens.filter(
+    (token) => !token.name?.includes(ONDO_TOKENIZED_TOKEN_NAME),
+  );
+}
+
 export function useBatchSellTokens() {
   const allWalletTokens = useTokensWithBalance({
     chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
@@ -57,10 +66,14 @@ export function useBatchSellTokens() {
 
   return useMemo(
     () =>
-      removeStablecoinsFromSourceTokens({
-        tokens: allWalletTokens,
-        stablecoinsByChain,
-      }),
+      flow(
+        (tokens: BridgeToken[]) =>
+          removeStablecoinsFromSourceTokens({
+            tokens,
+            stablecoinsByChain,
+          }),
+        removeOndoTokenizedTokens,
+      )(allWalletTokens),
     [allWalletTokens, stablecoinsByChain],
   );
 }

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
+import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
+import {
+  removeStablecoinsFromSourceTokens,
+  SUPPORTED_BATCH_SELL_CHAIN_IDS,
+} from './BatchSellTokenSelect.utils';
+
+export function useBatchSellTokens() {
+  const allWalletTokens = useTokensWithBalance({
+    chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
+  });
+  const stablecoinsByChain = useSelector(selectBatchSellDestStablecoinsByChain);
+
+  return useMemo(
+    () =>
+      removeStablecoinsFromSourceTokens({
+        tokens: allWalletTokens,
+        stablecoinsByChain,
+      }),
+    [allWalletTokens, stablecoinsByChain],
+  );
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Batch Sell source token selection now centralizes eligible-token logic in a dedicated `useBatchSellTokens` hook instead of inline filtering in `BatchSellTokenSelect`.

The hook loads wallet tokens for supported Batch Sell chains, then filters out:

- configured destination stablecoins (unchanged behavior, moved from `BatchSellTokenSelect.utils`)
- tokens whose name includes `"Ondo Tokenized"`
- tokens with `rwaData` set (RWA / stock-class assets)

Sorting by fiat value remains in the view (`sortBatchSellTokens` + user sort direction); the hook returns an unsorted list.

**Motivation:** Batch Sell should not offer RWA or Ondo-tokenized positions as sellable sources. Colocating filters in one hook keeps the screen simpler and makes the exclusion rules easier to test and extend.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Excluded RWA and Ondo tokenized assets from Batch Sell source token selection

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4585

## **Manual testing steps**

```gherkin
Feature: Batch Sell source token filtering

  Scenario: RWA and Ondo tokens are not offered as Batch Sell sources
    Given I have a wallet with fungible tokens, at least one token with rwaData, and at least one "Ondo Tokenized …" token on a supported Batch Sell network
    And Batch Sell is available for my account

    When I open Batch Sell source token selection
    Then RWA tokens and Ondo Tokenized tokens do not appear in the source token list
    And destination stablecoins for the selected chain are still not shown as sources
    And ordinary fungible tokens with balance still appear and can be selected

  Scenario: Sorting still works on the filtered list
    Given I have multiple eligible non-RWA source tokens on the same network

    When I open Batch Sell source token selection
    And I toggle the balance sort control
    Then the visible tokens reorder by fiat value without RWA or Ondo tokens reappearing
```

**Commands run locally:**

```bash
yarn jest app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.test.ts
yarn jest app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

https://github.com/user-attachments/assets/254020a2-ca43-44cf-b751-6aa44a9913da




<!-- [screenshots/recordings] -->

Only eligible fungible source tokens appear; RWA (`rwaData`) and `"Ondo Tokenized"` names are hidden.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only eligibility filtering for Batch Sell token selection with existing stablecoin rules preserved and new unit tests; no auth, payments, or transaction execution changes.
> 
> **Overview**
> Batch Sell source token eligibility moves into a new **`useBatchSellTokens`** hook. **`BatchSellTokenSelect`** now consumes that hook instead of wiring **`useTokensWithBalance`** and stablecoin filtering inline; fiat sorting and network pills still run in the screen on the filtered list.
> 
> The hook loads tokens for supported Batch Sell chains, then filters out destination stablecoins (same behavior as before, relocated from **`BatchSellTokenSelect.utils`**), tokens whose name includes **"Ondo Tokenized"**, and any token with **`rwaData`**. Dedicated hook tests cover chain scoping, stablecoin exclusion, and the new RWA/Ondo rules; the old stablecoin-filter unit test was removed from the screen test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3b598b7e561b2faf84482888e13eddecd1355e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->