### PR TITLE
chore(ci): disable automatic Namespace shadow CI triggers (INFRA-3678)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,6 +11,7 @@ There are also plenty of open issues we'd love help with. Search the [`good firs
 If you're picking up a bounty or an existing issue, feel free to ask clarifying questions on the issue as you go about your work.
 
 ### Submitting a pull request
+
 When you're done with your project / bugfix / feature and ready to submit a PR, there are a couple guidelines we ask you to follow:
 
 - [ ] **Make sure you followed our [`coding guidelines`](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)**: These guidelines aim to maintain consistency and readability across the codebase. They help ensure that the code is easy to understand, maintain, and modify, which is particularly important when working with multiple contributors.
@@ -25,6 +26,6 @@ When you're done with your project / bugfix / feature and ready to submit a PR, 
 
 ### Shadow CI jobs
 
-CI jobs prefixed with `[shadow]` (e.g., from `ci-namespace-shadow.yml`) are **advisory only** and never gate merge. They run the same test suite on Namespace runners for performance benchmarking. If a shadow job fails, it does not indicate a problem with your PR -- it reflects the state of the Namespace runner migration trial.
+The Namespace shadow CI (`ci-namespace-shadow.yml`) no longer runs automatically: its automatic triggers (PRs, pushes to `main`, hourly schedule) are disabled now that the Phase 5d benchmark is complete. It is retained for on-demand runs via manual `workflow_dispatch`, or you can dispatch `ci.yml` directly with `runner_provider=namespace`. Any `[shadow]`-prefixed jobs were always **advisory only** and never gated merge.
 
 And that's it! Thanks for helping out.

--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -1,53 +1,24 @@
 name: CI (Namespace shadow)
 
-# Fire-and-forget dispatcher for the Namespace shadow benchmark (INFRA-3631).
+# On-demand dispatcher for Namespace shadow runs (INFRA-3631 / INFRA-3678).
 #
-# This workflow does NOT use `workflow_call`. Instead, it dispatches `ci.yml`
-# as a separate `workflow_dispatch` run with `runner_provider=namespace`.
+# Automatic triggers (pull_request, push to main, hourly schedule) are disabled:
+# the Phase 5d benchmark is complete (INFRA-3631) and the failure investigation
+# is closed (INFRA-3652). The workflow is retained for on-demand runs only
+# (e.g. INFRA-3639 swap testing) via manual workflow_dispatch.
 #
-# Why a dispatch instead of a call:
-#   - `workflow_call` nests the called workflow's jobs into THIS workflow's
-#     check suite on the PR. With the repo's merge queue ALLGREEN policy,
-#     any shadow flake would block merges.
-#   - `workflow_dispatch` runs live in the Actions tab only -- invisible to
-#     PR checks. The shadow can fail freely; it never blocks the queue,
-#     never duplicates commit statuses, never posts PR comments.
+# It dispatches `ci.yml` as a separate `workflow_dispatch` run with
+# `runner_provider=namespace` (not `workflow_call`), so shadow runs live in the
+# Actions tab only and never appear in PR checks or the merge queue. The OIDC,
+# token-exchange, and dispatch steps use continue-on-error so this job's own
+# check always concludes success even when the dispatch cannot run.
 #
-# This workflow's own GitHub check must never block merges: OIDC, token exchange,
-# and dispatch steps use continue-on-error / non-failing scripts so the job
-# conclusion stays success even when shadow dispatch cannot run.
-#
-# Correlation back to the originating PR:
-#   - The dispatched run's display name is set via `run-name` in ci.yml to
-#     `ci [shadow PR #<num> @ <sha>]`, so it's identifiable in the Actions
-#     tab at a glance.
-#   - The dispatcher job posts a GitHub Actions step summary linking the PR
-#     to the dispatched shadow run URL, reachable from the PR Checks tab.
-#
-# Authentication: Token Exchange Service (same pattern as triage-forwarder.yml
-# and shared-services-workflows deploy.yml — OIDC → POST /api/exchange/token).
-#
-# Prerequisites:
-#   - Repo/org Actions variable: TOKEN_EXCHANGE_URL (already used elsewhere in
-#     metamask-mobile, e.g. triage-forwarder).
-#   - Rego policy in token-exchange-service: explicit policy
-#     mm-metamask-mobile-namespace-shadow-ci-token-exchange (matches OIDC
-#     `workflow_ref` claim for .github/workflows/ci-namespace-shadow.yml).
-#
-# Fork PRs: the job `if` below skips the entire job for fork head repos, so OIDC
-# exchange never runs for untrusted forks (same model as not exposing secrets).
-
+# Authentication: Token Exchange Service (same pattern as triage-forwarder.yml —
+# OIDC → POST /api/exchange/token). Prerequisites:
+#   - Actions variable TOKEN_EXCHANGE_URL (already used elsewhere, e.g. triage-forwarder).
+#   - Rego policy mm-metamask-mobile-namespace-shadow-ci-token-exchange in
+#     token-exchange-service (matches the OIDC `workflow_ref` claim).
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - ".github/CODEOWNERS"
-  push:
-    branches: [main]
-  schedule:
-    - cron: "0 * * * *"
   workflow_dispatch:
 
 concurrency:
@@ -62,8 +33,8 @@ jobs:
   dispatch-shadow:
     name: "[shadow] Dispatch"
     runs-on: ubuntu-latest
-    # Fork PRs use head.repo != github.repository — skip (no shadow, no token exchange).
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Manual dispatch only. If pull_request triggers are ever restored, re-add a
+    # fork-PR guard here so OIDC/token exchange never runs for untrusted forks.
     steps:
       - name: Get OIDC token for token-exchange-service
         id: oidc


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Namespace shadow CI (`.github/workflows/ci-namespace-shadow.yml`, "CI (Namespace shadow)") is a fire-and-forget dispatcher that runs on every PR, every push to `main`, and an hourly cron, dispatching `ci.yml` on Namespace runners purely to collect Cirrus→Namespace migration benchmark data. It is advisory: it never appears in PR checks and never gates the merge queue.

1. **Reason for the change:** the benchmark phase the shadow CI was built for is complete (INFRA-3631) and the failure investigation is closed (INFRA-3652), so it no longer needs to fire automatically on every PR/push/hour.
2. **Improvement/solution:** remove the automatic triggers (`pull_request`, `push`, `schedule`) from `ci-namespace-shadow.yml` and keep `workflow_dispatch` only, so the workflow is retained for on-demand runs (e.g. swap profile testing under INFRA-3639). All `runner_provider` plumbing in `ci.yml` and the build/E2E workflows is left fully intact (318 references unchanged) — the in-progress Namespace migration (Phases 6–8) still depends on it. This is a pause of an advisory workflow, not a Cirrus decommission. No impact on production CI (Cirrus) or the merge queue; no `[shadow]` job is a required status check.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3678

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CI configuration change only (GitHub Actions workflow triggers + a CONTRIBUTING note); there is no app behavior to exercise. Validation performed instead:

- `ci-namespace-shadow.yml` parses with `on:` reduced to `workflow_dispatch` only (actionlint clean).
- `runner_provider` references in `.github` workflows unchanged vs `main` (318) — no migration plumbing removed.
- No `[shadow]` job present in `main` branch-protection required checks.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

`N/A` 

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.