### PR TITLE
fix(ramp): dismiss headless session on host refocus

### DIFF
--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx
@@ -60,6 +60,15 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+// Focus-dismissal is unit-tested in its own suite. Here we only assert the
+// Host wires the `disabled` flag correctly from its params, so mock the hook
+// and capture its arguments.
+const mockUseHeadlessSessionFocusDismissal = jest.fn();
+jest.mock('../../headless/useHeadlessSessionFocusDismissal', () => ({
+  useHeadlessSessionFocusDismissal: (...args: unknown[]) =>
+    mockUseHeadlessSessionFocusDismissal(...args),
+}));
+
 jest.mock('../../hooks/useContinueWithQuote', () => ({
   __esModule: true,
   default: (options?: unknown) => {
@@ -568,6 +577,47 @@ describe('HeadlessHost', () => {
       unmount();
 
       expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Focus-dismissal suppression wiring', () => {
+    it('disables the focus-dismissal hook when suppressFocusDismissal param is set', () => {
+      const quote = buildNativeQuote();
+      const session = seedSession(quote);
+      renderHost({
+        headlessSessionId: session.id,
+        suppressFocusDismissal: true,
+      });
+      expect(mockUseHeadlessSessionFocusDismissal).toHaveBeenCalledWith(
+        session.id,
+        mockIsFocused,
+        { disabled: true },
+      );
+    });
+
+    it('disables the focus-dismissal hook when nativeFlowError param is set', () => {
+      const quote = buildNativeQuote();
+      const session = seedSession(quote);
+      renderHost({
+        headlessSessionId: session.id,
+        nativeFlowError: 'OTP rejected',
+      });
+      expect(mockUseHeadlessSessionFocusDismissal).toHaveBeenCalledWith(
+        session.id,
+        mockIsFocused,
+        { disabled: true },
+      );
+    });
+
+    it('leaves the focus-dismissal hook enabled when neither suppress nor error params are set', () => {
+      const quote = buildNativeQuote();
+      const session = seedSession(quote);
+      renderHost({ headlessSessionId: session.id });
+      expect(mockUseHeadlessSessionFocusDismissal).toHaveBeenCalledWith(
+        session.id,
+        mockIsFocused,
+        { disabled: false },
+      );
     });
   });
 });

--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
@@ -24,6 +24,7 @@ import {
   setStatus,
 } from '../../headless/sessionRegistry';
 import { setHeadlessEntryCardTouchThrough } from '../../headless/headlessEntryNavigation';
+import { useHeadlessSessionFocusDismissal } from '../../headless/useHeadlessSessionFocusDismissal';
 import { useHeadlessSessionDismissal } from '../../headless/useHeadlessSessionDismissal';
 import { getChainIdFromAssetId } from '../../headless/useHeadlessBuy';
 import useContinueWithQuote, {
@@ -75,6 +76,9 @@ function HeadlessHost() {
   }, [navigation, isFocused]);
 
   useHeadlessSessionDismissal(headlessSessionId);
+  useHeadlessSessionFocusDismissal(headlessSessionId, isFocused, {
+    disabled: Boolean(nativeFlowError),
+  });
 
   useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {

--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
@@ -49,6 +49,14 @@ export interface HeadlessHostParams {
    * then closes the session.
    */
   nativeFlowError?: string;
+  /**
+   * Set by programmatic navigations that re-reveal this Host without a user
+   * back-out (e.g. OtpCode routing back after a successful OTP with no
+   * amount/currency/assetId). Disables the focus-dismissal heuristic so the
+   * regained focus is not misread as `user_dismissed` and the live session
+   * is kept. A genuine subsequent back-out still closes the session.
+   */
+  suppressFocusDismissal?: boolean;
 }
 
 /**
@@ -63,7 +71,7 @@ function HeadlessHost() {
   const navigation = useNavigation();
   const isFocused = useIsFocused();
   const { styles } = useStyles(styleSheet, {});
-  const { headlessSessionId, nativeFlowError } =
+  const { headlessSessionId, nativeFlowError, suppressFocusDismissal } =
     useParams<HeadlessHostParams>();
   const session = getSession(headlessSessionId);
 
@@ -77,7 +85,7 @@ function HeadlessHost() {
 
   useHeadlessSessionDismissal(headlessSessionId);
   useHeadlessSessionFocusDismissal(headlessSessionId, isFocused, {
-    disabled: Boolean(nativeFlowError),
+    disabled: Boolean(nativeFlowError) || Boolean(suppressFocusDismissal),
   });
 
   useEffect(() => {

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.test.tsx
@@ -309,6 +309,91 @@ describe('V2OtpCode', () => {
     });
   });
 
+  it('navigates to HEADLESS_HOST with suppressFocusDismissal when headless and no amount/currency/assetId params', async () => {
+    jest.useRealTimers();
+
+    mockUseParams.mockReturnValue({
+      email: 'test@example.com',
+      stateToken: 'test-state-token',
+      amount: undefined,
+      currency: undefined,
+      assetId: undefined,
+      headlessSessionId: 'headless-buy-abc',
+    });
+
+    const mockToken = { accessToken: 'otp-token', ttl: 3600 };
+    mockVerifyUserOtp.mockResolvedValue(mockToken);
+    mockSetAuthToken.mockResolvedValue(true);
+
+    const { getByTestId } = renderWithTheme(<V2OtpCode />);
+
+    await act(async () => {
+      fireEvent.changeText(getByTestId('otp-code-input'), '123456');
+    });
+
+    // Programmatic refocus of the still-mounted Host must flag itself so the
+    // host's focus-dismissal heuristic does not kill the live session.
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('RampHeadlessHost', {
+        headlessSessionId: 'headless-buy-abc',
+        suppressFocusDismissal: true,
+      });
+    });
+
+    mockUseParams.mockReturnValue({
+      email: 'test@example.com',
+      stateToken: 'test-state-token',
+      amount: '100',
+      currency: 'USD',
+      assetId: 'eip155:1/erc20:0x123',
+    });
+  });
+
+  it('navigates back to HEADLESS_HOST with nativeFlowError (not suppressFocusDismissal) when headless post-auth routing fails', async () => {
+    jest.useRealTimers();
+
+    mockUseParams.mockReturnValue({
+      email: 'test@example.com',
+      stateToken: 'test-state-token',
+      amount: '100',
+      currency: 'USD',
+      assetId: 'eip155:1/erc20:0x123',
+      headlessSessionId: 'headless-buy-abc',
+    });
+
+    const mockToken = { accessToken: 'otp-token', ttl: 3600 };
+    mockVerifyUserOtp.mockResolvedValue(mockToken);
+    mockSetAuthToken.mockResolvedValue(true);
+    mockGetBuyQuote.mockRejectedValue(new Error('Limit exceeded'));
+
+    const { getByTestId } = renderWithTheme(<V2OtpCode />);
+
+    await act(async () => {
+      fireEvent.changeText(getByTestId('otp-code-input'), '123456');
+    });
+
+    // Failure must keep routing through nativeFlowError (so failSession runs);
+    // the success-only suppress flag must NOT be set on this path.
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('RampHeadlessHost', {
+        headlessSessionId: 'headless-buy-abc',
+        nativeFlowError: 'Limit exceeded',
+      });
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      'RampHeadlessHost',
+      expect.objectContaining({ suppressFocusDismissal: true }),
+    );
+
+    mockUseParams.mockReturnValue({
+      email: 'test@example.com',
+      stateToken: 'test-state-token',
+      amount: '100',
+      currency: 'USD',
+      assetId: 'eip155:1/erc20:0x123',
+    });
+  });
+
   it('handles resend OTP', async () => {
     mockSendUserOtp.mockResolvedValue({ stateToken: 'new-state-token' });
 

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
@@ -294,8 +294,14 @@ const V2OtpCode = () => {
             }
           }
         } else if (headlessSessionId) {
+          // Successful auth with no amount/currency/assetId: route back to the
+          // still-mounted Host. This is a programmatic refocus, not a user
+          // back-out, so flag it to disable the host's focus-dismissal
+          // heuristic — otherwise the regained focus would be misread as
+          // `user_dismissed` and kill the live session.
           navigation.navigate(Routes.RAMP.HEADLESS_HOST, {
             headlessSessionId,
+            suppressFocusDismissal: true,
           });
         } else {
           navigation.navigate(Routes.RAMP.AMOUNT_INPUT);

--- a/app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts
@@ -1,0 +1,232 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import {
+  __resetSessionRegistryForTests,
+  closeSession,
+  createSession,
+  getSession,
+} from './sessionRegistry';
+import type { HeadlessBuyCallbacks, HeadlessBuyParams } from './types';
+import type { Quote } from '../types';
+
+import { useHeadlessSessionFocusDismissal } from './useHeadlessSessionFocusDismissal';
+
+const mockNavigation = { goBack: jest.fn() };
+const mockDismissHeadlessFlow = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+jest.mock('./headlessEntryNavigation', () => ({
+  dismissHeadlessFlow: (navigation: unknown) =>
+    mockDismissHeadlessFlow(navigation),
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), log: jest.fn() },
+}));
+
+const mockQuote = {
+  provider: '/providers/transak-native',
+  quote: {
+    amountIn: 25,
+    amountOut: 0.01,
+    paymentMethod: '/payments/debit-credit-card',
+  },
+  providerInfo: {
+    id: '/providers/transak-native',
+    name: 'Transak',
+    type: 'native' as const,
+  },
+} as unknown as Quote;
+
+const baseParams: HeadlessBuyParams = {
+  quote: mockQuote,
+  assetId: 'eip155:1/erc20:0xabc',
+  amount: 25,
+  paymentMethodId: '/payments/debit-credit-card',
+};
+
+function buildCallbacks(): HeadlessBuyCallbacks {
+  return {
+    onOrderCreated: jest.fn(),
+    onError: jest.fn(),
+    onClose: jest.fn(),
+  };
+}
+
+function flushDismissalTimer() {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  __resetSessionRegistryForTests();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useHeadlessSessionFocusDismissal', () => {
+  it('does not close on the initial focused host mount', () => {
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    renderHook(
+      ({ isFocused }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused),
+      { initialProps: { isFocused: true } },
+    );
+
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).not.toHaveBeenCalled();
+    expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+    expect(getSession(session.id)).toBeDefined();
+  });
+
+  it('closes and dismisses when the host regains focus after a blur', () => {
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused),
+      { initialProps: { isFocused: true } },
+    );
+
+    rerender({ isFocused: false });
+    rerender({ isFocused: true });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+    expect(callbacks.onClose).toHaveBeenCalledWith({
+      reason: 'user_dismissed',
+    });
+    expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
+    expect(mockDismissHeadlessFlow).toHaveBeenCalledWith(mockNavigation);
+    expect(getSession(session.id)).toBeUndefined();
+  });
+
+  it('closes when a reset-built host mounts blurred and is later revealed', () => {
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused),
+      { initialProps: { isFocused: false } },
+    );
+
+    rerender({ isFocused: true });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).toHaveBeenCalledWith({
+      reason: 'user_dismissed',
+    });
+    expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
+    expect(getSession(session.id)).toBeUndefined();
+  });
+
+  it('does not close for a transient refocus that blurs again before the deferred check runs', () => {
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused),
+      { initialProps: { isFocused: false } },
+    );
+
+    rerender({ isFocused: true });
+    rerender({ isFocused: false });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).not.toHaveBeenCalled();
+    expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+    expect(getSession(session.id)).toBeDefined();
+  });
+
+  it('does not dismiss when the session was already closed before the deferred check runs', () => {
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused),
+      { initialProps: { isFocused: false } },
+    );
+
+    rerender({ isFocused: true });
+    closeSession(session.id, { reason: 'completed' });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+    expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'completed' });
+    expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+  });
+
+  it('does not let a blur from one session close a different session', () => {
+    const firstCallbacks = buildCallbacks();
+    const firstSession = createSession(baseParams, firstCallbacks);
+    const secondCallbacks = buildCallbacks();
+    const secondSession = createSession(baseParams, secondCallbacks);
+
+    const { rerender } = renderHook(
+      ({
+        headlessSessionId,
+        isFocused,
+      }: {
+        headlessSessionId: string;
+        isFocused: boolean;
+      }) => useHeadlessSessionFocusDismissal(headlessSessionId, isFocused),
+      {
+        initialProps: {
+          headlessSessionId: firstSession.id,
+          isFocused: false,
+        },
+      },
+    );
+
+    rerender({
+      headlessSessionId: secondSession.id,
+      isFocused: true,
+    });
+    flushDismissalTimer();
+
+    expect(firstCallbacks.onClose).not.toHaveBeenCalled();
+    expect(secondCallbacks.onClose).not.toHaveBeenCalled();
+    expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+    expect(getSession(firstSession.id)).toBeDefined();
+    expect(getSession(secondSession.id)).toBeDefined();
+  });
+
+  it('does not convert a disabled focus transition into a user dismissal', () => {
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused, disabled }: { isFocused: boolean; disabled: boolean }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused, { disabled }),
+      {
+        initialProps: {
+          isFocused: false,
+          disabled: false,
+        },
+      },
+    );
+
+    rerender({ isFocused: true, disabled: true });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).not.toHaveBeenCalled();
+    expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+    expect(getSession(session.id)).toBeDefined();
+  });
+});

--- a/app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts
@@ -229,4 +229,70 @@ describe('useHeadlessSessionFocusDismissal', () => {
     expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
     expect(getSession(session.id)).toBeDefined();
   });
+
+  it('does not close on a suppressed (disabled) refocus even when the session blurred first', () => {
+    // Mirrors the OtpCode success/empty-params path: the host blurs while a
+    // native-flow screen is on top, then a programmatic navigate re-reveals it
+    // with suppressFocusDismissal → disabled true. The regained focus must NOT
+    // be read as a user dismissal.
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused, disabled }: { isFocused: boolean; disabled: boolean }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused, { disabled }),
+      {
+        initialProps: {
+          isFocused: true,
+          disabled: false,
+        },
+      },
+    );
+
+    // Blur while a native-flow screen is pushed (dismissal not yet suppressed).
+    rerender({ isFocused: false, disabled: false });
+    // Programmatic refocus arrives with suppression armed.
+    rerender({ isFocused: true, disabled: true });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).not.toHaveBeenCalled();
+    expect(mockDismissHeadlessFlow).not.toHaveBeenCalled();
+    expect(getSession(session.id)).toBeDefined();
+  });
+
+  it('still detects a genuine back-out after a disabled refocus clears the blur marker', () => {
+    // Hardening: the disabled branch resets the blur marker, so a disabled
+    // refocus does not "arm" a later dismissal. A subsequent genuine
+    // blur→refocus while enabled must produce its own user_dismissed close.
+    const callbacks = buildCallbacks();
+    const session = createSession(baseParams, callbacks);
+
+    const { rerender } = renderHook(
+      ({ isFocused, disabled }: { isFocused: boolean; disabled: boolean }) =>
+        useHeadlessSessionFocusDismissal(session.id, isFocused, { disabled }),
+      {
+        initialProps: {
+          isFocused: false,
+          disabled: false,
+        },
+      },
+    );
+
+    // Disabled refocus: must clear the blur marker and not close.
+    rerender({ isFocused: true, disabled: true });
+    flushDismissalTimer();
+    expect(callbacks.onClose).not.toHaveBeenCalled();
+
+    // Now a genuine blur→refocus while enabled: should close this time.
+    rerender({ isFocused: false, disabled: false });
+    rerender({ isFocused: true, disabled: false });
+    flushDismissalTimer();
+
+    expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+    expect(callbacks.onClose).toHaveBeenCalledWith({
+      reason: 'user_dismissed',
+    });
+    expect(mockDismissHeadlessFlow).toHaveBeenCalledTimes(1);
+    expect(getSession(session.id)).toBeUndefined();
+  });
 });

--- a/app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts
+++ b/app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+
+import { dismissHeadlessFlow } from './headlessEntryNavigation';
+import { closeSession, getSession } from './sessionRegistry';
+
+interface UseHeadlessSessionFocusDismissalOptions {
+  disabled?: boolean;
+}
+
+/**
+ * Closes a live headless session when HEADLESS_HOST is revealed again after
+ * another native-flow screen was popped off the same stack.
+ *
+ * The host is intentionally kept at the stack base for post-auth resets. That
+ * means backing out of EnterEmail, BasicInfo, KycWebview, etc. can refocus the
+ * transparent host without unmounting it, so unmount-based cleanup never runs.
+ */
+export function useHeadlessSessionFocusDismissal(
+  headlessSessionId: string | undefined,
+  isFocused: boolean,
+  options: UseHeadlessSessionFocusDismissalOptions = {},
+): void {
+  const navigation = useNavigation();
+  const navigationRef = useRef(navigation);
+  navigationRef.current = navigation;
+
+  const latestIsFocusedRef = useRef(isFocused);
+  latestIsFocusedRef.current = isFocused;
+
+  const latestHeadlessSessionIdRef = useRef(headlessSessionId);
+  latestHeadlessSessionIdRef.current = headlessSessionId;
+
+  const blurredSessionIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!headlessSessionId || options.disabled) {
+      blurredSessionIdRef.current = undefined;
+      return;
+    }
+
+    if (!isFocused) {
+      blurredSessionIdRef.current = headlessSessionId;
+      return;
+    }
+
+    if (blurredSessionIdRef.current !== headlessSessionId) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      if (!latestIsFocusedRef.current) {
+        return;
+      }
+
+      if (latestHeadlessSessionIdRef.current !== headlessSessionId) {
+        return;
+      }
+
+      if (!getSession(headlessSessionId)) {
+        return;
+      }
+
+      blurredSessionIdRef.current = undefined;
+      closeSession(headlessSessionId, { reason: 'user_dismissed' });
+      dismissHeadlessFlow(navigationRef.current);
+    }, 0);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [headlessSessionId, isFocused, options.disabled]);
+}
+
+export default useHeadlessSessionFocusDismissal;


### PR DESCRIPTION
## **Description**

Adds a focused headless-session dismissal hook for the Ramp headless buy host. `HEADLESS_HOST` remains mounted at the base of the Ramp stack while native-flow screens such as EnterEmail, BasicInfo, KycProcessing, and KycWebview are pushed or reset above it. When a user backs out of one of those screens, the transparent host can be revealed again without unmounting, so the existing unmount and `beforeRemove` cleanup paths do not fire.

This change arms dismissal only after the same `headlessSessionId` has blurred, then closes the live session and dismisses the headless modal if the host regains focus. The hook defers the close by one tick and re-checks focus/session identity to avoid treating transient `navigation.reset` focus blips as user dismissal. The `nativeFlowError` path disables this user-dismissal heuristic so auth failures continue to close through `failSession`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3630

## **Manual testing steps**

```gherkin
Feature: Headless buy native-flow dismissal

  Scenario: user backs out of a native-flow screen in headless buy
    Given a headless buy session is active and has navigated from RampHeadlessHost to a native-flow screen such as EnterEmail
    When the user taps the screen back button or performs a native stack back action
    Then the headless session is closed with reason "user_dismissed"
    And the RampHeadlessEntry modal is dismissed instead of revealing a transparent RampHeadlessHost with a live session
```

## **Screenshots/Recordings**

N/A — this is a headless lifecycle fix with no visible UI change. Validation evidence is in unit test output and static checks.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — this change adds a small lifecycle hook and does not introduce performance-sensitive rendering, data loading, or production instrumentation paths. The checklist below was consciously assessed as not applicable for this PR.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `node_modules/.bin/prettier --check app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts` — passed
- `NODE_OPTIONS=--max-old-space-size=8192 node_modules/.bin/eslint app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts` — passed
- `node_modules/.bin/jest app/components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.test.ts app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.test.tsx --runInBand --forceExit` — both suites printed `PASS`, but the local Jest process hung after reporting results and had to be terminated; the same behavior reproduced with the bundled Node runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes headless buy session lifecycle and navigation edge cases (OTP return vs user back-out); mistakes could close sessions early or leave stale sessions, but behavior is heavily unit-tested.
> 
> **Overview**
> Adds **`useHeadlessSessionFocusDismissal`** so a headless buy session closes with `user_dismissed` when **`HEADLESS_HOST`** becomes focused again after the user backs off a native-flow screen (the host stays mounted at the stack base, so unmount/`beforeRemove` alone did not run).
> 
> **HeadlessHost** wires the hook and turns it off when **`nativeFlowError`** or **`suppressFocusDismissal`** is set. **OtpCode** sets **`suppressFocusDismissal: true`** on successful OTP when routing back to the host without amount/currency/assetId, so programmatic refocus is not treated as dismissal; failures still use **`nativeFlowError`** only.
> 
> Unit tests cover the hook, host wiring, and OTP navigation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc79e8685b8944bb0327abe400f394120b005f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

