### PR TITLE
chore: share address QR MMDS bottom sheet migration and pure black fix

### DIFF
--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -72,7 +72,7 @@ export const ShareAddressQR = () => {
   }, [address, toBlockExplorer]);
 
   return (
-    <BottomSheet ref={sheetRef}>
+    <BottomSheet ref={sheetRef} goBack={handleOnBack}>
       <BottomSheetHeader
         onClose={handleOnBack}
         closeButtonProps={{ testID: ShareAddressQRIds.GO_BACK }}

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import { strings } from '../../../../../../locales/i18n';
 import {
   ParamListBase,
@@ -12,13 +9,15 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import {
+  BottomSheet,
+  BottomSheetHeader,
+  type BottomSheetRef,
   Box,
   BoxFlexDirection,
   BoxAlignItems,
   Button,
   ButtonVariant,
   ButtonSize,
-  HeaderStandard,
   TextVariant,
   TextColor,
   FontWeight,
@@ -74,11 +73,12 @@ export const ShareAddressQR = () => {
 
   return (
     <BottomSheet ref={sheetRef}>
-      <HeaderStandard
-        title={`${accountGroupName} / ${networkName}`}
+      <BottomSheetHeader
         onClose={handleOnBack}
         closeButtonProps={{ testID: ShareAddressQRIds.GO_BACK }}
-      />
+      >
+        {`${accountGroupName} / ${networkName}`}
+      </BottomSheetHeader>
       <Box
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Center}

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
@@ -129,7 +129,7 @@ const QRAccountDisplay = (props: QRAccountDisplayProps) => {
   };
 
   return (
-    <Box twClassName="bg-default items-center">
+    <Box twClassName="items-center">
       {renderLabel()}
       {renderDescription()}
       <Box twClassName="mt-8 items-center">


### PR DESCRIPTION
## **Description**

Replace the `ShareAddressQR` legacy component-library bottom sheet with the MetaMask design system `BottomSheet` and `BottomSheetHeader`. This keeps the sheet on the current MMDS implementation we already upgraded to, while preserving the existing QR content and explorer action. Also remove the `bg-default` background class from `QRAccountDisplay` so the sheet content renders without the extra background layer.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Share address QR bottom sheet

  Scenario: user opens the share address QR sheet
    Given the app is running on iOS
    When user opens the share address QR flow
    Then the sheet uses the design system bottom sheet and renders the QR content correctly
```

## **Screenshots/Recordings**

### **After**

https://github.com/user-attachments/assets/61009c7f-b575-40cb-8992-2b8bcdf84788

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only bottom sheet swap and a single Tailwind class removal on shared QR display; no auth, networking, or data-flow changes.
> 
> **Overview**
> Migrates the **Share address QR** sheet from the legacy component-library bottom sheet to **MetaMask Design System** `BottomSheet` and `BottomSheetHeader`, wiring **`goBack`** and the close control to the same navigation handler while keeping the QR, copy, and block-explorer behavior unchanged.
> 
> Removes the **`bg-default`** wrapper on `QRAccountDisplay` so the address block does not add an extra background layer inside the sheet (visual fix for contrast/“pure black” appearance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a7edd698f8ff12373a02dde7b3f3b986863c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->