### PR TITLE
chore: bump `@metamask/connectivity-controller` to `^0.2.0`

### DIFF
--- a/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
+++ b/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
@@ -11,6 +11,7 @@ import {
 import { NetInfoConnectivityAdapter } from './netinfo-connectivity-adapter';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import Logger from '../../../../util/Logger';
+import { flushPromises } from '../../../../util/test/utils';
 
 // Mock NetInfoConnectivityAdapter since it uses NetInfo which requires native modules
 jest.mock('./netinfo-connectivity-adapter');
@@ -97,8 +98,7 @@ describe('ConnectivityControllerInit', () => {
     const { controller } = connectivityControllerInit(getInitRequestMock());
 
     // init() runs asynchronously; flush pending microtasks before asserting.
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
 
     expect(mockNetInfoAdapter.getStatus).toHaveBeenCalled();
     expect(controller.state.connectivityStatus).toBe(
@@ -112,8 +112,7 @@ describe('ConnectivityControllerInit', () => {
 
     const { controller } = connectivityControllerInit(getInitRequestMock());
 
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
 
     expect(Logger.error).toHaveBeenCalledWith(
       initError,

--- a/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
+++ b/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
@@ -37,7 +37,7 @@ describe('ConnectivityControllerInit', () => {
 
     // Mock NetInfoConnectivityAdapter
     mockNetInfoAdapter = {
-      getStatus: jest.fn().mockReturnValue(CONNECTIVITY_STATUSES.Online),
+      getStatus: jest.fn().mockResolvedValue(CONNECTIVITY_STATUSES.Online),
       onConnectivityChange: jest.fn(),
       destroy: jest.fn(),
     } as unknown as jest.Mocked<NetInfoConnectivityAdapter>;

--- a/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
+++ b/app/core/Engine/controllers/connectivity/connectivity-controller-init.test.ts
@@ -10,9 +10,14 @@ import {
 } from '@metamask/connectivity-controller';
 import { NetInfoConnectivityAdapter } from './netinfo-connectivity-adapter';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import Logger from '../../../../util/Logger';
 
 // Mock NetInfoConnectivityAdapter since it uses NetInfo which requires native modules
 jest.mock('./netinfo-connectivity-adapter');
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
 
 function getInitRequestMock(): jest.Mocked<
   MessengerClientInitRequest<ConnectivityControllerMessenger>
@@ -81,6 +86,41 @@ describe('ConnectivityControllerInit', () => {
 
     expect(mockNetInfoAdapter.onConnectivityChange).toHaveBeenCalledWith(
       expect.any(Function),
+    );
+  });
+
+  it('seeds initial connectivity status via controller.init()', async () => {
+    mockNetInfoAdapter.getStatus.mockResolvedValue(
+      CONNECTIVITY_STATUSES.Offline,
+    );
+
+    const { controller } = connectivityControllerInit(getInitRequestMock());
+
+    // init() runs asynchronously; flush pending microtasks before asserting.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockNetInfoAdapter.getStatus).toHaveBeenCalled();
+    expect(controller.state.connectivityStatus).toBe(
+      CONNECTIVITY_STATUSES.Offline,
+    );
+  });
+
+  it('logs and keeps default state when controller.init() rejects', async () => {
+    const initError = new Error('netinfo unavailable');
+    mockNetInfoAdapter.getStatus.mockRejectedValue(initError);
+
+    const { controller } = connectivityControllerInit(getInitRequestMock());
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      initError,
+      'ConnectivityController: failed to initialize',
+    );
+    expect(controller.state.connectivityStatus).toBe(
+      CONNECTIVITY_STATUSES.Online,
     );
   });
 });

--- a/app/core/Engine/controllers/connectivity/connectivity-controller-init.ts
+++ b/app/core/Engine/controllers/connectivity/connectivity-controller-init.ts
@@ -3,6 +3,7 @@ import {
   type ConnectivityControllerMessenger,
 } from '@metamask/connectivity-controller';
 
+import Logger from '../../../../util/Logger';
 import { MessengerClientInitFunction } from '../../types';
 
 import { NetInfoConnectivityAdapter } from './netinfo-connectivity-adapter';
@@ -29,6 +30,16 @@ export const connectivityControllerInit: MessengerClientInitFunction<
   const controller = new ConnectivityController({
     messenger: controllerMessenger,
     connectivityAdapter,
+  });
+
+  // Fire-and-forget: fetches the initial connectivity status from the adapter
+  // and seeds controller state. Failure leaves the default (online) in place;
+  // subsequent NetInfo events will correct it via the subscription path.
+  controller.init().catch((error) => {
+    Logger.error(
+      error as Error,
+      'ConnectivityController: failed to initialize',
+    );
   });
 
   return {

--- a/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.test.ts
+++ b/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.test.ts
@@ -117,32 +117,25 @@ describe('NetInfoConnectivityAdapter', () => {
   });
 
   describe('onConnectivityChange', () => {
-    it('fetches initial state and calls callback', async () => {
+    it('subscribes without fetching initial state', () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
 
       adapter.onConnectivityChange(callback);
 
-      // Wait for initial fetch
-      await Promise.resolve();
-
-      expect(netInfoFetch).toHaveBeenCalled();
-      // Event listener is set up in constructor
+      // Adapter no longer fetches initial state — the controller's init()
+      // is responsible for seeding initial state via getStatus().
+      expect(netInfoFetch).not.toHaveBeenCalled();
       expect(netInfoAddEventListener).toHaveBeenCalledTimes(1);
-      expect(callback).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Online);
+      expect(callback).not.toHaveBeenCalled();
     });
 
-    it('calls callback when connectivity changes to offline', async () => {
+    it('calls callback when connectivity changes to offline', () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
 
       adapter.onConnectivityChange(callback);
 
-      // Wait for initial fetch
-      await Promise.resolve();
-      callback.mockClear();
-
-      // Simulate NetInfo state change (listener is set up in constructor)
       const addEventListenerCallback = (netInfoAddEventListener as jest.Mock)
         .mock.calls[0]?.[0];
       addEventListenerCallback({
@@ -153,22 +146,12 @@ describe('NetInfoConnectivityAdapter', () => {
       expect(callback).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Offline);
     });
 
-    it('calls callback when connectivity changes to online', async () => {
-      (netInfoFetch as jest.Mock).mockResolvedValue({
-        isConnected: false,
-        isInternetReachable: false,
-      });
-
+    it('calls callback when connectivity changes to online', () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
 
       adapter.onConnectivityChange(callback);
 
-      // Wait for initial fetch
-      await Promise.resolve();
-      callback.mockClear();
-
-      // Simulate NetInfo state change (listener is set up in constructor)
       const addEventListenerCallback = (netInfoAddEventListener as jest.Mock)
         .mock.calls[0]?.[0];
       addEventListenerCallback({
@@ -179,17 +162,12 @@ describe('NetInfoConnectivityAdapter', () => {
       expect(callback).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Online);
     });
 
-    it('uses isConnected fallback when isInternetReachable is null', async () => {
+    it('uses isConnected fallback when isInternetReachable is null', () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
 
       adapter.onConnectivityChange(callback);
 
-      // Wait for initial fetch
-      await Promise.resolve();
-      callback.mockClear();
-
-      // Simulate NetInfo state with null isInternetReachable (listener is set up in constructor)
       const addEventListenerCallback = (netInfoAddEventListener as jest.Mock)
         .mock.calls[0]?.[0];
       addEventListenerCallback({
@@ -200,7 +178,7 @@ describe('NetInfoConnectivityAdapter', () => {
       expect(callback).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Online);
     });
 
-    it('supports multiple callbacks', async () => {
+    it('supports multiple callbacks', () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback1 = jest.fn();
       const callback2 = jest.fn();
@@ -208,17 +186,6 @@ describe('NetInfoConnectivityAdapter', () => {
       adapter.onConnectivityChange(callback1);
       adapter.onConnectivityChange(callback2);
 
-      // Wait for initial fetch
-      await Promise.resolve();
-
-      // Both callbacks should be called with initial state
-      expect(callback1).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Online);
-      expect(callback2).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Online);
-
-      callback1.mockClear();
-      callback2.mockClear();
-
-      // Simulate NetInfo state change (listener is set up in constructor)
       const addEventListenerCallback = (netInfoAddEventListener as jest.Mock)
         .mock.calls[0]?.[0];
       addEventListenerCallback({
@@ -226,7 +193,6 @@ describe('NetInfoConnectivityAdapter', () => {
         isInternetReachable: false,
       });
 
-      // Both callbacks should be notified of the change
       expect(callback1).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Offline);
       expect(callback2).toHaveBeenCalledWith(CONNECTIVITY_STATUSES.Offline);
     });
@@ -238,10 +204,6 @@ describe('NetInfoConnectivityAdapter', () => {
       const callback = jest.fn();
 
       adapter.onConnectivityChange(callback);
-
-      // Wait for initial fetch
-      await Promise.resolve();
-
       adapter.destroy();
 
       expect(mockUnsubscribe).toHaveBeenCalled();
@@ -259,16 +221,11 @@ describe('NetInfoConnectivityAdapter', () => {
       }).not.toThrow();
     });
 
-    it('stops calling callbacks after destroy', async () => {
+    it('stops calling callbacks after destroy', () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
 
       adapter.onConnectivityChange(callback);
-
-      // Wait for initial fetch
-      await Promise.resolve();
-      callback.mockClear();
-
       adapter.destroy();
 
       // Simulate NetInfo state change after destroy

--- a/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.test.ts
+++ b/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.test.ts
@@ -43,6 +43,35 @@ describe('NetInfoConnectivityAdapter', () => {
       expect(netInfoFetch).toHaveBeenCalled();
     });
 
+    it('prefers listener-supplied state over a stale in-flight fetch', async () => {
+      // Fetch resolves with stale data (online) only after we deliberately release it.
+      let resolveFetch!: (state: {
+        isConnected: boolean;
+        isInternetReachable: boolean;
+      }) => void;
+      (netInfoFetch as jest.Mock).mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+      );
+
+      adapter = new NetInfoConnectivityAdapter();
+      const pending = adapter.getStatus();
+
+      // Listener delivers fresher state (offline) while the fetch is in flight.
+      const addEventListenerCallback = (netInfoAddEventListener as jest.Mock)
+        .mock.calls[0]?.[0];
+      addEventListenerCallback({
+        isConnected: false,
+        isInternetReachable: false,
+      });
+
+      // Now let the stale fetch resolve — it must not clobber the listener state.
+      resolveFetch({ isConnected: true, isInternetReachable: true });
+
+      await expect(pending).resolves.toBe(CONNECTIVITY_STATUSES.Offline);
+    });
+
     it('returns Online when isInternetReachable is true', async () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();

--- a/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.test.ts
+++ b/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.test.ts
@@ -31,12 +31,19 @@ describe('NetInfoConnectivityAdapter', () => {
   });
 
   describe('getStatus', () => {
-    it('returns Online by default when no state is available', () => {
+    it('fetches NetInfo state when none has been observed yet', async () => {
+      (netInfoFetch as jest.Mock).mockResolvedValue({
+        isConnected: true,
+        isInternetReachable: true,
+      });
       adapter = new NetInfoConnectivityAdapter();
-      expect(adapter.getStatus()).toBe(CONNECTIVITY_STATUSES.Online);
+      await expect(adapter.getStatus()).resolves.toBe(
+        CONNECTIVITY_STATUSES.Online,
+      );
+      expect(netInfoFetch).toHaveBeenCalled();
     });
 
-    it('returns Online when isInternetReachable is true', () => {
+    it('returns Online when isInternetReachable is true', async () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
       adapter.onConnectivityChange(callback);
@@ -49,10 +56,12 @@ describe('NetInfoConnectivityAdapter', () => {
         isInternetReachable: true,
       });
 
-      expect(adapter.getStatus()).toBe(CONNECTIVITY_STATUSES.Online);
+      await expect(adapter.getStatus()).resolves.toBe(
+        CONNECTIVITY_STATUSES.Online,
+      );
     });
 
-    it('returns Offline when isInternetReachable is false', () => {
+    it('returns Offline when isInternetReachable is false', async () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
       adapter.onConnectivityChange(callback);
@@ -65,10 +74,12 @@ describe('NetInfoConnectivityAdapter', () => {
         isInternetReachable: false,
       });
 
-      expect(adapter.getStatus()).toBe(CONNECTIVITY_STATUSES.Offline);
+      await expect(adapter.getStatus()).resolves.toBe(
+        CONNECTIVITY_STATUSES.Offline,
+      );
     });
 
-    it('falls back to isConnected when isInternetReachable is null', () => {
+    it('falls back to isConnected when isInternetReachable is null', async () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
       adapter.onConnectivityChange(callback);
@@ -81,10 +92,12 @@ describe('NetInfoConnectivityAdapter', () => {
         isInternetReachable: null,
       });
 
-      expect(adapter.getStatus()).toBe(CONNECTIVITY_STATUSES.Online);
+      await expect(adapter.getStatus()).resolves.toBe(
+        CONNECTIVITY_STATUSES.Online,
+      );
     });
 
-    it('returns Offline when both isInternetReachable and isConnected are false', () => {
+    it('returns Offline when both isInternetReachable and isConnected are false', async () => {
       adapter = new NetInfoConnectivityAdapter();
       const callback = jest.fn();
       adapter.onConnectivityChange(callback);
@@ -97,7 +110,9 @@ describe('NetInfoConnectivityAdapter', () => {
         isInternetReachable: false,
       });
 
-      expect(adapter.getStatus()).toBe(CONNECTIVITY_STATUSES.Offline);
+      await expect(adapter.getStatus()).resolves.toBe(
+        CONNECTIVITY_STATUSES.Offline,
+      );
     });
   });
 
@@ -230,7 +245,10 @@ describe('NetInfoConnectivityAdapter', () => {
       adapter.destroy();
 
       expect(mockUnsubscribe).toHaveBeenCalled();
-      expect(adapter.getStatus()).toBe(CONNECTIVITY_STATUSES.Online); // Should still work but with no state
+      // After destroy, state is cleared; getStatus refetches and falls back to the default mock (Online).
+      await expect(adapter.getStatus()).resolves.toBe(
+        CONNECTIVITY_STATUSES.Online,
+      );
     });
 
     it('can be called multiple times without error', () => {

--- a/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.ts
+++ b/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.ts
@@ -42,26 +42,17 @@ export class NetInfoConnectivityAdapter implements ConnectivityAdapter {
   /**
    * Returns the current connectivity status.
    *
-   * For initial state, we default to online since NetInfo requires async
-   * fetch for initial state. The actual state will be determined once
-   * the subscription callback fires or initial fetch completes.
+   * If no NetInfo state has been observed yet, fetches it asynchronously so
+   * the controller's `init()` resolves with an accurate initial value rather
+   * than a default-online guess.
    *
-   * @returns The current connectivity status.
+   * @returns A promise resolving to the current connectivity status.
    */
-  getStatus(): ConnectivityStatus {
+  async getStatus(): Promise<ConnectivityStatus> {
     if (!this.#currentState) {
-      return CONNECTIVITY_STATUSES.Online;
+      this.#currentState = await netInfoFetch();
     }
-
-    // Use isInternetReachable for actual internet connectivity
-    // Falls back to isConnected if isInternetReachable is null (still determining)
-    const isOnline =
-      this.#currentState.isInternetReachable ??
-      this.#currentState.isConnected ??
-      false;
-    return isOnline
-      ? CONNECTIVITY_STATUSES.Online
-      : CONNECTIVITY_STATUSES.Offline;
+    return this.#statusFromState(this.#currentState);
   }
 
   /**
@@ -81,13 +72,29 @@ export class NetInfoConnectivityAdapter implements ConnectivityAdapter {
   }
 
   /**
+   * Derives a {@link ConnectivityStatus} from a NetInfo state.
+   *
+   * Uses `isInternetReachable` for actual internet connectivity and falls
+   * back to `isConnected` if `isInternetReachable` is null (still determining).
+   *
+   * @param state - The NetInfo state to inspect.
+   * @returns The derived connectivity status.
+   */
+  #statusFromState(state: NetInfoState): ConnectivityStatus {
+    const isOnline = state.isInternetReachable ?? state.isConnected ?? false;
+    return isOnline
+      ? CONNECTIVITY_STATUSES.Online
+      : CONNECTIVITY_STATUSES.Offline;
+  }
+
+  /**
    * Updates the current state and notifies all registered callbacks.
    *
    * @param state - The new NetInfo state.
    */
   #update(state: NetInfoState): void {
     this.#currentState = state;
-    const status = this.getStatus();
+    const status = this.#statusFromState(state);
 
     this.#onConnectivityChangeCallbacks.forEach((callback) => callback(status));
   }

--- a/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.ts
+++ b/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.ts
@@ -17,7 +17,7 @@ import {
  * - Uses NetInfo to detect network connectivity
  * - Uses `isInternetReachable` for actual internet connectivity (preferred)
  * - Falls back to `isConnected` if `isInternetReachable` is null (still determining)
- * - Fetches initial state asynchronously on subscription
+ * - Fetches initial state on demand via {@link getStatus} (used by the controller's `init()`)
  * - Subscribes to NetInfo state changes
  * - Handles cleanup of NetInfo subscriptions
  *
@@ -58,17 +58,13 @@ export class NetInfoConnectivityAdapter implements ConnectivityAdapter {
   /**
    * Registers a callback to be called when connectivity status changes.
    *
-   * Fetches the initial state asynchronously and then subscribes to changes.
+   * Initial status is fetched by the controller's `init()` via
+   * {@link getStatus}; this method only subscribes to subsequent changes.
    *
    * @param callback - Function called with the new connectivity status.
    */
   onConnectivityChange(callback: (status: ConnectivityStatus) => void): void {
     this.#onConnectivityChangeCallbacks.push(callback);
-
-    // Fetch initial state first
-    netInfoFetch().then((state: NetInfoState) => {
-      this.#update(state);
-    });
   }
 
   /**

--- a/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.ts
+++ b/app/core/Engine/controllers/connectivity/netinfo-connectivity-adapter.ts
@@ -50,7 +50,13 @@ export class NetInfoConnectivityAdapter implements ConnectivityAdapter {
    */
   async getStatus(): Promise<ConnectivityStatus> {
     if (!this.#currentState) {
-      this.#currentState = await netInfoFetch();
+      const fetched = await netInfoFetch();
+      // A NetInfo event may have populated `#currentState` while the fetch
+      // was in flight; that listener-supplied state is at least as fresh as
+      // the fetched snapshot, so only seed when we still have nothing.
+      if (!this.#currentState) {
+        this.#currentState = fetched;
+      }
     }
     return this.#statusFromState(this.#currentState);
   }

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "@metamask/chomp-api-service": "^3.1.0",
     "@metamask/client-controller": "^1.0.1",
     "@metamask/compliance-controller": "2.1.0",
-    "@metamask/connectivity-controller": "^0.1.0",
+    "@metamask/connectivity-controller": "^0.2.0",
     "@metamask/controller-utils": "^12.1.0",
     "@metamask/core-backend": "^6.3.0",
     "@metamask/delegation-controller": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8258,16 +8258,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/connectivity-controller@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@metamask/connectivity-controller@npm:0.1.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-  checksum: 10/b73982779bc1a7e86b21e63303b313c498ab34bd64eeb80b0fc9046d2041a567bc212a08d3987f05b083951e8bd4f3fb0540c3042d70d685bd4c200cba44b724
-  languageName: node
-  linkType: hard
-
 "@metamask/connectivity-controller@npm:^0.2.0":
   version: 0.2.0
   resolution: "@metamask/connectivity-controller@npm:0.2.0"
@@ -35359,7 +35349,7 @@ __metadata:
     "@metamask/chomp-api-service": "npm:^3.1.0"
     "@metamask/client-controller": "npm:^1.0.1"
     "@metamask/compliance-controller": "npm:2.1.0"
-    "@metamask/connectivity-controller": "npm:^0.1.0"
+    "@metamask/connectivity-controller": "npm:^0.2.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/core-backend": "npm:^6.3.0"
     "@metamask/delegation-controller": "npm:^2.0.2"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/connectivity-controller` from `^0.1.0` to `^0.2.0`.

**Why:** v0.2.0 ships a breaking change to the `ConnectivityAdapter` interface — `getStatus()` must now return `Promise<ConnectivityStatus>` — and also introduces an async `init()` method and a `setConnectivityStatus()` action on the controller. The mobile `NetInfoConnectivityAdapter` had to be updated to satisfy the new interface, otherwise the project would not type-check against `0.2.0`.

**Upstream changelog (0.1.0 → 0.2.0):** https://github.com/MetaMask/core/blob/main/packages/connectivity-controller/CHANGELOG.md
- Added: `init()` (async) — exposed as `ConnectivityController:init`.
- Added: `setConnectivityStatus()` — exposed as `ConnectivityController:setConnectivityStatus`.
- **BREAKING:** `ConnectivityAdapter.getStatus()` must return `Promise<ConnectivityStatus>`.
- Internal bumps: `@metamask/messenger` `^0.3.0` → `^1.0.0`, `@metamask/base-controller` `^9.0.0` → `^9.0.1`.

**What changed locally:**
- `NetInfoConnectivityAdapter.getStatus()` is now `async`. When no NetInfo state has been observed yet, it awaits `netInfoFetch()` so callers (`ConnectivityController.init()`) resolve with an accurate value instead of a default-online guess. Re-checks `#currentState` after the await so a listener-supplied value mid-flight isn't clobbered by a stale fetch.
- Extracted a synchronous `#statusFromState(state)` helper so the synchronous `#update()` path (driven by the NetInfo event subscription) still emits non-Promise statuses to callbacks.
- Wired up the new `init()`: `connectivityControllerInit` calls `controller.init()` fire-and-forget (with `Logger.error` on rejection) so initial state is seeded from the adapter instead of the default `Online`. On failure we keep the default state; subsequent NetInfo events correct it via the subscription path.
- Removed the now-redundant `netInfoFetch()` inside the adapter's `onConnectivityChange` — initial state is `init()`'s job, so the subscription path is purely for subsequent change events.
- Adapter tests updated for the async signature and the listener-vs-fetch race regression; controller-init tests cover the success and rejection paths of `init()`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Update the controller to the latest version

## **Manual testing steps**

```gherkin
Feature: Connectivity status after dependency bump

  Scenario: App boots offline
    Given the device has no internet connectivity
    When the app is launched
    Then the offline banner is shown shortly after startup

  Scenario: Device goes offline
    Given the app is open with network connectivity
    When the device loses internet connectivity
    Then the offline banner is shown

  Scenario: Device comes back online
    Given the app is open with the offline banner visible
    When the device regains internet connectivity
    Then the offline banner is dismissed
```

## **Screenshots/Recordings**

### **Before**

N/A — dependency bump, no UI change expected.

### **After**

N/A — dependency bump, no UI change expected.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connectivity initialization used for offline/online UX; failures are handled but wrong initial status could briefly mislead the UI until NetInfo events arrive.
> 
> **Overview**
> Upgrades **`@metamask/connectivity-controller`** to **^0.2.0** and adapts mobile to the breaking **`ConnectivityAdapter.getStatus()` → `Promise`** contract.
> 
> **`NetInfoConnectivityAdapter`** now **awaits `netInfoFetch()`** when no state exists yet (instead of defaulting to online), **prefers listener-updated state** over a stale in-flight fetch, and **stops fetching on `onConnectivityChange`**—initial seeding moves to **`controller.init()`** via `getStatus()`. Status mapping is centralized in **`#statusFromState`**.
> 
> **`connectivityControllerInit`** **invokes `controller.init()`** (fire-and-forget), **logs failures** with `Logger`, and **keeps default online** until NetInfo events correct it. Tests cover successful seeding, init rejection, and the async adapter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3532652a89d3ce7a17d5070651f8e636d26516b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
