### PR TITLE
feat(money): gate fiat deposit by asset eligibility and add amount-limit alert

### DIFF
--- a/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch
+++ b/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/hooks/ExtraTransactionsPublishHook.cjs b/dist/hooks/ExtraTransactionsPublishHook.cjs
+index e182a81d3096512ec8726e31dea9465fca60f861..0e0301e037d9fc7ccf1cf9c2b0404e8c7327d62d 100644
+--- a/dist/hooks/ExtraTransactionsPublishHook.cjs
++++ b/dist/hooks/ExtraTransactionsPublishHook.cjs
+@@ -115,6 +115,7 @@ _ExtraTransactionsPublishHook_addTransactionBatch = new WeakMap(), _ExtraTransac
+     };
+     await __classPrivateFieldGet(this, _ExtraTransactionsPublishHook_addTransactionBatch, "f").call(this, {
+         from,
++        isInternal: true,
+         networkClientId,
+         requireApproval: false,
+         transactions,
+diff --git a/dist/hooks/ExtraTransactionsPublishHook.mjs b/dist/hooks/ExtraTransactionsPublishHook.mjs
+index 67d39aa5786e0d89ca851e07f30c8eeefe556724..3b0927b1eb0f634bf780bc221fd0ff8c5768c51e 100644
+--- a/dist/hooks/ExtraTransactionsPublishHook.mjs
++++ b/dist/hooks/ExtraTransactionsPublishHook.mjs
+@@ -111,6 +111,7 @@ _ExtraTransactionsPublishHook_addTransactionBatch = new WeakMap(), _ExtraTransac
+     };
+     await __classPrivateFieldGet(this, _ExtraTransactionsPublishHook_addTransactionBatch, "f").call(this, {
+         from,
++        isInternal: true,
+         networkClientId,
+         requireApproval: false,
+         transactions,

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.styles.tsx
@@ -5,7 +5,6 @@ const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
     list: {
       paddingBottom: 16,
-      backgroundColor: params.theme.colors.background.default,
     },
     row: {
       flexDirection: 'row',

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import { TransactionType, CHAIN_IDS } from '@metamask/transaction-controller';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MoneyAddMoneySheet from './MoneyAddMoneySheet';
 import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
-import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
-import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
-import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
+import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
+import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { useCanFiatDepositAsset } from '../../../Ramp/hooks/useCanFiatDepositAsset';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
-  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
 } from '../../../Earn/constants/musd';
+import { MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID } from '../../../Ramp/utils/getMoneyAccountFiatDepositAssetId';
 
 const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
-const mockGetChainIdForBuyFlow = jest.fn();
-const mockGoToBuy = jest.fn();
 const mockInitiateDeposit = jest.fn(() => Promise.resolve());
 
 jest.mock('@react-navigation/native', () => {
@@ -30,21 +31,28 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
-jest.mock('../../../Earn/hooks/useMusdConversionFlowData', () => ({
-  useMusdConversionFlowData: jest.fn(),
-}));
-
-jest.mock('../../../Ramp/hooks/useRampNavigation', () => ({
-  useRampNavigation: jest.fn(),
-}));
-
-jest.mock('../../hooks/useMoneyAccountBalance', () => ({
-  __esModule: true,
-  default: jest.fn(),
+jest.mock('../../../Earn/hooks/useMusdBalance', () => ({
+  useMusdBalance: jest.fn(),
 }));
 
 jest.mock('../../hooks/useMoneyAccount', () => ({
   useMoneyAccountDeposit: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig',
+  () => ({
+    useMMPayFiatConfig: jest.fn(),
+  }),
+);
+
+jest.mock('../../../../../selectors/tokenBalancesController', () => ({
+  ...jest.requireActual('../../../../../selectors/tokenBalancesController'),
+  selectHasAnyNonZeroTokenBalance: jest.fn(),
+}));
+
+jest.mock('../../../Ramp/hooks/useCanFiatDepositAsset', () => ({
+  useCanFiatDepositAsset: jest.fn(),
 }));
 
 jest.mock('@metamask/design-system-react-native', () => {
@@ -79,20 +87,25 @@ describe('MoneyAddMoneySheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockGetChainIdForBuyFlow.mockReturnValue(MUSD_CONVERSION_DEFAULT_CHAIN_ID);
-
-    (useMusdConversionFlowData as jest.Mock).mockReturnValue({
-      getChainIdForBuyFlow: mockGetChainIdForBuyFlow,
-    });
-    (useRampNavigation as jest.Mock).mockReturnValue({
-      goToBuy: mockGoToBuy,
-    });
-    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
-      totalFiatFormatted: '$1,203.89',
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '1203.89',
+      fiatBalanceAggregatedFormatted: '$1,203.89',
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '1203.89',
+      tokenBalanceByChain: { [CHAIN_IDS.MAINNET]: '1203.89' },
     });
     (useMoneyAccountDeposit as jest.Mock).mockReturnValue({
       initiateDeposit: mockInitiateDeposit,
     });
+    (useMMPayFiatConfig as jest.Mock).mockReturnValue({
+      enabledTransactionTypes: [TransactionType.moneyAccountDeposit],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+    (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
+      true,
+    );
+    // Default: canDeposit = true (flag on + provider available)
+    (useCanFiatDepositAsset as jest.Mock).mockReturnValue(true);
   });
 
   it('renders all four options', () => {
@@ -102,7 +115,7 @@ describe('MoneyAddMoneySheet', () => {
 
     expect(getByText('Convert crypto')).toBeOnTheScreen();
     expect(getByText('Deposit funds')).toBeOnTheScreen();
-    expect(getByText('Transfer your $1,203.89 mUSD')).toBeOnTheScreen();
+    expect(getByText('Add your $1,203.89 mUSD')).toBeOnTheScreen();
     expect(getByText('Receive from external wallet')).toBeOnTheScreen();
     expect(getByText('Coming soon')).toBeOnTheScreen();
     expect(
@@ -139,24 +152,105 @@ describe('MoneyAddMoneySheet', () => {
   });
 
   it('preserves the locale fiat prefix in the Move mUSD row', () => {
-    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
-      totalFiatFormatted: 'CA$1,500.00',
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '1500.00',
+      fiatBalanceAggregatedFormatted: 'CA$1,500.00',
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '1500.00',
+      tokenBalanceByChain: { [CHAIN_IDS.MAINNET]: '1500.00' },
     });
     const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
 
-    expect(getByText('Transfer your CA$1,500.00 mUSD')).toBeOnTheScreen();
+    expect(getByText('Add your CA$1,500.00 mUSD')).toBeOnTheScreen();
   });
 
-  it('falls back to the no-amount copy when the mUSD balance is unavailable', () => {
-    (useMoneyAccountBalance as jest.Mock).mockReturnValue({
-      totalFiatFormatted: undefined,
+  it('shows the move-mUSD row disabled with the "Add mUSD" label when the selected EVM account has no mUSD tokens or fiat balance', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: undefined,
+      fiatBalanceAggregatedFormatted: '$0.00',
+      hasMusdBalanceOnAnyChain: false,
+      tokenBalanceAggregated: '0',
+      tokenBalanceByChain: {},
     });
-    const { getByText } = renderWithProvider(<MoneyAddMoneySheet />);
 
-    expect(getByText('Transfer your mUSD')).toBeOnTheScreen();
+    const { getByTestId, getByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION),
+    ).toBeOnTheScreen();
+    expect(getByText('Add mUSD')).toBeOnTheScreen();
+
+    fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockInitiateDeposit).not.toHaveBeenCalled();
   });
 
-  it('navigates to the Ramps buy flow with mUSD pre-selected when Deposit funds is pressed', () => {
+  it('shows the move-mUSD row disabled with the "Add mUSD" label when the selected EVM account mUSD fiat balance is zero', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '0',
+      fiatBalanceAggregatedFormatted: '$0.00',
+      hasMusdBalanceOnAnyChain: false,
+      tokenBalanceAggregated: '0',
+      tokenBalanceByChain: {},
+    });
+
+    const { getByTestId, getByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION),
+    ).toBeOnTheScreen();
+    expect(getByText('Add mUSD')).toBeOnTheScreen();
+
+    fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockInitiateDeposit).not.toHaveBeenCalled();
+  });
+
+  it('shows the move-mUSD row with the "Add your $X mUSD" label when the selected EVM account mUSD fiat balance is positive', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '12.34',
+      fiatBalanceAggregatedFormatted: '$12.34',
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '12.34',
+      tokenBalanceByChain: { [CHAIN_IDS.MAINNET]: '12.34' },
+    });
+
+    const { getByTestId, getByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION),
+    ).toBeOnTheScreen();
+    expect(getByText('Add your $12.34 mUSD')).toBeOnTheScreen();
+  });
+
+  it('shows the move-mUSD row with the token amount when the user has mUSD tokens but rates are unavailable', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: undefined,
+      fiatBalanceAggregatedFormatted: '$0.00',
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '42.5',
+      tokenBalanceByChain: { [CHAIN_IDS.MAINNET]: '42.5' },
+    });
+
+    const { getByTestId, getByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION),
+    ).toBeOnTheScreen();
+    expect(getByText('Add your 42.50 mUSD')).toBeOnTheScreen();
+  });
+
+  it('initiates a deposit with autoSelectFiatPayment when Deposit funds is pressed', () => {
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 
     fireEvent.press(
@@ -164,8 +258,8 @@ describe('MoneyAddMoneySheet', () => {
     );
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
-    expect(mockGoToBuy).toHaveBeenCalledWith({
-      assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({
+      autoSelectFiatPayment: true,
     });
   });
 
@@ -180,14 +274,152 @@ describe('MoneyAddMoneySheet', () => {
     expect(mockInitiateDeposit).toHaveBeenCalledWith();
   });
 
-  it('closes the sheet when Move mUSD is pressed (interim, no flow wired yet)', () => {
+  it('hides the Deposit funds option when moneyAccountDeposit is not in enabledTransactionTypes', () => {
+    (useMMPayFiatConfig as jest.Mock).mockReturnValue({
+      enabledTransactionTypes: [],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+    // useCanFiatDepositAsset returns false when flag is off
+    (useCanFiatDepositAsset as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(
+      queryByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+    ).toBeNull();
+  });
+
+  it('disables the Convert crypto option when no account has any crypto balance', () => {
+    (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockInitiateDeposit).not.toHaveBeenCalled();
+  });
+
+  it('enables the Convert crypto option when at least one account has a crypto balance', () => {
+    (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
+      true,
+    );
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockInitiateDeposit).toHaveBeenCalledWith();
+  });
+
+  it('shows Deposit funds when canDeposit is true (flag on + provider available)', () => {
+    (useCanFiatDepositAsset as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(
+      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+    ).toBeOnTheScreen();
+  });
+
+  it('hides Deposit funds when canDeposit is false (flag off)', () => {
+    (useMMPayFiatConfig as jest.Mock).mockReturnValue({
+      enabledTransactionTypes: [],
+      maxDelayMinutesForPaymentMethods: 10,
+    });
+    (useCanFiatDepositAsset as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(
+      queryByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+    ).toBeNull();
+  });
+
+  it('hides Deposit funds when canDeposit is false (no supporting provider in region)', () => {
+    (useCanFiatDepositAsset as jest.Mock).mockReturnValue(false);
+
+    const { queryByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    expect(
+      queryByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+    ).toBeNull();
+  });
+
+  it('calls useCanFiatDepositAsset without an explicit assetId (resolved internally from the flag)', () => {
+    (useCanFiatDepositAsset as jest.Mock).mockReturnValue(true);
+
+    renderWithProvider(<MoneyAddMoneySheet />);
+
+    // The assetId is now resolved inside useCanFiatDepositAsset via
+    // useMoneyAccountFiatDepositAssetId, which reads the
+    // confirmations_pay_fiat.assetPerTransactionType flag and falls back to
+    // MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID (native ETH mainnet, eip155:1/slip44:60).
+    expect(useCanFiatDepositAsset as jest.Mock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        assetId: expect.anything(),
+      }),
+    );
+    // The default fallback constant is still eip155:1/slip44:60
+    expect(MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID).toBe('eip155:1/slip44:60');
+  });
+
+  it('initiates a deposit pre-selecting mUSD on the highest-balance chain when Move mUSD is pressed', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '1500.00',
+      fiatBalanceAggregatedFormatted: '$1,500.00',
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '1500.00',
+      tokenBalanceByChain: {
+        [CHAIN_IDS.MAINNET]: '500.00',
+        [CHAIN_IDS.LINEA_MAINNET]: '1000.00',
+      },
+    });
+
     const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
 
     fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).not.toHaveBeenCalled();
-    expect(mockGoToBuy).not.toHaveBeenCalled();
-    expect(mockInitiateDeposit).not.toHaveBeenCalled();
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({
+      intent: 'addMusd',
+      preferredPaymentToken: {
+        address: MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.LINEA_MAINNET],
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      },
+    });
+  });
+
+  it('falls back to the default mUSD chain when no per-chain balances are available', () => {
+    (useMusdBalance as jest.Mock).mockReturnValue({
+      fiatBalanceAggregated: '12.34',
+      fiatBalanceAggregatedFormatted: '$12.34',
+      hasMusdBalanceOnAnyChain: true,
+      tokenBalanceAggregated: '12.34',
+      tokenBalanceByChain: undefined,
+    });
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION));
+
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({
+      intent: 'addMusd',
+      preferredPaymentToken: {
+        address: MUSD_TOKEN_ADDRESS_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+        chainId: MUSD_CONVERSION_DEFAULT_CHAIN_ID,
+      },
+    });
   });
 });

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -1,6 +1,10 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
+import BigNumber from 'bignumber.js';
+import { TransactionType } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import {
   BottomSheet,
   BottomSheetHeader,
@@ -17,14 +21,16 @@ import {
 import Tag from '../../../../../component-library/components/Tags/Tag';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
-import { useMusdConversionFlowData } from '../../../Earn/hooks/useMusdConversionFlowData';
-import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
+import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
-  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
 } from '../../../Earn/constants/musd';
-import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
+import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
+import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
+import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { useCanFiatDepositAsset } from '../../../Ramp/hooks/useCanFiatDepositAsset';
 import styleSheet from './MoneyAddMoneySheet.styles';
 import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 
@@ -35,17 +41,33 @@ interface Option {
   icon: IconName;
   onPress: () => void;
   testID: string;
+  disabled?: boolean;
 }
 
 const MoneyAddMoneySheet: React.FC = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { styles } = useStyles(styleSheet, {});
+  const surfaceClass = useElevatedSurface();
 
-  const { totalFiatFormatted } = useMoneyAccountBalance();
-  const { getChainIdForBuyFlow } = useMusdConversionFlowData();
-  const { goToBuy } = useRampNavigation();
+  const {
+    fiatBalanceAggregated,
+    fiatBalanceAggregatedFormatted,
+    hasMusdBalanceOnAnyChain,
+    tokenBalanceAggregated,
+    tokenBalanceByChain,
+  } = useMusdBalance();
   const { initiateDeposit } = useMoneyAccountDeposit();
+  const { enabledTransactionTypes } = useMMPayFiatConfig();
+  const hasAnyCryptoBalance = useSelector(selectHasAnyNonZeroTokenBalance);
+  const isFiatDepositEnabled = useMemo(
+    () => enabledTransactionTypes.includes(TransactionType.moneyAccountDeposit),
+    [enabledTransactionTypes],
+  );
+
+  const canDeposit = useCanFiatDepositAsset({
+    isFiatDepositFlagEnabled: isFiatDepositEnabled,
+  });
 
   const closeAndNavigate = useCallback((navigateFn: () => void) => {
     sheetRef.current?.onCloseBottomSheet(navigateFn);
@@ -61,34 +83,49 @@ const MoneyAddMoneySheet: React.FC = () => {
     });
   }, [closeAndNavigate, initiateDeposit]);
 
-  // TODO(MUSD-479): point to the Ramps "Add funds" amount-entry screen
-  // (Figma 2547:8780). Interim: unified smart-routed Buy flow with mUSD
-  // pre-selected so the destination matches the Money Hub experience.
   const handleDepositFunds = useCallback(() => {
-    const chainId = getChainIdForBuyFlow
-      ? getChainIdForBuyFlow()
-      : MUSD_CONVERSION_DEFAULT_CHAIN_ID;
     closeAndNavigate(() => {
-      goToBuy({ assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId] });
+      initiateDeposit({ autoSelectFiatPayment: true }).catch(() => undefined);
     });
-  }, [closeAndNavigate, getChainIdForBuyFlow, goToBuy]);
+  }, [closeAndNavigate, initiateDeposit]);
 
-  // TODO: wire to the "move external mUSD → Money Account" flow once the
-  // dedicated ticket lands. Interim: close sheet.
   const handleMoveMusd = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet();
-  }, []);
+    let sourceChainId: Hex = MUSD_CONVERSION_DEFAULT_CHAIN_ID;
+    let bestBalance = new BigNumber(0);
+    for (const [chainId, balance] of Object.entries(
+      tokenBalanceByChain ?? {},
+    )) {
+      const candidate = new BigNumber(balance ?? 0);
+      if (candidate.isGreaterThan(bestBalance)) {
+        sourceChainId = chainId as Hex;
+        bestBalance = candidate;
+      }
+    }
 
-  let moveMusdLabel: string;
-  if (totalFiatFormatted) {
-    moveMusdLabel = strings('money.add_money_sheet.move_musd', {
-      amount: totalFiatFormatted,
+    closeAndNavigate(() => {
+      initiateDeposit({
+        intent: 'addMusd',
+        preferredPaymentToken: {
+          address: MUSD_TOKEN_ADDRESS_BY_CHAIN[sourceChainId],
+          chainId: sourceChainId,
+        },
+      }).catch(() => undefined);
     });
-  } else {
-    moveMusdLabel = strings('money.add_money_sheet.move_musd_no_amount');
-  }
+  }, [closeAndNavigate, initiateDeposit, tokenBalanceByChain]);
 
-  const options: Option[] = [
+  const parsedMusdFiat = Number(fiatBalanceAggregated);
+  const hasParsedFiatBalance =
+    Number.isFinite(parsedMusdFiat) && parsedMusdFiat > 0;
+  const hasMusdBalance = hasMusdBalanceOnAnyChain || hasParsedFiatBalance;
+
+  const moveMusdAmount = hasParsedFiatBalance
+    ? fiatBalanceAggregatedFormatted
+    : new BigNumber(tokenBalanceAggregated).toFixed(2);
+  const moveMusdLabel = hasMusdBalance
+    ? strings('money.add_money_sheet.move_musd', { amount: moveMusdAmount })
+    : strings('money.add_money_sheet.add_musd');
+
+  const baseOptions: Option[] = [
     {
       label: strings('money.add_money_sheet.convert_crypto'),
       description: strings('money.add_money_sheet.convert_crypto_description'),
@@ -96,15 +133,27 @@ const MoneyAddMoneySheet: React.FC = () => {
       icon: IconName.Refresh,
       onPress: handleConvertCrypto,
       testID: MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      disabled: !hasAnyCryptoBalance,
     },
-    {
-      label: strings('money.add_money_sheet.deposit_funds'),
-      description: strings('money.add_money_sheet.deposit_funds_description'),
-      descriptionTestID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_DESCRIPTION,
-      icon: IconName.AttachMoney,
-      onPress: handleDepositFunds,
-      testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
-    },
+    ...(canDeposit
+      ? [
+          {
+            label: strings('money.add_money_sheet.deposit_funds'),
+            description: strings(
+              'money.add_money_sheet.deposit_funds_description',
+            ),
+            descriptionTestID:
+              MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_DESCRIPTION,
+            icon: IconName.AttachMoney,
+            onPress: handleDepositFunds,
+            testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+          },
+        ]
+      : []),
+  ];
+
+  const options: Option[] = [
+    ...baseOptions,
     {
       label: moveMusdLabel,
       description: strings('money.add_money_sheet.move_musd_description'),
@@ -112,6 +161,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       icon: IconName.Add,
       onPress: handleMoveMusd,
       testID: MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+      disabled: !hasMusdBalance,
     },
   ];
 
@@ -121,6 +171,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       goBack={handleGoBack}
       testID={MoneyAddMoneySheetTestIds.CONTAINER}
       keyboardAvoidingViewEnabled={false}
+      twClassName={surfaceClass}
     >
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         <Text variant={TextVariant.HeadingSm}>
@@ -131,17 +182,24 @@ const MoneyAddMoneySheet: React.FC = () => {
         {options.map((item) => (
           <TouchableOpacity
             key={item.testID}
-            onPress={item.onPress}
+            disabled={item.disabled}
+            onPress={item.disabled ? undefined : item.onPress}
             style={styles.row}
             testID={item.testID}
           >
             <Icon
               name={item.icon}
               size={IconSize.Lg}
-              color={IconColor.IconDefault}
+              color={
+                item.disabled ? IconColor.IconMuted : IconColor.IconDefault
+              }
             />
             <View style={styles.rowLabelContainer}>
-              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                color={item.disabled ? TextColor.TextAlternative : undefined}
+              >
                 {item.label}
               </Text>
               {item.description ? (

--- a/app/components/Views/confirmations/constants/alerts.ts
+++ b/app/components/Views/confirmations/constants/alerts.ts
@@ -1,4 +1,5 @@
 export enum AlertKeys {
+  AddressPoisoning = 'address_poisoning',
   AddressTrustSignalMalicious = 'address_trust_signal_malicious',
   AddressTrustSignalWarning = 'address_trust_signal_warning',
   BatchedUnusedApprovals = 'batched_unused_approvals',
@@ -12,6 +13,7 @@ export enum AlertKeys {
   InsufficientPayTokenBalance = 'insufficient_pay_token_balance',
   InsufficientPayTokenNative = 'insufficient_pay_token_native',
   InsufficientPayTokenFees = 'insufficient_pay_token_fees',
+  FiatBuyAmountLimit = 'fiat_buy_amount_limit',
   InsufficientMoneyAccountBalance = 'insufficient_money_account_balance',
   InsufficientPerpsBalance = 'insufficient_perps_balance',
   InsufficientPredictBalance = 'insufficient_predict_balance',

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
@@ -18,6 +18,7 @@ import { useNoPayTokenQuotesAlert } from './useNoPayTokenQuotesAlert';
 import { useInsufficientPredictBalanceAlert } from './useInsufficientPredictBalanceAlert';
 import { useInsufficientPerpsBalanceAlert } from './useInsufficientPerpsBalanceAlert';
 import { useInsufficientMoneyAccountBalanceAlert } from './useInsufficientMoneyAccountBalanceAlert';
+import { useFiatBuyLimitAlert } from './useFiatBuyLimitAlert';
 import { useBurnAddressAlert } from './useBurnAddressAlert';
 import { useTokenTrustSignalAlerts } from './useTokenTrustSignalAlerts';
 import { useAddressTrustSignalAlerts } from './useAddressTrustSignalAlerts';
@@ -27,6 +28,7 @@ import { useGasSponsorshipWarningAlert } from './useGasSponsorshipWarningAlert';
 import { useFirstTimeInteractionAlert } from './useFirstTimeInteractionAlert';
 import { useHeadlessBuyErrorAlert } from './useHeadlessBuyErrorAlert';
 import { useTokenContractAlert } from './useTokenContractAlert';
+import { useAddressPoisoningAlert } from './useAddressPoisoningAlert';
 
 jest.mock('./useBlockaidAlerts');
 jest.mock('./useGasEstimateFailedAlert');
@@ -42,6 +44,7 @@ jest.mock('./useNoPayTokenQuotesAlert');
 jest.mock('./useInsufficientPredictBalanceAlert');
 jest.mock('./useInsufficientPerpsBalanceAlert');
 jest.mock('./useInsufficientMoneyAccountBalanceAlert');
+jest.mock('./useFiatBuyLimitAlert');
 jest.mock('./useBurnAddressAlert');
 jest.mock('./useTokenTrustSignalAlerts');
 jest.mock('./useAddressTrustSignalAlerts');
@@ -49,6 +52,7 @@ jest.mock('./useOriginTrustSignalAlerts');
 jest.mock('./useFirstTimeInteractionAlert');
 jest.mock('./useHeadlessBuyErrorAlert');
 jest.mock('./useTokenContractAlert');
+jest.mock('./useAddressPoisoningAlert');
 
 describe('useConfirmationAlerts', () => {
   const ALERT_MESSAGE_MOCK = 'This is a test alert message.';
@@ -162,6 +166,15 @@ describe('useConfirmationAlerts', () => {
     },
   ];
 
+  const mockAddressPoisoningAlert: Alert[] = [
+    {
+      key: 'AddressPoisoningAlert',
+      title: 'Test Address Poisoning Alert',
+      message: ALERT_MESSAGE_MOCK,
+      severity: Severity.Danger,
+    },
+  ];
+
   const mockOriginTrustSignalAlerts: Alert[] = [
     {
       key: 'OriginTrustSignalAlert',
@@ -202,6 +215,7 @@ describe('useConfirmationAlerts', () => {
     (useInsufficientPredictBalanceAlert as jest.Mock).mockReturnValue([]);
     (useInsufficientPerpsBalanceAlert as jest.Mock).mockReturnValue([]);
     (useInsufficientMoneyAccountBalanceAlert as jest.Mock).mockReturnValue([]);
+    (useFiatBuyLimitAlert as jest.Mock).mockReturnValue([]);
     (useBurnAddressAlert as jest.Mock).mockReturnValue([]);
     (useTokenTrustSignalAlerts as jest.Mock).mockReturnValue([]);
     (useAddressTrustSignalAlerts as jest.Mock).mockReturnValue([]);
@@ -209,6 +223,7 @@ describe('useConfirmationAlerts', () => {
     (useFirstTimeInteractionAlert as jest.Mock).mockReturnValue([]);
     (useHeadlessBuyErrorAlert as jest.Mock).mockReturnValue([]);
     (useTokenContractAlert as jest.Mock).mockReturnValue([]);
+    (useAddressPoisoningAlert as jest.Mock).mockReturnValue([]);
   });
 
   it('returns empty array if no alerts', () => {
@@ -277,6 +292,9 @@ describe('useConfirmationAlerts', () => {
     (useTokenTrustSignalAlerts as jest.Mock).mockReturnValue(
       mockTokenTrustSignalAlerts,
     );
+    (useAddressPoisoningAlert as jest.Mock).mockReturnValue(
+      mockAddressPoisoningAlert,
+    );
     (useAddressTrustSignalAlerts as jest.Mock).mockReturnValue(
       mockAddressTrustSignalAlerts,
     );
@@ -301,6 +319,7 @@ describe('useConfirmationAlerts', () => {
       ...mockInsufficientPredictBalanceAlert,
       ...mockBurnAddressAlert,
       ...mockTokenTrustSignalAlerts,
+      ...mockAddressPoisoningAlert,
       ...mockTokenContractAlert,
       ...mockUpgradeAccountAlert,
       ...mockOriginTrustSignalAlerts,

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -14,12 +14,14 @@ import { useNoPayTokenQuotesAlert } from './useNoPayTokenQuotesAlert';
 import { useInsufficientPredictBalanceAlert } from './useInsufficientPredictBalanceAlert';
 import { useInsufficientPerpsBalanceAlert } from './useInsufficientPerpsBalanceAlert';
 import { useInsufficientMoneyAccountBalanceAlert } from './useInsufficientMoneyAccountBalanceAlert';
+import { useFiatBuyLimitAlert } from './useFiatBuyLimitAlert';
 import { useBurnAddressAlert } from './useBurnAddressAlert';
 import { useTokenTrustSignalAlerts } from './useTokenTrustSignalAlerts';
 import { useAddressTrustSignalAlerts } from './useAddressTrustSignalAlerts';
 import { useOriginTrustSignalAlerts } from './useOriginTrustSignalAlerts';
 import { useHeadlessBuyErrorAlert } from './useHeadlessBuyErrorAlert';
 import { useFirstTimeInteractionAlert } from './useFirstTimeInteractionAlert';
+import { useAddressPoisoningAlert } from './useAddressPoisoningAlert';
 import { useTokenContractAlert } from './useTokenContractAlert';
 
 function useSignatureAlerts(): Alert[] {
@@ -42,10 +44,12 @@ function useTransactionAlerts(): Alert[] {
   const insufficientPerpsBalanceAlert = useInsufficientPerpsBalanceAlert();
   const insufficientMoneyAccountBalanceAlert =
     useInsufficientMoneyAccountBalanceAlert();
+  const fiatBuyLimitAlert = useFiatBuyLimitAlert();
   const burnAddressAlert = useBurnAddressAlert();
   const headlessBuyErrorAlert = useHeadlessBuyErrorAlert();
   const tokenTrustSignalAlerts = useTokenTrustSignalAlerts();
   const firstTimeInteractionAlert = useFirstTimeInteractionAlert();
+  const addressPoisoningAlert = useAddressPoisoningAlert();
   const tokenContractAlert = useTokenContractAlert();
 
   return useMemo(
@@ -61,10 +65,12 @@ function useTransactionAlerts(): Alert[] {
       ...insufficientPredictBalanceAlert,
       ...insufficientPerpsBalanceAlert,
       ...insufficientMoneyAccountBalanceAlert,
+      ...fiatBuyLimitAlert,
       ...burnAddressAlert,
       ...headlessBuyErrorAlert,
       ...tokenTrustSignalAlerts,
       ...firstTimeInteractionAlert,
+      ...addressPoisoningAlert,
       ...tokenContractAlert,
     ],
     [
@@ -79,10 +85,12 @@ function useTransactionAlerts(): Alert[] {
       insufficientPredictBalanceAlert,
       insufficientPerpsBalanceAlert,
       insufficientMoneyAccountBalanceAlert,
+      fiatBuyLimitAlert,
       burnAddressAlert,
       headlessBuyErrorAlert,
       tokenTrustSignalAlerts,
       firstTimeInteractionAlert,
+      addressPoisoningAlert,
       tokenContractAlert,
     ],
   );

--- a/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.test.ts
@@ -1,0 +1,321 @@
+import { AlertKeys } from '../../constants/alerts';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { Severity } from '../../types/alerts';
+import { useFiatBuyLimitAlert } from './useFiatBuyLimitAlert';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { useTransactionPayFiatPayment } from '../pay/useTransactionPayData';
+import { useRampsBuyLimits } from '../../../../UI/Ramp/hooks/useRampsBuyLimits';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID } from '../../../../UI/Ramp/utils/getMoneyAccountFiatDepositAssetId';
+
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../pay/useTransactionPayData');
+jest.mock('../../../../UI/Ramp/hooks/useRampsBuyLimits');
+// Default mock returns the ETH mainnet fallback (eip155:1/slip44:60),
+// matching MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID. Individual tests may override.
+jest.mock('../../../../UI/Ramp/hooks/useMoneyAccountFiatDepositAssetId', () => ({
+  useMoneyAccountFiatDepositAssetId: () => 'eip155:1/slip44:60',
+}));
+
+function runHook({ pendingAmount }: { pendingAmount?: string } = {}) {
+  return renderHookWithProvider(() =>
+    useFiatBuyLimitAlert({ pendingAmount }),
+  );
+}
+
+describe('useFiatBuyLimitAlert', () => {
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
+  const useRampsBuyLimitsMock = jest.mocked(useRampsBuyLimits);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      txParams: { from: '0x0' },
+      type: TransactionType.moneyAccountDeposit,
+    } as unknown as TransactionMeta);
+
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+      amountFiat: '100',
+    });
+
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'USD',
+    });
+  });
+
+  it('returns blocking alert when fiat moneyAccountDeposit and amountLimitError is present', () => {
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: 'Amount exceeds maximum limit of $500',
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '600' });
+
+    expect(result.current).toEqual([
+      {
+        key: AlertKeys.FiatBuyAmountLimit,
+        field: RowAlertKey.Amount,
+        title: 'Amount out of range',
+        message: 'Amount exceeds maximum limit of $500',
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ]);
+  });
+
+  it('returns empty array when amountLimitError is null', () => {
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '100' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns empty array when transaction type is not moneyAccountDeposit', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      txParams: { from: '0x0' },
+      type: TransactionType.simpleSend,
+    } as unknown as TransactionMeta);
+
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: 'Amount exceeds maximum limit of $500',
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '600' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns empty array when no payment method id is present', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      amountFiat: '100',
+    });
+
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: 'Amount exceeds maximum limit of $500',
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '600' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns empty array when fiatPayment is undefined', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: 'Amount exceeds maximum limit of $500',
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '600' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('uses pendingAmount over fiatPayment amountFiat', () => {
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'USD',
+    });
+
+    runHook({ pendingAmount: '250' });
+
+    expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 250,
+      }),
+    );
+  });
+
+  it('falls back to fiatPayment amountFiat when no pendingAmount provided', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+      amountFiat: '150',
+    });
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'USD',
+    });
+
+    runHook();
+
+    expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 150,
+      }),
+    );
+  });
+
+  it('uses caipAssetId from fiatPayment when present', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+      amountFiat: '100',
+      caipAssetId: 'eip155:1/slip44:60',
+    });
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'USD',
+    });
+
+    runHook();
+
+    expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: 'eip155:1/slip44:60',
+      }),
+    );
+  });
+
+  it('falls back to MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID when caipAssetId is not present', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-card',
+      amountFiat: '100',
+    });
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: null,
+      currency: 'USD',
+    });
+
+    runHook();
+
+    expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: MONEY_ACCOUNT_FIAT_DEPOSIT_ASSET_ID,
+      }),
+    );
+  });
+
+  it('does not affect non-moneyAccountDeposit flows (e.g. perps)', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      txParams: { from: '0x0' },
+      type: TransactionType.moneyAccountWithdraw,
+    } as unknown as TransactionMeta);
+
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: 'Some limit error',
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '600' });
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  describe('backend LIMIT_EXCEEDED fallback (UB2 parity)', () => {
+    it('prefers client-side structured limit message even when quoteError is present', () => {
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: 'pm-card',
+        amountFiat: '600',
+        quoteError: {
+          code: 'LIMIT_EXCEEDED',
+          message: 'Backend says minimum is $20',
+        },
+      });
+
+      // Provider WITH structured limits: getProviderLimitMessage returns the
+      // client-side message and ignores backendError.
+      useRampsBuyLimitsMock.mockReturnValue({
+        amountLimitError: 'Amount exceeds maximum limit of $500',
+        currency: 'USD',
+      });
+
+      const { result } = runHook({ pendingAmount: '600' });
+
+      expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backendError: 'Backend says minimum is $20',
+        }),
+      );
+      expect(result.current).toEqual([
+        {
+          key: AlertKeys.FiatBuyAmountLimit,
+          field: RowAlertKey.Amount,
+          title: 'Amount out of range',
+          message: 'Amount exceeds maximum limit of $500',
+          severity: Severity.Danger,
+          isBlocking: true,
+        },
+      ]);
+    });
+
+    it('surfaces backend LIMIT_EXCEEDED message when provider has no structured limits', () => {
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: 'pm-card',
+        amountFiat: '10',
+        quoteError: {
+          code: 'LIMIT_EXCEEDED',
+          message: 'Minimum purchase is $20',
+        },
+      });
+
+      // Provider WITHOUT structured limits: useRampsBuyLimits would return null
+      // without a backendError, but echoes the backend message when one is
+      // passed (mirrors getProviderLimitMessage's fallback leg).
+      useRampsBuyLimitsMock.mockImplementation(({ backendError }) => ({
+        amountLimitError: backendError ?? null,
+        currency: 'USD',
+      }));
+
+      const { result } = runHook({ pendingAmount: '10' });
+
+      expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backendError: 'Minimum purchase is $20',
+        }),
+      );
+      expect(result.current).toEqual([
+        {
+          key: AlertKeys.FiatBuyAmountLimit,
+          field: RowAlertKey.Amount,
+          title: 'Amount out of range',
+          message: 'Minimum purchase is $20',
+          severity: Severity.Danger,
+          isBlocking: true,
+        },
+      ]);
+    });
+
+    it('does not pass backendError (or surface limit) for QUOTE_FAILED errors', () => {
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: 'pm-card',
+        amountFiat: '50',
+        quoteError: {
+          code: 'QUOTE_FAILED',
+          message: 'Provider temporarily unavailable',
+        },
+      });
+
+      useRampsBuyLimitsMock.mockImplementation(({ backendError }) => ({
+        amountLimitError: backendError ?? null,
+        currency: 'USD',
+      }));
+
+      const { result } = runHook({ pendingAmount: '50' });
+
+      expect(useRampsBuyLimitsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backendError: undefined,
+        }),
+      );
+      expect(result.current).toStrictEqual([]);
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { Alert, Severity } from '../../types/alerts';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { AlertKeys } from '../../constants/alerts';
+import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../utils/transaction';
+import { useTransactionPayFiatPayment } from '../pay/useTransactionPayData';
+import { useRampsBuyLimits } from '../../../../UI/Ramp/hooks/useRampsBuyLimits';
+import { useMoneyAccountFiatDepositAssetId } from '../../../../UI/Ramp/hooks/useMoneyAccountFiatDepositAssetId';
+
+export function useFiatBuyLimitAlert({
+  pendingAmount,
+}: {
+  pendingAmount?: string;
+} = {}): Alert[] {
+  const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
+  const fiatPayment = useTransactionPayFiatPayment();
+  const paymentMethodId = fiatPayment?.selectedPaymentMethodId;
+
+  const flagAssetId = useMoneyAccountFiatDepositAssetId();
+  const assetId = fiatPayment?.caipAssetId ?? flagAssetId;
+
+  const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountDeposit,
+  ]);
+
+  const isGated = isMoneyAccountDeposit && Boolean(paymentMethodId);
+
+  const amount = Number(pendingAmount ?? fiatPayment?.amountFiat ?? '0');
+
+  // Only treat the backend message as a limit error when the provider
+  // explicitly classified it as LIMIT_EXCEEDED. Generic QUOTE_FAILED messages
+  // are left to useNoPayTokenQuotesAlert so they are not mislabelled as limits.
+  const backendError =
+    fiatPayment?.quoteError?.code === 'LIMIT_EXCEEDED'
+      ? fiatPayment.quoteError.message
+      : undefined;
+
+  const { amountLimitError } = useRampsBuyLimits({
+    assetId: isGated ? assetId : undefined,
+    amount,
+    paymentMethodId,
+    backendError,
+  });
+
+  return useMemo(() => {
+    if (!isGated || !amountLimitError) {
+      return [];
+    }
+
+    return [
+      {
+        key: AlertKeys.FiatBuyAmountLimit,
+        field: RowAlertKey.Amount,
+        title: strings('alert_system.fiat_buy_amount_limit.title'),
+        message: amountLimitError,
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ];
+  }, [isGated, amountLimitError]);
+}

--- a/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
@@ -49,6 +49,14 @@ jest.mock('./useInsufficientMoneyAccountBalanceAlert', () => ({
   ],
 }));
 
+jest.mock('./useFiatBuyLimitAlert', () => ({
+  useFiatBuyLimitAlert: () => [
+    {
+      id: 'alert-8',
+    },
+  ],
+}));
+
 describe('usePendingAmountAlerts', () => {
   it('returns alerts', () => {
     const { result } = renderHook(() =>
@@ -61,6 +69,7 @@ describe('usePendingAmountAlerts', () => {
       { id: 'alert-4' },
       { id: 'alert-5' },
       { id: 'alert-7' },
+      { id: 'alert-8' },
       { id: 'alert-6' },
     ]);
   });

--- a/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.ts
@@ -5,6 +5,7 @@ import { useMMPayHardwareAccountAlert } from './useMMPayHardwareAccountAlert';
 import { useInsufficientPredictBalanceAlert } from './useInsufficientPredictBalanceAlert';
 import { useInsufficientPerpsBalanceAlert } from './useInsufficientPerpsBalanceAlert';
 import { useInsufficientMoneyAccountBalanceAlert } from './useInsufficientMoneyAccountBalanceAlert';
+import { useFiatBuyLimitAlert } from './useFiatBuyLimitAlert';
 import { useAccountNoFundsAlert } from './useAccountNoFundsAlert';
 
 export function usePendingAmountAlerts({
@@ -31,6 +32,10 @@ export function usePendingAmountAlerts({
       pendingAmount: pendingTokenAmount ?? '0',
     });
 
+  const fiatBuyLimitAlert = useFiatBuyLimitAlert({
+    pendingAmount: pendingTokenAmount,
+  });
+
   const accountNoFundsAlert = useAccountNoFundsAlert();
 
   return useMemo(
@@ -40,6 +45,7 @@ export function usePendingAmountAlerts({
       ...insufficientPredictBalanceAlert,
       ...insufficientPerpsBalanceAlert,
       ...insufficientMoneyAccountBalanceAlert,
+      ...fiatBuyLimitAlert,
       ...accountNoFundsAlert,
     ],
     [
@@ -48,6 +54,7 @@ export function usePendingAmountAlerts({
       insufficientPredictBalanceAlert,
       insufficientPerpsBalanceAlert,
       insufficientMoneyAccountBalanceAlert,
+      fiatBuyLimitAlert,
       accountNoFundsAlert,
     ],
   );

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
@@ -106,6 +106,7 @@ function getAlertNames(alerts: Alert[]): string[] {
 }
 
 const ALERTS_NAME_METRICS: AlertNameMetrics = {
+  [AlertKeys.AddressPoisoning]: 'address_poisoning',
   [AlertKeys.AddressTrustSignalMalicious]: 'address_trust_signal_malicious',
   [AlertKeys.AddressTrustSignalWarning]: 'address_trust_signal_warning',
   [AlertKeys.BatchedUnusedApprovals]: 'batched_unused_approvals',
@@ -134,6 +135,7 @@ const ALERTS_NAME_METRICS: AlertNameMetrics = {
   [AlertKeys.TokenContractAddress]: 'token_contract_address',
   [AlertKeys.TokenTrustSignalMalicious]: 'token_trust_signal_malicious',
   [AlertKeys.TokenTrustSignalWarning]: 'token_trust_signal_warning',
+  [AlertKeys.FiatBuyAmountLimit]: 'fiat_buy_amount_limit',
 };
 
 function getAlertName(alertKey: string): string {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmountAlerts.ts
@@ -9,6 +9,7 @@ const PENDING_AMOUNT_ALERTS: AlertKeys[] = [
   AlertKeys.InsufficientPredictBalance,
   AlertKeys.InsufficientPerpsBalance,
   AlertKeys.InsufficientMoneyAccountBalance,
+  AlertKeys.FiatBuyAmountLimit,
 ];
 
 const KEYBOARD_ALERTS: AlertKeys[] = [
@@ -19,6 +20,7 @@ const KEYBOARD_ALERTS: AlertKeys[] = [
   AlertKeys.InsufficientPredictBalance,
   AlertKeys.InsufficientPerpsBalance,
   AlertKeys.InsufficientMoneyAccountBalance,
+  AlertKeys.FiatBuyAmountLimit,
 ];
 
 const ON_CHANGE_ALERTS = [
@@ -27,6 +29,7 @@ const ON_CHANGE_ALERTS = [
   AlertKeys.InsufficientPredictBalance,
   AlertKeys.InsufficientPerpsBalance,
   AlertKeys.InsufficientMoneyAccountBalance,
+  AlertKeys.FiatBuyAmountLimit,
 ];
 
 export function useTransactionCustomAmountAlerts({

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -114,11 +114,14 @@
       "title": "Insufficient funds for post quote"
     },
     "no_pay_token_quotes": {
-      "message": "This payment route isn't available right now. Try changing the amount, network, or token and we'll find the best option.",
+      "message": "This payment route isn't available right now. Try changing the amount or payment method and we'll find the best option.",
       "title": "No quotes"
     },
     "account_no_funds": {
       "message": "No funds available. Use a different account."
+    },
+    "fiat_buy_amount_limit": {
+      "title": "Amount out of range"
     },
     "headless_buy_error": {
       "title": "Fiat purchase failed",
@@ -127,6 +130,11 @@
     "mmpay_hardware_account": {
       "title": "Wallet not supported",
       "message": "Hardware wallets aren't supported.\nSwitch wallets to continue."
+    },
+    "address_poisoning": {
+      "title": "Address poisoning detected",
+      "message": "This address closely resembles one you've used before. It may have been designed to trick you into sending funds to the wrong recipient.",
+      "badge": "Poisoned"
     },
     "burn_address": {
       "message": "You're sending your assets to a burn address. If you continue, you'll lose your assets.",
@@ -279,6 +287,8 @@
     "import_srp": "Import using Secret Recovery Phrase",
     "sign_in_with_google": "Sign in with Google",
     "sign_in_with_apple": "Sign in with Apple",
+    "continue_with_telegram": "Continue with Telegram",
+    "sign_in_with_telegram": "Sign in with Telegram",
     "your_wallet": "You successfully reset your wallet!",
     "delete_current": "Reset current wallet",
     "have_existing_wallet": "I have an existing wallet",
@@ -710,8 +720,14 @@
     "could_not_resolve_name": "Couldn't resolve name",
     "invalid_address": "Invalid address",
     "contractAddressError": "You are sending tokens to the token's contract address. This may result in the loss of these tokens.",
+    "compare_addresses": "Compare addresses",
+    "entered_malicious": "The Address You Entered",
+    "known_safe_address": "Known Address",
     "smart_contract_address": "Smart contract address",
     "smart_contract_address_warning": "The recipient address may not support direct token transfers, which could result in fund loss. Only continue if you're certain this contract can receive your transfer.",
+    "unavailable_network_connection": "Unavailable network connection",
+    "unavailable_network_connection_description": "The connection with {{network}} is unreliable. Update network connectivity details before continuing or try again later.",
+    "update": "Update",
     "i_understand": "I understand",
     "cancel": "Cancel",
     "new_address_title": "New address",
@@ -1042,8 +1058,7 @@
       "title": "Notifications from {{traderName}}",
       "allow_push_notifications": "Allow push notifications",
       "allow_push_notifications_desc": "Get notified on {{traderName}}'s trading activity",
-      "manage_traders": "Manage traders you follow",
-      "save": "Save"
+      "manage_traders": "Manage traders you follow"
     },
     "trader_notifications_setup": {
       "description": "Get real-time alerts on trades from the traders you follow",
@@ -1087,12 +1102,15 @@
       "fallback_title": "Position not available",
       "fallback_subtitle": "We couldn't load this position right now.",
       "fallback_back_to_profile": "Back to profile",
-      "fallback_back_to_leaderboard": "Back to leaderboard"
+      "fallback_back_to_leaderboard": "Back to leaderboard",
+      "sell": "Sell"
     },
     "quick_buy": {
       "title": "Buy {{symbol}}",
       "market_cap_label": "Market cap",
       "pay_with": "Pay with",
+      "buy_mode": "Buy",
+      "with": "with",
       "total": "Total",
       "network_fee": "Network fee",
       "slippage": "Slippage",
@@ -1102,7 +1120,26 @@
       "no_quotes": "No quotes available for this token",
       "loading": "Loading...",
       "unavailable": "Swap unavailable",
-      "unsupported_chain": "This chain is not supported for Quick Buy yet"
+      "unsupported_chain": "This chain is not supported for Quick Buy yet",
+      "quote_details_title": "Quote details",
+      "select_quote_title": "Select quote",
+      "rate": "Rate",
+      "get_new_quote": "Get new quote",
+      "available_balance": "{{amount}} available",
+      "toggle_amount_display": "Switch between token and dollar amount",
+      "includes_mm_fee": "Includes {{fee}}% MM fee",
+      "pay_with_no_tokens": "No tokens available to pay with",
+      "receive_with_no_tokens": "No tokens available to receive",
+      "pay_with_filter_all": "All",
+      "buy_label": "Buy",
+      "sell_label": "Sell",
+      "receive": "Receive",
+      "toast_pending_buy": "Buying {{amount}} of {{symbol}} with {{counter}}",
+      "toast_pending_sell": "Selling {{amount}} of {{symbol}} for {{counter}}",
+      "toast_complete_buy": "Bought {{amount}} of {{symbol}} with {{counter}}",
+      "toast_complete_sell": "Sold {{amount}} of {{symbol}} for {{counter}}",
+      "toast_failed_buy": "Couldn't buy {{symbol}}",
+      "toast_failed_sell": "Couldn't sell {{symbol}}"
     }
   },
   "perps": {
@@ -1123,6 +1160,15 @@
     "discovery_banner": {
       "title": "Trade {{symbol}} perp",
       "subtitle": "Multiply your P&L up to {{leverage}}"
+    },
+    "service_interruption": {
+      "title": "We're experiencing an outage",
+      "description": "Some services may be unavailable while the team works on a fix.",
+      "contact_support": "Contact support"
+    },
+    "competition_banner": {
+      "title": "Competition leaderboard",
+      "description": "See where you rank in the Perps trading competition"
     },
     "today": "Today",
     "yesterday": "Yesterday",
@@ -1288,7 +1334,9 @@
       "toast_completed_subtitle": "{{amount}} USDC moved to your wallet",
       "toast_completed_any_token_subtitle": "{{amount}} {{token}} moved to your wallet",
       "toast_error_title": "Something went wrong",
-      "toast_error_description": "Failed to proceed with withdrawal"
+      "toast_error_description": "Failed to proceed with withdrawal",
+      "toast_start_error_description": "Your withdrawal wasn’t started.",
+      "try_again": "Try again"
     },
     "quote": {
       "network_fee": "Network fee",
@@ -1402,7 +1450,8 @@
         "liquidation_warning": "You will be liquidated if price {{direction}} by {{percentage}}",
         "drops": "drops",
         "rises": "rises",
-        "set_leverage": "Set {{leverage}}x"
+        "set_leverage": "Set {{leverage}}x",
+        "price_unavailable": "Price information unavailable"
       },
       "type": {
         "title": "Order type",
@@ -1458,6 +1507,22 @@
       "pay_with_token_required": "Token selection required",
       "select_token_to_pay_with": "Please select a token to pay with before placing your order",
       "initializing": "Initializing order..."
+    },
+    "slippage": {
+      "config_title": "Set slippage",
+      "config_description": "Your transaction won't go through if the price shifts beyond this threshold.",
+      "set": "Set",
+      "cancel": "Cancel",
+      "custom": "Custom",
+      "use_custom_title": "Use custom slippage",
+      "row_format": "Est: {{est}}% / Max: {{value}}%",
+      "row_format_pending": "Est: -- / Max: {{value}}%",
+      "input_label": "Max slippage percentage",
+      "decrement_label": "Decrease slippage",
+      "increment_label": "Increase slippage",
+      "out_of_range": "Enter a value between {{min}}% and {{max}}%",
+      "slippage": "Slippage",
+      "exceeds_max": "Estimated slippage ({{est}}%) exceeds your max slippage ({{max}}%). Increase the cap or reduce the order size."
     },
     "price_deviation_warning": {
       "message": "Price has deviated too much from the spot price. New positions cannot be opened at this time."
@@ -1791,10 +1856,13 @@
       "pay_attention_to_volatility": "Pay attention to volatility and slippage",
       "badge": {
         "experimental": "EXPERIMENTAL",
-        "equity": "STOCK",
         "commodity": "COMMODITY",
         "crypto": "CRYPTO",
-        "forex": "FOREX"
+        "forex": "FOREX",
+        "stock": "STOCK",
+        "pre-ipo": "PRE-IPO",
+        "index": "INDEX",
+        "etf": "ETF"
       }
     },
     "buttons": {
@@ -1829,7 +1897,7 @@
         "provider_fee": "Provider fee",
         "bridge_fee": "Bridge fee",
         "total": "Total fees",
-        "discount_message": "You're saving {{percentage}}% with MetaMask Rewards."
+        "discount_message": "You're saving {{percentage}}% on fees as a VIP."
       },
       "closing_fees": {
         "title": "Closing fees",
@@ -1914,6 +1982,10 @@
       "pay_with": {
         "title": "Pay with",
         "content": "Choose which token or balance to use to pay for this trade. You can pay with your Perps balance or select another token from your wallet."
+      },
+      "slippage": {
+        "title": "Estimated slippage",
+        "content": "Slippage is the difference between the expected price and the price at which your order is filled. Larger orders or low-liquidity markets may have higher slippage."
       }
     },
     "connection": {
@@ -1972,14 +2044,20 @@
         "stocks": "Stocks",
         "commodities": "Commodities",
         "forex": "Forex",
-        "new": "New"
+        "new": "New",
+        "pre_ipo": "Pre-IPO",
+        "indices": "Indices",
+        "etfs": "ETFs"
       },
       "filter_by": "Filter by",
       "forex": "Forex",
       "watchlist": "Watchlist",
       "markets": "Markets",
       "explore_markets": "Explore markets",
-      "see_all_perps": "See all perps"
+      "see_all_perps": "See all perps",
+      "top_movers": "Top movers",
+      "gainers": "Gainers",
+      "losers": "Losers"
     },
     "learn_more": {
       "title": "Learn about Perps",
@@ -2230,10 +2308,33 @@
   },
   "predict": {
     "title": "MetaMask Predictions",
+    "home": {
+      "portfolio_module_placeholder": "Portfolio module",
+      "live_now_placeholder": "Live now",
+      "categories_placeholder": "Categories",
+      "popular_today_placeholder": "Popular today",
+      "trending_placeholder": "Trending"
+    },
+    "homepage_discovery": {
+      "btc_title": "BTC Price: {{price}}",
+      "btc_price_to_beat": "Price to beat: {{price}}",
+      "btc_live": "Live",
+      "nba_2026_champion_title": "NBA 2026 Champion",
+      "fifa_world_cup_2026_title": "FIFA World Cup 2026",
+      "events_in_total": "{{count}} events in total",
+      "events_in_total_overflow": "{{count}}+ events in total",
+      "props_pill": "Props",
+      "championship_unavailable": "No championship market to show yet.",
+      "mens_world_cup_title": "Men's World Cup",
+      "mens_world_cup_events": "{{count}} men's world cup events",
+      "mens_world_cup_events_overflow": "{{count}}+ men's world cup events",
+      "winner_unavailable": "No World Cup markets to show yet."
+    },
     "world_cup": {
       "title": "World Cup",
+      "predictions_title": "World Cup predictions",
       "banner_title": "World Cup 2026",
-      "banner_description": "Trade on World Cup markets",
+      "banner_description": "Trade every match, every moment.",
       "tabs": {
         "all": "All",
         "props": "Props",
@@ -2243,8 +2344,8 @@
         "group_stage": "Group Stage",
         "round_of_32": "Round of 32",
         "round_of_16": "Round of 16",
-        "quarterfinals": "Quarterfinals",
-        "semifinals": "Semifinals",
+        "quarterfinals": "Quarter-finals",
+        "semifinals": "Semi-finals",
         "third_place": "Third Place",
         "final": "Final",
         "group_a": "Group A",
@@ -2258,8 +2359,7 @@
         "group_i": "Group I",
         "group_j": "Group J",
         "group_k": "Group K",
-        "group_l": "Group L",
-        "third_place_match": "Third Place Match"
+        "group_l": "Group L"
       }
     },
     "prediction_markets": "Prediction markets",
@@ -2301,7 +2401,9 @@
       "ended": "Ended",
       "resolved_early": "Resolved early",
       "disclaimer": "This information may be incomplete. All market rules, resolution criteria, and final outcomes are governed solely by Polymarket. Trades should be made based on the full rules available on Polymarket.",
-      "your_picks": "Your picks"
+      "your_picks": "Your picks",
+      "entry": "Entry",
+      "claim": "Claim"
     },
     "tab": {
       "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
@@ -2309,14 +2411,21 @@
       "new_prediction": "New prediction",
       "resolved_markets": "Resolved markets"
     },
+    "positions_empty": {
+      "description": "Your predictions will appear here, showing your stake and market movements",
+      "browse_markets": "Browse markets"
+    },
     "tabs": {
       "about": "About",
+      "active_positions": "Active positions",
       "positions": "Positions",
+      "history": "History",
       "outcomes": "Outcomes"
     },
     "outcome_groups": {
       "game_lines": "Game Lines",
       "first_half": "1st Half",
+      "first_set": "1st Set",
       "team_totals": "Team Totals",
       "touchdowns": "Touchdowns",
       "rushing": "Rushing",
@@ -2338,6 +2447,7 @@
       "moneyline": "Moneyline",
       "spreads": "Spreads",
       "totals": "Totals",
+      "nrfi": "Will there be a run in the first inning?",
       "both_teams_to_score": "Both Teams to Score",
       "first_half_moneyline": "1H Moneyline",
       "first_half_spreads": "1H Spreads",
@@ -2345,6 +2455,9 @@
       "points": "Points",
       "assists": "Assists",
       "rebounds": "Rebounds",
+      "basketball_total_points": "Totals",
+      "basketball_odd_even": "Odd/Even Score",
+      "basketball_team_to_score_first": "Team to Score First",
       "goalscorers": "Goalscorers",
       "exact_score": "Exact Score",
       "halftime_result": "Halftime Result",
@@ -2357,10 +2470,17 @@
       "soccer_anytime_goalscorer": "Goalscorers",
       "soccer_exact_score": "Exact Score",
       "soccer_halftime_result": "Halftime Result",
-      "total_corners": "Corners"
+      "total_corners": "Corners",
+      "tennis_set_totals": "Total Sets",
+      "tennis_set_handicap": "Set Handicap",
+      "tennis_match_totals": "Total Games",
+      "tennis_first_set_totals": "1st Set Total Games",
+      "tennis_first_set_winner": "1st Set Winner",
+      "tennis_completed_match": "Completed Match"
     },
     "sell_position": "Sell position",
     "odds": "Odds",
+    "your_positions": "Your positions",
     "cash_out": "Cash out",
     "cash_out_info": "Funds will be added to your available balance",
     "buy_preview_outcome_at_price": "{{outcome}} at {{price}}",
@@ -2405,6 +2525,11 @@
     "markets_won": "Markets won",
     "won_markets_text": "Won {{count}} market{{s}}",
     "available_balance": "Available balance",
+    "portfolio": {
+      "available_amount": "{{amount}} available",
+      "value_accessibility": "Portfolio value, {{value}}",
+      "value_hidden_accessibility": "Portfolio value hidden"
+    },
     "claim_amount_text": "Claim ${{amount}}",
     "claim_winnings_text": "Claim winnings",
     "claiming_text": "Claiming...",
@@ -2453,6 +2578,11 @@
       "buy_title": "Predicted",
       "sell_title": "Cashed out",
       "claim_title": "Claimed winnings",
+      "claim_pending": "Claim pending",
+      "claim_pending_accessibility_label": "{{predictionStatus}}, {{marketTitle}}, opens market details",
+      "prediction_lost_title": "Prediction lost",
+      "prediction_resolved_title": "Prediction resolved",
+      "prediction_won_title": "Prediction won",
       "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
       "sell_detail": "Sold at {{priceCents}} per share",
       "claim_detail": "Claimed winnings",
@@ -2590,7 +2720,10 @@
       "order_not_fully_filled": "Failed to fill your order",
       "buy_order_not_fully_filled": "Not enough shares available at market price to place your order right now.",
       "sell_order_not_fully_filled": "There isn't enough demand at market price to cash out right now.",
-      "preview_not_available": "No preview available"
+      "preview_not_available": "No preview available",
+      "market_pending_resolution": "This market is pending resolution.",
+      "market_not_accepting_bets": "This market is no longer accepting bets.",
+      "market_bettable_check_failed": "We couldn't confirm this market is accepting bets. Try again."
     },
     "game_details_footer": {
       "pick_a_winner": "Pick a winner",
@@ -2948,12 +3081,20 @@
   "onboarding_interest_questionnaire": {
     "title": "What do you want to do with MetaMask?",
     "description": "Select all that apply.",
-    "option_buy_and_sell_crypto": "Buy and sell crypto",
+    "option_buy_and_sell_crypto": "Buy and sell crypto tokens",
     "option_consolidate_wallets": "Consolidate your wallets",
-    "option_advanced_trades": "Make advanced trades",
+    "option_advanced_trades": "Trade perpetuals",
     "option_predict_sports_events": "Predict sports and events",
     "option_crypto_as_money": "Use crypto as money",
     "option_connect_apps_sites": "Connect to apps or sites",
+    "continue": "Continue"
+  },
+  "onboarding_crypto_experience_questionnaire": {
+    "title": "What's your experience with crypto?",
+    "option_new": "New",
+    "option_beginner": "Beginner",
+    "option_intermediate": "Intermediate",
+    "option_advanced": "Advanced",
     "continue": "Continue"
   },
   "template_confirmation": {
@@ -3276,8 +3417,27 @@
     "notifications_desc": "Manage your notifications",
     "allow_notifications": "Allow notifications",
     "enable_push_notifications": "Enable push notifications",
-    "allow_notifications_desc": "Stay in the loop on what’s happening in your wallet with notifications. To use notifications, we use a profile to sync some settings across your devices.",
+    "allow_notifications_desc": "Choose what you're notified about and how.",
     "notifications_opts": {
+      "preferences_title": "Preferences",
+      "push_recommended": "Push",
+      "in_app": "In-app",
+      "status_push": "Push",
+      "status_in_app": "In app",
+      "status_off": "Off",
+      "select_all": "Select all",
+      "deselect_all": "Deselect all",
+      "select_accounts_title": "Accounts",
+      "select_accounts_desc": "Choose which accounts you'd like to get notifications for.",
+      "wallet_activity_title": "Wallet Activity",
+      "wallet_activity_desc": "Buy, sells, transfers, swaps and rewards",
+      "perps_title": "Trading Activity",
+      "perps_desc": "Perps position changes, liquidations, funding rates, and margin updates",
+      "social_ai_title": "Trading Signals",
+      "social_ai_desc": "Updates from traders and assets you follow, plus currated market news",
+      "marketing_title": "Updates and Rewards",
+      "marketing_desc": "Product updates, feature announcements, and new releases",
+      "marketing_disclaimer": "By turning this on, you agree to receive product news and marketing updates from MetaMask.",
       "customize_session_title": "Customize your notifications",
       "customize_session_desc": "Turn on the types of notifications you want to receive:",
       "account_session_title": "Account activity",
@@ -3291,8 +3451,7 @@
       "snaps_title": "Snaps",
       "snaps_desc": "New features and updates",
       "products_announcements_title": "Product announcements",
-      "products_announcements_desc": "New products and features",
-      "perps_title": "Perps trading"
+      "products_announcements_desc": "New products and features"
     },
     "contacts_title": "Contacts",
     "contacts_desc": "Add, edit, remove, and manage your accounts.",
@@ -3660,6 +3819,16 @@
         "unlink_money_account_button": "Unlink Money Account from Card",
         "unlink_money_account_disabled_hint": "No active linkage to remove."
       },
+      "identity": {
+        "title": "Identity",
+        "description": "Clears the persisted authentication session. Use this after toggling MM_DEV_API_ENV — otherwise a prod-minted JWT keeps being handed to dev-API consumers until it expires. Current MM_DEV_API_ENV: {{env}}.",
+        "clear_auth_session_button": "Clear persisted auth session"
+      },
+      "notifications": {
+        "title": "Notifications",
+        "description": "Reset the push notification pre-prompt flag to re-trigger the sheet on next eligible launch.",
+        "reset_prompt": "Reset push pre-prompt"
+      },
       "haptics": {
         "title": "Haptics",
         "description": "Preview haptic feedback on a physical device. This bypasses in-app reduced-haptics and the remote kill switch so you can evaluate each pattern. Simulators often do not play haptics.",
@@ -3953,13 +4122,18 @@
     "risky": "Risky",
     "malicious_token_title": "Malicious token",
     "malicious_token_description": "{{symbol}} is a malicious token. Avoid interacting with it or trading it.",
+    "malicious_token_description_no_symbol": "This is a malicious token. Avoid interacting with it or trading it.",
     "malicious_token_banner_description": "{{symbol}} is flagged as malicious. It's likely to steal funds from anyone who interacts with it.",
+    "malicious_token_banner_description_no_symbol": "This token is flagged as malicious. It's likely to steal funds from anyone who interacts with it.",
     "suspicious_token_description": "{{symbol}} is a suspicious token.",
+    "suspicious_token_description_no_symbol": "This is a suspicious token.",
     "verified_token_title": "Verified token",
     "verified_token_description": "{{symbol}} is actively traded and is widely recognized. Verification is not an endorsement by MetaMask.",
     "risky_token_title": "Suspicious token",
     "risky_token_description": "{{symbol}} is flagged as suspicious. Take a look at the risks before you continue.",
+    "risky_token_description_no_symbol": "This token is flagged as suspicious. Take a look at the risks before you continue.",
     "malicious_token_sheet_description": "Serious risk signals detected on {{symbol}}. We recommend not trading this token.",
+    "malicious_token_sheet_description_no_symbol": "Serious risk signals detected on this token. We recommend not trading this token.",
     "got_it": "Got it",
     "proceed": "Proceed",
     "continue_anyway": "Continue anyway",
@@ -5206,6 +5380,11 @@
       "title": "Nothing to see here",
       "message": "This is where you can find notifications once there’s activity in your wallet. "
     },
+    "disabled": {
+      "title": "Turn on notifications",
+      "message": "Choose what you're notified about and how.",
+      "cta": "Notification settings"
+    },
     "list": {
       "0": "All",
       "1": "Wallet",
@@ -5227,30 +5406,50 @@
     "push_onboarding": {
       "new_user": {
         "title": "Never miss a move",
-        "body": "Get real-time alerts when prices hit your targets, your trades confirm, and your portfolio moves. Plus product updates and rewards along the way. We'll share updates based on your interactions with MetaMask.",
-        "button_yes": "Yes",
+        "body": "Get real-time alerts on price moves, trade confirmations, portfolio activity, and rewards based on how you use MetaMask.",
+        "button_yes": "Enable notifications",
         "button_not_now": "Not now",
         "preview_card_1": {
-          "eyebrow": "METAMASK",
           "time": "now",
           "title": "ETH is up 4.2% today",
           "message": "Now at $2,668.51 — above your price alert"
         },
         "preview_card_2": {
-          "eyebrow": "METAMASK",
           "time": "1h ago",
           "title": "Received 0.25 ETH",
           "message": "From 0x9a21…4f8c · $640.29"
+        },
+        "toast": {
+          "notifications_on": {
+            "title": "Notifications are on",
+            "description": "We'll send you transactions, price alerts, and updates."
+          },
+          "notifications_off": {
+            "title": "Notifications are off",
+            "description": "Turn them on anytime in Settings → Notifications."
+          }
         }
       },
       "existing_user": {
         "title": "Introducing personalized alerts",
-        "body": "Get notifications that match how you trade. Update anytime.",
+        "body": "Get notifications that match how you trade, based on how you use MetaMask.",
         "card_title": "What you'll get",
         "card_description": "Personalized alerts and updates tailored to your trading activity.",
         "button_confirm": "Confirm",
-        "button_not_now": "Not now"
-      }
+        "button_not_now": "Not now",
+        "toast": {
+          "personalized_alerts_on": {
+            "title": "Personalized alerts is on",
+            "description": "Manage this anytime in Settings."
+          },
+          "personalized_alerts_off": {
+            "title": "Personalized alerts is off",
+            "description": "Turn it on anytime in Settings."
+          }
+        }
+      },
+      "toast_enabled": "Notifications enabled",
+      "toast_settings_hint": "You can enable notifications any time in Settings > Notifications"
     }
   },
   "protect_your_wallet_modal": {
@@ -5339,6 +5538,15 @@
     "message": "We couldn't load that page",
     "return_home": "Return to home page"
   },
+  "agentic_cli_approval": {
+    "title": "Review request",
+    "error": {
+      "title": "Something went wrong",
+      "load_description": "We couldn't load this approval request. Check your connection and try again.",
+      "submit_description": "We couldn't complete this approval. Close this screen and start the CLI request again.",
+      "try_again": "Try again"
+    }
+  },
   "offline_mode": {
     "title": "You're offline",
     "text": "Unable to connect to the blockchain host.",
@@ -5361,6 +5569,7 @@
     "pay_with": "Pay with",
     "buying_via": "Buying via {{providerName}}.",
     "change_provider": "Change provider.",
+    "circuit_breaker_open": "This service is temporarily unavailable. Please try again in about 30 minutes.",
     "payment_error": "Something went wrong. Please try again.",
     "no_payment_methods_available": "No payment methods are available.",
     "error_fetching_quotes": "Something went wrong. Please try again.",
@@ -6641,29 +6850,45 @@
     "apy_label": "{{percentage}}% APY",
     "apy_currency_suffix": " • mUSD",
     "apy_info_label": "APY info",
+    "deposit_tooltip_title": "Earn up to {{percentage}}%",
+    "deposit_tooltip_description": "Add funds to your Money account and earn up to {{percentage}}% APY automatically. You can add funds by converting your existing stablecoin balance or depositing directly from your bank or card.",
+    "balance_unavailable": "Balance unavailable",
+    "balance_retry": "Retry",
+    "balance_no_account": "Money account not found",
     "onboarding": {
-      "step_progress": "Step {{current}} of {{total}}",
-      "title": "Add money",
-      "description": "Fund your account and start earning APY.",
-      "add": "Add funds",
-      "step2_title": "Get your MetaMask Card",
-      "step2_description": "Spend your Money balance while it earns, anywhere Mastercard is accepted.",
-      "step2_cta": "Get card",
-      "link_card_title": "Link your MetaMask Card",
-      "link_card_description": "Spend your balance while it earns, anywhere Mastercard is accepted.",
-      "link_card_cta": "Link card"
+      "step_1": {
+        "title": "Fund your account",
+        "description": "Drop in some funds. Your Money account will handle the rest.",
+        "cta": "Add funds"
+      },
+      "step_2": {
+        "no_card_account": {
+          "title": "Get your MetaMask Card",
+          "description": "Spend your balance and earn on purchases.",
+          "cta_primary": "Get card",
+          "cta_secondary": "Skip"
+        },
+        "unlinked_card_account": {
+          "title": "Link your MetaMask Card",
+          "description": "Spend your balance and earn on purchases.",
+          "cta_primary": "Link card",
+          "cta_secondary": "Skip"
+        }
+      }
     },
     "rive_onboarding": {
       "step1_title": "Money accounts are here",
       "step1_body": "Earn up to {{percentage}}% APY on your balance, available across your entire wallet.",
-      "step1_footer_text": "APY is variable and may change at any time.",
+      "step1_footer_text": "APY is variable and not guaranteed.",
       "step2_title": "Earn automatically",
       "step2_body": "Move stablecoins with no exchange fees. Funds start earning right away.",
-      "step2_footer_text": "APY is variable and may change at any time.",
+      "step2_footer_text": "Money account uses Veda infrastructure.",
       "step3_title": "Spend anywhere",
       "step3_body": "Get up to {{percentage}}% back on purchases by linking your Money account to a MetaMask card.",
+      "step3_footer_text": "Includes Steakhouse Financial monitoring.",
       "step4_title": "Trade and earn in one place",
       "step4_body": "Use your Money balance to trade across MetaMask while still earning yield.",
+      "step4_footer_text": "Powered by Monad.",
       "continue": "Continue"
     },
     "action": {
@@ -6679,8 +6904,9 @@
     },
     "how_it_works": {
       "title": "How it works",
-      "description_prefix": "Deposit mUSD into your Money account and earn up to",
-      "description_suffix": ". Your balance is dollar-backed and ready to spend, trade, or send anytime."
+      "description_prefix": "Add mUSD to your Money account and earn up to",
+      "description_suffix": " (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime.",
+      "description_no_apy": "Add mUSD to your Money account. Your balance is dollar-backed and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "Add"
@@ -6696,9 +6922,9 @@
       "description": "See how your money can grow over time by converting your crypto to mUSD.",
       "description_with_amounts_prefix": "Convert your {{total}} in assets and you could earn up to",
       "description_with_amounts_suffix": "in one year.",
-      "convert": "Convert",
+      "add": "Add",
       "convert_cta": "Convert your crypto",
-      "no_fee": "No MetaMask fee",
+      "no_fee": "No fee",
       "view_all": "View all",
       "view_potential_earnings": "View potential earnings"
     },
@@ -6710,17 +6936,18 @@
       "cashback": "{{percentage}}% mUSD back",
       "get_now": "Get now",
       "link_title": "Link MetaMask Card",
-      "link_subtitle": "Spend your Money balance and earn on purchases. Plus, up to {{apy}}% APY on your balance.",
+      "link_subtitle": "Spend your balance and earn on purchases.",
+      "link_subtitle_no_apy": "Spend your balance and earn on purchases.",
       "link_bullet_cashback": "Get {{percentage}}% mUSD back",
-      "link_bullet_apy": "Earn up to {{apy}}% APY",
+      "link_bullet_apy": "Earn up to ~{{apy}}% APY (variable)",
       "link_card": "Link card",
-      "link_pending_title": "Linking card",
-      "link_pending_description": "Approving spending limit…",
-      "link_success_title": "Card linked successfully",
-      "link_success_description": "You can now spend while you earn",
-      "link_error": "Couldn't link card",
+      "link_pending_title": "Linking your card",
+      "link_success_title": "Your card is ready to use",
+      "link_error": "Something went wrong linking your card",
       "link_card_sheet_title": "Spend and earn",
-      "link_card_sheet_description": "Link your card so you can spend your Money balance while it earns {{apy}}% APY.",
+      "link_card_sheet_description_prefix": "Link your card so you can spend your Money balance and earn mUSD back on purchases—all while earning up to",
+      "link_card_sheet_description_suffix": " (variable).",
+      "link_card_sheet_description_no_apy": "Link your card so you can spend your Money balance and earn mUSD back on purchases.",
       "link_card_sheet_cta": "Link card",
       "manage_card": "Manage",
       "avail_balance": "Avail. balance"
@@ -6728,6 +6955,7 @@
     "what_you_get": {
       "title": "What you get",
       "benefit_auto_earn": "Auto-earn up to",
+      "benefit_auto_earn_variable": "(variable)",
       "benefit_dollar_backed": "Keep your money secure in mUSD, a 1:1 dollar-backed stablecoin",
       "benefit_liquidity": "Get full liquidity with no lockups, so you can trade or withdraw anytime",
       "benefit_spend_prefix": "Spend at 150M+ merchants with MetaMask Card and earn ",
@@ -6745,8 +6973,8 @@
       "convert_crypto_description": "From any account",
       "deposit_funds": "Deposit funds",
       "deposit_funds_description": "From debit card or bank",
-      "move_musd": "Transfer your {{amount}} mUSD",
-      "move_musd_no_amount": "Transfer your mUSD",
+      "move_musd": "Add your {{amount}} mUSD",
+      "add_musd": "Add mUSD",
       "move_musd_description": "From your balance",
       "receive_external": "Receive from external wallet",
       "coming_soon": "Coming soon"
@@ -6758,12 +6986,34 @@
       "contact_support": "Contact support"
     },
     "transfer_sheet": {
-      "title": "Transfer funds",
-      "between_accounts": "Between accounts",
+      "title": "Transfer funds to",
+      "between_accounts": "Another account",
       "perps_account": "Perps account",
       "predictions_account": "Predictions account",
       "send_external": "Send to external address",
       "withdraw_to_bank": "Withdraw to bank"
+    },
+    "toasts": {
+      "in_progress_title": "Transaction in progress",
+      "in_progress_body": "This may take a few minutes.",
+      "deposit_in_progress_title_convert": "Converting crypto",
+      "deposit_in_progress_title_add_musd": "Adding funds",
+      "success_title": "Transaction complete",
+      "deposit_success_title_convert": "Conversion complete",
+      "deposit_success_title_add_musd": "Funds added",
+      "deposit_success_body": "{{amount}} added to Money account.",
+      "deposit_success_body_no_amount": "Added to Money account.",
+      "withdraw_in_progress_title": "Transfer in progress",
+      "withdraw_success_title": "Transfer complete",
+      "withdraw_success_body": "{{amount}} added to {{destination}}.",
+      "withdraw_success_body_no_amount": "Added to {{destination}}.",
+      "withdraw_fallback_destination": "your account",
+      "deposit_failed_title_convert": "Conversion failed",
+      "deposit_failed_title_add_musd": "Failed to add funds",
+      "deposit_failed_body_convert": "Unable to convert. Try again.",
+      "deposit_failed_body_add_musd": "Unable to add funds. Try again.",
+      "withdraw_failed_title": "Transfer failed",
+      "withdraw_failed_body": "Unable to transfer funds. Try again."
     },
     "apy_tooltip": {
       "title": "Annual Percentage Yield (APY)",
@@ -6777,7 +7027,7 @@
     },
     "earn_crypto_info_sheet": {
       "title": "Earn on your crypto",
-      "body": "Illustration assumes {{percentage}}% Annual Percentage Yield (APY) remains unchanged for one year. APY is variable and may change due to various factors. No guarantee of return."
+      "body": "Projection assumes {{percentage}}% Annual Percentage Yield (APY) remains unchanged for one year. APY is variable and is not guaranteed. No guarantee of return."
     },
     "activity": {
       "title": "Activity",
@@ -6789,7 +7039,7 @@
     },
     "condensed_cards": {
       "how_it_works_title": "How it works",
-      "how_it_works_subtitle": "See how your money works for you",
+      "how_it_works_subtitle": "See how your money can grow",
       "musd_title": "MetaMask USD",
       "musd_subtitle": "Learn more about mUSD",
       "what_you_get_title": "What you get",
@@ -6802,7 +7052,8 @@
       "sent": "Sent",
       "transferred": "Transferred",
       "card_transaction": "Card transaction",
-      "converted": "Converted"
+      "converted": "Converted",
+      "failed": "Failed"
     },
     "convert_stablecoins": {
       "title": "Convert your stablecoins",
@@ -6821,8 +7072,9 @@
     "how_it_works_page": {
       "header_title": "Money",
       "section_title": "How it works",
-      "description_1": "Deposit mUSD into your Money account and earn up to {{percentage}}% APY (variable) automatically. Funds go into a DeFi vault that generates returns across audited lending markets—no staking, no claiming, no lock-ups.",
+      "description_1": "Add mUSD into your Money account and earn up to {{percentage}}% APY (variable) automatically. Funds go into a DeFi vault, administered by Veda with risk monitoring by Steakhouse Financial. The rate is generated by third-party DeFi platforms that deploy funds in blockchain protocols. No staking, no claiming, no lock-ups.",
       "description_2": "Your Money balance is your spending balance. Link your MetaMask Card to spend at 150M+ merchants worldwide. Your money keeps earning until the moment you use it.",
+      "description_3": "Money account is powered by Monad.",
       "faq_title": "Frequently asked questions",
       "faq_placeholder_answer": "Coming soon.",
       "faq_q1": "How does the {{percentage}}% APY work?",
@@ -7094,12 +7346,20 @@
     "confirm": "Confirm",
     "pay_with_bottom_sheet": {
       "title": "Pay with",
+      "receive_title": "Receive",
       "last_used": "Last used",
       "bank_and_card": "Bank and card",
       "crypto": "Crypto",
+      "perps": "Perps",
+      "perps_account": "Perps account",
+      "predict": "Predict",
+      "predict_account": "Predict account",
+      "add": "Add",
       "available_balance": "{{balance}} available",
       "other_assets": "Other assets",
-      "other_assets_description": "Select from your tokens"
+      "other_assets_description": "Select from your tokens",
+      "other_assets_receive_description": "Select the token you want to receive",
+      "money_balance": "Money balance"
     },
     "staking_footer": {
       "part1": "By continuing, you agree to our ",
@@ -7152,8 +7412,8 @@
       "perps_withdraw": "Withdraw",
       "predict_deposit": "Add Prediction funds",
       "predict_withdraw": "Withdraw",
-      "money_account_add_money": "Add money",
-      "money_account_transfer_money": "Transfer money"
+      "money_account_add_money": "Add funds",
+      "money_account_transfer_money": "Transfer funds"
     },
     "sub_title": {
       "permit": "This site wants permission to spend your tokens.",
@@ -7183,6 +7443,9 @@
       },
       "musd_conversion": {
         "transaction_fee": "mUSD conversion fees include network costs and may include provider fees. No MetaMask fee applies when you convert to mUSD."
+      },
+      "money_account_deposit": {
+        "transaction_fee": "Money Account deposit fees include network costs and may include provider fees."
       },
       "money_account_withdraw": {
         "transaction_fee": "MetaMask will swap your mUSD for your desired token. Swap providers may charge a fee, but MetaMask won't."
@@ -7273,7 +7536,8 @@
       "buy_button": "Buy crypto",
       "buy_predict": "Add funds to your wallet to use Predictions.",
       "buy_perps": "Add funds to your wallet to use Perps.",
-      "projected_five_year_balance": "Projected 5-year balance:"
+      "projected_balance": "Projected {{projectedYears}}-year balance:",
+      "earn_up_to_apy": "Earn up to {{percentage}}% APY"
     },
     "unlimited": "Unlimited",
     "all": "All",
@@ -7328,7 +7592,18 @@
     "batch_sell_review_title": "Batch Sell Review",
     "batch_sell_select_stablecoin": "Select a stablecoin",
     "batch_sell_total_received": "Total received",
+    "batch_sell_minimum_received": "Minimum received",
+    "batch_sell_quote_details_row": "{{tokenSymbol}} • {{slippage}} slippage",
+    "batch_sell_no_quote_available": "No quote available",
+    "batch_sell_high_price_impact": "High price impact",
+    "batch_sell_high_price_impact_description": "This trade has an estimated {{priceImpact}} price impact, which reflects how much your trade changes the market price. The quote already reflects this.",
     "batch_sell_review": "Review",
+    "batch_sell_searching_best_quotes": "Searching for best quotes",
+    "batch_sell_you_sell": "You sell",
+    "batch_sell_token_count": "{{tokenCount}} tokens",
+    "batch_sell_toggle_you_sell": "Toggle token details",
+    "batch_sell_sell_all": "Sell all",
+    "batch_sell_includes_metamask_fee": "Includes {{fee}}% MetaMask fee",
     "batch_sell_customize_token": "Customize {{tokenSymbol}}",
     "batch_sell_remove_token": "Remove {{tokenSymbol}}",
     "batch_sell_checkbox_label": "Batch Sell token",
@@ -7362,6 +7637,7 @@
     "quote_info_title": "Rate",
     "network_fee_info_title": "Network fee",
     "network_fee_info_content": "Network fees depend on how busy the network is and how complex your transaction is.",
+    "batch_sell_network_fee_info_content": "Network fees depend on how busy the network is and how complex your transaction is. If you don't have enough to cover the fee, we'll take it from the token you're converting to.",
     "network_fee_info_content_sponsored": "This network fee is paid by MetaMask, so you can transact without {{nativeToken}} in your account.",
     "points": "Est. points",
     "points_tooltip": "Points",
@@ -7388,6 +7664,9 @@
     "title": "Bridge",
     "submitting_transaction": "Submitting",
     "fetching_quote": "Fetching quote",
+    "fee_includes": "Includes",
+    "fee_percentage": "{{feePercentage}}%",
+    "fee_percentage_meta_mask": "{{feePercentage}}% MM fee.",
     "fee_disclaimer": "Includes {{feePercentage}}% MetaMask fee.",
     "no_mm_fee": "No MM fee",
     "token_suspicious": "Suspicious",
@@ -7395,6 +7674,16 @@
     "no_mm_fee_disclaimer": "No MetaMask fee swapping into {{destTokenSymbol}}.",
     "hardware_wallet_not_supported": "Hardware wallets aren't supported yet. Use a hot wallet to continue.",
     "hardware_wallet_not_supported_solana": "Hardware wallets aren't supported for Solana yet. Use a hot wallet to continue.",
+    "hardware_wallet_progress": {
+      "approved_token": "Approved {{amount}} {{symbol}}",
+      "approving_token": "Approving {{amount}} {{symbol}}",
+      "send_token": "Send {{amount}} {{symbol}}",
+      "sending_token": "Sending {{amount}} {{symbol}}",
+      "sent_token": "Sent {{amount}} {{symbol}}",
+      "spender_address": "Spender {{address}}",
+      "recipient_address": "Recipient {{address}}",
+      "rejected": "Rejected"
+    },
     "price_impact_info_title": "Price impact",
     "price_impact_info_description": "This is how your trade changes the market price of a token. It depends on the trade size, available liquidity, and provider fees. MetaMask doesn't control price impact.",
     "price_impact_info_gasless_description": "Price impact reflects how your swap order affects the market price of the asset. If you don't hold enough funds for gas, part of your source token is automatically allocated to cover fees, which increases price impact. MetaMask does not influence or control price impact.",
@@ -7489,9 +7778,11 @@
   "account_status": {
     "account_already_exists": "Wallet already exists",
     "account_already_exists_description": "A wallet using \"{{accountName}}\" already exists. Do you want to try logging in instead?",
+    "account_already_exists_telegram_description": "A wallet is already linked to this Telegram account. Do you want to unlock this wallet?",
     "log_in": "Log in",
     "account_not_found": "Wallet not found",
     "account_not_found_description": "We couldn’t find a wallet for \"{{accountName}}\". Do you want to create a new one with this login?",
+    "account_not_found_telegram_description": "We couldn't find a wallet linked to this Telegram account. Do you want to create a new one with this login?",
     "create_new_wallet": "Create a new wallet",
     "use_different_login_method": "Use a different login method",
     "account_already_exists_ios_new_user_description": "A wallet using \"{{accountName}}\" already exists. Do you want to unlock this wallet?",
@@ -8179,7 +8470,16 @@
       "retry": "Try again",
       "on_linea": "on Linea",
       "account_label": "Account",
-      "token_label": "Token"
+      "token_label": "Token",
+      "money_account_label": "Money account",
+      "money_account_token_symbol": "mUSD",
+      "use_money_account_cta": "Use Money account",
+      "spend_and_earn_title": "Spend and earn",
+      "spend_and_earn_description_prefix": "Link your balance to your card and get mUSD back on purchases. Plus, earn up to ",
+      "spend_and_earn_description_apy": "{{apy}}% APY",
+      "spend_and_earn_description_suffix": " (variable) on your balance.",
+      "spend_and_earn_description_no_apy": "Link your balance to your card and get mUSD back on purchases.",
+      "spend_and_earn_cta": "Link card"
     },
     "cashback_screen": {
       "title": "mUSD Back",
@@ -8299,8 +8599,7 @@
     "report_submitted": "Error report has been submitted."
   },
   "pay_with_modal": {
-    "title": "Select payment method",
-    "title_receive": "Select receive token",
+    "modal_title": "Select a token",
     "no_gas": "No native balance for gas",
     "not_supported": "Not supported",
     "crypto": "Crypto"
@@ -8407,14 +8706,33 @@
     },
     "main_title": "Rewards",
     "vip": {
+      "progress_to_next_tier": "{{pointsRemaining}} points to next tier",
       "bps_unit": "bps",
+      "badge_label": "VIP Fox {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
+      "points_label": "Points",
+      "revenue_share_label": "Revenue share",
+      "swap_fees_label": "Swap fees",
+      "perps_fees_label": "Perps fees",
+      "referral_points_label": "Referral points",
+      "points_from_referrals_label": "Points from referrals",
+      "referrals_label": "VIP Referrals",
+      "tier_benefits_title": "Tier benefits",
+      "splash_title": "WELCOME\nTO GOLD\nFOX VIP",
+      "splash_description": "Unlock exclusive perks, early features, and curated rewards. By invitation only.",
+      "splash_accept_invite": "Accept invite",
+      "splash_not_now": "Not now",
+      "next_tier_value": "{{value}} next tier",
+      "equity_rebate_label": "Equity rebate",
+      "equity_rebate_header": "Equity rebate: {{value}}%",
+      "equity_rebate_next_tier": "↑ {{value}}% at next tier",
+      "equity_rebate_top_tier": "Top tier reached.",
       "error_title": "We couldn’t load your VIP dashboard",
       "error_description": "Check your connection and try again.",
       "retry_button": "Retry",
       "tiers_title": "Tiers",
-      "tier_thresholds": "{{swaps}} Swaps • {{perps}} Perps",
+      "tier_thresholds": "{{points}} points",
       "bps_value": "{{bps}} bps"
     },
     "referral_title": "Referrals",
@@ -8517,6 +8835,7 @@
       "show_less": "Show less",
       "linking_progress": "Adding accounts... ({{current}}/{{total}})",
       "accounts_linked_count": "{{linked}}/{{total}} enrolled",
+      "accounts_added": "Accounts added",
       "add_all_accounts": "Add all accounts",
       "environment_selector": "Environment",
       "environment_cancel": "Cancel",
@@ -8541,15 +8860,22 @@
     },
     "optout": {
       "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "description": "This will remove your accounts from the Rewards program and your progress in any campaigns you've joined. Only do this if you are absolutely sure you want to erase your progress.",
+      "erase_button": "Erase progress",
       "modal": {
         "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
+        "confirmation_description": "This will erase all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
+        "type_to_confirm": "Type 'erase progress' to continue",
+        "confirm_phrase": "erase progress",
         "cancel": "Cancel",
         "confirm": "Confirm",
+        "error_title": "Something went wrong",
         "error_message": "Failed to opt out of Rewards. Please try again.",
         "processing": "Processing..."
+      },
+      "request_received": {
+        "title": "Request received",
+        "description": "In about 7 days, your progress will be fully erased. If you made this request by mistake, please contact support through the app."
       }
     },
     "toast_dismiss": "Dismiss",
@@ -8583,7 +8909,10 @@
       },
       "info": {
         "title": "Share your code with friends",
-        "description": "Referral bonuses vary by campaign. Check each one for details."
+        "description": "Referral bonuses vary by campaign. Check each one for details.",
+        "vip_title": "Earn revenue share on every swap and perp your referrals make. Your rate scales with your tier.",
+        "vip_referrals_label": "Referrals",
+        "vip_revenue_share_label": "Revenue share"
       },
       "referral_code_copied": "Referral code copied to clipboard"
     },
@@ -8693,7 +9022,7 @@
       "checking_opt_in_status": "Checking opt in status",
       "swap": "Swap",
       "swap_ondo_assets": "Swap Ondo Assets",
-      "open_position": "Open Position",
+      "open_position": "Trade now",
       "how_it_works": "How it works",
       "ondo": {
         "entries_closed_title": "Entries closed",
@@ -8815,7 +9144,7 @@
       "label_notional_volume": "Notional volume",
       "pending": "Pending",
       "qualified": "Qualified",
-      "open_position_cta": "Open Position",
+      "open_position_cta": "Trade now",
       "leaderboard_title": "Leaderboard",
       "leaderboard_total_participants": "{{count}} participants",
       "last_updated": "Last updated: {{time}}",
@@ -8836,7 +9165,7 @@
       "stats_notional_volume_threshold": "${{amount}} required",
       "stats_qualified_title": "You're qualified",
       "stats_qualified_description": "Keep trading to improve your PnL and climb the leaderboard before the competition ends.",
-      "stats_qualify_for_rank_title": "Qualify for this rank",
+      "stats_qualify_for_rank_title": "Qualify for the leaderboard",
       "stats_qualify_for_rank_description": "Trade {{notionalRemaining}} more in notional volume to become eligible.",
       "stats_error_title": "Unable to load stats",
       "stats_error_description": "We had a problem loading your stats. Please try again.",
@@ -8928,6 +9257,8 @@
       "predict_withdraw": "Withdrawal",
       "money_account_deposit": "Deposit to Money Account",
       "money_account_withdraw": "Transfer from Money Account",
+      "money_account_sent": "Sent {{symbol}}",
+      "money_account_received": "Received",
       "default": "Transaction details"
     },
     "label": {
@@ -8938,9 +9269,16 @@
       "receive_token": "Receive token",
       "retry_button": "Try again",
       "total": "Total",
+      "total_amount": "Total amount",
       "account": "Account",
-      "received_total": "Received total"
+      "received_total": "Received total",
+      "from": "From",
+      "to": "To",
+      "network": "Network",
+      "you_sent": "You sent",
+      "token_received": "Token received"
     },
+    "view_on_block_explorer": "View on block explorer",
     "summary_title": {
       "bridge_approval": "Approve {{approveSymbol}}",
       "bridge_approval_loading": "Approve",
@@ -8978,6 +9316,20 @@
       "title": "Success",
       "description": "Return to the app to continue."
     },
+    "show_cli_link_success": {
+      "title": "MetaMask Agent CLI link successful",
+      "description": "Return to the CLI to continue."
+    },
+    "show_otp": {
+      "title": "Enter this code",
+      "description": "Enter {{otp}} in {{dappName}} to finish connecting. This code expires in {{seconds}} seconds.",
+      "modal_title": "Link MetaMask Agent CLI",
+      "modal_description": "Pair MetaMask Mobile with your MetaMask Agent CLI.",
+      "code_label": "ENTER THIS CODE IN THE CLI",
+      "expires_in": "Expires in {{time}}",
+      "expired": "Code expired",
+      "security_notice": "Securing the connection first. You'll authorize CLI access in the next step"
+    },
     "show_not_found": {
       "title": "Connection Not Found",
       "description": "Please establish a new connection from the app to continue."
@@ -8985,6 +9337,11 @@
     "show_internal_error": {
       "title": "Something went wrong",
       "description": "An unexpected error occurred. Please try again."
+    },
+    "agentic_cli_dashboard_webview": {
+      "title": "Select project",
+      "load_error": "Unable to load approval page.",
+      "closed_error": "Dashboard approval closed."
     },
     "show_method_error": {
       "title": "Request failed",
@@ -9004,6 +9361,8 @@
     "title": "Explore",
     "crypto_movers": "Crypto movers",
     "perps_movers": "Perps movers",
+    "perps_movers_pill_gainers": "Gainers",
+    "perps_movers_pill_losers": "Losers",
     "trending_tokens": "Trending",
     "crypto": "Crypto",
     "stocks": "Stocks",
@@ -9033,7 +9392,7 @@
     "high_to_low": "High to low",
     "low_to_high": "Low to high",
     "apply": "Apply",
-    "search_placeholder": "Search tokens, sites, URLs",
+    "search_placeholder": "Search tokens, markets and URLs",
     "cancel": "Cancel",
     "perps": "Perps",
     "rwa_perps_section": "Perps",
@@ -9046,11 +9405,17 @@
     "crypto_perps_section": "Perps",
     "predictions": "Predictions",
     "no_results": "No results found",
+    "no_results_for_feed": "No {{feedName}} results for \"{{query}}\"",
+    "no_results_for_query": "No results found for \"{{query}}\"",
+    "no_results_check_popular": "Check out other popular assets",
+    "showing_all_results_for": "We found {{count}} other results for \"{{query}}\"",
     "popular": "Popular",
     "sites": "Sites",
     "popular_sites": "Popular sites",
     "search_sites": "Search sites",
     "view_all": "View all",
+    "view_more": "View more",
+    "view_x_more": "View {{count}} more",
     "enable_basic_functionality": "Enable basic functionality",
     "basic_functionality_disabled_title": "Explore is not available",
     "basic_functionality_disabled_description": "We can't fetch the required metadata when basic functionality is disabled.",
@@ -9070,6 +9435,14 @@
       "crypto": "Crypto",
       "sports": "Sports",
       "dapps": "Sites"
+    },
+    "search_tabs": {
+      "all": "All",
+      "crypto": "Crypto",
+      "perps": "Perps",
+      "stocks": "Stocks",
+      "predictions": "Predictions",
+      "sites": "Sites"
     }
   },
   "ota_update_modal": {
@@ -9228,6 +9601,12 @@
       "import_nfts": "Import NFTs",
       "import_nfts_description": "Easily add your collectibles",
       "view_more": "View more",
+      "more": {
+        "title": "More",
+        "import_token": "Import a token",
+        "import_nft": "Import an NFT",
+        "contact_support": "Contact support"
+      },
       "positions": {
         "no_tp_sl": "No TP/SL"
       }
@@ -9256,5 +9635,8 @@
       "social": "Social",
       "other": "Other"
     }
+  },
+  "stepper_card": {
+    "more_information": "More information"
   }
 }


### PR DESCRIPTION
## **Description**

Wires the Ramps buy-limit hooks (PR #31184) into the MM Pay money-account deposit UI: an eligibility gate that hides "Deposit Funds" when the asset is unsupported in the user's region, and an inline amount-limit alert that blocks Continue until the entered amount is valid.

**Stacks on:** `feat/ramps-fiat-deposit-hooks` (PR #31184). Merge that first.

### Eligibility gate — `MoneyAddMoneySheet`

Replaces the UB1 `rampRoutingDecision` check with `useCanFiatDepositAsset`. The "Deposit Funds" row is shown only when the flag is on **and** a provider supports the deposit asset in the user's region. The asset is resolved from `confirmations_pay_fiat.assetPerTransactionType.moneyAccountDeposit` (mUSD in the current env).

- India + onramp.money + mUSD unsupported → "Deposit Funds" hidden. ✓
- Supported region → shown and enabled. ✓
- Fails closed while loading (returns `false` until the query settles). ✓

### Amount-limit alert — `useFiatBuyLimitAlert`

New blocking alert (`AlertKeys.FiatBuyAmountLimit`) that validates the entered fiat amount against the provider's `limits.fiat[currency][paymentMethodId]` buy limits.

- Shows **"Amount out of range"** as the row title and the specific error (e.g. "Minimum $20" or "Maximum $500") in the red `AlertMessage` box **above** the Continue button — matching the placement of all other amount-validation alerts.
- Continue is disabled until valid.
- Also surfaces a backend `LIMIT_EXCEEDED` message from `fiatPayment.quoteError` as a fallback when the provider has no structured limit catalog (UB2 parity).
- Wired into `usePendingAmountAlerts`, `useConfirmationAlerts`, `useTransactionCustomAmountAlerts`, and `useConfirmationAlertMetrics`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MetaMask/core#9029, MetaMask/core#9030

## **Manual testing steps**

```gherkin
Feature: MM Pay fiat deposit eligibility gate

  Scenario: deposit hidden in unsupported region
    Given the user's region is India (IN)
    And mUSD has no on-ramp provider in India
    When user opens the Add Money sheet
    Then the "Deposit Funds" option is not shown

  Scenario: deposit shown in supported region
    Given the user's region is US or EU
    When user opens the Add Money sheet
    Then the "Deposit Funds" option is visible

Feature: Fiat deposit amount-limit validation

  Scenario: amount below minimum
    Given the user is on the fiat deposit custom-amount screen
    When the user enters an amount below the provider minimum (e.g. $5 when min is $20)
    Then an error appears above Continue: "Amount out of range" / "Minimum $20"
    And Continue is disabled

  Scenario: amount above maximum
    When the user enters an amount above the provider maximum (e.g. $600 when max is $500)
    Then an error appears above Continue: "Amount out of range" / "Maximum $500"
    And Continue is disabled

  Scenario: valid amount
    When the user enters a valid amount within the provider's limits
    Then no limit error is shown
    And Continue is enabled
```

## **Screenshots/Recordings**

### **Before**

Deposit Funds shown regardless of region. No amount validation before quoting.

### **After**

<!-- Add screenshots showing the gate + the error above Continue -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.