### PR TITLE
feat: implement native fiat provider checks and update MoneyAddMoneyS…

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -8,6 +8,7 @@ import { useMusdBalance } from '../../../Earn/hooks/useMusdBalance';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
 import {
   getRampRoutingDecision,
   UnifiedRampRoutingType,
@@ -51,6 +52,10 @@ jest.mock(
 jest.mock('../../../../../selectors/tokenBalancesController', () => ({
   ...jest.requireActual('../../../../../selectors/tokenBalancesController'),
   selectHasAnyNonZeroTokenBalance: jest.fn(),
+}));
+
+jest.mock('../../../Ramp/hooks/useHasNativeFiatProvider', () => ({
+  useHasNativeFiatProvider: jest.fn(),
 }));
 
 jest.mock('../../../../../reducers/fiatOrders', () => ({
@@ -107,6 +112,7 @@ describe('MoneyAddMoneySheet', () => {
     (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
       true,
     );
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
     (getRampRoutingDecision as jest.Mock).mockReturnValue(null);
   });
 
@@ -335,50 +341,101 @@ describe('MoneyAddMoneySheet', () => {
     ).toBeNull();
   });
 
-  it('shows the Deposit funds option when the ramp routing decision is DEPOSIT', () => {
-    (getRampRoutingDecision as jest.Mock).mockReturnValue(
-      UnifiedRampRoutingType.DEPOSIT,
+  it('shows the Deposit funds option enabled when a native provider is available', () => {
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
     );
 
-    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
-
-    expect(
-      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
-    ).toBeOnTheScreen();
+    expect(mockInitiateDeposit).toHaveBeenCalledWith({
+      autoSelectFiatPayment: true,
+    });
   });
 
-  it('shows the Deposit funds option when the ramp routing decision is AGGREGATOR', () => {
-    (getRampRoutingDecision as jest.Mock).mockReturnValue(
-      UnifiedRampRoutingType.AGGREGATOR,
+  it('shows the Deposit funds option disabled with "Coming soon" when no native provider serves the region', () => {
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(false);
+
+    const { getByTestId, getAllByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
     );
 
-    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
-
-    expect(
+    fireEvent.press(
       getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows the Deposit funds option when the ramp routing decision is null (fail-open)', () => {
-    (getRampRoutingDecision as jest.Mock).mockReturnValue(null);
-
-    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
-
-    expect(
-      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows the Deposit funds option when the ramp routing decision is ERROR (fail-open)', () => {
-    (getRampRoutingDecision as jest.Mock).mockReturnValue(
-      UnifiedRampRoutingType.ERROR,
     );
 
-    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+    // Two "Coming soon" tags now: the disabled Deposit row + Receive external.
+    expect(getAllByText('Coming soon')).toHaveLength(2);
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockInitiateDeposit).not.toHaveBeenCalled();
+  });
 
-    expect(
-      getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
-    ).toBeOnTheScreen();
+  // Returns the option-row testIDs in rendered order. Each row carries its
+  // testID on both the composite TouchableOpacity and its host view, so we
+  // dedupe to first occurrence (which preserves render order).
+  const getOptionOrder = (
+    root: ReturnType<typeof renderWithProvider>['UNSAFE_root'],
+  ): string[] => {
+    const optionTestIds: string[] = [
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+      MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+    ];
+    const seen = new Set<string>();
+    return root
+      .findAll((node) => optionTestIds.includes(node.props.testID))
+      .map((node) => node.props.testID as string)
+      .filter((id) => {
+        if (seen.has(id)) {
+          return false;
+        }
+        seen.add(id);
+        return true;
+      });
+  };
+
+  it('keeps the original order when all options are enabled', () => {
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(true);
+
+    const { UNSAFE_root } = renderWithProvider(<MoneyAddMoneySheet />);
+    const order = getOptionOrder(UNSAFE_root);
+
+    expect(order).toEqual([
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+      MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+    ]);
+  });
+
+  it('moves the disabled Deposit funds (Coming soon) row to the bottom of the options', () => {
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(false);
+
+    const { UNSAFE_root } = renderWithProvider(<MoneyAddMoneySheet />);
+    const order = getOptionOrder(UNSAFE_root);
+
+    expect(order).toEqual([
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+    ]);
+  });
+
+  it('groups multiple disabled options at the bottom preserving their relative order', () => {
+    (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+    (useHasNativeFiatProvider as jest.Mock).mockReturnValue(false);
+
+    const { UNSAFE_root } = renderWithProvider(<MoneyAddMoneySheet />);
+    const order = getOptionOrder(UNSAFE_root);
+
+    expect(order).toEqual([
+      MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+    ]);
   });
 
   it('initiates a deposit pre-selecting mUSD on the highest-balance chain when Move mUSD is pressed', () => {

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -30,6 +30,7 @@ import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
 import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { useHasNativeFiatProvider } from '../../../Ramp/hooks/useHasNativeFiatProvider';
 import {
   getRampRoutingDecision,
   UnifiedRampRoutingType,
@@ -45,6 +46,7 @@ interface Option {
   onPress: () => void;
   testID: string;
   disabled?: boolean;
+  comingSoon?: boolean;
 }
 
 const MoneyAddMoneySheet: React.FC = () => {
@@ -64,6 +66,7 @@ const MoneyAddMoneySheet: React.FC = () => {
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const hasAnyCryptoBalance = useSelector(selectHasAnyNonZeroTokenBalance);
   const rampRoutingDecision = useSelector(getRampRoutingDecision);
+  const hasNativeFiatProvider = useHasNativeFiatProvider();
   const isFiatDepositEnabled = useMemo(
     () => enabledTransactionTypes.includes(TransactionType.moneyAccountDeposit),
     [enabledTransactionTypes],
@@ -148,6 +151,8 @@ const MoneyAddMoneySheet: React.FC = () => {
             icon: IconName.AttachMoney,
             onPress: handleDepositFunds,
             testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+            disabled: !hasNativeFiatProvider,
+            comingSoon: !hasNativeFiatProvider,
           },
         ]
       : []),
@@ -166,6 +171,11 @@ const MoneyAddMoneySheet: React.FC = () => {
     },
   ];
 
+  const orderedOptions: Option[] = [
+    ...options.filter((option) => !option.disabled),
+    ...options.filter((option) => option.disabled),
+  ];
+
   return (
     <BottomSheet
       ref={sheetRef}
@@ -180,7 +190,7 @@ const MoneyAddMoneySheet: React.FC = () => {
         </Text>
       </BottomSheetHeader>
       <View style={styles.list}>
-        {options.map((item) => (
+        {orderedOptions.map((item) => (
           <TouchableOpacity
             key={item.testID}
             disabled={item.disabled}
@@ -195,24 +205,40 @@ const MoneyAddMoneySheet: React.FC = () => {
                 item.disabled ? IconColor.IconMuted : IconColor.IconDefault
               }
             />
-            <View style={styles.rowLabelContainer}>
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={item.disabled ? TextColor.TextAlternative : undefined}
-              >
-                {item.label}
-              </Text>
-              {item.description ? (
+            {item.comingSoon ? (
+              <View style={styles.disabledRowContent}>
                 <Text
-                  variant={TextVariant.BodySm}
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
                   color={TextColor.TextAlternative}
-                  testID={item.descriptionTestID}
                 >
-                  {item.description}
+                  {item.label}
                 </Text>
-              ) : null}
-            </View>
+                <Tag
+                  label={strings('money.add_money_sheet.coming_soon')}
+                  style={styles.comingSoonTag}
+                />
+              </View>
+            ) : (
+              <View style={styles.rowLabelContainer}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={item.disabled ? TextColor.TextAlternative : undefined}
+                >
+                  {item.label}
+                </Text>
+                {item.description ? (
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                    testID={item.descriptionTestID}
+                  >
+                    {item.description}
+                  </Text>
+                ) : null}
+              </View>
+            )}
           </TouchableOpacity>
         ))}
         <View

--- a/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.test.ts
+++ b/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useHasNativeFiatProvider } from './useHasNativeFiatProvider';
+import { useRampsProviders } from './useRampsProviders';
+
+jest.mock('./useRampsProviders');
+
+describe('useHasNativeFiatProvider', () => {
+  const useRampsProvidersMock = jest.mocked(useRampsProviders);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function mockProviders(providers: unknown[]) {
+    useRampsProvidersMock.mockReturnValue({
+      providers,
+    } as unknown as ReturnType<typeof useRampsProviders>);
+  }
+
+  it('returns true when a native provider exists', () => {
+    mockProviders([
+      { id: '/providers/transak', type: 'aggregator' },
+      { id: '/providers/transak-native', type: 'native' },
+    ]);
+    const { result } = renderHook(() => useHasNativeFiatProvider());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when only aggregator providers exist', () => {
+    mockProviders([{ id: '/providers/transak', type: 'aggregator' }]);
+    const { result } = renderHook(() => useHasNativeFiatProvider());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the provider list is empty', () => {
+    mockProviders([]);
+    const { result } = renderHook(() => useHasNativeFiatProvider());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when provider type is absent (pre-v2 catalog)', () => {
+    mockProviders([{ id: '/providers/transak' }]);
+    const { result } = renderHook(() => useHasNativeFiatProvider());
+    expect(result.current).toBe(false);
+  });
+});

--- a/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts
+++ b/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts
@@ -1,0 +1,19 @@
+import { useRampsProviders } from './useRampsProviders';
+
+/**
+ * Returns whether the user's region has at least one NATIVE fiat on-ramp
+ * provider (e.g. Transak Native).
+ *
+ * Headless fiat deposit (MM Pay / Money Account, Perps, Predict) is only
+ * supported on native providers for v0, so consumers use this to gate the
+ * fiat payment option where no native provider serves the region (e.g.
+ * Brazil, which only exposes the aggregator). Read-only — it never mutates
+ * provider selection or any controller state, so it has no effect on the
+ * standalone Buy flows.
+ */
+export function useHasNativeFiatProvider(): boolean {
+  const { providers } = useRampsProviders();
+  return providers.some((provider) => provider.type === 'native');
+}
+
+export default useHasNativeFiatProvider;

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -133,6 +133,10 @@ jest.mock('../../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   }),
 }));
 
+jest.mock('../../../../../UI/Ramp/hooks/useHasNativeFiatProvider', () => ({
+  useHasNativeFiatProvider: () => true,
+}));
+
 jest.mock('../../../../../UI/Ramp/hooks/useRampsPaymentMethods', () => ({
   useRampsPaymentMethods: () => ({
     paymentMethods: [],

--- a/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatPaymentHighlightedActions.test.ts
@@ -11,6 +11,9 @@ import Engine from '../../../../../core/Engine';
 jest.mock('./useMMPayFiatConfig');
 jest.mock('./useTransactionPayData');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+jest.mock('../../../../UI/Ramp/hooks/useHasNativeFiatProvider', () => ({
+  useHasNativeFiatProvider: () => true,
+}));
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../../../../../core/Engine', () => ({
   context: {

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.test.ts
@@ -3,21 +3,26 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useHasNativeFiatProvider } from '../../../../UI/Ramp/hooks/useHasNativeFiatProvider';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 
 jest.mock('./useMMPayFiatConfig');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
+jest.mock('../../../../UI/Ramp/hooks/useHasNativeFiatProvider');
 jest.mock('../transactions/useTransactionMetadataRequest');
 
 describe('useIsFiatPaymentAvailable', () => {
   const useMMPayFiatConfigMock = jest.mocked(useMMPayFiatConfig);
   const useRampsPaymentMethodsMock = jest.mocked(useRampsPaymentMethods);
+  const useHasNativeFiatProviderMock = jest.mocked(useHasNativeFiatProvider);
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    useHasNativeFiatProviderMock.mockReturnValue(true);
 
     useMMPayFiatConfigMock.mockReturnValue({
       enabledTransactionTypes: [TransactionType.perpsDeposit],
@@ -61,6 +66,13 @@ describe('useIsFiatPaymentAvailable', () => {
     useRampsPaymentMethodsMock.mockReturnValue({
       paymentMethods: [],
     } as unknown as ReturnType<typeof useRampsPaymentMethods>);
+
+    const { result } = renderHook(() => useIsFiatPaymentAvailable());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when no native provider serves the region', () => {
+    useHasNativeFiatProviderMock.mockReturnValue(false);
 
     const { result } = renderHook(() => useIsFiatPaymentAvailable());
     expect(result.current).toBe(false);

--- a/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsFiatPaymentAvailable.ts
@@ -1,20 +1,24 @@
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useHasNativeFiatProvider } from '../../../../UI/Ramp/hooks/useHasNativeFiatProvider';
 import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 
 /**
  * Returns whether fiat payment is available for the current transaction.
- * True when the transaction type is fiat-enabled via remote feature flags
- * AND at least one Ramps payment method exists.
+ * True when the transaction type is fiat-enabled via remote feature flags,
+ * at least one Ramps payment method exists, AND the region has a native
+ * on-ramp provider (headless fiat deposit is native-only for v0).
  */
 export function useIsFiatPaymentAvailable(): boolean {
   const transactionMeta = useTransactionMetadataRequest();
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const { paymentMethods } = useRampsPaymentMethods();
+  const hasNativeFiatProvider = useHasNativeFiatProvider();
 
   return (
     hasTransactionType(transactionMeta, enabledTransactionTypes) &&
-    paymentMethods.length > 0
+    paymentMethods.length > 0 &&
+    hasNativeFiatProvider
   );
 }


### PR DESCRIPTION
## **Description**

Headless fiat deposit (MM Pay / Money Account) is **native-only for v0**, but the availability check only verified that the transaction type was fiat-enabled and that *some* Ramps payment method existed. In regions that expose only an **aggregator** provider (e.g. Brazil), aggregator payment methods exist, so the fiat option was offered, the user got a quote, and then the buy froze because the headless flow restricts quoting to native providers (`restrictToKnownOrNativeProviders: true`) and none were available.

This PR adds a region-level **native-provider gate** so the fiat deposit path is only offered where a native on-ramp provider actually serves the user's region:

- New shared, read-only hook `useHasNativeFiatProvider` that returns whether the current region exposes at least one provider of `type: 'native'`. It never mutates provider selection or controller state, so it has no effect on the standalone Buy flows.
- `useIsFiatPaymentAvailable` (the single chokepoint consumed by the confirmation custom-amount info, highlighted actions, and automatic pay-token selection) now also requires a native provider, gating all headless consumers at one place.
- `MoneyAddMoneySheet` "Deposit funds" row now renders **disabled with a "Coming soon" tag** (matching the existing "Receive external" row) when no native provider serves the region, instead of silently hiding it or letting the user hit a dead-end quote. The existing UNSUPPORTED (geolocation-failure) hide behavior is preserved. Disabled options are grouped at the bottom of the list for a cleaner layout.

Native **selection** is still guaranteed by the existing Transaction Pay flow, which auto-selects with `restrictToKnownOrNativeProviders: true`; this change only governs **visibility/availability** of the option.

## **Changelog**

CHANGELOG entry: Fixed the Money Account "Add money" sheet offering fiat deposits in regions without a native on-ramp provider — the deposit option is now shown as "Coming soon" where unavailable, preventing a stuck buy flow.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3615

## **Manual testing steps**

```gherkin
Feature: Native-only fiat deposit gating

  Scenario: Region with a native on-ramp provider
    Given my region exposes a native fiat provider (e.g. Transak Native)
    When I open the Money Account "Add money" sheet
    Then the "Deposit funds" option is enabled
    And tapping it starts the fiat deposit flow normally

  Scenario: Region with only an aggregator provider
    Given my region exposes only aggregator fiat providers (e.g. Brazil)
    When I open the Money Account "Add money" sheet
    Then the "Deposit funds" option is shown disabled with a "Coming soon" tag
    And it is grouped with the other disabled options at the bottom of the list
    And I cannot reach the fiat quote/buy screen from it

  Scenario: Geolocation failure (UNSUPPORTED)
    Given the ramp routing decision is UNSUPPORTED
    When I open the Money Account "Add money" sheet
    Then the "Deposit funds" option is not shown at all
```

## **Screenshots/Recordings**

### **Before**

<!-- Aggregator-only region: "Deposit funds" enabled → quote → stuck/frozen buy -->

### **After**

https://github.com/user-attachments/assets/3e73f852-4188-4264-9b0e-ab49e792efb1

<!-- Aggregator-only region: "Deposit funds" shown as disabled "Coming soon" at bottom of list -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

<!-- N/A: JS-only change (a read-only Redux/React Query selector gate + presentational sheet update); no new heavy operations or native code. -->

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when fiat deposit is offered in Money and confirmation pay flows (region/provider catalog dependent); read-only and does not alter standalone Buy or provider selection, but incorrect gating could hide or show fiat incorrectly.
> 
> **Overview**
> Adds a **native on-ramp provider gate** so headless fiat deposit (MM Pay / Money Account, confirmations pay flows) is only offered where the region exposes at least one `type: 'native'` provider—fixing aggregator-only regions where payment methods existed but quoting/buy could stall.
> 
> Introduces read-only **`useHasNativeFiatProvider`** (from `useRampsProviders`) and wires it into **`useIsFiatPaymentAvailable`**, which now also requires a native provider alongside feature flags and payment methods—centralizing availability for custom-amount UI, highlighted fiat actions, and automatic pay-token selection.
> 
> **`MoneyAddMoneySheet`** marks **Deposit funds** disabled with a **Coming soon** tag when no native provider serves the region (still hidden on `UNSUPPORTED` routing), sorts **disabled options to the bottom**, and uses a dedicated coming-soon row layout. Tests cover the hook, availability logic, sheet behavior, and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87286b40af16018f662abe03fb66fa74d540bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->