### PR TITLE
chore: cleanup perps top movers buttons cp-7.81.0

### DIFF
--- a/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.tsx
+++ b/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.tsx
@@ -52,7 +52,7 @@ const TogglePill: React.FC<TogglePillProps> = ({
       accessibilityRole="button"
       accessibilityState={{ selected: isSelected }}
       style={tw.style(
-        'flex-1 rounded-xl items-center',
+        'flex-1 rounded-lg items-center justify-center py-1',
         isSelected ? 'bg-icon-default' : 'bg-muted',
       )}
     >


### PR DESCRIPTION
## **Description**

Makes Gainers/Loser buttons larger and more accessible

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: css bug

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<img width="428" height="260" alt="Screenshot 2026-06-05 at 6 54 09 AM" src="https://github.com/user-attachments/assets/a9f4a656-a388-4ba5-8bc9-870bbe369fc7" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class changes on a Perps home UI toggle with no logic, data, or auth impact.
> 
> **Overview**
> Updates the **Gainers / Losers** toggle styling in `PerpsTopMoversSection` so the pills are easier to tap and read.
> 
> `TogglePill` now uses **`rounded-lg`** instead of **`rounded-xl`**, adds **`justify-center`** and **`py-1`** for vertical padding and centered label alignment—matching the PR goal of larger, more accessible buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ad85409777d4720d1325514ee6dc0c93ffe7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->