### PR TITLE
feat: remove env variable hiding money option for perps/predict transactions

### DIFF
--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -586,143 +586,47 @@ describe('selectMetaMaskPayFlags extended flags', () => {
     );
   });
 
-  describe('enablePerpsMoneyAccountTransactions', () => {
-    afterEach(() => {
-      delete process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED;
-    });
+  it('returns default enablePerpsMoneyAccountTransactions when flag is absent', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
 
-    it('returns default (false) when flag is absent and env var is unset', () => {
-      const state = cloneDeep(mockedEmptyFlagsState);
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
-      ).toEqual(PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
-    });
-
-    it('returns false when remote flag is true but env var is unset', () => {
-      const state = cloneDeep(mockedEmptyFlagsState);
-      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
-        {
-          confirmations_pay_extended: {
-            enablePerpsMoneyAccountTransactions: true,
-          },
-        };
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
-      ).toBe(false);
-    });
-
-    it('returns false when env var is true but remote flag is absent', () => {
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'true';
-
-      const state = cloneDeep(mockedEmptyFlagsState);
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
-      ).toBe(false);
-    });
-
-    it('returns true when both env var and remote flag are true', () => {
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'true';
-
-      const state = cloneDeep(mockedEmptyFlagsState);
-      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
-        {
-          confirmations_pay_extended: {
-            enablePerpsMoneyAccountTransactions: true,
-          },
-        };
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
-      ).toBe(true);
-    });
-
-    it('returns false when env var is set to a non-true value', () => {
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'false';
-
-      const state = cloneDeep(mockedEmptyFlagsState);
-      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
-        {
-          confirmations_pay_extended: {
-            enablePerpsMoneyAccountTransactions: true,
-          },
-        };
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
-      ).toBe(false);
-    });
+    expect(
+      selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+    ).toEqual(PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
   });
 
-  describe('enablePredictMoneyAccountTransactions', () => {
-    afterEach(() => {
-      delete process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED;
-    });
+  it('returns enablePerpsMoneyAccountTransactions from flag value', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay_extended: {
+          enablePerpsMoneyAccountTransactions: true,
+        },
+      };
 
-    it('returns default (false) when flag is absent and env var is unset', () => {
-      const state = cloneDeep(mockedEmptyFlagsState);
+    expect(
+      selectMetaMaskPayFlags(state).enablePerpsMoneyAccountTransactions,
+    ).toBe(true);
+  });
 
-      expect(
-        selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
-      ).toEqual(PAY_ENABLE_PREDICT_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
-    });
+  it('returns default enablePredictMoneyAccountTransactions when flag is absent', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
 
-    it('returns false when remote flag is true but env var is unset', () => {
-      const state = cloneDeep(mockedEmptyFlagsState);
-      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
-        {
-          confirmations_pay_extended: {
-            enablePredictMoneyAccountTransactions: true,
-          },
-        };
+    expect(
+      selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
+    ).toEqual(PAY_ENABLE_PREDICT_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
+  });
 
-      expect(
-        selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
-      ).toBe(false);
-    });
+  it('returns enablePredictMoneyAccountTransactions from flag value', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmations_pay_extended: {
+          enablePredictMoneyAccountTransactions: true,
+        },
+      };
 
-    it('returns false when env var is true but remote flag is absent', () => {
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'true';
-
-      const state = cloneDeep(mockedEmptyFlagsState);
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
-      ).toBe(false);
-    });
-
-    it('returns true when both env var and remote flag are true', () => {
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'true';
-
-      const state = cloneDeep(mockedEmptyFlagsState);
-      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
-        {
-          confirmations_pay_extended: {
-            enablePredictMoneyAccountTransactions: true,
-          },
-        };
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
-      ).toBe(true);
-    });
-
-    it('returns false when env var is set to a non-true value', () => {
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED = 'false';
-
-      const state = cloneDeep(mockedEmptyFlagsState);
-      state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
-        {
-          confirmations_pay_extended: {
-            enablePredictMoneyAccountTransactions: true,
-          },
-        };
-
-      expect(
-        selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
-      ).toBe(false);
-    });
+    expect(
+      selectMetaMaskPayFlags(state).enablePredictMoneyAccountTransactions,
+    ).toBe(true);
   });
 });

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -130,14 +130,12 @@ export const selectMetaMaskPayFlags = createSelector(
       PAY_ENABLE_DEPOSIT_WALLET_WITHDRAW_DEFAULT;
 
     const enablePerpsMoneyAccountTransactions =
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED === 'true' &&
-      ((metaMaskPayExtendedFlags?.enablePerpsMoneyAccountTransactions as boolean) ??
-        PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
+      (metaMaskPayExtendedFlags?.enablePerpsMoneyAccountTransactions as boolean) ??
+      PAY_ENABLE_PERPS_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT;
 
     const enablePredictMoneyAccountTransactions =
-      process.env.MONEY_ACCOUNT_PERPS_PREDICT_ENABLED === 'true' &&
-      ((metaMaskPayExtendedFlags?.enablePredictMoneyAccountTransactions as boolean) ??
-        PAY_ENABLE_PREDICT_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT);
+      (metaMaskPayExtendedFlags?.enablePredictMoneyAccountTransactions as boolean) ??
+      PAY_ENABLE_PREDICT_MONEY_ACCOUNT_TRANSACTIONS_DEFAULT;
 
     return {
       attemptsMax,

--- a/package.json
+++ b/package.json
@@ -344,7 +344,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^66.0.0",
-    "@metamask/transaction-pay-controller": "^23.1.0",
+    "@metamask/transaction-pay-controller": "^23.2.0",
     "@metamask/tron-wallet-snap": "^1.25.6",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7879,7 +7879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^8.2.0, @metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.2":
+"@metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.2":
   version: 8.3.2
   resolution: "@metamask/assets-controller@npm:8.3.2"
   dependencies:
@@ -7916,7 +7916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^108.3.0, @metamask/assets-controllers@npm:^108.4.0, @metamask/assets-controllers@npm:^108.5.0":
+"@metamask/assets-controllers@npm:^108.4.0, @metamask/assets-controllers@npm:^108.5.0":
   version: 108.5.0
   resolution: "@metamask/assets-controllers@npm:108.5.0"
   dependencies:
@@ -8114,7 +8114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^72.0.0, @metamask/bridge-status-controller@npm:^72.0.2":
+"@metamask/bridge-status-controller@npm:^72.0.2":
   version: 72.0.2
   resolution: "@metamask/bridge-status-controller@npm:72.0.2"
   dependencies:
@@ -9700,15 +9700,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "@metamask/ramps-controller@npm:14.1.0"
+"@metamask/ramps-controller@npm:^14.1.0, @metamask/ramps-controller@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "@metamask/ramps-controller@npm:14.1.1"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/profile-sync-controller": "npm:^28.1.1"
-  checksum: 10/248112e5dc9258b2cda77f89eb63ad9cc13d9632df9b8b5ac112f54951c3e8e8ae797ba7462a57f084fa22fc00a68eb13d9b78f534659ad833baffa49a0abfc7
+  checksum: 10/f018f6514e2bd336d13225e1df1f48a07f487ea7de26cdd72b1fe03e337c1ce0473f9b025c01ee37f1936141e222039b99930dce0474aa7b74b65fa97aa373a6
   languageName: node
   linkType: hard
 
@@ -10433,32 +10433,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^23.1.0":
-  version: 23.1.0
-  resolution: "@metamask/transaction-pay-controller@npm:23.1.0"
+"@metamask/transaction-pay-controller@npm:^23.2.0":
+  version: 23.2.0
+  resolution: "@metamask/transaction-pay-controller@npm:23.2.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/assets-controller": "npm:^8.2.0"
-    "@metamask/assets-controllers": "npm:^108.3.0"
+    "@metamask/assets-controller": "npm:^8.3.2"
+    "@metamask/assets-controllers": "npm:^108.5.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^73.2.0"
-    "@metamask/bridge-status-controller": "npm:^72.0.0"
+    "@metamask/bridge-controller": "npm:^73.2.1"
+    "@metamask/bridge-status-controller": "npm:^72.0.2"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/ramps-controller": "npm:^14.1.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.1"
-    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/ramps-controller": "npm:^14.1.1"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/transaction-controller": "npm:^67.0.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/67269d459f4c95bf7416a7ebf1e35d5b2195733e7b638f54a63deb3a907fcd528973a07cfc4cb79e4c5cd324d4ed92e4f01a74283af749f19ded652e3aab2e90
+  checksum: 10/4d4e9f060eebc0c131ee7cd287f467138ea39164d40d301c7c71abef31f61c3294e0f6f9608e43c9b6ea277cb1ba7edc5551d179402a4ca8b5af69af62fc2867
   languageName: node
   linkType: hard
 
@@ -35467,7 +35468,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^66.0.0"
-    "@metamask/transaction-pay-controller": "npm:^23.1.0"
+    "@metamask/transaction-pay-controller": "npm:^23.2.0"
     "@metamask/tron-wallet-snap": "npm:^1.25.6"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^2.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

The PR updated transaction-pay-controller and remove env variable hiding money option on perps / predict pages.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1407

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling money-account flows on perps/predict can now happen whenever remote flags are on, without a separate env kill-switch; rollout depends on feature-flag configuration.
> 
> **Overview**
> Removes the build-time gate **`MONEY_ACCOUNT_PERPS_PREDICT_ENABLED`** so **perps** and **predict** money-account transaction options follow **`confirmations_pay_extended`** remote flags only (with existing defaults when flags are absent).
> 
> **`selectMetaMaskPayFlags`** no longer ANDs those booleans with the env var; **`enablePerpsMoneyAccountTransactions`** and **`enablePredictMoneyAccountTransactions`** now mirror other extended pay flags. Unit tests drop env-var matrix cases and assert default vs remote-flag behavior only.
> 
> Bumps **`@metamask/transaction-pay-controller`** from `^23.1.0` to **`^23.2.0`** (lockfile pulls related controller updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 828690a82553b84ddaeed19a4a4676f430c8c5d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->