### PR TITLE
feat(perps): add ADR58 ETH position debug banner on home

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -230,6 +230,8 @@ export const PerpsHomeViewSelectorsIDs = {
   WITHDRAW_BUTTON: 'perps-home-withdraw-button',
   ADD_FUNDS_BUTTON: 'perps-home-add-funds-button',
   POSITIONS_PNL_VALUE: 'perps-home-positions-pnl-value',
+  // ADR58 POC (DO NOT MERGE): debug banner shown when an open ETH position exists
+  ETH_POSITION_BANNER: 'perps-home-eth-position-banner',
   SERVICE_INTERRUPTION_BANNER: 'perps-service-interruption-banner',
   COMPETITION_BANNER: 'perps-home-competition-banner',
   // TabBar mock items (for testing)

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
@@ -129,6 +129,19 @@ const styleSheet = (params: { theme: Theme }) => {
     positionsOrdersContainer: {
       paddingHorizontal: 16,
     },
+    // ADR58 POC (DO NOT MERGE): debug banner styles
+    adr58EthPositionBanner: {
+      backgroundColor: colors.error.default,
+      marginHorizontal: 16,
+      marginBottom: 12,
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      borderRadius: 8,
+    },
+    adr58EthPositionBannerText: {
+      color: colors.primary.inverse,
+      fontWeight: 'bold',
+    },
     whatsHappeningSection: {
       borderTopWidth: 1,
       borderTopColor: colors.border.muted,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useMemo,
 } from 'react';
-import { View, Modal, NativeScrollEvent } from 'react-native';
+import { View, Text, Modal, NativeScrollEvent } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   SafeAreaView,
@@ -216,6 +216,11 @@ const PerpsHomeView = ({
     sortBy,
     isLoading,
   } = usePerpsHomeData({});
+
+  // ADR58 POC (DO NOT MERGE): detect an open ETH perps position to gate the debug banner
+  const hasEthPosition = positions.some(
+    (position) => position.symbol === 'ETH',
+  );
 
   // Calculate positions subtitle with P&L
   const hasPositions = positions.length > 0;
@@ -535,6 +540,18 @@ const PerpsHomeView = ({
         <PerpsCompetitionBanner
           testID={PerpsHomeViewSelectorsIDs.COMPETITION_BANNER}
         />
+
+        {/* ADR58 POC (DO NOT MERGE): debug banner shown above positions when an open ETH position exists */}
+        {hasEthPosition && (
+          <View
+            testID={PerpsHomeViewSelectorsIDs.ETH_POSITION_BANNER}
+            style={styles.adr58EthPositionBanner}
+          >
+            <Text style={styles.adr58EthPositionBannerText}>
+              ADR58 POC: ETH POSITION DETECTED
+            </Text>
+          </View>
+        )}
 
         {/* Positions Section */}
         <PerpsHomeSection


### PR DESCRIPTION
## **Description**

ADR58 POC (**DO NOT MERGE**): show a red debug banner on Perps home when the account has an open ETH position. Banner text is exactly `ADR58 POC: ETH POSITION DETECTED`, placed above the positions list; hidden when flat.

[TAT-3215](https://consensyssoftware.atlassian.net/browse/TAT-3215)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Recipe validation (iOS testnet, 21/21 pass):

```bash
temp/recipe/harness/mobile/runner/bin/metamask-recipe run \
  temp/tasks/mms-recipe-dev/20260605T083453Z-tat-3215/artifacts/recipe.json \
  --adapter mobile --project-root . \
  --artifacts-dir temp/tasks/mms-recipe-dev/20260605T083453Z-tat-3215/artifacts \
  --slot local-mobile-1
```

- AC1: no ETH position → banner absent (`perps-home-eth-position-banner` not mounted)
- AC2: open ETH position → red banner above positions list
- AC3: exact banner copy asserted via `ui.wait_for` text

## **Screenshots/Recordings**

### **Before**

N/A — new debug banner (baseline: Perps home without banner when flat).

### **After**

Drag local evidence images from `temp/tasks/mms-recipe-dev/20260605T083453Z-tat-3215/pr-package/images/`:
- `01-tat-3215-eth-banner-absent.png` — no open ETH position
- `02-tat-3215-eth-banner-present.png` — banner visible above ETH position

## **Pre-merge author checklist**

- [ ] I've followed MetaMask contributor docs and coding standards.
- [ ] I've completed the PR template to the best of my ability.
- [ ] I've included tests if applicable — N/A (debug POC; recipe-backed validation only).
- [ ] I've applied the right labels on the PR.

Made with [Cursor](https://cursor.com)

[TAT-3215]: https://consensyssoftware.atlassian.net/browse/TAT-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ