### PR TITLE
fix: Smoke e2e tests flakiness

### DIFF
--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -201,7 +201,7 @@ export const dismissDeveloperMenuPlaywright = async (): Promise<void> => {
  * @throws {Error} Throws an error if app fails to stabilize within timeout
  */
 export const waitForAppReady = async (
-  timeout: number = 20000,
+  timeout: number = 60000,
 ): Promise<void> => {
   const startTime = Date.now();
 

--- a/tests/helpers/swap/smart-transactions-mocks.ts
+++ b/tests/helpers/swap/smart-transactions-mocks.ts
@@ -71,7 +71,7 @@ export async function setupSmartTransactionsMocks(
   // Mock POST /getFees – returns a single fee tier so createSignedTransactions
   // produces a non-empty rawTxs array that can be forwarded to Anvil.
   await setupMockRequest(mockServer, {
-    url: /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/getFees/,
+    url: /\.api\.cx\.metamask\.io\/(v\d+\/)?networks\/\d+\/getFees/,
     response: GET_FEES_RESPONSE,
     requestMethod: 'POST',
     responseCode: 200,
@@ -83,7 +83,7 @@ export async function setupSmartTransactionsMocks(
     .forPost('/proxy')
     .matching((request) => {
       const url = getDecodedProxiedURL(request.url);
-      return /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/submitTransactions/.test(
+      return /\.api\.cx\.metamask\.io\/(v\d+\/)?networks\/\d+\/submitTransactions/.test(
         url,
       );
     })
@@ -150,11 +150,117 @@ export async function setupSmartTransactionsMocks(
   };
 
   await setupMockRequest(mockServer, {
-    url: /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/batchStatus/,
+    url: /\.api\.cx\.metamask\.io\/(v\d+\/)?networks\/\d+\/batchStatus/,
     response: GET_BATCH_STATUS_SUCCESS,
     requestMethod: 'GET',
     responseCode: 200,
   });
+
+  // -- 7702 Relay mocks --
+  // When a quote has gasIncluded7702: true the delegation-7702-publish hook
+  // bypasses STX and submits through the Sentinel relay API instead.
+  // We mock both the submit (JSON-RPC POST) and polling (GET) endpoints,
+  // and send a simple tx to Anvil so TransactionController finds a receipt.
+
+  const RELAY_UUID = 'relay-7702-e2e-uuid';
+  let relayTxHash: string | undefined;
+
+  // Mock POST eth_sendRelayTransaction – JSON-RPC to sentinel root URL.
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      // Relay submit goes to the root sentinel URL (no path beyond /)
+      return /tx-sentinel[^/]*\.api\.cx\.metamask\.io\/?$/.test(url);
+    })
+    .asPriority(1000)
+    .thenCallback(async (request) => {
+      let rpcId: unknown = 1;
+      try {
+        const bodyText = await request.body.getText();
+        const body = JSON.parse(bodyText ?? '{}');
+        rpcId = body?.id ?? 1;
+      } catch {
+        // Ignore parse errors
+      }
+
+      // Impersonate the test wallet and send a dummy tx to Anvil so a real
+      // receipt exists when TransactionController polls eth_getTransactionReceipt.
+      const walletAddress = '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3';
+      try {
+        const anvilUrl = getActualAnvilRpcUrl();
+
+        await fetch(anvilUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'anvil_impersonateAccount',
+            params: [walletAddress],
+            id: 1,
+          }),
+        });
+
+        const txResp = await fetch(anvilUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'eth_sendTransaction',
+            params: [{ from: walletAddress, to: walletAddress, value: '0x0' }],
+            id: 2,
+          }),
+        });
+
+        const txResult = await txResp.json();
+        relayTxHash = txResult?.result;
+
+        await fetch(anvilUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'anvil_stopImpersonatingAccount',
+            params: [walletAddress],
+            id: 3,
+          }),
+        });
+      } catch {
+        // Non-fatal: the relay UUID is still returned.
+      }
+
+      return {
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          result: { uuid: RELAY_UUID },
+          id: rpcId,
+        },
+      };
+    });
+
+  // Mock GET /smart-transactions/{uuid} – relay polling endpoint.
+  // waitForRelayResult polls this until status !== PENDING.
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return /tx-sentinel[^/]*\.api\.cx\.metamask\.io.*\/smart-transactions\//.test(
+        url,
+      );
+    })
+    .asPriority(1000)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        transactions: [
+          {
+            hash: relayTxHash,
+            status: 'VALIDATED',
+          },
+        ],
+      },
+    }));
 
   // Mock GET /getTxStatus – fallback for same-chain swap tests.
   // Registered at priority 1 so bridge-mocks.ts (priority 999) always wins

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -374,7 +374,6 @@ class TestSnaps {
     });
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton, {
-      checkStability: true,
       elemDescription: 'date-time picker OK',
     });
 
@@ -391,7 +390,6 @@ class TestSnaps {
     });
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton, {
-      checkStability: true,
       elemDescription: 'date picker OK',
     });
   }
@@ -403,7 +401,6 @@ class TestSnaps {
     });
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton, {
-      checkStability: true,
       elemDescription: 'time picker OK',
     });
   }

--- a/tests/smoke/ramps/onramp-unified-buy.spec.ts
+++ b/tests/smoke/ramps/onramp-unified-buy.spec.ts
@@ -16,7 +16,7 @@ import {
   setupDepositOnRampMocks,
   setupBuyOnRampMocks,
 } from '../../api-mocking/mock-responses/ramps/ramps-mocks';
-import { remoteFeatureFlagRampsUnifiedEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { remoteFeatureFlagRampsUnifiedMatrixForE2E } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { ONRAMP_PERSONA } from '../../api-mocking/mock-responses/ramps/onramp-persona-data';
 
@@ -32,7 +32,7 @@ const selectedRegion = RampsRegions[RampsRegionsEnum.UNITED_STATES];
 
 const newUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
-    ...remoteFeatureFlagRampsUnifiedEnabled(true),
+    ...remoteFeatureFlagRampsUnifiedMatrixForE2E(true, true),
     depositConfig: {
       active: true,
       providerApiKey: 'DUMMY_VALUE_FOR_TESTING',
@@ -46,7 +46,7 @@ const newUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
 const returningUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(
     mockServer,
-    remoteFeatureFlagRampsUnifiedEnabled(true),
+    remoteFeatureFlagRampsUnifiedMatrixForE2E(true, true),
   );
   await setupBuyOnRampMocks(mockServer, selectedRegion);
 };
@@ -81,6 +81,7 @@ describe(SmokeMoney('Onramp Unified Buy'), () => {
         fixture: new FixtureBuilder()
           .withNetworkController(CustomNetworks.Tenderly.Mainnet.providerConfig)
           .withRampsSelectedRegion(selectedRegion)
+          .withRampsUnifiedBuyRemoteFlagsSeededForE2E()
           .withMetaMetricsOptIn()
           .build(),
         restartDevice: true,
@@ -148,6 +149,7 @@ describe(SmokeMoney('Onramp Unified Buy'), () => {
         fixture: new FixtureBuilder()
           .withNetworkController(CustomNetworks.Tenderly.Mainnet.providerConfig)
           .withRampsSelectedRegion(selectedRegion)
+          .withRampsUnifiedBuyRemoteFlagsSeededForE2E()
           .withMetaMetricsOptIn()
           .build(),
         restartDevice: true,

--- a/tests/smoke/stake/stake-action-smoke.spec.ts
+++ b/tests/smoke/stake/stake-action-smoke.spec.ts
@@ -135,7 +135,7 @@ describe(SmokeStake('Stake from Actions'), (): void => {
         await loginToApp();
 
         await Assertions.expectElementToBeVisible(WalletView.earnButton, {
-          timeout: 45000,
+          timeout: 60000,
           description:
             'Earn button should be visible after balance loads from fixture state',
         });

--- a/tests/smoke/swap/bridge-action-smoke.spec.ts
+++ b/tests/smoke/swap/bridge-action-smoke.spec.ts
@@ -84,11 +84,11 @@ describe(SmokeSwap('Bridge functionality'), () => {
         // Open keypad by tapping source amount input (keypad is in BottomSheet, closed after token selection)
         await QuoteView.tapSourceAmountInput();
         await QuoteView.enterAmount(quantity);
-        await QuoteView.dismissKeypad();
         await Assertions.expectElementToBeVisible(QuoteView.networkFeeLabel, {
           timeout: 60000,
           description: 'Network fee label visible',
         });
+        await QuoteView.dismissKeypad();
         await Assertions.expectElementToBeVisible(QuoteView.confirmBridge, {
           description: 'Confirm bridge button visible',
         });

--- a/tests/smoke/swap/gasless-swap.spec.ts
+++ b/tests/smoke/swap/gasless-swap.spec.ts
@@ -28,7 +28,7 @@ describe(SmokeSwap('Gasless Swap - '), (): void => {
     jest.setTimeout(180000);
   });
 
-  it.skip('completes a gasless ETH to MUSD swap', async (): Promise<void> => {
+  it('completes a gasless ETH to MUSD swap', async (): Promise<void> => {
     await withFixtures(
       {
         fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {
@@ -107,7 +107,7 @@ describe(SmokeSwap('Gasless Swap - '), (): void => {
     );
   });
 
-  it.skip('completes a gasless USDC to MUSD swap (ERC-20 source with approval)', async (): Promise<void> => {
+  it('completes a gasless USDC to MUSD swap (ERC-20 source with approval)', async (): Promise<void> => {
     await withFixtures(
       {
         fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {
@@ -187,7 +187,7 @@ describe(SmokeSwap('Gasless Swap - '), (): void => {
     );
   });
 
-  it.skip('completes a gasless 7702 ETH to MUSD swap (native source)', async (): Promise<void> => {
+  it('completes a gasless 7702 ETH to MUSD swap (native source)', async (): Promise<void> => {
     await withFixtures(
       {
         fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

### `gasless-swap.spec.ts`
- Fixed and re-enabled skipped E2E swap test.
- Added mocks to match the actual Sentinel API URLs used by the app, and added relay endpoint mocks for the EIP-7702 gasless swap flow, which uses a different transaction submission path than the standard Smart Transactions flow.   

### `bridge-action-smoke.spec.ts`
- Moved `dismissKeypad()` to **after** the network fee label assertion (instead of before)
- The fee label needs time to appear (60s timeout) while the quote is fetched; dismissing the keypad first could interfere with quote loading or obscure the assertion
- Waiting for the fee label first, then dismissing the keypad, matches the correct user flow
### `TestSnaps.ts`
- Removed `checkStability: true` from date-time picker, date picker, and time picker OK button taps
- On iOS, calendar/time picker animations prevent Detox’s stability check from passing, causing the interactive UI snap test to time out
- The OK button is stationary; the calendar view above it is what animates
### `onramp-unified-buy.spec.ts`
- Fixed a flaky test caused by a race with remote feature flag loading:
  1. Seeded V1/V2 flags into `RemoteFeatureFlagController` initial state via `.withRampsUnifiedBuyRemoteFlagsSeededForE2E()`, so flags are available on first render without waiting for the mock server
  2. Switched mock server flags from `remoteFeatureFlagRampsUnifiedEnabled` (`minimumVersion: '7.63.0'`) to `remoteFeatureFlagRampsUnifiedMatrixForE2E(true, true)` (`'0.0.0'`), keeping consistency with seeded state if the controller refreshes mid-test
## `stake-action-smoke.spec.ts`
- Increased the Earn button visibility timeout from **45s → 60s**
- The Earn button depends on balance loading from fixture state, which can take longer on Android / slower CI machines

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: test falkiness on stake and bridge tests

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/6d8b3707-917d-46a6-969d-943172f032f2



### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E tests and mock helpers; production wallet code is untouched.
> 
> **Overview**
> Stabilizes smoke E2E by tightening waits, mocks, and test ordering—**no production app behavior changes**.
> 
> **Swap / STX mocks:** Sentinel URL matchers now accept versioned `*.api.cx.metamask.io` paths (not only `transaction.api…`). New mocks cover the **EIP-7702 gasless relay** path (`eth_sendRelayTransaction` + relay polling), with a dummy Anvil tx so receipts resolve. **Gasless swap** specs are **re-enabled** (removed `it.skip`).
> 
> **Bridge smoke:** `dismissKeypad()` runs **after** waiting for the network fee label (60s), so quote loading isn’t disrupted.
> 
> **Onramp unified buy:** Fixtures seed unified-buy remote flags via `.withRampsUnifiedBuyRemoteFlagsSeededForE2E()` and mocks use `remoteFeatureFlagRampsUnifiedMatrixForE2E` to avoid flag-load races.
> 
> **Detox / timing:** `waitForAppReady` default **60s**; stake Earn button wait **60s**; TestSnaps picker OK taps drop `checkStability` on iOS where calendar animation blocks stability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297372cd621c0bf3ac94a4dd8158cf474b777dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->