### PR TITLE
fix: use the correct feature flag name for chomp config

### DIFF
--- a/app/core/Engine/controllers/chomp-api-service-init.test.ts
+++ b/app/core/Engine/controllers/chomp-api-service-init.test.ts
@@ -46,7 +46,7 @@ describe('chompApiServiceInit', () => {
     const { controller } = chompApiServiceInit(
       getInitRequestMock({
         remoteFeatureFlags: {
-          earnChompApiConfig: { baseUrl: 'https://chomp.example.com' },
+          moneyAccountChompConfig: { baseUrl: 'https://chomp.example.com' },
         },
       }),
     );
@@ -58,7 +58,7 @@ describe('chompApiServiceInit', () => {
     chompApiServiceInit(
       getInitRequestMock({
         remoteFeatureFlags: {
-          earnChompApiConfig: { baseUrl: 'https://chomp.example.com' },
+          moneyAccountChompConfig: { baseUrl: 'https://chomp.example.com' },
         },
       }),
     );
@@ -96,7 +96,7 @@ describe('chompApiServiceInit', () => {
       chompApiServiceInit(
         getInitRequestMock({
           remoteFeatureFlags: {
-            earnChompApiConfig: { baseUrl: 'https://chomp.example.com' },
+            moneyAccountChompConfig: { baseUrl: 'https://chomp.example.com' },
           },
         }),
       );

--- a/app/core/Engine/controllers/chomp-api-service-init.ts
+++ b/app/core/Engine/controllers/chomp-api-service-init.ts
@@ -49,7 +49,7 @@ export const chompApiServiceInit: MessengerClientInitFunction<
       'RemoteFeatureFlagController:getState',
     );
     const chompApiConfig = parseChompApiConfig(
-      featureState.remoteFeatureFlags?.earnChompApiConfig,
+      featureState.remoteFeatureFlags?.moneyAccountChompConfig,
     );
 
     if (chompApiConfig) {

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -2982,12 +2982,12 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  earnChompApiConfig: {
-    name: 'earnChompApiConfig',
+  moneyAccountChompConfig: {
+    name: 'moneyAccountChompConfig',
     type: FeatureFlagType.Remote,
     inProd: false,
     productionDefault: {
-      baseUrl: 'https://chomp.dev-api.cx.metamask.io',
+      baseUrl: 'https://chomp.api.cx.metamask.io',
     },
     status: FeatureFlagStatus.Active,
   },

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -2982,16 +2982,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  moneyAccountChompConfig: {
-    name: 'moneyAccountChompConfig',
-    type: FeatureFlagType.Remote,
-    inProd: false,
-    productionDefault: {
-      baseUrl: 'https://chomp.api.cx.metamask.io',
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
   earnFeatureFlagTemplate: {
     name: 'earnFeatureFlagTemplate',
     type: FeatureFlagType.Remote,
@@ -4573,7 +4563,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      baseUrl: 'https://chomp.dev-api.cx.metamask.io',
+      baseUrl: 'https://chomp.api.cx.metamask.io',
     },
     status: FeatureFlagStatus.Active,
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**
The feature flag name in the chomp service init didn't match the state in launch darkly.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: use correct chomp api feature flag name

## **Related issues**
Fixes: There is no JIRA ticket for this work
<!-- mms-check: type=issue-link required=true -->


## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->
N/A

## **Screenshots/Recordings**
N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong flag name could have left production on the dev Chomp fallback; the registry URL change affects E2E mocks and any path that relied on the old dev default for that flag.
> 
> **Overview**
> **Chomp API base URL** now reads remote config from `moneyAccountChompConfig` instead of `earnChompApiConfig`, matching LaunchDarkly / client-config.
> 
> `chompApiServiceInit` and its unit tests use the new flag key. The E2E feature-flag registry drops the stray `earnChompApiConfig` entry and sets `moneyAccountChompConfig`’s production default `baseUrl` to `https://chomp.api.cx.metamask.io` (was the dev host).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29a005fb28af6ff65b62a176c0fc7cad12899cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->