### PR TITLE
feat(perps): ADR58 POC ETH position debug banner [DO NOT MERGE]

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -230,6 +230,8 @@ export const PerpsHomeViewSelectorsIDs = {
   WITHDRAW_BUTTON: 'perps-home-withdraw-button',
   ADD_FUNDS_BUTTON: 'perps-home-add-funds-button',
   POSITIONS_PNL_VALUE: 'perps-home-positions-pnl-value',
+  // ADR58 POC debug banner (TAT-3215) — DO NOT MERGE
+  ADR58_DEBUG_BANNER: 'perps-home-adr58-debug-banner',
   SERVICE_INTERRUPTION_BANNER: 'perps-service-interruption-banner',
   COMPETITION_BANNER: 'perps-home-competition-banner',
   // TabBar mock items (for testing)

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.styles.ts
@@ -129,6 +129,20 @@ const styleSheet = (params: { theme: Theme }) => {
     positionsOrdersContainer: {
       paddingHorizontal: 16,
     },
+    // ADR58 POC debug banner (TAT-3215) — DO NOT MERGE
+    adr58DebugBanner: {
+      backgroundColor: colors.error.default,
+      marginHorizontal: 16,
+      marginBottom: 16,
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderRadius: 8,
+    },
+    adr58DebugBannerText: {
+      color: colors.error.inverse,
+      fontSize: 14,
+      fontWeight: '600',
+    },
     whatsHappeningSection: {
       borderTopWidth: 1,
       borderTopColor: colors.border.muted,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useMemo,
 } from 'react';
-import { View, Modal, NativeScrollEvent } from 'react-native';
+import { View, Modal, NativeScrollEvent, Text } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   SafeAreaView,
@@ -535,6 +535,19 @@ const PerpsHomeView = ({
         <PerpsCompetitionBanner
           testID={PerpsHomeViewSelectorsIDs.COMPETITION_BANNER}
         />
+
+        {/* ADR58 POC debug banner (TAT-3215) — DO NOT MERGE.
+            Shows only when the account has an open ETH perps position. */}
+        {positions.some((position) => position.symbol === 'ETH') && (
+          <View
+            style={styles.adr58DebugBanner}
+            testID={PerpsHomeViewSelectorsIDs.ADR58_DEBUG_BANNER}
+          >
+            <Text style={styles.adr58DebugBannerText}>
+              ADR58 POC: ETH POSITION DETECTED
+            </Text>
+          </View>
+        )}
 
         {/* Positions Section */}
         <PerpsHomeSection


### PR DESCRIPTION
## Description

**⚠️ DO NOT MERGE** — debug-only ADR58 proof-of-concept (TAT-3215).

Adds a red debug banner on the Perps home page when the account has an open ETH position. The banner reads `ADR58 POC: ETH POSITION DETECTED` and renders above the open positions list; it is hidden when there is no open ETH position. Minimal and trivially revertible: 3 files, +30/−1, all tagged `ADR58`/`TAT-3215`.

## Changelog

CHANGELOG entry: null

## Related issues

Fixes: [TAT-3215](https://consensyssoftware.atlassian.net/browse/TAT-3215)

## Screenshots/Recordings

| AC1 — no ETH position → no banner | AC2 / AC3 — ETH position → red banner, exact text, above positions |
| --- | --- |
| <img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/tat-3215-feat-adr58-eth-debug-banner-mme1-1718/01-ac1-no-banner.png" width="300" /> | <img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/tat-3215-feat-adr58-eth-debug-banner-mme1-1718/02-ac2-banner.png" width="300" /> |

_Captured on iOS simulator `mm-1`, HyperLiquid testnet. Wallet state shown is a testnet dev fixture account._

## Validation

Recipe-backed, ran live on iOS — **PASS 17/17**. The recipe opens a real testnet ETH position (order `54396383914`, 0.0066 ETH), asserts the banner, then closes the position in teardown (account left clean).

| AC | Claim | Proof |
| --- | --- | --- |
| AC1 | No open ETH position → no banner | `assert_positions` count 0 + `ui.wait_for` banner `present:false` + AC1 screenshot |
| AC2 | Open ETH position → red banner above positions list | Real fill + `assert_positions` open + banner `visible:true` + AC2 screenshot |
| AC3 | Text exactly `ADR58 POC: ETH POSITION DETECTED` | banner testID text-match assertion + AC2 screenshot |
| AC4 | Minimal + easy to revert | diff = 3 files, +30/−1, all tagged |
| AC5 | Marked DO NOT MERGE | branch + PR title; debug-only banner |

Checks: `tsc --noEmit` exit 0; eslint (3 changed files) 0 errors.

## Manual testing steps

```gherkin
Scenario: ETH position toggles the debug banner
  Given I am on the Perps home page with no open ETH position
  Then I do not see the ADR58 banner
  When I open an ETH perps position
  Then I see a red "ADR58 POC: ETH POSITION DETECTED" banner above the positions list
```

## Gaps

- iOS only (Android not run).


[TAT-3215]: https://consensyssoftware.atlassian.net/browse/TAT-3215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ