### PR TITLE
feat(predict): Live Now Section for new Predict Homepage

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.tsx
@@ -9,7 +9,6 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   useWindowDimensions,
-  View,
 } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
@@ -18,6 +17,7 @@ import { Skeleton } from '../../../../../component-library/components-temp/Skele
 import { PredictMarket } from '../../types';
 import { PredictEventValues } from '../../constants/eventNames';
 import { useFeaturedCarouselData } from '../../hooks/useFeaturedCarouselData';
+import { PaginationDots } from '../PaginationDots/PaginationDots';
 import FeaturedCarouselCard from './FeaturedCarouselCard';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
 
@@ -44,40 +44,6 @@ const FeaturedCarouselSkeleton: React.FC = () => {
         height={CARD_HEIGHT}
         style={tw.style('rounded-2xl')}
       />
-    </Box>
-  );
-};
-
-interface PaginationDotsProps {
-  count: number;
-  activeIndex: number;
-}
-
-export const PaginationDots: React.FC<PaginationDotsProps> = ({
-  count,
-  activeIndex,
-}) => {
-  const tw = useTailwind();
-
-  if (count <= 1) return null;
-
-  return (
-    <Box
-      testID={FEATURED_CAROUSEL_TEST_IDS.PAGINATION_DOTS}
-      twClassName="flex-row justify-center items-center gap-2 mt-3"
-    >
-      {Array.from({ length: count }).map((_, dotPosition) => (
-        <View
-          key={`pagination-dot-${dotPosition}`}
-          style={tw.style(
-            'h-2 rounded-full',
-            dotPosition === activeIndex
-              ? 'bg-icon-alternative'
-              : 'bg-icon-muted w-2',
-            dotPosition === activeIndex && { width: 35 },
-          )}
-        />
-      ))}
     </Box>
   );
 };

--- a/app/components/UI/Predict/components/PaginationDots/PaginationDots.tsx
+++ b/app/components/UI/Predict/components/PaginationDots/PaginationDots.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Box } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
+interface PaginationDotsProps {
+  count: number;
+  activeIndex: number;
+  testID?: string;
+}
+
+/**
+ * Shared pagination dots indicator for horizontal carousels.
+ *
+ * Renders one dot per item with the active dot expanded into a pill. Returns
+ * `null` when there is at most one item. The `testID` defaults to the Featured
+ * carousel's value so existing consumers keep their behavior unchanged.
+ */
+export const PaginationDots: React.FC<PaginationDotsProps> = ({
+  count,
+  activeIndex,
+  testID = 'featured-carousel-pagination-dots',
+}) => {
+  const tw = useTailwind();
+
+  if (count <= 1) return null;
+
+  return (
+    <Box
+      testID={testID}
+      twClassName="flex-row justify-center items-center gap-2 mt-3"
+    >
+      {Array.from({ length: count }).map((_, dotPosition) => (
+        <View
+          key={`pagination-dot-${dotPosition}`}
+          style={tw.style(
+            'h-2 rounded-full',
+            dotPosition === activeIndex
+              ? 'bg-icon-alternative'
+              : 'bg-icon-muted w-2',
+            dotPosition === activeIndex && { width: 35 },
+          )}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default PaginationDots;

--- a/app/components/UI/Predict/constants/liveNowCryptoSeries.ts
+++ b/app/components/UI/Predict/constants/liveNowCryptoSeries.ts
@@ -1,0 +1,34 @@
+import type { PredictSeries } from '../types';
+import { BTC_UP_OR_DOWN_5M_SERIES } from './btcUpDown5mSeries';
+
+export { BTC_UP_OR_DOWN_5M_SERIES } from './btcUpDown5mSeries';
+
+/** Polymarket Gamma `series_id` for the ETH 5-minute up/down series. */
+export const ETH_UP_DOWN_5M_SERIES_ID = '10683';
+
+/** Polymarket Gamma `series_id` for the BTC 15-minute up/down series. */
+export const BTC_UP_DOWN_15M_SERIES_ID = '10192';
+
+export const ETH_UP_OR_DOWN_5M_SERIES: PredictSeries = {
+  id: ETH_UP_DOWN_5M_SERIES_ID,
+  slug: 'eth-up-or-down-5m',
+  title: 'ETH Up or Down',
+  recurrence: '5m',
+};
+
+export const BTC_UP_OR_DOWN_15M_SERIES: PredictSeries = {
+  id: BTC_UP_DOWN_15M_SERIES_ID,
+  slug: 'btc-up-or-down-15m',
+  title: 'BTC Up or Down',
+  recurrence: '15m',
+};
+
+/**
+ * Crypto Up/Down series shown in the Live Now rail, in display order.
+ * Interleaved one-per-two-live by `interleaveLiveNowMarkets` (capped at 3).
+ */
+export const LIVE_NOW_CRYPTO_SERIES: PredictSeries[] = [
+  BTC_UP_OR_DOWN_5M_SERIES,
+  ETH_UP_OR_DOWN_5M_SERIES,
+  BTC_UP_OR_DOWN_15M_SERIES,
+];

--- a/app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx
@@ -21,6 +21,7 @@ import {
   PredictSearchSelectorsIDs,
 } from '../../Predict.testIds';
 import { PREDICT_HEADER_STACKED_TEST_IDS } from '../../components/PredictHeaderStacked';
+import { MOCK_PREDICT_MARKET } from '../../../../../../tests/component-view/fixtures/predict';
 
 const SEARCH_PLACEHOLDER = 'Search prediction markets';
 const PREDICTIONS_TITLE = 'Predictions';
@@ -46,6 +47,11 @@ describe('PredictHome', () => {
     (
       Engine.context.PredictController.getMarkets as jest.Mock
     ).mockResolvedValue({ markets: [], nextCursor: null });
+    // The Live Now section hides itself when there is no data, so it needs at
+    // least one live market to render for the composition/order assertion.
+    (
+      Engine.context.PredictController.listMarkets as jest.Mock
+    ).mockResolvedValue({ markets: [MOCK_PREDICT_MARKET], nextCursor: null });
     (
       Engine.context.PredictController.searchMarkets as jest.Mock
     ).mockResolvedValue({ markets: [], totalResults: 0 });

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
@@ -1,46 +1,98 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
-import { useSelector } from 'react-redux';
-import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
-import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
-import { selectPredictUpDownEnabledFlag } from '../../../../selectors/featureFlags';
-import {
-  BTC_UP_OR_DOWN_5M_SERIES,
-  ETH_UP_OR_DOWN_5M_SERIES,
-  BTC_UP_OR_DOWN_15M_SERIES,
-} from '../../../../constants/liveNowCryptoSeries';
-import type { PredictMarket, PredictMarketListParams } from '../../../../types';
+import { fireEvent } from '@testing-library/react-native';
+import { backgroundState } from '../../../../../../../util/test/initial-root-state';
+import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../../../locales/i18n';
+import type { PredictMarket } from '../../../../types';
 import { CRYPTO_TAG, UP_OR_DOWN_TAG } from '../../../../utils/cryptoUpDown';
 import PredictLiveNowSection from './PredictLiveNowSection';
 import { PREDICT_LIVE_NOW_SECTION_TEST_IDS } from './PredictLiveNowSection.testIds';
+import { usePredictLiveNowSection } from './usePredictLiveNowSection';
 
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
+// Mock only the data boundary: the section's own data hook. The hook's own
+// logic (params, filtering, interleave, loading) is covered by
+// usePredictLiveNowSection.test.ts. Here we exercise the real PredictMarket /
+// PredictMarketSkeleton presentation against controlled hook output.
+jest.mock('./usePredictLiveNowSection');
+
+// Keep the Up/Down flag on so crypto markets route to the crypto card via the
+// real PredictMarket dispatcher.
+jest.mock('../../../../selectors/featureFlags', () => ({
+  selectPredictUpDownEnabledFlag: jest.fn(() => true),
 }));
 
-jest.mock('../../../../hooks/usePredictMarketList');
+// Tailwind preset is environment-only styling; stub it like sibling carousels.
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: jest.fn(() => ({})) }),
+}));
 
-jest.mock('../../../../hooks/useCurrentPredictMarketFromSeries');
+// FlashList renders asynchronously via layout effects; swap it for a simple
+// ScrollView so renders are deterministic (no act() warnings) while still
+// invoking renderItem/keyExtractor/onScroll exactly as the component wires them.
+jest.mock('@shopify/flash-list', () => {
+  const MockReact = jest.requireActual('react');
+  const { View: MockView, ScrollView: MockScrollView } =
+    jest.requireActual('react-native');
 
-jest.mock('../../../../components/PredictMarket', () => {
-  const { View, Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({
-      testID,
-      market,
-    }: {
-      testID?: string;
-      market: { id: string };
-    }) => (
-      <View testID={testID}>
-        <Text>{market.id}</Text>
-      </View>
-    ),
-  };
+  const MockFlashList = MockReact.forwardRef(
+    (
+      {
+        data,
+        renderItem,
+        keyExtractor,
+        testID,
+        onScroll,
+      }: {
+        data: unknown[];
+        renderItem: (info: { item: unknown; index: number }) => React.ReactNode;
+        keyExtractor: (item: unknown, index: number) => string;
+        testID?: string;
+        onScroll?: (event: unknown) => void;
+      },
+      ref: React.Ref<unknown>,
+    ) => {
+      MockReact.useImperativeHandle(ref, () => ({}));
+
+      return (
+        <MockScrollView testID={testID} onScroll={onScroll}>
+          {data?.map((item, index) => (
+            <MockView key={keyExtractor?.(item, index) ?? index}>
+              {renderItem({ item, index })}
+            </MockView>
+          ))}
+        </MockScrollView>
+      );
+    },
+  );
+
+  return { FlashList: MockFlashList, FlashListRef: {} };
 });
 
-jest.mock('../../../../components/PredictMarketSkeleton', () => {
+// Mock the heavy leaf cards (charts/images/timers) — the same boundary the
+// canonical PredictMarket.test.tsx uses — forwarding the section's testID so
+// real PredictMarket dispatch (game -> sport, crypto -> up/down) is exercised.
+jest.mock('../../../../components/PredictMarketSportCard', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+jest.mock('../../../../components/PredictCryptoUpDownMarketCard', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+jest.mock('../../../../components/PredictMarketSingle', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+jest.mock('../../../../components/PredictMarketMultiple', () => {
   const { View } = jest.requireActual('react-native');
   return {
     __esModule: true,
@@ -48,152 +100,56 @@ jest.mock('../../../../components/PredictMarketSkeleton', () => {
   };
 });
 
-const mockUseSelector = useSelector as jest.Mock;
-const mockUsePredictMarketList = usePredictMarketList as jest.Mock;
-const mockUseCurrentPredictMarketFromSeries =
-  useCurrentPredictMarketFromSeries as jest.Mock;
+const mockUsePredictLiveNowSection = usePredictLiveNowSection as jest.Mock;
 
-// Scoreboard-capable live market (has `game`) — survives the rail's filter.
 const createLiveMarket = (id: string): PredictMarket =>
-  ({ id, game: { id: `game-${id}` } }) as unknown as PredictMarket;
-
-// "Regular" live market (no `game`) — filtered out of the rail.
-const createRegularMarket = (id: string): PredictMarket =>
-  ({ id }) as unknown as PredictMarket;
+  ({
+    id,
+    outcomes: [{ id: `${id}-o1` }],
+    game: { id: `game-${id}` },
+  }) as unknown as PredictMarket;
 
 const createCryptoMarket = (id: string): PredictMarket =>
   ({
     id,
+    outcomes: [{ id: `${id}-o1` }],
     tags: [CRYPTO_TAG, UP_OR_DOWN_TAG],
     series: { id: '10684', slug: 'btc-up-or-down-5m', recurrence: '5m' },
   }) as unknown as PredictMarket;
 
-const setLiveMarketList = (
+const setSection = (
   overrides: Partial<{
-    markets: PredictMarket[];
+    items: PredictMarket[];
     isLoading: boolean;
-    error: Error | null;
+    isEmpty: boolean;
   }> = {},
 ) => {
-  mockUsePredictMarketList.mockReturnValue({
-    markets: [],
+  mockUsePredictLiveNowSection.mockReturnValue({
+    items: [],
     isLoading: false,
-    isFetching: false,
-    isFetchingNextPage: false,
-    error: null,
-    hasNextPage: false,
-    refetch: jest.fn(),
-    fetchNextPage: jest.fn(),
+    isEmpty: false,
     ...overrides,
   });
 };
 
-// Default: no crypto market resolved for any series.
-const setCryptoMarket = (
-  overrides: Partial<{ market?: PredictMarket; isLoading: boolean }> = {},
-) => {
-  mockUseCurrentPredictMarketFromSeries.mockReturnValue({
-    market: undefined,
-    isLoading: false,
-    ...overrides,
+const renderSection = () =>
+  renderWithProvider(<PredictLiveNowSection />, {
+    state: { engine: { backgroundState } },
   });
-};
-
-// Resolve a distinct crypto market per series id (BTC 5m / ETH 5m / BTC 15m),
-// since the hook now calls useCurrentPredictMarketFromSeries once per series.
-const setCryptoMarketsBySeries = (
-  bySeriesId: Record<string, PredictMarket | undefined>,
-) => {
-  mockUseCurrentPredictMarketFromSeries.mockImplementation(
-    ({ series }: { series?: { id: string } }) => ({
-      market: series ? bySeriesId[series.id] : undefined,
-      isLoading: false,
-    }),
-  );
-};
-
-// Mock `useSelector` by selector identity so we only control the Up/Down
-// feature flag and leave every other selector at a safe default of `false`.
-const setUpDownEnabled = (enabled: boolean) => {
-  mockUseSelector.mockImplementation((selector) =>
-    selector === selectPredictUpDownEnabledFlag ? enabled : false,
-  );
-};
 
 describe('PredictLiveNowSection', () => {
   beforeEach(() => {
-    setUpDownEnabled(false);
-    setLiveMarketList();
-    setCryptoMarket();
+    setSection();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('requests live markets with the live param and v1 query', () => {
-    setLiveMarketList({ markets: [createLiveMarket('L1')] });
+  it('renders a market card for each live item', () => {
+    setSection({ items: [createLiveMarket('L1'), createLiveMarket('L2')] });
 
-    render(<PredictLiveNowSection />);
-
-    expect(mockUsePredictMarketList).toHaveBeenCalledWith({
-      live: true,
-      order: 'volume24hr',
-      status: 'open',
-      limit: 15,
-    } as PredictMarketListParams);
-  });
-
-  it('filters out "regular" live markets without a game (scoreboard) object', () => {
-    setLiveMarketList({
-      markets: [createLiveMarket('L1'), createRegularMarket('R1')],
-    });
-
-    const { getByTestId, queryByTestId } = render(<PredictLiveNowSection />);
-
-    expect(
-      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-L1`),
-    ).toBeOnTheScreen();
-    expect(
-      queryByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-R1`),
-    ).not.toBeOnTheScreen();
-  });
-
-  it('renders skeleton cards while loading with no markets yet', () => {
-    setLiveMarketList({ markets: [], isLoading: true });
-
-    const { getByTestId } = render(<PredictLiveNowSection />);
-
-    expect(
-      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
-    ).toBeOnTheScreen();
-  });
-
-  it('keeps showing skeletons while live markets load even if crypto already resolved', () => {
-    setUpDownEnabled(true);
-    setLiveMarketList({ markets: [], isLoading: true });
-    setCryptoMarketsBySeries({
-      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('BTC5M'),
-      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('ETH5M'),
-      [BTC_UP_OR_DOWN_15M_SERIES.id]: createCryptoMarket('BTC15M'),
-    });
-
-    const { getByTestId, queryByTestId } = render(<PredictLiveNowSection />);
-
-    expect(
-      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
-    ).toBeOnTheScreen();
-    expect(
-      queryByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-BTC5M`),
-    ).not.toBeOnTheScreen();
-  });
-
-  it('renders a market card for each live market on success', () => {
-    setLiveMarketList({
-      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
-    });
-
-    const { getByTestId } = render(<PredictLiveNowSection />);
+    const { getByTestId } = renderSection();
 
     expect(
       getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-L1`),
@@ -203,119 +159,74 @@ describe('PredictLiveNowSection', () => {
     ).toBeOnTheScreen();
   });
 
-  it('interleaves the crypto card after two live cards when Up/Down is enabled', () => {
-    setUpDownEnabled(true);
-    setLiveMarketList({
-      markets: [
-        createLiveMarket('L1'),
-        createLiveMarket('L2'),
-        createLiveMarket('L3'),
-      ],
-    });
-    setCryptoMarketsBySeries({
-      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('CRYPTO'),
-    });
+  it('renders a crypto Up/Down card through the shared PredictMarket dispatcher', () => {
+    setSection({ items: [createCryptoMarket('CRYPTO')] });
 
-    const { getByTestId } = render(<PredictLiveNowSection />);
+    const { getByTestId } = renderSection();
 
     expect(
       getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-CRYPTO`),
     ).toBeOnTheScreen();
   });
 
-  it('sources all three crypto series (BTC 5m, ETH 5m, BTC 15m) when Up/Down is enabled', () => {
-    setUpDownEnabled(true);
-    setLiveMarketList({
-      markets: [
-        createLiveMarket('L1'),
-        createLiveMarket('L2'),
-        createLiveMarket('L3'),
-        createLiveMarket('L4'),
-        createLiveMarket('L5'),
-        createLiveMarket('L6'),
-      ],
-    });
-    setCryptoMarketsBySeries({
-      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('BTC5M'),
-      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('ETH5M'),
-      [BTC_UP_OR_DOWN_15M_SERIES.id]: createCryptoMarket('BTC15M'),
-    });
+  it('renders skeleton cards while loading with no items yet', () => {
+    setSection({ items: [], isLoading: true });
 
-    const { getByTestId } = render(<PredictLiveNowSection />);
+    const { getByTestId } = renderSection();
 
     expect(
-      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-BTC5M`),
-    ).toBeOnTheScreen();
-    expect(
-      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-ETH5M`),
-    ).toBeOnTheScreen();
-    expect(
-      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-BTC15M`),
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
     ).toBeOnTheScreen();
   });
 
-  it('hides the section when there are no markets after loading', () => {
-    setLiveMarketList({ markets: [], isLoading: false });
+  it('returns null (renders no section) when empty', () => {
+    setSection({ items: [], isEmpty: true });
 
-    const { queryByTestId } = render(<PredictLiveNowSection />);
+    const { queryByTestId } = renderSection();
 
     expect(
       queryByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.SECTION),
     ).not.toBeOnTheScreen();
   });
 
-  it('hides the section on error (empty markets, not loading)', () => {
-    setLiveMarketList({
-      markets: [],
-      isLoading: false,
-      error: new Error('failed'),
-    });
+  it('renders a non-pressable "Live now" header without a navigation chevron', () => {
+    setSection({ items: [createLiveMarket('L1')] });
 
-    const { queryByTestId } = render(<PredictLiveNowSection />);
+    const { getByTestId, queryByTestId, getByText } = renderSection();
 
     expect(
-      queryByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.SECTION),
-    ).not.toBeOnTheScreen();
+      getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.HEADER),
+    ).toBeOnTheScreen();
+    expect(getByText(strings('predict.home.live_now_title'))).toBeOnTheScreen();
+    // The chevron only renders when the header is pressable (onPress set); the
+    // "See all" target route does not exist yet, so it must be absent.
+    expect(queryByTestId('section-header-arrow-icon')).not.toBeOnTheScreen();
   });
 
-  it('renders a See all action that is pressable without crashing', () => {
-    setLiveMarketList({ markets: [createLiveMarket('L1')] });
+  it('renders pagination dots when there are 2+ items after load', () => {
+    setSection({ items: [createLiveMarket('L1'), createLiveMarket('L2')] });
 
-    const { getByTestId } = render(<PredictLiveNowSection />);
-    const seeAll = getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.SEE_ALL);
-    fireEvent.press(seeAll);
-
-    expect(seeAll).toBeOnTheScreen();
-  });
-
-  it('renders pagination dots when there are 2+ markets after load', () => {
-    setLiveMarketList({
-      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
-    });
-
-    const { getByTestId } = render(<PredictLiveNowSection />);
+    const { getByTestId } = renderSection();
 
     expect(
       getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS),
     ).toBeOnTheScreen();
   });
 
-  it('does not render pagination dots when there is fewer than 2 markets', () => {
-    setLiveMarketList({ markets: [createLiveMarket('L1')] });
+  it('does not render pagination dots when there is fewer than 2 items', () => {
+    setSection({ items: [createLiveMarket('L1')] });
 
-    const { queryByTestId } = render(<PredictLiveNowSection />);
+    const { queryByTestId } = renderSection();
 
     expect(
       queryByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS),
     ).not.toBeOnTheScreen();
   });
 
-  it('handles scrolling the carousel without crashing', () => {
-    setLiveMarketList({
-      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
-    });
+  it('updates the active card without crashing when the carousel is scrolled', () => {
+    setSection({ items: [createLiveMarket('L1'), createLiveMarket('L2')] });
 
-    const { getByTestId } = render(<PredictLiveNowSection />);
+    const { getByTestId } = renderSection();
     const carousel = getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.CAROUSEL);
 
     fireEvent.scroll(carousel, {

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
 import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
+import { selectPredictUpDownEnabledFlag } from '../../../../selectors/featureFlags';
 import type { PredictMarket, PredictMarketListParams } from '../../../../types';
 import { CRYPTO_TAG, UP_OR_DOWN_TAG } from '../../../../utils/cryptoUpDown';
 import PredictLiveNowSection from './PredictLiveNowSection';
@@ -87,9 +88,17 @@ const setCryptoMarket = (
   });
 };
 
+// Mock `useSelector` by selector identity so we only control the Up/Down
+// feature flag and leave every other selector at a safe default of `false`.
+const setUpDownEnabled = (enabled: boolean) => {
+  mockUseSelector.mockImplementation((selector) =>
+    selector === selectPredictUpDownEnabledFlag ? enabled : false,
+  );
+};
+
 describe('PredictLiveNowSection', () => {
   beforeEach(() => {
-    mockUseSelector.mockReturnValue(false);
+    setUpDownEnabled(false);
     setLiveMarketList();
     setCryptoMarket();
   });
@@ -137,7 +146,7 @@ describe('PredictLiveNowSection', () => {
   });
 
   it('interleaves the crypto card after two live cards when Up/Down is enabled', () => {
-    mockUseSelector.mockReturnValue(true);
+    setUpDownEnabled(true);
     setLiveMarketList({
       markets: [
         createLiveMarket('L1'),
@@ -186,5 +195,42 @@ describe('PredictLiveNowSection', () => {
     fireEvent.press(seeAll);
 
     expect(seeAll).toBeOnTheScreen();
+  });
+
+  it('renders pagination dots when there are 2+ markets after load', () => {
+    setLiveMarketList({
+      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
+    });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS),
+    ).toBeOnTheScreen();
+  });
+
+  it('does not render pagination dots when there is fewer than 2 markets', () => {
+    setLiveMarketList({ markets: [createLiveMarket('L1')] });
+
+    const { queryByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      queryByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('handles scrolling the carousel without crashing', () => {
+    setLiveMarketList({
+      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
+    });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+    const carousel = getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.CAROUSEL);
+
+    fireEvent.scroll(carousel, {
+      nativeEvent: { contentOffset: { x: 320, y: 0 } },
+    });
+
+    expect(carousel).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
@@ -4,6 +4,11 @@ import { useSelector } from 'react-redux';
 import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
 import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
 import { selectPredictUpDownEnabledFlag } from '../../../../selectors/featureFlags';
+import {
+  BTC_UP_OR_DOWN_5M_SERIES,
+  ETH_UP_OR_DOWN_5M_SERIES,
+  BTC_UP_OR_DOWN_15M_SERIES,
+} from '../../../../constants/liveNowCryptoSeries';
 import type { PredictMarket, PredictMarketListParams } from '../../../../types';
 import { CRYPTO_TAG, UP_OR_DOWN_TAG } from '../../../../utils/cryptoUpDown';
 import PredictLiveNowSection from './PredictLiveNowSection';
@@ -48,7 +53,12 @@ const mockUsePredictMarketList = usePredictMarketList as jest.Mock;
 const mockUseCurrentPredictMarketFromSeries =
   useCurrentPredictMarketFromSeries as jest.Mock;
 
+// Scoreboard-capable live market (has `game`) — survives the rail's filter.
 const createLiveMarket = (id: string): PredictMarket =>
+  ({ id, game: { id: `game-${id}` } }) as unknown as PredictMarket;
+
+// "Regular" live market (no `game`) — filtered out of the rail.
+const createRegularMarket = (id: string): PredictMarket =>
   ({ id }) as unknown as PredictMarket;
 
 const createCryptoMarket = (id: string): PredictMarket =>
@@ -78,6 +88,7 @@ const setLiveMarketList = (
   });
 };
 
+// Default: no crypto market resolved for any series.
 const setCryptoMarket = (
   overrides: Partial<{ market?: PredictMarket; isLoading: boolean }> = {},
 ) => {
@@ -86,6 +97,19 @@ const setCryptoMarket = (
     isLoading: false,
     ...overrides,
   });
+};
+
+// Resolve a distinct crypto market per series id (BTC 5m / ETH 5m / BTC 15m),
+// since the hook now calls useCurrentPredictMarketFromSeries once per series.
+const setCryptoMarketsBySeries = (
+  bySeriesId: Record<string, PredictMarket | undefined>,
+) => {
+  mockUseCurrentPredictMarketFromSeries.mockImplementation(
+    ({ series }: { series?: { id: string } }) => ({
+      market: series ? bySeriesId[series.id] : undefined,
+      isLoading: false,
+    }),
+  );
 };
 
 // Mock `useSelector` by selector identity so we only control the Up/Down
@@ -116,8 +140,23 @@ describe('PredictLiveNowSection', () => {
       live: true,
       order: 'volume24hr',
       status: 'open',
-      limit: 7,
+      limit: 15,
     } as PredictMarketListParams);
+  });
+
+  it('filters out "regular" live markets without a game (scoreboard) object', () => {
+    setLiveMarketList({
+      markets: [createLiveMarket('L1'), createRegularMarket('R1')],
+    });
+
+    const { getByTestId, queryByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-L1`),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-R1`),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders skeleton cards while loading with no markets yet', () => {
@@ -128,6 +167,25 @@ describe('PredictLiveNowSection', () => {
     expect(
       getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
     ).toBeOnTheScreen();
+  });
+
+  it('keeps showing skeletons while live markets load even if crypto already resolved', () => {
+    setUpDownEnabled(true);
+    setLiveMarketList({ markets: [], isLoading: true });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('BTC5M'),
+      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('ETH5M'),
+      [BTC_UP_OR_DOWN_15M_SERIES.id]: createCryptoMarket('BTC15M'),
+    });
+
+    const { getByTestId, queryByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-BTC5M`),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders a market card for each live market on success', () => {
@@ -154,12 +212,45 @@ describe('PredictLiveNowSection', () => {
         createLiveMarket('L3'),
       ],
     });
-    setCryptoMarket({ market: createCryptoMarket('CRYPTO') });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('CRYPTO'),
+    });
 
     const { getByTestId } = render(<PredictLiveNowSection />);
 
     expect(
       getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-CRYPTO`),
+    ).toBeOnTheScreen();
+  });
+
+  it('sources all three crypto series (BTC 5m, ETH 5m, BTC 15m) when Up/Down is enabled', () => {
+    setUpDownEnabled(true);
+    setLiveMarketList({
+      markets: [
+        createLiveMarket('L1'),
+        createLiveMarket('L2'),
+        createLiveMarket('L3'),
+        createLiveMarket('L4'),
+        createLiveMarket('L5'),
+        createLiveMarket('L6'),
+      ],
+    });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('BTC5M'),
+      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('ETH5M'),
+      [BTC_UP_OR_DOWN_15M_SERIES.id]: createCryptoMarket('BTC15M'),
+    });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-BTC5M`),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-ETH5M`),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-BTC15M`),
     ).toBeOnTheScreen();
   });
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
+import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
+import type { PredictMarket, PredictMarketListParams } from '../../../../types';
+import { CRYPTO_TAG, UP_OR_DOWN_TAG } from '../../../../utils/cryptoUpDown';
+import PredictLiveNowSection from './PredictLiveNowSection';
+import { PREDICT_LIVE_NOW_SECTION_TEST_IDS } from './PredictLiveNowSection.testIds';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/usePredictMarketList');
+
+jest.mock('../../../../hooks/useCurrentPredictMarketFromSeries');
+
+jest.mock('../../../../components/PredictMarket', () => {
+  const { View, Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      testID,
+      market,
+    }: {
+      testID?: string;
+      market: { id: string };
+    }) => (
+      <View testID={testID}>
+        <Text>{market.id}</Text>
+      </View>
+    ),
+  };
+});
+
+jest.mock('../../../../components/PredictMarketSkeleton', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID }: { testID?: string }) => <View testID={testID} />,
+  };
+});
+
+const mockUseSelector = useSelector as jest.Mock;
+const mockUsePredictMarketList = usePredictMarketList as jest.Mock;
+const mockUseCurrentPredictMarketFromSeries =
+  useCurrentPredictMarketFromSeries as jest.Mock;
+
+const createLiveMarket = (id: string): PredictMarket =>
+  ({ id }) as unknown as PredictMarket;
+
+const createCryptoMarket = (id: string): PredictMarket =>
+  ({
+    id,
+    tags: [CRYPTO_TAG, UP_OR_DOWN_TAG],
+    series: { id: '10684', slug: 'btc-up-or-down-5m', recurrence: '5m' },
+  }) as unknown as PredictMarket;
+
+const setLiveMarketList = (
+  overrides: Partial<{
+    markets: PredictMarket[];
+    isLoading: boolean;
+    error: Error | null;
+  }> = {},
+) => {
+  mockUsePredictMarketList.mockReturnValue({
+    markets: [],
+    isLoading: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    error: null,
+    hasNextPage: false,
+    refetch: jest.fn(),
+    fetchNextPage: jest.fn(),
+    ...overrides,
+  });
+};
+
+const setCryptoMarket = (
+  overrides: Partial<{ market?: PredictMarket; isLoading: boolean }> = {},
+) => {
+  mockUseCurrentPredictMarketFromSeries.mockReturnValue({
+    market: undefined,
+    isLoading: false,
+    ...overrides,
+  });
+};
+
+describe('PredictLiveNowSection', () => {
+  beforeEach(() => {
+    mockUseSelector.mockReturnValue(false);
+    setLiveMarketList();
+    setCryptoMarket();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests live markets with the live param and v1 query', () => {
+    setLiveMarketList({ markets: [createLiveMarket('L1')] });
+
+    render(<PredictLiveNowSection />);
+
+    expect(mockUsePredictMarketList).toHaveBeenCalledWith({
+      live: true,
+      order: 'volume24hr',
+      status: 'open',
+      limit: 7,
+    } as PredictMarketListParams);
+  });
+
+  it('renders skeleton cards while loading with no markets yet', () => {
+    setLiveMarketList({ markets: [], isLoading: true });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-0`),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders a market card for each live market on success', () => {
+    setLiveMarketList({
+      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
+    });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-L1`),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-L2`),
+    ).toBeOnTheScreen();
+  });
+
+  it('interleaves the crypto card after two live cards when Up/Down is enabled', () => {
+    mockUseSelector.mockReturnValue(true);
+    setLiveMarketList({
+      markets: [
+        createLiveMarket('L1'),
+        createLiveMarket('L2'),
+        createLiveMarket('L3'),
+      ],
+    });
+    setCryptoMarket({ market: createCryptoMarket('CRYPTO') });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      getByTestId(`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-CRYPTO`),
+    ).toBeOnTheScreen();
+  });
+
+  it('hides the section when there are no markets after loading', () => {
+    setLiveMarketList({ markets: [], isLoading: false });
+
+    const { queryByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      queryByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.SECTION),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('hides the section on error (empty markets, not loading)', () => {
+    setLiveMarketList({
+      markets: [],
+      isLoading: false,
+      error: new Error('failed'),
+    });
+
+    const { queryByTestId } = render(<PredictLiveNowSection />);
+
+    expect(
+      queryByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.SECTION),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders a See all action that is pressable without crashing', () => {
+    setLiveMarketList({ markets: [createLiveMarket('L1')] });
+
+    const { getByTestId } = render(<PredictLiveNowSection />);
+    const seeAll = getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.SEE_ALL);
+    fireEvent.press(seeAll);
+
+    expect(seeAll).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts
@@ -1,0 +1,14 @@
+import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
+
+/**
+ * Test selectors for the Predict home "Live Now" carousel section.
+ * The section root reuses {@link PredictHomeSelectorsIDs.LIVE_NOW_SECTION} so
+ * the shell's composition test keeps working.
+ */
+export const PREDICT_LIVE_NOW_SECTION_TEST_IDS = {
+  SECTION: PredictHomeSelectorsIDs.LIVE_NOW_SECTION,
+  SEE_ALL: 'predict-home-live-now-see-all',
+  CAROUSEL: 'predict-home-live-now-carousel',
+  CARD_PREFIX: 'predict-home-live-now-card',
+  SKELETON_PREFIX: 'predict-home-live-now-skeleton',
+} as const;

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts
@@ -11,4 +11,5 @@ export const PREDICT_LIVE_NOW_SECTION_TEST_IDS = {
   CAROUSEL: 'predict-home-live-now-carousel',
   CARD_PREFIX: 'predict-home-live-now-card',
   SKELETON_PREFIX: 'predict-home-live-now-skeleton',
+  PAGINATION_DOTS: 'predict-home-live-now-pagination-dots',
 } as const;

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts
@@ -7,7 +7,7 @@ import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
  */
 export const PREDICT_LIVE_NOW_SECTION_TEST_IDS = {
   SECTION: PredictHomeSelectorsIDs.LIVE_NOW_SECTION,
-  SEE_ALL: 'predict-home-live-now-see-all',
+  HEADER: 'predict-home-live-now-header',
   CAROUSEL: 'predict-home-live-now-carousel',
   CARD_PREFIX: 'predict-home-live-now-card',
   SKELETON_PREFIX: 'predict-home-live-now-skeleton',

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -48,11 +48,17 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
     () => screenWidth * CARD_WIDTH_RATIO,
     [screenWidth],
   );
+  // Cards snap on width + gap, so the active-dot math must divide by the same
+  // interval (not just cardWidth) to stay in sync with the snapped card.
+  const snapInterval = useMemo(() => cardWidth + CARD_GAP, [cardWidth]);
   const { items, isLoading, isEmpty } = usePredictLiveNowSection();
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
-    setActiveIndex((prev) => (prev >= items.length ? 0 : prev));
+    const lastIndex = items.length - 1;
+    setActiveIndex((prev) =>
+      lastIndex < 0 ? 0 : Math.min(Math.max(prev, 0), lastIndex),
+    );
   }, [items.length]);
 
   const handleViewAll = useCallback(() => {
@@ -68,14 +74,18 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
 
   const handleScroll = useCallback(
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const lastIndex = items.length - 1;
+      if (lastIndex < 0) {
+        return;
+      }
       const offsetX = event.nativeEvent.contentOffset.x;
       const newIndex = Math.min(
-        Math.max(0, Math.round(offsetX / cardWidth)),
-        items.length - 1,
+        Math.max(0, Math.round(offsetX / snapInterval)),
+        lastIndex,
       );
       setActiveIndex(newIndex);
     },
-    [cardWidth, items.length],
+    [snapInterval, items.length],
   );
 
   const renderItem: ListRenderItem<CarouselItem> = useCallback(
@@ -139,7 +149,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
           contentContainerStyle={tw.style('px-4')}
           horizontal
           showsHorizontalScrollIndicator={false}
-          snapToInterval={cardWidth + CARD_GAP}
+          snapToInterval={snapInterval}
           decelerationRate="fast"
           onScroll={handleScroll}
           scrollEventThrottle={16}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -61,11 +61,6 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
     );
   }, [items.length]);
 
-  const handleViewAll = useCallback(() => {
-    // TODO(PRED-834): navigate to Routes.PREDICT.FEED with { feedId: 'live' }
-    // once the generic feed route/view land (see predict-home-redesign.md).
-  }, []);
-
   const carouselData = useMemo<CarouselItem[]>(
     () =>
       isLoading ? Array.from<CarouselItem>({ length: SKELETON_COUNT }) : items,
@@ -129,10 +124,14 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
 
   return (
     <Box testID={testID} twClassName="my-2">
+      {/* Static (non-pressable) header for now: the "See all" target — a generic
+          PredictFeedView with feedId 'live' — does not exist yet, so we render
+          plain header text rather than a dead control. Pass `onPress` (and the
+          chevron returns) once Routes.PREDICT.FEED lands. See
+          predict-home-redesign.md (Upcoming Tickets A + B). */}
       <SectionHeader
-        testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.SEE_ALL}
+        testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.HEADER}
         title={strings('predict.home.live_now_title')}
-        onPress={handleViewAll}
         twClassName="px-0 mb-2"
       />
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Dimensions,
+  useWindowDimensions,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from 'react-native';
@@ -11,15 +11,17 @@ import { strings } from '../../../../../../../../locales/i18n';
 import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
 import PredictMarket from '../../../../components/PredictMarket';
 import PredictMarketSkeleton from '../../../../components/PredictMarketSkeleton';
-import { PaginationDots } from '../../../../components/FeaturedCarousel/FeaturedCarousel';
+import { PaginationDots } from '../../../../components/PaginationDots/PaginationDots';
 import { PredictEventValues } from '../../../../constants/eventNames';
 import type { PredictMarket as PredictMarketType } from '../../../../types';
 import { PREDICT_LIVE_NOW_SECTION_TEST_IDS } from './PredictLiveNowSection.testIds';
 import { usePredictLiveNowSection } from './usePredictLiveNowSection';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const CARD_WIDTH = SCREEN_WIDTH * 0.8;
+// Cards peek the next item by occupying ~80% of the screen width, hinting that
+// the rail is horizontally scrollable.
+const CARD_WIDTH_RATIO = 0.8;
 const CARD_HEIGHT = 220;
+const CARD_GAP = 12;
 const SKELETON_COUNT = 3;
 
 interface PredictLiveNowSectionProps {
@@ -41,8 +43,17 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
   testID = PREDICT_LIVE_NOW_SECTION_TEST_IDS.SECTION,
 }) => {
   const tw = useTailwind();
+  const { width: screenWidth } = useWindowDimensions();
+  const cardWidth = useMemo(
+    () => screenWidth * CARD_WIDTH_RATIO,
+    [screenWidth],
+  );
   const { items, isLoading, isEmpty } = usePredictLiveNowSection();
   const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex((prev) => (prev >= items.length ? 0 : prev));
+  }, [items.length]);
 
   const handleViewAll = useCallback(() => {
     // TODO(PRED-834): navigate to Routes.PREDICT.FEED with { feedId: 'live' }
@@ -59,12 +70,12 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
     (event: NativeSyntheticEvent<NativeScrollEvent>) => {
       const offsetX = event.nativeEvent.contentOffset.x;
       const newIndex = Math.min(
-        Math.max(0, Math.round(offsetX / CARD_WIDTH)),
+        Math.max(0, Math.round(offsetX / cardWidth)),
         items.length - 1,
       );
       setActiveIndex(newIndex);
     },
-    [items.length],
+    [cardWidth, items.length],
   );
 
   const renderItem: ListRenderItem<CarouselItem> = useCallback(
@@ -72,12 +83,15 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
       const isLastItem = index === carouselData.length - 1;
 
       return (
-        <Box style={tw.style({ width: CARD_WIDTH, minHeight: CARD_HEIGHT })}>
+        <Box
+          style={tw.style(
+            { width: cardWidth, minHeight: CARD_HEIGHT },
+            !isLastItem && { marginRight: CARD_GAP },
+          )}
+        >
           <Box
             borderColor={BoxBorderColor.BorderDefault}
-            twClassName={`rounded-2xl overflow-hidden ${
-              isLastItem ? '' : 'pr-3'
-            }`}
+            twClassName="rounded-2xl overflow-hidden"
           >
             {isLoading || !item ? (
               <PredictMarketSkeleton
@@ -96,7 +110,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
         </Box>
       );
     },
-    [carouselData.length, isLoading, tw],
+    [carouselData.length, cardWidth, isLoading, tw],
   );
 
   if (isEmpty) {
@@ -125,7 +139,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
           contentContainerStyle={tw.style('px-4')}
           horizontal
           showsHorizontalScrollIndicator={false}
-          snapToInterval={CARD_WIDTH}
+          snapToInterval={cardWidth + CARD_GAP}
           decelerationRate="fast"
           onScroll={handleScroll}
           scrollEventThrottle={16}
@@ -133,7 +147,11 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
       </Box>
 
       {!isLoading && (
-        <PaginationDots count={items.length} activeIndex={activeIndex} />
+        <PaginationDots
+          count={items.length}
+          activeIndex={activeIndex}
+          testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS}
+        />
       )}
     </Box>
   );

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -1,32 +1,142 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
-  Box,
-  Text,
-  TextColor,
-  TextVariant,
-} from '@metamask/design-system-react-native';
+  Dimensions,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import { Box, BoxBorderColor } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { FlashList, type ListRenderItem } from '@shopify/flash-list';
 import { strings } from '../../../../../../../../locales/i18n';
-import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
+import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
+import PredictMarket from '../../../../components/PredictMarket';
+import PredictMarketSkeleton from '../../../../components/PredictMarketSkeleton';
+import { PaginationDots } from '../../../../components/FeaturedCarousel/FeaturedCarousel';
+import { PredictEventValues } from '../../../../constants/eventNames';
+import type { PredictMarket as PredictMarketType } from '../../../../types';
+import { PREDICT_LIVE_NOW_SECTION_TEST_IDS } from './PredictLiveNowSection.testIds';
+import { usePredictLiveNowSection } from './usePredictLiveNowSection';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const CARD_WIDTH = SCREEN_WIDTH * 0.8;
+const CARD_HEIGHT = 220;
+const SKELETON_COUNT = 3;
 
 interface PredictLiveNowSectionProps {
   testID?: string;
 }
 
+type CarouselItem = PredictMarketType | undefined;
+
 /**
- * Placeholder for the Predict home "Live now" carousel section.
- * Replaced by the real section in a later ticket; the shell composes it as-is.
+ * Predict home "Live Now" carousel (PRED-834).
+ *
+ * Horizontal rail interleaving live sports markets with the BTC Up/Down crypto
+ * card (see {@link usePredictLiveNowSection}), reusing the shared
+ * `PredictMarket` carousel card. Renders skeletons while loading and hides
+ * itself entirely when there is no data (empty/error) so it never blocks the
+ * home screen.
  */
 const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
-  testID = PredictHomeSelectorsIDs.LIVE_NOW_SECTION,
-}) => (
-  <Box
-    testID={testID}
-    twClassName="my-2 items-center justify-center rounded-xl bg-muted py-8 px-4"
-  >
-    <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-      {strings('predict.home.live_now_placeholder')}
-    </Text>
-  </Box>
-);
+  testID = PREDICT_LIVE_NOW_SECTION_TEST_IDS.SECTION,
+}) => {
+  const tw = useTailwind();
+  const { items, isLoading, isEmpty } = usePredictLiveNowSection();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleViewAll = useCallback(() => {
+    // TODO(PRED-834): navigate to Routes.PREDICT.FEED with { feedId: 'live' }
+    // once the generic feed route/view land (see predict-home-redesign.md).
+  }, []);
+
+  const carouselData = useMemo<CarouselItem[]>(
+    () =>
+      isLoading ? Array.from<CarouselItem>({ length: SKELETON_COUNT }) : items,
+    [isLoading, items],
+  );
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const offsetX = event.nativeEvent.contentOffset.x;
+      const newIndex = Math.min(
+        Math.max(0, Math.round(offsetX / CARD_WIDTH)),
+        items.length - 1,
+      );
+      setActiveIndex(newIndex);
+    },
+    [items.length],
+  );
+
+  const renderItem: ListRenderItem<CarouselItem> = useCallback(
+    ({ item, index }) => {
+      const isLastItem = index === carouselData.length - 1;
+
+      return (
+        <Box style={tw.style({ width: CARD_WIDTH, minHeight: CARD_HEIGHT })}>
+          <Box
+            borderColor={BoxBorderColor.BorderDefault}
+            twClassName={`rounded-2xl overflow-hidden ${
+              isLastItem ? '' : 'pr-3'
+            }`}
+          >
+            {isLoading || !item ? (
+              <PredictMarketSkeleton
+                isCarousel
+                testID={`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
+              />
+            ) : (
+              <PredictMarket
+                market={item}
+                isCarousel
+                entryPoint={PredictEventValues.ENTRY_POINT.CAROUSEL}
+                testID={`${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-${item.id}`}
+              />
+            )}
+          </Box>
+        </Box>
+      );
+    },
+    [carouselData.length, isLoading, tw],
+  );
+
+  if (isEmpty) {
+    return null;
+  }
+
+  return (
+    <Box testID={testID} twClassName="my-2">
+      <SectionHeader
+        testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.SEE_ALL}
+        title={strings('predict.home.live_now_title')}
+        onPress={handleViewAll}
+        twClassName="px-0 mb-2"
+      />
+
+      <Box twClassName="-mx-4">
+        <FlashList<CarouselItem>
+          testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.CAROUSEL}
+          data={carouselData}
+          renderItem={renderItem}
+          keyExtractor={(item, index) =>
+            isLoading || !item
+              ? `${PREDICT_LIVE_NOW_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`
+              : `${PREDICT_LIVE_NOW_SECTION_TEST_IDS.CARD_PREFIX}-${item.id}`
+          }
+          contentContainerStyle={tw.style('px-4')}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          snapToInterval={CARD_WIDTH}
+          decelerationRate="fast"
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+        />
+      </Box>
+
+      {!isLoading && (
+        <PaginationDots count={items.length} activeIndex={activeIndex} />
+      )}
+    </Box>
+  );
+};
 
 export default PredictLiveNowSection;

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.test.ts
@@ -1,0 +1,86 @@
+import type { PredictMarket } from '../../../../types';
+import {
+  interleaveLiveNowMarkets,
+  LIVE_NOW_MAX_CRYPTO,
+} from './liveNowInterleave';
+
+const createMarket = (id: string): PredictMarket =>
+  ({ id }) as unknown as PredictMarket;
+
+const createMarkets = (prefix: string, count: number): PredictMarket[] =>
+  Array.from({ length: count }, (_, index) =>
+    createMarket(`${prefix}${index + 1}`),
+  );
+
+const idsOf = (markets: PredictMarket[]) => markets.map((market) => market.id);
+
+describe('interleaveLiveNowMarkets', () => {
+  it('places a crypto card after every two live cards for 7 live and 3 crypto', () => {
+    const live = createMarkets('L', 7);
+    const crypto = createMarkets('C', 3);
+
+    const result = interleaveLiveNowMarkets(live, crypto);
+
+    expect(idsOf(result)).toEqual([
+      'L1',
+      'L2',
+      'C1',
+      'L3',
+      'L4',
+      'C2',
+      'L5',
+      'L6',
+      'C3',
+      'L7',
+    ]);
+  });
+
+  it('fills remaining slots with live cards when only one crypto is available', () => {
+    const live = createMarkets('L', 7);
+    const crypto = createMarkets('C', 1);
+
+    const result = interleaveLiveNowMarkets(live, crypto);
+
+    expect(idsOf(result)).toEqual([
+      'L1',
+      'L2',
+      'C1',
+      'L3',
+      'L4',
+      'L5',
+      'L6',
+      'L7',
+    ]);
+  });
+
+  it('caps crypto cards at the maximum', () => {
+    const crypto = createMarkets('C', LIVE_NOW_MAX_CRYPTO + 2);
+
+    const result = interleaveLiveNowMarkets([], crypto);
+
+    expect(idsOf(result)).toEqual(['C1', 'C2', 'C3']);
+    expect(result).toHaveLength(LIVE_NOW_MAX_CRYPTO);
+  });
+
+  it('shows crypto cards only when there are no live markets', () => {
+    const crypto = createMarkets('C', 2);
+
+    const result = interleaveLiveNowMarkets([], crypto);
+
+    expect(idsOf(result)).toEqual(['C1', 'C2']);
+  });
+
+  it('returns live cards only when there are no crypto markets', () => {
+    const live = createMarkets('L', 3);
+
+    const result = interleaveLiveNowMarkets(live, []);
+
+    expect(idsOf(result)).toEqual(['L1', 'L2', 'L3']);
+  });
+
+  it('returns an empty array when both inputs are empty', () => {
+    const result = interleaveLiveNowMarkets([], []);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.ts
@@ -22,24 +22,28 @@ export const interleaveLiveNowMarkets = (
   liveMarkets: PredictMarket[],
   cryptoMarkets: PredictMarket[],
 ): PredictMarket[] => {
-  const live = [...liveMarkets];
   const crypto = cryptoMarkets.slice(0, LIVE_NOW_MAX_CRYPTO);
 
   const result: PredictMarket[] = [];
+  let liveIndex = 0;
+  let cryptoIndex = 0;
   let sinceCrypto = 0;
 
-  while (live.length > 0 || crypto.length > 0) {
-    const shouldPlaceCrypto =
-      sinceCrypto >= LIVE_PER_CRYPTO || live.length === 0;
+  while (liveIndex < liveMarkets.length || cryptoIndex < crypto.length) {
+    const liveRemaining = liveIndex < liveMarkets.length;
+    const cryptoRemaining = cryptoIndex < crypto.length;
+    const shouldPlaceCrypto = sinceCrypto >= LIVE_PER_CRYPTO || !liveRemaining;
 
-    if (shouldPlaceCrypto && crypto.length > 0) {
-      result.push(crypto.shift() as PredictMarket);
+    if (shouldPlaceCrypto && cryptoRemaining) {
+      result.push(crypto[cryptoIndex]);
+      cryptoIndex += 1;
       sinceCrypto = 0;
       continue;
     }
 
-    if (live.length > 0) {
-      result.push(live.shift() as PredictMarket);
+    if (liveRemaining) {
+      result.push(liveMarkets[liveIndex]);
+      liveIndex += 1;
       sinceCrypto += 1;
       continue;
     }

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.ts
@@ -1,0 +1,52 @@
+import type { PredictMarket } from '../../../../types';
+
+/** Max number of crypto Up/Down cards shown in the Live Now rail. */
+export const LIVE_NOW_MAX_CRYPTO = 3;
+
+/** Live cards shown between each crypto card (Figma: 2 live, 1 crypto, ...). */
+const LIVE_PER_CRYPTO = 2;
+
+/**
+ * Interleaves live (sports) markets with crypto Up/Down markets for the
+ * Live Now carousel.
+ *
+ * Figma order: every 3rd slot is a crypto card, i.e. `2 live, 1 crypto`
+ * repeating (`L L C L L C L L C L`). Crypto is capped at {@link LIVE_NOW_MAX_CRYPTO};
+ * any extra live markets fill the remaining slots. When there are no live
+ * markets, the (capped) crypto markets are shown on their own.
+ *
+ * Pure + deterministic so it can be unit-tested in isolation; the section
+ * hook supplies the already-fetched/curated input arrays.
+ */
+export const interleaveLiveNowMarkets = (
+  liveMarkets: PredictMarket[],
+  cryptoMarkets: PredictMarket[],
+): PredictMarket[] => {
+  const live = [...liveMarkets];
+  const crypto = cryptoMarkets.slice(0, LIVE_NOW_MAX_CRYPTO);
+
+  const result: PredictMarket[] = [];
+  let sinceCrypto = 0;
+
+  while (live.length > 0 || crypto.length > 0) {
+    const shouldPlaceCrypto =
+      sinceCrypto >= LIVE_PER_CRYPTO || live.length === 0;
+
+    if (shouldPlaceCrypto && crypto.length > 0) {
+      result.push(crypto.shift() as PredictMarket);
+      sinceCrypto = 0;
+      continue;
+    }
+
+    if (live.length > 0) {
+      result.push(live.shift() as PredictMarket);
+      sinceCrypto += 1;
+      continue;
+    }
+
+    // No live left and no crypto eligible to place — nothing more to add.
+    break;
+  }
+
+  return result;
+};

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.test.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.test.ts
@@ -1,0 +1,209 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
+import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
+import { selectPredictUpDownEnabledFlag } from '../../../../selectors/featureFlags';
+import {
+  BTC_UP_OR_DOWN_5M_SERIES,
+  ETH_UP_OR_DOWN_5M_SERIES,
+  BTC_UP_OR_DOWN_15M_SERIES,
+} from '../../../../constants/liveNowCryptoSeries';
+import type { PredictMarket, PredictMarketListParams } from '../../../../types';
+import { CRYPTO_TAG, UP_OR_DOWN_TAG } from '../../../../utils/cryptoUpDown';
+import {
+  usePredictLiveNowSection,
+  LIVE_NOW_FETCH_LIMIT,
+  LIVE_NOW_LIVE_LIMIT,
+} from './usePredictLiveNowSection';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/usePredictMarketList');
+jest.mock('../../../../hooks/useCurrentPredictMarketFromSeries');
+
+const mockUseSelector = useSelector as jest.Mock;
+const mockUsePredictMarketList = usePredictMarketList as jest.Mock;
+const mockUseCurrentPredictMarketFromSeries =
+  useCurrentPredictMarketFromSeries as jest.Mock;
+
+// Scoreboard-capable live market (has `game`).
+const createLiveMarket = (id: string): PredictMarket =>
+  ({ id, game: { id: `game-${id}` } }) as unknown as PredictMarket;
+
+// "Regular" live market (no `game`).
+const createRegularMarket = (id: string): PredictMarket =>
+  ({ id }) as unknown as PredictMarket;
+
+const createCryptoMarket = (id: string): PredictMarket =>
+  ({
+    id,
+    tags: [CRYPTO_TAG, UP_OR_DOWN_TAG],
+    series: { id, slug: 'crypto-up-or-down', recurrence: '5m' },
+  }) as unknown as PredictMarket;
+
+const setLiveMarketList = (
+  overrides: Partial<{
+    markets: PredictMarket[];
+    isLoading: boolean;
+    error: Error | null;
+  }> = {},
+) => {
+  mockUsePredictMarketList.mockReturnValue({
+    markets: [],
+    isLoading: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    error: null,
+    hasNextPage: false,
+    refetch: jest.fn(),
+    fetchNextPage: jest.fn(),
+    ...overrides,
+  });
+};
+
+// Default: no crypto market resolved, not loading, for every series.
+const setNoCrypto = ({ isLoading = false }: { isLoading?: boolean } = {}) => {
+  mockUseCurrentPredictMarketFromSeries.mockReturnValue({
+    market: undefined,
+    isLoading,
+  });
+};
+
+// Resolve a distinct crypto market per series id (BTC 5m / ETH 5m / BTC 15m).
+const setCryptoMarketsBySeries = (
+  bySeriesId: Record<string, PredictMarket | undefined>,
+  { isLoading = false }: { isLoading?: boolean } = {},
+) => {
+  mockUseCurrentPredictMarketFromSeries.mockImplementation(
+    ({ series }: { series?: { id: string } }) => ({
+      market: series ? bySeriesId[series.id] : undefined,
+      isLoading,
+    }),
+  );
+};
+
+const setUpDownEnabled = (enabled: boolean) => {
+  mockUseSelector.mockImplementation((selector) =>
+    selector === selectPredictUpDownEnabledFlag ? enabled : false,
+  );
+};
+
+const ids = (markets: PredictMarket[]) => markets.map((market) => market.id);
+
+describe('usePredictLiveNowSection', () => {
+  beforeEach(() => {
+    setUpDownEnabled(false);
+    setLiveMarketList();
+    setNoCrypto();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests live markets with the live param and over-fetch limit', () => {
+    renderHook(() => usePredictLiveNowSection());
+
+    expect(mockUsePredictMarketList).toHaveBeenCalledWith({
+      live: true,
+      order: 'volume24hr',
+      status: 'open',
+      limit: LIVE_NOW_FETCH_LIMIT,
+    } as PredictMarketListParams);
+  });
+
+  it('keeps scoreboard markets and drops regular markets without a game', () => {
+    setLiveMarketList({
+      markets: [createLiveMarket('L1'), createRegularMarket('R1')],
+    });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(ids(result.current.items)).toEqual(['L1']);
+  });
+
+  it('caps scoreboard markets at the display limit', () => {
+    const live = Array.from({ length: LIVE_NOW_LIVE_LIMIT + 4 }, (_, i) =>
+      createLiveMarket(`L${i}`),
+    );
+    setLiveMarketList({ markets: live });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(result.current.items).toHaveLength(LIVE_NOW_LIVE_LIMIT);
+  });
+
+  it('omits crypto markets when the Up/Down flag is off', () => {
+    setUpDownEnabled(false);
+    setLiveMarketList({
+      markets: [createLiveMarket('L1'), createLiveMarket('L2')],
+    });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('C1'),
+    });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(ids(result.current.items)).toEqual(['L1', 'L2']);
+  });
+
+  it('interleaves three crypto series in 2-live-1-crypto order when enabled', () => {
+    setUpDownEnabled(true);
+    setLiveMarketList({
+      markets: [
+        createLiveMarket('L1'),
+        createLiveMarket('L2'),
+        createLiveMarket('L3'),
+        createLiveMarket('L4'),
+        createLiveMarket('L5'),
+        createLiveMarket('L6'),
+      ],
+    });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('BTC5M'),
+      [ETH_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('ETH5M'),
+      [BTC_UP_OR_DOWN_15M_SERIES.id]: createCryptoMarket('BTC15M'),
+    });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(ids(result.current.items)).toEqual([
+      'L1',
+      'L2',
+      'BTC5M',
+      'L3',
+      'L4',
+      'ETH5M',
+      'L5',
+      'L6',
+      'BTC15M',
+    ]);
+  });
+
+  it('reports loading while the live list loads even if crypto already resolved', () => {
+    setUpDownEnabled(true);
+    setLiveMarketList({ markets: [], isLoading: true });
+    setCryptoMarketsBySeries({
+      [BTC_UP_OR_DOWN_5M_SERIES.id]: createCryptoMarket('BTC5M'),
+    });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  it('reports empty when nothing resolves after loading settles', () => {
+    setUpDownEnabled(true);
+    setLiveMarketList({ markets: [], isLoading: false });
+    setNoCrypto({ isLoading: false });
+
+    const { result } = renderHook(() => usePredictLiveNowSection());
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isEmpty).toBe(true);
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { BTC_UP_OR_DOWN_5M_SERIES } from '../../../../constants/btcUpDown5mSeries';
+import {
+  BTC_UP_OR_DOWN_5M_SERIES,
+  ETH_UP_OR_DOWN_5M_SERIES,
+  BTC_UP_OR_DOWN_15M_SERIES,
+} from '../../../../constants/liveNowCryptoSeries';
 import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
 import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
 import { selectPredictUpDownEnabledFlag } from '../../../../selectors/featureFlags';
@@ -8,7 +12,20 @@ import type { PredictMarket } from '../../../../types';
 import { isCryptoUpDown } from '../../../../utils/cryptoUpDown';
 import { interleaveLiveNowMarkets } from './liveNowInterleave';
 
-/** Max live (sports) markets pulled for the Live Now rail (ticket v1). */
+/**
+ * Over-fetch live markets so client-side filtering (keep scoreboard-capable
+ * markets only) still leaves enough to fill the rail.
+ *
+ * Kept deliberately modest: `listMarkets` does not resolve until the provider
+ * has loaded the team rosters for every sports league present in the batch
+ * (one `/teams` request per league, all awaited before any market returns).
+ * A larger limit pulls in more leagues and makes the whole live list wait on
+ * the slowest roster fetch, so this is tuned to roughly 2x the display cap
+ * rather than a blanket over-fetch.
+ */
+export const LIVE_NOW_FETCH_LIMIT = 15;
+
+/** Max live (scoreboard) markets displayed in the Live Now rail after filtering. */
 export const LIVE_NOW_LIVE_LIMIT = 7;
 
 export interface UsePredictLiveNowSectionResult {
@@ -23,10 +40,16 @@ export interface UsePredictLiveNowSectionResult {
 /**
  * Data source for the Predict home "Live Now" carousel.
  *
- * Pulls up to {@link LIVE_NOW_LIVE_LIMIT} live markets via the generic
- * `usePredictMarketList` ( `live: true` as a first-class param), plus the BTC
- * 5m Up/Down crypto market resolved from its series. The two are interleaved
- * (`2 live, 1 crypto, ...`) by {@link interleaveLiveNowMarkets}.
+ * Pulls live markets via the generic `usePredictMarketList` (`live: true` as a
+ * first-class param), then keeps only the scoreboard-capable ones (`market.game`
+ * present) — the generic-card "regular" markets are filtered out. Because that
+ * filtering happens client-side, the query is over-fetched
+ * ({@link LIVE_NOW_FETCH_LIMIT}) and the survivors are capped at
+ * {@link LIVE_NOW_LIVE_LIMIT}.
+ *
+ * Alongside, the BTC 5m / ETH 5m / BTC 15m Up/Down crypto markets are resolved
+ * from their series and interleaved (`2 live, 1 crypto, ...`) by
+ * {@link interleaveLiveNowMarkets} (crypto capped at 3).
  *
  * Crypto is only included when the Up/Down feature flag is on — `PredictMarket`
  * itself only renders the crypto card when that flag is enabled, so gating here
@@ -39,34 +62,62 @@ export interface UsePredictLiveNowSectionResult {
 export const usePredictLiveNowSection = (): UsePredictLiveNowSectionResult => {
   const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
 
-  const { markets: liveMarkets, isLoading: isLiveLoading } =
+  const { markets: liveMarketsRaw, isLoading: isLiveLoading } =
     usePredictMarketList({
       live: true,
       order: 'volume24hr',
       status: 'open',
-      limit: LIVE_NOW_LIVE_LIMIT,
+      limit: LIVE_NOW_FETCH_LIMIT,
     });
 
-  const { market: cryptoMarket, isLoading: isCryptoLoading } =
-    useCurrentPredictMarketFromSeries({
-      series: BTC_UP_OR_DOWN_5M_SERIES,
-      enabled: upDownEnabled,
-    });
+  // Keep only scoreboard-capable live markets (those with `game`); drop the
+  // generic-card "regular" markets, then cap to the display limit.
+  const liveMarkets = useMemo(
+    () =>
+      liveMarketsRaw
+        .filter((market) => Boolean(market.game))
+        .slice(0, LIVE_NOW_LIVE_LIMIT),
+    [liveMarketsRaw],
+  );
+
+  const btc5m = useCurrentPredictMarketFromSeries({
+    series: BTC_UP_OR_DOWN_5M_SERIES,
+    enabled: upDownEnabled,
+  });
+  const eth5m = useCurrentPredictMarketFromSeries({
+    series: ETH_UP_OR_DOWN_5M_SERIES,
+    enabled: upDownEnabled,
+  });
+  const btc15m = useCurrentPredictMarketFromSeries({
+    series: BTC_UP_OR_DOWN_15M_SERIES,
+    enabled: upDownEnabled,
+  });
 
   const cryptoMarkets = useMemo<PredictMarket[]>(() => {
-    if (!upDownEnabled || !cryptoMarket || !isCryptoUpDown(cryptoMarket)) {
+    if (!upDownEnabled) {
       return [];
     }
-    return [cryptoMarket];
-  }, [upDownEnabled, cryptoMarket]);
+    return [btc5m.market, eth5m.market, btc15m.market].filter(
+      (market): market is PredictMarket =>
+        Boolean(market) && isCryptoUpDown(market as PredictMarket),
+    );
+  }, [upDownEnabled, btc5m.market, eth5m.market, btc15m.market]);
 
   const items = useMemo(
     () => interleaveLiveNowMarkets(liveMarkets, cryptoMarkets),
     [liveMarkets, cryptoMarkets],
   );
 
-  const isLoading =
-    (isLiveLoading || (upDownEnabled && isCryptoLoading)) && items.length === 0;
+  const isCryptoLoading =
+    btc5m.isLoading || eth5m.isLoading || btc15m.isLoading;
+
+  // Reveal the rail only once its primary content (the live list) has settled,
+  // and — when crypto is enabled — the crypto series too. Crypto markets carry
+  // no team rosters so they resolve almost immediately; gating purely on
+  // `items.length` would otherwise flash a crypto-only rail and then reflow
+  // when the slower live games land. Crypto is fast, so also waiting on it adds
+  // negligible delay while guaranteeing a single, stable reveal.
+  const isLoading = isLiveLoading || (upDownEnabled && isCryptoLoading);
   const isEmpty = !isLoading && items.length === 0;
 
   return { items, isLoading, isEmpty };

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { BTC_UP_OR_DOWN_5M_SERIES } from '../../../../constants/btcUpDown5mSeries';
+import { useCurrentPredictMarketFromSeries } from '../../../../hooks/useCurrentPredictMarketFromSeries';
+import { usePredictMarketList } from '../../../../hooks/usePredictMarketList';
+import { selectPredictUpDownEnabledFlag } from '../../../../selectors/featureFlags';
+import type { PredictMarket } from '../../../../types';
+import { isCryptoUpDown } from '../../../../utils/cryptoUpDown';
+import { interleaveLiveNowMarkets } from './liveNowInterleave';
+
+/** Max live (sports) markets pulled for the Live Now rail (ticket v1). */
+export const LIVE_NOW_LIVE_LIMIT = 7;
+
+export interface UsePredictLiveNowSectionResult {
+  /** Interleaved live + crypto markets ready for the carousel. */
+  items: PredictMarket[];
+  /** Initial load with nothing to show yet (render skeletons). */
+  isLoading: boolean;
+  /** No data after load (hide the section entirely). */
+  isEmpty: boolean;
+}
+
+/**
+ * Data source for the Predict home "Live Now" carousel.
+ *
+ * Pulls up to {@link LIVE_NOW_LIVE_LIMIT} live markets via the generic
+ * `usePredictMarketList` ( `live: true` as a first-class param), plus the BTC
+ * 5m Up/Down crypto market resolved from its series. The two are interleaved
+ * (`2 live, 1 crypto, ...`) by {@link interleaveLiveNowMarkets}.
+ *
+ * Crypto is only included when the Up/Down feature flag is on — `PredictMarket`
+ * itself only renders the crypto card when that flag is enabled, so gating here
+ * keeps the data and the renderer in sync.
+ *
+ * Errors are non-blocking: `usePredictMarketList` returns `[]` rather than
+ * throwing, so a failed fetch collapses to the empty (hidden) state and never
+ * blocks the home screen.
+ */
+export const usePredictLiveNowSection = (): UsePredictLiveNowSectionResult => {
+  const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
+
+  const { markets: liveMarkets, isLoading: isLiveLoading } =
+    usePredictMarketList({
+      live: true,
+      order: 'volume24hr',
+      status: 'open',
+      limit: LIVE_NOW_LIVE_LIMIT,
+    });
+
+  const { market: cryptoMarket, isLoading: isCryptoLoading } =
+    useCurrentPredictMarketFromSeries({
+      series: BTC_UP_OR_DOWN_5M_SERIES,
+      enabled: upDownEnabled,
+    });
+
+  const cryptoMarkets = useMemo<PredictMarket[]>(() => {
+    if (!upDownEnabled || !cryptoMarket || !isCryptoUpDown(cryptoMarket)) {
+      return [];
+    }
+    return [cryptoMarket];
+  }, [upDownEnabled, cryptoMarket]);
+
+  const items = useMemo(
+    () => interleaveLiveNowMarkets(liveMarkets, cryptoMarkets),
+    [liveMarkets, cryptoMarkets],
+  );
+
+  const isLoading =
+    (isLiveLoading || (upDownEnabled && isCryptoLoading)) && items.length === 0;
+  const isEmpty = !isLoading && items.length === 0;
+
+  return { items, isLoading, isEmpty };
+};

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2307,7 +2307,8 @@
     "title": "MetaMask Predictions",
     "home": {
       "portfolio_module_placeholder": "Portfolio module",
-      "live_now_placeholder": "Live now",
+      "live_now_title": "Live now",
+      "see_all": "See all",
       "categories_placeholder": "Categories",
       "popular_today_placeholder": "Popular today",
       "trending_placeholder": "Trending"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2308,7 +2308,6 @@
     "home": {
       "portfolio_module_placeholder": "Portfolio module",
       "live_now_title": "Live now",
-      "see_all": "See all",
       "categories_placeholder": "Categories",
       "popular_today_placeholder": "Popular today",
       "trending_placeholder": "Trending"

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -333,6 +333,10 @@ jest.mock('../../app/core/Engine', () => {
           markets: [],
           nextCursor: null,
         }),
+        listMarkets: jest.fn().mockResolvedValue({
+          markets: [],
+          nextCursor: null,
+        }),
         searchMarkets: jest
           .fn()
           .mockResolvedValue({ markets: [], totalResults: 0 }),


### PR DESCRIPTION
## **Description**

Implements the **Live Now** section for the redesigned Predict homepage (`PredictHome`), part of epic **PRED-834 — IA & Navigation Overhaul**.

This replaces the previous `live_now_placeholder` with a real horizontal carousel that interleaves **live sports (scoreboard) markets** with **Crypto Up/Down cards** (BTC 5m, ETH 5m, BTC 15m), reusing the existing Predict card components.

**Why:** the redesigned homepage needs a curated, non-blocking "Live Now" rail per Figma, sourced from the new generic `listMarkets` API rather than category-based fetching.

**What changed:**

- **New data hook `usePredictLiveNowSection`** — fetches live markets via the generic `usePredictMarketList({ live: true, order: 'volume24hr', status: 'open', limit: 15 })`, then keeps only **scoreboard-capable** markets (those with a `game` object) and caps them at 7 — the generic-card "regular" live markets (e.g. esports without a scoreboard) are filtered out. Alongside, it resolves the **three** Crypto Up/Down series (BTC 5m, ETH 5m, BTC 15m), each gated behind the Up/Down feature flag. Errors are non-blocking: a failed fetch collapses to the hidden/empty state and never blocks the home screen.
- **New crypto-series constants `liveNowCryptoSeries.ts`** — `ETH_UP_OR_DOWN_5M_SERIES` (`10683`) and `BTC_UP_OR_DOWN_15M_SERIES` (`10192`), plus an ordered `LIVE_NOW_CRYPTO_SERIES` array (BTC 5m, ETH 5m, BTC 15m) re-exporting the existing BTC 5m series. IDs confirmed against the Gamma API; all carry `up-or-down` + `crypto` tags so they render as crypto cards with no renderer change.
- **New pure utility `interleaveLiveNowMarkets`** — deterministic `2 live, 1 crypto` interleave (Figma order `L L C L L C …`), crypto capped at 3, with graceful fallbacks (crypto-only when nothing is live, live-only when no crypto). Implemented as an index-pointer walk (no array mutation or casts) and extracted as a pure function so it's unit-testable in isolation.
- **`PredictLiveNowSection` component** — renders a `SectionHeader` (title) and a horizontal `FlashList` of reused `PredictMarket` cards, with `PredictMarketSkeleton` placeholders during load and **pagination dots** (reusing `PaginationDots` extracted from `FeaturedCarousel` with `onScroll` active-index tracking). The header is intentionally **static/non-pressable** for now (no `onPress` ⇒ no chevron) since the "See all" target route does not exist yet — rather than shipping a dead control. The section hides itself entirely on empty/error so it never blocks the home screen.
- **Load-time + reveal optimization** — `listMarkets` does not resolve until the provider has loaded team rosters (`/teams`) for every sports league in the batch, so the fetch limit is kept modest (`LIVE_NOW_FETCH_LIMIT = 15`, ≈2x the 7-card cap) to avoid dragging extra leagues into the blocking roster fetch. The loading gate reveals the rail only once the live list (and, when enabled, crypto) has settled — `isLoading = isLiveLoading || (upDownEnabled && isCryptoLoading)` — so the rail goes skeletons → full rail in one shot instead of flashing the fast crypto cards first and reflowing when the slower games land.
- **Localization** — added `predict.home.live_now_title` ("Live now") and `predict.home.see_all` ("See all", reserved for the upcoming "See all" wiring); removed the unused `live_now_placeholder`.
- **Tests** — split by responsibility: (a) `liveNowInterleave.test.ts` for ordering semantics; (b) `usePredictLiveNowSection.test.ts` (`renderHook`) for all data logic — `live: true` + over-fetch `limit: 15`, scoreboard filtering, the live cap, flag gating, three-crypto-series interleave order, and loading/empty transitions incl. the crypto-first-flash case; (c) `PredictLiveNowSection.test.tsx` for presentation, rendering the **real** `PredictMarket` / `PredictMarketSkeleton` via `renderWithProvider` and mocking only the data hook, `@shopify/flash-list`, and the heavy leaf cards (matching the canonical `PredictMarket.test.tsx` boundary). Plus an updated `PredictHome` view test + global component-view Engine mock (`listMarkets`).

**Notable decisions / constraints:**

- **"See all" deferred (no dead CTA)** — the target, a generic `PredictFeedView` with `feedId: 'live'`, does not exist yet (lands in follow-up tickets: generic Predict feed route + generic feed view). Rather than ship a pressable that does nothing, the header renders as static text now; passing `onPress` (which restores the chevron) is a one-line change once `Routes.PREDICT.FEED` exists.
- **Scoreboard-only filter** — the rail shows only live markets with a `game` (scoreboard) object; generic-card "regular" live markets are dropped via a binary `Boolean(market.game)` check (not a league allow-list). A companion handoff doc inventories live markets that currently lack scoreboard UX, for a follow-up sprint to extend league support.
- **Three crypto series** — BTC 5m, ETH 5m, BTC 15m are sourced via three fixed `useCurrentPredictMarketFromSeries` calls (rules-of-hooks safe), validated with `isCryptoUpDown`, and capped at 3 by the interleave (order encoded in `LIVE_NOW_CRYPTO_SERIES`).
- **Local FlashList over reusing `TrendingView`'s carousel** — avoids cross-module coupling.
- **Flag-off behavior is unchanged** — the section only renders inside the `predictHomeRedesign`-gated `PredictHome`; the legacy `PredictFeed` homepage is untouched.

## **Changelog**

CHANGELOG entry: null

<!-- Not end-user-facing yet: the section only renders behind the `predictHomeRedesign` feature flag, which is off in production. -->

## **Related issues**

Refs: PRED-834

## **Manual testing steps**

```gherkin
Feature: Predict Live Now homepage carousel

  Scenario: User sees the Live Now rail with live and crypto markets
    Given the predictHomeRedesign feature flag is enabled
    And there are open live sports (scoreboard) markets and Crypto Up/Down markets available
    When the user opens the Predict home screen
    Then a "Live now" section is shown with a horizontal carousel
    And the carousel interleaves live markets with Crypto Up/Down cards (2 live, 1 crypto)
    And up to three crypto cards (BTC 5m, ETH 5m, BTC 15m) appear across the rail
    And the "Live now" header is shown as static text (no pressable "See all" yet)
    And pagination dots reflect the active card while scrolling
    And the existing Predict market/event cards are reused

  Scenario: Only scoreboard-capable live markets are shown
    Given the live markets feed contains a mix of sports (scoreboard) and "regular" markets
    When the user opens the Predict home screen
    Then only the sports (scoreboard) markets appear in the rail
    And the "regular" live markets without a scoreboard are not shown

  Scenario: Rail reveals in one shot, no crypto-only flash
    Given the predictHomeRedesign feature flag is enabled
    And the crypto markets resolve faster than the live sports markets
    When the user opens the Predict home screen
    Then skeleton cards remain until the live list has loaded
    And the rail is not shown with only crypto cards before the live games arrive
    And once loaded the interleaved rail appears in a single, stable reveal

  Scenario: Loading state does not block the home screen
    Given the Live Now data is still loading
    When the user opens the Predict home screen
    Then skeleton cards are shown in the carousel
    And the rest of the home screen renders normally

  Scenario: Empty or failed fetch hides the section
    Given the live markets request returns no markets or fails
    When the user opens the Predict home screen
    Then the Live Now section is not rendered
    And the home screen is not blocked

  Scenario: Legacy homepage is unaffected
    Given the predictHomeRedesign feature flag is disabled
    When the user opens the Predict home screen
    Then the existing PredictFeed homepage is shown unchanged
```

> Local QA tip: the section renders behind `predictHomeRedesign`. Enable it via the in-app Feature Flag Override (Settings → Developer Options) or by temporarily overriding `selectPredictHomeRedesignEnabledFlag` locally. Do not commit any flag override.

## **Screenshots/Recordings**

### **Before**

<!-- Placeholder "Live now" text in PredictHome (predictHomeRedesign on). -->

### **After**

<!-- Live Now carousel with interleaved live sports + Crypto Up/Down (BTC 5m, ETH 5m, BTC 15m) cards and pagination dots. Attach device recording before requesting review. -->

https://github.com/user-attachments/assets/801b4227-bb37-4429-a3c1-a1347c6d7da6

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## Files changed

| File | Type | Notes |
| --- | --- | --- |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx` | Modified | Replaced placeholder with carousel + skeletons + pagination dots; static (non-pressable) header |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts` | Added | Data hook: live markets (over-fetch + scoreboard filter + cap), 3 crypto series, interleave, single-reveal gate |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.test.ts` | Added | Hook tests (`renderHook`): params/over-fetch, scoreboard filter + cap, flag gating, 3-series interleave, loading/empty transitions |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.ts` | Added | Pure `2 live / 1 crypto` interleave utility (index-pointer walk, no casts) |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/liveNowInterleave.test.ts` | Added | Unit tests for the interleave utility |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx` | Added | Presentation tests rendering real `PredictMarket`/skeleton via `renderWithProvider` (mocks data hook + FlashList + leaf cards); static-header, pagination, scroll |
| `app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.testIds.ts` | Added | Section test IDs (header/carousel/card/skeleton/pagination) |
| `app/components/UI/Predict/constants/liveNowCryptoSeries.ts` | Added | ETH 5m + BTC 15m series constants + ordered `LIVE_NOW_CRYPTO_SERIES` |
| `app/components/UI/Predict/components/PaginationDots/PaginationDots.tsx` | Added | Shared pagination dots (extracted from `FeaturedCarousel`, optional `testID`) |
| `app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.tsx` | Modified | Consume shared `PaginationDots` instead of inline copy |
| `app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx` | Modified | Mock `listMarkets` so the section renders in the shell view test |
| `locales/languages/en.json` | Modified | Added `live_now_title` + `see_all`; removed `live_now_placeholder` |
| `tests/component-view/mocks.ts` | Modified | Added default `PredictController.listMarkets` Engine mock |

_Diff vs `main`: ~13 files changed (the new constants/test files are untracked until staged)._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only behind `predictHomeRedesign`; failed fetches hide the section and do not block the home screen. No auth or payment changes.
> 
> **Overview**
> Replaces the Predict home **Live now** placeholder with a real horizontal carousel that mixes **scoreboard live sports** markets with up to three **Crypto Up/Down** series (BTC 5m, ETH 5m, BTC 15m).
> 
> **Data:** `usePredictLiveNowSection` loads live markets via `listMarkets` (`live: true`, modest over-fetch), keeps only markets with a `game`, caps at 7, resolves crypto from series when the Up/Down flag is on, and orders items with `interleaveLiveNowMarkets` (2 live, 1 crypto). Loading waits on both live and crypto so the rail does not flash crypto-only first; empty/error hides the section.
> 
> **UI:** `PredictLiveNowSection` uses `FlashList`, shared `PredictMarket` cards, skeletons, and **`PaginationDots`** extracted from `FeaturedCarousel`. The header is static (no “See all” until a feed route exists).
> 
> **Supporting:** `liveNowCryptoSeries` constants, locale `live_now_title`, tests for interleave/hook/UI, and `listMarkets` mocks for home view tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc4e8389bda0f634bde41a5e9a55771e6d340cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->