### PR TITLE
fix(card): return to money tab after auth and broaden link CTA

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
@@ -456,11 +456,14 @@ describe('CardAuthentication Component', () => {
       });
     });
 
-    it('pops Card.ROOT off the root navigator on successful login when postAuthRedirect is set (no inner Card-stack reset, no cross-stack navigate)', async () => {
+    it('navigates root to HOME_TABS on successful login when postAuthRedirect targets a tab', async () => {
       mockRouteParams = {
         postAuthRedirect: {
-          screen: Routes.MONEY.ROOT,
-          params: { screen: Routes.MONEY.HOME },
+          screen: Routes.HOME_TABS,
+          params: {
+            screen: Routes.MONEY.ROOT,
+            params: { screen: Routes.MONEY.HOME },
+          },
         },
       };
       mockSubmitMutateAsync.mockResolvedValue({ done: true });
@@ -476,12 +479,85 @@ describe('CardAuthentication Component', () => {
       fireEvent.press(loginButton);
 
       await waitFor(() => {
-        expect(mockNavigationServiceGoBack).toHaveBeenCalledTimes(1);
+        expect(mockNavigationServiceNavigate).toHaveBeenCalledWith(
+          Routes.HOME_TABS,
+          {
+            screen: Routes.MONEY.ROOT,
+            params: { screen: Routes.MONEY.HOME },
+          },
+        );
       });
-      // The origin (e.g. the Money tab) lives below Card.ROOT in the outer
-      // navigator — popping reveals it without touching its own state or
-      // doing a cross-stack navigate.
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockNavigationServiceGoBack).not.toHaveBeenCalled();
+      expect(mockReset).not.toHaveBeenCalled();
+    });
+
+    it('returns to Money tab when login completed from sign-up entry path (CARD-416)', async () => {
+      mockRouteParams = {
+        postAuthRedirect: {
+          screen: Routes.HOME_TABS,
+          params: {
+            screen: Routes.MONEY.ROOT,
+            params: { screen: Routes.MONEY.HOME },
+          },
+        },
+      };
+      mockSubmitMutateAsync.mockResolvedValue({ done: true });
+      render();
+      const emailInput = screen.getByTestId('email-field');
+      const passwordInput = screen.getByTestId('password-field');
+      const loginButton = screen.getByTestId(
+        CardAuthenticationSelectors.VERIFY_ACCOUNT_BUTTON,
+      );
+
+      fireEvent.changeText(emailInput, 'test@example.com');
+      fireEvent.changeText(passwordInput, 'password123');
+      fireEvent.press(loginButton);
+
+      await waitFor(() => {
+        expect(mockNavigationServiceNavigate).toHaveBeenCalledWith(
+          Routes.HOME_TABS,
+          {
+            screen: Routes.MONEY.ROOT,
+            params: { screen: Routes.MONEY.HOME },
+          },
+        );
+      });
+      expect(mockNavigationServiceGoBack).not.toHaveBeenCalled();
+    });
+
+    it('dispatches CommonActions.navigate locally for in-flow postAuthRedirect target (e.g. CardHome)', async () => {
+      mockRouteParams = {
+        postAuthRedirect: {
+          screen: Routes.CARD.HOME,
+        },
+      };
+      mockSubmitMutateAsync.mockResolvedValue({ done: true });
+      render();
+      const emailInput = screen.getByTestId('email-field');
+      const passwordInput = screen.getByTestId('password-field');
+      const loginButton = screen.getByTestId(
+        CardAuthenticationSelectors.VERIFY_ACCOUNT_BUTTON,
+      );
+
+      fireEvent.changeText(emailInput, 'test@example.com');
+      fireEvent.changeText(passwordInput, 'password123');
+      fireEvent.press(loginButton);
+
+      await waitFor(() => {
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'NAVIGATE',
+            payload: expect.objectContaining({
+              name: Routes.CARD.HOME,
+              params: undefined,
+            }),
+          }),
+        );
+      });
       expect(mockNavigationServiceNavigate).not.toHaveBeenCalled();
+      expect(mockNavigationServiceGoBack).not.toHaveBeenCalled();
       expect(mockReset).not.toHaveBeenCalled();
     });
 

--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -1,4 +1,9 @@
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import {
+  useNavigation,
+  useRoute,
+  RouteProp,
+  CommonActions,
+} from '@react-navigation/native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Platform, TouchableOpacity, TextInputProps } from 'react-native';
 import {
@@ -215,7 +220,19 @@ const CardAuthentication = () => {
         }
 
         if (postAuthRedirect) {
-          NavigationService.navigation?.goBack();
+          if (postAuthRedirect.screen === Routes.HOME_TABS) {
+            NavigationService.navigation?.navigate(
+              postAuthRedirect.screen,
+              postAuthRedirect.params,
+            );
+          } else {
+            navigation.dispatch(
+              CommonActions.navigate(
+                postAuthRedirect.screen,
+                postAuthRedirect.params,
+              ),
+            );
+          }
           return;
         }
 

--- a/app/components/UI/Card/hooks/useCardPostAuthRedirect.test.ts
+++ b/app/components/UI/Card/hooks/useCardPostAuthRedirect.test.ts
@@ -38,8 +38,11 @@ describe('useCardPostAuthRedirect', () => {
 
     const { result } = renderHook(() => useCardPostAuthRedirect());
     expect(result.current).toEqual({
-      screen: Routes.MONEY.ROOT,
-      params: { screen: Routes.MONEY.HOME },
+      screen: Routes.HOME_TABS,
+      params: {
+        screen: Routes.MONEY.ROOT,
+        params: { screen: Routes.MONEY.HOME },
+      },
     });
   });
 

--- a/app/components/UI/Card/hooks/useCardPostAuthRedirect.ts
+++ b/app/components/UI/Card/hooks/useCardPostAuthRedirect.ts
@@ -4,8 +4,11 @@ import Routes from '../../../../constants/navigation/Routes';
 import type { LinkFlowOrigin } from './useMoneyAccountCardLinkage';
 
 export const MONEY_HOME_CARD_ORIGIN: LinkFlowOrigin = {
-  screen: Routes.MONEY.ROOT,
-  params: { screen: Routes.MONEY.HOME },
+  screen: Routes.HOME_TABS,
+  params: {
+    screen: Routes.MONEY.ROOT,
+    params: { screen: Routes.MONEY.HOME },
+  },
 };
 
 const isLinkFlowOrigin = (value: unknown): value is LinkFlowOrigin =>

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -1030,10 +1030,7 @@ describe('MoneyHomeView', () => {
       fireEvent.press(getByTestId(MoneyMetaMaskCardTestIds.LINK_BUTTON));
 
       expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
-      expect(mockStartLinkFlow).toHaveBeenCalledWith({
-        screen: Routes.MONEY.ROOT,
-        params: { screen: Routes.MONEY.HOME },
-      });
+      expect(mockStartLinkFlow).toHaveBeenCalledWith(MONEY_HOME_CARD_ORIGIN);
       expect(mockNavigate).not.toHaveBeenCalledWith(Routes.CARD.ROOT, {
         screen: Routes.CARD.HOME,
       });
@@ -1066,10 +1063,7 @@ describe('MoneyHomeView', () => {
         });
 
         expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
-        expect(mockStartLinkFlow).toHaveBeenCalledWith({
-          screen: Routes.MONEY.ROOT,
-          params: { screen: Routes.MONEY.HOME },
-        });
+        expect(mockStartLinkFlow).toHaveBeenCalledWith(MONEY_HOME_CARD_ORIGIN);
         expect(mockNavigate).not.toHaveBeenCalledWith(Routes.CARD.ROOT, {
           screen: Routes.CARD.HOME,
         });
@@ -1305,6 +1299,30 @@ describe('MoneyHomeView', () => {
 
       expect(
         getByTestId(MoneyMetaMaskCardTestIds.VIRTUAL_CARD_ROW),
+      ).toBeOnTheScreen();
+    });
+
+    it('selects mode="link" when card-authenticated even if selected wallet is not a cardholder account', () => {
+      mockSelectIsCardholder.mockReturnValue(false);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: true,
+        isCardAuthenticated: true,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'USDC' },
+        canLink: true,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.LINK_CONTAINER),
       ).toBeOnTheScreen();
     });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -118,8 +118,12 @@ const MoneyHomeView = () => {
 
   const isCardholder = useSelector(selectIsCardholder);
   const hasMetalCard = useSelector(selectHasMetalCard);
-  const { startLinkFlow, isCardLinkedToMoneyAccount, isLinking } =
-    useMoneyAccountCardLinkage();
+  const {
+    startLinkFlow,
+    isCardAuthenticated,
+    isCardLinkedToMoneyAccount,
+    isLinking,
+  } = useMoneyAccountCardLinkage();
 
   const { isVisible: isOnboardingCardVisible } = useOnboardingStep({
     stepperId: STEPPER_IDS.MONEY,
@@ -203,10 +207,7 @@ const MoneyHomeView = () => {
   }, [navigation]);
 
   const handleLinkCardPress = useCallback(() => {
-    startLinkFlow({
-      screen: Routes.MONEY.ROOT,
-      params: { screen: Routes.MONEY.HOME },
-    });
+    startLinkFlow(MONEY_HOME_CARD_ORIGIN);
   }, [startLinkFlow]);
 
   const handleApyInfoPress = useCallback(() => {
@@ -284,7 +285,7 @@ const MoneyHomeView = () => {
   let metamaskCardMode: 'upsell' | 'link' | 'manage';
   if (isCardLinkedToMoneyAccount) {
     metamaskCardMode = 'manage';
-  } else if (isCardholder) {
+  } else if (isCardAuthenticated || isCardholder) {
     metamaskCardMode = 'link';
   } else {
     metamaskCardMode = 'upsell';

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -7,8 +7,8 @@ import MoneyOnboardingCard, {
 import { useOnboardingStep } from '../../hooks/useOnboardingStep';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMoneyAccountCardLinkage } from '../../../Card/hooks/useMoneyAccountCardLinkage';
+import { MONEY_HOME_CARD_ORIGIN } from '../../../Card/hooks/useCardPostAuthRedirect';
 import { strings } from '../../../../../../locales/i18n';
-import Routes from '../../../../../constants/navigation/Routes';
 import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 
 jest.mock('@metamask/design-system-twrnc-preset', () => {
@@ -222,10 +222,7 @@ describe('MoneyOnboardingCard', () => {
       fireEvent.press(getByTestId('money-onboarding-card-cta-button'));
 
       expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
-      expect(mockStartLinkFlow).toHaveBeenCalledWith({
-        screen: Routes.MONEY.ROOT,
-        params: { screen: Routes.MONEY.HOME },
-      });
+      expect(mockStartLinkFlow).toHaveBeenCalledWith(MONEY_HOME_CARD_ORIGIN);
     });
 
     it('calls incrementStep when Skip CTA is pressed', () => {
@@ -302,10 +299,7 @@ describe('MoneyOnboardingCard', () => {
       fireEvent.press(getByTestId('money-onboarding-card-cta-button'));
 
       expect(mockStartLinkFlow).toHaveBeenCalledTimes(1);
-      expect(mockStartLinkFlow).toHaveBeenCalledWith({
-        screen: Routes.MONEY.ROOT,
-        params: { screen: Routes.MONEY.HOME },
-      });
+      expect(mockStartLinkFlow).toHaveBeenCalledWith(MONEY_HOME_CARD_ORIGIN);
     });
 
     it('calls incrementStep when Skip CTA is pressed', () => {

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -3,8 +3,8 @@ import { Box } from '@metamask/design-system-react-native';
 import moneyOnboardingStepperStep1 from '../../../../../images/money-onboarding-stepper-step-1.png';
 import moneyOnboardingStepperStep2 from '../../../../../images/money-onboarding-stepper-step-2.png';
 import { strings } from '../../../../../../locales/i18n';
-import Routes from '../../../../../constants/navigation/Routes';
 import { useMoneyAccountCardLinkage } from '../../../Card/hooks/useMoneyAccountCardLinkage';
+import { MONEY_HOME_CARD_ORIGIN } from '../../../Card/hooks/useCardPostAuthRedirect';
 import { useOnboardingStep, STEPPER_IDS } from '../../hooks/useOnboardingStep';
 import StepperCard, {
   type StepperCardStep,
@@ -40,10 +40,7 @@ const MoneyOnboardingCard = () => {
   }, [initiateDeposit]);
 
   const handleCardCtaPress = useCallback(() => {
-    startLinkFlow({
-      screen: Routes.MONEY.ROOT,
-      params: { screen: Routes.MONEY.HOME },
-    });
+    startLinkFlow(MONEY_HOME_CARD_ORIGIN);
   }, [startLinkFlow]);
 
   const handleSkipPress = useCallback(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Two related bugs in the Money Account → Card linkage flow ([CARD-416](https://consensyssoftware.atlassian.net/browse/CARD-416)):

**1. Post-login redirect from Sign-up lands on Sign-up instead of Money tab.**

When a non-authenticated, non-cardholder user tapped **Get now** on the Money tab, opened the Card sign-up flow, then tapped **I already have an account** and completed login, they were dropped back on the first Sign-up screen instead of the Money tab.

- Root cause: `CardAuthentication.performLogin` used `NavigationService.navigation?.goBack()` for the `postAuthRedirect` branch. `goBack()` on the root container ref delegates to the focused screen's navigator and pops only one screen — fine for the shallow `CardHome → CardAuth` path, but for the deeper `Money tab → CardWelcome → CARD.ONBOARDING.ROOT → SignUp → CardAuthentication` stack it revealed `SignUp`.
- Naïve fix (`navigate(MONEY.ROOT, …)`) was wrong too: `Routes.MONEY.ROOT` is **also** registered at the root stack (as a backup for deeplinks), so navigating to it pushes a full-page Money screen on top of `CARD.ROOT` instead of returning to the Money tab inside `HomeTabs`.

**Solution.** Encode `MONEY_HOME_CARD_ORIGIN` as a `HOME_TABS`-prefixed absolute root-level path:

```ts
{ screen: HOME_TABS, params: { screen: MONEY.ROOT, params: { screen: MONEY.HOME } } }
```

In `CardAuthentication.performLogin`, branch on `postAuthRedirect.screen === HOME_TABS`:

- Tab-exit origins (Money): `NavigationService.navigation.navigate(HOME_TABS, …)` — `HOME_TABS` sits below `CARD.ROOT` in the root stack, so React Navigation pops `CARD.ROOT` off and focuses the target tab. Stack-depth-independent.
- In-flow origins (e.g. `CardHome`): `navigation.dispatch(CommonActions.navigate(screen, params))` on the local navigator — return to a sibling Card screen without dismissing the Card flow.

Three Money-side call sites that inlined the old origin shape (`MoneyHomeView.handleLinkCardPress`, `MoneyOnboardingCard.handleCardCtaPress`) now import the `MONEY_HOME_CARD_ORIGIN` constant.

**2. "Get now" upsell shown when the user is card-authenticated but on a non-cardholder wallet.**

`MoneyHomeView` gated the `'link'` CTA mode on `isCardholder` only. `selectIsCardholder` checks whether the *currently selected EVM wallet account* is in `cardholderAccounts`, which is too narrow: a card-authenticated user on a different wallet account hit the `else` branch and saw the **Get now** upsell instead of **Link card**.

**Solution.** Broaden the condition to `(isCardAuthenticated || isCardholder)`. This mirrors `useMoneyAccountCardLinkage.startLinkFlow`'s readiness branches — any user who is authenticated (can directly link) or whose selected wallet is a cardholder (can log in then link) sees the **Link card** CTA. Only users with no card account anywhere see the upsell.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed post-login from the Card sign-up flow not returning to the Money tab when initiated from Money Account, and corrected the "Link card" CTA on the Money tab to appear for any card-authenticated user.

## **Related issues**

Fixes: [CARD-416](https://consensyssoftware.atlassian.net/browse/CARD-416)

## **Manual testing steps**

```gherkin
Feature: Money Account → Card post-auth redirect and CTA mode

  Background:
    Given the Money Account feature flag is enabled
    And I am on the Money tab

  Scenario: non-authenticated non-cardholder logs in from the sign-up flow
    Given I am not authenticated with Card and I have no cardholder accounts
    And I tap "Get now" on the Money tab Card row
    And I am on the Card Welcome screen
    And I tap "Apply now"
    And I am on the Card Sign-up screen

    When I tap "I already have an account"
    And I submit valid credentials on the Card Authentication screen
    And I submit the OTP code

    Then I should land on the Money tab inside the bottom tab bar
    And I should NOT land on the Card Sign-up screen
    And I should NOT see a full-page Money screen above the Card modal

  Scenario: cardholder needing auth from CardHome stays in the Card flow
    Given I am a cardholder but my Card session has expired
    And I am on Card Home and tap the "Link card" CTA
    And I am on the Card Authentication screen

    When I submit valid credentials
    And I submit the OTP code

    Then I should land back on Card Home inside the Card modal
    And the Card modal should remain open

  Scenario: card-authenticated user on a non-cardholder wallet sees "Link card"
    Given I am card-authenticated
    And the currently selected wallet account is NOT a cardholder account
    And my Money Account is not yet delegated for the Card

    When I view the Money tab

    Then the MetaMask Card row should display the "Link card" CTA
    And it should NOT display the "Get now" upsell

  Scenario: user with no card account anywhere sees the upsell
    Given I am not card-authenticated
    And no wallet account is a cardholder account

    When I view the Money tab

    Then the MetaMask Card row should display the "Get now" upsell
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

[CARD-416]: https://consensyssoftware.atlassian.net/browse/CARD-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CARD-416]: https://consensyssoftware.atlassian.net/browse/CARD-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-login navigation in Card authentication and root vs nested Money routes; behavior is covered by new tests but wrong routing could still strand users in Card or on the wrong screen.
> 
> **Overview**
> Fixes **CARD-416** by changing how Money → Card flows return after login and how the Money tab picks the Card CTA.
> 
> **Post-auth navigation:** `MONEY_HOME_CARD_ORIGIN` now targets `HOME_TABS` with nested Money home params instead of `MONEY.ROOT` alone, so returning from Card auth lands on the **Money tab inside the bottom tabs** rather than popping to Sign-up or pushing a duplicate full-screen Money route. `CardAuthentication` no longer uses `goBack()` for `postAuthRedirect`; it **navigates root to `HOME_TABS`** when the redirect is tab-scoped, or **`CommonActions.navigate` on the Card stack** for in-flow targets like `CardHome`. Money entry points (`MoneyHomeView`, `MoneyOnboardingCard`) pass the shared `MONEY_HOME_CARD_ORIGIN` into `startLinkFlow` / `postAuthRedirect`.
> 
> **Money tab Card row:** MetaMask Card **link** mode is shown when the user is **`isCardAuthenticated` or `isCardholder`**, so card-authenticated users on a non-cardholder wallet see **Link card** instead of the **Get now** upsell.
> 
> Tests cover tab redirect, sign-up path (CARD-416), in-flow Card Home redirect, origin constant wiring, and the new link-mode rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8333c888a077f62634d4663f7012a90a934a443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->