### PR TITLE
feat(analytics): track External Link Clicked on block explorer taps (TMCU-300)

### DIFF
--- a/app/components/UI/AccountApproval/showWarningBanner.test.tsx
+++ b/app/components/UI/AccountApproval/showWarningBanner.test.tsx
@@ -3,9 +3,13 @@ import { Linking } from 'react-native';
 import { fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import ShowWarningBanner from './showWarningBanner';
-import { MetaMetricsEvents } from '../../../core/Analytics';
 import { CONNECTING_TO_A_DECEPTIVE_SITE } from '../../../constants/urls';
 
+jest.mock('../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../util/analytics/externalLinkTracking'),
+  trackExternalLinkClicked: jest.fn(),
+}));
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 const mockTrackEvent = jest.fn();
 jest.mock('../../../util/analytics/analytics', () => ({
   analytics: {
@@ -37,10 +41,14 @@ describe('ShowWarningBanner', () => {
 
     fireEvent.press(getByText('Learn more'));
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-      }),
+    expect(jest.mocked(trackExternalLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        location: 'dapp_connection_request',
+        text: 'Learn More',
+        url_domain: CONNECTING_TO_A_DECEPTIVE_SITE,
+      },
     );
   });
 

--- a/app/components/UI/AccountApproval/showWarningBanner.tsx
+++ b/app/components/UI/AccountApproval/showWarningBanner.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../../component-library/components/Icons/Icon';
 import { CONNECTING_TO_A_DECEPTIVE_SITE } from '../../../constants/urls';
 import { AccordionHeaderHorizontalAlignment } from '../../../component-library/components/Accordions/Accordion';
-import { MetaMetricsEvents } from '../../../core/Analytics';
 import { analytics } from '../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import {
@@ -23,6 +22,7 @@ import {
   TextColor,
   FontWeight,
 } from '@metamask/design-system-react-native';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 
 const descriptionArray = [
   strings('accounts.fake_metamask'),
@@ -32,16 +32,14 @@ const descriptionArray = [
 
 const goToLearnMore = () => {
   Linking.openURL(CONNECTING_TO_A_DECEPTIVE_SITE);
-  analytics.trackEvent(
-    AnalyticsEventBuilder.createEventBuilder(
-      MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-    )
-      .addProperties({
-        location: 'dapp_connection_request',
-        text: 'Learn More',
-        url_domain: CONNECTING_TO_A_DECEPTIVE_SITE,
-      })
-      .build(),
+  trackExternalLinkClicked(
+    analytics.trackEvent,
+    AnalyticsEventBuilder.createEventBuilder,
+    {
+      location: 'dapp_connection_request',
+      text: 'Learn More',
+      url_domain: CONNECTING_TO_A_DECEPTIVE_SITE,
+    },
   );
 };
 

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.test.tsx
@@ -11,6 +11,11 @@ import { initialState } from '../../_mocks_/initialState';
 import BlockExplorersModal from './BlockExplorersModal';
 import { fireEvent } from '@testing-library/react-native';
 
+jest.mock('../../../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 const mockNavigate = jest.fn();
 
 const mockTx = {
@@ -151,6 +156,14 @@ describe('BlockExplorersModal', () => {
         url: expect.stringContaining('etherscan.io'),
       }),
     });
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'bridge_transaction_details',
+        url: expect.stringContaining('etherscan.io'),
+      }),
+    );
   });
 
   it('should navigate to webview when destination chain explorer button is pressed', () => {

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -24,6 +24,8 @@ import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
 import { useMultichainBlockExplorerTxUrl } from '../../hooks/useMultichainBlockExplorerTxUrl';
 import { Transaction } from '@metamask/keyring-api';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
@@ -43,6 +45,7 @@ interface BlockExplorersModalRouteParams {
 
 const BlockExplorersModal = () => {
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const route =
     useRoute<RouteProp<{ params: BlockExplorersModalRouteParams }, 'params'>>();
   const { styles } = useStyles(styleSheet, {});
@@ -89,6 +92,15 @@ const BlockExplorersModal = () => {
             variant={ButtonVariant.Secondary}
             isFullWidth
             onPress={() => {
+              trackEvent(
+                createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+                  .addProperties({
+                    location: 'bridge_transaction_details',
+                    text: srcExplorerData.explorerName,
+                    url_domain: srcExplorerData.explorerTxUrl,
+                  })
+                  .build(),
+              );
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
                 params: {
@@ -119,6 +131,15 @@ const BlockExplorersModal = () => {
             variant={ButtonVariant.Secondary}
             isFullWidth
             onPress={() => {
+              trackEvent(
+                createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+                  .addProperties({
+                    location: 'bridge_transaction_details',
+                    text: bridgeDestExplorerData.explorerName,
+                    url_domain: bridgeDestExplorerData.explorerTxUrl,
+                  })
+                  .build(),
+              );
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
                 params: {

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import BottomSheet from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
@@ -70,6 +70,26 @@ const BlockExplorersModal = () => {
     txHash: bridgeTxHistoryItem?.status.destChain?.txHash,
   });
 
+  const handleBlockExplorerPress = useCallback(
+    (url: string | undefined, text: string) => {
+      if (!url) {
+        return;
+      }
+      trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
+        location: 'bridge_transaction_details',
+        text,
+        url,
+      });
+      navigation.navigate(Routes.WEBVIEW.MAIN, {
+        screen: Routes.WEBVIEW.SIMPLE,
+        params: {
+          url,
+        },
+      });
+    },
+    [trackEvent, createEventBuilder, navigation],
+  );
+
   return (
     <BottomSheet>
       <BottomSheetHeader>
@@ -91,26 +111,12 @@ const BlockExplorersModal = () => {
           <Button
             variant={ButtonVariant.Secondary}
             isFullWidth
-            onPress={() => {
-              const url = srcExplorerData.explorerTxUrl;
-              if (!url) {
-                return;
-              }
-              trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
-                location: 'bridge_transaction_details',
-                text:
-                  srcExplorerData.explorerName ??
-                  srcExplorerData.chainName ??
-                  '',
-                url,
-              });
-              navigation.navigate(Routes.WEBVIEW.MAIN, {
-                screen: Routes.WEBVIEW.SIMPLE,
-                params: {
-                  url,
-                },
-              });
-            }}
+            onPress={() =>
+              handleBlockExplorerPress(
+                srcExplorerData.explorerTxUrl,
+                srcExplorerData.explorerName ?? srcExplorerData.chainName ?? '',
+              )
+            }
           >
             <Box
               flexDirection={FlexDirection.Row}
@@ -133,26 +139,14 @@ const BlockExplorersModal = () => {
           <Button
             variant={ButtonVariant.Secondary}
             isFullWidth
-            onPress={() => {
-              const url = bridgeDestExplorerData.explorerTxUrl;
-              if (!url) {
-                return;
-              }
-              trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
-                location: 'bridge_transaction_details',
-                text:
-                  bridgeDestExplorerData.explorerName ??
+            onPress={() =>
+              handleBlockExplorerPress(
+                bridgeDestExplorerData.explorerTxUrl,
+                bridgeDestExplorerData.explorerName ??
                   bridgeDestExplorerData.chainName ??
                   '',
-                url,
-              });
-              navigation.navigate(Routes.WEBVIEW.MAIN, {
-                screen: Routes.WEBVIEW.SIMPLE,
-                params: {
-                  url,
-                },
-              });
-            }}
+              )
+            }
           >
             <Box
               flexDirection={FlexDirection.Row}

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -25,7 +25,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { useMultichainBlockExplorerTxUrl } from '../../hooks/useMultichainBlockExplorerTxUrl';
 import { Transaction } from '@metamask/keyring-api';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
@@ -92,15 +92,11 @@ const BlockExplorersModal = () => {
             variant={ButtonVariant.Secondary}
             isFullWidth
             onPress={() => {
-              trackEvent(
-                createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-                  .addProperties({
-                    location: 'bridge_transaction_details',
-                    text: srcExplorerData.explorerName,
-                    url_domain: srcExplorerData.explorerTxUrl,
-                  })
-                  .build(),
-              );
+              trackExternalLinkClicked(trackEvent, createEventBuilder, {
+                location: 'bridge_transaction_details',
+                text: srcExplorerData.explorerName,
+                url_domain: srcExplorerData.explorerTxUrl,
+              });
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
                 params: {
@@ -131,15 +127,11 @@ const BlockExplorersModal = () => {
             variant={ButtonVariant.Secondary}
             isFullWidth
             onPress={() => {
-              trackEvent(
-                createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-                  .addProperties({
-                    location: 'bridge_transaction_details',
-                    text: bridgeDestExplorerData.explorerName,
-                    url_domain: bridgeDestExplorerData.explorerTxUrl,
-                  })
-                  .build(),
-              );
+              trackExternalLinkClicked(trackEvent, createEventBuilder, {
+                location: 'bridge_transaction_details',
+                text: bridgeDestExplorerData.explorerName,
+                url_domain: bridgeDestExplorerData.explorerTxUrl,
+              });
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
                 params: {

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -25,7 +25,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { useMultichainBlockExplorerTxUrl } from '../../hooks/useMultichainBlockExplorerTxUrl';
 import { Transaction } from '@metamask/keyring-api';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const styleSheet = (params: { theme: Theme }) =>
   StyleSheet.create({
@@ -96,13 +96,13 @@ const BlockExplorersModal = () => {
               if (!url) {
                 return;
               }
-              trackExternalLinkClicked(trackEvent, createEventBuilder, {
+              trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
                 location: 'bridge_transaction_details',
                 text:
                   srcExplorerData.explorerName ??
                   srcExplorerData.chainName ??
                   '',
-                url_domain: url,
+                url,
               });
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
@@ -138,13 +138,13 @@ const BlockExplorersModal = () => {
               if (!url) {
                 return;
               }
-              trackExternalLinkClicked(trackEvent, createEventBuilder, {
+              trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
                 location: 'bridge_transaction_details',
                 text:
                   bridgeDestExplorerData.explorerName ??
                   bridgeDestExplorerData.chainName ??
                   '',
-                url_domain: url,
+                url,
               });
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,

--- a/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BlockExplorersModal.tsx
@@ -92,15 +92,22 @@ const BlockExplorersModal = () => {
             variant={ButtonVariant.Secondary}
             isFullWidth
             onPress={() => {
+              const url = srcExplorerData.explorerTxUrl;
+              if (!url) {
+                return;
+              }
               trackExternalLinkClicked(trackEvent, createEventBuilder, {
                 location: 'bridge_transaction_details',
-                text: srcExplorerData.explorerName,
-                url_domain: srcExplorerData.explorerTxUrl,
+                text:
+                  srcExplorerData.explorerName ??
+                  srcExplorerData.chainName ??
+                  '',
+                url_domain: url,
               });
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
                 params: {
-                  url: srcExplorerData.explorerTxUrl,
+                  url,
                 },
               });
             }}
@@ -127,15 +134,22 @@ const BlockExplorersModal = () => {
             variant={ButtonVariant.Secondary}
             isFullWidth
             onPress={() => {
+              const url = bridgeDestExplorerData.explorerTxUrl;
+              if (!url) {
+                return;
+              }
               trackExternalLinkClicked(trackEvent, createEventBuilder, {
                 location: 'bridge_transaction_details',
-                text: bridgeDestExplorerData.explorerName,
-                url_domain: bridgeDestExplorerData.explorerTxUrl,
+                text:
+                  bridgeDestExplorerData.explorerName ??
+                  bridgeDestExplorerData.chainName ??
+                  '',
+                url_domain: url,
               });
               navigation.navigate(Routes.WEBVIEW.MAIN, {
                 screen: Routes.WEBVIEW.SIMPLE,
                 params: {
-                  url: bridgeDestExplorerData.explorerTxUrl,
+                  url,
                 },
               });
             }}

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -49,7 +49,7 @@ import TagColored, {
 // import { renderShortAddress } from '../../../../../util/address';
 import { isHardwareAccount } from '../../../../../util/address';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { isTransactionMarkedAsGasFeeSponsored } from '../../../../Views/confirmations/utils/transaction';
 
 const styles = StyleSheet.create({
@@ -453,12 +453,12 @@ export const BridgeTransactionDetails = (
             onPress={() => {
               // For swaps, go directly to block explorer web view
               if (isSwap && swapSrcExplorerData?.explorerTxUrl) {
-                trackExternalLinkClicked(trackEvent, createEventBuilder, {
+                trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
                   location: 'bridge_transaction_details',
                   text: strings(
                     'bridge_transaction_details.view_on_block_explorer',
                   ),
-                  url_domain: swapSrcExplorerData.explorerTxUrl,
+                  url: swapSrcExplorerData.explorerTxUrl,
                 });
                 navigation.navigate(Routes.WEBVIEW.MAIN, {
                   screen: Routes.WEBVIEW.SIMPLE,

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -49,7 +49,7 @@ import TagColored, {
 // import { renderShortAddress } from '../../../../../util/address';
 import { isHardwareAccount } from '../../../../../util/address';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { isTransactionMarkedAsGasFeeSponsored } from '../../../../Views/confirmations/utils/transaction';
 
 const styles = StyleSheet.create({
@@ -453,17 +453,13 @@ export const BridgeTransactionDetails = (
             onPress={() => {
               // For swaps, go directly to block explorer web view
               if (isSwap && swapSrcExplorerData?.explorerTxUrl) {
-                trackEvent(
-                  createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-                    .addProperties({
-                      location: 'bridge_transaction_details',
-                      text: strings(
-                        'bridge_transaction_details.view_on_block_explorer',
-                      ),
-                      url_domain: swapSrcExplorerData.explorerTxUrl,
-                    })
-                    .build(),
-                );
+                trackExternalLinkClicked(trackEvent, createEventBuilder, {
+                  location: 'bridge_transaction_details',
+                  text: strings(
+                    'bridge_transaction_details.view_on_block_explorer',
+                  ),
+                  url_domain: swapSrcExplorerData.explorerTxUrl,
+                });
                 navigation.navigate(Routes.WEBVIEW.MAIN, {
                   screen: Routes.WEBVIEW.SIMPLE,
                   params: {

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -48,6 +48,8 @@ import TagColored, {
 } from '../../../../../component-library/components-temp/TagColored';
 // import { renderShortAddress } from '../../../../../util/address';
 import { isHardwareAccount } from '../../../../../util/address';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { isTransactionMarkedAsGasFeeSponsored } from '../../../../Views/confirmations/utils/transaction';
 
 const styles = StyleSheet.create({
@@ -184,6 +186,7 @@ export const BridgeTransactionDetails = (
   props: BridgeTransactionDetailsProps,
 ) => {
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const evmTxMeta = props.route.params.evmTxMeta;
   const multiChainTx = props.route.params.multiChainTx;
@@ -450,6 +453,17 @@ export const BridgeTransactionDetails = (
             onPress={() => {
               // For swaps, go directly to block explorer web view
               if (isSwap && swapSrcExplorerData?.explorerTxUrl) {
+                trackEvent(
+                  createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+                    .addProperties({
+                      location: 'bridge_transaction_details',
+                      text: strings(
+                        'bridge_transaction_details.view_on_block_explorer',
+                      ),
+                      url_domain: swapSrcExplorerData.explorerTxUrl,
+                    })
+                    .build(),
+                );
                 navigation.navigate(Routes.WEBVIEW.MAIN, {
                   screen: Routes.WEBVIEW.SIMPLE,
                   params: {

--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -44,7 +44,7 @@ import AppConstants from '../../../core/AppConstants';
 import { useTheme } from '../../../util/theme';
 import { analytics } from '../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { selectChainId } from '../../../selectors/networkController';
 import {
   selectDisplayNftMedia,
@@ -261,13 +261,13 @@ const CollectibleOverview = ({
             collectible?.address,
             chainId,
           );
-          trackExternalLinkClicked(
+          trackBlockExplorerLinkClicked(
             analytics.trackEvent,
             AnalyticsEventBuilder.createEventBuilder,
             {
               location: 'collectible_overview',
               text: strings('collectible.collectible_asset_contract'),
-              url_domain: url,
+              url,
             },
           );
           openLink(url);

--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -42,6 +42,9 @@ import {
 } from 'react-native-gesture-handler';
 import AppConstants from '../../../core/AppConstants';
 import { useTheme } from '../../../util/theme';
+import { analytics } from '../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import { selectChainId } from '../../../selectors/networkController';
 import {
   selectDisplayNftMedia,
@@ -253,10 +256,24 @@ const CollectibleOverview = ({
       key: strings('collectible.collectible_asset_contract'),
       value: renderShortAddress(collectible?.address),
       onPress: () => {
-        if (isMainNet(chainId))
-          openLink(
-            etherscanLink.createTokenTrackerLink(collectible?.address, chainId),
+        if (isMainNet(chainId)) {
+          const url = etherscanLink.createTokenTrackerLink(
+            collectible?.address,
+            chainId,
           );
+          analytics.trackEvent(
+            AnalyticsEventBuilder.createEventBuilder(
+              MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+            )
+              .addProperties({
+                location: 'collectible_overview',
+                text: strings('collectible.collectible_asset_contract'),
+                url_domain: url,
+              })
+              .build(),
+          );
+          openLink(url);
+        }
       },
       type: FieldType.Text,
     }),

--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -44,7 +44,7 @@ import AppConstants from '../../../core/AppConstants';
 import { useTheme } from '../../../util/theme';
 import { analytics } from '../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
-import { MetaMetricsEvents } from '../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { selectChainId } from '../../../selectors/networkController';
 import {
   selectDisplayNftMedia,
@@ -261,16 +261,14 @@ const CollectibleOverview = ({
             collectible?.address,
             chainId,
           );
-          analytics.trackEvent(
-            AnalyticsEventBuilder.createEventBuilder(
-              MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-            )
-              .addProperties({
-                location: 'collectible_overview',
-                text: strings('collectible.collectible_asset_contract'),
-                url_domain: url,
-              })
-              .build(),
+          trackExternalLinkClicked(
+            analytics.trackEvent,
+            AnalyticsEventBuilder.createEventBuilder,
+            {
+              location: 'collectible_overview',
+              text: strings('collectible.collectible_asset_contract'),
+              url_domain: url,
+            },
           );
           openLink(url);
         }

--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -261,6 +261,9 @@ const CollectibleOverview = ({
             collectible?.address,
             chainId,
           );
+          if (!url) {
+            return;
+          }
           trackBlockExplorerLinkClicked(
             analytics.trackEvent,
             AnalyticsEventBuilder.createEventBuilder,

--- a/app/components/UI/DeprecatedNetworkModal/DeprecatedNetworkModal.test.tsx
+++ b/app/components/UI/DeprecatedNetworkModal/DeprecatedNetworkModal.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../util/test/renderWithProvider';
+import DeprecatedNetworkModal from './DeprecatedNetworkModal';
+import { CONNECTING_TO_DEPRECATED_NETWORK } from '../../../constants/urls';
+
+jest.mock('../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../util/analytics/externalLinkTracking'),
+  trackExternalLinkClicked: jest.fn(),
+}));
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+describe('DeprecatedNetworkModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('tracks External Link Clicked when Learn more is pressed', () => {
+    const { getByText } = renderWithProvider(<DeprecatedNetworkModal />);
+
+    fireEvent.press(getByText('Learn more'));
+
+    expect(jest.mocked(trackExternalLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        location: 'dapp_connection_request',
+        text: 'Learn More',
+        url_domain: CONNECTING_TO_DEPRECATED_NETWORK,
+      },
+    );
+  });
+
+  it('opens CONNECTING_TO_DEPRECATED_NETWORK URL when Learn more is pressed', () => {
+    const { getByText } = renderWithProvider(<DeprecatedNetworkModal />);
+
+    fireEvent.press(getByText('Learn more'));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      CONNECTING_TO_DEPRECATED_NETWORK,
+    );
+  });
+});

--- a/app/components/UI/DeprecatedNetworkModal/DeprecatedNetworkModal.tsx
+++ b/app/components/UI/DeprecatedNetworkModal/DeprecatedNetworkModal.tsx
@@ -11,12 +11,12 @@ import Button, {
 import { CONNECTING_TO_DEPRECATED_NETWORK } from '../../../constants/urls';
 import BottomSheet from '../../../component-library/components/BottomSheets/BottomSheet';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   Text,
   TextVariant,
   TextColor,
 } from '@metamask/design-system-react-native';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 
 const DeprecatedNetworkModal = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -29,15 +29,11 @@ const DeprecatedNetworkModal = () => {
 
   const goToLearnMore = () => {
     Linking.openURL(CONNECTING_TO_DEPRECATED_NETWORK);
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'dapp_connection_request',
-          text: 'Learn More',
-          url_domain: CONNECTING_TO_DEPRECATED_NETWORK,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'dapp_connection_request',
+      text: 'Learn More',
+      url_domain: CONNECTING_TO_DEPRECATED_NETWORK,
+    });
   };
 
   const sheetRef = useRef(null);

--- a/app/components/UI/HardwareWallet/AccountSelector/index.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/index.tsx
@@ -7,6 +7,8 @@ import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import { IAccount } from './types';
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAccountsBalance } from './hooks';
 import { useTheme } from '../../../../util/theme';
 import { createStyle } from './styles';
@@ -43,7 +45,27 @@ const AccountSelector = (props: ISelectQRAccountsProps) => {
   const styles = createStyle(colors);
   const providerConfig = useSelector(selectProviderConfig);
   const accountsBalance = useAccountsBalance(accounts);
-  const { toBlockExplorer } = useBlockExplorer();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const { toBlockExplorer, getBlockExplorerUrl } = useBlockExplorer();
+
+  const handleToBlockExplorer = useCallback(
+    (address: string) => {
+      const url = getBlockExplorerUrl(address);
+      if (url) {
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+            .addProperties({
+              location: 'hardware_wallet_account',
+              text: 'external-link',
+              url_domain: url,
+            })
+            .build(),
+        );
+      }
+      toBlockExplorer(address);
+    },
+    [createEventBuilder, getBlockExplorerUrl, toBlockExplorer, trackEvent],
+  );
 
   const [checkedAccounts, setCheckedAccounts] = useState<Set<number>>(
     new Set(),
@@ -108,7 +130,7 @@ const AccountSelector = (props: ISelectQRAccountsProps) => {
               address={item.address}
               balance={item.balance}
               ticker={providerConfig.ticker}
-              toBlockExplorer={toBlockExplorer}
+              toBlockExplorer={handleToBlockExplorer}
             />
           </View>
         )}

--- a/app/components/UI/HardwareWallet/AccountSelector/index.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/index.tsx
@@ -8,7 +8,7 @@ import { strings } from '../../../../../locales/i18n';
 import { IAccount } from './types';
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import { useAccountsBalance } from './hooks';
 import { useTheme } from '../../../../util/theme';
 import { createStyle } from './styles';
@@ -52,15 +52,11 @@ const AccountSelector = (props: ISelectQRAccountsProps) => {
     (address: string) => {
       const url = getBlockExplorerUrl(address);
       if (url) {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-            .addProperties({
-              location: 'hardware_wallet_account',
-              text: 'external-link',
-              url_domain: url,
-            })
-            .build(),
-        );
+        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+          location: 'hardware_wallet_account',
+          text: 'external-link',
+          url_domain: url,
+        });
       }
       toBlockExplorer(address);
     },

--- a/app/components/UI/HardwareWallet/AccountSelector/index.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/index.tsx
@@ -54,7 +54,7 @@ const AccountSelector = (props: ISelectQRAccountsProps) => {
       if (url) {
         trackExternalLinkClicked(trackEvent, createEventBuilder, {
           location: 'hardware_wallet_account',
-          text: 'external-link',
+          text: strings('asset_details.options.view_on_block'),
           url_domain: url,
         });
       }

--- a/app/components/UI/HardwareWallet/AccountSelector/index.tsx
+++ b/app/components/UI/HardwareWallet/AccountSelector/index.tsx
@@ -8,7 +8,7 @@ import { strings } from '../../../../../locales/i18n';
 import { IAccount } from './types';
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import { useAccountsBalance } from './hooks';
 import { useTheme } from '../../../../util/theme';
 import { createStyle } from './styles';
@@ -52,10 +52,10 @@ const AccountSelector = (props: ISelectQRAccountsProps) => {
     (address: string) => {
       const url = getBlockExplorerUrl(address);
       if (url) {
-        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
           location: 'hardware_wallet_account',
           text: strings('asset_details.options.view_on_block'),
-          url_domain: url,
+          url,
         });
       }
       toBlockExplorer(address);

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.test.tsx
@@ -13,6 +13,11 @@ import { otherControllersMock } from '../../../../Views/confirmations/__mocks__/
 import { MUSD_TOKEN_ADDRESS } from '../../../Earn/constants/musd';
 import { MoneySentDetails } from './MoneySentDetails';
 
+jest.mock('../../../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 const mockNavigate = jest.fn();
 
 jest.mock(
@@ -221,6 +226,13 @@ describe('MoneySentDetails', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       'Webview',
       expect.objectContaining({ screen: 'SimpleWebview' }),
+    );
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'money_transaction_details',
+      }),
     );
   });
 

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
@@ -33,6 +33,8 @@ import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { Box } from '../../../Box/Box';
 import { AlignItems, FlexDirection } from '../../../Box/box.types';
 import Name from '../../../Name/Name';
@@ -80,6 +82,7 @@ function useRecipient(): Hex | undefined {
 export function MoneySentDetails() {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { transactionMeta } = useTransactionDetails();
   const networkConfigurations = useSelector(selectNetworkConfigurations);
 
@@ -118,11 +121,27 @@ export function MoneySentDetails() {
     if (!url) {
       return;
     }
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'money_transaction_details',
+          text: strings('transaction_details.view_on_block_explorer'),
+          url_domain: url,
+        })
+        .build(),
+    );
     navigation.navigate(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: { url, title },
     });
-  }, [chainId, navigation, networkConfigurations, transactionMeta]);
+  }, [
+    chainId,
+    createEventBuilder,
+    navigation,
+    networkConfigurations,
+    trackEvent,
+    transactionMeta,
+  ]);
 
   return (
     <ScrollView>

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
@@ -34,7 +34,7 @@ import BadgeWrapper, {
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { Box } from '../../../Box/Box';
 import { AlignItems, FlexDirection } from '../../../Box/box.types';
 import Name from '../../../Name/Name';
@@ -121,10 +121,10 @@ export function MoneySentDetails() {
     if (!url) {
       return;
     }
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'money_transaction_details',
       text: strings('transaction_details.view_on_block_explorer'),
-      url_domain: url,
+      url,
     });
     navigation.navigate(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,

--- a/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
+++ b/app/components/UI/Money/components/MoneyTransactionDetailsSheet/MoneySentDetails.tsx
@@ -34,7 +34,7 @@ import BadgeWrapper, {
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { Box } from '../../../Box/Box';
 import { AlignItems, FlexDirection } from '../../../Box/box.types';
 import Name from '../../../Name/Name';
@@ -121,15 +121,11 @@ export function MoneySentDetails() {
     if (!url) {
       return;
     }
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'money_transaction_details',
-          text: strings('transaction_details.view_on_block_explorer'),
-          url_domain: url,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'money_transaction_details',
+      text: strings('transaction_details.view_on_block_explorer'),
+      url_domain: url,
+    });
     navigation.navigate(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: { url, title },

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
@@ -7,6 +7,11 @@ import type { MultichainTransactionDisplayData } from '../../hooks/useMultichain
 import type { Transaction } from '@metamask/keyring-api';
 import Routes from '../../../constants/navigation/Routes';
 
+jest.mock('../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 const mockNavigate = jest.fn();
 const mockOnCloseBottomSheet = jest.fn();
 const mockUseRoute = jest.fn();
@@ -254,5 +259,12 @@ describe('MultichainTransactionDetailsSheet', () => {
         url: `https://explorer.example.com/tx/${mockTransaction.id}?chain=${mockTransaction.chain}`,
       },
     });
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'transaction_details_modal',
+      }),
+    );
   });
 });

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
@@ -264,6 +264,7 @@ describe('MultichainTransactionDetailsSheet', () => {
       expect.any(Function),
       expect.objectContaining({
         location: 'transaction_details_modal',
+        text: 'View details',
       }),
     );
   });

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
@@ -40,7 +40,7 @@ import {
 import Routes from '../../../constants/navigation/Routes';
 import { useTheme } from '../../../util/theme';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 
 export interface MultichainTransactionDetailsSheetParams {
   displayData: MultichainTransactionDisplayData;
@@ -104,10 +104,10 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
 
       if (!url) return;
 
-      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
         location: 'transaction_details_modal',
         text: label,
-        url_domain: url,
+        url,
       });
 
       // Close the bottom sheet and navigate to webview

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
@@ -39,6 +39,8 @@ import {
 } from '../../../core/Multichain/utils';
 import Routes from '../../../constants/navigation/Routes';
 import { useTheme } from '../../../util/theme';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 
 export interface MultichainTransactionDetailsSheetParams {
   displayData: MultichainTransactionDisplayData;
@@ -70,6 +72,7 @@ const styles = StyleSheet.create({
 
 const MultichainTransactionDetailsSheet: React.FC = () => {
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const route = useRoute<MultichainTransactionDetailsSheetRouteProp>();
   const sheetRef = useRef<BottomSheetRef>(null);
   const { typography } = useTheme();
@@ -101,6 +104,16 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
 
       if (!url) return;
 
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+          .addProperties({
+            location: 'transaction_details_modal',
+            text: label,
+            url_domain: url,
+          })
+          .build(),
+      );
+
       // Close the bottom sheet and navigate to webview
       sheetRef.current?.onCloseBottomSheet(() => {
         navigation.navigate(Routes.WEBVIEW.MAIN, {
@@ -109,7 +122,15 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
         });
       });
     },
-    [id, chain, from?.address, to?.address, navigation],
+    [
+      id,
+      chain,
+      createEventBuilder,
+      from?.address,
+      navigation,
+      to?.address,
+      trackEvent,
+    ],
   );
 
   const renderDetailRow = (

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
@@ -40,7 +40,7 @@ import {
 import Routes from '../../../constants/navigation/Routes';
 import { useTheme } from '../../../util/theme';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 
 export interface MultichainTransactionDetailsSheetParams {
   displayData: MultichainTransactionDisplayData;
@@ -104,15 +104,11 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
 
       if (!url) return;
 
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-          .addProperties({
-            location: 'transaction_details_modal',
-            text: label,
-            url_domain: url,
-          })
-          .build(),
-      );
+      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        location: 'transaction_details_modal',
+        text: label,
+        url_domain: url,
+      });
 
       // Close the bottom sheet and navigate to webview
       sheetRef.current?.onCloseBottomSheet(() => {

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
@@ -86,9 +86,9 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
   }, []);
 
   const viewOnBlockExplorer = useCallback(
-    (label: string) => {
+    (rowKey: string, analyticsText?: string) => {
       let url = '';
-      switch (label) {
+      switch (rowKey) {
         case TransactionDetailRow.TransactionID:
           url = getTransactionUrl(id, chain);
           break;
@@ -106,7 +106,7 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
 
       trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
         location: 'transaction_details_modal',
-        text: label,
+        text: analyticsText ?? rowKey,
         url,
       });
 
@@ -150,7 +150,9 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
       >
         {isLink ? (
           <TouchableOpacity
-            onPress={() => viewOnBlockExplorer(label)}
+            onPress={() =>
+              viewOnBlockExplorer(label, formatAddress(value, 'short'))
+            }
             style={styles.blockExplorerLink}
           >
             <Text variant={TextVariant.BodyMd} color={TextColor.PrimaryDefault}>
@@ -216,7 +218,10 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
           size={ButtonSize.Lg}
           label={strings('networks.view_details')}
           onPress={() =>
-            viewOnBlockExplorer(TransactionDetailRow.TransactionID)
+            viewOnBlockExplorer(
+              TransactionDetailRow.TransactionID,
+              strings('networks.view_details'),
+            )
           }
           endIconName={IconName.Export}
         />

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.test.tsx
@@ -4,6 +4,9 @@ import PerpsFundingTransactionView from './PerpsFundingTransactionView';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { PerpsTransactionSelectorsIDs } from '../../Perps.testIds';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
@@ -40,6 +43,10 @@ jest.mock('../../hooks', () => ({
   }),
 }));
 
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
+
 jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
   selectSelectedInternalAccountByScope: () => () => ({
     address: '0x1234567890123456789012345678901234567890',
@@ -58,6 +65,11 @@ describe('PerpsFundingTransactionView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteParams = { transaction: mockTransaction };
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
   });
 
   afterEach(() => {
@@ -181,6 +193,11 @@ describe('PerpsFundingTransactionView with missing transaction', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteParams = {};
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
   });
 
   it('renders not found message when transaction is missing', () => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsFundingTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const PerpsFundingTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -73,15 +73,11 @@ const PerpsFundingTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'perps_transaction_details',
-          text: strings('perps.transactions.view_on_explorer'),
-          url_domain: explorerUrl,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'perps_transaction_details',
+      text: strings('perps.transactions.view_on_explorer'),
+      url_domain: explorerUrl,
+    });
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
@@ -29,11 +29,14 @@ import {
   formatTransactionDate,
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsFundingTransactionView.styles';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 const PerpsFundingTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
 
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const route = useRoute<PerpsFundingTransactionRouteProp>();
 
   const selectedInternalAccount = useSelector(
@@ -70,6 +73,15 @@ const PerpsFundingTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'perps_transaction_details',
+          text: strings('perps.transactions.view_on_explorer'),
+          url_domain: explorerUrl,
+        })
+        .build(),
+    );
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsFundingTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const PerpsFundingTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -73,10 +73,10 @@ const PerpsFundingTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'perps_transaction_details',
       text: strings('perps.transactions.view_on_explorer'),
-      url_domain: explorerUrl,
+      url: explorerUrl,
     });
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsOrderTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const PerpsOrderTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -73,15 +73,11 @@ const PerpsOrderTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'perps_transaction_details',
-          text: strings('perps.transactions.view_on_explorer'),
-          url_domain: explorerUrl,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'perps_transaction_details',
+      text: strings('perps.transactions.view_on_explorer'),
+      url_domain: explorerUrl,
+    });
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -27,10 +27,13 @@ import {
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsOrderTransactionView.styles';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 const PerpsOrderTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const route = useRoute<PerpsOrderTransactionRouteProp>();
   const selectedInternalAccount = useSelector(
     selectSelectedInternalAccountByScope,
@@ -70,6 +73,15 @@ const PerpsOrderTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'perps_transaction_details',
+          text: strings('perps.transactions.view_on_explorer'),
+          url_domain: explorerUrl,
+        })
+        .build(),
+    );
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsOrderTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const PerpsOrderTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -73,10 +73,10 @@ const PerpsOrderTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'perps_transaction_details',
       text: strings('perps.transactions.view_on_explorer'),
-      url_domain: explorerUrl,
+      url: explorerUrl,
     });
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -36,10 +36,13 @@ import {
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsPositionTransactionView.styles';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 const PerpsPositionTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const route = useRoute<PerpsPositionTransactionRouteProp>();
   const selectedInternalAccount = useSelector(
     selectSelectedInternalAccountByScope,
@@ -85,6 +88,15 @@ const PerpsPositionTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'perps_transaction_details',
+          text: strings('perps.transactions.view_on_explorer'),
+          url_domain: explorerUrl,
+        })
+        .build(),
+    );
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -37,7 +37,7 @@ import {
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsPositionTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const PerpsPositionTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -88,10 +88,10 @@ const PerpsPositionTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'perps_transaction_details',
       text: strings('perps.transactions.view_on_explorer'),
-      url_domain: explorerUrl,
+      url: explorerUrl,
     });
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -37,7 +37,7 @@ import {
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsPositionTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 const PerpsPositionTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -88,15 +88,11 @@ const PerpsPositionTransactionView: React.FC = () => {
     if (!explorerUrl) {
       return;
     }
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'perps_transaction_details',
-          text: strings('perps.transactions.view_on_explorer'),
-          url_domain: explorerUrl,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'perps_transaction_details',
+      text: strings('perps.transactions.view_on_explorer'),
+      url_domain: explorerUrl,
+    });
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {

--- a/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
@@ -25,7 +25,7 @@ import Spinner from '../../../AnimatedSpinner';
 import useAnalytics from '../../hooks/useAnalytics';
 import { analytics } from '../../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { PROVIDER_LINKS } from '../types';
 import Account from './Account';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
@@ -261,13 +261,13 @@ const OrderDetails: React.FC<Props> = ({ order }: Props) => {
 
   const handleExplorerLinkPress = useCallback(
     (url: string) => {
-      trackExternalLinkClicked(
+      trackBlockExplorerLinkClicked(
         analytics.trackEvent,
         AnalyticsEventBuilder.createEventBuilder,
         {
           location: 'ramp_order_details',
           text: 'Etherscan Transaction',
-          url_domain: url,
+          url,
         },
       );
       Linking.openURL(url);

--- a/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
@@ -25,7 +25,7 @@ import Spinner from '../../../AnimatedSpinner';
 import useAnalytics from '../../hooks/useAnalytics';
 import { analytics } from '../../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { PROVIDER_LINKS } from '../types';
 import Account from './Account';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
@@ -261,16 +261,14 @@ const OrderDetails: React.FC<Props> = ({ order }: Props) => {
 
   const handleExplorerLinkPress = useCallback(
     (url: string) => {
-      analytics.trackEvent(
-        AnalyticsEventBuilder.createEventBuilder(
-          MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-        )
-          .addProperties({
-            location: 'ramp_order_details',
-            text: 'Etherscan Transaction',
-            url_domain: url,
-          })
-          .build(),
+      trackExternalLinkClicked(
+        analytics.trackEvent,
+        AnalyticsEventBuilder.createEventBuilder,
+        {
+          location: 'ramp_order_details',
+          text: 'Etherscan Transaction',
+          url_domain: url,
+        },
       );
       Linking.openURL(url);
       trackEvent('ONRAMP_EXTERNAL_LINK_CLICKED', {

--- a/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
@@ -23,6 +23,9 @@ import { FiatOrder, getProviderName } from '../../../../../reducers/fiatOrders';
 import { useLegacySwapsBlockExplorer } from '../../../Bridge/hooks/useLegacySwapsBlockExplorer';
 import Spinner from '../../../AnimatedSpinner';
 import useAnalytics from '../../hooks/useAnalytics';
+import { analytics } from '../../../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { PROVIDER_LINKS } from '../types';
 import Account from './Account';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
@@ -258,6 +261,17 @@ const OrderDetails: React.FC<Props> = ({ order }: Props) => {
 
   const handleExplorerLinkPress = useCallback(
     (url: string) => {
+      analytics.trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(
+          MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+        )
+          .addProperties({
+            location: 'ramp_order_details',
+            text: 'Etherscan Transaction',
+            url_domain: url,
+          })
+          .build(),
+      );
       Linking.openURL(url);
       trackEvent('ONRAMP_EXTERNAL_LINK_CLICKED', {
         location: 'Order Details Screen',

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
@@ -4,6 +4,11 @@ import { Linking, useColorScheme } from 'react-native';
 import SecurityTrustScreen from './SecurityTrustScreen';
 import { strings } from '../../../../../locales/i18n';
 
+jest.mock('../../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
@@ -206,6 +211,21 @@ describe('SecurityTrustScreen', () => {
     fireEvent.press(backButton);
 
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('tracks External Link Clicked when block explorer button is pressed', () => {
+    const { getByText } = render(<SecurityTrustScreen />);
+
+    fireEvent.press(getByText('Etherscan'));
+
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'security_trust_page',
+        url: expect.stringContaining('etherscan.io'),
+      }),
+    );
   });
 
   it('opens external link when link is pressed', () => {

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -165,7 +165,7 @@ const SecurityTrustScreen: React.FC = () => {
   const tokenType = params?.isNative ? 'Native' : 'ERC-20';
 
   const openLink = useCallback(
-    (url: string, ctaType: string) => {
+    (url: string, ctaType: string, linkText?: string) => {
       // Track CTA click
       trackEvent(
         createEventBuilder(MetaMetricsEvents.SECURITY_PAGE_CTA_CLICKED)
@@ -177,6 +177,18 @@ const SecurityTrustScreen: React.FC = () => {
           })
           .build(),
       );
+
+      if (ctaType === 'block_explorer') {
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+            .addProperties({
+              location: 'security_trust_page',
+              text: linkText ?? strings('security_trust.etherscan'),
+              url_domain: url,
+            })
+            .build(),
+        );
+      }
 
       Linking.openURL(url).catch(() => null);
     },
@@ -655,7 +667,12 @@ const SecurityTrustScreen: React.FC = () => {
                   return blockExplorerUrl ? (
                     <ButtonBase
                       onPress={() =>
-                        openLink(blockExplorerUrl, 'block_explorer')
+                        openLink(
+                          blockExplorerUrl,
+                          'block_explorer',
+                          blockExplorerName ||
+                            strings('security_trust.etherscan'),
+                        )
                       }
                       size={ButtonBaseSize.Md}
                       twClassName={(pressed) =>

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -43,6 +43,7 @@ import TokenDetailsStickyFooter from '../../TokenDetails/components/TokenDetails
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 
 const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
@@ -179,15 +180,11 @@ const SecurityTrustScreen: React.FC = () => {
       );
 
       if (ctaType === 'block_explorer') {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-            .addProperties({
-              location: 'security_trust_page',
-              text: linkText ?? strings('security_trust.etherscan'),
-              url_domain: url,
-            })
-            .build(),
-        );
+        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+          location: 'security_trust_page',
+          text: linkText ?? strings('security_trust.etherscan'),
+          url_domain: url,
+        });
       }
 
       Linking.openURL(url).catch(() => null);

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -43,7 +43,7 @@ import TokenDetailsStickyFooter from '../../TokenDetails/components/TokenDetails
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
-import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 
 const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
@@ -180,10 +180,10 @@ const SecurityTrustScreen: React.FC = () => {
       );
 
       if (ctaType === 'block_explorer') {
-        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
           location: 'security_trust_page',
           text: linkText ?? strings('security_trust.etherscan'),
-          url_domain: url,
+          url,
         });
       }
 

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.test.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.test.tsx
@@ -173,6 +173,19 @@ jest.mock('../../../../core/NotificationManager', () => ({
   showSimpleNotification: jest.fn(),
 }));
 
+jest.mock('./useAssetVisibility', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    handleHideToken: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../../util/analytics/externalLinkTracking';
+
 const mockLoggerLog = jest.fn();
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
@@ -462,6 +475,14 @@ describe('MoreTokenActionsMenu', () => {
           title: 'Etherscan',
         },
       });
+      expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Function),
+        expect.objectContaining({
+          location: 'token_details_menu',
+          url: 'https://etherscan.io/token/0x123',
+        }),
+      );
     });
 
     it('opens InAppBrowser when View on block explorer is pressed and InAppBrowser is available', async () => {
@@ -527,7 +548,7 @@ describe('MoreTokenActionsMenu', () => {
       });
     });
 
-    it('hides token, shows notification and tracks event when onConfirm is called', async () => {
+    it('hides token and shows notification when onConfirm is called', async () => {
       updateRouteParams({
         hasPerpsMarket: false,
         hasBalance: true,
@@ -582,7 +603,6 @@ describe('MoreTokenActionsMenu', () => {
           description: expect.any(String),
         }),
       );
-      expect(mockTrackEvent).toHaveBeenCalled();
     });
 
     it('fires onActionTapped with view_on_explorer when View on block explorer is pressed', async () => {

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
@@ -14,7 +14,7 @@ import Engine from '../../../../core/Engine';
 import NotificationManager from '../../../../core/NotificationManager';
 import { getDecimalChainId } from '../../../../util/networks';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
-import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import { WalletActionsBottomSheetSelectorsIDs } from '../../../Views/WalletActions/WalletActionsBottomSheet.testIds';
 import Logger from '../../../../util/Logger';
 import { Hex, isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
@@ -129,10 +129,10 @@ const MoreTokenActionsMenu = () => {
     }
 
     if (url) {
-      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
         location: 'token_details_menu',
         text: strings('asset_details.options.view_on_block'),
-        url_domain: url,
+        url,
       });
       onActionTapped?.(TokenDetailsAction.ViewOnExplorer);
       goToBrowserUrl(url, explorer.getBlockExplorerName(asset.chainId));

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
@@ -128,16 +128,27 @@ const MoreTokenActionsMenu = () => {
     }
 
     if (url) {
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+          .addProperties({
+            location: 'token_details_menu',
+            text: strings('asset_details.options.view_on_block'),
+            url_domain: url,
+          })
+          .build(),
+      );
       onActionTapped?.(TokenDetailsAction.ViewOnExplorer);
       goToBrowserUrl(url, explorer.getBlockExplorerName(asset.chainId));
     }
   }, [
+    createEventBuilder,
     isNativeCurrency,
     explorer,
     asset.chainId,
     asset.address,
     goToBrowserUrl,
     onActionTapped,
+    trackEvent,
   ]);
 
   const handleRemoveToken = useCallback(() => {

--- a/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+++ b/app/components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
@@ -14,6 +14,7 @@ import Engine from '../../../../core/Engine';
 import NotificationManager from '../../../../core/NotificationManager';
 import { getDecimalChainId } from '../../../../util/networks';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import { WalletActionsBottomSheetSelectorsIDs } from '../../../Views/WalletActions/WalletActionsBottomSheet.testIds';
 import Logger from '../../../../util/Logger';
 import { Hex, isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
@@ -128,15 +129,11 @@ const MoreTokenActionsMenu = () => {
     }
 
     if (url) {
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-          .addProperties({
-            location: 'token_details_menu',
-            text: strings('asset_details.options.view_on_block'),
-            url_domain: url,
-          })
-          .build(),
-      );
+      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        location: 'token_details_menu',
+        text: strings('asset_details.options.view_on_block'),
+        url_domain: url,
+      });
       onActionTapped?.(TokenDetailsAction.ViewOnExplorer);
       goToBrowserUrl(url, explorer.getBlockExplorerName(asset.chainId));
     }

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -16,7 +16,7 @@ import {
 import Logger from '../../../../util/Logger';
 import { analytics } from '../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
-import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import EthereumAddress from '../../EthereumAddress';
 import TransactionSummary from '../../../Views/TransactionSummary';
 import { toDateFormat } from '../../../../util/date';
@@ -263,7 +263,7 @@ class TransactionDetails extends PureComponent {
     const { rpcBlockExplorer } = this.state;
     try {
       const { url, title } = getBlockExplorerTxUrl(RPC, hash, rpcBlockExplorer);
-      trackExternalLinkClicked(
+      trackBlockExplorerLinkClicked(
         analytics.trackEvent,
         AnalyticsEventBuilder.createEventBuilder,
         {
@@ -271,7 +271,7 @@ class TransactionDetails extends PureComponent {
           text: `${strings('transactions.view_on')} ${getBlockExplorerName(
             rpcBlockExplorer,
           )}`,
-          url_domain: url,
+          url,
         },
       );
       navigation.push('Webview', {

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -16,7 +16,7 @@ import {
 import Logger from '../../../../util/Logger';
 import { analytics } from '../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
-import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import EthereumAddress from '../../EthereumAddress';
 import TransactionSummary from '../../../Views/TransactionSummary';
 import { toDateFormat } from '../../../../util/date';
@@ -263,18 +263,16 @@ class TransactionDetails extends PureComponent {
     const { rpcBlockExplorer } = this.state;
     try {
       const { url, title } = getBlockExplorerTxUrl(RPC, hash, rpcBlockExplorer);
-      analytics.trackEvent(
-        AnalyticsEventBuilder.createEventBuilder(
-          MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-        )
-          .addProperties({
-            location: 'transaction_details',
-            text: `${strings('transactions.view_on')} ${getBlockExplorerName(
-              rpcBlockExplorer,
-            )}`,
-            url_domain: url,
-          })
-          .build(),
+      trackExternalLinkClicked(
+        analytics.trackEvent,
+        AnalyticsEventBuilder.createEventBuilder,
+        {
+          location: 'transaction_details',
+          text: `${strings('transactions.view_on')} ${getBlockExplorerName(
+            rpcBlockExplorer,
+          )}`,
+          url_domain: url,
+        },
       );
       navigation.push('Webview', {
         screen: 'SimpleWebview',

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -14,6 +14,9 @@ import {
   getBlockExplorerTxUrl,
 } from '../../../../util/networks';
 import Logger from '../../../../util/Logger';
+import { analytics } from '../../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
 import EthereumAddress from '../../EthereumAddress';
 import TransactionSummary from '../../../Views/TransactionSummary';
 import { toDateFormat } from '../../../../util/date';
@@ -260,6 +263,19 @@ class TransactionDetails extends PureComponent {
     const { rpcBlockExplorer } = this.state;
     try {
       const { url, title } = getBlockExplorerTxUrl(RPC, hash, rpcBlockExplorer);
+      analytics.trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(
+          MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+        )
+          .addProperties({
+            location: 'transaction_details',
+            text: `${strings('transactions.view_on')} ${getBlockExplorerName(
+              rpcBlockExplorer,
+            )}`,
+            url_domain: url,
+          })
+          .build(),
+      );
       navigation.push('Webview', {
         screen: 'SimpleWebview',
         params: { url, title },

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -10,6 +10,12 @@ import { mockNetworkState } from '../../../../util/test/network';
 import type { NetworkState } from '@metamask/network-controller';
 import { isHardwareAccount } from '../../../../util/address';
 import { TransactionType } from '@metamask/transaction-controller';
+import { analytics } from '../../../../util/analytics/analytics';
+jest.mock('../../../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: jest.fn(),
+  },
+}));
 
 const Stack = createStackNavigator();
 const mockEthQuery = {
@@ -309,6 +315,15 @@ describe('TransactionDetails', () => {
 
     fireEvent.press(getByText(props.buttonText));
 
+    expect(analytics.trackEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        name: 'External Link Clicked',
+        properties: expect.objectContaining({
+          location: 'transaction_details',
+          url_domain: props.expectedUrl,
+        }),
+      }),
+    );
     expect(navigationMock.push).toHaveBeenCalledWith('Webview', {
       params: expect.objectContaining({ url: props.expectedUrl }),
       screen: 'SimpleWebview',

--- a/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.test.tsx
@@ -11,6 +11,7 @@ import type { NetworkState } from '@metamask/network-controller';
 import { isHardwareAccount } from '../../../../util/address';
 import { TransactionType } from '@metamask/transaction-controller';
 import { analytics } from '../../../../util/analytics/analytics';
+import { getExternalLinkHostname } from '../../../../util/analytics/externalLinkTracking';
 jest.mock('../../../../util/analytics/analytics', () => ({
   analytics: {
     trackEvent: jest.fn(),
@@ -320,7 +321,7 @@ describe('TransactionDetails', () => {
         name: 'External Link Clicked',
         properties: expect.objectContaining({
           location: 'transaction_details',
-          url_domain: props.expectedUrl,
+          url_domain: getExternalLinkHostname(props.expectedUrl),
         }),
       }),
     );

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -42,7 +42,7 @@ import Device from '../../../util/device';
 import Logger from '../../../util/Logger';
 import { analytics } from '../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import {
   findBlockExplorerForNonEvmChainId,
   findBlockExplorerForRpc,
@@ -478,7 +478,7 @@ class Transactions extends PureComponent {
         title = result.title;
       }
 
-      trackExternalLinkClicked(
+      trackBlockExplorerLinkClicked(
         analytics.trackEvent,
         AnalyticsEventBuilder.createEventBuilder,
         {
@@ -486,7 +486,7 @@ class Transactions extends PureComponent {
           text: title
             ? `${strings('transactions.view_full_history_on')} ${title}`
             : strings('asset_details.options.view_on_block'),
-          url_domain: url,
+          url,
         },
       );
 

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -42,7 +42,7 @@ import Device from '../../../util/device';
 import Logger from '../../../util/Logger';
 import { analytics } from '../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
-import { MetaMetricsEvents } from '../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import {
   findBlockExplorerForNonEvmChainId,
   findBlockExplorerForRpc,
@@ -478,18 +478,16 @@ class Transactions extends PureComponent {
         title = result.title;
       }
 
-      analytics.trackEvent(
-        AnalyticsEventBuilder.createEventBuilder(
-          MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-        )
-          .addProperties({
-            location: 'transactions_list',
-            text: title
-              ? `${strings('transactions.view_full_history_on')} ${title}`
-              : strings('asset_details.options.view_on_block'),
-            url_domain: url,
-          })
-          .build(),
+      trackExternalLinkClicked(
+        analytics.trackEvent,
+        AnalyticsEventBuilder.createEventBuilder,
+        {
+          location: 'transactions_list',
+          text: title
+            ? `${strings('transactions.view_full_history_on')} ${title}`
+            : strings('asset_details.options.view_on_block'),
+          url_domain: url,
+        },
       );
 
       navigation.push('Webview', {

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -478,6 +478,10 @@ class Transactions extends PureComponent {
         title = result.title;
       }
 
+      if (!url) {
+        throw new Error('Missing block explorer URL');
+      }
+
       trackBlockExplorerLinkClicked(
         analytics.trackEvent,
         AnalyticsEventBuilder.createEventBuilder,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -40,6 +40,9 @@ import { baseStyles, fontStyles } from '../../../styles/common';
 import { isHardwareAccount } from '../../../util/address';
 import Device from '../../../util/device';
 import Logger from '../../../util/Logger';
+import { analytics } from '../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   findBlockExplorerForNonEvmChainId,
   findBlockExplorerForRpc,
@@ -474,6 +477,20 @@ class Transactions extends PureComponent {
         url = result.url;
         title = result.title;
       }
+
+      analytics.trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(
+          MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+        )
+          .addProperties({
+            location: 'transactions_list',
+            text: title
+              ? `${strings('transactions.view_full_history_on')} ${title}`
+              : strings('asset_details.options.view_on_block'),
+            url_domain: url,
+          })
+          .build(),
+      );
 
       navigation.push('Webview', {
         screen: 'SimpleWebview',

--- a/app/components/Views/AccountActions/AccountActions.test.tsx
+++ b/app/components/Views/AccountActions/AccountActions.test.tsx
@@ -10,6 +10,7 @@ import renderWithProvider from '../../../util/test/renderWithProvider';
 import Engine from '../../../core/Engine';
 import Routes from '../../../constants/navigation/Routes';
 import AccountActions from './AccountActions';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { AccountActionsBottomSheetSelectorsIDs } from './AccountActionsBottomSheet.testIds';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import {
@@ -27,6 +28,10 @@ import * as Networks7702 from '../confirmations/hooks/7702/useEIP7702Networks';
 // eslint-disable-next-line import-x/no-namespace
 import * as AddressUtils from '../../../util/address';
 import { RPC } from '../../../constants/network';
+jest.mock('../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
 
 jest.mock('../confirmations/hooks/7702/useEIP7702Networks', () => ({
   useEIP7702Networks: jest
@@ -384,6 +389,14 @@ describe('AccountActions', () => {
         title: 'Etherscan (Multichain)',
       },
     });
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'account_actions',
+        url: expect.stringContaining('etherscan.io'),
+      }),
+    );
   });
 
   it('navigates to webview with custom RPC explorer when View on Block Explorer is clicked', () => {

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -20,7 +20,7 @@ import AccountAction from '../AccountAction/AccountAction';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 
 import { MetaMetricsEvents } from '../../../core/Analytics';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { selectProviderConfig } from '../../../selectors/networkController';
 import { strings } from '../../../../locales/i18n';
 // Internal dependencies
@@ -113,10 +113,10 @@ const AccountActions = () => {
   const viewOnBlockExplorer = () => {
     sheetRef.current?.onCloseBottomSheet(() => {
       if (blockExplorer) {
-        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
           location: 'account_actions',
           text: `${strings('drawer.view_in')} ${blockExplorer.blockExplorerName}`,
-          url_domain: blockExplorer.url,
+          url: blockExplorer.url,
         });
         goToBrowserUrl(blockExplorer.url, blockExplorer.title);
       }

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -20,6 +20,7 @@ import AccountAction from '../AccountAction/AccountAction';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 
 import { MetaMetricsEvents } from '../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { selectProviderConfig } from '../../../selectors/networkController';
 import { strings } from '../../../../locales/i18n';
 // Internal dependencies
@@ -112,15 +113,11 @@ const AccountActions = () => {
   const viewOnBlockExplorer = () => {
     sheetRef.current?.onCloseBottomSheet(() => {
       if (blockExplorer) {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-            .addProperties({
-              location: 'account_actions',
-              text: `${strings('drawer.view_in')} ${blockExplorer.blockExplorerName}`,
-              url_domain: blockExplorer.url,
-            })
-            .build(),
-        );
+        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+          location: 'account_actions',
+          text: `${strings('drawer.view_in')} ${blockExplorer.blockExplorerName}`,
+          url_domain: blockExplorer.url,
+        });
         goToBrowserUrl(blockExplorer.url, blockExplorer.title);
       }
       trackEvent(

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -112,6 +112,15 @@ const AccountActions = () => {
   const viewOnBlockExplorer = () => {
     sheetRef.current?.onCloseBottomSheet(() => {
       if (blockExplorer) {
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+            .addProperties({
+              location: 'account_actions',
+              text: `${strings('drawer.view_in')} ${blockExplorer.blockExplorerName}`,
+              url_domain: blockExplorer.url,
+            })
+            .build(),
+        );
         goToBrowserUrl(blockExplorer.url, blockExplorer.title);
       }
       trackEvent(

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -77,7 +77,6 @@ import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBui
 import Routes from '../../../constants/navigation/Routes';
 import { RESET_PASSWORD_GUIDE_URL } from '../../../constants/urls';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import FoxRiveLoaderAnimation, {
   type FoxRiveLoaderAnimationRef,
 } from './FoxRiveLoaderAnimation/FoxRiveLoaderAnimation';
@@ -545,18 +544,11 @@ const ChoosePassword = () => {
   );
 
   const learnMore = useCallback(() => {
-    trackExternalLinkClicked(
-      (event) =>
-        trackOnboarding(event, (arg: ITrackingEvent) =>
-          dispatch(saveEvent([arg])),
-        ),
-      MetricsEventBuilder.createEventBuilder,
-      {
-        text: 'Learn More',
-        location: 'choose_password',
-        url_domain: RESET_PASSWORD_GUIDE_URL,
-      },
-    );
+    track(MetaMetricsEvents.EXTERNAL_LINK_CLICKED, {
+      text: 'Learn More',
+      location: 'choose_password',
+      url_domain: RESET_PASSWORD_GUIDE_URL,
+    });
 
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
@@ -565,7 +557,7 @@ const ChoosePassword = () => {
         title: 'support.metamask.io',
       },
     });
-  }, [dispatch, navigation]);
+  }, [navigation, track]);
 
   const toggleShowPassword = useCallback((index: number) => {
     setShowPasswordIndex((prev) => {

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -77,6 +77,7 @@ import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBui
 import Routes from '../../../constants/navigation/Routes';
 import { RESET_PASSWORD_GUIDE_URL } from '../../../constants/urls';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import FoxRiveLoaderAnimation, {
   type FoxRiveLoaderAnimationRef,
 } from './FoxRiveLoaderAnimation/FoxRiveLoaderAnimation';
@@ -544,11 +545,18 @@ const ChoosePassword = () => {
   );
 
   const learnMore = useCallback(() => {
-    track(MetaMetricsEvents.EXTERNAL_LINK_CLICKED, {
-      text: 'Learn More',
-      location: 'choose_password',
-      url: RESET_PASSWORD_GUIDE_URL,
-    });
+    trackExternalLinkClicked(
+      (event) =>
+        trackOnboarding(event, (arg: ITrackingEvent) =>
+          dispatch(saveEvent([arg])),
+        ),
+      MetricsEventBuilder.createEventBuilder,
+      {
+        text: 'Learn More',
+        location: 'choose_password',
+        url_domain: RESET_PASSWORD_GUIDE_URL,
+      },
+    );
 
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
@@ -557,7 +565,7 @@ const ChoosePassword = () => {
         title: 'support.metamask.io',
       },
     });
-  }, [navigation, track]);
+  }, [dispatch, navigation]);
 
   const toggleShowPassword = useCallback((index: number) => {
     setShowPasswordIndex((prev) => {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx
@@ -12,7 +12,6 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { mockNetworkState } from '../../../../../util/test/network';
-
 // QRAccountDisplay is mocked because it uses the safeview context.
 // This is a workaround to render the component.
 jest.mock('../../../QRAccountDisplay', () => {
@@ -59,6 +58,11 @@ jest.mock('../../../QRAccountDisplay', () => {
   };
 });
 
+jest.mock('../../../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 let mockAccount = internalAccount1;
@@ -308,6 +312,14 @@ describe('ShareAddress', () => {
       },
     });
     expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'share_address',
+        url: 'https://etherscan.io',
+      }),
+    );
   });
 
   it('renders different account types correctly', () => {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
@@ -32,7 +32,7 @@ import {
   getQrCodeViewedAccountType,
   trackQrCodeViewed,
 } from '../../../../../util/analytics/qrCodeViewedTracking';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddress: {
@@ -77,15 +77,11 @@ export const ShareAddress = () => {
 
   const handleExplorerLinkPress = useCallback(() => {
     if (blockExplorer) {
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-          .addProperties({
-            location: 'share_address',
-            text: explorerButtonText,
-            url_domain: blockExplorer.url,
-          })
-          .build(),
-      );
+      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        location: 'share_address',
+        text: explorerButtonText,
+        url_domain: blockExplorer.url,
+      });
       navigation.navigate('Webview', {
         screen: 'SimpleWebview',
         params: {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
@@ -32,7 +32,7 @@ import {
   getQrCodeViewedAccountType,
   trackQrCodeViewed,
 } from '../../../../../util/analytics/qrCodeViewedTracking';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddress: {
@@ -77,10 +77,10 @@ export const ShareAddress = () => {
 
   const handleExplorerLinkPress = useCallback(() => {
     if (blockExplorer) {
-      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
         location: 'share_address',
         text: explorerButtonText,
-        url_domain: blockExplorer.url,
+        url: blockExplorer.url,
       });
       navigation.navigate('Webview', {
         screen: 'SimpleWebview',

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
@@ -32,6 +32,7 @@ import {
   getQrCodeViewedAccountType,
   trackQrCodeViewed,
 } from '../../../../../util/analytics/qrCodeViewedTracking';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddress: {
@@ -65,8 +66,26 @@ export const ShareAddress = () => {
     });
   }, [account, createEventBuilder, trackEvent]);
 
+  const explorerButtonText = strings(
+    'multichain_accounts.share_address.view_on_explorer_button',
+    {
+      explorer:
+        blockExplorer?.blockExplorerName ??
+        strings('multichain_accounts.share_address.view_on_block_explorer'),
+    },
+  );
+
   const handleExplorerLinkPress = useCallback(() => {
     if (blockExplorer) {
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+          .addProperties({
+            location: 'share_address',
+            text: explorerButtonText,
+            url_domain: blockExplorer.url,
+          })
+          .build(),
+      );
       navigation.navigate('Webview', {
         screen: 'SimpleWebview',
         params: {
@@ -75,7 +94,13 @@ export const ShareAddress = () => {
         },
       });
     }
-  }, [blockExplorer, navigation]);
+  }, [
+    blockExplorer,
+    createEventBuilder,
+    explorerButtonText,
+    navigation,
+    trackEvent,
+  ]);
 
   const handleOnBack = useCallback(() => {
     navigation.goBack();
@@ -117,16 +142,7 @@ export const ShareAddress = () => {
           testID={ShareAddressIds.SHARE_ADDRESS_VIEW_ON_EXPLORER_BUTTON}
           style={tw.style('mt-1 self-center')}
         >
-          {strings(
-            'multichain_accounts.share_address.view_on_explorer_button',
-            {
-              explorer:
-                blockExplorer?.blockExplorerName ??
-                strings(
-                  'multichain_accounts.share_address.view_on_block_explorer',
-                ),
-            },
-          )}
+          {explorerButtonText}
         </Button>
       </Box>
     </BottomSheet>

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
@@ -163,11 +163,25 @@ jest.mock(
   }),
 );
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(() => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: jest.requireActual(
+      '../../../../../util/analytics/AnalyticsEventBuilder',
+    ).AnalyticsEventBuilder.createEventBuilder,
+  })),
+}));
+
 // Mock useBlockExplorer hook
 jest.mock('../../../../hooks/useBlockExplorer', () => ({
   __esModule: true,
   default: jest.fn().mockReturnValue({
     toBlockExplorer: jest.fn(),
+    getBlockExplorerUrl: jest
+      .fn()
+      .mockReturnValue('https://etherscan.io/address/0x123'),
     getBlockExplorerName: jest.fn().mockReturnValue('Etherscan (Multichain)'),
   }),
 }));
@@ -376,6 +390,9 @@ describe('ShareAddressQR', () => {
   it('navigates to block explorer when View on Etherscan button is pressed', () => {
     // Arrange
     const mockToBlockExplorer = jest.fn();
+    const mockGetBlockExplorerUrl = jest
+      .fn()
+      .mockReturnValue('https://etherscan.io/address/0x123');
     const mockGetBlockExplorerName = jest
       .fn()
       .mockReturnValue('Etherscan (Multichain)');
@@ -384,6 +401,7 @@ describe('ShareAddressQR', () => {
     ).default;
     useBlockExplorer.mockReturnValue({
       toBlockExplorer: mockToBlockExplorer,
+      getBlockExplorerUrl: mockGetBlockExplorerUrl,
       getBlockExplorerName: mockGetBlockExplorerName,
     });
 
@@ -394,6 +412,15 @@ describe('ShareAddressQR', () => {
     fireEvent.press(explorerButton);
 
     // Assert
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'External Link Clicked',
+        properties: expect.objectContaining({
+          location: 'share_address_qr',
+          url_domain: 'https://etherscan.io/address/0x123',
+        }),
+      }),
+    );
     expect(mockToBlockExplorer).toHaveBeenCalledTimes(1);
   });
 

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
@@ -417,7 +417,7 @@ describe('ShareAddressQR', () => {
         name: 'External Link Clicked',
         properties: expect.objectContaining({
           location: 'share_address_qr',
-          url_domain: 'https://etherscan.io/address/0x123',
+          url_domain: 'etherscan.io',
         }),
       }),
     );

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
@@ -163,17 +163,6 @@ jest.mock(
   }),
 );
 
-const mockTrackEvent = jest.fn();
-
-jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
-  useAnalytics: jest.fn(() => ({
-    trackEvent: mockTrackEvent,
-    createEventBuilder: jest.requireActual(
-      '../../../../../util/analytics/AnalyticsEventBuilder',
-    ).AnalyticsEventBuilder.createEventBuilder,
-  })),
-}));
-
 // Mock useBlockExplorer hook
 jest.mock('../../../../hooks/useBlockExplorer', () => ({
   __esModule: true,

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -35,7 +35,7 @@ import {
   trackQrCodeViewed,
 } from '../../../../../util/analytics/qrCodeViewedTracking';
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from './ShareAddressQR.testIds';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -99,15 +99,11 @@ export const ShareAddressQR = () => {
     if (!url) {
       return;
     }
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'share_address_qr',
-          text: explorerButtonText,
-          url_domain: url,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'share_address_qr',
+      text: explorerButtonText,
+      url_domain: url,
+    });
     toBlockExplorer(address);
   }, [
     address,

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -35,6 +35,7 @@ import {
   trackQrCodeViewed,
 } from '../../../../../util/analytics/qrCodeViewedTracking';
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from './ShareAddressQR.testIds';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -71,8 +72,15 @@ export const ShareAddressQR = () => {
 
   const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const { toBlockExplorer, getBlockExplorerName } = useBlockExplorer(chainId);
+  const { toBlockExplorer, getBlockExplorerUrl, getBlockExplorerName } =
+    useBlockExplorer(chainId);
   const networkImageSource = getNetworkImageSource({ chainId });
+  const explorerButtonText = strings(
+    'multichain_accounts.share_address.view_on_explorer_button',
+    {
+      explorer: getBlockExplorerName(),
+    },
+  );
 
   useEffect(() => {
     trackQrCodeViewed(trackEvent, createEventBuilder, {
@@ -87,8 +95,28 @@ export const ShareAddressQR = () => {
   }, [navigation]);
 
   const handleViewOnBlockExplorer = useCallback(() => {
+    const url = getBlockExplorerUrl(address);
+    if (!url) {
+      return;
+    }
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'share_address_qr',
+          text: explorerButtonText,
+          url_domain: url,
+        })
+        .build(),
+    );
     toBlockExplorer(address);
-  }, [address, toBlockExplorer]);
+  }, [
+    address,
+    createEventBuilder,
+    explorerButtonText,
+    getBlockExplorerUrl,
+    toBlockExplorer,
+    trackEvent,
+  ]);
 
   return (
     <BottomSheet ref={sheetRef} goBack={handleOnBack}>
@@ -158,12 +186,7 @@ export const ShareAddressQR = () => {
           testID={ShareAddressQRIds.SHARE_ADDRESS_QR_COPY_BUTTON}
           style={tw.style('mt-1 self-center')}
         >
-          {strings(
-            'multichain_accounts.share_address.view_on_explorer_button',
-            {
-              explorer: getBlockExplorerName(),
-            },
-          )}
+          {explorerButtonText}
         </Button>
       </Box>
     </BottomSheet>

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -35,7 +35,7 @@ import {
   trackQrCodeViewed,
 } from '../../../../../util/analytics/qrCodeViewedTracking';
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from './ShareAddressQR.testIds';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -99,10 +99,10 @@ export const ShareAddressQR = () => {
     if (!url) {
       return;
     }
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'share_address_qr',
       text: explorerButtonText,
-      url_domain: url,
+      url,
     });
     toBlockExplorer(address);
   }, [

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -7,6 +7,9 @@ import MultichainTransactionsView from './MultichainTransactionsView';
 import { selectNonEvmTransactions } from '../../../selectors/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { ButtonProps } from '../../../component-library/components/Buttons/Button/Button.types';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 
 jest.useFakeTimers();
 
@@ -67,6 +70,10 @@ jest.mock('../../../util/networks', () => ({
   getBlockExplorerName: jest.fn(() => 'Explorer'),
 }));
 
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
+
 describe('MultichainTransactionsView', () => {
   const mockNavigation = { navigate: jest.fn() };
   const mockSelectedAddress = '7RoSF9fUNf1XgRYsb7Qh4SoVkRmirHzZVELGNiNQzZNV';
@@ -109,6 +116,12 @@ describe('MultichainTransactionsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
+
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
 
     // Ensure selector returns a static instance
     const mockTransactionsData = { transactions: mockTransactions };

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import { BtcScope, SolScope, TransactionType } from '@metamask/keyring-api';
 import MultichainTransactionsView from './MultichainTransactionsView';
 import { selectNonEvmTransactions } from '../../../selectors/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { ButtonProps } from '../../../component-library/components/Buttons/Button/Button.types';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../util/test/analyticsMock';
-import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
-
+import { configureUseAnalyticsExternalLinkMock } from '../../../util/test/analyticsMock';
 jest.useFakeTimers();
 
+jest.mock('../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual('../../../util/analytics/externalLinkTracking'),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 const mockUseTheme = jest.fn();
 jest.mock('../../../util/theme', () => ({
   useTheme: () => mockUseTheme(),
@@ -117,11 +120,7 @@ describe('MultichainTransactionsView', () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock();
 
     // Ensure selector returns a static instance
     const mockTransactionsData = { transactions: mockTransactions };
@@ -182,5 +181,33 @@ describe('MultichainTransactionsView', () => {
     expect(
       queryByText('transactions.view_full_history_on'),
     ).not.toBeOnTheScreen();
+  });
+
+  it('tracks External Link Clicked when view more explorer link is pressed', () => {
+    customRender(
+      <MultichainTransactionsView
+        selectedAddress={mockSelectedAddress}
+        chainId={SolScope.Mainnet}
+      />,
+    );
+
+    const { default: MockButton } = jest.requireMock(
+      '../../../component-library/components/Buttons/Button',
+    ) as { default: { lastProps: ButtonProps } };
+
+    MockButton.lastProps.onPress?.();
+
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'multichain_activity_tab',
+        url: 'https://solscan.io/account/testaddress',
+      }),
+    );
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Webview', {
+      screen: 'SimpleWebview',
+      params: { url: 'https://solscan.io/account/testaddress' },
+    });
   });
 });

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -14,6 +14,9 @@ import { useTheme } from '../../../util/theme';
 import { strings } from '../../../../locales/i18n';
 import { baseStyles } from '../../../styles/common';
 import { getAddressUrl } from '../../../core/Multichain/utils';
+import { getBlockExplorerName } from '../../../util/networks';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import { selectNonEvmTransactions } from '../../../selectors/multichain/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import MultichainTransactionListItem from '../../UI/MultichainTransactionListItem';
@@ -91,6 +94,7 @@ const MultichainTransactionsView = ({
   const style = styles();
   const defaultNavigation = useNavigation();
   const nav = navigation ?? defaultNavigation;
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { namespace } = parseCaipChainId(chainId as CaipChainId);
   const isBitcoinNetwork = namespace === KnownCaipNamespace.Bip122;
 
@@ -153,6 +157,15 @@ const MultichainTransactionsView = ({
       showDisclaimer={showDisclaimer}
       showExplorerLink={!isBitcoinNetwork}
       onViewMore={() => {
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+            .addProperties({
+              location: 'multichain_activity_tab',
+              text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(url)}`,
+              url_domain: url,
+            })
+            .build(),
+        );
         nav.navigate('Webview', {
           screen: 'SimpleWebview',
           params: { url },

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -157,6 +157,9 @@ const MultichainTransactionsView = ({
       showDisclaimer={showDisclaimer}
       showExplorerLink={!isBitcoinNetwork}
       onViewMore={() => {
+        if (!url) {
+          return;
+        }
         trackExternalLinkClicked(trackEvent, createEventBuilder, {
           location: 'multichain_activity_tab',
           text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(url)}`,

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -16,7 +16,7 @@ import { baseStyles } from '../../../styles/common';
 import { getAddressUrl } from '../../../core/Multichain/utils';
 import { getBlockExplorerName } from '../../../util/networks';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { selectNonEvmTransactions } from '../../../selectors/multichain/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import MultichainTransactionListItem from '../../UI/MultichainTransactionListItem';
@@ -160,10 +160,10 @@ const MultichainTransactionsView = ({
         if (!url) {
           return;
         }
-        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
           location: 'multichain_activity_tab',
           text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(url)}`,
-          url_domain: url,
+          url,
         });
         nav.navigate('Webview', {
           screen: 'SimpleWebview',

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -16,7 +16,7 @@ import { baseStyles } from '../../../styles/common';
 import { getAddressUrl } from '../../../core/Multichain/utils';
 import { getBlockExplorerName } from '../../../util/networks';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { selectNonEvmTransactions } from '../../../selectors/multichain/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import MultichainTransactionListItem from '../../UI/MultichainTransactionListItem';
@@ -157,15 +157,11 @@ const MultichainTransactionsView = ({
       showDisclaimer={showDisclaimer}
       showExplorerLink={!isBitcoinNetwork}
       onViewMore={() => {
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-            .addProperties({
-              location: 'multichain_activity_tab',
-              text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(url)}`,
-              url_domain: url,
-            })
-            .build(),
-        );
+        trackExternalLinkClicked(trackEvent, createEventBuilder, {
+          location: 'multichain_activity_tab',
+          text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(url)}`,
+          url_domain: url,
+        });
         nav.navigate('Webview', {
           screen: 'SimpleWebview',
           params: { url },

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -47,7 +47,7 @@ import BigNumber from 'bignumber.js';
 import { getDecimalChainId } from '../../../util/networks';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { renderShortText } from '../../../util/general';
 import { prefixUrlWithProtocol } from '../../../util/browser';
 import { formatTimestampToYYYYMMDD } from '../../../util/date';
@@ -162,10 +162,10 @@ const NftDetails = () => {
       if (!url) {
         return;
       }
-      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
         location: 'nft_details',
         text,
-        url_domain: url,
+        url,
       });
       navigation.navigate('Webview', {
         screen: 'SimpleWebview',

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -156,6 +156,28 @@ const NftDetails = () => {
     }
   };
 
+  const openBlockExplorer = useCallback(
+    (url: string | undefined, text: string) => {
+      if (!url) {
+        return;
+      }
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+          .addProperties({
+            location: 'nft_details',
+            text,
+            url_domain: url,
+          })
+          .build(),
+      );
+      navigation.navigate('Webview', {
+        screen: 'SimpleWebview',
+        params: { url },
+      });
+    },
+    [createEventBuilder, navigation, trackEvent],
+  );
+
   const getDateCreatedTimestamp = (dateString: string) => {
     const date = new Date(dateString);
     return Math.floor(date.getTime() / 1000);
@@ -435,12 +457,10 @@ const NftDetails = () => {
                   </TouchableOpacity>
                 }
                 onValuePress={() => {
-                  navigation.navigate('Webview', {
-                    screen: 'SimpleWebview',
-                    params: {
-                      url: blockExplorerTokenLink(),
-                    },
-                  });
+                  openBlockExplorer(
+                    blockExplorerTokenLink(),
+                    strings('nft_details.contract_address'),
+                  );
                 }}
               />
             ) : null}
@@ -465,12 +485,10 @@ const NftDetails = () => {
               }
               onValuePress={() => {
                 if (collectible.collection?.creator) {
-                  navigation.navigate('Webview', {
-                    screen: 'SimpleWebview',
-                    params: {
-                      url: blockExplorerTokenLink(),
-                    },
-                  });
+                  openBlockExplorer(
+                    blockExplorerTokenLink(),
+                    strings('nft_details.contract_address'),
+                  );
                 }
               }}
             />
@@ -579,12 +597,10 @@ const NftDetails = () => {
             }
             onValuePress={() => {
               if (collectible.collection?.creator) {
-                navigation.navigate('Webview', {
-                  screen: 'SimpleWebview',
-                  params: {
-                    url: blockExplorerAccountLink(),
-                  },
-                });
+                openBlockExplorer(
+                  blockExplorerAccountLink(),
+                  strings('nft_details.creator'),
+                );
               }
             }}
           />

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -47,6 +47,7 @@ import BigNumber from 'bignumber.js';
 import { getDecimalChainId } from '../../../util/networks';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { renderShortText } from '../../../util/general';
 import { prefixUrlWithProtocol } from '../../../util/browser';
 import { formatTimestampToYYYYMMDD } from '../../../util/date';
@@ -161,15 +162,11 @@ const NftDetails = () => {
       if (!url) {
         return;
       }
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-          .addProperties({
-            location: 'nft_details',
-            text,
-            url_domain: url,
-          })
-          .build(),
-      );
+      trackExternalLinkClicked(trackEvent, createEventBuilder, {
+        location: 'nft_details',
+        text,
+        url_domain: url,
+      });
       navigation.navigate('Webview', {
         screen: 'SimpleWebview',
         params: { url },

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.test.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.test.tsx
@@ -100,7 +100,7 @@ describe('BlockExplorerFooter', () => {
         .addProperties({
           location: 'notification_detail',
           text: strings('asset_details.options.view_on_block'),
-          url_domain: 'https://blockexplorer.com/tx/0x123',
+          url_domain: 'blockexplorer.com',
         })
         .build(),
     );

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.test.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.test.tsx
@@ -95,6 +95,17 @@ describe('BlockExplorerFooter', () => {
     expect(Linking.openURL).toHaveBeenCalled();
     expect(trackEventMock).toHaveBeenCalledWith(
       AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+      )
+        .addProperties({
+          location: 'notification_detail',
+          text: strings('asset_details.options.view_on_block'),
+          url_domain: 'https://blockexplorer.com/tx/0x123',
+        })
+        .build(),
+    );
+    expect(trackEventMock).toHaveBeenCalledWith(
+      AnalyticsEventBuilder.createEventBuilder(
         MetaMetricsEvents.NOTIFICATION_DETAIL_CLICKED,
       )
         .addProperties({

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
@@ -14,7 +14,7 @@ import { ModalFooterBlockExplorer } from '../../../../../util/notifications/noti
 import useStyles from '../useStyles';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import onChainAnalyticProperties from '../../../../../util/notifications/methods/notification-analytics';
 import {
   INotification,
@@ -57,10 +57,10 @@ export default function BlockExplorerFooter(props: BlockExplorerFooterProps) {
   const txHashUrl = `${url}/tx/${props.txHash}`;
 
   const onPress = () => {
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'notification_detail',
       text: strings('asset_details.options.view_on_block'),
-      url_domain: txHashUrl,
+      url: txHashUrl,
     });
     Linking.openURL(txHashUrl);
     trackEvent(

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
@@ -14,6 +14,7 @@ import { ModalFooterBlockExplorer } from '../../../../../util/notifications/noti
 import useStyles from '../useStyles';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import onChainAnalyticProperties from '../../../../../util/notifications/methods/notification-analytics';
 import {
   INotification,
@@ -56,15 +57,11 @@ export default function BlockExplorerFooter(props: BlockExplorerFooterProps) {
   const txHashUrl = `${url}/tx/${props.txHash}`;
 
   const onPress = () => {
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'notification_detail',
-          text: strings('asset_details.options.view_on_block'),
-          url_domain: txHashUrl,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'notification_detail',
+      text: strings('asset_details.options.view_on_block'),
+      url_domain: txHashUrl,
+    });
     Linking.openURL(txHashUrl);
     trackEvent(
       createEventBuilder(MetaMetricsEvents.NOTIFICATION_DETAIL_CLICKED)

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
@@ -56,6 +56,15 @@ export default function BlockExplorerFooter(props: BlockExplorerFooterProps) {
   const txHashUrl = `${url}/tx/${props.txHash}`;
 
   const onPress = () => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'notification_detail',
+          text: strings('asset_details.options.view_on_block'),
+          url_domain: txHashUrl,
+        })
+        .build(),
+    );
     Linking.openURL(txHashUrl);
     trackEvent(
       createEventBuilder(MetaMetricsEvents.NOTIFICATION_DETAIL_CLICKED)

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.test.tsx
@@ -20,7 +20,6 @@ import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../util/test/accountsCo
 import { strings } from '../../../../../locales/i18n';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { ReduxStore } from '../../../../core/redux/types';
-
 const initialState = {
   privacy: { approvedHosts: {} },
   browser: { history: [] },
@@ -92,6 +91,7 @@ jest.mock('../../../../core/Authentication/hooks/useAuthCapabilities', () => ({
 
 describe('SecuritySettings', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockGoBack.mockClear();
     mockUseParamsValues = {
       scrollToDetectNFTs: undefined,

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -12,8 +12,8 @@ import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
 import { SEED_PHRASE_HINTS } from '../../../../constants/storage';
 import HintModal from '../../../UI/HintModal';
-import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import {
   ClearCookiesSection,
   DeleteMetaMetricsData,
@@ -301,15 +301,11 @@ const Settings: React.FC = () => {
             labelTextVariant={LibraryTextVariant.BodySMMedium}
             onPress={() => {
               Linking.openURL(SIMULATION_DETALS_ARTICLE_URL);
-              trackEvent(
-                createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-                  .addProperties({
-                    location: 'app_settings',
-                    text: strings('app_settings.simulation_details_learn_more'),
-                    url_domain: SIMULATION_DETALS_ARTICLE_URL,
-                  })
-                  .build(),
-              );
+              trackExternalLinkClicked(trackEvent, createEventBuilder, {
+                location: 'app_settings',
+                text: strings('app_settings.simulation_details_learn_more'),
+                url_domain: SIMULATION_DETALS_ARTICLE_URL,
+              });
             }}
             label={strings('app_settings.simulation_details_learn_more')}
           />

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
@@ -21,6 +21,9 @@ import {
   KEYRING_ACCOUNT_LIST_ITEM,
   KEYRING_ACCOUNT_LIST_ITEM_BUTTON,
 } from './KeyringAccountListItem.constants';
+import { analytics } from '../../../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 interface KeyringAccountListItemProps {
   account: InternalAccount;
@@ -34,6 +37,19 @@ const KeyringAccountListItem = ({
   const { styles } = useStyles(stylesheet, {});
 
   const handlePress = useCallback(() => {
+    analytics.trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+      )
+        .addProperties({
+          location: 'snap_keyring_account',
+          text: strings(
+            'app_settings.snaps.keyring_account_list_item.public_address',
+          ),
+          url_domain: blockExplorerUrl,
+        })
+        .build(),
+    );
     Linking.openURL(blockExplorerUrl);
   }, [blockExplorerUrl]);
 

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
@@ -23,7 +23,7 @@ import {
 } from './KeyringAccountListItem.constants';
 import { analytics } from '../../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
-import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 interface KeyringAccountListItemProps {
   account: InternalAccount;
@@ -37,18 +37,16 @@ const KeyringAccountListItem = ({
   const { styles } = useStyles(stylesheet, {});
 
   const handlePress = useCallback(() => {
-    analytics.trackEvent(
-      AnalyticsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-      )
-        .addProperties({
-          location: 'snap_keyring_account',
-          text: strings(
-            'app_settings.snaps.keyring_account_list_item.public_address',
-          ),
-          url_domain: blockExplorerUrl,
-        })
-        .build(),
+    trackExternalLinkClicked(
+      analytics.trackEvent,
+      AnalyticsEventBuilder.createEventBuilder,
+      {
+        location: 'snap_keyring_account',
+        text: strings(
+          'app_settings.snaps.keyring_account_list_item.public_address',
+        ),
+        url_domain: blockExplorerUrl,
+      },
     );
     Linking.openURL(blockExplorerUrl);
   }, [blockExplorerUrl]);

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
@@ -23,7 +23,7 @@ import {
 } from './KeyringAccountListItem.constants';
 import { analytics } from '../../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
-import { trackExternalLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 
 interface KeyringAccountListItemProps {
   account: InternalAccount;
@@ -37,7 +37,7 @@ const KeyringAccountListItem = ({
   const { styles } = useStyles(stylesheet, {});
 
   const handlePress = useCallback(() => {
-    trackExternalLinkClicked(
+    trackBlockExplorerLinkClicked(
       analytics.trackEvent,
       AnalyticsEventBuilder.createEventBuilder,
       {
@@ -45,7 +45,7 @@ const KeyringAccountListItem = ({
         text: strings(
           'app_settings.snaps.keyring_account_list_item.public_address',
         ),
-        url_domain: blockExplorerUrl,
+        url: blockExplorerUrl,
       },
     );
     Linking.openURL(blockExplorerUrl);

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/test/KeyringAccountListItem.test.tsx
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/test/KeyringAccountListItem.test.tsx
@@ -12,6 +12,13 @@ import {
   createMockSnapInternalAccount,
 } from '../../../../../../util/test/accountsControllerTestUtils';
 
+jest.mock('../../../../../../util/analytics/externalLinkTracking', () => ({
+  ...jest.requireActual(
+    '../../../../../../util/analytics/externalLinkTracking',
+  ),
+  trackBlockExplorerLinkClicked: jest.fn(),
+}));
+import { trackBlockExplorerLinkClicked } from '../../../../../../util/analytics/externalLinkTracking';
 describe('KeyringAccountListItem', () => {
   const mockInternalAccount = createMockSnapInternalAccount(
     MOCK_ADDRESS_1,
@@ -45,5 +52,13 @@ describe('KeyringAccountListItem', () => {
     fireEvent.press(exportButton);
 
     expect(Linking.openURL).toHaveBeenCalledWith(mockBlockExplorerUrl);
+    expect(jest.mocked(trackBlockExplorerLinkClicked)).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        location: 'snap_keyring_account',
+        url: mockBlockExplorerUrl,
+      }),
+    );
   });
 });

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
@@ -14,6 +14,9 @@ import { updateIncomingTransactions } from '../../../util/transaction-controller
 import { useUnifiedTxActions } from './useUnifiedTxActions';
 import { useTransactionsQuery } from './useTransactionsQuery';
 import { selectTransactions } from './helpers/transformations';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 
 // Type helper for UNSAFE_queryByType with mocked string components
 const asComponentType = (name: string) => name as unknown as ComponentType;
@@ -126,6 +129,18 @@ jest.mock('../../hooks/useBlockExplorer', () => ({
     getBlockExplorerName: jest.fn().mockReturnValue('Etherscan'),
   }),
 }));
+
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.mocked(useAnalytics).mockReturnValue(
+    createMockUseAnalyticsHook({
+      createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+    }),
+  );
+});
 
 const mockSelectBridgeHistoryForAccount = jest.fn(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -39,7 +39,7 @@ import {
   getBlockExplorerName,
 } from '../../../util/networks';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { useTheme } from '../../../util/theme';
 import { updateIncomingTransactions } from '../../../util/transaction-controller';
 import { useStyles } from '../../hooks/useStyles';
@@ -403,17 +403,13 @@ const UnifiedTransactionsView = ({
         : undefined;
     }
 
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'activity_tab',
-          text: title
-            ? `${strings('transactions.view_full_history_on')} ${title}`
-            : strings('asset_details.options.view_on_block'),
-          url_domain: url,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'activity_tab',
+      text: title
+        ? `${strings('transactions.view_full_history_on')} ${title}`
+        : strings('asset_details.options.view_on_block'),
+      url_domain: url,
+    });
 
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
@@ -470,15 +466,11 @@ const UnifiedTransactionsView = ({
       return;
     }
 
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'activity_tab',
-          text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(nonEvmExplorerUrl)}`,
-          url_domain: nonEvmExplorerUrl,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'activity_tab',
+      text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(nonEvmExplorerUrl)}`,
+      url_domain: nonEvmExplorerUrl,
+    });
 
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -34,7 +34,12 @@ import {
 } from '../../../selectors/transactionController';
 import { baseStyles } from '../../../styles/common';
 import { areAddressesEqual, isHardwareAccount } from '../../../util/address';
-import { getBlockExplorerAddressUrl } from '../../../util/networks';
+import {
+  getBlockExplorerAddressUrl,
+  getBlockExplorerName,
+} from '../../../util/networks';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../core/Analytics';
 import { useTheme } from '../../../util/theme';
 import { updateIncomingTransactions } from '../../../util/transaction-controller';
 import { useStyles } from '../../hooks/useStyles';
@@ -110,6 +115,7 @@ const UnifiedTransactionsView = ({
   location,
 }: UnifiedTransactionsViewProps) => {
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { colors } = useTheme();
   const tw = useTailwind();
   const { styles } = useStyles(styleSheet, {});
@@ -397,6 +403,18 @@ const UnifiedTransactionsView = ({
         : undefined;
     }
 
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'activity_tab',
+          text: title
+            ? `${strings('transactions.view_full_history_on')} ${title}`
+            : strings('asset_details.options.view_on_block'),
+          url_domain: url,
+        })
+        .build(),
+    );
+
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {
@@ -405,8 +423,10 @@ const UnifiedTransactionsView = ({
       },
     });
   }, [
+    createEventBuilder,
     navigation,
     blockExplorerUrl,
+    trackEvent,
     selectedAccountGroupEvmAddress,
     popularListBlockExplorer,
     enabledEVMChainIds,
@@ -450,13 +470,23 @@ const UnifiedTransactionsView = ({
       return;
     }
 
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'activity_tab',
+          text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(nonEvmExplorerUrl)}`,
+          url_domain: nonEvmExplorerUrl,
+        })
+        .build(),
+    );
+
     navigation.navigate('Webview', {
       screen: 'SimpleWebview',
       params: {
         url: nonEvmExplorerUrl,
       },
     });
-  }, [navigation, nonEvmExplorerUrl]);
+  }, [createEventBuilder, navigation, nonEvmExplorerUrl, trackEvent]);
 
   const footerComponent = useMemo(() => {
     if (isFetchingNextPage) {

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -39,7 +39,7 @@ import {
   getBlockExplorerName,
 } from '../../../util/networks';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
 import { useTheme } from '../../../util/theme';
 import { updateIncomingTransactions } from '../../../util/transaction-controller';
 import { useStyles } from '../../hooks/useStyles';
@@ -407,12 +407,12 @@ const UnifiedTransactionsView = ({
       return;
     }
 
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'activity_tab',
       text: title
         ? `${strings('transactions.view_full_history_on')} ${title}`
         : strings('asset_details.options.view_on_block'),
-      url_domain: url,
+      url,
     });
 
     navigation.navigate('Webview', {
@@ -470,10 +470,10 @@ const UnifiedTransactionsView = ({
       return;
     }
 
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'activity_tab',
       text: `${strings('transactions.view_full_history_on')} ${getBlockExplorerName(nonEvmExplorerUrl)}`,
-      url_domain: nonEvmExplorerUrl,
+      url: nonEvmExplorerUrl,
     });
 
     navigation.navigate('Webview', {

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -403,6 +403,10 @@ const UnifiedTransactionsView = ({
         : undefined;
     }
 
+    if (!url) {
+      return;
+    }
+
     trackExternalLinkClicked(trackEvent, createEventBuilder, {
       location: 'activity_tab',
       text: title

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.test.tsx
@@ -13,9 +13,7 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { ApprovalSummaryLine } from './approval-summary-line';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
-import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
-
+import { configureUseAnalyticsExternalLinkMock } from '../../../../../../util/test/analyticsMock';
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../hooks/tokens/useTokenWithBalance');
 jest.mock('../../../../../../selectors/bridgeStatusController');
@@ -68,11 +66,7 @@ describe('ApprovalSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock();
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/approval-summary-line.test.tsx
@@ -12,6 +12,9 @@ import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useB
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { ApprovalSummaryLine } from './approval-summary-line';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../hooks/tokens/useTokenWithBalance');
@@ -19,6 +22,9 @@ jest.mock('../../../../../../selectors/bridgeStatusController');
 jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -61,6 +67,12 @@ describe('ApprovalSummaryLine', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/default-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/default-summary-line.test.tsx
@@ -13,9 +13,7 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { DefaultSummaryLine } from './default-summary-line';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
-import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
-
+import { configureUseAnalyticsExternalLinkMock } from '../../../../../../util/test/analyticsMock';
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../../../../selectors/bridgeStatusController');
 jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
@@ -65,11 +63,7 @@ describe('DefaultSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock();
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/default-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/default-summary-line.test.tsx
@@ -12,12 +12,18 @@ import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useB
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { DefaultSummaryLine } from './default-summary-line';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../../../../selectors/bridgeStatusController');
 jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -58,6 +64,12 @@ describe('DefaultSummaryLine', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.test.tsx
@@ -13,6 +13,9 @@ import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useB
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { DepositSummaryLine } from './deposit-summary-line';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../hooks/useNetworkName');
@@ -21,6 +24,9 @@ jest.mock('../../../../../../selectors/bridgeStatusController');
 jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -74,6 +80,12 @@ describe('DepositSummaryLine', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/deposit-summary-line.test.tsx
@@ -14,9 +14,7 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { DepositSummaryLine } from './deposit-summary-line';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
-import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
-
+import { configureUseAnalyticsExternalLinkMock } from '../../../../../../util/test/analyticsMock';
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../hooks/useNetworkName');
 jest.mock('../../../hooks/tokens/useTokenWithBalance');
@@ -81,11 +79,7 @@ describe('DepositSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock();
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
@@ -16,9 +16,7 @@ import { useTransactionDetails } from '../../../hooks/activity/useTransactionDet
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { ReceiveSummaryLine } from './receive-summary-line';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
-import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
-
+import { configureUseAnalyticsExternalLinkMock } from '../../../../../../util/test/analyticsMock';
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../hooks/useNetworkName');
 jest.mock('../../../../../../selectors/bridgeStatusController');
@@ -61,11 +59,7 @@ describe('ReceiveSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock();
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
@@ -15,6 +15,9 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { ReceiveSummaryLine } from './receive-summary-line';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../hooks/useNetworkName');
@@ -23,6 +26,9 @@ jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/activity/useTransactionDetails');
 jest.mock('../../../hooks/tokens/useTokenWithBalance');
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -54,6 +60,12 @@ describe('ReceiveSummaryLine', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
@@ -17,8 +17,7 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { SourceHashSummaryLine } from './source-hash-summary-line';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
-import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
+import { configureUseAnalyticsExternalLinkMock } from '../../../../../../util/test/analyticsMock';
 
 const mockNavigate = jest.fn();
 
@@ -78,11 +77,7 @@ describe('SourceHashSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock();
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
@@ -16,6 +16,9 @@ import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useB
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { SourceHashSummaryLine } from './source-hash-summary-line';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
 const mockNavigate = jest.fn();
 
@@ -26,6 +29,9 @@ jest.mock('../../../../../../selectors/bridgeStatusController');
 jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -71,6 +77,12 @@ describe('SourceHashSummaryLine', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.test.tsx
@@ -115,7 +115,7 @@ describe('TransactionSummaryLine', () => {
         .addProperties({
           location: 'transaction_details_summary',
           text: 'Explorer',
-          url_domain: 'https://explorer.example',
+          url_domain: 'explorer.example',
         })
         .build(),
     );

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.test.tsx
@@ -10,7 +10,7 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { useMultichainBlockExplorerTxUrl } from '../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl';
 import { TransactionSummaryLine } from './transaction-summary-line';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { configureUseAnalyticsExternalLinkMock } from '../../../../../../util/test/analyticsMock';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
@@ -69,12 +69,7 @@ describe('TransactionSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    jest.mocked(useAnalytics).mockReturnValue(
-      createMockUseAnalyticsHook({
-        trackEvent: trackEventMock,
-        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
-      }),
-    );
+    configureUseAnalyticsExternalLinkMock(trackEventMock);
 
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.test.tsx
@@ -9,10 +9,19 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { useMultichainBlockExplorerTxUrl } from '../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl';
 import { TransactionSummaryLine } from './transaction-summary-line';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { createMockUseAnalyticsHook } from '../../../../../../util/test/analyticsMock';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { AnalyticsEventBuilder } from '../../../../../../util/analytics/AnalyticsEventBuilder';
 
 const mockNavigate = jest.fn();
+const trackEventMock = jest.fn();
 
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
+
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -60,6 +69,13 @@ describe('TransactionSummaryLine', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        trackEvent: trackEventMock,
+        createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+      }),
+    );
+
     useMultichainBlockExplorerTxUrlMock.mockReturnValue({
       explorerTxUrl: 'https://explorer.example',
       explorerName: 'Explorer',
@@ -92,6 +108,17 @@ describe('TransactionSummaryLine', () => {
 
     fireEvent.press(getByTestId('block-explorer-button'));
 
+    expect(trackEventMock).toHaveBeenCalledWith(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+      )
+        .addProperties({
+          location: 'transaction_details_summary',
+          text: 'Explorer',
+          url_domain: 'https://explorer.example',
+        })
+        .build(),
+    );
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.tsx
@@ -9,6 +9,8 @@ import { getIntlDateTimeFormatter } from '../../../../../../util/intl';
 import { useMultichainBlockExplorerTxUrl } from '../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl';
 import { ProgressListItem } from '../../progress-list';
 import { getErrorMessage, getSeverity } from '../../../utils/transaction';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 
 interface TransactionSummaryLineProps {
   chainId?: Hex;
@@ -30,6 +32,7 @@ export function TransactionSummaryLine({
   txHash,
 }: TransactionSummaryLineProps) {
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const resolvedChainId = chainId ?? transactionMeta.chainId;
   const rawHash = txHash ?? transactionMeta.hash;
@@ -54,11 +57,28 @@ export function TransactionSummaryLine({
       return;
     }
 
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+        .addProperties({
+          location: 'transaction_details_summary',
+          text: explorerName ?? title,
+          url_domain: explorerTxUrl,
+        })
+        .build(),
+    );
+
     navigation.navigate(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: { url: explorerTxUrl, title: explorerName },
     });
-  }, [explorerName, explorerTxUrl, navigation]);
+  }, [
+    createEventBuilder,
+    explorerName,
+    explorerTxUrl,
+    navigation,
+    title,
+    trackEvent,
+  ]);
 
   return (
     <ProgressListItem

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.tsx
@@ -10,7 +10,7 @@ import { useMultichainBlockExplorerTxUrl } from '../../../../../UI/Bridge/hooks/
 import { ProgressListItem } from '../../progress-list';
 import { getErrorMessage, getSeverity } from '../../../utils/transaction';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { trackExternalLinkClicked } from '../../../../../../util/analytics/externalLinkTracking';
+import { trackBlockExplorerLinkClicked } from '../../../../../../util/analytics/externalLinkTracking';
 
 interface TransactionSummaryLineProps {
   chainId?: Hex;
@@ -57,10 +57,10 @@ export function TransactionSummaryLine({
       return;
     }
 
-    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, {
       location: 'transaction_details_summary',
       text: explorerName ?? title,
-      url_domain: explorerTxUrl,
+      url: explorerTxUrl,
     });
 
     navigation.navigate(Routes.WEBVIEW.MAIN, {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-summary-line.tsx
@@ -10,7 +10,7 @@ import { useMultichainBlockExplorerTxUrl } from '../../../../../UI/Bridge/hooks/
 import { ProgressListItem } from '../../progress-list';
 import { getErrorMessage, getSeverity } from '../../../utils/transaction';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { trackExternalLinkClicked } from '../../../../../../util/analytics/externalLinkTracking';
 
 interface TransactionSummaryLineProps {
   chainId?: Hex;
@@ -57,15 +57,11 @@ export function TransactionSummaryLine({
       return;
     }
 
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-        .addProperties({
-          location: 'transaction_details_summary',
-          text: explorerName ?? title,
-          url_domain: explorerTxUrl,
-        })
-        .build(),
-    );
+    trackExternalLinkClicked(trackEvent, createEventBuilder, {
+      location: 'transaction_details_summary',
+      text: explorerName ?? title,
+      url_domain: explorerTxUrl,
+    });
 
     navigation.navigate(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,

--- a/app/util/analytics/externalLinkTracking.test.ts
+++ b/app/util/analytics/externalLinkTracking.test.ts
@@ -1,0 +1,79 @@
+import {
+  trackExternalLinkClicked,
+  ExternalLinkClickedProperties,
+} from './externalLinkTracking';
+import { MetaMetricsEvents } from '../../core/Analytics';
+import { ITrackingEvent } from './analytics.types';
+
+jest.mock('../../core/Analytics');
+
+describe('externalLinkTracking', () => {
+  const mockTrackEvent = jest.fn();
+  const mockCreateEventBuilder = jest.fn();
+  const mockAddProperties = jest.fn();
+  const mockBuild = jest.fn();
+
+  const mockProperties: ExternalLinkClickedProperties = {
+    location: 'account_actions',
+    text: 'View on Etherscan',
+    url_domain: 'https://etherscan.io/address/0x123',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    mockAddProperties.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    mockBuild.mockReturnValue({
+      name: 'External Link Clicked',
+      properties: mockProperties,
+      sensitiveProperties: {},
+      saveDataRecording: false,
+      isAnonymous: false,
+      hasProperties: true,
+    } as ITrackingEvent);
+  });
+
+  it('creates event with EXTERNAL_LINK_CLICKED', () => {
+    trackExternalLinkClicked(
+      mockTrackEvent,
+      mockCreateEventBuilder,
+      mockProperties,
+    );
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+    );
+  });
+
+  it('adds link properties to the event builder', () => {
+    trackExternalLinkClicked(
+      mockTrackEvent,
+      mockCreateEventBuilder,
+      mockProperties,
+    );
+
+    expect(mockAddProperties).toHaveBeenCalledWith(mockProperties);
+  });
+
+  it('builds and tracks the event', () => {
+    trackExternalLinkClicked(
+      mockTrackEvent,
+      mockCreateEventBuilder,
+      mockProperties,
+    );
+
+    expect(mockBuild).toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'External Link Clicked',
+      }),
+    );
+  });
+});

--- a/app/util/analytics/externalLinkTracking.test.ts
+++ b/app/util/analytics/externalLinkTracking.test.ts
@@ -55,10 +55,20 @@ describe('externalLinkTracking', () => {
       );
     });
 
+    it('extracts hostname from protocol-less explorer URLs', () => {
+      expect(getExternalLinkHostname('etherscan.io/tx/0x123')).toBe(
+        'etherscan.io',
+      );
+    });
+
     it('falls back to regex extraction when URL parsing fails', () => {
       expect(
         getExternalLinkHostname('https://blockexplorer.com/tx/0x123'),
       ).toBe('blockexplorer.com');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(getExternalLinkHostname('')).toBe('');
     });
 
     it('returns the original string when hostname cannot be extracted', () => {

--- a/app/util/analytics/externalLinkTracking.test.ts
+++ b/app/util/analytics/externalLinkTracking.test.ts
@@ -60,6 +60,12 @@ describe('externalLinkTracking', () => {
         getExternalLinkHostname('https://blockexplorer.com/tx/0x123'),
       ).toBe('blockexplorer.com');
     });
+
+    it('returns the original string when hostname cannot be extracted', () => {
+      expect(getExternalLinkHostname('not-a-valid-url')).toBe(
+        'not-a-valid-url',
+      );
+    });
   });
 
   describe('trackExternalLinkClicked', () => {

--- a/app/util/analytics/externalLinkTracking.test.ts
+++ b/app/util/analytics/externalLinkTracking.test.ts
@@ -1,5 +1,7 @@
 import {
   trackExternalLinkClicked,
+  trackBlockExplorerLinkClicked,
+  getExternalLinkHostname,
   ExternalLinkClickedProperties,
 } from './externalLinkTracking';
 import { MetaMetricsEvents } from '../../core/Analytics';
@@ -40,40 +42,78 @@ describe('externalLinkTracking', () => {
     } as ITrackingEvent);
   });
 
-  it('creates event with EXTERNAL_LINK_CLICKED', () => {
-    trackExternalLinkClicked(
-      mockTrackEvent,
-      mockCreateEventBuilder,
-      mockProperties,
-    );
+  describe('getExternalLinkHostname', () => {
+    it('returns hostname from a valid HTTPS URL', () => {
+      expect(
+        getExternalLinkHostname('https://etherscan.io/address/0x123'),
+      ).toBe('etherscan.io');
+    });
 
-    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-      MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
-    );
+    it('returns hostname from a valid HTTP URL', () => {
+      expect(getExternalLinkHostname('http://explorer.example/tx/0xabc')).toBe(
+        'explorer.example',
+      );
+    });
+
+    it('falls back to regex extraction when URL parsing fails', () => {
+      expect(
+        getExternalLinkHostname('https://blockexplorer.com/tx/0x123'),
+      ).toBe('blockexplorer.com');
+    });
   });
 
-  it('adds link properties to the event builder', () => {
-    trackExternalLinkClicked(
-      mockTrackEvent,
-      mockCreateEventBuilder,
-      mockProperties,
-    );
+  describe('trackExternalLinkClicked', () => {
+    it('creates event with EXTERNAL_LINK_CLICKED', () => {
+      trackExternalLinkClicked(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        mockProperties,
+      );
 
-    expect(mockAddProperties).toHaveBeenCalledWith(mockProperties);
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.EXTERNAL_LINK_CLICKED,
+      );
+    });
+
+    it('adds link properties to the event builder', () => {
+      trackExternalLinkClicked(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        mockProperties,
+      );
+
+      expect(mockAddProperties).toHaveBeenCalledWith(mockProperties);
+    });
+
+    it('builds and tracks the event', () => {
+      trackExternalLinkClicked(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        mockProperties,
+      );
+
+      expect(mockBuild).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'External Link Clicked',
+        }),
+      );
+    });
   });
 
-  it('builds and tracks the event', () => {
-    trackExternalLinkClicked(
-      mockTrackEvent,
-      mockCreateEventBuilder,
-      mockProperties,
-    );
+  describe('trackBlockExplorerLinkClicked', () => {
+    it('sends url_domain as hostname only', () => {
+      trackBlockExplorerLinkClicked(mockTrackEvent, mockCreateEventBuilder, {
+        location: 'account_actions',
+        text: 'View on Etherscan',
+        url: 'https://etherscan.io/address/0x123',
+      });
 
-    expect(mockBuild).toHaveBeenCalled();
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'External Link Clicked',
-      }),
-    );
+      expect(mockAddProperties).toHaveBeenCalledWith({
+        location: 'account_actions',
+        text: 'View on Etherscan',
+        url_domain: 'etherscan.io',
+      });
+    });
   });
 });

--- a/app/util/analytics/externalLinkTracking.ts
+++ b/app/util/analytics/externalLinkTracking.ts
@@ -41,10 +41,18 @@ type ExternalLinkEventFactory<TEvent> = (event: IMetaMetricsEvent) => {
  * @returns URL hostname, or the original string if parsing fails
  */
 export const getExternalLinkHostname = (url: string): string => {
+  if (!url) {
+    return url;
+  }
+
+  const normalizedUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(url)
+    ? url
+    : `https://${url}`;
+
   try {
-    return new URL(url).hostname;
+    return new URL(normalizedUrl).hostname;
   } catch {
-    const match = url.match(/^https?:\/\/([^/?#]+)/i);
+    const match = url.match(/^(?:https?:\/\/)?([^/?#:]+)/i);
     return match?.[1] ?? url;
   }
 };

--- a/app/util/analytics/externalLinkTracking.ts
+++ b/app/util/analytics/externalLinkTracking.ts
@@ -1,0 +1,41 @@
+import { MetaMetricsEvents } from '../../core/Analytics';
+import { IMetaMetricsEvent, JsonMap } from './analytics.types';
+
+/**
+ * Properties for External Link Clicked tracking.
+ *
+ * @property location - Screen or context in snake_case
+ * @property text - Visible link or button label
+ * @property url_domain - Full external URL
+ */
+export interface ExternalLinkClickedProperties extends JsonMap {
+  location: string;
+  text: string;
+  url_domain: string;
+}
+
+/**
+ * Track External Link Clicked with the mobile analytics schema.
+ * Generic over the event type so callers using either MetricsEventBuilder
+ * (ITrackingEvent) or AnalyticsEventBuilder (AnalyticsTrackingEvent) are
+ * both accepted without a lossy union parameter.
+ *
+ * @param trackEvent - trackEvent function (MetaMetrics or useAnalytics)
+ * @param createEventBuilder - createEventBuilder function (MetricsEventBuilder or AnalyticsEventBuilder)
+ * @param properties - Link properties
+ */
+export const trackExternalLinkClicked = <TEvent>(
+  trackEvent: (event: TEvent) => void,
+  createEventBuilder: (event: IMetaMetricsEvent) => {
+    addProperties: (properties: ExternalLinkClickedProperties) => {
+      build: () => TEvent;
+    };
+  },
+  properties: ExternalLinkClickedProperties,
+): void => {
+  trackEvent(
+    createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+      .addProperties(properties)
+      .build(),
+  );
+};

--- a/app/util/analytics/externalLinkTracking.ts
+++ b/app/util/analytics/externalLinkTracking.ts
@@ -28,6 +28,12 @@ export interface BlockExplorerLinkClickedProperties extends JsonMap {
   url: string;
 }
 
+type ExternalLinkEventFactory<TEvent> = (event: IMetaMetricsEvent) => {
+  addProperties: (properties: ExternalLinkClickedProperties) => {
+    build: () => TEvent;
+  };
+};
+
 /**
  * Extract hostname from an external URL for block explorer analytics.
  *
@@ -43,6 +49,18 @@ export const getExternalLinkHostname = (url: string): string => {
   }
 };
 
+const emitExternalLinkClicked = <TEvent>(
+  trackEvent: (event: TEvent) => void,
+  createEventBuilder: ExternalLinkEventFactory<TEvent>,
+  properties: ExternalLinkClickedProperties,
+): void => {
+  trackEvent(
+    createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
+      .addProperties(properties)
+      .build(),
+  );
+};
+
 /**
  * Track External Link Clicked with the mobile analytics schema.
  * Generic over the event type so callers using either MetricsEventBuilder
@@ -55,18 +73,10 @@ export const getExternalLinkHostname = (url: string): string => {
  */
 export const trackExternalLinkClicked = <TEvent>(
   trackEvent: (event: TEvent) => void,
-  createEventBuilder: (event: IMetaMetricsEvent) => {
-    addProperties: (properties: ExternalLinkClickedProperties) => {
-      build: () => TEvent;
-    };
-  },
+  createEventBuilder: ExternalLinkEventFactory<TEvent>,
   properties: ExternalLinkClickedProperties,
 ): void => {
-  trackEvent(
-    createEventBuilder(MetaMetricsEvents.EXTERNAL_LINK_CLICKED)
-      .addProperties(properties)
-      .build(),
-  );
+  emitExternalLinkClicked(trackEvent, createEventBuilder, properties);
 };
 
 /**
@@ -79,15 +89,11 @@ export const trackExternalLinkClicked = <TEvent>(
  */
 export const trackBlockExplorerLinkClicked = <TEvent>(
   trackEvent: (event: TEvent) => void,
-  createEventBuilder: (event: IMetaMetricsEvent) => {
-    addProperties: (properties: ExternalLinkClickedProperties) => {
-      build: () => TEvent;
-    };
-  },
+  createEventBuilder: ExternalLinkEventFactory<TEvent>,
   properties: BlockExplorerLinkClickedProperties,
 ): void => {
   const { location, text, url } = properties;
-  trackExternalLinkClicked(trackEvent, createEventBuilder, {
+  emitExternalLinkClicked(trackEvent, createEventBuilder, {
     location,
     text,
     url_domain: getExternalLinkHostname(url),

--- a/app/util/analytics/externalLinkTracking.ts
+++ b/app/util/analytics/externalLinkTracking.ts
@@ -6,13 +6,42 @@ import { IMetaMetricsEvent, JsonMap } from './analytics.types';
  *
  * @property location - Screen or context in snake_case
  * @property text - Visible link or button label
- * @property url_domain - Full external URL
+ * @property url_domain - Full external URL (non–block-explorer links)
  */
 export interface ExternalLinkClickedProperties extends JsonMap {
   location: string;
   text: string;
   url_domain: string;
 }
+
+/**
+ * Input for block explorer External Link Clicked tracking.
+ * `url_domain` is sent as the URL hostname only.
+ *
+ * @property location - Screen or context in snake_case
+ * @property text - Visible link or button label
+ * @property url - Full block explorer URL used to derive hostname
+ */
+export interface BlockExplorerLinkClickedProperties extends JsonMap {
+  location: string;
+  text: string;
+  url: string;
+}
+
+/**
+ * Extract hostname from an external URL for block explorer analytics.
+ *
+ * @param url - Full URL string
+ * @returns URL hostname, or the original string if parsing fails
+ */
+export const getExternalLinkHostname = (url: string): string => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    const match = url.match(/^https?:\/\/([^/?#]+)/i);
+    return match?.[1] ?? url;
+  }
+};
 
 /**
  * Track External Link Clicked with the mobile analytics schema.
@@ -38,4 +67,29 @@ export const trackExternalLinkClicked = <TEvent>(
       .addProperties(properties)
       .build(),
   );
+};
+
+/**
+ * Track External Link Clicked for block explorer taps.
+ * Sends `url_domain` as the URL hostname (not the full path).
+ *
+ * @param trackEvent - trackEvent function (MetaMetrics or useAnalytics)
+ * @param createEventBuilder - createEventBuilder function (MetricsEventBuilder or AnalyticsEventBuilder)
+ * @param properties - Block explorer link properties
+ */
+export const trackBlockExplorerLinkClicked = <TEvent>(
+  trackEvent: (event: TEvent) => void,
+  createEventBuilder: (event: IMetaMetricsEvent) => {
+    addProperties: (properties: ExternalLinkClickedProperties) => {
+      build: () => TEvent;
+    };
+  },
+  properties: BlockExplorerLinkClickedProperties,
+): void => {
+  const { location, text, url } = properties;
+  trackExternalLinkClicked(trackEvent, createEventBuilder, {
+    location,
+    text,
+    url_domain: getExternalLinkHostname(url),
+  });
 };

--- a/app/util/test/analyticsMock.ts
+++ b/app/util/test/analyticsMock.ts
@@ -5,7 +5,6 @@
  */
 
 import type { UseAnalyticsHook } from '../../components/hooks/useAnalytics/useAnalytics.types';
-import { useAnalytics } from '../../components/hooks/useAnalytics/useAnalytics';
 import {
   AnalyticsEventBuilder,
   type AnalyticsTrackingEvent,
@@ -135,7 +134,13 @@ export const createMockUseAnalyticsHook = (
 export const configureUseAnalyticsExternalLinkMock = (
   trackEventMock: jest.Mock = jest.fn(),
 ): jest.Mock => {
-  jest.mocked(useAnalytics).mockReturnValue(
+  const { useAnalytics } = jest.requireMock(
+    '../../components/hooks/useAnalytics/useAnalytics',
+  ) as {
+    useAnalytics: jest.Mock<UseAnalyticsHook, []>;
+  };
+
+  useAnalytics.mockReturnValue(
     createMockUseAnalyticsHook({
       trackEvent: trackEventMock,
       createEventBuilder: AnalyticsEventBuilder.createEventBuilder,

--- a/app/util/test/analyticsMock.ts
+++ b/app/util/test/analyticsMock.ts
@@ -5,7 +5,11 @@
  */
 
 import type { UseAnalyticsHook } from '../../components/hooks/useAnalytics/useAnalytics.types';
-import type { AnalyticsTrackingEvent } from '../analytics/AnalyticsEventBuilder';
+import { useAnalytics } from '../../components/hooks/useAnalytics/useAnalytics';
+import {
+  AnalyticsEventBuilder,
+  type AnalyticsTrackingEvent,
+} from '../analytics/AnalyticsEventBuilder';
 
 export interface MockAnalytics {
   isEnabled: jest.Mock<boolean, []>;
@@ -124,6 +128,22 @@ export const createMockUseAnalyticsHook = (
  *   createMockUseAnalyticsHook({ createEventBuilder: mockCreateEventBuilder }),
  * );
  */
+/**
+ * Configures a mocked `useAnalytics` hook for external link tracking tests.
+ * Call from `beforeEach` after `jest.mock('.../useAnalytics')`.
+ */
+export const configureUseAnalyticsExternalLinkMock = (
+  trackEventMock: jest.Mock = jest.fn(),
+): jest.Mock => {
+  jest.mocked(useAnalytics).mockReturnValue(
+    createMockUseAnalyticsHook({
+      trackEvent: trackEventMock,
+      createEventBuilder: AnalyticsEventBuilder.createEventBuilder,
+    }),
+  );
+  return trackEventMock;
+};
+
 export const createMockEventBuilder = (
   buildReturnValue?: AnalyticsTrackingEvent,
 ) => ({


### PR DESCRIPTION
## **Description**

### Summary

This PR implements [TMCU-300](https://consensyssoftware.atlassian.net/browse/TMCU-300): add consistent **`External Link Clicked`** analytics whenever a user opens a block explorer (or other external link tracked under this event) from MetaMask Mobile.

The work is delivered across these commits on this branch:

1. **Inline tracking** — add `EXTERNAL_LINK_CLICKED` at every block explorer entry point while **preserving existing legacy events** additively (e.g. `NAVIGATION_TAPS_VIEW_ETHERSCAN`, `TOKEN_DETAILS_ACTION_CLICKED`, `NOTIFICATION_DETAIL_CLICKED`, `ONRAMP_EXTERNAL_LINK_CLICKED`).
2. **Shared utility** — extract `trackExternalLinkClicked` in `app/util/analytics/externalLinkTracking.ts` and refactor block explorer call sites to use it.
3. **Full coverage** — extend the utility to the remaining non–block-explorer `External Link Clicked` call sites (Choose Password, phishing banner, deprecated network modal, Security Settings).
4. **Safety fixes** — guard optional URLs before tracking; skip empty explorer URLs in activity views; fix hardware wallet link `text` label.
5. **Test fixes** — add `useAnalytics` mocks in summary-line, activity view, and perps tests updated for external link tracking.
6. **Hostname schema** — block explorer taps send the URL **hostname** in `url_domain` (e.g. `etherscan.io`), not the full path, via `trackBlockExplorerLinkClicked`.

### Motivation

Product analytics needs a single, queryable event when users leave the app via external links—especially block explorers—so we can measure engagement by screen, label, and destination. Mobile already defines this event in `MetaMetrics.events.ts`; this PR wires it up comprehensively across the app using the **existing mobile schema** (not the extension schema).

For block explorers specifically, sending only the hostname avoids leaking transaction hashes, addresses, or other path segments in analytics while still identifying which explorer was used.

### Event schema

Every `External Link Clicked` fire uses these properties:

| Property | Description |
|----------|-------------|
| `location` | Screen/context in snake_case (e.g. `account_actions`, `activity_tab`, `token_details_menu`) |
| `text` | Visible button or link label shown to the user |
| `url_domain` | Destination identifier — see below |

**`url_domain` by link type:**

| Link type | `url_domain` value | Example |
|-----------|-------------------|---------|
| Block explorer | URL **hostname only** | `etherscan.io` |
| Other external links | **Full URL** | `https://support.metamask.io/...` |

### Shared utility

`app/util/analytics/externalLinkTracking.ts` exports:

- `ExternalLinkClickedProperties` — typed `{ location, text, url_domain }`
- `BlockExplorerLinkClickedProperties` — typed `{ location, text, url }` (full URL input; hostname derived internally)
- `getExternalLinkHostname(url)` — extracts hostname via `URL` API with regex fallback
- `trackExternalLinkClicked(trackEvent, createEventBuilder, properties)` — generic helper for non–block-explorer links
- `trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, properties)` — block explorer helper; sends `url_domain` as hostname

Both helpers are generic and compatible with `useAnalytics` and direct `analytics.trackEvent` / `AnalyticsEventBuilder` usage (same pattern as `actionButtonTracking.ts`).

**Block explorer taps (functional components):**
```ts
trackBlockExplorerLinkClicked(trackEvent, createEventBuilder, { location, text, url });
```

**Other external links:**
```ts
trackExternalLinkClicked(trackEvent, createEventBuilder, { location, text, url_domain });
```

**Class components / direct analytics:**
```ts
trackBlockExplorerLinkClicked(analytics.trackEvent, AnalyticsEventBuilder.createEventBuilder, { ... });
```

**Onboarding flow (Choose Password):** uses `MetricsEventBuilder` + `trackOnboarding` callback so delayed analytics during onboarding still work.

### Block explorer call sites (27 files)

| Area | Files | `location` value(s) |
|------|-------|---------------------|
| Accounts / QR | `ShareAddressQR`, `ShareAddress`, `AccountActions`, `AccountSelector`, `KeyringAccountListItem` | `share_address_qr`, `share_address`, `account_actions`, `hardware_wallet_account`, `snap_keyring_account` |
| Activity / transactions | `transaction-summary-line`, `MultichainTransactionDetailsSheet`, `UnifiedTransactionsView`, `MultichainTransactionsView`, `TransactionDetails/index.js`, `Transactions/index.js` | `transaction_details_summary`, `transaction_details_modal`, `activity_tab`, `multichain_activity_tab`, `transaction_details`, `transactions_list` |
| Tokens / NFTs | `MoreTokenActionsMenu`, `SecurityTrustScreen`, `NftDetails`, `CollectibleOverview` | `token_details_menu`, `security_trust_page`, `nft_details`, `collectible_overview` |
| Bridge / Perps / Money / Notifications / Ramp | `TransactionDetails`, `BlockExplorersModal`, 3 Perps views, `MoneySentDetails`, `BlockExplorerFooter`, `OrderDetails` | `bridge_transaction_details`, `perps_transaction_details`, `money_transaction_details`, `notification_detail`, `ramp_order_details` |

### Other External Link Clicked call sites (4 files)

| File | Context | `location` |
|------|---------|------------|
| `ChoosePassword/index.tsx` | Reset password guide link | `choose_password` |
| `showWarningBanner.tsx` | Phishing / deceptive site learn more | `dapp_connection_request` |
| `DeprecatedNetworkModal.tsx` | Deprecated network learn more | `dapp_connection_request` |
| `SecuritySettings.tsx` | Simulation details article | `app_settings` |

### Legacy events preserved

This PR does **not** remove or replace domain-specific events. Where they already existed, both events fire:

- `AccountActions` — still fires `NAVIGATION_TAPS_VIEW_ETHERSCAN`
- `MoreTokenActionsMenu` — still fires `TOKEN_DETAILS_ACTION_CLICKED`
- `BlockExplorerFooter` — still fires `NOTIFICATION_DETAIL_CLICKED`
- `OrderDetails` — still fires `ONRAMP_EXTERNAL_LINK_CLICKED` for ramp-specific tracking (with full URL in `url_domain` per ramp schema)

### Out of scope

The following are **different events** and were intentionally **not** migrated to `trackExternalLinkClicked`:

- `ONRAMP_EXTERNAL_LINK_CLICKED` (Ramp Aggregator quotes, provider links, etc.)
- `RAMPS_EXTERNAL_LINK_CLICKED` (unified Ramp native flow)

### Bug fixes included

- `ChoosePassword` previously sent property `url` instead of `url_domain`. Migration to the shared utility aligns it with the standard schema.
- `UnifiedTransactionsView` / `MultichainTransactionsView` — skip tracking when explorer URL is empty.
- `HardwareWallet/AccountSelector` — use correct visible link label for `text`.

### Tests added/updated

- **New:** `app/util/analytics/externalLinkTracking.test.ts` (includes `getExternalLinkHostname` and `trackBlockExplorerLinkClicked`)
- **Updated:** `ShareAddressQR.test.tsx`, `BlockExplorerFooter.test.tsx`, `transaction-summary-line.test.tsx`, `TransactionDetails/index.test.tsx` (assert hostname in `url_domain` for block explorer taps)
- **Mocks added:** `useAnalytics` in summary-line sibling tests, `UnifiedTransactionsView.test.tsx`, `MultichainTransactionsView.test.tsx`, `PerpsFundingTransactionView.test.tsx`

All targeted unit tests pass locally.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-300

## **Manual testing steps**

```gherkin
Feature: External Link Clicked analytics on block explorer taps

  Scenario: View account on block explorer from Account Actions
    Given I have an EVM account with a configured block explorer
    When I open Account Actions and tap "View in Etherscan" (or equivalent)
    Then the block explorer URL opens
    And an "External Link Clicked" event is tracked with location "account_actions"
    And url_domain is the explorer hostname (e.g. "etherscan.io"), not the full URL

  Scenario: View transaction on block explorer from Activity
    Given I have at least one confirmed transaction in Activity
    When I open transaction details and tap "View on block explorer"
    Then the explorer opens for that transaction hash
    And an "External Link Clicked" event is tracked with location "transaction_details" or "activity_tab"
    And url_domain is the explorer hostname only

  Scenario: View token contract on block explorer from Token Details menu
    Given I am on Token Details for an EVM token
    When I open the actions menu and tap "View on block explorer"
    Then the contract address opens in the block explorer
    And an "External Link Clicked" event is tracked with location "token_details_menu"
    And url_domain is the explorer hostname only

  Scenario: Learn more link on Security Settings
    Given I am on Settings > Security & Privacy
    When I tap the simulation details "Learn more" link
    Then the support article opens in the browser
    And an "External Link Clicked" event is tracked with location "app_settings"
    And url_domain is the full support article URL
```

Analytics verification can be done via Segment debugger / analytics dev tools when enabled, confirming event name `External Link Clicked` and properties `location`, `text`, `url_domain` (hostname for block explorers; full URL for other external links).

## **Screenshots/Recordings**

N/A — analytics-only change with no UI modifications.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-300]: https://consensyssoftware.atlassian.net/browse/TMCU-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation with no auth or transaction logic changes; block explorer events intentionally omit path segments from `url_domain`.
> 
> **Overview**
> Introduces **`app/util/analytics/externalLinkTracking.ts`** with `trackExternalLinkClicked`, `trackBlockExplorerLinkClicked`, and `getExternalLinkHostname`, then refactors dozens of call sites to fire **`External Link Clicked`** with consistent `location`, `text`, and `url_domain` properties.
> 
> **Block explorer** taps now go through the shared helper so **`url_domain` is the explorer hostname** (e.g. `etherscan.io`), not the full URL. **Other external links** (phishing learn more, deprecated network modal, Security Settings article, Choose Password guide) use `trackExternalLinkClicked` with the full URL in `url_domain`; Choose Password is corrected from `url` to `url_domain`.
> 
> Coverage spans accounts/QR, activity and transaction UIs, tokens/NFTs, bridge/perps/money/ramp/notifications, and related flows. **Existing domain-specific analytics** (e.g. `NAVIGATION_TAPS_VIEW_ETHERSCAN`, ramp on-ramp events) are left in place where they already existed. **Empty explorer URLs** are guarded before tracking in activity views and several handlers.
> 
> Unit tests are added/updated for the utility and key screens, plus **`configureUseAnalyticsExternalLinkMock`** for confirmation summary-line and activity tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c312e8de08674c3c66653e690a889844e8517c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->