### PR TITLE
feat: Fully enable react compiler and bump to stable version

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -25,11 +25,10 @@ const CODE_SIGNING_KEYIDS = {
 module.exports = {
   name: 'MetaMask',
   displayName: 'MetaMask',
-  experiments: {
-    reactCompiler: {
-      enabled: true,
-    },
-  },
+  // NOTE: React Compiler is enabled via the `react-compiler` babel plugin in
+  // babel.config.js, not here. This repo uses the React Native community Metro
+  // transformer, which doesn't pass the `supportsReactCompiler` caller flag that
+  // Expo's `experiments.reactCompiler` relies on, so the flag would be a no-op.
   plugins: [
     [
       'expo-build-properties',

--- a/babel.config.js
+++ b/babel.config.js
@@ -64,12 +64,7 @@ module.exports = {
   presets: ['babel-preset-expo'],
   // Babel can find the plugin without the `babel-plugin-` prefix. Ex. `babel-plugin-react-compiler` -> `react-compiler`
   plugins: [
-    [
-      'react-compiler',
-      {
-        target: '18',
-      },
-    ],
+    ['react-compiler'],
     'transform-inline-environment-variables',
     dynamicImportToRequire,
     // NOTE: react-native-reanimated/plugin must be listed LAST.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,4 @@
-const ReactCompilerConfig = {
-  target: '18',
-};
+const isTestEnv = process.env.NODE_ENV === 'test';
 
 // Hermes (RN's bytecode compiler) does not accept dynamic `import()` syntax —
 // even inside dead code branches — and aborts with "Invalid expression
@@ -64,7 +62,9 @@ module.exports = {
   presets: ['babel-preset-expo'],
   // Babel can find the plugin without the `babel-plugin-` prefix. Ex. `babel-plugin-react-compiler` -> `react-compiler`
   plugins: [
-    ['react-compiler'],
+    // Disabled under Jest (see isTestEnv note above) to avoid the jest.mock
+    // hoisting conflict with the compiler-injected `_c` helper.
+    ...(isTestEnv ? [] : ['react-compiler']),
     'transform-inline-environment-variables',
     dynamicImportToRequire,
     // NOTE: react-native-reanimated/plugin must be listed LAST.

--- a/babel.config.js
+++ b/babel.config.js
@@ -68,14 +68,6 @@ module.exports = {
       'react-compiler',
       {
         target: '18',
-        sources: (filename) => {
-          // Match file paths or directories to include in the React Compiler.
-          const pathsToInclude = [
-            'app/components/Nav',
-            'app/components/UI/DeepLinkModal',
-          ];
-          return pathsToInclude.some((path) => filename.includes(path));
-        },
       },
     ],
     'transform-inline-environment-variables',

--- a/package.json
+++ b/package.json
@@ -631,7 +631,7 @@
     "babel-loader": "^9.1.3",
     "babel-plugin-inline-import": "^3.0.0",
     "babel-plugin-module-resolver": "^5.0.2",
-    "babel-plugin-react-compiler": "^19.1.0-rc.2",
+    "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "babel-plugin-transform-remove-console": "6.9.4",
     "base64-js": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22870,15 +22870,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-react-compiler@npm:^19.1.0-rc.2":
-  version: 19.1.0-rc.2
-  resolution: "babel-plugin-react-compiler@npm:19.1.0-rc.2"
-  dependencies:
-    "@babel/types": "npm:^7.26.0"
-  checksum: 10/4904021f1e47a8e7f9eb251b48b4c9c9cc3c9c91ff6ab4c8969ac5b6d0b34d91f3137770ba3e4d267a5ee2c113d938b99615f0e3ea3aa9a0948b87085710ef28
-  languageName: node
-  linkType: hard
-
 "babel-plugin-react-native-web@npm:~0.21.0":
   version: 0.21.2
   resolution: "babel-plugin-react-native-web@npm:0.21.2"
@@ -35576,7 +35567,7 @@ __metadata:
     babel-loader: "npm:^9.1.3"
     babel-plugin-inline-import: "npm:^3.0.0"
     babel-plugin-module-resolver: "npm:^5.0.2"
-    babel-plugin-react-compiler: "npm:^19.1.0-rc.2"
+    babel-plugin-react-compiler: "npm:^1.0.0"
     babel-plugin-transform-inline-environment-variables: "npm:^0.4.4"
     babel-plugin-transform-remove-console: "npm:6.9.4"
     base64-js: "npm:^1.5.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR bumps React Compiler to a stable version (v1.0.0) and fully enables it across the code base.

The React Compiler automatically avoids unnecessary re-rendering on the
`Login -> Wallet -> Token Details` flow.

Methodology: React DevTools Profiler exports, averaged across 3 runs
per configuration on the same flow.

Summary of compiled files
| Extension | Files | What it is |
|-----------|------:|------------|
| `.tsx`    | 1,438 | React components (and some hooks) in TypeScript + JSX |
| `.ts`     |   523 | Hooks and modules exporting hooks/components in plain TS |
| `.svg`    |   386 | SVGs turned into React components by the SVG transformer |
| `.js`     |    32 | Legacy components/hooks still in plain JS/JSX |
| **Total** | **2,379** | |

**Result: ~60% fewer component re-renders** (211 → 85 on average),
which cuts React's rendering work by roughly 40%, potentially freeing up the JS thread bandwidth.
Measured with the React DevTools Profiler, averaged across 3 runs.


## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-634

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - React compiler auto optimizes components across the app. No explicit functional changes were made.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

Tested profiles
[without-react-compiler-profile-1.json](https://github.com/user-attachments/files/28651142/without-react-compiler-profile-1.json)
[without-react-compiler-profile-2.json.json](https://github.com/user-attachments/files/28651144/without-react-compiler-profile-2.json.json)
[without-react-compiler-profile-3.json.json](https://github.com/user-attachments/files/28651145/without-react-compiler-profile-3.json.json)
[with-react-compiler-profile-1.json](https://github.com/user-attachments/files/28651146/with-react-compiler-profile-1.json)
[with-react-compiler-profile-2.json](https://github.com/user-attachments/files/28651148/with-react-compiler-profile-2.json)
[with-react-compiler-profile-3.json](https://github.com/user-attachments/files/28651149/with-react-compiler-profile-3.json)

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> App-wide compile-time transforms affect every React component at build time; Jest is excluded but production behavior changes broadly with limited diff surface for runtime regressions.
> 
> **Overview**
> Upgrades **React Compiler** to stable **`babel-plugin-react-compiler@^1.0.0`** and turns it on for the whole Metro bundle instead of a small path allowlist.
> 
> **`babel.config.js`** now registers the plain **`react-compiler`** Babel plugin for all non-test builds (the previous plugin only compiled `Nav` and `DeepLinkModal`). The plugin is **skipped when `NODE_ENV === 'test'`** so Jest avoids hoisting issues with the compiler’s **`_c`** helper.
> 
> **`app.config.js`** drops **`experiments.reactCompiler`** and documents that Expo’s flag is ineffective here because the community Metro transformer does not set **`supportsReactCompiler`**; compilation is Babel-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ed2bd05a8ce8f06977ade4de82432c0e1bb4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->