### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,12 +253,20 @@ If no files are staged, the checker automatically falls back to changed working-
 
 ### First-time setup (after clone)
 
+Configure `.js.env` (internal contributors: copy from 1Password; external: set `MM_INFURA_PROJECT_ID` from [developer.metamask.io](https://developer.metamask.io)), then:
+
 ```bash
-cp -n .js.env.example .js.env   # add MM_INFURA_PROJECT_ID for real RPC connectivity
-CI=true yarn setup:github-ci --node
+yarn setup:expo
 ```
 
-`setup:github-ci --node` is the Linux/CI path: skips native iOS/Android builds, runs LavaMoat allow-scripts, patches, Husky, and generates `app/util/termsOfUse/termsOfUseContent.ts` (gitignored).
+`setup:expo` skips native iOS/Android builds, runs LavaMoat allow-scripts, patches, Husky, and generates `app/util/termsOfUse/termsOfUseContent.ts` (gitignored). Use `yarn setup:github-ci --node` only for CI-style headless installs (no `yarn clean`).
+
+### Daily dev workflow
+
+```bash
+yarn watch:clean   # first Metro start, or after cache issues
+yarn watch         # subsequent starts
+```
 
 ### Recommended dev path on Linux
 
@@ -266,7 +274,7 @@ Expo/JS-only development — no iOS simulator on Linux. For on-device UI, use an
 
 | Goal                  | Command                                                                                  |
 | --------------------- | ---------------------------------------------------------------------------------------- |
-| Metro bundler         | `yarn watch` (omit `CI=true` for hot reload)                                             |
+| Metro bundler         | `yarn watch:clean` (first run) then `yarn watch`                                         |
 | Typecheck             | `yarn lint:tsc`                                                                          |
 | Unit test (one file)  | `NODE_OPTIONS='--max-old-space-size=8192' yarn jest <file> --forceExit --coverage=false` |
 | Prove bundle pipeline | `yarn gen-bundle:android`                                                                |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,3 +243,39 @@ bash scripts/check-ab-testing-compliance.sh --staged
 ```
 
 If no files are staged, the checker automatically falls back to changed working-tree files.
+
+## Cursor Cloud specific instructions
+
+### Toolchain
+
+- Use **Node.js 20.18.0** (`.nvmrc`). The cloud VM may default to a newer Node at `/exec-daemon/node`; run `nvm use 20.18.0` (or `nvm install` first) before yarn commands.
+- **Yarn 4.14.1** via corepack (`corepack enable`).
+
+### First-time setup (after clone)
+
+```bash
+cp -n .js.env.example .js.env   # add MM_INFURA_PROJECT_ID for real RPC connectivity
+CI=true yarn setup:github-ci --node
+```
+
+`setup:github-ci --node` is the Linux/CI path: skips native iOS/Android builds, runs LavaMoat allow-scripts, patches, Husky, and generates `app/util/termsOfUse/termsOfUseContent.ts` (gitignored).
+
+### Recommended dev path on Linux
+
+Expo/JS-only development — no iOS simulator on Linux. For on-device UI, use an Android emulator + Runway `.apk` (see `docs/readme/expo-environment.md`).
+
+| Goal                  | Command                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| Metro bundler         | `yarn watch` (omit `CI=true` for hot reload)                                             |
+| Typecheck             | `yarn lint:tsc`                                                                          |
+| Unit test (one file)  | `NODE_OPTIONS='--max-old-space-size=8192' yarn jest <file> --forceExit --coverage=false` |
+| Prove bundle pipeline | `yarn gen-bundle:android`                                                                |
+| Verify Metro          | `curl http://localhost:8081/status` → `packager-status:running`                          |
+
+### Jest memory
+
+Large suites can OOM on default heap. CI uses 12–20 GB; cloud agents should set at least `NODE_OPTIONS='--max-old-space-size=8192'` for focused tests.
+
+### Secrets
+
+`.js.env` is required. Without `MM_INFURA_PROJECT_ID`, the app cannot reach blockchain networks. Sentry/card legacy keys may log warnings at Metro startup but do not block the bundler.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting how to develop MetaMask Mobile in Linux cloud VMs, aligned with the team's standard Expo workflow.

## Context

Cloud agents need Linux-specific guidance that differs from the macOS-focused README. The team's usual workflow is:

1. Configure `.js.env` (Infura + feature flags)
2. `yarn setup:expo`
3. `yarn watch:clean` (then `yarn watch` for subsequent runs)

## Changes

- Toolchain notes (Node 20.18.0, Yarn 4.14.1)
- First-time setup via `yarn setup:expo` (not CI-only `setup:github-ci`)
- Daily dev workflow: `watch:clean` → `watch`
- Command reference table for Metro, typecheck, tests, bundle verification
- Jest memory guidance
- `.js.env` / Infura secret notes

## Verification

Environment re-setup and verified in Cursor Cloud using the team workflow:
- `yarn setup:expo` completed (LavaMoat, Foundry, Terms of Use, inpage bridge)
- `yarn watch:clean` — Metro running on `:8081` with Expo dev client URL
- `curl http://localhost:8081/status` → `packager-status:running`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba84158f-e6d9-49ed-b08a-6876d3918932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba84158f-e6d9-49ed-b08a-6876d3918932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

