### PR TITLE
chore: add design system deprecation jsdoc

### DIFF
--- a/app/component-library/components-temp/HeaderRoot/HeaderRoot.tsx
+++ b/app/component-library/components-temp/HeaderRoot/HeaderRoot.tsx
@@ -18,6 +18,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 // Internal dependencies.
 import { HeaderRootProps } from './HeaderRoot.types';
 
+/**
+ * @deprecated Please update your code to use `HeaderRoot` from `@metamask/design-system-react-native`.
+ */
 const HeaderRoot: React.FC<HeaderRootProps> = ({
   children,
   title,

--- a/app/component-library/components-temp/HeaderStandardAnimated/HeaderStandardAnimated.tsx
+++ b/app/component-library/components-temp/HeaderStandardAnimated/HeaderStandardAnimated.tsx
@@ -20,6 +20,9 @@ import Animated, {
 import HeaderCompactStandard from '../HeaderCompactStandard';
 import { HeaderStandardAnimatedProps } from './HeaderStandardAnimated.types';
 
+/**
+ * @deprecated Please update your code to use `HeaderStandardAnimated` from `@metamask/design-system-react-native`.
+ */
 const HeaderStandardAnimated: React.FC<HeaderStandardAnimatedProps> = ({
   title,
   titleProps,

--- a/app/component-library/components-temp/HeaderStandardAnimated/useHeaderStandardAnimated.ts
+++ b/app/component-library/components-temp/HeaderStandardAnimated/useHeaderStandardAnimated.ts
@@ -13,6 +13,8 @@ import { UseHeaderStandardAnimatedReturn } from './HeaderStandardAnimated.types'
  * Use with HeaderStandardAnimated placed outside the ScrollView as a sibling.
  * Use the returned onScroll with Animated.ScrollView for UI-thread scroll updates (zero lag).
  *
+ * @deprecated Please update your code to use `useHeaderStandardAnimated` from `@metamask/design-system-react-native`.
+ *
  * @returns Object containing scrollY, titleSectionHeightSv, setTitleSectionHeight, and onScroll.
  *
  * @example

--- a/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
+++ b/app/component-library/components-temp/SectionHeader/SectionHeader.tsx
@@ -20,6 +20,8 @@ import { SectionHeaderProps } from './SectionHeader.types';
 /**
  * SectionHeader — homepage section header with optional press-to-navigate.
  *
+ * @deprecated Please update your code to use `SectionHeader` from `@metamask/design-system-react-native`.
+ *
  * @version 1 - UX Team (interim component)
  *
  * This is a v1 implementation created by the UX team to unblock RC milestones

--- a/app/component-library/components-temp/Skeleton/Skeleton.tsx
+++ b/app/component-library/components-temp/Skeleton/Skeleton.tsx
@@ -5,9 +5,6 @@ import {
 } from '@metamask/design-system-react-native';
 import { hasTestOverrides } from '../../../util/test/utils';
 
-/**
- * @deprecated Please update your code to use `Skeleton` from `@metamask/design-system-react-native`.
- */
 const Skeleton: React.FC<SkeletonProps> = (props) => (
   <DSRNSkeleton
     autoPlay={!hasTestOverrides && !process.env.JEST_WORKER_ID}

--- a/app/component-library/components-temp/Skeleton/Skeleton.tsx
+++ b/app/component-library/components-temp/Skeleton/Skeleton.tsx
@@ -5,6 +5,9 @@ import {
 } from '@metamask/design-system-react-native';
 import { hasTestOverrides } from '../../../util/test/utils';
 
+/**
+ * @deprecated Please update your code to use `Skeleton` from `@metamask/design-system-react-native`.
+ */
 const Skeleton: React.FC<SkeletonProps> = (props) => (
   <DSRNSkeleton
     autoPlay={!hasTestOverrides && !process.env.JEST_WORKER_ID}

--- a/app/component-library/components-temp/TitleStandard/TitleStandard.tsx
+++ b/app/component-library/components-temp/TitleStandard/TitleStandard.tsx
@@ -19,6 +19,8 @@ import { TitleStandardProps } from './TitleStandard.types';
  * TitleStandard is a component that displays a title with optional accessories
  * in a left-aligned layout.
  *
+ * @deprecated Please update your code to use `TitleStandard` from `@metamask/design-system-react-native`.
+ *
  * @example
  * ```tsx
  * <TitleStandard

--- a/app/component-library/components-temp/TitleSubpage/TitleSubpage.tsx
+++ b/app/component-library/components-temp/TitleSubpage/TitleSubpage.tsx
@@ -19,6 +19,8 @@ import { TitleSubpageProps } from './TitleSubpage.types';
  * TitleSubpage is a component that displays a title with optional accessories
  * in a left-aligned layout, with an optional startAccessory to the left.
  *
+ * @deprecated Please update your code to use `TitleSubpage` from `@metamask/design-system-react-native`.
+ *
  * @example
  * ```tsx
  * <TitleSubpage

--- a/app/component-library/components/Select/SelectButton/SelectButton.tsx
+++ b/app/component-library/components/Select/SelectButton/SelectButton.tsx
@@ -23,6 +23,9 @@ import {
   SELECTBUTTON_TESTID,
 } from './SelectButton.constants';
 
+/**
+ * @deprecated Please update your code to use `SelectButton` from `@metamask/design-system-react-native`.
+ */
 const SelectButton: React.FC<SelectButtonProps> = ({
   style,
   size = DEFAULT_SELECTBUTTON_SIZE,

--- a/app/component-library/components/Tags/Tag/Tag.tsx
+++ b/app/component-library/components/Tags/Tag/Tag.tsx
@@ -12,6 +12,9 @@ import { useStyles } from '../../../hooks';
 import styleSheet from './Tag.styles';
 import { TagProps } from './Tag.types';
 
+/**
+ * @deprecated Please update your code to use `Tag` from `@metamask/design-system-react-native`.
+ */
 const Tag = ({ label, style, ...props }: TagProps) => {
   const { styles } = useStyles(styleSheet, { style });
 

--- a/app/components/UI/Box/Box.tsx
+++ b/app/components/UI/Box/Box.tsx
@@ -57,6 +57,9 @@ export interface BoxProps extends ViewProps {
   testID?: string;
 }
 
+/**
+ * @deprecated Please update your code to use `Box` from `@metamask/design-system-react-native`.
+ */
 export const Box = React.forwardRef<View, BoxProps>(
   ({ children, ...props }, ref) => (
     <View


### PR DESCRIPTION
## **Description**

Adds missing `@deprecated` JSDoc tags to legacy local components that now have confirmed equivalents in `@metamask/design-system-react-native`.

This documents the migration path for the remaining matching components in `app/component-library` and adds the requested deprecation tag to `app/components/UI/Box`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Design system deprecation JSDoc coverage

  Scenario: component deprecation tags are documented
    Given the local component library contains legacy components that match design-system-react-native exports

    When the component files are inspected
    Then matching legacy components include @deprecated JSDoc pointing to @metamask/design-system-react-native
```

Validation performed:

- `rg "@deprecated" app/component-library/components-temp/HeaderRoot app/component-library/components-temp/HeaderStandardAnimated app/component-library/components-temp/SectionHeader app/component-library/components/Select/SelectButton app/component-library/components-temp/Skeleton app/component-library/components/Tags/Tag app/component-library/components-temp/TitleStandard app/component-library/components-temp/TitleSubpage app/components/UI/Box`
- Exact-name audit against installed `@metamask/design-system-react-native` exports
- `yarn lint:tsc`

## **Screenshots/Recordings**

### **Before**

N/A - documentation-only JSDoc update.

### **After**

N/A - documentation-only JSDoc update.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only changes with no behavioral impact; may surface IDE deprecation warnings for existing imports.
> 
> **Overview**
> Adds **`@deprecated` JSDoc** on legacy local UI wrappers so IDEs and docs steer imports toward **`@metamask/design-system-react-native`** for components that already have same-named package exports.
> 
> Coverage spans **`components-temp`** (`HeaderRoot`, `HeaderStandardAnimated`, `useHeaderStandardAnimated`, `SectionHeader`, `Skeleton`, `TitleStandard`, `TitleSubpage`), **`component-library`** (`SelectButton`, `Tag`), and **`app/components/UI/Box`**. Each tag names the matching design-system symbol; existing descriptions (e.g. `SectionHeader` interim v1 note, `useHeaderStandardAnimated` hook docs) are preserved where present.
> 
> **No runtime, styling, or export changes**—documentation-only migration hints aligned with an export-name audit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e656c2b0457a0807b8d673e10f52d969a30be115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->