### PR TITLE
refactor(notifications): centralize backend template override for on-…

### DIFF
--- a/app/components/UI/Notification/List/index.test.tsx
+++ b/app/components/UI/Notification/List/index.test.tsx
@@ -15,6 +15,7 @@ import NotificationsList, {
   NotificationsListItem,
   TEST_IDS,
   useNotificationOnClick,
+  applyNotificationTemplate,
 } from './';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
@@ -38,6 +39,90 @@ beforeEach(() => {
     .mockReturnValue(
       createMockUseAnalyticsHook({ trackEvent: mockTrackEvent }),
     );
+});
+
+describe('applyNotificationTemplate', () => {
+  // Cast needed: baseItem is a minimal stub, not a full MenuItemState
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const baseItem: any = {
+    title: 'Client title',
+    description: { start: 'Client description', end: 'Client end' },
+    image: { url: 'https://example.com/image.png' },
+    badgeIcon: 'badge',
+    createdAt: '2024-01-01',
+  };
+
+  it('returns item unchanged when template is absent', () => {
+    expect(applyNotificationTemplate(baseItem, undefined)).toBe(baseItem);
+  });
+
+  it('returns item unchanged when item is undefined', () => {
+    expect(
+      applyNotificationTemplate(undefined, { title: 'Backend' }),
+    ).toBeUndefined();
+  });
+
+  it('overrides title when template.title is present', () => {
+    const result = applyNotificationTemplate(baseItem, {
+      title: 'Backend title',
+    });
+    expect(result?.title).toBe('Backend title');
+  });
+
+  it('falls back to client title when template.title is empty string', () => {
+    const result = applyNotificationTemplate(baseItem, { title: '' });
+    expect(result?.title).toBe('Client title');
+  });
+
+  it('overrides description.start when template.body is present', () => {
+    const result = applyNotificationTemplate(baseItem, {
+      body: 'Backend body',
+    });
+    expect(result?.description?.start).toBe('Backend body');
+  });
+
+  it('drops description.end when template.body is set (prose full-width override)', () => {
+    const result = applyNotificationTemplate(baseItem, {
+      body: 'Backend body',
+    });
+    expect(result?.description?.end).toBeUndefined();
+  });
+
+  it('keeps description.end when template.body is empty string', () => {
+    const result = applyNotificationTemplate(baseItem, { body: '' });
+    expect(result?.description?.end).toBe('Client end');
+  });
+
+  it('does not affect description.end when only template.title is set', () => {
+    const result = applyNotificationTemplate(baseItem, {
+      title: 'Backend title',
+    });
+    expect(result?.description?.end).toBe('Client end');
+  });
+
+  it('falls back to client description when template.body is empty string', () => {
+    const result = applyNotificationTemplate(baseItem, { body: '' });
+    expect(result?.description?.start).toBe('Client description');
+  });
+
+  it('overrides both title and description when both are present', () => {
+    const result = applyNotificationTemplate(baseItem, {
+      title: 'Backend title',
+      body: 'Backend body',
+    });
+    expect(result?.title).toBe('Backend title');
+    expect(result?.description?.start).toBe('Backend body');
+  });
+
+  it('preserves non-copy fields (image, badgeIcon, createdAt)', () => {
+    const result = applyNotificationTemplate(baseItem, {
+      title: 'Backend title',
+      body: 'Backend body',
+    });
+    expect(result?.image).toEqual(baseItem.image);
+    expect(result?.badgeIcon).toBe(baseItem.badgeIcon);
+    expect(result?.createdAt).toBe(baseItem.createdAt);
+  });
 });
 
 describe('NotificationsList States', () => {

--- a/app/components/UI/Notification/List/index.tsx
+++ b/app/components/UI/Notification/List/index.tsx
@@ -28,6 +28,24 @@ export const TEST_IDS = {
   loadingContainer: 'notification-list-loading',
 };
 
+type MenuItemState = ReturnType<
+  (typeof NotificationComponentState)[keyof typeof NotificationComponentState]['createMenuItem']
+>;
+
+export function applyNotificationTemplate(
+  item: MenuItemState,
+  template: { title?: string; body?: string } | undefined,
+): MenuItemState {
+  if (!item || !template) return item;
+  return {
+    ...item,
+    ...(template.title && { title: template.title }),
+    ...(template.body && {
+      description: { start: template.body },
+    }),
+  };
+}
+
 interface NotificationsListProps {
   navigation: NavigationProp<ParamListBase>;
   allNotifications: INotification[];
@@ -122,7 +140,11 @@ export function NotificationsListItem(props: NotificationsListItemProps) {
         ? NotificationComponentState[props.notification.type]
         : undefined;
 
-    return notificationState?.createMenuItem(props.notification);
+    const item = notificationState?.createMenuItem(props.notification);
+    const notificationWithTemplate = props.notification as INotification & {
+      template?: { title?: string; body?: string };
+    };
+    return applyNotificationTemplate(item, notificationWithTemplate.template);
   }, [props.notification]);
 
   if (!isValidNotificationComponent(props.notification) || !menuItemState) {

--- a/app/util/notifications/notification-states/erc1155-sent-received/erc1155-sent-received.test.ts
+++ b/app/util/notifications/notification-states/erc1155-sent-received/erc1155-sent-received.test.ts
@@ -1,0 +1,23 @@
+import state from './erc1155-sent-received';
+import {
+  createMockNotificationERC1155Sent,
+  createMockNotificationERC1155Received,
+} from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('erc1155-sent-received handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string for sent', () => {
+      const item = state.createMenuItem(createMockNotificationERC1155Sent());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+
+    it('returns a non-empty string for received', () => {
+      const item = state.createMenuItem(
+        createMockNotificationERC1155Received(),
+      );
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/util/notifications/notification-states/erc20-sent-received/erc20-sent-received.test.ts
+++ b/app/util/notifications/notification-states/erc20-sent-received/erc20-sent-received.test.ts
@@ -1,0 +1,21 @@
+import state from './erc20-sent-received';
+import {
+  createMockNotificationERC20Sent,
+  createMockNotificationERC20Received,
+} from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('erc20-sent-received handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string for sent', () => {
+      const item = state.createMenuItem(createMockNotificationERC20Sent());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+
+    it('returns a non-empty string for received', () => {
+      const item = state.createMenuItem(createMockNotificationERC20Received());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/util/notifications/notification-states/erc721-sent-received/erc721-sent-received.test.ts
+++ b/app/util/notifications/notification-states/erc721-sent-received/erc721-sent-received.test.ts
@@ -1,0 +1,21 @@
+import state from './erc721-sent-received';
+import {
+  createMockNotificationERC721Sent,
+  createMockNotificationERC721Received,
+} from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('erc721-sent-received handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string for sent', () => {
+      const item = state.createMenuItem(createMockNotificationERC721Sent());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+
+    it('returns a non-empty string for received', () => {
+      const item = state.createMenuItem(createMockNotificationERC721Received());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/util/notifications/notification-states/eth-sent-received/eth-sent-received.test.ts
+++ b/app/util/notifications/notification-states/eth-sent-received/eth-sent-received.test.ts
@@ -1,0 +1,21 @@
+import state from './eth-sent-received';
+import {
+  createMockNotificationEthSent,
+  createMockNotificationEthReceived,
+} from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('eth-sent-received handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string for sent', () => {
+      const item = state.createMenuItem(createMockNotificationEthSent());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+
+    it('returns a non-empty string for received', () => {
+      const item = state.createMenuItem(createMockNotificationEthReceived());
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/util/notifications/notification-states/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.test.ts
+++ b/app/util/notifications/notification-states/lido-stake-ready-to-be-withdrawn/lido-stake-ready-to-be-withdrawn.test.ts
@@ -1,0 +1,24 @@
+import state from './lido-stake-ready-to-be-withdrawn';
+import { createMockNotificationLidoReadyToBeWithdrawn } from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('lido-stake-ready-to-be-withdrawn handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string', () => {
+      const item = state.createMenuItem(
+        createMockNotificationLidoReadyToBeWithdrawn(),
+      );
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createMenuItem description', () => {
+    it('returns a non-empty string', () => {
+      const item = state.createMenuItem(
+        createMockNotificationLidoReadyToBeWithdrawn(),
+      );
+      expect(typeof item.description.start).toBe('string');
+      expect((item.description.start as string).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/util/notifications/notification-states/lido-withdrawal-requested/lido-withdrawal-requested.test.ts
+++ b/app/util/notifications/notification-states/lido-withdrawal-requested/lido-withdrawal-requested.test.ts
@@ -1,0 +1,24 @@
+import state from './lido-withdrawal-requested';
+import { createMockNotificationLidoWithdrawalRequested } from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('lido-withdrawal-requested handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string', () => {
+      const item = state.createMenuItem(
+        createMockNotificationLidoWithdrawalRequested(),
+      );
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createMenuItem description', () => {
+    it('returns a non-empty string', () => {
+      const item = state.createMenuItem(
+        createMockNotificationLidoWithdrawalRequested(),
+      );
+      expect(typeof item.description.start).toBe('string');
+      expect((item.description.start as string).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/util/notifications/notification-states/stake/stake.test.ts
+++ b/app/util/notifications/notification-states/stake/stake.test.ts
@@ -1,0 +1,35 @@
+import state from './stake';
+import {
+  createMockNotificationRocketPoolStakeCompleted,
+  createMockNotificationRocketPoolUnStakeCompleted,
+  createMockNotificationLidoStakeCompleted,
+  createMockNotificationLidoWithdrawalCompleted,
+} from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('stake handler', () => {
+  const mockFactories = [
+    {
+      name: 'RocketPool stake',
+      factory: createMockNotificationRocketPoolStakeCompleted,
+    },
+    {
+      name: 'RocketPool unstake',
+      factory: createMockNotificationRocketPoolUnStakeCompleted,
+    },
+    { name: 'Lido stake', factory: createMockNotificationLidoStakeCompleted },
+    {
+      name: 'Lido withdrawal completed',
+      factory: createMockNotificationLidoWithdrawalCompleted,
+    },
+  ];
+
+  describe('createMenuItem title', () => {
+    mockFactories.forEach(({ name, factory }) => {
+      it(`returns a non-empty string (${name})`, () => {
+        const item = state.createMenuItem(factory());
+        expect(typeof item.title).toBe('string');
+        expect(item.title.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/app/util/notifications/notification-states/swap-completed/swap-completed.test.ts
+++ b/app/util/notifications/notification-states/swap-completed/swap-completed.test.ts
@@ -1,0 +1,14 @@
+import state from './swap-completed';
+import { createMockNotificationMetaMaskSwapsCompleted } from '../../../../components/UI/Notification/__mocks__/mock_notifications';
+
+describe('swap-completed handler', () => {
+  describe('createMenuItem title', () => {
+    it('returns a non-empty string', () => {
+      const item = state.createMenuItem(
+        createMockNotificationMetaMaskSwapsCompleted(),
+      );
+      expect(typeof item.title).toBe('string');
+      expect(item.title.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
…chain in-app notifications

Moves template title/body application out of individual notification-state handlers and into a single applyNotificationTemplate utility called in NotificationsListItem. Any on-chain handler now benefits from backend-provided copy without modification, including description when template.body is present. Adds unit tests for applyNotificationTemplate and per-handler smoke tests.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
