### PR TITLE
chore: if no network fees in batch sell show insufficient funds

### DIFF
--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
@@ -510,6 +510,24 @@ describe('BatchSellFinalReviewModal', () => {
     ).not.toBe(true);
   });
 
+  it('blocks Sell all when the network fee is unavailable even if trades are available', () => {
+    const { getByTestId, getByText } = renderModal({
+      isBatchSellTradeAvailable: true,
+      isBatchSellTradesLoading: false,
+      isNetworkFeeUnavailable: true,
+      networkFee: {
+        formatted: '--',
+        formattedFiat: '-',
+      },
+    });
+
+    expect(getByText('Insufficient balance')).toBeOnTheScreen();
+    expect(
+      getByTestId(BatchSellFinalReviewModalSelectorsIDs.SELL_ALL_BUTTON).props
+        .accessibilityState.disabled,
+    ).toBe(true);
+  });
+
   it('shows insufficient funds when gasless destination-token fee cannot be covered', () => {
     const { getByTestId, getByText, queryByTestId } = renderModal({
       isGasless: true,

--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
@@ -67,6 +67,7 @@ interface MockBatchSellQuoteData {
   isGasless: boolean;
   isBatchSellTradeAvailable: boolean;
   isBatchSellTradesLoading: boolean;
+  isNetworkFeeUnavailable: boolean;
   hasAnyQuote: boolean;
   hasPendingQuoteRows: boolean;
   needsNewQuote: boolean;
@@ -118,6 +119,7 @@ const defaultQuoteData: MockBatchSellQuoteData = {
   isGasless: false,
   isBatchSellTradeAvailable: true,
   isBatchSellTradesLoading: false,
+  isNetworkFeeUnavailable: false,
   hasAnyQuote: true,
   hasPendingQuoteRows: false,
   needsNewQuote: false,
@@ -474,6 +476,38 @@ describe('BatchSellFinalReviewModal', () => {
       getByTestId(BatchSellFinalReviewModalSelectorsIDs.SELL_ALL_BUTTON).props
         .accessibilityState.disabled,
     ).toBe(true);
+  });
+
+  it('shows insufficient balance when the network fee is unavailable', () => {
+    const { getByTestId, getByText, queryByTestId } = renderModal({
+      isBatchSellTradeAvailable: false,
+      isBatchSellTradesLoading: false,
+      isNetworkFeeUnavailable: true,
+      networkFee: {
+        formatted: '--',
+        formattedFiat: '-',
+      },
+    });
+    const getTextColor = (text: string) =>
+      StyleSheet.flatten(getByText(text).props.style).color;
+
+    expect(
+      queryByTestId(
+        BatchSellFinalReviewModalSelectorsIDs.NETWORK_FEE_VALUES_SKELETON,
+      ),
+    ).toBeNull();
+    expect(getByText('Insufficient balance')).toBeOnTheScreen();
+    expect(getTextColor('Network fee')).toBe(errorTextColor);
+    expect(getTextColor('--')).toBe(errorTextColor);
+    expect(getTextColor('-')).toBe(errorTextColor);
+    expect(
+      getByTestId(BatchSellFinalReviewModalSelectorsIDs.SELL_ALL_BUTTON).props
+        .accessibilityState.disabled,
+    ).toBe(true);
+    expect(
+      getByTestId(BatchSellFinalReviewModalSelectorsIDs.SELL_ALL_BUTTON).props
+        .accessibilityState.busy,
+    ).not.toBe(true);
   });
 
   it('shows insufficient funds when gasless destination-token fee cannot be covered', () => {

--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
@@ -314,12 +314,15 @@ export function BatchSellFinalReviewModal() {
     ],
   );
   const isBatchSellTradesLoading = batchSellQuoteData.isBatchSellTradesLoading;
+  const isNetworkFeeUnavailable = batchSellQuoteData.isNetworkFeeUnavailable;
   const hasInsufficientGaslessDestinationToken =
     batchSellQuoteData.isGasless &&
     !isBatchSellTradesLoading &&
     !batchSellQuoteData.isBatchSellTradeAvailable;
   const hasInsufficientGas =
-    hasSufficientGas === false || hasInsufficientGaslessDestinationToken;
+    !isNetworkFeeUnavailable &&
+    (hasSufficientGas === false || hasInsufficientGaslessDestinationToken);
+  const hasNetworkFeeError = hasInsufficientGas || isNetworkFeeUnavailable;
   const isSellAllDisabled =
     batchSellQuoteData.isLoading ||
     isBatchSellTradesLoading ||
@@ -341,6 +344,10 @@ export function BatchSellFinalReviewModal() {
   const actionButtonLabel = (() => {
     if (batchSellQuoteData.needsNewQuote) {
       return strings('quote_expired_modal.get_new_quote');
+    }
+
+    if (isNetworkFeeUnavailable) {
+      return strings('bridge.insufficient_balance');
     }
 
     if (hasInsufficientGas) {
@@ -427,7 +434,7 @@ export function BatchSellFinalReviewModal() {
       />
       <NetworkFeeRow
         networkFee={batchSellQuoteData.networkFee}
-        hasInsufficientGas={hasInsufficientGas}
+        hasInsufficientGas={hasNetworkFeeError}
         isLoading={isBatchSellTradesLoading}
         onInfoPress={handleOpenNetworkFeeInfo}
       />

--- a/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
+++ b/app/components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx
@@ -330,6 +330,7 @@ export function BatchSellFinalReviewModal() {
     !batchSellQuoteData.hasAnyQuote ||
     batchSellQuoteData.hasPendingQuoteRows ||
     isSubmittingTx ||
+    isNetworkFeeUnavailable ||
     hasInsufficientGas;
   const isButtonDisabled = batchSellQuoteData.needsNewQuote
     ? false

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts
@@ -317,6 +317,7 @@ export function useBatchSellQuoteData({
   const hasAnyQuote = availableRecommendedQuotes.length > 0;
   const totalNetworkFee = batchSellTrades.totalNetworkFee;
   const isBatchSellTradesLoading = Boolean(batchSellTrades.isLoading);
+  const isNetworkFeeUnavailable = !isBatchSellTradesLoading && !totalNetworkFee;
 
   // Quote-level gasless params are not reliable for Batch Sell because gasless
   // behavior is only simulated when the controller calls obtainGaslessBatch.
@@ -519,6 +520,7 @@ export function useBatchSellQuoteData({
     isGasless,
     isBatchSellTradeAvailable: batchSellTrades.isBatchSellTradeAvailable,
     isBatchSellTradesLoading,
+    isNetworkFeeUnavailable,
     hasAnyQuote,
     hasPendingQuoteRows,
     needsNewQuote,

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
@@ -559,6 +559,7 @@ describe('useBatchSellQuoteData', () => {
     expect(result.current.networkFee.formatted).toBe('--');
     expect(result.current.isBatchSellTradeAvailable).toBe(false);
     expect(result.current.isBatchSellTradesLoading).toBe(false);
+    expect(result.current.isNetworkFeeUnavailable).toBe(true);
     expect(result.current.networkFee.formattedFiat).toBe('-');
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7682,6 +7682,7 @@
     "error_banner_description": "This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.",
     "stock_token_error_banner_description": "This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.\n\nPlease note if you are attempting to trade Ondo Tokenised Stocks you may be geo-restricted e.g. via US, EU, UK and BR.",
     "insufficient_funds": "Insufficient funds",
+    "insufficient_balance": "Insufficient balance",
     "insufficient_gas": "Insufficient gas",
     "select_amount": "Select amount",
     "bridge_to": "Bridge to",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Users reported being unable to proceed past the Batch Sell final review modal when network fees could not be loaded from the backend. The primary CTA stayed disabled while still showing "Sell all", with no explanation.

This change detects when batch sell trades have finished loading but `totalNetworkFee` is unavailable from `selectBatchSellTrades`, and surfaces that state in the final review modal:

- CTA label changes from "Sell all" to **"Insufficient balance"**
- Network fee row title and fallback values (`--` / `-`) render in the danger/error color
- Existing insufficient-gas and gasless insufficient-funds paths are unchanged and still show "Insufficient funds"

Implementation adds `isNetworkFeeUnavailable` to `useBatchSellQuoteData` (`!isBatchSellTradesLoading && !totalNetworkFee`) and wires it through `BatchSellFinalReviewModal`.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Fixed Batch Sell final review showing a disabled "Sell all" button with no explanation when network fees fail to load

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [SWAPS-4570](https://consensyssoftware.atlassian.net/browse/SWAPS-4570)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch Sell network fee unavailable error state

  Scenario: user sees insufficient balance when network fee cannot be loaded
    Given a wallet with multiple tokens eligible for Batch Sell
    And quotes have loaded on the Batch Sell review screen
    And the obtainGaslessBatch response does not provide a total network fee (or trades fetch fails to resolve fee data)

    When the user opens the Batch Sell final review modal
    Then the primary CTA is disabled
    And the CTA label reads "Insufficient balance"
    And the network fee row title is styled with the danger/error color
    And the network fee fallback values ("--" / "-") are styled with the danger/error color

  Scenario: user still sees insufficient funds for known gas insufficiency
    Given a wallet on Batch Sell final review with a resolved network fee
    And the user does not have enough native gas (or gasless destination token balance) to cover the fee

    When the user views the final review modal
    Then the CTA label reads "Insufficient funds"
    And the network fee row values are styled with the danger/error color

  Scenario: happy path is unchanged
    Given a wallet with sufficient balance and a resolved network fee

    When the user opens the Batch Sell final review modal
    Then the CTA label reads "Sell all"
    And the CTA is enabled
    And the network fee row shows the fee in default styling
```

**Unit tests**

```bash
yarn jest app/components/UI/Bridge/components/BatchSellFinalReviewModal/BatchSellFinalReviewModal.test.tsx
yarn jest app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — add before/after screenshots from manual testing before marking ready for review.

### **Before**

N/A

### **After**

<img width="598" height="1144" alt="Screenshot 2026-06-08 at 2 08 34 PM" src="https://github.com/user-attachments/assets/799e8071-6dac-4f46-ac6e-298794c9cd86" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4570]: https://consensyssoftware.atlassian.net/browse/SWAPS-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Batch Sell error handling and copy; no change to trade submission or fee calculation logic beyond gating the CTA when fee data is missing.
> 
> **Overview**
> Fixes Batch Sell **final review** when batch trades finish loading but **`totalNetworkFee` is missing**: users no longer see a disabled **Sell all** with no reason.
> 
> **`useBatchSellQuoteData`** exposes **`isNetworkFeeUnavailable`** (`!isBatchSellTradesLoading && !totalNetworkFee`). **`BatchSellFinalReviewModal`** uses it to disable the primary CTA, label the button **Insufficient balance** (new `bridge.insufficient_balance` copy), and pass **`hasNetworkFeeError`** into the network fee row so title and `--` / `-` placeholders use error styling. Known **Insufficient funds** paths for insufficient gas or gasless destination-token balance stay separate and are not shown when the fee itself is unavailable.
> 
> Unit tests cover the hook flag and modal behavior, including blocking **Sell all** even when trades are otherwise available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c27e6f56531ec03fa54c3de4b95c00028489894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->