### PR TITLE
fix(money): derive account funding state from balance not transaction count (MUSD-933)

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, fireEvent, within } from '@testing-library/react-native';
 import { Linking } from 'react-native';
+import BigNumber from 'bignumber.js';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MoneyHomeView from './MoneyHomeView';
 import { MoneyHomeViewTestIds } from './MoneyHomeView.testIds';
@@ -308,7 +309,7 @@ describe('MoneyHomeView', () => {
       musdFiatFormatted: '$1.00',
       musdSHFvdFiatFormatted: '$2.00',
       totalFiatRaw: '3',
-      tokenTotal: undefined,
+      tokenTotal: new BigNumber('3'),
       withdrawableMusd: undefined,
       isAggregatedBalanceLoading: false,
       isBalanceFetchError: false,
@@ -571,12 +572,25 @@ describe('MoneyHomeView', () => {
       });
     });
 
-    it('MoneyHowItWorks stays mounted in noAccount state (empty tx count)', () => {
+    it('MoneyHowItWorks stays mounted in noAccount state when balance is unfunded', () => {
       mockUseMoneyAccountInfo.mockReturnValue({
         hasMoneyAccount: false,
         primaryMoneyAccount: undefined,
         isMoneyAccountFeatureEnabled: true,
       });
+      mockUseMoneyAccountBalance.mockReturnValue({
+        totalFiatFormatted: '$0.00',
+        totalFiatRaw: '0',
+        tokenTotal: new BigNumber(0),
+        isAggregatedBalanceLoading: false,
+        isBalanceFetchError: false,
+        isBalanceFetching: false,
+        refetchBalance: mockRefetchBalance,
+        apyPercent: 5,
+        vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: [],
         deposits: [],
@@ -592,7 +606,7 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  it('hides the how it works section in filled state', () => {
+  it('hides the how it works section in funded state', () => {
     const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
     expect(
       queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
@@ -613,7 +627,7 @@ describe('MoneyHomeView', () => {
     expect(getByTestId(MoneyMetaMaskCardTestIds.CONTAINER)).toBeOnTheScreen();
   });
 
-  it('hides the what you get section in filled state', () => {
+  it('hides the what you get section in funded state', () => {
     const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
     expect(
       queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
@@ -739,11 +753,24 @@ describe('MoneyHomeView', () => {
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.POTENTIAL_EARNINGS);
   });
 
-  it('opens the MUSD learn more URL when learn more is pressed in empty state', () => {
+  it('opens the MUSD learn more URL when learn more is pressed in unfunded state', () => {
     const mockOpenURL = jest
       .spyOn(Linking, 'openURL')
       .mockResolvedValue(undefined);
 
+    mockUseMoneyAccountBalance.mockReturnValue({
+      totalFiatFormatted: '$0.00',
+      totalFiatRaw: '0',
+      tokenTotal: new BigNumber(0),
+      isAggregatedBalanceLoading: false,
+      isBalanceFetchError: false,
+      isBalanceFetching: false,
+      refetchBalance: mockRefetchBalance,
+      apyPercent: 5,
+      vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
+      musdBalanceQuery: { data: undefined, isLoading: false },
+      musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+    } as unknown as ReturnType<typeof useMoneyAccountBalance>);
     mockUseMoneyAccountTransactions.mockReturnValue({
       allTransactions: [],
       deposits: [],
@@ -846,12 +873,12 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  describe('milestone state (1-9 transactions)', () => {
+  describe('funded state (positive balance)', () => {
     beforeEach(() => {
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: Array.from({ length: 3 }, (_, index) => ({
           ...MOCK_MONEY_TRANSACTIONS[index % MOCK_MONEY_TRANSACTIONS.length],
-          id: `milestone-${index}`,
+          id: `funded-${index}`,
         })),
         deposits: [],
         transfers: [],
@@ -939,7 +966,7 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  describe('card-unlinked state (milestone + has cardholder)', () => {
+  describe('card-unlinked state (funded + has cardholder)', () => {
     beforeEach(() => {
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: Array.from({ length: 3 }, (_, index) => ({
@@ -1077,8 +1104,26 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  describe('empty state (0 transactions)', () => {
+  describe('unfunded state (zero balance)', () => {
     beforeEach(() => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        totalFiatFormatted: '$0.00',
+        musdFiatFormatted: '$0.00',
+        musdSHFvdFiatFormatted: '$0.00',
+        totalFiatRaw: '0',
+        tokenTotal: new BigNumber(0),
+        withdrawableMusd: undefined,
+        isAggregatedBalanceLoading: false,
+        isBalanceFetchError: false,
+        isBalanceFetching: false,
+        refetchBalance: mockRefetchBalance,
+        apyDecimal: 0.05,
+        apyPercent: 5,
+        apyPercentFormatted: '5%',
+        vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: [],
         deposits: [],
@@ -1161,7 +1206,39 @@ describe('MoneyHomeView', () => {
     });
   });
 
-  describe('filled state navigation handlers', () => {
+  describe('balance not ready (tokenTotal undefined)', () => {
+    beforeEach(() => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        totalFiatFormatted: '$3.00',
+        totalFiatRaw: '3',
+        tokenTotal: undefined,
+        isAggregatedBalanceLoading: false,
+        isBalanceFetchError: false,
+        isBalanceFetching: false,
+        refetchBalance: mockRefetchBalance,
+        apyPercent: 5,
+        vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      } as unknown as ReturnType<typeof useMoneyAccountBalance>);
+    });
+
+    it('renders neither the funded nor the unfunded blocks', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        queryByTestId(MoneyCondensedInfoCardsTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('navigation handlers', () => {
     it('navigates to Potential Earnings when View all is pressed on potential earnings section', () => {
       mockUseMoneyDepositTokens.mockReturnValueOnce({
         tokens: Array.from({ length: 6 }, (_, i) => ({

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -1221,6 +1221,14 @@ describe('MoneyHomeView', () => {
         musdBalanceQuery: { data: undefined, isLoading: false },
         musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: [],
+        deposits: [],
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+        mockDataEnabled: false,
+      });
     });
 
     it('renders neither the funded nor the unfunded blocks', () => {
@@ -1232,6 +1240,61 @@ describe('MoneyHomeView', () => {
       expect(
         queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
       ).not.toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('spent-to-zero (zero balance with activity)', () => {
+    beforeEach(() => {
+      mockUseMoneyAccountBalance.mockReturnValue({
+        totalFiatFormatted: '$0.00',
+        musdFiatFormatted: '$0.00',
+        musdSHFvdFiatFormatted: '$0.00',
+        totalFiatRaw: '0',
+        tokenTotal: new BigNumber(0),
+        withdrawableMusd: undefined,
+        isAggregatedBalanceLoading: false,
+        isBalanceFetchError: false,
+        isBalanceFetching: false,
+        refetchBalance: mockRefetchBalance,
+        apyDecimal: 0.05,
+        apyPercent: 5,
+        apyPercentFormatted: '5%',
+        vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      } as unknown as ReturnType<typeof useMoneyAccountBalance>);
+      mockUseMoneyAccountTransactions.mockReturnValue({
+        allTransactions: Array.from({ length: 3 }, (_, index) => ({
+          ...MOCK_MONEY_TRANSACTIONS[index % MOCK_MONEY_TRANSACTIONS.length],
+          id: `spent-to-zero-${index}`,
+        })),
+        deposits: [],
+        transfers: [],
+        submittedTransactions: [],
+        moneyAddress: '0x0000000000000000000000000000000000000001',
+        mockDataEnabled: false,
+      });
+    });
+
+    it('renders condensed info cards', () => {
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        getByTestId(MoneyCondensedInfoCardsTestIds.CONTAINER),
+      ).toBeOnTheScreen();
+    });
+
+    it('hides expanded HowItWorks section', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+      expect(
+        queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('hides expanded WhatYouGet section', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
       expect(
         queryByTestId(MoneyWhatYouGetTestIds.CONTAINER),
       ).not.toBeOnTheScreen();

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -121,7 +121,7 @@ const MoneyHomeView = () => {
   });
 
   const balanceReady = tokenTotal !== undefined;
-  const isFunded = isAccountFunded(tokenTotal);
+  const isFunded = isAccountFunded(tokenTotal) || activityItems.length > 0;
 
   let displayState: MoneyBalanceDisplayState;
   if (!hasMoneyAccount) {
@@ -394,7 +394,7 @@ const MoneyHomeView = () => {
           apy={apyPercent}
         />
         <Divider />
-        {balanceReady && isFunded && (
+        {isFunded && (
           <>
             <MoneyCondensedInfoCards
               onHowItWorksPress={handleHowItWorksHeaderPress}

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -33,6 +33,7 @@ import useMoneyAccountInfo from '../../hooks/useMoneyAccountInfo';
 import { useOnboardingStep, STEPPER_IDS } from '../../hooks/useOnboardingStep';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { moneyFormatFiat } from '../../utils/moneyFormatFiat';
+import { isAccountFunded } from '../../utils/isAccountFunded';
 import { calculateProjectedEarnings } from '../../utils/projections';
 import { MUSD_MAINNET_ASSET_FOR_DETAILS } from '../../../../Views/Homepage/Sections/Cash/CashGetMusdEmptyState.constants';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
@@ -54,14 +55,6 @@ import { MONEY_ONBOARDING_TOTAL_STEPS } from '../../components/MoneyOnboardingCa
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 const Divider = () => <Box twClassName="h-px bg-border-muted my-5" />;
 
-type MoneyHomeState = 'empty' | 'milestone' | 'filled';
-
-const getMoneyHomeState = (transactionCount: number): MoneyHomeState => {
-  if (transactionCount === 0) return 'empty';
-  if (transactionCount < 10) return 'milestone';
-  return 'filled';
-};
-
 const MoneyHomeView = () => {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
@@ -72,6 +65,7 @@ const MoneyHomeView = () => {
   const {
     totalFiatFormatted,
     totalFiatRaw,
+    tokenTotal,
     vaultApyQuery,
     isAggregatedBalanceLoading,
     isBalanceFetchError,
@@ -126,8 +120,8 @@ const MoneyHomeView = () => {
     totalSteps: MONEY_ONBOARDING_TOTAL_STEPS,
   });
 
-  const homeState = getMoneyHomeState(activityItems.length);
-  const isMilestone = homeState === 'milestone' || homeState === 'filled';
+  const balanceReady = tokenTotal !== undefined;
+  const isFunded = isAccountFunded(tokenTotal);
 
   let displayState: MoneyBalanceDisplayState;
   if (!hasMoneyAccount) {
@@ -341,7 +335,7 @@ const MoneyHomeView = () => {
               <Divider />
             </>
           )}
-        {!isMilestone && (
+        {balanceReady && !isFunded && (
           <>
             <MoneyHowItWorks
               apy={apyPercent}
@@ -400,7 +394,7 @@ const MoneyHomeView = () => {
           apy={apyPercent}
         />
         <Divider />
-        {isMilestone && (
+        {balanceReady && isFunded && (
           <>
             <MoneyCondensedInfoCards
               onHowItWorksPress={handleHowItWorksHeaderPress}
@@ -410,7 +404,7 @@ const MoneyHomeView = () => {
             <Divider />
           </>
         )}
-        {!isMilestone && (
+        {balanceReady && !isFunded && (
           <MoneyWhatYouGet
             apy={apyPercent}
             onLearnMorePress={handleLearnMorePress}

--- a/app/components/UI/Money/utils/isAccountFunded.test.ts
+++ b/app/components/UI/Money/utils/isAccountFunded.test.ts
@@ -1,0 +1,21 @@
+import { BigNumber } from 'bignumber.js';
+import { isAccountFunded } from './isAccountFunded';
+
+describe('isAccountFunded', () => {
+  it('returns false when tokenTotal is undefined', () => {
+    expect(isAccountFunded(undefined)).toBe(false);
+  });
+
+  it('returns false when tokenTotal is zero', () => {
+    expect(isAccountFunded(new BigNumber(0))).toBe(false);
+  });
+
+  it('returns true when tokenTotal is positive', () => {
+    expect(isAccountFunded(new BigNumber('0.01'))).toBe(true);
+    expect(isAccountFunded(new BigNumber(100))).toBe(true);
+  });
+
+  it('returns false when tokenTotal is negative', () => {
+    expect(isAccountFunded(new BigNumber(-1))).toBe(false);
+  });
+});

--- a/app/components/UI/Money/utils/isAccountFunded.ts
+++ b/app/components/UI/Money/utils/isAccountFunded.ts
@@ -1,0 +1,4 @@
+import type BigNumber from 'bignumber.js';
+
+export const isAccountFunded = (tokenTotal: BigNumber | undefined): boolean =>
+  tokenTotal !== undefined && tokenTotal.gt(0);

--- a/app/components/UI/Money/utils/isAccountFunded.ts
+++ b/app/components/UI/Money/utils/isAccountFunded.ts
@@ -1,4 +1,4 @@
 import type BigNumber from 'bignumber.js';
 
-export const isAccountFunded = (tokenTotal: BigNumber | undefined): boolean =>
-  tokenTotal !== undefined && tokenTotal.gt(0);
+export const isAccountFunded = (fiatTotal): boolean =>
+  fiatTotal !== undefined && new BigNumber(fiatTotal).gt(0);

--- a/app/components/UI/Money/utils/isAccountFunded.ts
+++ b/app/components/UI/Money/utils/isAccountFunded.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import type BigNumber from 'bignumber.js';
 
-export const isAccountFunded = (fiatTotal: BigNumber | undefined): boolean =>
-  fiatTotal !== undefined && new BigNumber(fiatTotal).gt(0);
+export const isAccountFunded = (tokenTotal: BigNumber | undefined): boolean =>
+  tokenTotal !== undefined && tokenTotal.gt(0);

--- a/app/components/UI/Money/utils/isAccountFunded.ts
+++ b/app/components/UI/Money/utils/isAccountFunded.ts
@@ -1,4 +1,4 @@
-import type BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
-export const isAccountFunded = (fiatTotal): boolean =>
+export const isAccountFunded = (fiatTotal: BigNumber | undefined): boolean =>
   fiatTotal !== undefined && new BigNumber(fiatTotal).gt(0);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The money account home screen decided whether a user had "funded" their account by counting transactions (`getMoneyHomeState(activityItems.length)`). This is an unreliable signal: a user can hold a balance without any transactions on the account, so funded users were incorrectly shown onboarding/empty-state copy and sections.

This change derives the funded state from the account balance combined with past activity, instead of from transaction count alone. An account is treated as funded when it has a balance greater than zero **or** any past activity:

- A new pure helper `isAccountFunded(tokenTotal)` returns `true` only when the balance is defined and greater than zero. The screen reads `tokenTotal` (mUSD + vmUSD) from `useMoneyAccountBalance`.
- The funded decision is the union of two complementary signals: `isAccountFunded(tokenTotal) || activityItems.length > 0`. Balance catches "funded with no transaction surfaced yet" (the original bug); past activity catches "had funds and spent down to zero" — spending always leaves a transaction, and transaction history never decreases, so this is the monotonic "have they ever been active" signal we want.
- While the balance is still resolving (`tokenTotal === undefined`, i.e. loading or fetch error) the unfunded sections are withheld to avoid a flash of the wrong state. If there is past activity the funded sections still render immediately, since activity alone confidently confirms funded.
- The activity list itself remains transaction-driven, as it should be.

This combination resolves the failure mode the ticket flagged (a spent-to-zero account looking new): such an account always retains its spend transaction, so it stays funded without needing a separate historical-activity fetch. The only residual case is an account that was funded with no surfaced transaction and then drained to zero with no surfaced transaction — not expected in practice given the activity feed merges money and card transactions.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where money accounts that already held a balance were incorrectly shown onboarding/empty-state content.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-933

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account funding state

  Scenario: Funded account with no transactions shows the funded UI
    Given a money account that holds a balance greater than zero
    And the account has no transactions

    When the user opens the money account home screen
    Then the funded sections are shown (condensed info cards)
    And the onboarding/empty-state sections are not shown (How it works, What you get)

  Scenario: Unfunded account shows the onboarding UI
    Given a money account with a zero balance
    And the account has no past activity

    When the user opens the money account home screen
    Then the onboarding/empty-state sections are shown
    And the funded sections are not shown

  Scenario: Spent-to-zero account still shows the funded UI
    Given a money account with a zero balance
    And the account has past activity (e.g. a previous spend)

    When the user opens the money account home screen
    Then the funded sections are shown
    And the onboarding/empty-state sections are not shown

  Scenario: State does not flash while the balance loads
    Given a money account whose balance is still loading

    When the user opens the money account home screen
    Then neither the funded nor the unfunded sections are shown until the balance resolves
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — this change only swaps the input used to derive an existing UI state (transaction count → balance); there is no visual redesign. The corrected behavior is covered by unit tests and verified manually.

### **After**

<!-- [screenshots/recordings] -->

N/A — see above.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which onboarding vs funded sections users see on a money-critical screen; logic is covered by new unit tests but wrong balance/activity signals could still mis-route UX.
> 
> **Overview**
> **Money home** no longer treats “funded” vs onboarding UI as a function of transaction count (`empty` / `milestone` / `filled`). It now uses **`tokenTotal`** from `useMoneyAccountBalance` plus a new **`isAccountFunded`** helper, with **`isFunded = isAccountFunded(tokenTotal) || activityItems.length > 0`** so users with balance but no txs see funded UI, and spent-to-zero accounts with history stay funded.
> 
> **Section gating** swaps `isMilestone` for `isFunded` and adds **`balanceReady`** (`tokenTotal !== undefined`): onboarding blocks (**How it works**, **What you get**, mUSD row) render only when balance is ready and not funded; condensed cards when funded. While balance is unresolved and there is no activity, neither funded nor unfunded blocks show to avoid flashing the wrong state.
> 
> **Tests** are renamed and expanded for unfunded, funded, balance-not-ready, and spent-to-zero scenarios, with mocks supplying realistic `tokenTotal` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfe2bb0eb5469c114daa5eca9c05ec4534eed1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

