### PR TITLE
fix: use pending block tag when fetching EIP-7702 authorization nonce

### DIFF
--- a/app/util/transactions/delegation.test.ts
+++ b/app/util/transactions/delegation.test.ts
@@ -7,7 +7,12 @@ import { SignMessenger, getDelegationTransaction } from './delegation';
 import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import { Hex } from '@metamask/utils';
 
-const mockGetNonceLock = jest.fn();
+const mockQuery = jest.fn();
+
+jest.mock('@metamask/controller-utils', () => ({
+  ...jest.requireActual('@metamask/controller-utils'),
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
 
 const mockIsAtomicBatchSupported: jest.MockedFn<
   TransactionController['isAtomicBatchSupported']
@@ -18,9 +23,11 @@ jest.spyOn(Math, 'random').mockReturnValue(0);
 jest.mock('../../core/Engine', () => ({
   context: {
     TransactionController: {
-      getNonceLock: () => mockGetNonceLock(),
       isAtomicBatchSupported: (request: IsAtomicBatchSupportedRequest) =>
         mockIsAtomicBatchSupported(request),
+    },
+    NetworkController: {
+      getNetworkClientById: jest.fn().mockReturnValue({ provider: {} }),
     },
   },
 }));
@@ -81,10 +88,7 @@ describe('Transaction Delegation Utils', () => {
       },
     ]);
 
-    mockGetNonceLock.mockResolvedValue({
-      nonceDetails: { params: { nextNetworkNonce: NONCE_MOCK } },
-      releaseLock: jest.fn(),
-    });
+    mockQuery.mockResolvedValue(`0x${NONCE_MOCK.toString(16)}`);
   });
 
   describe('getDelegationTransaction', () => {
@@ -149,7 +153,7 @@ describe('Transaction Delegation Utils', () => {
       });
     });
 
-    it('calls KeyringController to sign authorization', async () => {
+    it('calls KeyringController to sign authorization with pending nonce', async () => {
       await getDelegationTransaction(messengerMock, TRANSACTION_META_MOCK);
 
       expect(sign7702Mock).toHaveBeenCalledWith({
@@ -158,6 +162,16 @@ describe('Transaction Delegation Utils', () => {
         from: TRANSACTION_META_MOCK.txParams.from,
         nonce: NONCE_MOCK,
       });
+    });
+
+    it('fetches nonce using pending block tag', async () => {
+      await getDelegationTransaction(messengerMock, TRANSACTION_META_MOCK);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        'getTransactionCount',
+        [TRANSACTION_META_MOCK.txParams.from, 'pending'],
+      );
     });
 
     it('throws if chain does not support EIP-7702', async () => {

--- a/app/util/transactions/delegation.ts
+++ b/app/util/transactions/delegation.ts
@@ -25,7 +25,8 @@ import { limitedCalls } from '../../core/Delegation/caveatBuilder/limitedCallsBu
 import { Messenger } from '@metamask/messenger';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
-import { toHex } from '@metamask/controller-utils';
+import { query, toHex } from '@metamask/controller-utils';
+import EthQuery from '@metamask/eth-query';
 import Engine from '../../core/Engine';
 import { exactExecutionBatch } from '../../core/Delegation/caveatBuilder/exactExecutionBatchBuilder';
 import { exactExecution } from '../../core/Delegation/caveatBuilder/exactExecutionBuilder';
@@ -134,13 +135,7 @@ async function buildAuthorizationList<MessengerType extends SignMessenger>(
     throw new Error('Upgrade contract address not found');
   }
 
-  const nonceLock = await TransactionController.getNonceLock(
-    from,
-    networkClientId,
-  );
-
-  const nonce = nonceLock.nonceDetails.params.nextNetworkNonce;
-  nonceLock.releaseLock();
+  const nonce = await getNetworkNonce(from as Hex, networkClientId);
 
   const authorizationSignature = (await messenger.call(
     'KeyringController:signEip7702Authorization',
@@ -242,6 +237,21 @@ function buildUnsignedDelegation(
   log('Delegation', delegation);
 
   return delegation;
+}
+
+async function getNetworkNonce(
+  address: Hex,
+  networkClientId: string,
+): Promise<number> {
+  const { NetworkController } = Engine.context;
+  const networkClient = NetworkController.getNetworkClientById(networkClientId);
+  const ethQuery = new EthQuery(networkClient.provider);
+  const nonceHex = (await query(ethQuery, 'getTransactionCount', [
+    address,
+    'pending',
+  ])) as string;
+
+  return parseInt(nonceHex, 16);
 }
 
 function buildCaveats(


### PR DESCRIPTION
## **Description**

When building an EIP-7702 authorization for the delegation flow, the nonce for the authorization tuple was previously obtained via `TransactionController.getNonceLock`. That path uses `NonceTracker`, which calls `eth_getTransactionCount` against a **cached block number** supplied by `PollingBlockTracker` (polled every ~20 s). On fast chains, several blocks can be confirmed between polls, so `getTransactionCount(address, <stale_block>)` under-reports the account's nonce — returning a value lower than the current on-chain nonce. An EIP-7702 authorization signed with a nonce that does not match the chain's current nonce is immediately invalid when Relay attempts to submit the bundle.

This PR replaces the `getNonceLock` call in `buildAuthorizationList` with a direct `eth_getTransactionCount(address, "pending")` query against the network provider via `EthQuery`. The `"pending"` block tag is the semantically correct choice here because:

- It reads the live mempool state, bypassing the block-tracker cache entirely.
- It accounts for any in-flight transactions already accepted by the node, preventing the authorization nonce from colliding with them.
- Relay submits the EIP-7702 bundle immediately after this function returns, so latency between signing and submission is negligible.

The `getNonceLock` machinery (local nonce-tracking, lock, release) is unnecessary for this use case; the authorization nonce must reflect the chain, not the local pending-tx cache.

## **Changelog**

CHANGELOG entry: Fixed EIP-7702 authorization signing to use the pending on-chain nonce, preventing delegation transactions from failing when the nonce tracker's cached block is stale.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: perps deposit delegation

  Scenario: user submits a perps deposit on a fast chain
    Given the user has a non-upgraded EOA
    And the chain has confirmed transactions since the last block-tracker poll

    When user initiates a perps deposit
    Then the EIP-7702 authorization is signed with the correct pending nonce
    And the delegation transaction is accepted by Relay
```

## **Screenshots/Recordings**

N/A — internal signing logic, no UI change.

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how authorization nonces are sourced for EIP-7702 delegation bundles; incorrect behavior would break Relay submission but the scope is limited to the delegation authorization path.
> 
> **Overview**
> **EIP-7702 delegation signing** now loads the authorization nonce from the network with `eth_getTransactionCount(address, "pending")` instead of `TransactionController.getNonceLock`, so the signed nonce matches live chain/mempool state rather than a block-tracker–cached value.
> 
> `buildAuthorizationList` in `delegation.ts` calls a new `getNetworkNonce` helper that resolves the provider via `NetworkController` and `EthQuery`/`query`. Unit tests mock `query` and assert the pending block tag and the nonce passed into `KeyringController:signEip7702Authorization`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e56b201f47f47989dec358070241b7fe42880d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->