### PR TITLE
chore: pass feature_id to Unified SwapBridge events

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -282,15 +282,13 @@ const mockFormatAddressToAssetId = jest.fn<string | null, [string, string]>(
 );
 const mockIsNonEvmChainId = jest.fn<boolean, [string]>(() => false);
 jest.mock('@metamask/bridge-controller', () => ({
+  ...jest.requireActual('@metamask/bridge-controller'),
   formatAddressToAssetId: (address: string, chainId: string) =>
     mockFormatAddressToAssetId(address, chainId),
   formatChainIdToCaip: jest.fn(
     (chainId: string) => `eip155:${parseInt(chainId, 16)}`,
   ),
   isNonEvmChainId: (chainId: string) => mockIsNonEvmChainId(chainId),
-  UnifiedSwapBridgeEventName: {
-    AssetDetailTooltipClicked: 'AssetDetailTooltipClicked',
-  },
 }));
 
 jest.mock('../../../../../core/Multichain/utils', () => ({

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -32,6 +32,7 @@ import {
   setTokenSelectorNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
 import {
+  FeatureId,
   formatChainIdToCaip,
   UnifiedSwapBridgeEventName,
 } from '@metamask/bridge-controller';
@@ -361,6 +362,7 @@ export const BridgeTokenSelector: React.FC = () => {
           token_contract: item.address,
           chain_name: networkName,
           chain_id: item.chainId,
+          feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
         },
       );
     },

--- a/app/components/UI/Bridge/components/GaslessQuickPickOptions/index.tsx
+++ b/app/components/UI/Bridge/components/GaslessQuickPickOptions/index.tsx
@@ -1,5 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
-import { UnifiedSwapBridgeEventName } from '@metamask/bridge-controller';
+import {
+  FeatureId,
+  UnifiedSwapBridgeEventName,
+} from '@metamask/bridge-controller';
 import { QuickPickButtonOption } from '../SwapsKeypad/types';
 import { QuickPickButtons } from '../SwapsKeypad/QuickPickButtons';
 import { useShouldRenderMaxOption } from '../../hooks/useShouldRenderMaxOption';
@@ -45,6 +48,7 @@ export const GaslessQuickPickOptions = ({
         {
           input: 'token_amount_source',
           input_value: inputValue,
+          feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
           ...(preset && { input_amount_preset: preset }),
           // This Bridge-specific event bypasses the shared analytics wrappers,
           // so its A/B context still needs to be attached manually here.

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { debounce } from 'lodash';
 import BigNumber from 'bignumber.js';
 import {
+  FeatureId,
   formatAddressToAssetId,
   formatAddressToCaipReference,
 } from '@metamask/bridge-controller';
@@ -165,6 +166,7 @@ export function buildBatchSellQuoteRequestData({
             sourceToken,
             sourceAmount,
           ),
+          feature_id: FeatureId.BATCH_SELL,
         },
       });
 

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
@@ -1,6 +1,8 @@
 import { act } from '@testing-library/react-native';
 import { CaipAssetType, Hex } from '@metamask/utils';
 
+import { FeatureId } from '@metamask/bridge-controller';
+
 import Engine from '../../../../../core/Engine';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { createBridgeTestState } from '../../testUtils';
@@ -212,6 +214,7 @@ describe('useBatchSellQuoteRequest', () => {
           token_symbol_destination: 'USDC',
           token_security_type_destination: null,
           usd_amount_source: 1500,
+          feature_id: FeatureId.BATCH_SELL,
         }),
       }),
     ]);
@@ -293,6 +296,7 @@ describe('useBatchSellQuoteRequest', () => {
         token_symbol_destination: 'USDC',
         token_security_type_destination: null,
         usd_amount_source: 1500,
+        feature_id: FeatureId.BATCH_SELL,
       }),
     );
     expect(
@@ -304,6 +308,7 @@ describe('useBatchSellQuoteRequest', () => {
         token_symbol_destination: 'USDC',
         token_security_type_destination: null,
         usd_amount_source: 250,
+        feature_id: FeatureId.BATCH_SELL,
       }),
     );
   });

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -115,6 +115,7 @@ describe('useBridgeQuoteEvents', () => {
       ).toHaveBeenCalledWith('Unified SwapBridge Quotes Received', {
         best_quote_provider: 'lifi_jupiter',
         can_submit: true,
+        feature_id: 'unified_swap_bridge',
         gas_included: false,
         gas_included_7702: false,
         has_sufficient_gas_for_quote: null,

--- a/app/components/UI/Bridge/hooks/useTrackAllQuotesSortedEvent/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useTrackAllQuotesSortedEvent/index.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-native';
 import { useTrackAllQuotesSortedEvent } from './index';
 import Engine from '../../../../../core/Engine';
 import {
+  FeatureId,
   SortOrder,
   UnifiedSwapBridgeEventName,
   type Quote,
@@ -201,6 +202,7 @@ describe('useTrackAllQuotesSortedEvent', () => {
         token_symbol_source: 'ETH',
         token_symbol_destination: 'USDC',
         stx_enabled: true,
+        feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
         sort_order: SortOrder.COST_ASC,
         best_quote_provider: 'lifi',
       });

--- a/app/components/UI/Bridge/hooks/useTrackAllQuotesSortedEvent/index.ts
+++ b/app/components/UI/Bridge/hooks/useTrackAllQuotesSortedEvent/index.ts
@@ -1,4 +1,5 @@
 import {
+  FeatureId,
   formatProviderLabel,
   getNativeAssetForChainId,
   Quote,
@@ -48,6 +49,7 @@ export const useTrackAllQuotesSortedEvent = (
             : ' '),
         token_symbol_destination: destToken?.symbol ?? null,
         stx_enabled: smartTransactionsEnabled,
+        feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
         ...(isBridge && {
           sort_order: SortOrder.COST_ASC,
           best_quote_provider: formatProviderLabel(quote),

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/index.ts
@@ -1,3 +1,4 @@
+import { FeatureId } from '@metamask/bridge-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -66,6 +67,7 @@ export const useUnifiedSwapBridgeContext = () => {
       security_warnings: getSecurityWarnings(toToken),
       warnings: [], // TODO
       usd_amount_source: usdAmountSource,
+      feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
     }),
     [smartTransactionsEnabled, fromToken, toToken, usdAmountSource],
   );

--- a/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
+++ b/app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
@@ -1,4 +1,5 @@
 import '../../_mocks_/initialState';
+import { FeatureId } from '@metamask/bridge-controller';
 import { createBridgeTestState } from '../../testUtils';
 import { useUnifiedSwapBridgeContext } from '.';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
@@ -95,6 +96,7 @@ describe('useUnifiedSwapBridgeContext', () => {
       security_warnings: [],
       warnings: [],
       usd_amount_source: 0,
+      feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
     });
   });
 
@@ -199,6 +201,7 @@ describe('useUnifiedSwapBridgeContext', () => {
       security_warnings: [],
       warnings: [],
       usd_amount_source: 0,
+      feature_id: FeatureId.UNIFIED_SWAP_BRIDGE,
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -498,8 +498,13 @@ export function useQuickBuyController(
     return Number.isFinite(v) ? v : 0;
   }, [usdAmount]);
   const quotesAnalyticsContext = useMemo(
-    () => ({ traderAddress, caip19, amountUsd: quotedUsdAmountNumber }),
-    [traderAddress, caip19, quotedUsdAmountNumber],
+    () => ({
+      traderAddress,
+      caip19,
+      amountUsd: quotedUsdAmountNumber,
+      source: analyticsContext?.source,
+    }),
+    [traderAddress, caip19, quotedUsdAmountNumber, analyticsContext?.source],
   );
 
   const {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyQuotes.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyQuotes.ts
@@ -321,13 +321,9 @@ export function useQuickBuyQuotes({
     };
 
     try {
-      if (!analyticsContext?.source) {
-        throw new Error('QuickBuy source is required to fetch quotes');
-      }
-
       const result = await Engine.context.BridgeController.fetchQuotes(
         params,
-        getQuickBuyFeatureId(analyticsContext.source),
+        getQuickBuyFeatureId(analyticsContext?.source),
         controller.signal,
       );
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyQuotes.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyQuotes.ts
@@ -35,9 +35,11 @@ import { buildSocialLoggerErrorOptions } from '../../../../../../../util/social/
 import {
   SocialLeaderboardEventProperties,
   useSocialLeaderboardAnalytics,
+  type QuickBuySheetSource,
 } from '../../../../analytics';
 import { MetaMetricsEvents } from '../../../../../../../core/Analytics';
 import { getQuoteRefreshRate } from '../../../../../../UI/Bridge/utils/quoteUtils';
+import { getQuickBuyFeatureId } from '../utils/getQuickBuyFeatureId';
 
 export type QuickBuyQuote = QuoteResponse & L1GasFees & NonEvmFees;
 
@@ -48,6 +50,8 @@ export interface QuickBuyQuotesAnalyticsContext {
   caip19?: string;
   /** USD amount the user has selected; used as `amount_usd`. */
   amountUsd?: number;
+  /** Entry surface for FeatureId mapping on fetchQuotes. */
+  source?: QuickBuySheetSource;
 }
 
 export type EnrichedQuickBuyQuote = ReturnType<
@@ -317,11 +321,14 @@ export function useQuickBuyQuotes({
     };
 
     try {
+      if (!analyticsContext?.source) {
+        throw new Error('QuickBuy source is required to fetch quotes');
+      }
+
       const result = await Engine.context.BridgeController.fetchQuotes(
         params,
+        getQuickBuyFeatureId(analyticsContext.source),
         controller.signal,
-        // @ts-expect-error quickBuy has not been added as a FeatureId yet
-        'quickBuy',
       );
 
       if (controller.signal.aborted) {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyQuotes.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyQuotes.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { FeatureId } from '@metamask/bridge-controller';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../../../core/Engine';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
@@ -168,6 +169,18 @@ const setupSelectors = () => {
   );
 };
 
+type QuickBuyQuotesParams = Parameters<typeof useQuickBuyQuotes>[0];
+
+function quotesParams(params: QuickBuyQuotesParams): QuickBuyQuotesParams {
+  return {
+    ...params,
+    analyticsContext: {
+      source: 'leaderboard',
+      ...params.analyticsContext,
+    },
+  };
+}
+
 describe('useQuickBuyQuotes', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -185,11 +198,13 @@ describe('useQuickBuyQuotes', () => {
 
   it('returns idle state when any required input is missing', () => {
     const { result } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: undefined,
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: undefined,
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     expect(result.current.activeQuote).toBeUndefined();
@@ -202,11 +217,13 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
 
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     expect(fetchQuotesMock).not.toHaveBeenCalled();
@@ -223,12 +240,14 @@ describe('useQuickBuyQuotes', () => {
 
     const { rerender } = renderHook(
       ({ token }: { token: number }) =>
-        useQuickBuyQuotes({
-          sourceToken: createSourceToken(),
-          destToken: createDestToken(),
-          sourceTokenAmount: '0.001',
-          immediateFetchToken: token,
-        }),
+        useQuickBuyQuotes(
+          quotesParams({
+            sourceToken: createSourceToken(),
+            destToken: createDestToken(),
+            sourceTokenAmount: '0.001',
+            immediateFetchToken: token,
+          }),
+        ),
       { initialProps: { token: 0 } },
     );
 
@@ -244,12 +263,14 @@ describe('useQuickBuyQuotes', () => {
 
     const { rerender } = renderHook(
       ({ amount }: { amount: string }) =>
-        useQuickBuyQuotes({
-          sourceToken: createSourceToken(),
-          destToken: createDestToken(),
-          sourceTokenAmount: amount,
-          immediateFetchToken: 0,
-        }),
+        useQuickBuyQuotes(
+          quotesParams({
+            sourceToken: createSourceToken(),
+            destToken: createDestToken(),
+            sourceTokenAmount: amount,
+            immediateFetchToken: 0,
+          }),
+        ),
       { initialProps: { amount: '0.001' } },
     );
 
@@ -289,12 +310,14 @@ describe('useQuickBuyQuotes', () => {
 
     const { result, rerender } = renderHook(
       ({ token, amount }: { token: number; amount: string }) =>
-        useQuickBuyQuotes({
-          sourceToken: createSourceToken(),
-          destToken: createDestToken(),
-          sourceTokenAmount: amount,
-          immediateFetchToken: token,
-        }),
+        useQuickBuyQuotes(
+          quotesParams({
+            sourceToken: createSourceToken(),
+            destToken: createDestToken(),
+            sourceTokenAmount: amount,
+            immediateFetchToken: token,
+          }),
+        ),
       { initialProps: { token: 0, amount: '0.001' } },
     );
 
@@ -306,7 +329,7 @@ describe('useQuickBuyQuotes', () => {
     );
 
     expect(fetchQuotesMock).toHaveBeenCalledTimes(2);
-    const firstRequestSignal = fetchQuotesMock.mock.calls[0][1];
+    const firstRequestSignal = fetchQuotesMock.mock.calls[0][2];
     expect(firstRequestSignal.aborted).toBe(true);
 
     await act(async () => {
@@ -321,11 +344,13 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
 
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     act(() => {
@@ -342,17 +367,47 @@ describe('useQuickBuyQuotes', () => {
       gasIncluded: false,
       gasIncluded7702: false,
     });
+    expect(fetchQuotesMock.mock.calls[0][1]).toBe(
+      FeatureId.QUICK_BUY_FOLLOW_TRADING,
+    );
+  });
+
+  it('passes QUICK_BUY_TOKEN_DETAILS FeatureId when source is asset_details', async () => {
+    fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
+
+    renderHook(() =>
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+          analyticsContext: { source: 'asset_details' },
+        }),
+      ),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(QUICK_BUY_QUOTE_DEBOUNCE_MS);
+    });
+
+    await waitFor(() => expect(fetchQuotesMock).toHaveBeenCalled());
+
+    expect(fetchQuotesMock.mock.calls[0][1]).toBe(
+      FeatureId.QUICK_BUY_TOKEN_DETAILS,
+    );
   });
 
   it('flags isNoQuotesAvailable when fetchQuotes returns an empty array', async () => {
     fetchQuotesMock.mockResolvedValue([]);
 
     const { result } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     act(() => {
@@ -367,11 +422,13 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockRejectedValue(new Error('boom'));
 
     const { result } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     act(() => {
@@ -387,11 +444,13 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockRejectedValue(fetchError);
 
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     act(() => {
@@ -417,11 +476,13 @@ describe('useQuickBuyQuotes', () => {
 
   it('skips fetching when the atomic source amount normalizes to zero', () => {
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken({ decimals: 18 }),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken({ decimals: 18 }),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0',
+        }),
+      ),
     );
 
     act(() => {
@@ -433,13 +494,15 @@ describe('useQuickBuyQuotes', () => {
 
   it('skips fetching when sourceToken.decimals is undefined', () => {
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken({
-          decimals: undefined as unknown as number,
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken({
+            decimals: undefined as unknown as number,
+          }),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
         }),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      ),
     );
 
     act(() => {
@@ -454,16 +517,18 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockResolvedValue([fetched]);
 
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-        analyticsContext: {
-          traderAddress: '0xTRADER',
-          caip19: 'eip155:8453/erc20:0xDEST',
-          amountUsd: 50,
-        },
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+          analyticsContext: {
+            traderAddress: '0xTRADER',
+            caip19: 'eip155:8453/erc20:0xDEST',
+            amountUsd: 50,
+          },
+        }),
+      ),
     );
 
     act(() => {
@@ -497,15 +562,17 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockRejectedValue(new Error('network error'));
 
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-        analyticsContext: {
-          traderAddress: '0xTRADER',
-          caip19: 'eip155:8453/erc20:0xDEST',
-        },
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+          analyticsContext: {
+            traderAddress: '0xTRADER',
+            caip19: 'eip155:8453/erc20:0xDEST',
+          },
+        }),
+      ),
     );
 
     act(() => {
@@ -524,16 +591,18 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
 
     renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-        analyticsContext: {
-          traderAddress: '0xTRADER',
-          caip19: 'eip155:8453/erc20:0xDEST',
-          // amountUsd intentionally absent
-        },
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+          analyticsContext: {
+            traderAddress: '0xTRADER',
+            caip19: 'eip155:8453/erc20:0xDEST',
+            // amountUsd intentionally absent
+          },
+        }),
+      ),
     );
 
     act(() => {
@@ -555,11 +624,13 @@ describe('useQuickBuyQuotes', () => {
       .mockRejectedValue(new Error('network error'));
 
     const { result } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     await act(async () => {
@@ -601,11 +672,13 @@ describe('useQuickBuyQuotes', () => {
     );
 
     const { result } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     act(() => {
@@ -624,11 +697,13 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
 
     const { result, rerender } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     await act(async () => {
@@ -653,11 +728,13 @@ describe('useQuickBuyQuotes', () => {
     fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
 
     const { result, rerender } = renderHook(() =>
-      useQuickBuyQuotes({
-        sourceToken: createSourceToken(),
-        destToken: createDestToken(),
-        sourceTokenAmount: '0.001',
-      }),
+      useQuickBuyQuotes(
+        quotesParams({
+          sourceToken: createSourceToken(),
+          destToken: createDestToken(),
+          sourceTokenAmount: '0.001',
+        }),
+      ),
     );
 
     await act(async () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
@@ -1,0 +1,26 @@
+import { FeatureId } from '@metamask/bridge-controller';
+
+import { getQuickBuyFeatureId } from './getQuickBuyFeatureId';
+
+describe('getQuickBuyFeatureId', () => {
+  it('maps token-details surfaces to QUICK_BUY_TOKEN_DETAILS', () => {
+    expect(getQuickBuyFeatureId('asset_details')).toBe(
+      FeatureId.QUICK_BUY_TOKEN_DETAILS,
+    );
+    expect(getQuickBuyFeatureId('market_insights')).toBe(
+      FeatureId.QUICK_BUY_TOKEN_DETAILS,
+    );
+  });
+
+  it('maps follow-trading surfaces to QUICK_BUY_FOLLOW_TRADING', () => {
+    expect(getQuickBuyFeatureId('leaderboard')).toBe(
+      FeatureId.QUICK_BUY_FOLLOW_TRADING,
+    );
+    expect(getQuickBuyFeatureId('profile_position')).toBe(
+      FeatureId.QUICK_BUY_FOLLOW_TRADING,
+    );
+    expect(getQuickBuyFeatureId('notification')).toBe(
+      FeatureId.QUICK_BUY_FOLLOW_TRADING,
+    );
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
@@ -24,7 +24,7 @@ describe('getQuickBuyFeatureId', () => {
     );
   });
 
-  it('defaults to QUICK_BUY_FOLLOW_TRADING when source is missing', () => {
-    expect(getQuickBuyFeatureId()).toBe(FeatureId.QUICK_BUY_FOLLOW_TRADING);
+  it('defaults to UNKNOWN when source is missing', () => {
+    expect(getQuickBuyFeatureId()).toBe(FeatureId.UNKNOWN);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
@@ -23,4 +23,8 @@ describe('getQuickBuyFeatureId', () => {
       FeatureId.QUICK_BUY_FOLLOW_TRADING,
     );
   });
+
+  it('defaults to QUICK_BUY_FOLLOW_TRADING when source is missing', () => {
+    expect(getQuickBuyFeatureId()).toBe(FeatureId.QUICK_BUY_FOLLOW_TRADING);
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
@@ -2,7 +2,7 @@ import { FeatureId } from '@metamask/bridge-controller';
 
 import type { QuickBuySheetSource } from '../../../../analytics';
 
-export function getQuickBuyFeatureId(source: QuickBuySheetSource): FeatureId {
+export function getQuickBuyFeatureId(source?: QuickBuySheetSource): FeatureId {
   switch (source) {
     case 'asset_details':
     case 'market_insights':
@@ -11,8 +11,7 @@ export function getQuickBuyFeatureId(source: QuickBuySheetSource): FeatureId {
     case 'profile_position':
     case 'notification':
       return FeatureId.QUICK_BUY_FOLLOW_TRADING;
-    default: {
-      throw new Error(`Unsupported QuickBuy source: ${source satisfies never}`);
-    }
+    default:
+      return FeatureId.QUICK_BUY_FOLLOW_TRADING;
   }
 }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
@@ -1,0 +1,18 @@
+import { FeatureId } from '@metamask/bridge-controller';
+
+import type { QuickBuySheetSource } from '../../../../analytics';
+
+export function getQuickBuyFeatureId(source: QuickBuySheetSource): FeatureId {
+  switch (source) {
+    case 'asset_details':
+    case 'market_insights':
+      return FeatureId.QUICK_BUY_TOKEN_DETAILS;
+    case 'leaderboard':
+    case 'profile_position':
+    case 'notification':
+      return FeatureId.QUICK_BUY_FOLLOW_TRADING;
+    default: {
+      throw new Error(`Unsupported QuickBuy source: ${source satisfies never}`);
+    }
+  }
+}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
@@ -12,6 +12,6 @@ export function getQuickBuyFeatureId(source?: QuickBuySheetSource): FeatureId {
     case 'notification':
       return FeatureId.QUICK_BUY_FOLLOW_TRADING;
     default:
-      return FeatureId.QUICK_BUY_FOLLOW_TRADING;
+      return FeatureId.UNKNOWN;
   }
 }

--- a/package.json
+++ b/package.json
@@ -207,8 +207,6 @@
     "@metamask/keyring-api@npm:^21.4.0": "23.1.0",
     "@metamask/keyring-api@npm:^21.6.0": "23.1.0",
     "@metamask/keyring-api@npm:^22.0.0": "23.1.0",
-    "@metamask/bridge-controller@npm:^73.2.0": "npm:@metamask-previews/bridge-controller@73.2.1-preview-f5ff6e53c",
-    "@metamask/bridge-controller@npm:^73.2.1": "npm:@metamask-previews/bridge-controller@73.2.1-preview-f5ff6e53c",
     "@metamask/bridge-status-controller@npm:^71.0.0": "patch:@metamask/bridge-status-controller@npm%3A71.1.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-71.1.0-6140a0bdf3.patch",
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
     "@metamask/permission-controller": "^13.1.1",
@@ -246,8 +244,8 @@
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.12.0",
-    "@metamask/bridge-controller": "^74.0.0",
-    "@metamask/bridge-status-controller": "^72.0.2",
+    "@metamask/bridge-controller": "^75.0.0",
+    "@metamask/bridge-status-controller": "^72.1.0",
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/chomp-api-service": "^3.1.0",
     "@metamask/client-controller": "^1.0.1",
@@ -346,7 +344,7 @@
     "@metamask/storage-service": "^1.0.0",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/transaction-controller": "^67.0.0",
+    "@metamask/transaction-controller": "^67.1.0",
     "@metamask/transaction-pay-controller": "^23.5.0",
     "@metamask/tron-wallet-snap": "^1.25.6",
     "@metamask/utils": "^11.11.0",
@@ -807,24 +805,6 @@
       "eslint-import-resolver-typescript>unrs-resolver": false,
       "tsx>esbuild": false,
       "@metamask/transaction-pay-controller>@metamask/bridge-status-controller>@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography>keccak": false
-    }
-  },
-  "previewBuilds": {
-    "@metamask/bridge-controller": {
-      "type": "breaking",
-      "previewVersion": "73.2.1-preview-f5ff6e53c"
-    },
-    "@metamask/bridge-status-controller": {
-      "type": "non-breaking",
-      "previewVersion": "72.0.2-preview-f5ff6e53c"
-    },
-    "@metamask/transaction-controller": {
-      "type": "breaking",
-      "previewVersion": "66.0.1-preview-f5ff6e53c"
-    },
-    "@metamask/transaction-pay-controller": {
-      "type": "breaking",
-      "previewVersion": "23.1.0-preview-f5ff6e53c"
     }
   },
   "packageManager": "yarn@4.14.1",

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.12.0",
-    "@metamask/bridge-controller": "^75.0.0",
+    "@metamask/bridge-controller": "^75.1.0",
     "@metamask/bridge-status-controller": "^72.1.0",
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/chomp-api-service": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -207,6 +207,8 @@
     "@metamask/keyring-api@npm:^21.4.0": "23.1.0",
     "@metamask/keyring-api@npm:^21.6.0": "23.1.0",
     "@metamask/keyring-api@npm:^22.0.0": "23.1.0",
+    "@metamask/bridge-controller@npm:^73.2.0": "npm:@metamask-previews/bridge-controller@73.2.1-preview-f5ff6e53c",
+    "@metamask/bridge-controller@npm:^73.2.1": "npm:@metamask-previews/bridge-controller@73.2.1-preview-f5ff6e53c",
     "@metamask/bridge-status-controller@npm:^71.0.0": "patch:@metamask/bridge-status-controller@npm%3A71.1.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-71.1.0-6140a0bdf3.patch",
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
     "@metamask/permission-controller": "^13.1.1",
@@ -813,7 +815,7 @@
       "previewVersion": "73.2.1-preview-f5ff6e53c"
     },
     "@metamask/bridge-status-controller": {
-      "type": "breaking",
+      "type": "non-breaking",
       "previewVersion": "72.0.2-preview-f5ff6e53c"
     },
     "@metamask/transaction-controller": {

--- a/package.json
+++ b/package.json
@@ -807,6 +807,24 @@
       "@metamask/transaction-pay-controller>@metamask/bridge-status-controller>@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography>keccak": false
     }
   },
+  "previewBuilds": {
+    "@metamask/bridge-controller": {
+      "type": "breaking",
+      "previewVersion": "73.2.1-preview-f5ff6e53c"
+    },
+    "@metamask/bridge-status-controller": {
+      "type": "breaking",
+      "previewVersion": "72.0.2-preview-f5ff6e53c"
+    },
+    "@metamask/transaction-controller": {
+      "type": "breaking",
+      "previewVersion": "66.0.1-preview-f5ff6e53c"
+    },
+    "@metamask/transaction-pay-controller": {
+      "type": "breaking",
+      "previewVersion": "23.1.0-preview-f5ff6e53c"
+    }
+  },
   "packageManager": "yarn@4.14.1",
   "foundryup": {
     "binaries": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8082,9 +8082,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^74.0.0":
-  version: 74.0.0
-  resolution: "@metamask/bridge-controller@npm:74.0.0"
+"@metamask/bridge-controller@npm:@metamask-previews/bridge-controller@73.2.1-preview-f5ff6e53c":
+  version: 73.2.1-preview-f5ff6e53c
+  resolution: "@metamask-previews/bridge-controller@npm:73.2.1-preview-f5ff6e53c"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -8106,16 +8106,49 @@ __metadata:
     "@metamask/profile-sync-controller": "npm:^28.1.1"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^67.0.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/00f9f88567a0f43b1694bfd2becaef6036fc7fbdd0ad11590e0727d9e0163db241f354fd3dd9f22d731111be32b67a4e3c6e8f6d45b14dcaf1522110fc66f481
+  checksum: 10/ca69d50f26d2403926aad940ae47ea54dda844a9be6440dad7fdac91da4f322395de7dc795e5bcce8e33d5f301e1b50e696623c9cbc2d470250edb9787985ea9
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^75.0.0, @metamask/bridge-controller@npm:^75.1.0":
+"@metamask/bridge-controller@npm:^73.2.1":
+  version: 73.2.1
+  resolution: "@metamask/bridge-controller@npm:73.2.1"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/assets-controller": "npm:^8.3.2"
+    "@metamask/assets-controllers": "npm:^108.5.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.1.3"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
+    "@metamask/profile-sync-controller": "npm:^28.1.1"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/d1a540ace86ed9226ae5f02a65b6f00ab97d22a82fa14d766e2bebe9e4cc14ba6cbc36d965636916e136a17a9c85aa22ccb286425a760c9327de429230704a50
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-controller@npm:^75.0.0":
   version: 75.1.0
   resolution: "@metamask/bridge-controller@npm:75.1.0"
   dependencies:
@@ -8148,7 +8181,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^72.0.2, @metamask/bridge-status-controller@npm:^72.1.0":
+"@metamask/bridge-status-controller@npm:@metamask-previews/bridge-status-controller@72.0.2-preview-f5ff6e53c":
+  version: 72.0.2-preview-f5ff6e53c
+  resolution: "@metamask-previews/bridge-status-controller@npm:72.0.2-preview-f5ff6e53c"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/bridge-controller": "npm:^73.2.1"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
+    "@metamask/profile-sync-controller": "npm:^28.1.1"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/17be66c380f7a8013f3b99de8365dde44efaee89d3f5e3ca014af7ebc5fa871ac942e1815ac279145aa2d1db126acdb066764a82fc791524d5f3c9d9e29bd4af
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@npm:^72.0.2":
   version: 72.1.0
   resolution: "@metamask/bridge-status-controller@npm:72.1.0"
   dependencies:
@@ -10330,33 +10387,71 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^23.5.0":
-  version: 23.5.0
-  resolution: "@metamask/transaction-pay-controller@npm:23.5.0"
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@66.0.1-preview-f5ff6e53c":
+  version: 66.0.1-preview-f5ff6e53c
+  resolution: "@metamask-previews/transaction-controller@npm:66.0.1-preview-f5ff6e53c"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/approval-controller": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/core-backend": "npm:^6.3.2"
+    "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/6409cf2840861bab91f05883d401cab99a176ad164bee0247b03ec9add327c5fdf511ec004dab83f38111e47b108bcf5b290abe34da614b84609f83da1c82c76
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.1.0-preview-f5ff6e53c":
+  version: 23.1.0-preview-f5ff6e53c
+  resolution: "@metamask-previews/transaction-pay-controller@npm:23.1.0-preview-f5ff6e53c"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/assets-controller": "npm:^8.3.3"
-    "@metamask/assets-controllers": "npm:^108.6.0"
+    "@metamask/assets-controller": "npm:^8.3.2"
+    "@metamask/assets-controllers": "npm:^108.5.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^75.1.0"
-    "@metamask/bridge-status-controller": "npm:^72.1.0"
-    "@metamask/controller-utils": "npm:^12.1.1"
+    "@metamask/bridge-controller": "npm:^73.2.1"
+    "@metamask/bridge-status-controller": "npm:^72.0.2"
+    "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-controller": "npm:^27.0.0"
+    "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/ramps-controller": "npm:^14.1.1"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/transaction-controller": "npm:^67.1.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/fee0488d37c030298b29b6b8369a14bb2ff925c3c2cd1e555e8ee6236fecf040a4aaaaef6767dcca96e8154846ea7262ebc2bfc863c58657952245571a0391d0
+  checksum: 10/54bda4a631b44461f79cdab6e65d0e6e9ddefafb06422f04d35fa13bb57cc70087a91ea4a2c899f64d41048938b8217ff6c0e1328160b5675e35d661773bbfd3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8115,39 +8115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^75.1.0":
-  version: 75.1.0
-  resolution: "@metamask/bridge-controller@npm:75.1.0"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.1"
-    "@metamask/assets-controller": "npm:^8.3.3"
-    "@metamask/assets-controllers": "npm:^108.6.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.1"
-    "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^3.1.3"
-    "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/polling-controller": "npm:^16.0.6"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^67.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/bc4c2ab91337cfc2a277b9dbe3d02bd6600af2f174fd157e68c69e07839cb34d0b7fe6ccdf903535a3265380b4641c48a28b4a7e1dc489629ac8ae6e9b1b5a7f
-  languageName: node
-  linkType: hard
-
 "@metamask/bridge-status-controller@npm:^72.1.0":
   version: 72.1.0
   resolution: "@metamask/bridge-status-controller@npm:72.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8115,6 +8115,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/bridge-controller@npm:^75.1.0":
+  version: 75.1.0
+  resolution: "@metamask/bridge-controller@npm:75.1.0"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^39.0.1"
+    "@metamask/assets-controller": "npm:^8.3.3"
+    "@metamask/assets-controllers": "npm:^108.6.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.1.1"
+    "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.1.3"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
+    "@metamask/profile-sync-controller": "npm:^28.1.1"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/transaction-controller": "npm:^67.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/bc4c2ab91337cfc2a277b9dbe3d02bd6600af2f174fd157e68c69e07839cb34d0b7fe6ccdf903535a3265380b4641c48a28b4a7e1dc489629ac8ae6e9b1b5a7f
+  languageName: node
+  linkType: hard
+
 "@metamask/bridge-status-controller@npm:^72.1.0":
   version: 72.1.0
   resolution: "@metamask/bridge-status-controller@npm:72.1.0"
@@ -35210,7 +35243,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
-    "@metamask/bridge-controller": "npm:^75.0.0"
+    "@metamask/bridge-controller": "npm:^75.1.0"
     "@metamask/bridge-status-controller": "npm:^72.1.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,7 +7880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.2":
+"@metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.3":
   version: 8.3.3
   resolution: "@metamask/assets-controller@npm:8.3.3"
   dependencies:
@@ -7917,7 +7917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^108.4.0, @metamask/assets-controllers@npm:^108.5.0, @metamask/assets-controllers@npm:^108.6.0":
+"@metamask/assets-controllers@npm:^108.4.0, @metamask/assets-controllers@npm:^108.6.0":
   version: 108.6.0
   resolution: "@metamask/assets-controllers@npm:108.6.0"
   dependencies:
@@ -8082,20 +8082,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:@metamask-previews/bridge-controller@73.2.1-preview-f5ff6e53c":
-  version: 73.2.1-preview-f5ff6e53c
-  resolution: "@metamask-previews/bridge-controller@npm:73.2.1-preview-f5ff6e53c"
+"@metamask/bridge-controller@npm:^75.0.0, @metamask/bridge-controller@npm:^75.1.0":
+  version: 75.1.0
+  resolution: "@metamask/bridge-controller@npm:75.1.0"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
     "@ethersproject/constants": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.0"
-    "@metamask/assets-controller": "npm:^8.3.2"
-    "@metamask/assets-controllers": "npm:^108.5.0"
+    "@metamask/accounts-controller": "npm:^39.0.1"
+    "@metamask/assets-controller": "npm:^8.3.3"
+    "@metamask/assets-controllers": "npm:^108.6.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/controller-utils": "npm:^12.1.1"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/messenger": "npm:^1.2.0"
@@ -8106,36 +8106,36 @@ __metadata:
     "@metamask/profile-sync-controller": "npm:^28.1.1"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^66.0.1"
+    "@metamask/transaction-controller": "npm:^67.1.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/ca69d50f26d2403926aad940ae47ea54dda844a9be6440dad7fdac91da4f322395de7dc795e5bcce8e33d5f301e1b50e696623c9cbc2d470250edb9787985ea9
+  checksum: 10/bc4c2ab91337cfc2a277b9dbe3d02bd6600af2f174fd157e68c69e07839cb34d0b7fe6ccdf903535a3265380b4641c48a28b4a7e1dc489629ac8ae6e9b1b5a7f
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:@metamask-previews/bridge-status-controller@72.0.2-preview-f5ff6e53c":
-  version: 72.0.2-preview-f5ff6e53c
-  resolution: "@metamask-previews/bridge-status-controller@npm:72.0.2-preview-f5ff6e53c"
+"@metamask/bridge-status-controller@npm:^72.1.0":
+  version: 72.1.0
+  resolution: "@metamask/bridge-status-controller@npm:72.1.0"
   dependencies:
-    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/accounts-controller": "npm:^39.0.1"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^73.2.1"
-    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/bridge-controller": "npm:^75.0.0"
+    "@metamask/controller-utils": "npm:^12.1.1"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/keyring-controller": "npm:^27.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/polling-controller": "npm:^16.0.6"
     "@metamask/profile-sync-controller": "npm:^28.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^66.0.1"
+    "@metamask/transaction-controller": "npm:^67.1.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
-  checksum: 10/17be66c380f7a8013f3b99de8365dde44efaee89d3f5e3ca014af7ebc5fa871ac942e1815ac279145aa2d1db126acdb066764a82fc791524d5f3c9d9e29bd4af
+  checksum: 10/61b940736a8ce327de7e6bc87ed02a5256b0ad7fd6b3c2118d82592d3019b2c134b1779acdb4ea841df4d1b4f75a4046deb7157563223e98ac74b02d08696fa9
   languageName: node
   linkType: hard
 
@@ -10297,71 +10297,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@66.0.1-preview-f5ff6e53c":
-  version: 66.0.1-preview-f5ff6e53c
-  resolution: "@metamask-previews/transaction-controller@npm:66.0.1-preview-f5ff6e53c"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.0"
-    "@metamask/approval-controller": "npm:^9.0.1"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/core-backend": "npm:^6.3.2"
-    "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/6409cf2840861bab91f05883d401cab99a176ad164bee0247b03ec9add327c5fdf511ec004dab83f38111e47b108bcf5b290abe34da614b84609f83da1c82c76
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-pay-controller@npm:@metamask-previews/transaction-pay-controller@23.1.0-preview-f5ff6e53c":
-  version: 23.1.0-preview-f5ff6e53c
-  resolution: "@metamask-previews/transaction-pay-controller@npm:23.1.0-preview-f5ff6e53c"
+"@metamask/transaction-pay-controller@npm:^23.5.0":
+  version: 23.5.0
+  resolution: "@metamask/transaction-pay-controller@npm:23.5.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/assets-controller": "npm:^8.3.2"
-    "@metamask/assets-controllers": "npm:^108.5.0"
+    "@metamask/assets-controller": "npm:^8.3.3"
+    "@metamask/assets-controllers": "npm:^108.6.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^73.2.1"
-    "@metamask/bridge-status-controller": "npm:^72.0.2"
-    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/bridge-controller": "npm:^75.1.0"
+    "@metamask/bridge-status-controller": "npm:^72.1.0"
+    "@metamask/controller-utils": "npm:^12.1.1"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/keyring-controller": "npm:^27.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/ramps-controller": "npm:^14.1.1"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/transaction-controller": "npm:^66.0.1"
+    "@metamask/transaction-controller": "npm:^67.1.0"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/54bda4a631b44461f79cdab6e65d0e6e9ddefafb06422f04d35fa13bb57cc70087a91ea4a2c899f64d41048938b8217ff6c0e1328160b5675e35d661773bbfd3
+  checksum: 10/fee0488d37c030298b29b6b8369a14bb2ff925c3c2cd1e555e8ee6236fecf040a4aaaaef6767dcca96e8154846ea7262ebc2bfc863c58657952245571a0391d0
   languageName: node
   linkType: hard
 
@@ -35248,8 +35210,8 @@ __metadata:
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
-    "@metamask/bridge-controller": "npm:^74.0.0"
-    "@metamask/bridge-status-controller": "npm:^72.0.2"
+    "@metamask/bridge-controller": "npm:^75.0.0"
+    "@metamask/bridge-status-controller": "npm:^72.1.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.3.0"
     "@metamask/build-utils": "npm:^3.0.0"
@@ -35361,7 +35323,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.5.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
-    "@metamask/transaction-controller": "npm:^67.0.0"
+    "@metamask/transaction-controller": "npm:^67.1.0"
     "@metamask/transaction-pay-controller": "npm:^23.5.0"
     "@metamask/tron-wallet-snap": "npm:^1.25.6"
     "@metamask/utils": "npm:^11.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,7 +7880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.2, @metamask/assets-controller@npm:^8.3.3":
+"@metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.2":
   version: 8.3.3
   resolution: "@metamask/assets-controller@npm:8.3.3"
   dependencies:
@@ -8115,72 +8115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^73.2.1":
-  version: 73.2.1
-  resolution: "@metamask/bridge-controller@npm:73.2.1"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.0"
-    "@metamask/assets-controller": "npm:^8.3.2"
-    "@metamask/assets-controllers": "npm:^108.5.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^3.1.3"
-    "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/polling-controller": "npm:^16.0.6"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^66.0.1"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/d1a540ace86ed9226ae5f02a65b6f00ab97d22a82fa14d766e2bebe9e4cc14ba6cbc36d965636916e136a17a9c85aa22ccb286425a760c9327de429230704a50
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-controller@npm:^75.0.0":
-  version: 75.1.0
-  resolution: "@metamask/bridge-controller@npm:75.1.0"
-  dependencies:
-    "@ethersproject/address": "npm:^5.7.0"
-    "@ethersproject/bignumber": "npm:^5.7.0"
-    "@ethersproject/constants": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.1"
-    "@metamask/assets-controller": "npm:^8.3.3"
-    "@metamask/assets-controllers": "npm:^108.6.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.1"
-    "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^3.1.3"
-    "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/polling-controller": "npm:^16.0.6"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^67.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    reselect: "npm:^5.1.1"
-    uuid: "npm:^8.3.2"
-  checksum: 10/bc4c2ab91337cfc2a277b9dbe3d02bd6600af2f174fd157e68c69e07839cb34d0b7fe6ccdf903535a3265380b4641c48a28b4a7e1dc489629ac8ae6e9b1b5a7f
-  languageName: node
-  linkType: hard
-
 "@metamask/bridge-status-controller@npm:@metamask-previews/bridge-status-controller@72.0.2-preview-f5ff6e53c":
   version: 72.0.2-preview-f5ff6e53c
   resolution: "@metamask-previews/bridge-status-controller@npm:72.0.2-preview-f5ff6e53c"
@@ -8202,30 +8136,6 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/17be66c380f7a8013f3b99de8365dde44efaee89d3f5e3ca014af7ebc5fa871ac942e1815ac279145aa2d1db126acdb066764a82fc791524d5f3c9d9e29bd4af
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-status-controller@npm:^72.0.2":
-  version: 72.1.0
-  resolution: "@metamask/bridge-status-controller@npm:72.1.0"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^39.0.1"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^75.0.0"
-    "@metamask/controller-utils": "npm:^12.1.1"
-    "@metamask/gas-fee-controller": "npm:^26.2.2"
-    "@metamask/keyring-controller": "npm:^27.0.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/polling-controller": "npm:^16.0.6"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^67.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-    bignumber.js: "npm:^9.1.2"
-    uuid: "npm:^8.3.2"
-  checksum: 10/61b940736a8ce327de7e6bc87ed02a5256b0ad7fd6b3c2118d82592d3019b2c134b1779acdb4ea841df4d1b4f75a4046deb7157563223e98ac74b02d08696fa9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Integrates the required `feature_id` parameter from [MetaMask/core#8964](https://github.com/MetaMask/core/pull/8964) across Unified Swap/Bridge, Batch Sell, and Quick Buy quote flows.

**Why:** `bridge-controller` now requires `FeatureId` on `fetchQuotes` and on client-supplied analytics context for unified swap/bridge events. Without it, quote fetches and some metrics payloads are incomplete or fail type-checking against the new API.

**What changed:**

- **Unified Swap/Bridge:** Pass `feature_id: UNIFIED_SWAP_BRIDGE` in `useUnifiedSwapBridgeContext` (quote polling context) and on client `trackUnifiedSwapBridgeEvent` call sites (`useTrackAllQuotesSortedEvent`, `GaslessQuickPickOptions`, `BridgeTokenSelector` asset tooltip).
- **Batch Sell:** Pass `feature_id: BATCH_SELL` in `useBatchSellQuoteRequest` quote context.
- **Quick Buy:** Add `getQuickBuyFeatureId` to map `QuickBuySheetSource` → `FeatureId` (`QUICK_BUY_TOKEN_DETAILS` vs `QUICK_BUY_FOLLOW_TRADING`); thread analytics `source` through `useQuickBuyController` and pass the resolved id to `BridgeController.fetchQuotes(params, featureId, signal)`.
- **Tests:** Update/add unit tests for the above contexts and Quick Buy quote fetching.

**Follow-up after core#8964 merges:** Remove `previewBuilds` / resolutions and bump to released package versions.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [SWAPS-4561](https://consensyssoftware.atlassian.net/browse/SWAPS-4561)

Refs: [MetaMask/core#8964](https://github.com/MetaMask/core/pull/8964)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: feature_id on swap/bridge quote flows

  Scenario: Unified Swap/Bridge still fetches quotes
    Given the app is built with preview bridge-controller packages (yarn install)
    And I open Unified Swap/Bridge from a token or the wallet swap entry point
    When the swap form loads and requests quotes
    Then quotes load without errors and the swap flow remains usable

  Scenario: Batch Sell still fetches quotes
    Given Batch Sell is available in the build
    When I open Batch Sell and trigger a quote request
    Then quotes load without errors

  Scenario: Quick Buy still fetches quotes from follow-trading
    Given Social Leaderboard is enabled
    When I open a trader position and tap Buy to open Quick Buy
    Then the Quick Buy sheet loads quotes without error

  Scenario: Quick Buy still fetches quotes from token details
    Given socialAiAssetDetailsQuickBuy is enabled
    When I open Token Details and tap the Quick Buy (lightning) button
    Then the Quick Buy sheet loads quotes without error
```

**Automated verification run locally:**

```bash
yarn lint:tsc
yarn jest app/components/UI/Bridge/hooks/useUnifiedSwapBridgeContext/useUnifiedSwapBridgeContext.test.ts
yarn jest app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
yarn jest app/components/UI/Bridge/hooks/useTrackAllQuotesSortedEvent/index.test.ts
yarn jest app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
yarn jest app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyQuotes.test.ts
yarn jest app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — analytics and controller plumbing only; no user-visible UI changes.

### **Before**

N/A

### **After**


<img width="685" height="93" alt="Screenshot 2026-06-08 at 5 29 57 PM" src="https://github.com/user-attachments/assets/17109fe7-2203-4379-8b07-042da3401d5d" />
<img width="737" height="155" alt="Screenshot 2026-06-08 at 5 30 15 PM" src="https://github.com/user-attachments/assets/2ab8f297-2eb2-4eb7-adc8-a7e9c0eb37fe" />
<img width="685" height="181" alt="Screenshot 2026-06-08 at 5 30 26 PM" src="https://github.com/user-attachments/assets/fb0bbd0a-a2c9-458c-bdac-3c0849e3e251" />
<img width="520" height="195" alt="Screenshot 2026-06-08 at 5 30 54 PM" src="https://github.com/user-attachments/assets/211396df-29f6-47db-9663-4931b1c3605c" />
<img width="587" height="163" alt="Screenshot 2026-06-08 at 5 31 14 PM" src="https://github.com/user-attachments/assets/84a4cda8-6dae-41d3-aed0-824dd62633f6" />
<img width="683" height="89" alt="Screenshot 2026-06-08 at 5 31 29 PM" src="https://github.com/user-attachments/assets/9c9b1c9b-af89-4078-b43d-3a7322b89781" />
<img width="703" height="154" alt="Screenshot 2026-06-08 at 5 31 36 PM" src="https://github.com/user-attachments/assets/983088e4-3265-4251-80b1-bdfcdc0e956d" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4561]: https://consensyssoftware.atlassian.net/browse/SWAPS-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quote fetching and analytics context across Unified Swap/Bridge, Batch Sell, and Quick Buy; behavior should be unchanged aside from attribution, but a wrong or missing id could break typing or mislabel metrics after the controller API change.
> 
> **Overview**
> Bumps **`@metamask/bridge-controller`** (and related lockfile entries) so quote and analytics APIs can require a **`FeatureId`**, then threads that id through swap/bridge, batch sell, and Quick Buy.
> 
> **Unified Swap/Bridge** adds `feature_id: FeatureId.UNIFIED_SWAP_BRIDGE` to shared quote context (`useUnifiedSwapBridgeContext`) and to client `trackUnifiedSwapBridgeEvent` payloads (quotes sorted, gasless keypad input, token asset tooltip). **Batch Sell** adds `feature_id: FeatureId.BATCH_SELL` on batch quote request context.
> 
> **Quick Buy** introduces `getQuickBuyFeatureId` to map sheet entry `source` to `QUICK_BUY_TOKEN_DETAILS` vs `QUICK_BUY_FOLLOW_TRADING`, passes analytics `source` from `useQuickBuyController`, and calls `BridgeController.fetchQuotes(params, featureId, signal)` instead of a string literal. Unit tests are updated across these flows, including abort-signal argument index changes for the new `fetchQuotes` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06c3e07466684216f7714782965ebebec7ef197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->