### PR TITLE
fix(money): update transfer out bottom sheet copy (MUSD-907)

### DIFF
--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
@@ -97,7 +97,7 @@ describe('MoneyTransferSheet', () => {
     expect(comingSoonTags).toHaveLength(2);
   });
 
-  it('closes the sheet and calls initiateWithdrawal when "Between accounts" is pressed', () => {
+  it('closes the sheet and calls initiateWithdrawal when "Another account" is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
 
     fireEvent.press(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6976,8 +6976,8 @@
       "contact_support": "Contact support"
     },
     "transfer_sheet": {
-      "title": "Transfer funds",
-      "between_accounts": "Between accounts",
+      "title": "Transfer funds to",
+      "between_accounts": "Another account",
       "perps_account": "Perps account",
       "predictions_account": "Predictions account",
       "send_external": "Send to external address",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

During UAT, users were confused by the transfer-out bottom sheet: the heading "Transfer funds" and the first option "Between accounts" could be misread as transferring funds _into_ the Money Account. This PR updates the copy to be clearer, in line with the [Figma frame](https://www.figma.com/design/XKZ8hRqSn2iTiuzmlQLuYQ/Money-account?node-id=6799-34596):

- Sheet heading: "Transfer funds" → "Transfer funds to"
- First option: "Between accounts" → "Another account"

This is a copy-only change. No logic, layout, or behavior changes; the i18n keys and testIDs are unchanged. Only the English locale is edited (other locales are handled by the localization pipeline).

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the transfer bottom sheet copy to clarify the transfer destination

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-907](https://consensyssoftware.atlassian.net/browse/MUSD-907)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Transfer out bottom sheet copy

  Scenario: user opens the transfer bottom sheet
    Given I am on the Money Account home screen

    When user taps "Transfer"
    Then the sheet heading reads "Transfer funds to"
    And the first option reads "Another account"
    And the remaining options are unchanged
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/d8ad4c36-bcf2-4c85-bf25-eeb816a8c6af" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-907]: https://consensyssoftware.atlassian.net/browse/MUSD-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only English locale and test description changes with no logic, navigation, or testID updates.
> 
> **Overview**
> Updates **English copy** on the Money transfer-out bottom sheet so the destination is clearer after UAT confusion (users read “transfer funds” / “between accounts” as moving money *into* the Money Account).
> 
> The sheet title becomes **“Transfer funds to”** and the first option **“Another account”** via `money.transfer_sheet.title` and `money.transfer_sheet.between_accounts` in `en.json`. **i18n keys, testIDs, and behavior are unchanged**; a unit test description is aligned with the new label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113d548830365845758e7807dd302843d49351a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->