### PR TITLE
fix(card): route Card "Add funds → Fund with cash" through UB2 

### DIFF
--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx
@@ -12,6 +12,7 @@ import { CardFundingToken, FundingStatus } from '../../types';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+import useRampsUnifiedV2Enabled from '../../../Ramp/hooks/useRampsUnifiedV2Enabled';
 import { CardHomeSelectors } from '../../Views/CardHome/CardHome.testIds';
 import { RampsButtonClickData } from '../../../Ramp/hooks/useRampsButtonClickData';
 
@@ -19,6 +20,7 @@ import { RampsButtonClickData } from '../../../Ramp/hooks/useRampsButtonClickDat
 const mockUseParams = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockGoToBuy = jest.fn();
 const mockGoToDeposit = jest.fn();
 
 // Mock dependencies
@@ -148,8 +150,13 @@ describe('AddFundsBottomSheet', () => {
     });
 
     (useRampNavigation as jest.Mock).mockReturnValue({
+      goToBuy: mockGoToBuy,
       goToDeposit: mockGoToDeposit,
     });
+
+    // Default V2 enabled — the whole point of this migration is UB2 routing.
+    // Individual tests override to false where they need to assert V1 fallback.
+    (useRampsUnifiedV2Enabled as jest.Mock).mockReturnValue(true);
 
     (useDepositEnabled as jest.Mock).mockReturnValue({
       isDepositEnabled: true,
@@ -223,7 +230,7 @@ describe('AddFundsBottomSheet', () => {
     expect(getByText('Swap tokens into USDC on Linea')).toBeTruthy();
   });
 
-  it('handles deposit option press correctly', () => {
+  it('tracks analytics and trace with UNIFIED_BUY_2 ramp_type when Fund with cash is pressed', () => {
     const { getByText } = setupComponent();
 
     fireEvent.press(getByText('Fund with cash'));
@@ -239,7 +246,7 @@ describe('AddFundsBottomSheet', () => {
         button_text: 'Fund with cash',
         location: 'CardHome',
         chain_id_destination: '59144',
-        ramp_type: 'DEPOSIT',
+        ramp_type: 'UNIFIED_BUY_2',
         ramp_routing: undefined,
         is_authenticated: false,
         preferred_provider: undefined,
@@ -250,6 +257,20 @@ describe('AddFundsBottomSheet', () => {
     expect(trace).toHaveBeenCalledWith({
       name: TraceName.LoadDepositExperience,
     });
+  });
+
+  it('tags analytics with ramp_type DEPOSIT when the UB2 feature flag is disabled', () => {
+    (useRampsUnifiedV2Enabled as jest.Mock).mockReturnValue(false);
+
+    const { getByText } = setupComponent();
+
+    fireEvent.press(getByText('Fund with cash'));
+
+    expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ramp_type: 'DEPOSIT',
+      }),
+    );
   });
 
   it('handles swap option press correctly', () => {
@@ -321,12 +342,44 @@ describe('AddFundsBottomSheet', () => {
     expect(getByText('Swap tokens into ETH on Linea')).toBeTruthy();
   });
 
-  it('navigates to deposit route when deposit callback is executed', () => {
+  it('routes Fund with cash through goToBuy (UB2-aware) with the priority token CAIP-19 assetId', () => {
     const { getByText } = setupComponent();
 
     fireEvent.press(getByText('Fund with cash'));
 
-    expect(mockGoToDeposit).toHaveBeenCalled();
+    // goToBuy is the smart router in useRampNavigation; when V2 is enabled
+    // (default for this suite), it dispatches to UB2 (BuildQuote). See
+    // useRampNavigation.test.ts > 'goToBuy > when unified V2 is enabled'.
+    expect(mockGoToBuy).toHaveBeenCalledTimes(1);
+    expect(mockGoToBuy).toHaveBeenCalledWith({
+      assetId: `${mockPriorityToken.caipChainId}/erc20:${mockPriorityToken.address}`,
+    });
+  });
+
+  it('does NOT call the deprecated goToDeposit (UB1) when Fund with cash is pressed', () => {
+    // Regression guard: this entry point was migrated off goToDeposit (UB1)
+    // to goToBuy (UB2-aware). If someone reverts that, this test goes red.
+    const { getByText } = setupComponent();
+
+    fireEvent.press(getByText('Fund with cash'));
+
+    expect(mockGoToDeposit).not.toHaveBeenCalled();
+  });
+
+  it('falls back to goToBuy() with no intent when the priority token has no address', () => {
+    // No assetId → useRampNavigation routes UB2 to TokenSelection
+    // (see useRampNavigation.ts, 'V2: If no assetId and V2 is enabled').
+    const tokenWithoutAddress: CardFundingToken = {
+      ...mockPriorityToken,
+      address: null,
+    };
+
+    const { getByText } = setupComponent(tokenWithoutAddress);
+
+    fireEvent.press(getByText('Fund with cash'));
+
+    expect(mockGoToBuy).toHaveBeenCalledTimes(1);
+    expect(mockGoToBuy).toHaveBeenCalledWith(undefined);
   });
 
   it('renders component correctly', () => {

--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
@@ -65,7 +65,7 @@ const AddFundsBottomSheet: React.FC = () => {
   });
   const { trackEvent, createEventBuilder } = useAnalytics();
   const rampGeodetectedRegion = useSelector(getDetectedGeolocation);
-  const { goToDeposit } = useRampNavigation();
+  const { goToBuy } = useRampNavigation();
   const buttonClickData = useRampsButtonClickData();
   const isV2UnifiedEnabled = useRampsUnifiedV2Enabled();
 
@@ -84,8 +84,13 @@ const AddFundsBottomSheet: React.FC = () => {
   }, [priorityToken, openSwaps, closeBottomSheetAndNavigate]);
 
   const openDeposit = useCallback(() => {
+    const assetId =
+      priorityToken?.address && priorityToken?.caipChainId
+        ? `${priorityToken.caipChainId}/erc20:${priorityToken.address}`
+        : undefined;
+
     closeBottomSheetAndNavigate(() => {
-      goToDeposit();
+      goToBuy(assetId ? { assetId } : undefined);
     });
     trackEvent(
       createEventBuilder(
@@ -115,7 +120,7 @@ const AddFundsBottomSheet: React.FC = () => {
   }, [
     rampGeodetectedRegion,
     closeBottomSheetAndNavigate,
-    goToDeposit,
+    goToBuy,
     trackEvent,
     createEventBuilder,
     priorityToken,


### PR DESCRIPTION
## **Description**

The Card "Add funds → Fund with cash" entry point in `AddFundsBottomSheet` was calling the deprecated `goToDeposit()` from `useRampNavigation`, which is hardcoded to UB1 (`mode: DEPOSIT, overrideUnifiedRouting: true`) and bypasses the unified-routing decision entirely. As a result, users were always landed on the legacy deposit flow from Card, even when the Unified Buy v2 (UB2) feature flag was enabled — which is why TRAM-3539 was filed.

This PR switches the entry point to `goToBuy({ assetId })`, the smart router in `useRampNavigation` that respects `useRampsUnifiedV2Enabled` / `useRampsUnifiedV1Enabled` and dispatches to UB2 `BuildQuote` (or `TokenSelection` when no `assetId` is resolvable) when V2 is on, with graceful fallback to the V1 deposit / aggregator flow when V2 is off. The CAIP‑19 `assetId` is built from the card's `primaryFundingAsset` (`${caipChainId}/erc20:${address}`) so UB2 lands directly on the correct token.

This mirrors the pattern already established by `PopularTokenRow`, `useTokenAtomicActions`, `FundActionMenu`, and `TokenSelection` — all of which call `goToBuy({ assetId })`.

## **Changelog**

CHANGELOG entry: Fixed the Card "Fund with cash" option to route to the Unified Buy v2 flow when the feature is enabled, instead of always opening the legacy deposit flow.

## **Related issues**

Fixes: [TRAM-3538](https://consensyssoftware.atlassian.net/browse/TRAM-3538) (parent: [TRAM-3460](https://consensyssoftware.atlassian.net/browse/TRAM-3460) Ramps Hardening)

## **Manual testing steps**

```gherkin
Feature: Card "Add funds → Fund with cash" routes to UB2 when the feature flag is enabled

  Scenario: User taps "Fund with cash" with UB2 enabled
    Given the Unified Buy v2 feature flag (rampsUnifiedBuyV2Enabled) is ON
    And the user is on the Card screen with a linked card and a standard funding token (e.g. USDC on Linea)

    When the user taps "Add funds" and then "Fund with cash" in the bottom sheet
    Then the user is taken to the UB2 BuildQuote screen
    And the priority funding token is pre-selected as the destination asset
    And analytics report ramp_type=UNIFIED_BUY_2

  Scenario: User taps "Fund with cash" with UB2 disabled
    Given the Unified Buy v2 feature flag is OFF
    And the user is on the Card screen with a linked card

    When the user taps "Add funds" and then "Fund with cash"
    Then the user is taken to the legacy V1 / Deposit flow (existing behavior preserved)
    And analytics report ramp_type=DEPOSIT
```

> Note for reviewers: a fully end-to-end simulator smoke test required temporary local overrides (Add Funds button disable gate, `Engine.setSelectedAddress` for non-owned wallets, the priority token's presence in UB2's `allTokens` list). These are NOT part of this PR — they were stashed locally so the diff stays focused on the routing change. The UB2-vs-UB1 routing decision is fully covered by existing tests in `useRampNavigation.test.ts`, and this PR adds dedicated tests for the entry-point's behavior (see Test plan below).

**Tests:**

- `yarn jest app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx` — 18 tests pass, 5 new:
  - `routes Fund with cash through goToBuy (UB2-aware) with the priority token CAIP-19 assetId`
  - `does NOT call the deprecated goToDeposit (UB1) when Fund with cash is pressed` (regression guard)
  - `falls back to goToBuy() with no intent when the priority token has no address` (UB2 TokenSelection fallback)
  - `tracks analytics and trace with UNIFIED_BUY_2 ramp_type when Fund with cash is pressed`
  - `tags analytics with ramp_type DEPOSIT when the UB2 feature flag is disabled`

## **Screenshots/Recordings**

### **Before**

[<!-- Card → Add funds → Fund with cash lands on UB1 / legacy deposit screen -->
](https://github.com/user-attachments/assets/3b8b803d-27a9-4c16-ac76-0baa2c241b4f)

### **After**

[<!-- Card → Add funds → Fund with cash lands on UB2 BuildQuote (attach recorded video) -->](https://github.com/user-attachments/assets/fe485291-0dbd-41f2-b7d7-e12f19cbb8ad)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Existing `trace({ name: TraceName.LoadDepositExperience })` call in `openDeposit` is preserved.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TRAM-3539]: https://consensyssoftware.atlassian.net/browse/TRAM-3539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing ramp navigation from Card (money-on-ramp entry) but follows an established goToBuy pattern with flag-based fallback; scope is limited to one bottom sheet plus tests.
> 
> **Overview**
> **Card “Fund with cash”** no longer calls deprecated **`goToDeposit()`** (UB1 with forced deposit routing). It now uses **`goToBuy()`** from `useRampNavigation`, which respects Unified Buy v2 when the feature flag is on and falls back to legacy deposit when it is off.
> 
> When the card’s priority funding token has chain and address, navigation passes a **CAIP-19 `assetId`** (`${caipChainId}/erc20:${address}`) so UB2 can land on the right asset; if there is no address, it calls **`goToBuy(undefined)`** for token selection. Analytics **`ramp_type`** stays aligned with the flag (`UNIFIED_BUY_2` vs `DEPOSIT`); existing deposit click events and **`LoadDepositExperience`** tracing are unchanged.
> 
> Tests mock **`goToBuy`**, default V2 enabled, and add coverage for routing, **`goToDeposit`** regression, missing address, and analytics by flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f3029563b7d054c932be6b74ab7e1ed43db183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[TRAM-3538]: https://consensyssoftware.atlassian.net/browse/TRAM-3538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ