### PR TITLE
fix(money): correct card CTA mode and disable link during linkage

### DIFF
--- a/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.test.tsx
@@ -128,6 +128,24 @@ describe('StepperCard', () => {
       fireEvent.press(getByText('Go'));
       expect(onPress).toHaveBeenCalledTimes(1);
     });
+
+    it('does not fire primaryCta.onPress when disabled', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = render(
+        <StepperCard
+          steps={[
+            makeStep({
+              primaryCta: { text: 'Go', onPress, disabled: true },
+            }),
+          ]}
+          currentStep={0}
+          testID="stepper-card"
+        />,
+      );
+
+      fireEvent.press(getByTestId('stepper-card-cta-button'));
+      expect(onPress).not.toHaveBeenCalled();
+    });
   });
 
   describe('secondary CTA', () => {

--- a/app/component-library/components-temp/StepperCard/StepperCard.tsx
+++ b/app/component-library/components-temp/StepperCard/StepperCard.tsx
@@ -109,6 +109,7 @@ const StepperCard = ({
               variant={ButtonVariant.Secondary}
               size={ButtonSize.Lg}
               onPress={step.secondaryCta.onPress}
+              isDisabled={step.secondaryCta.disabled}
               twClassName="flex-1"
             >
               {step.secondaryCta.text}
@@ -118,6 +119,7 @@ const StepperCard = ({
             variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
             onPress={step.primaryCta.onPress}
+            isDisabled={step.primaryCta.disabled}
             twClassName="flex-1"
             testID={getTestId('cta-button')}
           >

--- a/app/component-library/components-temp/StepperCard/StepperCard.types.ts
+++ b/app/component-library/components-temp/StepperCard/StepperCard.types.ts
@@ -3,6 +3,7 @@ import { ImageSourcePropType } from 'react-native';
 export interface StepperCardCta {
   text: string;
   onPress: () => void;
+  disabled?: boolean;
 }
 
 export interface StepperCardStep {

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -117,8 +117,11 @@ const CardHome = () => {
     useCardProvisioning(data);
 
   // --- Money Account linkage ---
-  const { canLink: canLinkMoneyAccount, startLinkFlow: startMoneyAccountLink } =
-    useMoneyAccountCardLinkage();
+  const {
+    canLink: canLinkMoneyAccount,
+    startLinkFlow: startMoneyAccountLink,
+    isLinking: isMoneyAccountLinkInProgress,
+  } = useMoneyAccountCardLinkage();
   const { apyPercent: moneyAccountApyPercent } = useMoneyAccountBalance();
   const hasMetalCard = data?.card?.type === CardType.METAL;
   const handleLinkMoneyAccountCard = useCallback(
@@ -416,6 +419,7 @@ const CardHome = () => {
                 hideCardImage
                 apy={moneyAccountApyPercent}
                 showMetalCard={hasMetalCard}
+                isLinkDisabled={isMoneyAccountLinkInProgress}
                 onGetNowPress={handleLinkMoneyAccountCard}
                 onHeaderPress={handleLinkMoneyAccountCard}
                 onLinkPress={handleLinkMoneyAccountCard}

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -11,6 +11,7 @@ import {
   selectCardHomeDataStatus,
   selectIsCardAuthenticated,
   selectIsCardholder,
+  selectIsMoneyAccountCardLinkInProgress,
   selectIsMoneyAccountDelegatedForCard,
 } from '../../../../selectors/cardController';
 import {
@@ -141,6 +142,7 @@ const buildSelectors = (
     pendingMoneyAccountCardLink?: boolean;
     cardHomeDataStatus?: CardHomeDataStatusMock;
     isMonadSponsorshipEnabled?: boolean;
+    moneyAccountCardLinkInProgress?: boolean;
   } = {},
 ) => ({
   primaryMoneyAccount: { address: MONEY_ACCOUNT_ADDRESS },
@@ -153,6 +155,7 @@ const buildSelectors = (
   pendingMoneyAccountCardLink: false,
   cardHomeDataStatus: 'success' as CardHomeDataStatusMock,
   isMonadSponsorshipEnabled: true,
+  moneyAccountCardLinkInProgress: false,
   ...overrides,
 });
 
@@ -171,6 +174,8 @@ const applySelectorMocks = (state: ReturnType<typeof buildSelectors>) => {
     if (selector === selectCardHomeDataStatus) return state.cardHomeDataStatus;
     if (selector === selectIsMoneyAccountDelegatedForCard)
       return state.isAlreadyDelegated;
+    if (selector === selectIsMoneyAccountCardLinkInProgress)
+      return state.moneyAccountCardLinkInProgress;
     if (selector === selectPendingMoneyAccountCardLink)
       return state.pendingMoneyAccountCardLink;
     if (selector === getGasFeesSponsoredNetworkEnabled)
@@ -265,6 +270,50 @@ describe('useMoneyAccountCardLinkage', () => {
       applySelectorMocks(buildSelectors({ isMonadSponsorshipEnabled: false }));
       const { result } = renderLinkageHook();
       expect(result.current.canLink).toBe(false);
+    });
+
+    it('reports isLinking=true when controller linkage is in progress', () => {
+      applySelectorMocks(
+        buildSelectors({ moneyAccountCardLinkInProgress: true }),
+      );
+      const { result } = renderLinkageHook();
+      expect(result.current.isLinking).toBe(true);
+    });
+  });
+
+  describe('linkage in progress guards', () => {
+    const ORIGIN = {
+      screen: Routes.MONEY.ROOT,
+      params: { screen: Routes.MONEY.HOME },
+    } as const;
+
+    it('does not navigate from openLinkCardSheet when linkage is in progress', () => {
+      applySelectorMocks(
+        buildSelectors({ moneyAccountCardLinkInProgress: true }),
+      );
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.openLinkCardSheet();
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate from startLinkFlow when linkage is in progress', () => {
+      applySelectorMocks(
+        buildSelectors({ moneyAccountCardLinkInProgress: true }),
+      );
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -33,6 +33,7 @@ import {
   selectCardHomeDataStatus,
   selectIsCardAuthenticated,
   selectIsCardholder,
+  selectIsMoneyAccountCardLinkInProgress,
   selectIsMoneyAccountDelegatedForCard,
 } from '../../../../selectors/cardController';
 import {
@@ -111,6 +112,7 @@ export const useMoneyAccountCardLinkage =
     const pendingMoneyAccountCardLink = useSelector(
       selectPendingMoneyAccountCardLink,
     );
+    const linkInProgress = useSelector(selectIsMoneyAccountCardLinkInProgress);
     const isMonadSponsorshipEnabled = useSelector(
       getGasFeesSponsoredNetworkEnabled,
     )(vaultConfig?.chainId ?? '');
@@ -201,6 +203,9 @@ export const useMoneyAccountCardLinkage =
     }, [theme.colors.error.default, toastRef]);
 
     const openLinkCardSheet = useCallback((): void => {
+      if (linkInProgress) {
+        return;
+      }
       if (!canLink || !primaryMoneyAccount?.address) {
         showErrorToast();
         return;
@@ -208,10 +213,19 @@ export const useMoneyAccountCardLinkage =
       navigation.navigate(Routes.MONEY.MODALS.ROOT, {
         screen: Routes.MONEY.MODALS.LINK_CARD_SHEET,
       });
-    }, [canLink, primaryMoneyAccount?.address, navigation, showErrorToast]);
+    }, [
+      linkInProgress,
+      canLink,
+      primaryMoneyAccount?.address,
+      navigation,
+      showErrorToast,
+    ]);
 
     const startLinkFlow = useCallback(
       (origin: LinkFlowOrigin): void => {
+        if (linkInProgress) {
+          return;
+        }
         if (!hasRequirements || !primaryMoneyAccount?.address) {
           showErrorToast();
           return;
@@ -252,6 +266,7 @@ export const useMoneyAccountCardLinkage =
         });
       },
       [
+        linkInProgress,
         hasRequirements,
         moneyAccountCardToken,
         primaryMoneyAccount?.address,
@@ -374,7 +389,7 @@ export const useMoneyAccountCardLinkage =
       canLink,
 
       status,
-      isLinking: status === 'pending',
+      isLinking: linkInProgress,
       error,
 
       startLinkFlow,

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -24,10 +24,12 @@ import { strings } from '../../../../../../locales/i18n';
 import MOCK_MONEY_TRANSACTIONS from '../../constants/mockActivityData';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import useMoneyAccountInfo from '../../hooks/useMoneyAccountInfo';
-import { selectIsCardholder } from '../../../../../selectors/cardController';
+import {
+  selectHasMetalCard,
+  selectIsCardholder,
+} from '../../../../../selectors/cardController';
 import { useMoneyAccountCardLinkage } from '../../../Card/hooks/useMoneyAccountCardLinkage';
 import { MONEY_HOME_CARD_ORIGIN } from '../../../Card/hooks/useCardPostAuthRedirect';
-import { getDetectedGeolocation } from '../../../../../reducers/fiatOrders';
 import { moneyFormatFiat } from '../../utils/moneyFormatFiat';
 import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 
@@ -103,6 +105,7 @@ jest.mock('../../utils/moneyFormatFiat', () => ({
 jest.mock('../../../../../selectors/cardController', () => ({
   ...jest.requireActual('../../../../../selectors/cardController'),
   selectIsCardholder: jest.fn(),
+  selectHasMetalCard: jest.fn(),
   selectIsMoneyAccountDelegatedForCard: jest.fn(() => false),
 }));
 
@@ -147,13 +150,8 @@ jest.mock('../../hooks/useOnboardingStep', () => ({
   STEPPER_IDS: { MONEY: 'money-home-onboarding-stepper' },
 }));
 
-jest.mock('../../../../../reducers/fiatOrders', () => ({
-  ...jest.requireActual('../../../../../reducers/fiatOrders'),
-  getDetectedGeolocation: jest.fn(),
-}));
-
 const mockSelectIsCardholder = jest.mocked(selectIsCardholder);
-const mockGetDetectedGeolocation = jest.mocked(getDetectedGeolocation);
+const mockSelectHasMetalCard = jest.mocked(selectHasMetalCard);
 const mockUseMoneyAccountCardLinkage = jest.mocked(useMoneyAccountCardLinkage);
 const mockOpenLinkCardSheet = jest.fn();
 const mockStartLinkFlow = jest.fn();
@@ -223,13 +221,14 @@ describe('MoneyHomeView', () => {
     mockInitiateDeposit.mockResolvedValue(undefined);
 
     mockSelectIsCardholder.mockReturnValue(false);
-    mockGetDetectedGeolocation.mockReturnValue('US');
+    mockSelectHasMetalCard.mockReturnValue(false);
 
     mockOpenLinkCardSheet.mockReset();
     mockStartLinkFlow.mockReset();
     mockUseMoneyAccountCardLinkage.mockReturnValue({
       hasMoneyAccountRequirements: false,
       isCardAuthenticated: false,
+      isCardLinkedToMoneyAccount: false,
       primaryMoneyAccount: undefined,
       moneyAccountCardToken: null,
       canLink: false,
@@ -859,8 +858,6 @@ describe('MoneyHomeView', () => {
         mockDataEnabled: false,
       });
       mockSelectIsCardholder.mockReturnValue(true);
-      // Non-US so MetaMask card renders in link mode (manage mode is US-only).
-      mockGetDetectedGeolocation.mockReturnValue('GB');
     });
 
     it('renders MetaMask Card section in link mode', () => {
@@ -953,6 +950,7 @@ describe('MoneyHomeView', () => {
         mockUseMoneyAccountCardLinkage.mockReturnValue({
           hasMoneyAccountRequirements: true,
           isCardAuthenticated: true,
+          isCardLinkedToMoneyAccount: false,
           primaryMoneyAccount: { address: '0xabc' },
           moneyAccountCardToken: { symbol: 'USDC' },
           canLink: true,
@@ -1152,79 +1150,23 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  describe('Metal card geolocation gating', () => {
-    it('renders the Metal card row when geolocation is US', () => {
-      mockGetDetectedGeolocation.mockReturnValue('US');
-
-      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
-
-      expect(
-        getByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
-      ).toBeOnTheScreen();
-    });
-
-    it('renders the Metal card row when geolocation is a US sub-region (e.g. US-CA)', () => {
-      mockGetDetectedGeolocation.mockReturnValue('us-ca');
-
-      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
-
-      expect(
-        getByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
-      ).toBeOnTheScreen();
-    });
-
-    it('hides the Metal card row when geolocation is GB', () => {
-      mockGetDetectedGeolocation.mockReturnValue('GB');
-
-      const { queryByTestId, getByTestId } = renderWithProvider(
-        <MoneyHomeView />,
-      );
-
-      expect(
-        queryByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
-      ).not.toBeOnTheScreen();
-      expect(
-        getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
-      ).toBeOnTheScreen();
-    });
-
-    it('hides the Metal card row when geolocation is undefined (loading/unknown - fail closed)', () => {
-      mockGetDetectedGeolocation.mockReturnValue(undefined);
-
-      const { queryByTestId, getByTestId } = renderWithProvider(
-        <MoneyHomeView />,
-      );
-
-      expect(
-        queryByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
-      ).not.toBeOnTheScreen();
-      expect(
-        getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
-      ).toBeOnTheScreen();
-    });
-  });
-
   describe('MetaMask card mode selection', () => {
-    beforeEach(() => {
-      mockUseMoneyAccountTransactions.mockReturnValue({
-        allTransactions: Array.from({ length: 3 }, (_, index) => ({
-          ...MOCK_MONEY_TRANSACTIONS[index % MOCK_MONEY_TRANSACTIONS.length],
-          id: `mm-card-mode-${index}`,
-        })),
-        deposits: [],
-        transfers: [],
-        submittedTransactions: [],
-        moneyAddress: '0x0000000000000000000000000000000000000001',
-        mockDataEnabled: false,
-      });
-    });
-
-    it('selects mode="manage" when cardholder and US', () => {
+    it('selects mode="manage" when card is linked to money account', () => {
       mockSelectIsCardholder.mockReturnValue(true);
-      mockGetDetectedGeolocation.mockReturnValue('US');
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: false,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: true,
+        primaryMoneyAccount: undefined,
+        moneyAccountCardToken: null,
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
@@ -1233,9 +1175,8 @@ describe('MoneyHomeView', () => {
       ).toBeOnTheScreen();
     });
 
-    it('selects mode="link" when cardholder but not US', () => {
+    it('selects mode="link" when cardholder but not linked', () => {
       mockSelectIsCardholder.mockReturnValue(true);
-      mockGetDetectedGeolocation.mockReturnValue('GB');
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
@@ -1244,9 +1185,26 @@ describe('MoneyHomeView', () => {
       ).toBeOnTheScreen();
     });
 
+    it('selects mode="link" for cardholder even with zero transactions', () => {
+      mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: [],
+        deposits: [],
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+        mockDataEnabled: false,
+      });
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON),
+      ).toBeOnTheScreen();
+    });
+
     it('selects mode="upsell" when not cardholder', () => {
       mockSelectIsCardholder.mockReturnValue(false);
-      mockGetDetectedGeolocation.mockReturnValue('US');
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
@@ -1255,9 +1213,47 @@ describe('MoneyHomeView', () => {
       ).toBeOnTheScreen();
     });
 
+    it('disables the link button when linkage is in progress', () => {
+      mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: false,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: undefined,
+        moneyAccountCardToken: null,
+        canLink: false,
+        status: 'idle',
+        isLinking: true,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      const linkButton = getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON);
+
+      expect(linkButton.props.accessibilityState?.disabled).toBe(true);
+      fireEvent.press(linkButton);
+      expect(mockStartLinkFlow).not.toHaveBeenCalled();
+    });
+
     it('navigates to Card root when Manage is pressed in manage mode', () => {
       mockSelectIsCardholder.mockReturnValue(true);
-      mockGetDetectedGeolocation.mockReturnValue('US');
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: false,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: true,
+        primaryMoneyAccount: undefined,
+        moneyAccountCardToken: null,
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
@@ -1270,27 +1266,22 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  describe('Get now navigation', () => {
-    it('navigates to the card sign-up flow when the virtual card Get now button is pressed', () => {
-      mockGetDetectedGeolocation.mockReturnValue('GB');
+  describe('hasMetalCard selector wiring', () => {
+    it('uses 3% cashback copy in link mode when user holds a Metal card', () => {
+      mockSelectIsCardholder.mockReturnValue(true);
+      mockSelectHasMetalCard.mockReturnValue(true);
 
       const { getByText } = renderWithProvider(<MoneyHomeView />);
 
-      fireEvent.press(getByText(strings('money.metamask_card.get_now')));
-
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
-        screen: Routes.CARD.HOME,
-        params: { postAuthRedirect: MONEY_HOME_CARD_ORIGIN },
-      });
+      expect(getByText('Get 3% mUSD back')).toBeOnTheScreen();
     });
+  });
 
-    it('navigates to the card sign-up flow when the metal card Get now button is pressed', () => {
-      mockGetDetectedGeolocation.mockReturnValue('US');
+  describe('Get now navigation', () => {
+    it('navigates to the card sign-up flow when the virtual card Get now button is pressed', () => {
+      const { getByText } = renderWithProvider(<MoneyHomeView />);
 
-      const { getAllByText } = renderWithProvider(<MoneyHomeView />);
-      const buttons = getAllByText(strings('money.metamask_card.get_now'));
-
-      fireEvent.press(buttons[1]);
+      fireEvent.press(getByText(strings('money.metamask_card.get_now')));
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
         screen: Routes.CARD.HOME,

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -35,10 +35,12 @@ import { MUSD_MAINNET_ASSET_FOR_DETAILS } from '../../../../Views/Homepage/Secti
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import AppConstants from '../../../../../core/AppConstants';
 import NavigationService from '../../../../../core/NavigationService';
-import { selectIsCardholder } from '../../../../../selectors/cardController';
+import {
+  selectHasMetalCard,
+  selectIsCardholder,
+} from '../../../../../selectors/cardController';
 import { useMoneyAccountCardLinkage } from '../../../Card/hooks/useMoneyAccountCardLinkage';
 import { MONEY_HOME_CARD_ORIGIN } from '../../../Card/hooks/useCardPostAuthRedirect';
-import { getDetectedGeolocation } from '../../../../../reducers/fiatOrders';
 import Logger from '../../../../../util/Logger';
 import { useTheme } from '../../../../../util/theme';
 import { MoneyBalanceDisplayState } from '../../types';
@@ -98,9 +100,9 @@ const MoneyHomeView = () => {
     useMoneyAccountTransactions();
 
   const isCardholder = useSelector(selectIsCardholder);
-  const { startLinkFlow } = useMoneyAccountCardLinkage();
-  const geolocation = useSelector(getDetectedGeolocation);
-  const isUS = geolocation?.toUpperCase().split('-')[0] === 'US';
+  const hasMetalCard = useSelector(selectHasMetalCard);
+  const { startLinkFlow, isCardLinkedToMoneyAccount, isLinking } =
+    useMoneyAccountCardLinkage();
 
   const { isVisible: isOnboardingCardVisible } = useOnboardingStep({
     stepperId: STEPPER_IDS.MONEY,
@@ -109,7 +111,6 @@ const MoneyHomeView = () => {
 
   const homeState = getMoneyHomeState(allTransactions.length);
   const isMilestone = homeState === 'milestone' || homeState === 'filled';
-  const isCardholderWithMilestone = isMilestone && isCardholder;
 
   let displayState: MoneyBalanceDisplayState;
   if (!hasMoneyAccount) {
@@ -264,9 +265,9 @@ const MoneyHomeView = () => {
   );
 
   let metamaskCardMode: 'upsell' | 'link' | 'manage';
-  if (isCardholderWithMilestone && isUS) {
+  if (isCardLinkedToMoneyAccount) {
     metamaskCardMode = 'manage';
-  } else if (isCardholderWithMilestone) {
+  } else if (isCardholder) {
     metamaskCardMode = 'link';
   } else {
     metamaskCardMode = 'upsell';
@@ -374,7 +375,8 @@ const MoneyHomeView = () => {
           onHeaderPress={handleCardPress}
           onLinkPress={handleLinkCardPress}
           onManagePress={handleCardPress}
-          showMetalCard={isUS}
+          showMetalCard={hasMetalCard}
+          isLinkDisabled={isLinking}
           cardBalance={cardBalance}
           apy={apyPercent}
         />

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import MoneyMetaMaskCard from './MoneyMetaMaskCard';
 import { MoneyMetaMaskCardTestIds } from './MoneyMetaMaskCard.testIds';
+import { MoneySectionHeaderTestIds } from '../MoneySectionHeader/MoneySectionHeader.testIds';
 import { strings } from '../../../../../../locales/i18n';
 
 describe('MoneyMetaMaskCard', () => {
@@ -32,19 +33,16 @@ describe('MoneyMetaMaskCard', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders metal card row when showMetalCard is true', () => {
-    const { getByText, getByTestId } = render(
+  it('hides metal card upsell row in upsell mode even when showMetalCard is true', () => {
+    const { queryByTestId, getByTestId } = render(
       <MoneyMetaMaskCard onGetNowPress={jest.fn()} showMetalCard />,
     );
 
     expect(
-      getByText(strings('money.metamask_card.metal_card')),
-    ).toBeOnTheScreen();
+      queryByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
+    ).not.toBeOnTheScreen();
     expect(
-      getByText(strings('money.metamask_card.cashback', { percentage: '3' })),
-    ).toBeOnTheScreen();
-    expect(
-      getByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
+      getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
     ).toBeOnTheScreen();
   });
 
@@ -78,19 +76,6 @@ describe('MoneyMetaMaskCard', () => {
     );
 
     fireEvent.press(getByText(strings('money.metamask_card.get_now')));
-
-    expect(mockGetNow).toHaveBeenCalledTimes(1);
-    expect(mockGetNow.mock.calls[0]).toEqual([]);
-  });
-
-  it('calls onGetNowPress when metal card Get now is pressed', () => {
-    const mockGetNow = jest.fn();
-    const { getAllByText } = render(
-      <MoneyMetaMaskCard onGetNowPress={mockGetNow} showMetalCard />,
-    );
-    const getNowButtons = getAllByText(strings('money.metamask_card.get_now'));
-
-    fireEvent.press(getNowButtons[1]);
 
     expect(mockGetNow).toHaveBeenCalledTimes(1);
     expect(mockGetNow.mock.calls[0]).toEqual([]);
@@ -192,6 +177,39 @@ describe('MoneyMetaMaskCard', () => {
 
       fireEvent.press(getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON));
       expect(mockLink).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the link button when isLinkDisabled is true', () => {
+      const mockLink = jest.fn();
+      const { getByTestId } = render(
+        <MoneyMetaMaskCard
+          mode="link"
+          onGetNowPress={jest.fn()}
+          onLinkPress={mockLink}
+          isLinkDisabled
+        />,
+      );
+
+      const button = getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON);
+      fireEvent.press(button);
+      expect(mockLink).not.toHaveBeenCalled();
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+    });
+
+    it('does not render a tappable header when isLinkDisabled is true', () => {
+      const mockHeader = jest.fn();
+      const { queryByTestId } = render(
+        <MoneyMetaMaskCard
+          mode="link"
+          onGetNowPress={jest.fn()}
+          onHeaderPress={mockHeader}
+          isLinkDisabled
+        />,
+      );
+
+      expect(
+        queryByTestId(MoneySectionHeaderTestIds.CHEVRON),
+      ).not.toBeOnTheScreen();
     });
 
     it('renders link-specific section title', () => {
@@ -320,13 +338,35 @@ describe('MoneyMetaMaskCard', () => {
       props.onManagePress.mockClear();
     });
 
-    it('renders both balance and metal rows', () => {
-      const { getByTestId } = render(<MoneyMetaMaskCard {...props} />);
+    it('renders only the balance row', () => {
+      const { getByTestId, queryByTestId } = render(
+        <MoneyMetaMaskCard {...props} />,
+      );
       expect(
         getByTestId(MoneyMetaMaskCardTestIds.MANAGE_BALANCE_ROW),
       ).toBeOnTheScreen();
       expect(
-        getByTestId(MoneyMetaMaskCardTestIds.MANAGE_METAL_ROW),
+        queryByTestId(MoneyMetaMaskCardTestIds.MANAGE_METAL_ROW),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('renders 3% cashback when showMetalCard is true', () => {
+      const { getByText } = render(
+        <MoneyMetaMaskCard {...props} showMetalCard />,
+      );
+
+      expect(
+        getByText(strings('money.metamask_card.cashback', { percentage: '3' })),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders 1% cashback when showMetalCard is false', () => {
+      const { getByText } = render(
+        <MoneyMetaMaskCard {...props} showMetalCard={false} />,
+      );
+
+      expect(
+        getByText(strings('money.metamask_card.cashback', { percentage: '1' })),
       ).toBeOnTheScreen();
     });
 
@@ -343,14 +383,6 @@ describe('MoneyMetaMaskCard', () => {
       expect(props.onManagePress).toHaveBeenCalled();
     });
 
-    it('calls onGetNowPress when metal Get now is tapped', () => {
-      const { getByTestId } = render(<MoneyMetaMaskCard {...props} />);
-      fireEvent.press(
-        getByTestId(MoneyMetaMaskCardTestIds.MANAGE_METAL_GET_NOW),
-      );
-      expect(props.onGetNowPress).toHaveBeenCalled();
-    });
-
     it('does not render upsell or link content', () => {
       const { queryByTestId } = render(<MoneyMetaMaskCard {...props} />);
       expect(
@@ -361,8 +393,8 @@ describe('MoneyMetaMaskCard', () => {
   });
 
   describe('upsell mode (default)', () => {
-    it('renders virtual and metal card rows when showMetalCard is true', () => {
-      const { getByTestId } = render(
+    it('renders only the virtual card row regardless of showMetalCard', () => {
+      const { getByTestId, queryByTestId } = render(
         <MoneyMetaMaskCard onGetNowPress={jest.fn()} showMetalCard />,
       );
 
@@ -370,8 +402,8 @@ describe('MoneyMetaMaskCard', () => {
         getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
       ).toBeOnTheScreen();
       expect(
-        getByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
-      ).toBeOnTheScreen();
+        queryByTestId(MoneyMetaMaskCardTestIds.METAL_CARD_ROW),
+      ).not.toBeOnTheScreen();
     });
 
     it('renders only the virtual card row when showMetalCard is false', () => {

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
@@ -38,12 +38,13 @@ interface MoneyMetaMaskCardProps {
   onHeaderPress?: () => void;
   /** Called when the "Link card" button is pressed (link mode only). */
   onLinkPress?: () => void;
+  /** When true, disables the link-mode CTA and header navigation. */
+  isLinkDisabled?: boolean;
   /** Called when the "Manage" button is pressed (manage mode only). */
   onManagePress?: () => void;
   /**
-   * Whether to render the Metal card row in upsell mode. Defaults to `false`
-   * because the Metal card is currently only available to US users; the parent
-   * is expected to pass the geolocation-derived flag.
+   * Whether the user holds a Metal card. When true, link/manage layouts use the
+   * Metal card image and 3% cashback copy.
    */
   showMetalCard?: boolean;
   /** User's available card balance (manage mode only). */
@@ -137,11 +138,13 @@ const LinkContent = ({
   showMetalCard,
   apy,
   hideCardImage,
+  isLinkDisabled = false,
 }: {
   onLinkPress: () => void;
   showMetalCard: boolean;
   apy: number | undefined;
   hideCardImage: boolean;
+  isLinkDisabled?: boolean;
 }) => {
   const hasApy = apy !== undefined;
   const subtitle = hasApy
@@ -201,6 +204,7 @@ const LinkContent = ({
         variant={ButtonVariant.Secondary}
         size={ButtonSize.Lg}
         isFullWidth
+        isDisabled={isLinkDisabled}
         onPress={onLinkPress}
         testID={MoneyMetaMaskCardTestIds.LINK_BUTTON}
         twClassName="mt-3"
@@ -281,32 +285,23 @@ const ManageRow = ({
 const ManageContent = ({
   cardBalance,
   onManagePress,
-  onGetNowPress,
+  showMetalCard,
 }: {
   cardBalance: string;
   onManagePress: () => void;
-  onGetNowPress: () => void;
+  showMetalCard: boolean;
 }) => (
   <Box twClassName="gap-2" testID={MoneyMetaMaskCardTestIds.MANAGE_CONTAINER}>
     <ManageRow
-      imageSource={mmCardRegular}
+      imageSource={showMetalCard ? mmCardMetal : mmCardRegular}
       title={strings('money.metamask_card.avail_balance')}
       subtitle={cardBalance}
-      cashbackPercentage="1"
+      cashbackPercentage={showMetalCard ? '3' : '1'}
       ctaLabel={strings('money.metamask_card.manage_card')}
       onPress={onManagePress}
       containerTestID={MoneyMetaMaskCardTestIds.MANAGE_BALANCE_ROW}
       ctaTestID={MoneyMetaMaskCardTestIds.MANAGE_BUTTON}
       subtitleTestID={MoneyMetaMaskCardTestIds.MANAGE_BALANCE}
-    />
-    <ManageRow
-      imageSource={mmCardMetal}
-      title={strings('money.metamask_card.metal_card')}
-      cashbackPercentage="3"
-      ctaLabel={strings('money.metamask_card.get_now')}
-      onPress={onGetNowPress}
-      containerTestID={MoneyMetaMaskCardTestIds.MANAGE_METAL_ROW}
-      ctaTestID={MoneyMetaMaskCardTestIds.MANAGE_METAL_GET_NOW}
     />
   </Box>
 );
@@ -318,6 +313,7 @@ const MoneyMetaMaskCard = ({
   onLinkPress,
   onManagePress,
   showMetalCard = false,
+  isLinkDisabled = false,
   cardBalance,
   apy,
   hideCardImage = false,
@@ -336,6 +332,7 @@ const MoneyMetaMaskCard = ({
         showMetalCard={showMetalCard}
         apy={apy}
         hideCardImage={hideCardImage}
+        isLinkDisabled={isLinkDisabled}
       />
     );
   } else if (mode === 'manage') {
@@ -343,7 +340,7 @@ const MoneyMetaMaskCard = ({
       <ManageContent
         cardBalance={cardBalance ?? ''}
         onManagePress={handleManagePress}
-        onGetNowPress={onGetNowPress}
+        showMetalCard={showMetalCard}
       />
     );
   } else {
@@ -363,15 +360,6 @@ const MoneyMetaMaskCard = ({
           onPress={onGetNowPress}
           testID={MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW}
         />
-        {showMetalCard && (
-          <CardRow
-            imageSource={mmCardMetal}
-            cardName={strings('money.metamask_card.metal_card')}
-            cashbackPercentage="3"
-            onPress={onGetNowPress}
-            testID={MoneyMetaMaskCardTestIds.METAL_CARD_ROW}
-          />
-        )}
       </>
     );
   }
@@ -390,7 +378,7 @@ const MoneyMetaMaskCard = ({
     >
       <MoneySectionHeader
         title={strings(headerTitleKey)}
-        onPress={onHeaderPress}
+        onPress={mode === 'link' && isLinkDisabled ? undefined : onHeaderPress}
       />
       {content}
     </Box>

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -28,8 +28,12 @@ const MoneyOnboardingCard = () => {
   const { initiateDeposit } = useMoneyAccountDeposit();
   const { tokenTotal, isAggregatedBalanceLoading } = useMoneyAccountBalance();
 
-  const { startLinkFlow, isCardAuthenticated, isCardLinkedToMoneyAccount } =
-    useMoneyAccountCardLinkage();
+  const {
+    startLinkFlow,
+    isCardAuthenticated,
+    isCardLinkedToMoneyAccount,
+    isLinking,
+  } = useMoneyAccountCardLinkage();
 
   const handleRedirectToCryptoDeposit = useCallback(async () => {
     await initiateDeposit().catch(() => undefined);
@@ -112,6 +116,7 @@ const MoneyOnboardingCard = () => {
                 'money.onboarding.step_2.unlinked_card_account.cta_primary',
               ),
               onPress: handleCardCtaPress,
+              disabled: isLinking,
             },
             secondaryCta: {
               text: strings(
@@ -132,6 +137,7 @@ const MoneyOnboardingCard = () => {
                 'money.onboarding.step_2.no_card_account.cta_primary',
               ),
               onPress: handleCardCtaPress,
+              disabled: isLinking,
             },
             secondaryCta: {
               text: strings(
@@ -148,6 +154,7 @@ const MoneyOnboardingCard = () => {
     isVisibleAfterAutoSkip,
     isCardAuthenticated,
     isCardLinkedToMoneyAccount,
+    isLinking,
     handleRedirectToCryptoDeposit,
     handleCardCtaPress,
     handleSkipPress,

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -236,6 +236,7 @@ describe('CardController', () => {
       providerData: {},
       cardHomeData: null,
       cardHomeDataStatus: 'idle',
+      moneyAccountCardLinkInProgress: false,
     });
   });
 
@@ -2381,6 +2382,7 @@ describe('CardController — data pass-throughs', () => {
         await waitFor(() => controller.isLinkageInProgress() === true, 100);
 
         expect(controller.isLinkageInProgress()).toBe(true);
+        expect(controller.state.moneyAccountCardLinkInProgress).toBe(true);
 
         resolveApproveFunding();
         await linkPromise;

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -104,6 +104,12 @@ const metadata: StateMetadata<CardControllerState> = {
     includeInStateLogs: false,
     usedInUi: true,
   },
+  moneyAccountCardLinkInProgress: {
+    persist: false,
+    includeInDebugSnapshot: false,
+    includeInStateLogs: false,
+    usedInUi: true,
+  },
 };
 
 export const defaultCardControllerState: CardControllerState = {
@@ -114,6 +120,7 @@ export const defaultCardControllerState: CardControllerState = {
   providerData: {},
   cardHomeData: null,
   cardHomeDataStatus: 'idle',
+  moneyAccountCardLinkInProgress: false,
 };
 
 /**
@@ -136,7 +143,6 @@ export class CardController extends BaseController<
   private fetchCardHomeDataPromise: Promise<void> | null = null;
   private fetchGeneration = 0;
   private previousEvmAddress: string | null = null;
-  private linkMoneyAccountCardInFlight = false;
 
   constructor({
     messenger,
@@ -946,19 +952,23 @@ export class CardController extends BaseController<
     moneyAccountAddress: string;
     delegationAmountHuman: string;
   }): Promise<void> {
-    if (this.linkMoneyAccountCardInFlight) {
+    if (this.state.moneyAccountCardLinkInProgress) {
       throw new CardLinkageInProgressError();
     }
-    this.linkMoneyAccountCardInFlight = true;
+    this.update((state) => {
+      state.moneyAccountCardLinkInProgress = true;
+    });
     try {
       await this.#linkMoneyAccountCardUnsafe(params);
     } finally {
-      this.linkMoneyAccountCardInFlight = false;
+      this.update((state) => {
+        state.moneyAccountCardLinkInProgress = false;
+      });
     }
   }
 
   isLinkageInProgress(): boolean {
-    return this.linkMoneyAccountCardInFlight;
+    return this.state.moneyAccountCardLinkInProgress;
   }
 
   async #linkMoneyAccountCardUnsafe(params: {

--- a/app/core/Engine/controllers/card-controller/types.ts
+++ b/app/core/Engine/controllers/card-controller/types.ts
@@ -57,6 +57,8 @@ export type CardControllerState = {
   cardHomeData: Record<string, Json> | null;
   /** Fetch status for cardHomeData. Not persisted. */
   cardHomeDataStatus: CardHomeDataStatus;
+  /** True while `linkMoneyAccountCard` is in flight. Not persisted. */
+  moneyAccountCardLinkInProgress: boolean;
 };
 
 export type CardControllerActions = ControllerGetStateAction<

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -3,12 +3,14 @@ import {
   selectCardSelectedCountry,
   selectCardActiveProviderId,
   selectIsCardAuthenticated,
+  selectIsMoneyAccountCardLinkInProgress,
   selectCardholderAccounts,
   selectHasCardholderAccounts,
   selectIsCardholder,
   selectCardUserLocation,
   selectCardHomeData,
   selectCardHomeDataStatus,
+  selectHasMetalCard,
   selectCardPrimaryToken,
   selectCardAvailableTokens,
   selectCardFundingTokens,
@@ -27,7 +29,7 @@ import {
   type CardFundingAsset,
   type CardHomeData,
 } from '../core/Engine/controllers/card-controller/provider-types';
-import { FundingStatus } from '../components/UI/Card/types';
+import { FundingStatus, CardType } from '../components/UI/Card/types';
 import { selectSelectedInternalAccountByScope } from './multichainAccounts/accounts';
 import { isEthAccount } from '../core/Multichain/utils';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -69,6 +71,7 @@ const createMockRootState = (
           providerData: {},
           cardHomeData: null,
           cardHomeDataStatus: 'idle',
+          moneyAccountCardLinkInProgress: false,
           ...overrides,
         },
       },
@@ -76,6 +79,29 @@ const createMockRootState = (
   }) as unknown as RootState;
 
 describe('CardController selectors', () => {
+  describe('selectIsMoneyAccountCardLinkInProgress', () => {
+    it('returns false when CardController state is undefined', () => {
+      const state = {
+        engine: { backgroundState: {} },
+      } as unknown as RootState;
+      expect(selectIsMoneyAccountCardLinkInProgress(state)).toBe(false);
+    });
+
+    it('returns false when linkage is not in progress', () => {
+      const state = createMockRootState({
+        moneyAccountCardLinkInProgress: false,
+      });
+      expect(selectIsMoneyAccountCardLinkInProgress(state)).toBe(false);
+    });
+
+    it('returns true when linkage is in progress', () => {
+      const state = createMockRootState({
+        moneyAccountCardLinkInProgress: true,
+      });
+      expect(selectIsMoneyAccountCardLinkInProgress(state)).toBe(true);
+    });
+  });
+
   describe('selectCardSelectedCountry', () => {
     it('returns null when no country is selected', () => {
       const state = createMockRootState();
@@ -384,6 +410,53 @@ const mockCardHomeData: CardHomeData = {
     _links: { self: '/v1/delegation/chain/config' },
   },
 };
+
+describe('selectHasMetalCard', () => {
+  it('returns false when card home data is null', () => {
+    const state = createMockRootState({ cardHomeData: null });
+    expect(selectHasMetalCard(state)).toBe(false);
+  });
+
+  it('returns false when card is null', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        card: null,
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+    expect(selectHasMetalCard(state)).toBe(false);
+  });
+
+  it('returns false for a virtual card', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        card: {
+          id: 'card-1',
+          status: 'ACTIVE' as never,
+          type: CardType.VIRTUAL,
+          lastFour: '1234',
+        },
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+    expect(selectHasMetalCard(state)).toBe(false);
+  });
+
+  it('returns true for a metal card', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        ...mockCardHomeData,
+        card: {
+          id: 'card-1',
+          status: 'ACTIVE' as never,
+          type: CardType.METAL,
+          lastFour: '1234',
+        },
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+    expect(selectHasMetalCard(state)).toBe(true);
+  });
+});
 
 describe('selectCardPrimaryToken', () => {
   beforeEach(() => {

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -11,6 +11,7 @@ import {
   type CardHomeData,
 } from '../core/Engine/controllers/card-controller/provider-types';
 import {
+  CardType,
   FundingStatus,
   type CardLocation,
   type CardFundingToken,
@@ -80,6 +81,12 @@ export const selectIsCardAuthenticated = createSelector(
     cardState?.isAuthenticated ?? false,
 );
 
+export const selectIsMoneyAccountCardLinkInProgress = createSelector(
+  selectCardControllerState,
+  (cardState: CardControllerState | undefined) =>
+    cardState?.moneyAccountCardLinkInProgress ?? false,
+);
+
 export const selectCardholderAccounts = createSelector(
   selectCardControllerState,
   (cardState: CardControllerState | undefined) =>
@@ -132,6 +139,11 @@ export const selectCardHomeDataStatus = createSelector(
   selectCardControllerState,
   (cardState: CardControllerState | undefined): CardHomeDataStatus =>
     cardState?.cardHomeDataStatus ?? 'idle',
+);
+
+export const selectHasMetalCard = createSelector(
+  selectCardHomeData,
+  (data): boolean => data?.card?.type === CardType.METAL,
 );
 
 export const selectCardPrimaryToken = createSelector(

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -726,7 +726,8 @@
     "cardHomeDataStatus": "idle",
     "isAuthenticated": false,
     "cardholderAccounts": [],
-    "providerData": {}
+    "providerData": {},
+    "moneyAccountCardLinkInProgress": false
   },
   "ClientController": {
     "isUiOpen": false


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money tab MetaMask Card section could show **Get card** for users who already hold a Card, because mode selection depended on transaction count and US geolocation instead of cardholder and linkage state.

This PR drives the card section from cardholder/delegation signals only:

- **Not a cardholder** → upsell (Get card)
- **Cardholder, not linked** → link (Link card), with `startLinkFlow` handling auth → sheet
- **Card linked to Money account** → manage

Metal card upsell rows are removed (checkout disabled). The metal card image and 3% cashback copy appear only when the user actually holds a Metal card (`selectHasMetalCard`).

Link entrypoints (Money Home card section, Card Home, onboarding stepper) are disabled while delegation is in flight. Linkage progress is stored on `CardControllerState.moneyAccountCardLinkInProgress` so `useMoneyAccountCardLinkage.isLinking` is reactive app-wide; `startLinkFlow` / `openLinkCardSheet` no-op during in-progress linkage.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Money tab MetaMask Card section showing the wrong action for cardholders and disabled link actions while card linkage is in progress

## **Related issues**

<!--
Fixes: null
-->

Fixes: null

## **Manual testing steps**

<!--
```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```
-->

```gherkin
Feature: Money tab MetaMask Card CTA

  Scenario: non-cardholder sees Get card upsell
    Given the user has a Money account but is not a cardholder
    When the user opens the Money tab
    Then the MetaMask Card section shows the virtual card row with Get now
    And the Link card button is not shown

  Scenario: cardholder who has not linked sees Link card
    Given the user is a cardholder with a Card session
    And the Money account is not delegated for card spending
    When the user opens the Money tab
    Then the MetaMask Card section shows Link card
    When the user taps Link card
    Then the app starts the link flow (auth or link sheet as appropriate)

  Scenario: linked cardholder sees manage state
    Given the user is a cardholder
    And the primary Money account is already delegated for card spending
    When the user opens the Money tab
    Then the MetaMask Card section shows manage layout with Manage card

  Scenario: link actions disabled during in-flight linkage
    Given the user is a cardholder on the Money tab with Link card visible
    When the user confirms linkage from the link sheet and delegation is in progress
    Then the Link card button is disabled
    And tapping the section header does not restart the link flow
    And the onboarding card link CTA is disabled if visible
```

## **Screenshots/Recordings**

<!--
If applicable, add screenshots and/or recordings to visualize the before and after of your change.
-->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches card–Money delegation flow and shared controller state used across Money Home, Card Home, and onboarding; changes are guarded and well-tested but affect payment-adjacent UX.
> 
> **Overview**
> Fixes the Money tab MetaMask Card section showing the wrong CTA (e.g. **Get card** for existing cardholders) by driving **upsell / link / manage** from cardholder and Money-account delegation state instead of transaction count and US geolocation.
> 
> **Linkage in progress:** `CardController` now exposes `moneyAccountCardLinkInProgress` in controller state (replacing a private in-flight flag). `useMoneyAccountCardLinkage.isLinking` reads that flag app-wide; `startLinkFlow` and `openLinkCardSheet` no-op while linkage runs. Link entrypoints on Money Home, Card Home, onboarding (`StepperCard` optional `disabled` on CTAs), and `MoneyMetaMaskCard` (`isLinkDisabled`) disable duplicate taps.
> 
> **Metal card UI:** Adds `selectHasMetalCard` from card home data. `showMetalCard` means the user holds a Metal card (image + 3% cashback in link/manage), not region. Upsell no longer shows a Metal row; manage drops the extra Metal upsell row.
> 
> **Tests** updated for mode selection, disabled link, and controller linkage state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77b42031086f5ebaca6211a7a28305cdd0c46dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->