### PR TITLE
fix: in batch sell when all sliders set to zero treat as no quotes and block CTA

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReview.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReview.test.tsx
@@ -206,6 +206,15 @@ jest.mock('../../hooks/useBatchSellQuoteRequest', () => ({
       return token.balance;
     },
   ),
+  hasValidBatchSellSourceAmounts: jest.fn(
+    (
+      _sourceTokens: BridgeToken[],
+      batchSellSourceTokenAmounts: Record<string, string | undefined>,
+    ) =>
+      Object.values(batchSellSourceTokenAmounts).some(
+        (amount) => amount !== undefined && Number(amount) > 0,
+      ),
+  ),
   useBatchSellQuoteRequest: jest.fn(() => ({
     updateBatchSellQuoteParams: mockUpdateBatchSellQuoteParams,
     getNewQuote: mockGetNewQuote,
@@ -477,6 +486,25 @@ describe('BatchSellReview', () => {
 
     expect(getByText('Review')).toBeOnTheScreen();
     expect(reviewButton.props.accessibilityState.disabled).not.toBe(true);
+  });
+
+  it('disables the review button and clears quotes when all source amounts are zero', () => {
+    mockBatchSellSourceTokenAmounts = {
+      [ethAssetId]: '0',
+      [uniAssetId]: '0',
+    };
+    mockBatchSellQuoteData = {
+      ...defaultQuoteData,
+      hasAnyQuote: false,
+    };
+
+    const { getByTestId } = render(<BatchSellReview />);
+    const reviewButton = getByTestId(BatchSellReviewSelectorsIDs.REVIEW_BUTTON);
+
+    expect(reviewButton.props.accessibilityState.disabled).toBe(true);
+    expect(mockUpdateBatchSellQuoteParams).not.toHaveBeenCalled();
+    expect(Engine.context.BridgeController.resetState).toHaveBeenCalled();
+    expect(mockCancelBatchSellQuoteParams).toHaveBeenCalled();
   });
 
   it('shows UNKNOWN when there is no destination token match', () => {

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReview.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReview.tsx
@@ -48,8 +48,8 @@ import { getBatchSellSlippage } from '../../components/SlippageModal/utils';
 import { BatchSellReviewSelectorsIDs } from './BatchSellReview.testIds';
 import { BatchSellReviewTokenRow } from './BatchSellReviewTokenRow';
 import {
-  getBatchSellAtomicSourceAmount,
   getBatchSellSourceTokenAmount,
+  hasValidBatchSellSourceAmounts,
   useBatchSellQuoteRequest,
 } from '../../hooks/useBatchSellQuoteRequest';
 import { useBatchSellQuoteData } from '../../hooks/useBatchSellQuoteData';
@@ -129,19 +129,13 @@ export function BatchSellReview() {
   const { updateBatchSellQuoteParams, getNewQuote: handleGetNewQuote } =
     useBatchSellQuoteRequest();
   const batchSellQuoteData = useBatchSellQuoteData();
-  const hasValidBatchSellInputs = useMemo(
+  const hasValidSourceAmounts = useMemo(
     () =>
-      Boolean(selectedDestinationToken) &&
-      selectedTokens.some((token) => {
-        const assetId = formatAddressToAssetId(token.address, token.chainId);
-        return (
-          assetId &&
-          getBatchSellAtomicSourceAmount(
-            token,
-            batchSellSourceTokenAmounts[assetId],
-          )
-        );
-      }),
+      hasValidBatchSellSourceAmounts(
+        selectedTokens,
+        batchSellSourceTokenAmounts,
+        selectedDestinationToken,
+      ),
     [batchSellSourceTokenAmounts, selectedDestinationToken, selectedTokens],
   );
 
@@ -164,14 +158,17 @@ export function BatchSellReview() {
   }, [selectedTokens]);
 
   useEffect(() => {
-    if (hasValidBatchSellInputs) {
+    if (hasValidSourceAmounts) {
       updateBatchSellQuoteParams();
+    } else {
+      updateBatchSellQuoteParams.cancel();
+      Engine.context.BridgeController?.resetState?.();
     }
 
     return () => {
       updateBatchSellQuoteParams.cancel();
     };
-  }, [hasValidBatchSellInputs, updateBatchSellQuoteParams]);
+  }, [hasValidSourceAmounts, updateBatchSellQuoteParams]);
 
   useEffect(
     () => () => {
@@ -329,7 +326,8 @@ export function BatchSellReview() {
   const hasReviewableQuote =
     batchSellQuoteData.hasAnyQuote && !batchSellQuoteData.hasPendingQuoteRows;
   const isReviewButtonDisabled =
-    !shouldGetNewQuote && (isFetchingQuotes || !hasReviewableQuote);
+    !hasValidSourceAmounts ||
+    (!shouldGetNewQuote && (isFetchingQuotes || !hasReviewableQuote));
   let reviewButtonLabel = strings('bridge.batch_sell_review');
 
   if (shouldGetNewQuote) {

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts
@@ -11,6 +11,7 @@ import {
   selectBatchSellDestToken,
   selectBatchSellQuotes,
   selectBatchSellSlippages,
+  selectBatchSellSourceTokenAmounts,
   selectBatchSellSourceTokens,
   selectBatchSellTrades,
   selectBridgeFeatureFlags,
@@ -26,6 +27,7 @@ import {
   getSlippageDisplayValue,
 } from '../../components/SlippageModal/utils';
 import type { BridgeToken } from '../../types';
+import { hasValidBatchSellSourceAmounts } from '../useBatchSellQuoteRequest';
 import { getQuoteRefreshRate, isQuoteExpired } from '../../utils/quoteUtils';
 
 const UNKNOWN_DESTINATION_TOKEN_SYMBOL = 'UNKNOWN';
@@ -214,6 +216,9 @@ export function useBatchSellQuoteData({
 }: UseBatchSellQuoteDataOptions = {}) {
   const sourceTokens = useSelector(selectBatchSellSourceTokens);
   const selectedDestinationToken = useSelector(selectBatchSellDestToken);
+  const batchSellSourceTokenAmounts = useSelector(
+    selectBatchSellSourceTokenAmounts,
+  );
   const batchSellSlippages = useSelector(selectBatchSellSlippages);
   const batchSellQuotes = useSelector(selectBatchSellQuotes);
   const batchSellTrades = useSelector(selectBatchSellTrades);
@@ -251,16 +256,28 @@ export function useBatchSellQuoteData({
     }
   }, [batchSellQuotes.isLoading, recommendedQuotesRequestKey]);
 
+  const hasValidSourceAmounts = useMemo(
+    () =>
+      hasValidBatchSellSourceAmounts(
+        sourceTokens,
+        batchSellSourceTokenAmounts,
+        selectedDestinationToken,
+      ),
+    [batchSellSourceTokenAmounts, selectedDestinationToken, sourceTokens],
+  );
   const shouldHideStaleRefreshQuotes = Boolean(
     batchSellQuotes.isLoading &&
       lastFetchedRecommendedQuotesRequestKey.current &&
       lastFetchedRecommendedQuotesRequestKey.current ===
         recommendedQuotesRequestKey,
   );
-  const visibleRecommendedQuotes = useMemo(
-    () => (shouldHideStaleRefreshQuotes ? [] : recommendedQuotes),
-    [recommendedQuotes, shouldHideStaleRefreshQuotes],
-  );
+  const activeRecommendedQuotes = useMemo(() => {
+    if (!hasValidSourceAmounts || shouldHideStaleRefreshQuotes) {
+      return [];
+    }
+
+    return recommendedQuotes;
+  }, [hasValidSourceAmounts, recommendedQuotes, shouldHideStaleRefreshQuotes]);
   const hasStaleDestinationQuotes = recommendedQuotes.some(
     (quote) =>
       quote && !isQuoteForDestinationAssetId(quote, destinationAssetId),
@@ -268,7 +285,7 @@ export function useBatchSellQuoteData({
   const hasQuoteResultsForSelectedTokens =
     sourceTokens.length > 0 &&
     (Boolean(batchSellQuotes.quotesLastFetchedMs) ||
-      visibleRecommendedQuotes.length === sourceTokens.length);
+      activeRecommendedQuotes.length === sourceTokens.length);
   const quoteRows = useMemo(
     () =>
       sourceTokens.reduce<BatchSellQuoteRow[]>((rows, token) => {
@@ -279,7 +296,7 @@ export function useBatchSellQuoteData({
         rows.push({
           assetId,
           recommendedQuote: getRecommendedQuoteBySourceAndDestinationAssetId(
-            visibleRecommendedQuotes,
+            activeRecommendedQuotes,
             assetId,
             destinationAssetId,
           ),
@@ -288,7 +305,7 @@ export function useBatchSellQuoteData({
 
         return rows;
       }, []),
-    [destinationAssetId, sourceTokens, visibleRecommendedQuotes],
+    [activeRecommendedQuotes, destinationAssetId, sourceTokens],
   );
   const availableRecommendedQuotes = useMemo(
     () =>
@@ -311,9 +328,10 @@ export function useBatchSellQuoteData({
       totalNetworkFee?.asset && !isNativeAddress(totalNetworkFee.asset.address),
     );
   const isWaitingForQuoteRows =
-    !hasQuoteResultsForSelectedTokens ||
-    batchSellQuotes.isLoading ||
-    hasStaleDestinationQuotes;
+    hasValidSourceAmounts &&
+    (!hasQuoteResultsForSelectedTokens ||
+      batchSellQuotes.isLoading ||
+      hasStaleDestinationQuotes);
   const hasPendingQuoteRows = quoteRows.some(
     ({ recommendedQuote }) => !recommendedQuote && isWaitingForQuoteRows,
   );
@@ -328,11 +346,14 @@ export function useBatchSellQuoteData({
       batchSellQuotes.quotesLastFetchedMs ?? null,
     );
   const isLoading =
-    batchSellQuotes.isLoading ||
-    !hasQuoteResultsForSelectedTokens ||
-    hasStaleDestinationQuotes;
+    hasValidSourceAmounts &&
+    (batchSellQuotes.isLoading ||
+      !hasQuoteResultsForSelectedTokens ||
+      hasStaleDestinationQuotes);
   const isSummaryLoading =
-    (!hasAnyQuote || hasStaleDestinationQuotes) && isLoading;
+    hasValidSourceAmounts &&
+    (!hasAnyQuote || hasStaleDestinationQuotes) &&
+    isLoading;
   const totalReceived = useMemo(
     () =>
       sumRecommendedQuoteAmounts(availableRecommendedQuotes, 'toTokenAmount'),

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
@@ -10,6 +10,15 @@ jest.mock('../useBatchSellQuoteRequest', () => ({
     (_token: BridgeToken, sourceAmount?: string) =>
       sourceAmount && Number(sourceAmount) > 0 ? '1' : undefined,
   ),
+  hasValidBatchSellSourceAmounts: jest.fn(
+    (
+      _sourceTokens: BridgeToken[],
+      batchSellSourceTokenAmounts: Record<string, string | undefined>,
+    ) =>
+      Object.values(batchSellSourceTokenAmounts).some(
+        (amount) => amount !== undefined && Number(amount) > 0,
+      ),
+  ),
 }));
 
 jest.mock('../../../../../core/Engine', () => ({
@@ -235,6 +244,29 @@ describe('useBatchSellQuoteData', () => {
       refreshRate: 30000,
       priceImpactThreshold: { warning: 0.05 },
     };
+  });
+
+  it('reports no quotes when all source amounts are zero even if stale quotes exist', () => {
+    mockBatchSellSourceTokenAmounts = {
+      [ethAssetId]: '0',
+      [uniAssetId]: '0',
+    };
+
+    const { result } = renderHook(() => useBatchSellQuoteData());
+
+    expect(result.current.hasAnyQuote).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isSummaryLoading).toBe(false);
+    expect(result.current.hasPendingQuoteRows).toBe(false);
+    expect(result.current.totalReceived.formattedFiat).toBe('-');
+    expect(
+      Engine.context.BridgeController.updateBatchSellTrades,
+    ).not.toHaveBeenCalled();
+    expect(result.current.tokenData[ethAssetId]).toEqual(
+      expect.objectContaining({
+        isQuoteUnavailable: true,
+      }),
+    );
   });
 
   it('formats complete Batch Sell quote data', () => {

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
@@ -84,15 +84,15 @@ export function hasValidBatchSellSourceAmounts(
 
   return sourceTokens.some((token) => {
     const assetId = formatAddressToAssetId(token.address, token.chainId);
-    const sourceAmount = assetId
-      ? batchSellSourceTokenAmounts[assetId]
-      : undefined;
 
-    if (!sourceAmount) return false;
+    if (!assetId) return false;
 
-    const numericAmount = Number(sourceAmount);
-
-    return Number.isFinite(numericAmount) && numericAmount > 0;
+    return (
+      getBatchSellAtomicSourceAmount(
+        token,
+        batchSellSourceTokenAmounts[assetId],
+      ) !== undefined
+    );
   });
 }
 

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
@@ -75,6 +75,27 @@ export function getBatchSellAtomicSourceAmount(
   return atomicAmount.toFixed(0);
 }
 
+export function hasValidBatchSellSourceAmounts(
+  sourceTokens: BridgeToken[],
+  batchSellSourceTokenAmounts: Record<string, string | undefined>,
+  destToken: BridgeToken | undefined,
+) {
+  if (!destToken) return false;
+
+  return sourceTokens.some((token) => {
+    const assetId = formatAddressToAssetId(token.address, token.chainId);
+    const sourceAmount = assetId
+      ? batchSellSourceTokenAmounts[assetId]
+      : undefined;
+
+    if (!sourceAmount) return false;
+
+    const numericAmount = Number(sourceAmount);
+
+    return Number.isFinite(numericAmount) && numericAmount > 0;
+  });
+}
+
 function getBatchSellUsdAmountSource(token: BridgeToken, sourceAmount: string) {
   const balance = token.balance ? Number(token.balance) : 0;
   const numericSourceAmount = Number(sourceAmount);

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
@@ -155,6 +155,26 @@ describe('useBatchSellQuoteRequest', () => {
     ).toBe(false);
   });
 
+  it('returns false from hasValidBatchSellSourceAmounts when decimal amount is below one atomic unit', () => {
+    expect(
+      hasValidBatchSellSourceAmounts(
+        [ethToken],
+        { [ethAssetId]: '1e-19' },
+        usdcToken,
+      ),
+    ).toBe(false);
+    expect(
+      buildBatchSellQuoteRequestData({
+        batchSellSlippages: {},
+        batchSellSourceTokenAmounts: { [ethAssetId]: '1e-19' },
+        destToken: usdcToken,
+        smartTransactionsEnabled: false,
+        sourceTokens: [ethToken],
+        walletAddress: mockWalletAddress,
+      }),
+    ).toEqual([]);
+  });
+
   it('builds quote request data for non-zero Batch Sell source token amounts', () => {
     const quoteRequestData = buildBatchSellQuoteRequestData({
       batchSellSlippages: {

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
@@ -10,6 +10,7 @@ import {
   buildBatchSellQuoteRequestData,
   getBatchSellAtomicSourceAmount,
   getBatchSellSourceTokenAmount,
+  hasValidBatchSellSourceAmounts,
   useBatchSellQuoteRequest,
 } from '.';
 
@@ -116,6 +117,42 @@ describe('useBatchSellQuoteRequest', () => {
     const amount = getBatchSellAtomicSourceAmount(ethToken, '0.749');
 
     expect(amount).toBe('749000000000000000');
+  });
+
+  it('returns false from hasValidBatchSellSourceAmounts when all source amounts are zero', () => {
+    expect(
+      hasValidBatchSellSourceAmounts(
+        [ethToken, uniToken],
+        {
+          [ethAssetId]: '0',
+          'eip155:1/erc20:0x2222222222222222222222222222222222222222': '0',
+        },
+        usdcToken,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true from hasValidBatchSellSourceAmounts when at least one source amount is sellable', () => {
+    expect(
+      hasValidBatchSellSourceAmounts(
+        [ethToken, uniToken],
+        {
+          [ethAssetId]: '0',
+          'eip155:1/erc20:0x2222222222222222222222222222222222222222': '1',
+        },
+        usdcToken,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false from hasValidBatchSellSourceAmounts when destination token is missing', () => {
+    expect(
+      hasValidBatchSellSourceAmounts(
+        [ethToken],
+        { [ethAssetId]: ethToken.balance },
+        undefined,
+      ),
+    ).toBe(false);
   });
 
   it('builds quote request data for non-zero Batch Sell source token amounts', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

On Batch Sell review, moving every token slider to 0% left stale `BridgeController` quotes in place (often for the last adjusted token) and kept the Review CTA enabled, so users could open final review with nothing to sell.

This PR treats “no positive source amounts” as an invalid Batch Sell state:

- Adds `hasValidBatchSellSourceAmounts` to detect when at least one selected token has a positive decimal source amount in Redux (and a destination token is set).
- **BatchSellReview**: when invalid, cancels debounced quote updates, calls `BridgeController.resetState()`, and disables the Review button.
- **useBatchSellQuoteData**: gates `activeRecommendedQuotes` on valid source amounts and refresh-stale hiding in one memo; clears aggregated/row quote UI and skips trades when nothing is sellable.

Unit tests cover all-zero amounts, quote data aggregation, and review CTA/reset behavior.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Fixed Batch Sell review allowing Review and stale quotes when all token sliders are set to 0%

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [SWAPS-4580](https://consensyssoftware.atlassian.net/browse/SWAPS-4580)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch Sell review — all sliders at 0%

  Scenario: Review is disabled and quotes are cleared when every slider is 0%
    Given the user is on Batch Sell token select with 2+ tokens selected
    And the user continues to Batch Sell review
    And quotes have loaded for all tokens

    When the user sets every token slider to 0%
    Then the Review button is disabled
    And total received does not show a stale aggregate from prior quotes
    And per-token received amounts do not show live quotes for the last-adjusted token

  Scenario: Quotes and Review recover when at least one slider is above 0%
    Given the user is on Batch Sell review with all sliders at 0%

    When the user moves one token slider above 0%
    Then quotes are requested again
    And the Review button enables once quotes are ready
```

**Commands run locally:**

- `yarn jest app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts`
- `yarn jest app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts`
- `yarn jest app/components/UI/Bridge/Views/BatchSellReview/BatchSellReview.test.tsx`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/92fc793e-08f9-4646-9a89-940cf9e69394



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4580]: https://consensyssoftware.atlassian.net/browse/SWAPS-4580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Batch Sell UX and quote gating; no auth, payments, or broad architectural changes.
> 
> **Overview**
> Batch Sell review no longer treats **all sliders at 0%** as a quotable state. A shared **`hasValidBatchSellSourceAmounts`** helper (destination set + at least one positive atomic sell amount) drives both the review screen and quote aggregation.
> 
> On **Batch Sell review**, invalid amounts cancel debounced quote updates, **`BridgeController.resetState()`**, and keep **Review** disabled. **`useBatchSellQuoteData`** hides stale recommended quotes and loading/aggregate UI when nothing is sellable, and skips **`updateBatchSellTrades`**. Tests cover the helper, all-zero UX, and quote gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d36e9e32203d34bb672097ec2522b6132db850a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->