### PR TITLE
fix(rewards): campaign cta geo restriction

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.test.tsx
@@ -34,12 +34,25 @@ jest.mock('./CampaignOptInSheet', () => {
 // Controlled per-test via these variables
 let mockIsGeoRestricted = false;
 let mockIsGeoLoading = false;
+const mockUseCampaignGeoRestriction = jest.fn<
+  { isGeoRestricted: boolean; isGeoLoading: boolean },
+  [unknown?, Set<string>?, boolean?]
+>(() => ({
+  isGeoRestricted: mockIsGeoRestricted,
+  isGeoLoading: mockIsGeoLoading,
+}));
 jest.mock('../../hooks/useCampaignGeoRestriction', () => ({
   __esModule: true,
-  default: () => ({
-    isGeoRestricted: mockIsGeoRestricted,
-    isGeoLoading: mockIsGeoLoading,
-  }),
+  default: (
+    campaign: unknown,
+    customRestrictedCountries?: Set<string>,
+    isFeatureGeoRestricted?: boolean,
+  ) =>
+    mockUseCampaignGeoRestriction(
+      campaign,
+      customRestrictedCountries,
+      isFeatureGeoRestricted,
+    ),
 }));
 
 const mockShowToast = jest.fn();
@@ -265,6 +278,24 @@ describe('CampaignOptInCta', () => {
         />,
       );
       expect(queryByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON)).toBeNull();
+    });
+  });
+
+  describe('feature geo restriction', () => {
+    it('passes isFeatureGeoRestricted to useCampaignGeoRestriction', () => {
+      render(
+        <CampaignOptInCta
+          campaign={buildCampaign()}
+          participantStatus={notOptedIn}
+          isFeatureGeoRestricted
+        />,
+      );
+
+      expect(mockUseCampaignGeoRestriction).toHaveBeenCalledWith(
+        buildCampaign(),
+        undefined,
+        true,
+      );
     });
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignOptInCta.tsx
@@ -27,6 +27,8 @@ interface CampaignOptInCtaProps {
   onJoinPress?: () => void;
   /** An optional set of country codes that are restricted independently of the campaign's `excludedRegions`. Checked before `excludedRegions`. When the user's country matches this list the CTA shows "Check eligibility" and a geo-locked toast instead of opening the opt-in sheet. */
   customRestrictedCountries?: Set<string>;
+  /** When `true`, the user is geo-restricted because the underlying product feature is unavailable in their region. */
+  isFeatureGeoRestricted?: boolean;
 }
 
 /**
@@ -40,12 +42,14 @@ const CampaignOptInCta: React.FC<CampaignOptInCtaProps> = ({
   participantStatus,
   onJoinPress,
   customRestrictedCountries,
+  isFeatureGeoRestricted,
 }) => {
   const [isOptInSheetOpen, setIsOptInSheetOpen] = useState(false);
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const { isGeoRestricted, isGeoLoading } = useCampaignGeoRestriction(
     campaign,
     customRestrictedCountries,
+    isFeatureGeoRestricted,
   );
 
   const campaignStatus = getCampaignStatus(campaign);

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.test.tsx
@@ -27,6 +27,18 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
+jest.mock('../../hooks/useCampaignGeoRestriction', () => ({
+  __esModule: true,
+  default: (
+    _campaign: unknown,
+    _customRestrictedCountries: unknown,
+    isFeatureGeoRestricted?: boolean,
+  ) => ({
+    isGeoRestricted: isFeatureGeoRestricted === true,
+    isGeoLoading: false,
+  }),
+}));
+
 const mockShowToast = jest.fn();
 const mockEntriesClosed = jest.fn(() => ({ variant: 'icon' }));
 

--- a/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PerpsTradingCampaignCTA.tsx
@@ -1,21 +1,18 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
   Box,
   Button,
   ButtonSize,
   ButtonVariant,
-  IconName,
 } from '@metamask/design-system-react-native';
 import type { CampaignDto } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import type { UseGetCampaignParticipantStatusResult } from '../../hooks/useGetCampaignParticipantStatus';
 import { getCampaignStatus } from './CampaignTile.utils';
 import { strings } from '../../../../../../locales/i18n';
-import CampaignOptInSheet from './CampaignOptInSheet';
-import { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
 import { selectPerpsEligibility } from '../../../Perps/selectors/perpsController';
 import { useSelector } from 'react-redux';
-import useRewardsToast from '../../hooks/useRewardsToast';
 import { handleDeeplink } from '../../../../../core/DeeplinkManager';
+import CampaignOptInCta, { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
 
 interface PerpsTradingCampaignCTAProps {
   campaign: CampaignDto;
@@ -29,26 +26,11 @@ const PerpsTradingCampaignCTA: React.FC<PerpsTradingCampaignCTAProps> = ({
   campaign,
   participantStatus,
 }) => {
-  const { showToast, RewardsToastOptions } = useRewardsToast();
   const isPerpsEligible = useSelector(selectPerpsEligibility);
-  const [isOptInSheetOpen, setIsOptInSheetOpen] = useState(false);
 
   const campaignStatus = getCampaignStatus(campaign);
   const isLoading = participantStatus.isLoading;
   const isOptedIn = participantStatus?.status?.optedIn === true;
-
-  const handleGeoLockedPress = useCallback(() => {
-    showToast(
-      RewardsToastOptions.entriesClosed(
-        strings('rewards.campaign.geo_locked_toast_title'),
-        strings('rewards.campaign.geo_locked_toast_description'),
-      ),
-    );
-  }, [showToast, RewardsToastOptions]);
-
-  const handleJoinPress = useCallback(() => {
-    setIsOptInSheetOpen(true);
-  }, []);
 
   const handleOpenPosition = useCallback(async () => {
     await handleDeeplink({
@@ -56,21 +38,7 @@ const PerpsTradingCampaignCTA: React.FC<PerpsTradingCampaignCTAProps> = ({
     });
   }, []);
 
-  if (isLoading) {
-    return null;
-  }
-
-  // Campaign complete — no CTA (leaderboard section handles it)
-  if (campaignStatus === 'complete') {
-    return null;
-  }
-
-  if (campaignStatus !== 'active') {
-    return null;
-  }
-
-  // Opted in — show "Trade now"
-  if (isOptedIn) {
+  if (!isLoading && campaignStatus === 'active' && isOptedIn) {
     return (
       <Box twClassName="p-4 mb-2">
         <Button
@@ -86,45 +54,12 @@ const PerpsTradingCampaignCTA: React.FC<PerpsTradingCampaignCTAProps> = ({
     );
   }
 
-  // Not opted in — geo-restricted
-  if (!isPerpsEligible) {
-    return (
-      <Box twClassName="p-4 mb-2">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          isFullWidth
-          startIconName={IconName.Lock}
-          onPress={handleGeoLockedPress}
-          testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
-        >
-          {strings('rewards.campaign.geo_locked_cta')}
-        </Button>
-      </Box>
-    );
-  }
-
-  // Not opted in — eligible
   return (
-    <>
-      <Box twClassName="p-4 mb-2">
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          isFullWidth
-          onPress={handleJoinPress}
-          testID={CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON}
-        >
-          {strings('rewards.campaign_details.join_campaign')}
-        </Button>
-      </Box>
-      {isOptInSheetOpen && (
-        <CampaignOptInSheet
-          campaign={campaign}
-          onClose={() => setIsOptInSheetOpen(false)}
-        />
-      )}
-    </>
+    <CampaignOptInCta
+      campaign={campaign}
+      participantStatus={participantStatus}
+      isFeatureGeoRestricted={!isPerpsEligible}
+    />
   );
 };
 

--- a/app/components/UI/Rewards/components/Campaigns/PredictThePitchCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PredictThePitchCampaignCTA.test.tsx
@@ -10,6 +10,15 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { PredictEventValues } from '../../../Predict/constants/eventNames';
 
 const mockNavigate = jest.fn();
+let mockIsPredictEligible = true;
+
+jest.mock('../../../Predict/hooks/usePredictEligibility', () => ({
+  usePredictEligibility: () => ({
+    isEligible: mockIsPredictEligible,
+    country: 'US',
+    refreshEligibility: jest.fn(),
+  }),
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
@@ -23,15 +32,25 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
 
 jest.mock('../../hooks/useCampaignGeoRestriction', () => ({
   __esModule: true,
-  default: () => ({ isGeoRestricted: false, isGeoLoading: false }),
+  default: (
+    _campaign: unknown,
+    _customRestrictedCountries: unknown,
+    isFeatureGeoRestricted?: boolean,
+  ) => ({
+    isGeoRestricted: isFeatureGeoRestricted === true,
+    isGeoLoading: false,
+  }),
 }));
+
+const mockShowToast = jest.fn();
+const mockEntriesClosed = jest.fn(() => ({ variant: 'icon' }));
 
 jest.mock('../../hooks/useRewardsToast', () => ({
   __esModule: true,
   default: () => ({
-    showToast: jest.fn(),
+    showToast: mockShowToast,
     RewardsToastOptions: {
-      entriesClosed: jest.fn(),
+      entriesClosed: mockEntriesClosed,
     },
   }),
 }));
@@ -52,6 +71,10 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'rewards.predict_the_pitch_campaign.predict_now_cta': 'Predict now',
       'rewards.campaign_details.join_campaign': 'Join Campaign',
       'rewards.campaign.geo_loading': 'Checking eligibility',
+      'rewards.campaign.geo_locked_cta': 'Check eligibility',
+      'rewards.campaign.geo_locked_toast_title': 'Not available in your region',
+      'rewards.campaign.geo_locked_toast_description':
+        "This campaign isn't available where you are. Check back later for new campaigns.",
     };
     return map[key] ?? key;
   },
@@ -78,6 +101,7 @@ describe('PredictThePitchCampaignCTA', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-08-15T12:00:00.000Z'));
     jest.clearAllMocks();
+    mockIsPredictEligible = true;
   });
 
   afterEach(() => {
@@ -123,6 +147,30 @@ describe('PredictThePitchCampaignCTA', () => {
     fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
 
     expect(getByTestId('campaign-opt-in-sheet')).toBeOnTheScreen();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows the geo-locked CTA when predict is not eligible and the user is not opted in', () => {
+    mockIsPredictEligible = false;
+
+    const { getByTestId, getByText } = render(
+      <PredictThePitchCampaignCTA
+        campaign={buildCampaign()}
+        participantStatus={{
+          status: { optedIn: false, participantCount: 0 },
+          isLoading: false,
+        }}
+      />,
+    );
+
+    expect(getByText('Check eligibility')).toBeOnTheScreen();
+    fireEvent.press(getByTestId(CAMPAIGN_CTA_TEST_IDS.CTA_BUTTON));
+
+    expect(mockEntriesClosed).toHaveBeenCalledWith(
+      'Not available in your region',
+      "This campaign isn't available where you are. Check back later for new campaigns.",
+    );
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 

--- a/app/components/UI/Rewards/components/Campaigns/PredictThePitchCampaignCTA.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/PredictThePitchCampaignCTA.tsx
@@ -11,6 +11,7 @@ import type { UseGetCampaignParticipantStatusResult } from '../../hooks/useGetCa
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { PredictEventValues } from '../../../Predict/constants/eventNames';
+import { usePredictEligibility } from '../../../Predict/hooks/usePredictEligibility';
 import CampaignOptInCta, { CAMPAIGN_CTA_TEST_IDS } from './CampaignOptInCta';
 import { getCampaignStatus } from './CampaignTile.utils';
 
@@ -27,7 +28,7 @@ const PredictThePitchCampaignCTA: React.FC<PredictThePitchCampaignCTAProps> = ({
   participantStatus,
 }) => {
   const navigation = useNavigation();
-
+  const { isEligible: isPredictEligible } = usePredictEligibility();
   const campaignStatus = getCampaignStatus(campaign);
   const isLoading = participantStatus.isLoading;
   const isOptedIn = participantStatus.status?.optedIn === true;
@@ -61,6 +62,7 @@ const PredictThePitchCampaignCTA: React.FC<PredictThePitchCampaignCTAProps> = ({
     <CampaignOptInCta
       campaign={campaign}
       participantStatus={participantStatus}
+      isFeatureGeoRestricted={!isPredictEligible}
     />
   );
 };

--- a/app/components/UI/Rewards/hooks/useCampaignGeoRestriction.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignGeoRestriction.test.ts
@@ -228,4 +228,34 @@ describe('useCampaignGeoRestriction', () => {
       expect(result.current.isGeoRestricted).toBe(false);
     });
   });
+
+  describe('with isFeatureGeoRestricted', () => {
+    it('returns isGeoRestricted=true when the feature is geo-restricted', () => {
+      const { result } = renderHook(() =>
+        useCampaignGeoRestriction(buildCampaign(), undefined, true),
+      );
+      expect(result.current.isGeoRestricted).toBe(true);
+    });
+
+    it('returns isGeoLoading=false when feature is geo-restricted, even while campaign geo is loading', () => {
+      mockGeoStatus = 'loading';
+      setupSelectors();
+      const { result } = renderHook(() =>
+        useCampaignGeoRestriction(buildCampaign(), undefined, true),
+      );
+      expect(result.current.isGeoLoading).toBe(false);
+      expect(result.current.isGeoRestricted).toBe(true);
+    });
+
+    it('falls through to campaign geo checks when isFeatureGeoRestricted is false', () => {
+      const { result } = renderHook(() =>
+        useCampaignGeoRestriction(
+          buildCampaign({ excludedRegions: [] }),
+          undefined,
+          false,
+        ),
+      );
+      expect(result.current.isGeoRestricted).toBe(false);
+    });
+  });
 });

--- a/app/components/UI/Rewards/hooks/useCampaignGeoRestriction.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignGeoRestriction.ts
@@ -32,7 +32,6 @@ const useCampaignGeoRestriction = (
     geolocationStatus === 'idle';
 
   const isGeoRestricted = useMemo(() => {
-    if (__DEV__) return false;
     if (isFeatureGeoRestricted) return true;
     if (isGeoLoading) return true;
     const country = geolocation?.toUpperCase().split('-')[0];

--- a/app/components/UI/Rewards/hooks/useCampaignGeoRestriction.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignGeoRestriction.ts
@@ -15,10 +15,12 @@ interface UseCampaignGeoRestrictionResult {
  *
  * @param campaign - The campaign to check. Accepts `null` for convenience when the campaign has not yet loaded — in that case `isGeoLoading` is `true` and `isGeoRestricted` is `true` (safe/restricted default while undetermined).
  * @param customRestrictedCountries - An optional set of country codes that are restricted independently of the campaign's `excludedRegions`. When provided this list is checked first; if the user's country is found here the function returns `true` without consulting `excludedRegions`. If not found here, `excludedRegions` is still checked.
+ * @param isFeatureGeoRestricted - When `true`, the user is treated as geo-restricted because the underlying product feature (e.g. Predict, Perps) is unavailable in their region, regardless of campaign-level geo checks. Feature restriction is authoritative, so `isGeoLoading` is returned as `false` in that case.
  */
 const useCampaignGeoRestriction = (
   campaign: CampaignDto | null,
   customRestrictedCountries?: Set<string>,
+  isFeatureGeoRestricted?: boolean,
 ): UseCampaignGeoRestrictionResult => {
   const geolocation = useSelector(getDetectedGeolocation);
   const geolocationStatus = useSelector(selectGeolocationStatus);
@@ -31,6 +33,7 @@ const useCampaignGeoRestriction = (
 
   const isGeoRestricted = useMemo(() => {
     if (__DEV__) return false;
+    if (isFeatureGeoRestricted) return true;
     if (isGeoLoading) return true;
     const country = geolocation?.toUpperCase().split('-')[0];
 
@@ -44,9 +47,18 @@ const useCampaignGeoRestriction = (
     return campaign.excludedRegions.some(
       (region) => region.toUpperCase() === country,
     );
-  }, [isGeoLoading, geolocation, campaign, customRestrictedCountries]);
+  }, [
+    isGeoLoading,
+    geolocation,
+    campaign,
+    customRestrictedCountries,
+    isFeatureGeoRestricted,
+  ]);
 
-  return { isGeoRestricted, isGeoLoading };
+  return {
+    isGeoRestricted,
+    isGeoLoading: isFeatureGeoRestricted ? false : isGeoLoading,
+  };
 };
 
 export default useCampaignGeoRestriction;


### PR DESCRIPTION
## **Description**

`CampaignOptInCta` is the canonical component for the "not opted in" CTA flow in Rewards campaign detail pages. It handles geo-restriction detection (`useCampaignGeoRestriction`), the geo-locked "Check eligibility" button, the geo-loading state, and the opt-in sheet — but it only checked geo at the campaign level (`excludedRegions`) or via a custom country-code set.

This PR extends the abstraction with feature-level geo-restriction support so that campaigns backed by a product with its own eligibility API (Perps, Predict) can signal ineligibility through the same component.

**Changes:**

- **`useCampaignGeoRestriction`** — accepts a new optional `isFeatureGeoRestricted` param. When `true`, it short-circuits to `isGeoRestricted: true` before any campaign-level geo checks, without affecting `isGeoLoading`.
- **`CampaignOptInCta`** — accepts a new optional `isFeatureGeoRestricted` prop and forwards it to `useCampaignGeoRestriction`.
- **`PerpsTradingCampaignCTA`** — refactored to delegate the not-opted-in path entirely to `CampaignOptInCta` with `isFeatureGeoRestricted={!isPerpsEligible}`, removing ~65 lines of duplicated geo-locked/join UI logic.
- **`PredictThePitchCampaignCTA`** — uses `usePredictEligibility()` and passes `isFeatureGeoRestricted={!isPredictEligible}` to `CampaignOptInCta`, so Predict geo-blocking now surfaces the same locked CTA as Perps.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Campaign CTA should block geo-restricted users from opting in

## **Manual testing steps**

```gherkin
Feature: Geo-restricted campaign CTA

  Scenario: user is geo-blocked from Perps and views the Perps campaign
    Given the user is in a Perps-restricted region (isPerpsEligible = false)
    When the user opens the Perps Trading campaign detail page
    Then a "Check eligibility" button with a lock icon is shown
    When the user taps the button
    Then a toast appears saying the campaign is not available in their region
    And the opt-in sheet does NOT open

  Scenario: user is geo-blocked from Predict and views the Predict campaign
    Given the user is in a Predict-restricted region (isEligible = false from usePredictEligibility)
    When the user opens the Predict The Pitch campaign detail page
    Then a "Check eligibility" button with a lock icon is shown
    When the user taps the button
    Then a toast appears saying the campaign is not available in their region

  Scenario: eligible user views the Perps campaign
    Given the user is eligible for Perps
    When the user opens the Perps Trading campaign detail page and is not yet opted in
    Then a "Join Campaign" button is shown
    When the user taps it
    Then the opt-in sheet opens
```

## **Screenshots/Recordings**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-08 at 18 25 06" src="https://github.com/user-attachments/assets/b4745575-19ca-4b92-9026-46cf43d32533" />


### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can open campaign opt-in (product eligibility + removal of dev geo bypass); localized to Rewards campaign CTAs with solid test coverage.
> 
> **Overview**
> Adds **feature-level geo restriction** to the shared campaign opt-in flow so Perps/Predict eligibility blocks joining through the same **"Check eligibility"** UI as campaign geo rules.
> 
> `useCampaignGeoRestriction` now accepts optional `isFeatureGeoRestricted`: when true it treats the user as restricted immediately, skips campaign geo resolution, and returns `isGeoLoading: false`. **`CampaignOptInCta`** forwards a new `isFeatureGeoRestricted` prop into that hook.
> 
> **Perps** and **Predict** campaign CTAs delegate the not-opted-in path to `CampaignOptInCta` with `isFeatureGeoRestricted={!isPerpsEligible}` / `{!isPredictEligible}` (Predict now uses `usePredictEligibility`), removing duplicated geo-locked/join sheet logic in Perps. Tests cover hook behavior, prop wiring, and Predict’s geo-locked CTA.
> 
> Also removes the prior `__DEV__` early return that always allowed geo in development builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a31a1700f4cfdf2146feb8a80b825e05b900951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->