### PR TITLE
feat: enable Monad by default for existing users and prevent deletion

### DIFF
--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.constants.ts
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.constants.ts
@@ -3,6 +3,7 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 export const MAIN_CHAIN_IDS = new Set([
   CHAIN_IDS.MAINNET,
   CHAIN_IDS.LINEA_MAINNET,
+  CHAIN_IDS.MONAD,
 ] as string[]);
 
 export const ESTIMATED_ITEM_SIZE = 56;

--- a/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.test.tsx
@@ -733,6 +733,61 @@ describe('Network Selector', () => {
     });
   });
 
+  describe('renderRpcNetworks - delete guard for non-removable networks', () => {
+    const MENU_BUTTON_TEST_ID = 'button-menu-select-test-id';
+    const MONAD_MAINNET_CHAIN_ID = '0x8f';
+
+    const stateWithOnlyMonadMainnet = {
+      ...initialState,
+      engine: {
+        backgroundState: {
+          ...initialState.engine.backgroundState,
+          NetworkController: {
+            selectedNetworkClientId: 'mainnet',
+            networksMetadata: {
+              mainnet: { status: 'available', EIPS: { '1559': true } },
+            },
+            networkConfigurationsByChainId: {
+              '0x1':
+                initialState.engine.backgroundState.NetworkController
+                  .networkConfigurationsByChainId['0x1'],
+              [MONAD_MAINNET_CHAIN_ID]: {
+                blockExplorerUrls: ['https://monadscan.com'],
+                chainId: MONAD_MAINNET_CHAIN_ID,
+                defaultRpcEndpointIndex: 0,
+                name: 'Monad Mainnet',
+                nativeCurrency: 'MON',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'monad-mainnet',
+                    type: 'infura' as const,
+                    url: 'https://monad-mainnet.infura.io/v3/test',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it('does not show delete option when 3-dot menu is opened for Monad mainnet', async () => {
+      (isNetworkUiRedesignEnabled as jest.Mock).mockImplementation(() => true);
+      const { getAllByTestId, queryByTestId } = renderComponent(
+        stateWithOnlyMonadMainnet,
+      );
+
+      const menuButtons = getAllByTestId(MENU_BUTTON_TEST_ID);
+      fireEvent.press(menuButtons[2]);
+
+      await waitFor(() => {
+        expect(
+          queryByTestId(NetworkListModalSelectorsIDs.DELETE_NETWORK),
+        ).toBeNull();
+      });
+    });
+  });
+
   describe('network switching with connected dapp', () => {
     beforeEach(() => {
       // Reset only the specific mocks being asserted, not all mocks

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -39,6 +39,7 @@ import Networks, {
   isTestNet,
   getNetworkImageSource,
   isMainNet,
+  canDeleteNetwork,
 } from '../../../util/networks';
 import { LINEA_MAINNET, MAINNET } from '../../../constants/network';
 import {
@@ -628,7 +629,7 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
             }
             buttonProps={{
               onButtonClick: () => {
-                openModal(chainId, true, rpcUrl, false);
+                openModal(chainId, canDeleteNetwork(chainId), rpcUrl, false);
               },
             }}
             onTextClick={() =>
@@ -638,7 +639,7 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
               })
             }
             onLongPress={() => {
-              openModal(chainId, true, rpcUrl, false);
+              openModal(chainId, canDeleteNetwork(chainId), rpcUrl, false);
             }}
           />
         );

--- a/app/store/migrations/142.test.ts
+++ b/app/store/migrations/142.test.ts
@@ -1,0 +1,239 @@
+import { cloneDeep } from 'lodash';
+import {
+  NetworkConfiguration,
+  RpcEndpointType,
+} from '@metamask/network-controller';
+import { Hex } from '@metamask/utils';
+
+import { ensureValidState } from './util';
+import migrate from './142';
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const createTestState = () => ({
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        selectedNetworkClientId: 'mainnet',
+        networksMetadata: {},
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+          },
+          '0xaa36a7': {
+            chainId: '0xaa36a7',
+            rpcEndpoints: [
+              {
+                networkClientId: 'sepolia',
+                url: 'https://sepolia.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://sepolia.etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Sepolia',
+            nativeCurrency: 'SepoliaETH',
+          },
+          '0xe705': {
+            chainId: '0xe705',
+            rpcEndpoints: [
+              {
+                networkClientId: 'linea-sepolia',
+                url: 'https://linea-sepolia.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://sepolia.lineascan.build'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Linea Sepolia',
+            nativeCurrency: 'LineaETH',
+          },
+          '0xe708': {
+            chainId: '0xe708',
+            rpcEndpoints: [
+              {
+                networkClientId: 'linea-mainnet',
+                url: 'https://linea-mainnet.infura.io/v3/{infuraProjectId}',
+                type: 'infura',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://lineascan.build'],
+            defaultBlockExplorerUrlIndex: 0,
+            name: 'Linea Mainnet',
+            nativeCurrency: 'ETH',
+          },
+        },
+      },
+    },
+  },
+});
+
+const createMonadMainnetConfiguration = (): NetworkConfiguration => ({
+  chainId: '0x8f',
+  rpcEndpoints: [
+    {
+      networkClientId: 'monad-mainnet',
+      url: 'https://monad-mainnet.infura.io/v3/{infuraProjectId}',
+      type: RpcEndpointType.Infura,
+    },
+  ],
+  defaultRpcEndpointIndex: 0,
+  blockExplorerUrls: ['https://monadscan.com'],
+  defaultBlockExplorerUrlIndex: 0,
+  name: 'Monad Mainnet',
+  nativeCurrency: 'MON',
+});
+
+describe('Migration 142: Add `Monad Mainnet`', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toBe(state);
+    expect(migratedState).toStrictEqual({ some: 'state' });
+  });
+
+  it('adds `Monad Mainnet` as a default Infura network to state', () => {
+    const monadMainnetConfiguration = createMonadMainnetConfiguration();
+    const oldState = createTestState();
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedData = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              [monadMainnetConfiguration.chainId]: monadMainnetConfiguration,
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = migrate(oldState);
+
+    expect(migratedState).toStrictEqual(expectedData);
+  });
+
+  it('does not overwrite an existing `Monad Mainnet` NetworkConfiguration', () => {
+    const monadMainnetConfiguration = createMonadMainnetConfiguration();
+    const oldState = createTestState();
+    const networkConfigurationsByChainId = oldState.engine.backgroundState
+      .NetworkController.networkConfigurationsByChainId as Record<
+      Hex,
+      NetworkConfiguration
+    >;
+    const existingMonadConfiguration: NetworkConfiguration = {
+      ...monadMainnetConfiguration,
+      name: 'My Custom Monad',
+      rpcEndpoints: [
+        {
+          networkClientId: 'some-client-id',
+          url: 'https://some-custom-monad-rpc.example/rpc',
+          type: RpcEndpointType.Custom,
+        },
+      ],
+      blockExplorerUrls: ['https://my-custom-explorer.example'],
+    };
+    networkConfigurationsByChainId[monadMainnetConfiguration.chainId] =
+      existingMonadConfiguration;
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const expectedData = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              [monadMainnetConfiguration.chainId]: existingMonadConfiguration,
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = migrate(oldState);
+
+    expect(migratedState).toStrictEqual(expectedData);
+  });
+
+  it.each([
+    {
+      state: {
+        engine: {
+          backgroundState: {},
+        },
+      },
+      test: 'missing NetworkController',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: 'invalid',
+          },
+        },
+      },
+      test: 'invalid NetworkController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {},
+          },
+        },
+      },
+      test: 'missing networkConfigurationsByChainId',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            NetworkController: {
+              networkConfigurationsByChainId: 'invalid',
+            },
+          },
+        },
+      },
+      test: 'invalid networkConfigurationsByChainId state',
+    },
+  ])('does not modify state if the state is invalid - $test', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toStrictEqual(orgState);
+  });
+});

--- a/app/store/migrations/142.test.ts
+++ b/app/store/migrations/142.test.ts
@@ -87,19 +87,24 @@ const createTestState = () => ({
   },
 });
 
-const createMonadMainnetConfiguration = (): NetworkConfiguration => ({
+const QUICKNODE_MONAD_URL = 'https://failover.quicknode.example/monad';
+
+const createMonadMainnetConfiguration = (
+  failoverUrls?: string[],
+): NetworkConfiguration => ({
   chainId: '0x8f',
   rpcEndpoints: [
     {
       networkClientId: 'monad-mainnet',
       url: 'https://monad-mainnet.infura.io/v3/{infuraProjectId}',
       type: RpcEndpointType.Infura,
+      ...(failoverUrls ? { failoverUrls } : {}),
     },
   ],
   defaultRpcEndpointIndex: 0,
   blockExplorerUrls: ['https://monadscan.com'],
   defaultBlockExplorerUrlIndex: 0,
-  name: 'Monad Mainnet',
+  name: 'Monad',
   nativeCurrency: 'MON',
 });
 
@@ -118,10 +123,11 @@ describe('Migration 142: Add `Monad Mainnet`', () => {
     expect(migratedState).toStrictEqual({ some: 'state' });
   });
 
-  it('adds `Monad Mainnet` as a default Infura network to state', () => {
+  it('adds `Monad Mainnet` as a default Infura network to state without failoverUrls when QUICKNODE_MONAD_URL is not set', () => {
     const monadMainnetConfiguration = createMonadMainnetConfiguration();
     const oldState = createTestState();
     mockedEnsureValidState.mockReturnValue(true);
+    delete process.env.QUICKNODE_MONAD_URL;
 
     const expectedData = {
       engine: {
@@ -141,6 +147,36 @@ describe('Migration 142: Add `Monad Mainnet`', () => {
     const migratedState = migrate(oldState);
 
     expect(migratedState).toStrictEqual(expectedData);
+  });
+
+  it('adds `Monad Mainnet` with failoverUrls when QUICKNODE_MONAD_URL is set', () => {
+    const monadMainnetConfiguration = createMonadMainnetConfiguration([
+      QUICKNODE_MONAD_URL,
+    ]);
+    const oldState = createTestState();
+    mockedEnsureValidState.mockReturnValue(true);
+    process.env.QUICKNODE_MONAD_URL = QUICKNODE_MONAD_URL;
+
+    const expectedData = {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            ...oldState.engine.backgroundState.NetworkController,
+            networkConfigurationsByChainId: {
+              ...oldState.engine.backgroundState.NetworkController
+                .networkConfigurationsByChainId,
+              [monadMainnetConfiguration.chainId]: monadMainnetConfiguration,
+            },
+          },
+        },
+      },
+    };
+
+    const migratedState = migrate(oldState);
+
+    expect(migratedState).toStrictEqual(expectedData);
+
+    delete process.env.QUICKNODE_MONAD_URL;
   });
 
   it('does not overwrite an existing `Monad Mainnet` NetworkConfiguration', () => {

--- a/app/store/migrations/142.ts
+++ b/app/store/migrations/142.ts
@@ -49,6 +49,8 @@ const migration = (state: unknown): unknown => {
     return state;
   }
 
+  const quickNodeUrl = process.env.QUICKNODE_MONAD_URL;
+
   const monadMainnetConfig: NetworkConfiguration = {
     name: NetworkNickname[BuiltInNetworkName.MonadMainnet],
     chainId: ChainId[BuiltInNetworkName.MonadMainnet],
@@ -59,6 +61,7 @@ const migration = (state: unknown): unknown => {
         type: RpcEndpointType.Infura,
         url: `https://monad-mainnet.infura.io/v3/{infuraProjectId}`,
         networkClientId: NetworkType[BuiltInNetworkName.MonadMainnet],
+        ...(quickNodeUrl ? { failoverUrls: [quickNodeUrl] } : {}),
       },
     ],
     defaultRpcEndpointIndex: 0,

--- a/app/store/migrations/142.ts
+++ b/app/store/migrations/142.ts
@@ -1,0 +1,75 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+import {
+  BlockExplorerUrl,
+  BuiltInNetworkName,
+  ChainId,
+  NetworkNickname,
+  NetworkType,
+  NetworksTicker,
+} from '@metamask/controller-utils';
+import {
+  NetworkConfiguration,
+  RpcEndpointType,
+} from '@metamask/network-controller';
+
+/**
+ * Migration 142:
+ *
+ * Add Monad to NetworkController state.
+ */
+const migration = (state: unknown): unknown => {
+  const migrationVersion = 142;
+
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  if (
+    !hasProperty(state.engine.backgroundState, 'NetworkController') ||
+    !isObject(state.engine.backgroundState.NetworkController)
+  ) {
+    return state;
+  }
+
+  const { NetworkController } = state.engine.backgroundState;
+
+  if (
+    !hasProperty(NetworkController, 'networkConfigurationsByChainId') ||
+    !isObject(NetworkController.networkConfigurationsByChainId)
+  ) {
+    return state;
+  }
+
+  if (
+    NetworkController.networkConfigurationsByChainId[
+      ChainId[BuiltInNetworkName.MonadMainnet]
+    ]
+  ) {
+    return state;
+  }
+
+  const monadMainnetConfig: NetworkConfiguration = {
+    name: NetworkNickname[BuiltInNetworkName.MonadMainnet],
+    chainId: ChainId[BuiltInNetworkName.MonadMainnet],
+    blockExplorerUrls: [BlockExplorerUrl[BuiltInNetworkName.MonadMainnet]],
+    defaultBlockExplorerUrlIndex: 0,
+    rpcEndpoints: [
+      {
+        type: RpcEndpointType.Infura,
+        url: `https://monad-mainnet.infura.io/v3/{infuraProjectId}`,
+        networkClientId: NetworkType[BuiltInNetworkName.MonadMainnet],
+      },
+    ],
+    defaultRpcEndpointIndex: 0,
+    nativeCurrency: NetworksTicker[BuiltInNetworkName.MonadMainnet],
+  };
+
+  NetworkController.networkConfigurationsByChainId[
+    ChainId[BuiltInNetworkName.MonadMainnet]
+  ] = monadMainnetConfig;
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -142,6 +142,7 @@ import migration138 from './138';
 import migration139 from './139';
 import migration140 from './140';
 import migration141 from './141';
+import migration142 from './142';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -303,6 +304,7 @@ export const migrationList: MigrationsList = {
   139: migration139,
   140: migration140,
   141: migration141,
+  142: migration142,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -244,6 +244,8 @@ export const isLineaMainnet = (networkType) => networkType === LINEA_MAINNET;
 export const isLineaMainnetChainId = (chainId) =>
   chainId === CHAIN_IDS.LINEA_MAINNET;
 
+export const isMonadMainnetChainId = (chainId) => chainId === CHAIN_IDS.MONAD;
+
 export const isSolanaMainnet = (chainId) => chainId === SolScope.Mainnet;
 
 /**
@@ -356,7 +358,8 @@ export const canDeleteNetwork = (chainId) =>
     chainId &&
       !isTestNet(chainId) &&
       !isMainNet(chainId) &&
-      !isLineaMainnetChainId(chainId),
+      !isLineaMainnetChainId(chainId) &&
+      !isMonadMainnetChainId(chainId),
   );
 
 export function getNetworkTypeById(id) {

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -22,6 +22,7 @@ import NetworkList, {
   isWhitelistedRpcUrl,
   isWhitelistedNetworkName,
   canDeleteNetwork,
+  isMonadMainnetChainId,
 } from '.';
 import {
   convertNetworkId,
@@ -193,6 +194,18 @@ describe('network-utils', () => {
     });
     it('returns true for custom chain ID 0x2a', () => {
       expect(canDeleteNetwork('0x2a')).toBe(true);
+    });
+    it('returns false for Monad mainnet', () => {
+      expect(canDeleteNetwork(NETWORKS_CHAIN_ID.MONAD)).toBe(false);
+    });
+  });
+
+  describe('isMonadMainnetChainId', () => {
+    it('returns true for Monad mainnet chain ID', () => {
+      expect(isMonadMainnetChainId(NETWORKS_CHAIN_ID.MONAD)).toBe(true);
+    });
+    it('returns false for a different chain ID', () => {
+      expect(isMonadMainnetChainId('0x1')).toBe(false);
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This pull request adds support for the Monad Mainnet network throughout the application. The changes ensure Monad Mainnet is included as a default network, is not removable by users, and is properly handled in both the UI and state migrations. The update also includes tests to verify Monad Mainnet integration and protection against accidental deletion.

**Monad Mainnet Integration**

* Added Monad Mainnet (`CHAIN_IDS.MONAD`) to the set of main chain IDs in `MAIN_CHAIN_IDS`, ensuring it is recognized as a primary network.
* Implemented a migration (`142`) to add Monad Mainnet as a default Infura network in the application's persisted state, with logic to avoid overwriting existing custom configurations.

**Network Deletion Safeguards**

* Updated the `canDeleteNetwork` utility to prevent Monad Mainnet from being deleted, similar to other protected networks.
* Modified the Network Selector UI to use the updated `canDeleteNetwork` logic, disabling the delete option for Monad Mainnet.
* Added a test in `NetworkSelector.test.tsx` to ensure the delete option is not shown for Monad Mainnet in the UI.

**Utility and Test Enhancements**

* Added `isMonadMainnetChainId` utility and corresponding tests to check if a chain ID is Monad Mainnet, and verified that `canDeleteNetwork` returns `false` for Monad Mainnet.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Enabled Monad by default and no deletion

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/WPN-1131

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
  Scenario 1 - Monad mainnet cannot be deleted via the Network Selector (3-dot menu)

  1. Open the app and go the network switcher through the token category
  2. Ensure the network UI redesign is enabled and locate "Monad Mainnet" in the list
  3. Tap the ⋮ (three-dot) icon next to "Monad Mainnet"
  4. Verify the bottom sheet shows only Edit, with no Delete option
  5. Repeat with "Ethereum Mainnet" or "Linea" and confirm Delete is also absent
  6. Repeat with another network (e.g. Avalanche) and confirm Delete is present

  ---
  Scenario 2 - Monad mainnet cannot be deleted via Settings

  1. Go to Settings → Networks
  2. Tap on "Monad Mainnet" to open its details page
  3. Verify the trash/bin icon is absent from the top-right header
  4. Go back, tap on "Ethereum Mainnet", and confirm the bin icon is also absent
  5. Go back, tap on another network (e.g. Avalanche), and confirm the bin icon is present
  6. Tap the bin icon on another network and confirm the delete confirmation dialog appears
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" height="600" alt="before-delete" src="https://github.com/user-attachments/assets/55111147-4f13-4a72-9df0-7bb62da97810" />


<img width="300" height="600" alt="Settings-before" src="https://github.com/user-attachments/assets/2c9d4df1-1197-461f-a59e-ce83ad873272" />

### **After**

<img width="300" height="600" alt="after-noDelete" src="https://github.com/user-attachments/assets/35caa53d-142b-456c-8ebd-7002fabc1ce2" />

<img width="300" height="600" alt="Settings-after" src="https://github.com/user-attachments/assets/4b5ccbb1-8c06-497a-91f3-d24d9674eb51" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted store migration and default network configuration for all upgrading users; incorrect migration or chain ID handling could affect RPC/network lists, though changes mirror existing Linea/mainnet patterns with tests.
> 
> **Overview**
> Adds **Monad Mainnet** as a built-in default network for existing wallets and treats it like Ethereum and Linea for removal rules.
> 
> **State & defaults:** Migration **142** injects Monad into `NetworkController.networkConfigurationsByChainId` (Infura RPC, optional `QUICKNODE_MONAD_URL` failover) when missing, without overwriting user configs. **`MAIN_CHAIN_IDS`** now includes Monad.
> 
> **Deletion safeguards:** New **`isMonadMainnetChainId`** extends **`canDeleteNetwork`** so Monad cannot be deleted. **Network Selector** RPC rows pass **`canDeleteNetwork(chainId)`** into the network menu instead of always allowing delete (Settings network details already rely on the same helper).
> 
> **Tests:** Coverage for migration 142, `canDeleteNetwork` / `isMonadMainnetChainId`, and Network Selector UI confirming no delete action for Monad.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b8bc1ec9cc66e4eb4f8dc504cff4d6cb8b8884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->