### PR TITLE
chore(predict): add feed config types

### DIFF
--- a/app/components/UI/Predict/constants/feedConfig.test.ts
+++ b/app/components/UI/Predict/constants/feedConfig.test.ts
@@ -1,0 +1,132 @@
+import {
+  PREDICT_FEED_IDS,
+  PREDICT_FEED_REGISTRY,
+  isPredictFeedId,
+  resolvePredictFeedConfig,
+  resolvePredictFeedDefaultFilter,
+  resolvePredictFeedDefaultTab,
+  type PredictDynamicFilterConfig,
+  type PredictFeedFilterConfig,
+} from './feedConfig';
+
+const getAllStaticFilters = (): PredictFeedFilterConfig[] =>
+  Object.values(PREDICT_FEED_REGISTRY).flatMap((feed) =>
+    feed.tabs.flatMap((tab) => tab.filters.static),
+  );
+
+const getAllDynamicFilters = (): PredictDynamicFilterConfig[] =>
+  Object.values(PREDICT_FEED_REGISTRY)
+    .flatMap((feed) => feed.tabs.map((tab) => tab.filters.dynamic))
+    .filter((filter): filter is PredictDynamicFilterConfig => Boolean(filter));
+
+describe('feedConfig', () => {
+  it('centralizes the exact v1 feed ids and excludes World Cup', () => {
+    expect(Object.keys(PREDICT_FEED_REGISTRY)).toEqual([...PREDICT_FEED_IDS]);
+    expect(PREDICT_FEED_IDS).toEqual([
+      'sports',
+      'politics',
+      'crypto',
+      'live',
+      'trending',
+      'popular-today',
+    ]);
+    expect(isPredictFeedId('world-cup')).toBe(false);
+  });
+
+  it.each(PREDICT_FEED_IDS)('resolves known feed id %s', (feedId) => {
+    expect(isPredictFeedId(feedId)).toBe(true);
+    expect(resolvePredictFeedConfig(feedId)?.id).toBe(feedId);
+  });
+
+  it('returns undefined for unknown feed ids', () => {
+    expect(isPredictFeedId('unknown')).toBe(false);
+    expect(resolvePredictFeedConfig('unknown')).toBeUndefined();
+    expect(resolvePredictFeedConfig()).toBeUndefined();
+  });
+
+  it('defines at least one tab for every feed', () => {
+    Object.values(PREDICT_FEED_REGISTRY).forEach((feed) => {
+      expect(feed.tabs.length).toBeGreaterThan(0);
+    });
+  });
+
+  it.each(PREDICT_FEED_IDS)(
+    'uses the first tab as the default tab for %s',
+    (feedId) => {
+      expect(resolvePredictFeedDefaultTab(feedId)).toBe(
+        PREDICT_FEED_REGISTRY[feedId].tabs[0],
+      );
+    },
+  );
+
+  it('resolves every tab default filter from static filters', () => {
+    Object.values(PREDICT_FEED_REGISTRY).forEach((feed) => {
+      feed.tabs.forEach((tab) => {
+        const defaultFilter = tab.filters.static.find(
+          (filter) => filter.id === tab.defaultFilterId,
+        );
+
+        expect(defaultFilter).toBeDefined();
+        expect(resolvePredictFeedDefaultFilter(feed.id, tab.id)).toBe(
+          defaultFilter,
+        );
+      });
+    });
+  });
+
+  it('represents hidden-tab feeds with exactly one tab', () => {
+    (
+      ['politics', 'crypto', 'live', 'trending', 'popular-today'] as const
+    ).forEach((feedId) => {
+      expect(PREDICT_FEED_REGISTRY[feedId].tabs).toHaveLength(1);
+    });
+  });
+
+  it('defines the v1 sports tabs from the Figma shell', () => {
+    expect(PREDICT_FEED_REGISTRY.sports.tabs.map((tab) => tab.id)).toEqual([
+      'basketball',
+      'tennis',
+      'soccer',
+      'baseball',
+      'football',
+    ]);
+  });
+
+  it('uses related-tags dynamic filters with supported base slugs', () => {
+    const dynamicFilters = getAllDynamicFilters();
+    const sources = new Set(dynamicFilters.map((filter) => filter.source));
+    const baseTagSlugs = new Set(
+      dynamicFilters
+        .map((filter) => filter.baseTagSlug)
+        .filter((baseTagSlug): baseTagSlug is string => Boolean(baseTagSlug)),
+    );
+
+    expect(sources).toEqual(new Set(['related-tags']));
+    expect(baseTagSlugs).toEqual(
+      new Set(['sports', 'politics', 'crypto', 'all']),
+    );
+  });
+
+  it('keeps static market params category-free', () => {
+    const allowedParamKeys = new Set([
+      'tags',
+      'tagSlugs',
+      'series',
+      'order',
+      'status',
+      'live',
+      'search',
+      'limit',
+      'afterCursor',
+    ]);
+
+    getAllStaticFilters().forEach((filter) => {
+      const params = filter.params as Record<string, unknown>;
+
+      expect('category' in params).toBe(false);
+      expect(
+        Object.keys(params).every((key) => allowedParamKeys.has(key)),
+      ).toBe(true);
+    });
+  });
+});

--- a/app/components/UI/Predict/constants/feedConfig.test.ts
+++ b/app/components/UI/Predict/constants/feedConfig.test.ts
@@ -74,6 +74,25 @@ describe('feedConfig', () => {
     });
   });
 
+  it.each(PREDICT_FEED_IDS)(
+    'falls back to the first tab when resolving the default filter for %s without a tabId',
+    (feedId) => {
+      const firstTab = PREDICT_FEED_REGISTRY[feedId].tabs[0];
+      const expected = firstTab.filters.static.find(
+        (filter) => filter.id === firstTab.defaultFilterId,
+      );
+
+      expect(resolvePredictFeedDefaultFilter(feedId)).toBe(expected);
+    },
+  );
+
+  it('returns undefined when resolving the default filter for unknown feeds or tabs', () => {
+    expect(resolvePredictFeedDefaultFilter('unknown')).toBeUndefined();
+    expect(
+      resolvePredictFeedDefaultFilter('sports', 'unknown-tab'),
+    ).toBeUndefined();
+  });
+
   it('represents hidden-tab feeds with exactly one tab', () => {
     (
       ['politics', 'crypto', 'live', 'trending', 'popular-today'] as const

--- a/app/components/UI/Predict/constants/feedConfig.ts
+++ b/app/components/UI/Predict/constants/feedConfig.ts
@@ -1,4 +1,7 @@
-import type { PredictMarketListParams } from '../types';
+import type {
+  PredictFilterOptionSource,
+  PredictMarketListParams,
+} from '../types';
 
 export const PREDICT_FEED_IDS = [
   'sports',
@@ -12,7 +15,7 @@ export const PREDICT_FEED_IDS = [
 export type PredictFeedId = (typeof PREDICT_FEED_IDS)[number];
 
 export interface PredictDynamicFilterConfig {
-  source: 'related-tags' | 'hot-tags' | 'trending-series' | 'sports-leagues';
+  source: PredictFilterOptionSource;
   /** Polymarket related-tags root slug. Use 'all' for general popular/trending lists. */
   baseTagSlug?: string;
   baseParams?: PredictMarketListParams;

--- a/app/components/UI/Predict/constants/feedConfig.ts
+++ b/app/components/UI/Predict/constants/feedConfig.ts
@@ -1,0 +1,306 @@
+import type { PredictMarketListParams } from '../types';
+
+export const PREDICT_FEED_IDS = [
+  'sports',
+  'politics',
+  'crypto',
+  'live',
+  'trending',
+  'popular-today',
+] as const;
+
+export type PredictFeedId = (typeof PREDICT_FEED_IDS)[number];
+
+export interface PredictDynamicFilterConfig {
+  source: 'related-tags' | 'hot-tags' | 'trending-series' | 'sports-leagues';
+  /** Polymarket related-tags root slug. Use 'all' for general popular/trending lists. */
+  baseTagSlug?: string;
+  baseParams?: PredictMarketListParams;
+  limit?: number;
+}
+
+export interface PredictFeedFilterConfig {
+  id: string;
+  titleKey?: string;
+  label?: string;
+  params: PredictMarketListParams;
+}
+
+export interface PredictFeedFiltersConfig {
+  static: PredictFeedFilterConfig[];
+  dynamic?: PredictDynamicFilterConfig;
+}
+
+export interface PredictFeedTabConfig {
+  id: string;
+  titleKey: string;
+  defaultFilterId: string;
+  filters: PredictFeedFiltersConfig;
+}
+
+export interface PredictFeedConfig {
+  id: PredictFeedId;
+  titleKey: string;
+  header: {
+    showBackButton: boolean;
+    showSearchButton: boolean;
+  };
+  tabs: PredictFeedTabConfig[];
+}
+
+const FILTER_TITLE_KEYS = {
+  all: 'predict.feed.filters.all',
+  live: 'predict.feed.filters.live',
+} as const;
+
+const createAllFilter = (
+  params: PredictMarketListParams,
+): PredictFeedFilterConfig => ({
+  id: 'all',
+  titleKey: FILTER_TITLE_KEYS.all,
+  params,
+});
+
+const createLiveFilter = (
+  params: PredictMarketListParams,
+): PredictFeedFilterConfig => ({
+  id: 'live',
+  titleKey: FILTER_TITLE_KEYS.live,
+  params: {
+    ...params,
+    live: true,
+  },
+});
+
+const createCategoryFeed = ({
+  id,
+  titleKey,
+  tagSlug,
+}: {
+  id: Extract<PredictFeedId, 'politics' | 'crypto'>;
+  titleKey: string;
+  tagSlug: string;
+}): PredictFeedConfig => ({
+  id,
+  titleKey,
+  header: {
+    showBackButton: true,
+    showSearchButton: true,
+  },
+  tabs: [
+    {
+      id: 'all',
+      titleKey,
+      defaultFilterId: 'all',
+      filters: {
+        static: [
+          createAllFilter({
+            tagSlugs: [tagSlug],
+            status: 'open',
+            order: 'volume24hr',
+          }),
+        ],
+        dynamic: {
+          source: 'related-tags',
+          baseTagSlug: tagSlug,
+          baseParams: {
+            tagSlugs: [tagSlug],
+            status: 'open',
+            order: 'volume24hr',
+          },
+        },
+      },
+    },
+  ],
+});
+
+const createSportsTab = ({
+  id,
+  titleKey,
+}: {
+  id: string;
+  titleKey: string;
+}): PredictFeedTabConfig => {
+  const baseParams: PredictMarketListParams = {
+    tagSlugs: ['sports', id],
+    status: 'open',
+    order: 'volume24hr',
+  };
+
+  return {
+    id,
+    titleKey,
+    defaultFilterId: 'all',
+    filters: {
+      static: [createAllFilter(baseParams), createLiveFilter(baseParams)],
+      dynamic: {
+        source: 'related-tags',
+        baseTagSlug: 'sports',
+        baseParams,
+      },
+    },
+  };
+};
+
+export const PREDICT_FEED_REGISTRY: Record<PredictFeedId, PredictFeedConfig> = {
+  sports: {
+    id: 'sports',
+    titleKey: 'predict.category.sports',
+    header: {
+      showBackButton: true,
+      showSearchButton: true,
+    },
+    tabs: [
+      createSportsTab({
+        id: 'basketball',
+        titleKey: 'predict.feed.tabs.basketball',
+      }),
+      createSportsTab({
+        id: 'tennis',
+        titleKey: 'predict.feed.tabs.tennis',
+      }),
+      createSportsTab({
+        id: 'soccer',
+        titleKey: 'predict.feed.tabs.soccer',
+      }),
+      createSportsTab({
+        id: 'baseball',
+        titleKey: 'predict.feed.tabs.baseball',
+      }),
+      createSportsTab({
+        id: 'football',
+        titleKey: 'predict.feed.tabs.football',
+      }),
+    ],
+  },
+  politics: createCategoryFeed({
+    id: 'politics',
+    titleKey: 'predict.category.politics',
+    tagSlug: 'politics',
+  }),
+  crypto: createCategoryFeed({
+    id: 'crypto',
+    titleKey: 'predict.category.crypto',
+    tagSlug: 'crypto',
+  }),
+  live: {
+    id: 'live',
+    titleKey: 'predict.feed.live',
+    header: {
+      showBackButton: true,
+      showSearchButton: true,
+    },
+    tabs: [
+      {
+        id: 'live',
+        titleKey: 'predict.feed.live',
+        defaultFilterId: 'live',
+        filters: {
+          static: [
+            createLiveFilter({
+              status: 'open',
+              order: 'volume24hr',
+              limit: 10,
+            }),
+          ],
+        },
+      },
+    ],
+  },
+  trending: {
+    id: 'trending',
+    titleKey: 'predict.category.trending',
+    header: {
+      showBackButton: true,
+      showSearchButton: true,
+    },
+    tabs: [
+      {
+        id: 'all',
+        titleKey: 'predict.category.trending',
+        defaultFilterId: 'all',
+        filters: {
+          static: [
+            createAllFilter({
+              status: 'open',
+              order: 'volume24hr',
+              limit: 5,
+            }),
+          ],
+          dynamic: {
+            source: 'related-tags',
+            baseTagSlug: 'all',
+            baseParams: {
+              status: 'open',
+              order: 'volume24hr',
+              limit: 5,
+            },
+          },
+        },
+      },
+    ],
+  },
+  'popular-today': {
+    id: 'popular-today',
+    titleKey: 'predict.feed.popular_today',
+    header: {
+      showBackButton: true,
+      showSearchButton: true,
+    },
+    tabs: [
+      {
+        id: 'all',
+        titleKey: 'predict.feed.popular_today',
+        defaultFilterId: 'all',
+        filters: {
+          static: [
+            createAllFilter({
+              status: 'open',
+              order: 'volume24hr',
+              limit: 12,
+            }),
+          ],
+          dynamic: {
+            source: 'related-tags',
+            baseTagSlug: 'all',
+            baseParams: {
+              status: 'open',
+              order: 'volume24hr',
+              limit: 12,
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
+const PREDICT_FEED_ID_SET = new Set<string>(PREDICT_FEED_IDS);
+
+export const isPredictFeedId = (
+  value?: string | null,
+): value is PredictFeedId => Boolean(value && PREDICT_FEED_ID_SET.has(value));
+
+export const resolvePredictFeedConfig = (
+  feedId?: string | null,
+): PredictFeedConfig | undefined =>
+  isPredictFeedId(feedId) ? PREDICT_FEED_REGISTRY[feedId] : undefined;
+
+export const resolvePredictFeedDefaultTab = (
+  feedId?: string | null,
+): PredictFeedTabConfig | undefined =>
+  resolvePredictFeedConfig(feedId)?.tabs[0];
+
+export const resolvePredictFeedDefaultFilter = (
+  feedId?: string | null,
+  tabId?: string | null,
+): PredictFeedFilterConfig | undefined => {
+  const config = resolvePredictFeedConfig(feedId);
+  const tab = tabId
+    ? config?.tabs.find((candidateTab) => candidateTab.id === tabId)
+    : config?.tabs[0];
+
+  return tab?.filters.static.find(
+    (filter) => filter.id === tab.defaultFilterId,
+  );
+};

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -731,6 +731,7 @@ describe('polymarket utils', () => {
       const params = buildMarketListQueryParams({ tags: ['100', '200'] });
 
       expect(params.getAll('tag_id')).toEqual(['100', '200']);
+      expect(params.getAll('tag_slug')).toEqual([]);
     });
 
     it('appends multiple tagSlugs as repeated tag_slug params', () => {

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -15,6 +15,7 @@ import {
 import { PredictEventValues } from '../constants/eventNames';
 import type { TransactionActiveAbTestEntry } from '../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import type { PredictWorldCupTabKey } from '../constants/worldCupTabs';
+import type { PredictFeedId } from '../constants/feedConfig';
 
 export type PredictEntryPoint =
   | typeof PredictEventValues.ENTRY_POINT.CAROUSEL
@@ -33,9 +34,10 @@ export type PredictEntryPoint =
   | typeof PredictEventValues.ENTRY_POINT.HOME_SECTION
   | typeof PredictEventValues.ENTRY_POINT.EXPLORE;
 
-/** Predict market list parameters */
-export interface PredictMarketListParams {
+/** Predict market list route parameters */
+export interface PredictMarketListRouteParams {
   entryPoint?: PredictEntryPoint;
+  feedId?: PredictFeedId;
   tab?: PredictCategory;
   query?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -135,7 +137,7 @@ export type PredictSellPreviewProps =
 
 export interface PredictNavigationParamList extends ParamListBase {
   Predict: undefined;
-  PredictMarketList: PredictMarketListParams;
+  PredictMarketList: PredictMarketListRouteParams;
   PredictMarketDetails: PredictMarketDetailsParams;
   PredictPositions: PredictPositionsParams | undefined;
   PredictWorldCup: PredictWorldCupParams | undefined;

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -38,7 +38,18 @@ export type PredictEntryPoint =
 export interface PredictMarketListRouteParams {
   entryPoint?: PredictEntryPoint;
   feedId?: PredictFeedId;
+  /**
+   * Legacy top-level Predict feed tab key (hot / world-cup / base tabs).
+   * Consumed by `usePredictTabs`. Not interchangeable with `tabId`.
+   */
   tab?: PredictCategory;
+  /**
+   * Sub-tab id within a feed defined in the feed registry
+   * (e.g. `basketball`, `tennis`, `all`, `live`). Paired with `feedId`
+   * for deep-linking to a specific tab inside a feed. Kept as a plain
+   * string so the route stays decoupled from the registry shape.
+   */
+  tabId?: string;
   query?: string;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
 }

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -35,7 +35,7 @@ export type PredictEntryPoint =
   | typeof PredictEventValues.ENTRY_POINT.EXPLORE;
 
 /** Predict market list route parameters */
-export interface PredictMarketListParams {
+export interface PredictMarketListRouteParams {
   entryPoint?: PredictEntryPoint;
   feedId?: PredictFeedId;
   tab?: PredictCategory;
@@ -137,7 +137,7 @@ export type PredictSellPreviewProps =
 
 export interface PredictNavigationParamList extends ParamListBase {
   Predict: undefined;
-  PredictMarketList: PredictMarketListParams;
+  PredictMarketList: PredictMarketListRouteParams;
   PredictMarketDetails: PredictMarketDetailsParams;
   PredictPositions: PredictPositionsParams | undefined;
   PredictWorldCup: PredictWorldCupParams | undefined;

--- a/app/components/UI/Predict/types/navigation.ts
+++ b/app/components/UI/Predict/types/navigation.ts
@@ -35,7 +35,7 @@ export type PredictEntryPoint =
   | typeof PredictEventValues.ENTRY_POINT.EXPLORE;
 
 /** Predict market list route parameters */
-export interface PredictMarketListRouteParams {
+export interface PredictMarketListParams {
   entryPoint?: PredictEntryPoint;
   feedId?: PredictFeedId;
   tab?: PredictCategory;
@@ -137,7 +137,7 @@ export type PredictSellPreviewProps =
 
 export interface PredictNavigationParamList extends ParamListBase {
   Predict: undefined;
-  PredictMarketList: PredictMarketListRouteParams;
+  PredictMarketList: PredictMarketListParams;
   PredictMarketDetails: PredictMarketDetailsParams;
   PredictPositions: PredictPositionsParams | undefined;
   PredictWorldCup: PredictWorldCupParams | undefined;

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -104,7 +104,7 @@ import type {
 
 // Predict params
 import type {
-  PredictMarketListRouteParams,
+  PredictMarketListParams,
   PredictMarketDetailsParams,
   PredictActivityDetailParams,
   PredictBuyPreviewParams,
@@ -587,7 +587,7 @@ export interface RootStackParamList extends ParamListBase {
 
   // Predict routes
   Predict: undefined;
-  PredictMarketList: PredictMarketListRouteParams | undefined;
+  PredictMarketList: PredictMarketListParams | undefined;
   PredictMarketDetails: PredictMarketDetailsParams | undefined;
   PredictActivityDetail: PredictActivityDetailParams;
   PredictModals: undefined;

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -104,7 +104,7 @@ import type {
 
 // Predict params
 import type {
-  PredictMarketListParams,
+  PredictMarketListRouteParams,
   PredictMarketDetailsParams,
   PredictActivityDetailParams,
   PredictBuyPreviewParams,
@@ -587,7 +587,7 @@ export interface RootStackParamList extends ParamListBase {
 
   // Predict routes
   Predict: undefined;
-  PredictMarketList: PredictMarketListParams | undefined;
+  PredictMarketList: PredictMarketListRouteParams | undefined;
   PredictMarketDetails: PredictMarketDetailsParams | undefined;
   PredictActivityDetail: PredictActivityDetailParams;
   PredictModals: undefined;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2507,6 +2507,21 @@
       "politics": "Politics",
       "hot": "Hot"
     },
+    "feed": {
+      "live": "Live",
+      "popular_today": "Popular today",
+      "tabs": {
+        "basketball": "Basketball",
+        "tennis": "Tennis",
+        "soccer": "Soccer",
+        "baseball": "Baseball",
+        "football": "Football"
+      },
+      "filters": {
+        "all": "All",
+        "live": "Live"
+      }
+    },
     "search_placeholder": "Search prediction markets",
     "search_cancel": "Cancel",
     "search_empty_state": "No {{category}} markets available",


### PR DESCRIPTION
## **Description**

Adds the typed static Predict feed registry needed for the PRED-834 IA/navigation overhaul groundwork.

This introduces a centralized v1 feed config registry for `sports`, `politics`, `crypto`, `live`, `trending`, and `popular-today`, including typed feed IDs, headers, tabs, static filters, dynamic filter metadata, and resolver helpers for known/default feed lookup. The registry intentionally keeps World Cup out of the generic feed config path for v1.

The change also adds stable `feedId` support to Predict market-list route params and keeps market-list tag semantics backward compatible by treating `tags` as `tag_id` values and `tagSlugs` as `tag_slug` values.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-910

## **Manual testing steps**

N/A - this is config/type groundwork only and does not change any rendered user flow.

Automated validation performed:

```bash
yarn jest app/components/UI/Predict/constants/feedConfig.test.ts app/components/UI/Predict/providers/polymarket/utils.test.ts app/components/UI/Predict/queries/marketList.test.ts app/components/UI/Predict/queries/filterOptions.test.ts
git diff --check
yarn lint:tsc
```

`yarn lint:tsc` currently fails on unrelated branch-wide issues in Perps, Compliance, header `textProps`, `psl`, and wallet init types. No PRED-910 or `tagSlugs` type errors were reported.

## **Screenshots/Recordings**

N/A - no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A - config/type-only change; no runtime UI path changed.
- [x] I've tested with a power user scenario
  - N/A - config/type-only change; no wallet-size-sensitive runtime path changed.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A - no new runtime operation was added.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config, types, locales, and tests only; no runtime UI or trading paths are changed in this PR.
> 
> **Overview**
> Adds a **typed v1 Predict feed registry** (`feedConfig.ts`) for six feeds—sports, politics, crypto, live, trending, popular-today—with headers, tabs, static/dynamic filters, and resolver helpers; **World Cup is intentionally excluded** from this registry.
> 
> **Navigation groundwork:** `PredictMarketList` route params are renamed to `PredictMarketListRouteParams` and extended with optional **`feedId`** and **`tabId`** (distinct from legacy `tab`), wired through Predict and root navigation types.
> 
> **i18n** adds `predict.feed.*` strings for live, popular today, sports sub-tabs, and All/Live filters. **Tests** lock registry invariants (`feedConfig.test.ts`) and assert `tags`-only queries do not emit `tag_slug` params (`utils.test.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c456dc2719a845495a9d3e08e7d519e7bcee6060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->