### PR TITLE
refactor(MainNavigator): snap routes to native stack

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -424,20 +424,26 @@ const ExploreHome = () => {
 };
 
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-const SnapsSettingsStack = () => (
-  <Stack.Navigator>
-    <Stack.Screen
-      name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
-      component={SnapsSettingsList}
-      options={SnapsSettingsList.navigationOptions}
-    />
-    <Stack.Screen
-      name={Routes.SNAPS.SNAP_SETTINGS}
-      component={SnapSettings}
-      options={SnapSettings.navigationOptions}
-    />
-  </Stack.Navigator>
-);
+const SnapsSettingsStack = () => {
+  const { colors } = useTheme();
+  return (
+    <NativeStack.Navigator
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.background.default },
+      }}
+    >
+      <NativeStack.Screen
+        name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
+        component={SnapsSettingsList}
+      />
+      <NativeStack.Screen
+        name={Routes.SNAPS.SNAP_SETTINGS}
+        component={SnapSettings}
+      />
+    </NativeStack.Navigator>
+  );
+};
 ///: END:ONLY_INCLUDE_IF
 
 const SettingsFlow = () => {

--- a/app/components/Nav/Main/MainNavigator.test.tsx
+++ b/app/components/Nav/Main/MainNavigator.test.tsx
@@ -1479,6 +1479,20 @@ describe('MainNavigator', () => {
         );
         expect(renderInner(AssetStackFlow).toJSON()).toBeTruthy();
       });
+
+      it('renders SnapsSettingsStack inside SettingsFlow', () => {
+        const { root: mainRoot } = renderWithProvider(<MainNavigator />, {
+          state: initialRootState,
+        });
+        const SettingsFlow = getScreenComponent(mainRoot, Routes.SETTINGS_VIEW);
+        const { root: settingsRoot } = renderInner(SettingsFlow);
+
+        const SnapsSettingsStack = getScreenComponent(
+          settingsRoot,
+          Routes.SNAPS.SNAPS_SETTINGS_LIST,
+        );
+        expect(renderInner(SnapsSettingsStack).toJSON()).toBeTruthy();
+      });
     });
 
     describe('Money account conditional rendering', () => {

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,4 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+export const SNAP_SETTINGS_HEADER = 'snap-settings-header';
+export const SNAP_SETTINGS_BACK_BUTTON = 'snap-settings-back-button';
 export const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
 export const SNAP_SETTINGS_SCROLLVIEW = 'snap-settings-scrollview';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,8 +1,6 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-import { CommonSelectorsIDs } from '../../../../util/Common.testIds';
-
 export const SNAP_SETTINGS_HEADER = 'snap-settings-header';
-export const SNAP_SETTINGS_BACK_BUTTON = CommonSelectorsIDs.BACK_ARROW_BUTTON;
+export const SNAP_SETTINGS_BACK_BUTTON = 'snap-settings-back-button';
 export const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
 export const SNAP_SETTINGS_SCROLLVIEW = 'snap-settings-scrollview';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,6 +1,8 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+import { CommonSelectorsIDs } from '../../../../util/Common.testIds';
+
 export const SNAP_SETTINGS_HEADER = 'snap-settings-header';
-export const SNAP_SETTINGS_BACK_BUTTON = 'snap-settings-back-button';
+export const SNAP_SETTINGS_BACK_BUTTON = CommonSelectorsIDs.BACK_ARROW_BUTTON;
 export const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
 export const SNAP_SETTINGS_SCROLLVIEW = 'snap-settings-scrollview';
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
@@ -5,7 +5,9 @@ const styleSheet = () =>
   StyleSheet.create({
     snapSettingsContainer: {
       flex: 1,
-      marginHorizontal: 16,
+    },
+    scrollContent: {
+      paddingHorizontal: 16,
     },
     itemPaddedContainer: {
       paddingVertical: 16,

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -33,6 +33,7 @@ import {
   SNAP_SETTINGS_REMOVE_BUTTON,
   SNAP_SETTINGS_SCROLLVIEW,
 } from './SnapSettings.constants';
+import { SNAPS_HEADER_TITLE_PROPS } from '../SnapsSettingsList/SnapsSettingsList.constants';
 import { selectPermissionControllerState } from '../../../../selectors/snaps/permissionController';
 import KeyringSnapRemovalWarning from '../KeyringSnapRemovalWarning/KeyringSnapRemovalWarning';
 import { getAccountsBySnapId } from '../../../../core/SnapKeyring/utils/getAccountsBySnapId';
@@ -157,6 +158,7 @@ const SnapSettings = () => {
       >
         <HeaderStandard
           title={snap.manifest.proposedName}
+          titleProps={SNAPS_HEADER_TITLE_PROPS}
           onBack={handleBack}
           includesTopInset
           testID={SNAP_SETTINGS_HEADER}

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -7,7 +7,11 @@ import Engine from '../../../../core/Engine';
 import Text, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
-import { Button, ButtonVariant } from '@metamask/design-system-react-native';
+import {
+  Button,
+  ButtonVariant,
+  HeaderStandard,
+} from '@metamask/design-system-react-native';
 
 import stylesheet from './SnapSettings.styles';
 import {
@@ -16,7 +20,6 @@ import {
 } from '../../../../util/navigation/navUtils';
 import Routes from '../../../../constants/navigation/Routes';
 import { Snap } from '@metamask/snaps-utils';
-import { getNavigationOptionsTitle } from '../../../UI/Navbar';
 import { useNavigation } from '@react-navigation/native';
 import { SnapDetails } from '../components/SnapDetails';
 import { SnapDescription } from '../components/SnapDescription';
@@ -25,6 +28,8 @@ import { strings } from '../../../../../locales/i18n';
 import { useStyles } from '../../../hooks/useStyles';
 import { useSelector } from 'react-redux';
 import {
+  SNAP_SETTINGS_BACK_BUTTON,
+  SNAP_SETTINGS_HEADER,
   SNAP_SETTINGS_REMOVE_BUTTON,
   SNAP_SETTINGS_SCROLLVIEW,
 } from './SnapSettings.constants';
@@ -72,16 +77,9 @@ const SnapSettings = () => {
 
   const permissionsFromController = getPermissions(permissionsState, snap.id);
 
-  useEffect(() => {
-    navigation.setOptions(
-      getNavigationOptionsTitle(
-        `${snap.manifest.proposedName}`,
-        navigation,
-        false,
-        colors,
-      ),
-    );
-  }, [colors, navigation, snap.manifest.proposedName]);
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   const isKeyringSnap = Boolean(permissionsFromController?.snap_manageAccounts);
 
@@ -150,8 +148,26 @@ const SnapSettings = () => {
 
   return (
     <>
-      <SafeAreaView style={styles.snapSettingsContainer}>
-        <ScrollView testID={SNAP_SETTINGS_SCROLLVIEW}>
+      <SafeAreaView
+        edges={{ bottom: 'additive' }}
+        style={[
+          styles.snapSettingsContainer,
+          { backgroundColor: colors.background.default },
+        ]}
+      >
+        <HeaderStandard
+          title={snap.manifest.proposedName}
+          onBack={handleBack}
+          includesTopInset
+          testID={SNAP_SETTINGS_HEADER}
+          backButtonProps={{
+            testID: SNAP_SETTINGS_BACK_BUTTON,
+          }}
+        />
+        <ScrollView
+          testID={SNAP_SETTINGS_SCROLLVIEW}
+          contentContainerStyle={styles.scrollContent}
+        >
           <SnapDetails snap={snap} />
           <View style={styles.itemPaddedContainer}>
             <SnapDescription

--- a/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
+++ b/app/components/Views/Snaps/SnapSettings/test/SnapSettings.test.tsx
@@ -9,7 +9,11 @@ import {
   SubjectPermissions,
 } from '@metamask/permission-controller';
 import { SemVerVersion } from '@metamask/utils';
-import { SNAP_SETTINGS_REMOVE_BUTTON } from '../SnapSettings.constants';
+import {
+  SNAP_SETTINGS_BACK_BUTTON,
+  SNAP_SETTINGS_HEADER,
+  SNAP_SETTINGS_REMOVE_BUTTON,
+} from '../SnapSettings.constants';
 import { SNAP_DETAILS_CELL } from '../../components/SnapDetails/SnapDetails.constants';
 import SNAP_PERMISSIONS from '../../components/SnapPermissions/SnapPermissions.contants';
 import { SNAP_PERMISSION_CELL } from '../../components/SnapPermissionCell/SnapPermissionCell.constants';
@@ -256,6 +260,9 @@ describe('SnapSettings with non keyring snap', () => {
       },
     );
 
+    expect(getByTestId(SNAP_SETTINGS_HEADER)).toBeOnTheScreen();
+    expect(getByTestId(SNAP_SETTINGS_BACK_BUTTON)).toBeOnTheScreen();
+
     const removeButton = getByTestId(SNAP_SETTINGS_REMOVE_BUTTON);
     const description = getByTestId(SNAP_DETAILS_CELL);
     const permissionContainer = getByTestId(SNAP_PERMISSIONS);
@@ -265,6 +272,16 @@ describe('SnapSettings with non keyring snap', () => {
     expect(permissionContainer).toBeTruthy();
     expect(permissions.length).toBe(7);
     expect(removeButton).toHaveTextContent('Remove Filsnap');
+  });
+
+  it('calls navigation.goBack when header back button is pressed', () => {
+    const { getByTestId } = renderWithProvider(<SnapSettings />, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      state: initialState as any,
+    });
+
+    fireEvent(getByTestId(SNAP_SETTINGS_BACK_BUTTON), 'onPress');
+    expect(mockGoBack).toHaveBeenCalled();
   });
 
   it('remove snap and goes back when Remove button is pressed', async () => {

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
@@ -1,0 +1,5 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
+export const SNAPS_SETTINGS_LIST_HEADER = 'snaps-settings-list-header';
+export const SNAPS_SETTINGS_LIST_BACK_BUTTON =
+  'snaps-settings-list-back-button';
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
@@ -1,10 +1,9 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { TextColor } from '@metamask/design-system-react-native';
-import { CommonSelectorsIDs } from '../../../../util/Common.testIds';
 
 export const SNAPS_SETTINGS_LIST_HEADER = 'snaps-settings-list-header';
 export const SNAPS_SETTINGS_LIST_BACK_BUTTON =
-  CommonSelectorsIDs.BACK_ARROW_BUTTON;
+  'snaps-settings-list-back-button';
 
 /** Matches legacy `getNavigationOptionsTitle` primary header title color. */
 export const SNAPS_HEADER_TITLE_PROPS = {

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
@@ -1,5 +1,12 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
+import { TextColor } from '@metamask/design-system-react-native';
+
 export const SNAPS_SETTINGS_LIST_HEADER = 'snaps-settings-list-header';
 export const SNAPS_SETTINGS_LIST_BACK_BUTTON =
   'snaps-settings-list-back-button';
+
+/** Matches legacy `getNavigationOptionsTitle` primary header title color. */
+export const SNAPS_HEADER_TITLE_PROPS = {
+  color: TextColor.PrimaryDefault,
+} as const;
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
@@ -1,9 +1,10 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { TextColor } from '@metamask/design-system-react-native';
+import { CommonSelectorsIDs } from '../../../../util/Common.testIds';
 
 export const SNAPS_SETTINGS_LIST_HEADER = 'snaps-settings-list-header';
 export const SNAPS_SETTINGS_LIST_BACK_BUTTON =
-  'snaps-settings-list-back-button';
+  CommonSelectorsIDs.BACK_ARROW_BUTTON;
 
 /** Matches legacy `getNavigationOptionsTitle` primary header title color. */
 export const SNAPS_HEADER_TITLE_PROPS = {

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.test.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.test.tsx
@@ -1,6 +1,9 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import { Snap, Status } from '@metamask/snaps-utils';
+import { SnapId } from '@metamask/snaps-sdk';
+import { SemVerVersion } from '@metamask/utils';
 import SnapsSettingsList from './SnapsSettingsList';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../util/test/initial-root-state';
@@ -9,6 +12,7 @@ import {
   SNAPS_SETTINGS_LIST_BACK_BUTTON,
   SNAPS_SETTINGS_LIST_HEADER,
 } from './SnapsSettingsList.constants';
+import SNAP_ELEMENT from '../components/SnapElement/SnapElement.constants';
 
 const mockGoBack = jest.fn();
 
@@ -18,23 +22,55 @@ jest.mock('@react-navigation/native', () => {
     ...actualReactNavigation,
     useNavigation: () => ({
       goBack: mockGoBack,
+      navigate: jest.fn(),
     }),
   };
 });
 
-const initialState = {
+const createMockSnap = (id: SnapId, proposedName: string): Snap =>
+  ({
+    blocked: false,
+    enabled: true,
+    id,
+    permissionName: `wallet_snap_${id}`,
+    initialPermissions: {},
+    manifest: {
+      proposedName,
+      version: '1.0.0' as SemVerVersion,
+      description: 'Test snap',
+      manifestVersion: '0.1',
+      initialPermissions: {},
+      source: {
+        shasum: 'abc',
+        location: {
+          npm: {
+            filePath: 'dist/bundle.js',
+            packageName: String(id).replace('npm:', ''),
+            registry: 'https://registry.npmjs.org/',
+          },
+        },
+      },
+    },
+    status: 'running' as Status,
+    version: '1.0.0' as SemVerVersion,
+    versionHistory: [],
+  }) as Snap;
+
+const createStateWithSnaps = (snaps: Record<string, Snap>) => ({
   engine: {
     backgroundState: {
       ...backgroundState,
       SnapController: {
         isReady: true,
         snapStates: {},
-        snaps: {},
+        snaps,
         unencryptedSnapStates: {},
       },
     },
   },
-};
+});
+
+const initialState = createStateWithSnaps({});
 
 describe('SnapsSettingsList', () => {
   beforeEach(() => {
@@ -63,6 +99,33 @@ describe('SnapsSettingsList', () => {
 
     fireEvent(getByTestId(SNAPS_SETTINGS_LIST_BACK_BUTTON), 'onPress');
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('renders SnapElement for each installed snap', () => {
+    const filsnap = createMockSnap(
+      'npm:@chainsafe/filsnap' as SnapId,
+      'Filsnap',
+    );
+    const exampleSnap = createMockSnap(
+      'npm:@metamask/example-snap' as SnapId,
+      'Example Snap',
+    );
+    const state = createStateWithSnaps({
+      [filsnap.id]: filsnap,
+      [exampleSnap.id]: exampleSnap,
+    });
+
+    const { getAllByTestId, getByText } = renderWithProvider(
+      <SnapsSettingsList />,
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        state: state as any,
+      },
+    );
+
+    expect(getAllByTestId(SNAP_ELEMENT)).toHaveLength(2);
+    expect(getByText(filsnap.manifest.proposedName)).toBeOnTheScreen();
+    expect(getByText(exampleSnap.manifest.proposedName)).toBeOnTheScreen();
   });
 });
 ///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.test.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.test.tsx
@@ -1,0 +1,68 @@
+///: BEGIN:ONLY_INCLUDE_IF(snaps)
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import SnapsSettingsList from './SnapsSettingsList';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+import { strings } from '../../../../../locales/i18n';
+import {
+  SNAPS_SETTINGS_LIST_BACK_BUTTON,
+  SNAPS_SETTINGS_LIST_HEADER,
+} from './SnapsSettingsList.constants';
+
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+    }),
+  };
+});
+
+const initialState = {
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      SnapController: {
+        isReady: true,
+        snapStates: {},
+        snaps: {},
+        unencryptedSnapStates: {},
+      },
+    },
+  },
+};
+
+describe('SnapsSettingsList', () => {
+  beforeEach(() => {
+    mockGoBack.mockClear();
+  });
+
+  it('renders HeaderStandard with snaps title and back button', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <SnapsSettingsList />,
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        state: initialState as any,
+      },
+    );
+
+    expect(getByTestId(SNAPS_SETTINGS_LIST_HEADER)).toBeOnTheScreen();
+    expect(getByTestId(SNAPS_SETTINGS_LIST_BACK_BUTTON)).toBeOnTheScreen();
+    expect(getByText(strings('app_settings.snaps.title'))).toBeOnTheScreen();
+  });
+
+  it('calls navigation.goBack when back button is pressed', () => {
+    const { getByTestId } = renderWithProvider(<SnapsSettingsList />, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      state: initialState as any,
+    });
+
+    fireEvent(getByTestId(SNAPS_SETTINGS_LIST_BACK_BUTTON), 'onPress');
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+});
+///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
@@ -1,11 +1,12 @@
 ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-import React, { useEffect } from 'react';
-import { View, ScrollView } from 'react-native';
+import React, { useCallback } from 'react';
+import { ScrollView } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { HeaderStandard } from '@metamask/design-system-react-native';
 
 import { SnapElement } from '../components/SnapElement';
-import { getNavigationOptionsTitle } from '../../../UI/Navbar';
 import { createNavigationDetails } from '../../../../util/navigation/navUtils';
 import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
@@ -13,6 +14,10 @@ import { useStyles } from '../../../../component-library/hooks';
 import stylesheet from './SnapsSettingsList.styles';
 import { Snap } from '@metamask/snaps-utils';
 import { selectSnaps } from '../../../../selectors/snaps/snapController';
+import {
+  SNAPS_SETTINGS_LIST_BACK_BUTTON,
+  SNAPS_SETTINGS_LIST_HEADER,
+} from './SnapsSettingsList.constants';
 
 export const createSnapsSettingsListNavDetails = createNavigationDetails(
   Routes.SNAPS.SNAPS_SETTINGS_LIST,
@@ -20,29 +25,30 @@ export const createSnapsSettingsListNavDetails = createNavigationDetails(
 
 const SnapsSettingsList = () => {
   const navigation = useNavigation();
-  const { styles, theme } = useStyles(stylesheet, {});
-  const { colors } = theme;
+  const { styles } = useStyles(stylesheet, {});
   const snaps = useSelector(selectSnaps);
 
-  useEffect(() => {
-    navigation.setOptions(
-      getNavigationOptionsTitle(
-        strings('app_settings.snaps.title'),
-        navigation,
-        false,
-        colors,
-      ),
-    );
-  }, [colors, navigation, snaps]);
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView edges={{ bottom: 'additive' }} style={styles.container}>
+      <HeaderStandard
+        title={strings('app_settings.snaps.title')}
+        onBack={handleBack}
+        includesTopInset
+        testID={SNAPS_SETTINGS_LIST_HEADER}
+        backButtonProps={{
+          testID: SNAPS_SETTINGS_LIST_BACK_BUTTON,
+        }}
+      />
       <ScrollView>
         {(Object.values(snaps) as Snap[]).map((snap: Snap) => (
           <SnapElement {...snap} key={snap.id} />
         ))}
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
@@ -15,6 +15,7 @@ import stylesheet from './SnapsSettingsList.styles';
 import { Snap } from '@metamask/snaps-utils';
 import { selectSnaps } from '../../../../selectors/snaps/snapController';
 import {
+  SNAPS_HEADER_TITLE_PROPS,
   SNAPS_SETTINGS_LIST_BACK_BUTTON,
   SNAPS_SETTINGS_LIST_HEADER,
 } from './SnapsSettingsList.constants';
@@ -36,6 +37,7 @@ const SnapsSettingsList = () => {
     <SafeAreaView edges={{ bottom: 'additive' }} style={styles.container}>
       <HeaderStandard
         title={strings('app_settings.snaps.title')}
+        titleProps={SNAPS_HEADER_TITLE_PROPS}
         onBack={handleBack}
         includesTopInset
         testID={SNAPS_SETTINGS_LIST_HEADER}

--- a/tests/page-objects/Settings/SnapSettingsView.ts
+++ b/tests/page-objects/Settings/SnapSettingsView.ts
@@ -1,6 +1,5 @@
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
-import { CommonSelectorsIDs } from '../../../app/util/Common.testIds';
 
 class SnapSettingsView {
   get enabledToggle(): DetoxElement {
@@ -16,7 +15,11 @@ class SnapSettingsView {
   }
 
   get backButton(): DetoxElement {
-    return Matchers.getElementByID(CommonSelectorsIDs.BACK_ARROW_BUTTON);
+    return Matchers.getElementByID('snap-settings-back-button');
+  }
+
+  get listBackButton(): DetoxElement {
+    return Matchers.getElementByID('snaps-settings-list-back-button');
   }
 
   async toggleEnable(): Promise<void> {
@@ -43,8 +46,14 @@ class SnapSettingsView {
   }
 
   async tapBackButton(): Promise<void> {
-    await Gestures.tapAtIndex(this.backButton, 0, {
+    await Gestures.tap(this.backButton, {
       elemDescription: 'Snap Settings - Back Button',
+    });
+  }
+
+  async tapListBackButton(): Promise<void> {
+    await Gestures.tap(this.listBackButton, {
+      elemDescription: 'Snaps List - Back Button',
     });
   }
 }

--- a/tests/smoke/snaps/test-snap-management.spec.ts
+++ b/tests/smoke/snaps/test-snap-management.spec.ts
@@ -48,7 +48,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         await SnapSettingsView.toggleEnable();
 
         await SnapSettingsView.tapBackButton();
-        await SnapSettingsView.tapBackButton();
+        await SnapSettingsView.tapListBackButton();
         // Settings → AccountsMenu → close SettingsFlow
         await SettingsView.tapBackButton();
         await AccountMenu.tapBack();
@@ -81,7 +81,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         await SnapSettingsView.toggleEnable();
 
         await SnapSettingsView.tapBackButton();
-        await SnapSettingsView.tapBackButton();
+        await SnapSettingsView.tapListBackButton();
         // Settings → AccountsMenu → close SettingsFlow
         await SettingsView.tapBackButton();
         await AccountMenu.tapBack();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->
Migrates the nested Snaps settings stack (SnapsSettingsList → SnapSettings) from the legacy JS stack to @react-navigation/native-stack, and moves navigation chrome into in-screen HeaderStandard components. Parent SettingsFlow remains on the legacy stack for now (follow-up PR).


## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Refs: https://consensyssoftware.atlassian.net/browse/MCWP-585

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Snaps settings navigation (native stack)
  Scenario: Open snaps list from settings
    Given I am on a build where third-party snaps are enabled
    And I open Settings then Snaps
    Then I see the Snaps list with a standard header and back control
  Scenario: Open snap detail and go back
    Given I am on the Snaps list with at least one installed snap
    When I tap a snap
    Then I see Snap settings with the snap name in the header
    When I tap back
    Then I return to the Snaps list
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->
|BEFORE|AFTER|
|---|---|
|<img width="368" height="762" alt="snap before" src="https://github.com/user-attachments/assets/872d197f-c1a1-44fa-a09d-55a72742b69c" />|<img width="368" height="762" alt="snap after" src="https://github.com/user-attachments/assets/f164116f-8dc1-46ea-9892-775a20475b3f" />|


Android after:
<img width="368" height="762" alt="Snap android after" src="https://github.com/user-attachments/assets/500921d4-bc8d-4737-917b-7de2ede1da85" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and header UI refactor in settings only; snap enable/remove behavior is unchanged and covered by unit and smoke tests.
> 
> **Overview**
> Moves the nested **Snaps settings** flow (`SnapsSettingsList` → `SnapSettings`) from the legacy JS stack to **`NativeStack`**, with **`headerShown: false`** and themed **`contentStyle`**, while **SettingsFlow** stays on the legacy stack.
> 
> **SnapsSettingsList** and **SnapSettings** drop **`navigation.setOptions` / `getNavigationOptionsTitle`** in favor of in-screen **`HeaderStandard`** (shared title styling via **`SNAPS_HEADER_TITLE_PROPS`**) and explicit back **`testID`s**. Snap detail layout shifts horizontal padding into scroll **`contentContainerStyle`**.
> 
> Coverage updates: new **`SnapsSettingsList`** tests, header/back assertions on **`SnapSettings`**, a **`MainNavigator`** check that **`SnapsSettingsStack`** mounts under settings, and Detox targets the new list vs detail back buttons instead of the generic navbar back control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a981cda178d4ab572e264622ade504fd09e8ae4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->