### PR TITLE
feat: animated toggle

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
@@ -39,7 +39,8 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
   const { tradeMode, setTradeMode, hasSellableBalance } = useQuickBuyContext();
   const { colors } = useTheme();
   const slideAnim = useRef(new Animated.Value(0)).current;
-  const [itemWidth, setItemWidth] = useState(0);
+  const [buyWidth, setBuyWidth] = useState(0);
+  const [sellWidth, setSellWidth] = useState(0);
 
   const handlePress = (mode: QuickBuyTradeMode) => {
     if (tradeMode !== mode) {
@@ -48,15 +49,19 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
     }
   };
 
+  // buyWidth is the translateX offset for the sell position regardless of active mode.
+  // sellWidth is only used for the slider pill width when sell is active.
   useEffect(() => {
-    if (itemWidth === 0) return;
+    if (buyWidth === 0) return;
     Animated.spring(slideAnim, {
-      toValue: tradeMode === 'buy' ? 0 : itemWidth,
+      toValue: tradeMode === 'buy' ? 0 : buyWidth,
       useNativeDriver: true,
       tension: 180,
       friction: 20,
     }).start();
-  }, [tradeMode, itemWidth, slideAnim]);
+  }, [tradeMode, buyWidth, slideAnim]);
+
+  const sliderWidth = tradeMode === 'buy' ? buyWidth : sellWidth;
 
   return (
     <Box
@@ -65,12 +70,12 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
       testID={testID}
       style={styles.container}
     >
-      {itemWidth > 0 && (
+      {sliderWidth > 0 && (
         <Animated.View
           style={[
             styles.slider,
             {
-              width: itemWidth,
+              width: sliderWidth,
               backgroundColor: colors.background.muted,
               transform: [{ translateX: slideAnim }],
             },
@@ -80,9 +85,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
 
       <TouchableOpacity
         onPress={() => handlePress('buy')}
-        onLayout={(e) => {
-          if (itemWidth === 0) setItemWidth(e.nativeEvent.layout.width);
-        }}
+        onLayout={(e) => setBuyWidth(e.nativeEvent.layout.width)}
         accessibilityRole="button"
         accessibilityState={{ selected: tradeMode === 'buy' }}
         testID="quick-buy-trade-mode-buy"
@@ -103,6 +106,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
       <TouchableOpacity
         onPress={() => handlePress('sell')}
         disabled={!hasSellableBalance}
+        onLayout={(e) => setSellWidth(e.nativeEvent.layout.width)}
         accessibilityRole="button"
         accessibilityState={{
           selected: tradeMode === 'sell',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
@@ -1,5 +1,10 @@
 import React, { useRef, useEffect, useState } from 'react';
-import { TouchableOpacity, Animated, StyleSheet } from 'react-native';
+import {
+  TouchableOpacity,
+  Animated,
+  StyleSheet,
+  type LayoutRectangle,
+} from 'react-native';
 import {
   Box,
   BoxFlexDirection,
@@ -14,17 +19,12 @@ import type { QuickBuyTradeMode } from '../types';
 import { useTheme } from '../../../../../../../util/theme';
 import { playSelection } from '../../../../../../../util/haptics';
 
-const TOGGLE_PADDING = 4;
-
 const styles = StyleSheet.create({
   container: {
     position: 'relative',
   },
   slider: {
     position: 'absolute',
-    top: TOGGLE_PADDING,
-    bottom: TOGGLE_PADDING,
-    left: TOGGLE_PADDING,
     borderRadius: 10,
   },
 });
@@ -39,7 +39,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
   const { tradeMode, setTradeMode, hasSellableBalance } = useQuickBuyContext();
   const { colors } = useTheme();
   const slideAnim = useRef(new Animated.Value(0)).current;
-  const [buyWidth, setBuyWidth] = useState(0);
+  const [buyLayout, setBuyLayout] = useState<LayoutRectangle | null>(null);
   const [sellWidth, setSellWidth] = useState(0);
 
   const handlePress = (mode: QuickBuyTradeMode) => {
@@ -49,19 +49,17 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
     }
   };
 
-  // buyWidth is the translateX offset for the sell position regardless of active mode.
-  // sellWidth is only used for the slider pill width when sell is active.
   useEffect(() => {
-    if (buyWidth === 0) return;
+    if (!buyLayout) return;
     Animated.spring(slideAnim, {
-      toValue: tradeMode === 'buy' ? 0 : buyWidth,
+      toValue: tradeMode === 'buy' ? 0 : buyLayout.width,
       useNativeDriver: true,
       tension: 180,
       friction: 20,
     }).start();
-  }, [tradeMode, buyWidth, slideAnim]);
+  }, [tradeMode, buyLayout, slideAnim]);
 
-  const sliderWidth = tradeMode === 'buy' ? buyWidth : sellWidth;
+  const sliderWidth = tradeMode === 'buy' ? (buyLayout?.width ?? 0) : sellWidth;
 
   return (
     <Box
@@ -70,11 +68,14 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
       testID={testID}
       style={styles.container}
     >
-      {sliderWidth > 0 && (
+      {buyLayout && sliderWidth > 0 && (
         <Animated.View
           style={[
             styles.slider,
             {
+              left: buyLayout.x,
+              top: buyLayout.y,
+              height: buyLayout.height,
               width: sliderWidth,
               backgroundColor: colors.background.muted,
               transform: [{ translateX: slideAnim }],
@@ -85,7 +86,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
 
       <TouchableOpacity
         onPress={() => handlePress('buy')}
-        onLayout={(e) => setBuyWidth(e.nativeEvent.layout.width)}
+        onLayout={(e) => setBuyLayout(e.nativeEvent.layout)}
         accessibilityRole="button"
         accessibilityState={{ selected: tradeMode === 'buy' }}
         testID="quick-buy-trade-mode-buy"

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import React, { useRef, useEffect, useState } from 'react';
+import { TouchableOpacity, Animated, StyleSheet } from 'react-native';
 import {
   Box,
   BoxFlexDirection,
@@ -11,6 +11,23 @@ import {
 import { strings } from '../../../../../../../../locales/i18n';
 import { useQuickBuyContext } from '../useQuickBuyContext';
 import type { QuickBuyTradeMode } from '../types';
+import { useTheme } from '../../../../../../../util/theme';
+import { playSelection } from '../../../../../../../util/haptics';
+
+const TOGGLE_PADDING = 4;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+  },
+  slider: {
+    position: 'absolute',
+    top: TOGGLE_PADDING,
+    bottom: TOGGLE_PADDING,
+    left: TOGGLE_PADDING,
+    borderRadius: 10,
+  },
+});
 
 interface QuickBuyTradeModeToggleProps {
   testID?: string;
@@ -20,28 +37,57 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
   testID = 'quick-buy-trade-mode-toggle',
 }) => {
   const { tradeMode, setTradeMode, hasSellableBalance } = useQuickBuyContext();
+  const { colors } = useTheme();
+  const slideAnim = useRef(new Animated.Value(0)).current;
+  const [itemWidth, setItemWidth] = useState(0);
 
   const handlePress = (mode: QuickBuyTradeMode) => {
     if (tradeMode !== mode) {
+      playSelection();
       setTradeMode(mode);
     }
   };
+
+  useEffect(() => {
+    if (itemWidth === 0) return;
+    Animated.spring(slideAnim, {
+      toValue: tradeMode === 'buy' ? 0 : itemWidth,
+      useNativeDriver: true,
+      tension: 180,
+      friction: 20,
+    }).start();
+  }, [tradeMode, itemWidth, slideAnim]);
 
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
       twClassName="border border-muted rounded-xl p-1"
       testID={testID}
+      style={styles.container}
     >
+      {itemWidth > 0 && (
+        <Animated.View
+          style={[
+            styles.slider,
+            {
+              width: itemWidth,
+              backgroundColor: colors.background.muted,
+              transform: [{ translateX: slideAnim }],
+            },
+          ]}
+        />
+      )}
+
       <TouchableOpacity
         onPress={() => handlePress('buy')}
+        onLayout={(e) => {
+          if (itemWidth === 0) setItemWidth(e.nativeEvent.layout.width);
+        }}
         accessibilityRole="button"
         accessibilityState={{ selected: tradeMode === 'buy' }}
         testID="quick-buy-trade-mode-buy"
       >
-        <Box
-          twClassName={`rounded-[10px] px-3 py-1 ${tradeMode === 'buy' ? 'bg-muted' : ''}`}
-        >
+        <Box twClassName="rounded-[10px] px-3 py-1">
           <Text
             variant={TextVariant.BodySm}
             fontWeight={
@@ -65,7 +111,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
         testID="quick-buy-trade-mode-sell"
       >
         <Box
-          twClassName={`rounded-[10px] px-3 py-1 ${tradeMode === 'sell' ? 'bg-muted' : ''} ${!hasSellableBalance ? 'opacity-40' : ''}`}
+          twClassName={`rounded-[10px] px-3 py-1 ${!hasSellableBalance ? 'opacity-40' : ''}`}
         >
           <Text
             variant={TextVariant.BodySm}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Animates the Quickbuy mode toggle so that it slides nicely when picking the option. 


https://github.com/user-attachments/assets/44004018-1bd9-4d1b-85f2-91325f25df49



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Refs: TSA-607

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

N/A — simple change

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

n/a

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

n/a
<!-- [screenshots/recordings] -->

### **After**

n/a
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in Quick Buy with no trade logic or API changes; minor layout-measurement edge cases on first render are the main regression risk.
> 
> **Overview**
> The Social Leaderboard **Quick Buy** buy/sell mode control no longer toggles a static `bg-muted` highlight on each segment. It now uses a single **sliding pill** (`Animated.View`) that springs between Buy and Sell, sized from `onLayout` on each option.
> 
> **Selection feedback** adds `playSelection()` haptics when the mode changes, and the active background comes from `useTheme()` (`colors.background.muted`) instead of per-segment Tailwind classes. Sell stays disabled with reduced opacity when there is no sellable balance; font weight still reflects the selected mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3601c714fa54154abe0fb0bce5fa527e6d41f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->