### PR TITLE
test: add Playwright performance debug logging

### DIFF
--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -69,6 +69,7 @@ const newOverrides = [
       'app/components/UI/Predict/providers/polymarket/protocol/definitions.test.ts',
       'app/store/migrations/**',
       'app/util/networks/customNetworks.tsx',
+      'tests/framework/playwrightLogger.ts',
       'tests/framework/services/providers/emulator/reinstallLocalBuildFromPath.ts',
       '.yarn/plugins/plugin-usage-tracking.cjs',
       '.yarn/plugins/plugin-usage-tracking.test.ts',

--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -7,6 +7,9 @@ import {
   addOverhead,
   isOverheadTrackingActive,
 } from './PlaywrightUtilities.ts';
+import { createPlaywrightLogger } from './playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('PlaywrightAssertions');
 
 export interface VisibilityWithSettleOptions extends AssertionOptions {
   settleMs?: number;
@@ -117,6 +120,7 @@ export default class PlaywrightAssertions {
     if (isOverheadTrackingActive()) {
       addOverhead(Date.now() - t0);
     }
+    logger.debug('Waiting for element to be visible');
     await this.pollUntilVisible(el, this.getTimeout(options));
   }
 
@@ -268,9 +272,7 @@ export default class PlaywrightAssertions {
         return;
       } catch (error) {
         lastError = error;
-        console.log(
-          `PlaywrightAssertions: condition not met on attempt ${i + 1}`,
-        );
+        logger.debug(`Condition not met on attempt ${i + 1}/${maxRetries}`);
         await new Promise((resolve) => setTimeout(resolve, interval));
       }
     }

--- a/tests/framework/PlaywrightContextHelpers.ts
+++ b/tests/framework/PlaywrightContextHelpers.ts
@@ -6,6 +6,9 @@ import type {
 import { APP_PACKAGE_IDS } from './Constants';
 import { PlatformDetector } from './PlatformLocator';
 import { getDriver } from './PlaywrightUtilities';
+import { createPlaywrightLogger } from './playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('PlaywrightContextHelpers');
 
 type DetailedContext = IosDetailedContext | AndroidDetailedContext;
 
@@ -17,10 +20,12 @@ export default class PlaywrightContextHelpers {
   private static readonly POLL_INTERVAL_MS = 1_000;
 
   static async switchToNativeContext(): Promise<void> {
+    logger.debug('Switching to native app context');
     await getDriver().switchContext(NATIVE_APP);
   }
 
   static async switchToWebViewContext(dappUrl: string): Promise<void> {
+    logger.debug(`Switching to webview context for URL: ${dappUrl}`);
     // Strategy B: Try WebdriverIO's built-in URL matching first.
     // Falls back to manual polling on any failure (LavaMoat scuttling,
     // stale URL metadata on BrowserStack, platform quirks, etc.).
@@ -29,9 +34,10 @@ export default class PlaywrightContextHelpers {
         url: new RegExp(dappUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
         androidWebviewConnectTimeout: this.WEBVIEW_TIMEOUT_MS,
       });
+      logger.debug(`Switched to webview context for URL: ${dappUrl}`);
       return;
     } catch (err) {
-      console.log(
+      logger.debug(
         'WebdriverIO switchContext failed, falling back to manual polling:',
         this.getErrorMessage(err).slice(0, 300),
       );
@@ -52,7 +58,10 @@ export default class PlaywrightContextHelpers {
 
       if (selected?.id) {
         const switched = await this.attemptContextSwitch(selected.id);
-        if (switched) return;
+        if (switched) {
+          logger.debug(`Switched to webview context: ${selected.id}`);
+          return;
+        }
       }
 
       await sleep(this.POLL_INTERVAL_MS);
@@ -111,11 +120,11 @@ export default class PlaywrightContextHelpers {
       const message = this.getErrorMessage(err);
 
       if (LAVAMOAT_PATTERN.test(message)) {
-        console.log('Encountered LavaMoat scuttling, retrying...');
+        logger.debug('Encountered LavaMoat scuttling, retrying context switch');
         return false;
       }
 
-      console.log('Error switching to webview context:', message);
+      logger.debug('Error switching to webview context:', message);
       return false;
     }
   }

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -3,7 +3,10 @@ import { CurrentDeviceDetails } from './fixtures/playwright';
 import { PlatformDetector } from './PlatformLocator';
 import { PlaywrightElement } from './PlaywrightAdapter';
 import { boxedStep, getDriver } from './PlaywrightUtilities';
-import { createPlaywrightLogger, describeElement } from './playwrightLogger.ts';
+import {
+  createPlaywrightLogger,
+  debugElementAction,
+} from './playwrightLogger.ts';
 
 const logger = createPlaywrightLogger('PlaywrightGestures');
 
@@ -37,7 +40,7 @@ export default class PlaywrightGestures {
    */
   @boxedStep
   static async tap(elem: PlaywrightElement): Promise<void> {
-    logger.debug(`Tapping element${await describeElement(elem)}`);
+    await debugElementAction(logger, 'Tapping element', elem);
     await elem.unwrap().click();
   }
 
@@ -196,7 +199,7 @@ export default class PlaywrightGestures {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
-    logger.debug(`Wait and tap element${await describeElement(elem)}`);
+    await debugElementAction(logger, 'Wait and tap element', elem);
     await elem.unwrap().click();
   }
 
@@ -208,7 +211,7 @@ export default class PlaywrightGestures {
    */
   @boxedStep
   static async typeText(elem: PlaywrightElement, text: string): Promise<void> {
-    logger.debug(`Typing into element${await describeElement(elem)}`);
+    await debugElementAction(logger, 'Typing into element', elem);
     await elem.unwrap().addValue(text);
   }
 
@@ -267,7 +270,7 @@ export default class PlaywrightGestures {
     const x = location.x + size.width / 2;
     const y = location.y + size.height / 2;
 
-    logger.debug(`Long pressing element${await describeElement(elem)}`);
+    await debugElementAction(logger, 'Long pressing element', elem);
     await elem
       .unwrap()
       .touchAction([
@@ -288,7 +291,7 @@ export default class PlaywrightGestures {
   static async dblTap(elem: PlaywrightElement, intervalMs = 60): Promise<void> {
     const wrapped = elem.unwrap();
 
-    logger.debug(`Double tapping element${await describeElement(elem)}`);
+    await debugElementAction(logger, 'Double tapping element', elem);
     await wrapped.click();
 
     if (intervalMs > 0) {
@@ -314,7 +317,7 @@ export default class PlaywrightGestures {
       scrollableElement,
       duration,
     } = options || {};
-    logger.debug(`Scrolling element into view${await describeElement(elem)}`);
+    await debugElementAction(logger, 'Scrolling element into view', elem);
     await elem.unwrap().scrollIntoView({
       direction: scrollParams.direction,
       from,
@@ -351,8 +354,10 @@ export default class PlaywrightGestures {
     const safeBottom = windowSize.height * 0.85;
 
     if (elementBottom > safeBottom) {
-      logger.debug(
-        `Adjusting scroll to clear bottom nav for element${await describeElement(elem)}`,
+      await debugElementAction(
+        logger,
+        'Adjusting scroll to clear bottom nav for element',
+        elem,
       );
       const overshoot = Math.ceil(elementBottom - safeBottom) + 20;
       const midX = Math.floor(windowSize.width / 2);

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -3,6 +3,9 @@ import { CurrentDeviceDetails } from './fixtures/playwright';
 import { PlatformDetector } from './PlatformLocator';
 import { PlaywrightElement } from './PlaywrightAdapter';
 import { boxedStep, getDriver } from './PlaywrightUtilities';
+import { createPlaywrightLogger, describeElement } from './playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('PlaywrightGestures');
 
 export interface ScrollOptions {
   scrollParams?: { direction?: 'up' | 'down' };
@@ -17,8 +20,7 @@ export interface ScrollOptions {
  * PlaywrightGestures - Gesture helpers for WebdriverIO/Playwright
  *
  * This class provides gesture methods that wrap PlaywrightElement API.
- * Currently these are simple wrappers, but can be enhanced with retries,
- * stability checks, and logging in the future (similar to Detox Gestures).
+ * Currently these are simple wrappers with debug logging (similar to Detox Gestures).
  *
  * @example
  * const elem = await PlaywrightMatchers.getByXPath('...');
@@ -35,6 +37,7 @@ export default class PlaywrightGestures {
    */
   @boxedStep
   static async tap(elem: PlaywrightElement): Promise<void> {
+    logger.debug(`Tapping element${await describeElement(elem)}`);
     await elem.unwrap().click();
   }
 
@@ -193,6 +196,7 @@ export default class PlaywrightGestures {
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
+    logger.debug(`Wait and tap element${await describeElement(elem)}`);
     await elem.unwrap().click();
   }
 
@@ -204,6 +208,7 @@ export default class PlaywrightGestures {
    */
   @boxedStep
   static async typeText(elem: PlaywrightElement, text: string): Promise<void> {
+    logger.debug(`Typing into element${await describeElement(elem)}`);
     await elem.unwrap().addValue(text);
   }
 
@@ -238,6 +243,7 @@ export default class PlaywrightGestures {
       from,
       to,
     } = options || {};
+    logger.debug(`Swiping ${scrollParams.direction ?? 'up'}`);
     await drv.swipe({
       direction: scrollParams.direction,
       duration,
@@ -261,6 +267,7 @@ export default class PlaywrightGestures {
     const x = location.x + size.width / 2;
     const y = location.y + size.height / 2;
 
+    logger.debug(`Long pressing element${await describeElement(elem)}`);
     await elem
       .unwrap()
       .touchAction([
@@ -281,6 +288,7 @@ export default class PlaywrightGestures {
   static async dblTap(elem: PlaywrightElement, intervalMs = 60): Promise<void> {
     const wrapped = elem.unwrap();
 
+    logger.debug(`Double tapping element${await describeElement(elem)}`);
     await wrapped.click();
 
     if (intervalMs > 0) {
@@ -306,6 +314,7 @@ export default class PlaywrightGestures {
       scrollableElement,
       duration,
     } = options || {};
+    logger.debug(`Scrolling element into view${await describeElement(elem)}`);
     await elem.unwrap().scrollIntoView({
       direction: scrollParams.direction,
       from,
@@ -342,6 +351,9 @@ export default class PlaywrightGestures {
     const safeBottom = windowSize.height * 0.85;
 
     if (elementBottom > safeBottom) {
+      logger.debug(
+        `Adjusting scroll to clear bottom nav for element${await describeElement(elem)}`,
+      );
       const overshoot = Math.ceil(elementBottom - safeBottom) + 20;
       const midX = Math.floor(windowSize.width / 2);
       const startY = Math.floor(windowSize.height * 0.6);
@@ -392,13 +404,14 @@ export default class PlaywrightGestures {
       throw new Error('Package name or app id is not available');
     }
 
+    logger.debug(`Terminating app: ${bundleId}`);
     while (retries > 0) {
       try {
         await drv.terminateApp(bundleId);
         await new Promise((resolve) => setTimeout(resolve, retryDelay));
         return;
       } catch (error) {
-        console.log('Error terminating app', bundleId);
+        logger.warn(`Error terminating app ${bundleId}:`, error);
         retries--;
       }
     }
@@ -421,6 +434,7 @@ export default class PlaywrightGestures {
     if (!drv) throw new Error('Driver is not available');
 
     if (packageId) {
+      logger.debug(`Activating app: ${packageId}`);
       await drv.activateApp(packageId);
       return;
     }
@@ -429,6 +443,7 @@ export default class PlaywrightGestures {
       currentDeviceDetails?.platform === 'android' &&
       currentDeviceDetails.packageName
     ) {
+      logger.debug(`Activating app: ${currentDeviceDetails.packageName}`);
       await drv.activateApp(currentDeviceDetails.packageName);
       return;
     }
@@ -437,6 +452,7 @@ export default class PlaywrightGestures {
       currentDeviceDetails?.platform === 'ios' &&
       currentDeviceDetails.appId
     ) {
+      logger.debug(`Activating app: ${currentDeviceDetails.appId}`);
       await drv.activateApp(currentDeviceDetails.appId);
       return;
     }
@@ -453,6 +469,7 @@ export default class PlaywrightGestures {
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
 
+    logger.debug(`Backgrounding app for ${seconds}s`);
     await drv.execute('mobile: backgroundApp', { seconds });
   }
 
@@ -464,6 +481,7 @@ export default class PlaywrightGestures {
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
 
+    logger.debug('Hiding keyboard');
     if (PlatformDetector.isAndroid()) {
       await drv.hideKeyboard();
     } else {

--- a/tests/framework/PlaywrightMatchers.ts
+++ b/tests/framework/PlaywrightMatchers.ts
@@ -3,6 +3,9 @@ import { PlaywrightElement, wrapElement } from './PlaywrightAdapter';
 import { MatcherOptions } from './types';
 import { getDriver } from './PlaywrightUtilities';
 import { ChainablePromiseElement } from 'webdriverio';
+import { createPlaywrightLogger } from './playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('PlaywrightMatchers');
 
 /**
  * PlaywrightMatchers - Element selectors that return Playwright-like wrapped
@@ -23,6 +26,10 @@ import { ChainablePromiseElement } from 'webdriverio';
  * console.log(text);
  */
 export default class PlaywrightMatchers {
+  private static logFind(strategy: string, target: string): void {
+    logger.debug(`Finding element by ${strategy}: ${target}`);
+  }
+
   /**
    * Get element by accessibility ID (iOS) or content-desc/resource-id (Android)
    * This is the most common selector for mobile apps
@@ -33,6 +40,7 @@ export default class PlaywrightMatchers {
   static async getElementByAccessibilityId(
     elementId: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('accessibility id', elementId);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const element = await drv.$(`~${elementId}`);
@@ -52,6 +60,7 @@ export default class PlaywrightMatchers {
     options: MatcherOptions = {},
   ): Promise<PlaywrightElement> {
     const { exact = true } = options;
+    this.logFind('id', `${elementId}${exact ? '' : ' (partial)'}`);
 
     let locator: string;
     const isAndroid = await PlatformDetector.isAndroid();
@@ -81,6 +90,7 @@ export default class PlaywrightMatchers {
     text: string,
     exactMatch: boolean = false,
   ): Promise<PlaywrightElement> {
+    this.logFind('text', `${text}${exactMatch ? ' (exact)' : ''}`);
     let xpath = `//*[contains(@name,'${text}') or contains(@label,'${text}') or contains(@text,'${text}')]`;
     if (exactMatch) {
       xpath = `//*[@name='${text}' or @label='${text}' or @text='${text}']`;
@@ -96,6 +106,7 @@ export default class PlaywrightMatchers {
   static async getElementByCatchAll(
     identifier: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('catch-all', identifier);
     const isAndroid = await PlatformDetector.isAndroid();
     let xpath = '';
     if (isAndroid) {
@@ -114,6 +125,7 @@ export default class PlaywrightMatchers {
   static async getAllElementsByText(
     text: string,
   ): Promise<PlaywrightElement[]> {
+    this.logFind('all elements by text', text);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const elements = await drv.$$(`*.=${text}`);
@@ -132,6 +144,7 @@ export default class PlaywrightMatchers {
     options: MatcherOptions = {},
   ): Promise<PlaywrightElement> {
     const { lastElement = true } = options;
+    this.logFind('xpath', `${xpath}${lastElement ? ' (last)' : ' (first)'}`);
 
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
@@ -155,6 +168,7 @@ export default class PlaywrightMatchers {
   static async getLazyElementByXPath(
     xpath: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('lazy xpath', xpath);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const element = await drv.$(xpath);
@@ -169,6 +183,7 @@ export default class PlaywrightMatchers {
   static async getElementByClassName(
     className: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('class name', className);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const element = await drv.$(`.${className}`);
@@ -183,6 +198,7 @@ export default class PlaywrightMatchers {
   static async getAllElementsByClassName(
     className: string,
   ): Promise<PlaywrightElement[]> {
+    this.logFind('all elements by class name', className);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const elements = await drv.$$(`.${className}`);
@@ -202,6 +218,7 @@ export default class PlaywrightMatchers {
   static async getElementByAndroidUIAutomator(
     selector: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('android uiautomator', selector);
     const baseUiAutomatorSelector = 'android=new UiSelector()';
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
@@ -219,6 +236,7 @@ export default class PlaywrightMatchers {
   static async getElementByIOSPredicate(
     predicate: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('ios predicate', predicate);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const element = await drv.$(`-ios predicate string:${predicate}`);
@@ -235,6 +253,7 @@ export default class PlaywrightMatchers {
     name: string,
     lazy = false,
   ): Promise<PlaywrightElement> {
+    this.logFind('ios name', `${name}${lazy ? ' (lazy)' : ''}`);
     const isIOS = await PlatformDetector.isIOS();
     if (!isIOS) throw new Error('This function is only valid for iOS');
     const xpath = `//*[contains(@name,'${name}')]`;
@@ -253,6 +272,7 @@ export default class PlaywrightMatchers {
   static async getElementByIOSClassChain(
     chain: string,
   ): Promise<PlaywrightElement> {
+    this.logFind('ios class chain', chain);
     const drv = getDriver();
     if (!drv) throw new Error('Driver is not available');
     const element = await drv.$(`-ios class chain:${chain}`);

--- a/tests/framework/PlaywrightUtilities.ts
+++ b/tests/framework/PlaywrightUtilities.ts
@@ -17,6 +17,9 @@ import { ACCOUNT_ACTIVITY_WS } from '../websocket/constants.ts';
 // eslint-disable-next-line import-x/no-nodejs-modules
 import { execSync } from 'child_process';
 import type { CurrentDeviceDetails } from './fixtures/playwright';
+import { createPlaywrightLogger } from './playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('PlaywrightUtilities');
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, import-x/no-commonjs, @typescript-eslint/no-require-imports
 const deviceMatrix: DeviceMatrix = require('../performance/device-matrix.json');
@@ -169,10 +172,7 @@ export function boxedStep<This, Args extends unknown[], Return>(
             });
           } catch (screenshotError) {
             // Don't fail if screenshot fails
-            console.warn(
-              'Failed to capture error screenshot:',
-              screenshotError,
-            );
+            logger.warn('Failed to capture error screenshot:', screenshotError);
           }
           throw error;
         }
@@ -204,7 +204,7 @@ let _tracking = false;
 
 export function startOverheadTracking(): void {
   if (_tracking) {
-    console.warn(
+    logger.warn(
       'TimerHelper: startOverheadTracking() called while already active — nested measure() calls are not supported; inner call ignored',
     );
     return;
@@ -296,7 +296,7 @@ class PlaywrightUtilities {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.warn(
+      logger.warn(
         `Could not set Chrome as debug app (FRE may show): ${message}`,
       );
     }
@@ -308,7 +308,7 @@ class PlaywrightUtilities {
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.warn(
+      logger.warn(
         `Could not write Chrome command-line (FRE may show): ${message}`,
       );
     }
@@ -319,7 +319,7 @@ class PlaywrightUtilities {
       execSync(`adb shell pm clear ${CHROME_PACKAGE}`, { stdio: 'pipe' });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.warn(
+      logger.warn(
         `Could not clear Chrome data (Chrome may open with existing tabs): ${message}`,
       );
     }
@@ -435,6 +435,7 @@ class PlaywrightUtilities {
     const stop = launchArgs?.stop ?? true;
     const wait = launchArgs?.wait ?? true;
 
+    logger.debug(`Launching Android app ${pkg}/${activity}`);
     await drv.execute('mobile: startActivity', {
       component: `${pkg}/${activity}`,
       action: 'android.intent.action.MAIN',
@@ -471,6 +472,7 @@ class PlaywrightUtilities {
       launchArgs,
     });
 
+    logger.debug(`Launching iOS app ${bundleId}`);
     await drv.terminateApp(bundleId);
 
     await drv.execute('mobile: launchApp', {

--- a/tests/framework/fixtures/playwright/README.md
+++ b/tests/framework/fixtures/playwright/README.md
@@ -28,3 +28,19 @@ import type { CurrentDeviceDetails } from '../../framework/fixtures/playwright';
 3. Spread it into `base.extend` in `index.ts`.
 
 Provider implementations belong in `tests/framework/services/providers/`.
+
+## Debugging logs
+
+Playwright framework code uses `createPlaywrightLogger()` from `tests/framework/playwrightLogger.ts`. Log level defaults to **INFO**; set `E2E_LOG_LEVEL=debug` for verbose traces (element finds, taps, context switches).
+
+| Module                     | INFO (default)                 | DEBUG (`E2E_LOG_LEVEL=debug`)    |
+| -------------------------- | ------------------------------ | -------------------------------- |
+| `currentDeviceDetails`     | Resolved device summary        | ADB serial resolution            |
+| `deviceProvider`           | Provider create/teardown       | —                                |
+| `driver`                   | Session start/teardown         | —                                |
+| `performanceTracker`       | Metrics, quality gates, Sentry | Timer counts, session ID lookup  |
+| `PlaywrightMatchers`       | —                              | Element lookup strategy + target |
+| `PlaywrightGestures`       | —                              | Tap, type, swipe, app lifecycle  |
+| `PlaywrightContextHelpers` | —                              | Native/webview context switches  |
+
+For WebDriver HTTP command detail, set `WDIO_LOG_LEVEL=debug` when running tests.

--- a/tests/framework/fixtures/playwright/currentDeviceDetails.fixture.ts
+++ b/tests/framework/fixtures/playwright/currentDeviceDetails.fixture.ts
@@ -7,7 +7,10 @@ import {
   type EmulatorConfig,
 } from '../../types.ts';
 import { applyResolvedAndroidAdbToDevice } from '../../services/providers/emulator/android/resolveAndroidAdbUdid.ts';
+import { createPlaywrightLogger } from '../../playwrightLogger.ts';
 import type { CurrentDeviceDetails } from './types.ts';
+
+const logger = createPlaywrightLogger('currentDeviceDetails');
 
 export const currentDeviceDetailsFixture = {
   currentDeviceDetails: async (
@@ -16,6 +19,11 @@ export const currentDeviceDetailsFixture = {
     testInfo: TestInfo,
   ) => {
     const project = testInfo.project as FullProject<WebDriverConfig>;
+
+    logger.info(
+      `Resolving device details for project "${project.name}" (${testInfo.title})`,
+    );
+
     const platform = project.use.platform;
     const emulatorDevice = project.use.device as EmulatorConfig | undefined;
     const deviceNameField = emulatorDevice?.name;
@@ -48,12 +56,21 @@ export const currentDeviceDetailsFixture = {
       emulatorDevice?.provider === ProviderName.SIMULATOR;
 
     if (platform === Platform.ANDROID && isLocalEmulator && emulatorDevice) {
+      logger.debug(
+        `Resolving Android ADB serial for "${deviceNameField ?? deviceUdid}"`,
+      );
       await applyResolvedAndroidAdbToDevice(emulatorDevice, {
         setAndroidSerialEnv: true,
       });
+      logger.debug(
+        `Android ADB serial resolved: ${emulatorDevice.udid ?? 'unknown'}`,
+      );
     }
 
     const displayName = deviceNameField ?? deviceUdid ?? 'unknown';
+    const providerLabel = isBrowserstack
+      ? 'browserstack'
+      : (deviceConfig?.provider ?? 'unknown');
     const deviceDetails: CurrentDeviceDetails = {
       platform: platform as 'android' | 'ios',
       deviceName: displayName,
@@ -63,6 +80,14 @@ export const currentDeviceDetailsFixture = {
       launchableActivity,
       isBrowserstack,
     };
+
+    logger.info(
+      `Device details ready: platform=${platform}, device=${displayName}` +
+        (deviceDetails.udid ? `, udid=${deviceDetails.udid}` : '') +
+        `, provider=${providerLabel}` +
+        (packageName ? `, package=${packageName}` : '') +
+        (appId ? `, appId=${appId}` : ''),
+    );
 
     await use(deviceDetails);
   },

--- a/tests/framework/fixtures/playwright/currentDeviceDetails.fixture.ts
+++ b/tests/framework/fixtures/playwright/currentDeviceDetails.fixture.ts
@@ -1,10 +1,10 @@
 import type { FullProject, TestInfo } from '@playwright/test';
 import {
-  WebDriverConfig,
   Platform,
   ProviderName,
   type DeviceConfig,
   type EmulatorConfig,
+  type WebDriverConfig,
 } from '../../types.ts';
 import { applyResolvedAndroidAdbToDevice } from '../../services/providers/emulator/android/resolveAndroidAdbUdid.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';

--- a/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
+++ b/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
@@ -1,6 +1,6 @@
 import type { FullProject, TestInfo } from '@playwright/test';
 import { createServiceProvider, type ServiceProvider } from '../../services';
-import { WebDriverConfig } from '../../types.ts';
+import type { WebDriverConfig } from '../../types.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
 
 const logger = createPlaywrightLogger('deviceProvider');

--- a/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
+++ b/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
@@ -1,5 +1,9 @@
-import type { TestInfo } from '@playwright/test';
+import type { FullProject, TestInfo } from '@playwright/test';
 import { createServiceProvider, type ServiceProvider } from '../../services';
+import { WebDriverConfig } from '../../types.ts';
+import { createPlaywrightLogger } from '../../playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('deviceProvider');
 
 export const deviceProviderFixture = {
   deviceProvider: async (
@@ -7,7 +11,19 @@ export const deviceProviderFixture = {
     use: (deviceProvider: ServiceProvider) => Promise<void>,
     testInfo: TestInfo,
   ) => {
-    const deviceProvider = createServiceProvider(testInfo.project);
+    const project = testInfo.project as FullProject<WebDriverConfig>;
+    const providerName = project.use.device?.provider ?? 'unknown';
+
+    logger.info(
+      `Creating device provider "${providerName}" for project "${project.name}"`,
+    );
+
+    const deviceProvider = createServiceProvider(project);
+
     await use(deviceProvider);
+
+    logger.info(
+      `Device provider "${providerName}" teardown complete (sessionId=${deviceProvider.sessionId ?? 'none'})`,
+    );
   },
 };

--- a/tests/framework/fixtures/playwright/driver.fixture.ts
+++ b/tests/framework/fixtures/playwright/driver.fixture.ts
@@ -3,6 +3,9 @@ import { WebDriverConfig } from '../../types.ts';
 import { DEFAULT_IMPLICIT_WAIT_MS } from '../../Constants.ts';
 import { setDeviceInfo } from '../../DeviceInfoCache.ts';
 import type { TestLevelFixtures } from './types.ts';
+import { createPlaywrightLogger } from '../../playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('driver');
 
 export const driverFixture = {
   driver: async (
@@ -14,6 +17,10 @@ export const driverFixture = {
     const project = testInfo.project as FullProject<WebDriverConfig>;
 
     try {
+      logger.info(
+        `Starting WebDriver session for "${testInfo.title}" (project: ${project.name})`,
+      );
+
       driver = await deviceProvider.getDriver();
 
       // Wrapped in retry because BrowserStack sessions can transiently reject
@@ -27,8 +34,8 @@ export const driverFixture = {
         } catch (err) {
           if (attempt === maxRetries) throw err;
           const backoff = Math.min(2 ** attempt * 1000, 15000);
-          console.warn(
-            `driver.setTimeout failed (attempt ${attempt}/${maxRetries}), retrying in ${backoff}ms…`,
+          logger.warn(
+            `driver.setTimeout failed (attempt ${attempt}/${maxRetries}), retrying in ${backoff}ms`,
           );
           await new Promise((r) => setTimeout(r, backoff));
         }
@@ -47,6 +54,16 @@ export const driverFixture = {
 
       const deviceProviderName = project.use.device?.provider;
 
+      logger.info(
+        `WebDriver session ready: sessionId=${deviceProvider.sessionId ?? 'unknown'}, ` +
+          `platform=${platformName ?? 'unknown'}, ` +
+          `screen=${windowSize.width}x${windowSize.height}, ` +
+          `implicitWait=${implicitMs}ms, provider=${deviceProviderName ?? 'unknown'}` +
+          (deviceProvider.sessionCreationDurationMs !== undefined
+            ? `, sessionCreation=${deviceProvider.sessionCreationDurationMs}ms`
+            : ''),
+      );
+
       testInfo.annotations.push(
         {
           type: 'providerName',
@@ -61,13 +78,17 @@ export const driverFixture = {
       try {
         await deviceProvider.syncTestDetails?.({ name: testInfo.title });
       } catch (error) {
-        console.error('Failed to sync pre-test details:', error);
+        logger.error('Failed to sync pre-test details:', error);
       }
 
       await use(driver);
     } finally {
       const testStatus = testInfo.status;
       const testError = testInfo.error?.message;
+
+      logger.info(
+        `Tearing down WebDriver session for "${testInfo.title}" (status: ${testStatus ?? 'unknown'})`,
+      );
 
       try {
         await deviceProvider.syncTestDetails?.({
@@ -76,27 +97,28 @@ export const driverFixture = {
           reason: testError,
         });
       } catch (error) {
-        console.error('Failed to sync test details:', error);
+        logger.error('Failed to sync test details:', error);
       }
 
       try {
         if (driver) {
           await driver.deleteSession();
+          logger.info('WebDriver session deleted');
         }
       } catch (error) {
-        console.error('Failed to delete WebDriver session:', error);
+        logger.error('Failed to delete WebDriver session:', error);
       }
 
       try {
         delete globalThis.driver;
       } catch (error) {
-        console.error('Failed to clean up global driver:', error);
+        logger.error('Failed to clean up global driver:', error);
       }
 
       try {
         await deviceProvider.cleanup?.();
       } catch (error) {
-        console.error('Provider cleanup failed:', error);
+        logger.error('Provider cleanup failed:', error);
       }
     }
   },

--- a/tests/framework/fixtures/playwright/driver.fixture.ts
+++ b/tests/framework/fixtures/playwright/driver.fixture.ts
@@ -1,5 +1,5 @@
 import type { FullProject, TestInfo } from '@playwright/test';
-import { WebDriverConfig } from '../../types.ts';
+import type { WebDriverConfig } from '../../types.ts';
 import { DEFAULT_IMPLICIT_WAIT_MS } from '../../Constants.ts';
 import { setDeviceInfo } from '../../DeviceInfoCache.ts';
 import type { TestLevelFixtures } from './types.ts';

--- a/tests/framework/fixtures/playwright/performanceTracker.fixture.ts
+++ b/tests/framework/fixtures/playwright/performanceTracker.fixture.ts
@@ -90,10 +90,7 @@ export const performanceTrackerFixture = {
         } steps, ${metrics.total.toFixed(2)}s total`,
       );
     } catch (error) {
-      logger.error(
-        'Failed to attach performance metrics:',
-        (error as Error).message,
-      );
+      logger.error('Failed to attach performance metrics:', error);
     }
 
     const sessionId = getSessionIdFromAnnotations(testInfo.annotations);
@@ -121,7 +118,7 @@ export const performanceTrackerFixture = {
       } catch (error) {
         logger.error(
           `Failed to publish scenario "${testInfo.title}" to Sentry:`,
-          (error as Error).message,
+          error,
         );
       }
     }

--- a/tests/framework/fixtures/playwright/performanceTracker.fixture.ts
+++ b/tests/framework/fixtures/playwright/performanceTracker.fixture.ts
@@ -13,6 +13,9 @@ import {
 import { getTeamInfoFromTags } from '../../utils/teams';
 import { publishPerformanceScenarioToSentry } from '../../../reporters/providers/sentry/PerformanceSentryPublisher';
 import type { TestLevelFixtures } from './types.ts';
+import { createPlaywrightLogger } from '../../playwrightLogger.ts';
+
+const logger = createPlaywrightLogger('performanceTracker');
 
 function getSessionIdFromAnnotations(
   annotations?: { type: string; description?: string }[],
@@ -38,8 +41,8 @@ export const performanceTrackerFixture = {
       testInfo.retry > 0 &&
       hasQualityGateFailure(testId)
     ) {
-      console.log(
-        `⏭️ Aborting retry for "${testInfo.title}" - previous attempt failed due to Quality Gates (threshold exceeded, not a test execution error)`,
+      logger.info(
+        `Aborting retry for "${testInfo.title}" - previous attempt failed due to quality gates`,
       );
       throw new QualityGateError(
         `Quality Gates failed on a previous attempt for "${testInfo.title}". Retries are not allowed for quality gate failures.`,
@@ -52,8 +55,8 @@ export const performanceTrackerFixture = {
     const teamInfo = getTeamInfoFromTags(testTags);
     performanceTracker.setTeamInfo(teamInfo);
 
-    console.log(
-      `👥 Test assigned to team: ${teamInfo.teamName} (${teamInfo.teamId})`,
+    logger.info(
+      `Test assigned to team: ${teamInfo.teamName} (${teamInfo.teamId})`,
     );
 
     await use(performanceTracker);
@@ -62,13 +65,13 @@ export const performanceTrackerFixture = {
       return;
     }
 
-    console.log('🔍 Post-test cleanup: attaching performance metrics...');
-    console.log(
-      `📊 Found ${performanceTracker.timers.length} timers in tracker`,
+    logger.info('Post-test cleanup: attaching performance metrics');
+    logger.debug(
+      `Found ${performanceTracker.timers.length} timers in performance tracker`,
     );
 
     if (performanceTracker.timers.length === 0) {
-      console.log('⚠️ No timers found in performance tracker');
+      logger.warn('No timers found in performance tracker');
     }
 
     // Propagate BrowserStack session creation time (infra overhead, not counted in total)
@@ -81,14 +84,14 @@ export const performanceTrackerFixture = {
     let metrics: MetricsOutput | null = null;
     try {
       metrics = await performanceTracker.attachToTest(testInfo);
-      console.log(
-        `✅ Performance metrics attached: ${
+      logger.info(
+        `Performance metrics attached: ${
           metrics.steps.length
         } steps, ${metrics.total.toFixed(2)}s total`,
       );
     } catch (error) {
-      console.error(
-        '❌ Failed to attach performance metrics:',
+      logger.error(
+        'Failed to attach performance metrics:',
         (error as Error).message,
       );
     }
@@ -113,11 +116,11 @@ export const performanceTrackerFixture = {
         });
 
         if (sentToSentry) {
-          console.log(`📡 Scenario "${testInfo.title}" sent to Sentry`);
+          logger.info(`Scenario "${testInfo.title}" sent to Sentry`);
         }
       } catch (error) {
-        console.error(
-          `❌ Failed to publish scenario "${testInfo.title}" to Sentry:`,
+        logger.error(
+          `Failed to publish scenario "${testInfo.title}" to Sentry:`,
           (error as Error).message,
         );
       }
@@ -127,27 +130,27 @@ export const performanceTrackerFixture = {
       t.hasThreshold(),
     );
     if (hasThresholds) {
-      console.log('🔍 Validating quality gates...');
+      logger.info('Validating quality gates');
       try {
         QualityGatesValidator.assertThresholds(
           testInfo.title,
           performanceTracker.timers,
         );
-        console.log('✅ Quality gates PASSED');
+        logger.info('Quality gates passed');
       } catch (error) {
         if (
           (error as Error & { isQualityGateError?: boolean }).isQualityGateError
         ) {
           markQualityGateFailure(testId);
-          console.log(
-            '🚫 Quality gates FAILED - retries will be skipped for this test',
+          logger.warn(
+            'Quality gates failed - retries will be skipped for this test',
           );
         }
         throw error;
       }
     }
 
-    console.log('🔍 Looking for session ID...');
+    logger.debug('Looking for session ID');
 
     if (sessionId) {
       await testInfo.attach('session-data', {
@@ -163,9 +166,9 @@ export const performanceTrackerFixture = {
         contentType: 'application/json',
       });
 
-      console.log(`✅ Session data stored: ${sessionId}`);
+      logger.info(`Session data stored: ${sessionId}`);
     } else {
-      console.log('⚠️ No session ID found - video URL cannot be retrieved');
+      logger.warn('No session ID found - video URL cannot be retrieved');
     }
   },
 };

--- a/tests/framework/logger.ts
+++ b/tests/framework/logger.ts
@@ -48,7 +48,7 @@ export class Logger {
     this.name = options.name || '';
     this.prefix = options.prefix || 'E2E Framework';
     this.colors = options.colors !== false;
-    this.level = options.level || LogLevel.DEBUG;
+    this.level = options.level ?? LogLevel.DEBUG;
   }
 
   private colorize(text: string, color: keyof typeof this.colorCodes): string {

--- a/tests/framework/playwrightLogger.ts
+++ b/tests/framework/playwrightLogger.ts
@@ -3,7 +3,7 @@ import { createLogger, LogLevel } from './logger.ts';
 
 /**
  * Resolves log level for Playwright framework modules.
- * Defaults to INFO so debug traces are hidden unless E2E_LOG_LEVEL is lowered.
+ * Defaults to INFO so debug traces are hidden unless E2E_LOG_LEVEL is set to "debug" (or "trace").
  */
 export function resolvePlaywrightLogLevel(): LogLevel {
   const value = process.env.E2E_LOG_LEVEL?.toLowerCase();

--- a/tests/framework/playwrightLogger.ts
+++ b/tests/framework/playwrightLogger.ts
@@ -1,11 +1,12 @@
 import type { PlaywrightElement } from './PlaywrightAdapter.ts';
-import { createLogger, LogLevel } from './logger.ts';
+import { createLogger, type Logger, LogLevel } from './logger.ts';
 
 /**
  * Resolves log level for Playwright framework modules.
  * Defaults to INFO so debug traces are hidden unless E2E_LOG_LEVEL is set to "debug" (or "trace").
  */
 export function resolvePlaywrightLogLevel(): LogLevel {
+  // Bracket access so babel does not inline this env var at compile time.
   const value = process.env.E2E_LOG_LEVEL?.toLowerCase();
 
   switch (value) {
@@ -43,6 +44,31 @@ export function formatSelector(selector: unknown): string {
     return JSON.stringify(selector);
   }
   return String(selector);
+}
+
+/**
+ * Logs a debug message only when DEBUG is enabled, deferring expensive work
+ * (e.g. resolving element selectors) until after the level check.
+ */
+export async function debugLazy(
+  logger: Logger,
+  buildMessage: () => Promise<string> | string,
+): Promise<void> {
+  if (!logger.isLevelEnabled(LogLevel.DEBUG)) {
+    return;
+  }
+  logger.debug(await buildMessage());
+}
+
+export async function debugElementAction(
+  logger: Logger,
+  action: string,
+  elem: PlaywrightElement,
+): Promise<void> {
+  await debugLazy(
+    logger,
+    async () => `${action}${await describeElement(elem)}`,
+  );
 }
 
 export async function describeElement(

--- a/tests/framework/playwrightLogger.ts
+++ b/tests/framework/playwrightLogger.ts
@@ -1,0 +1,58 @@
+import type { PlaywrightElement } from './PlaywrightAdapter.ts';
+import { createLogger, LogLevel } from './logger.ts';
+
+/**
+ * Resolves log level for Playwright framework modules.
+ * Defaults to INFO so debug traces are hidden unless E2E_LOG_LEVEL is lowered.
+ */
+export function resolvePlaywrightLogLevel(): LogLevel {
+  const value = process.env.E2E_LOG_LEVEL?.toLowerCase();
+
+  switch (value) {
+    case 'error':
+      return LogLevel.ERROR;
+    case 'warn':
+    case 'warning':
+      return LogLevel.WARN;
+    case 'info':
+      return LogLevel.INFO;
+    case 'debug':
+      return LogLevel.DEBUG;
+    case 'trace':
+      return LogLevel.TRACE;
+    default:
+      return LogLevel.INFO;
+  }
+}
+
+export function createPlaywrightLogger(name: string) {
+  return createLogger({
+    name,
+    level: resolvePlaywrightLogLevel(),
+  });
+}
+
+export function formatSelector(selector: unknown): string {
+  if (selector === undefined || selector === null) {
+    return '';
+  }
+  if (typeof selector === 'string') {
+    return selector;
+  }
+  if (typeof selector === 'object') {
+    return JSON.stringify(selector);
+  }
+  return String(selector);
+}
+
+export async function describeElement(
+  elem: PlaywrightElement,
+): Promise<string> {
+  try {
+    const selector = await elem.unwrap().selector;
+    const label = formatSelector(selector);
+    return label ? ` [${label}]` : '';
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Add Playwright logger for performance test debugging

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1646

## **Manual testing steps**


<!-- mms-check: type=manual-testing required=true -->

```gherkin
N/A
```

## **Screenshots/Recordings**
N/A

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-framework logging only; no production app or auth/data paths. Slight behavior change is quieter default logs (INFO) unless E2E_LOG_LEVEL=debug.
> 
> **Overview**
> Introduces a shared **`playwrightLogger`** for E2E Playwright/Appium code, driven by **`E2E_LOG_LEVEL`** (default **INFO**; **`debug`**/`trace` for verbose traces). **`createPlaywrightLogger`** and lazy **`debugElementAction`** helpers avoid expensive selector resolution unless debug is on.
> 
> **`console.*` calls are replaced** across matchers, gestures, assertions, context switching, utilities, and performance fixtures with named module loggers—INFO for session/device/metrics lifecycle, DEBUG for finds, taps, webview switches, and retries. Fixture README documents the logging matrix; **`babel.config.tests.js`** excludes **`playwrightLogger.ts`** from env inlining so **`E2E_LOG_LEVEL`** works at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be07c8ce7544b9fb3eeb86f64f2044c30609dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->