### PR TITLE
fix(token-details): cp-7.81.0 show swap/quick buy when only viewed token held

### DIFF
--- a/app/components/UI/TokenDetails/hooks/useStickyTokenActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useStickyTokenActions.test.ts
@@ -4,6 +4,7 @@ import { useStickyTokenActions } from './useStickyTokenActions';
 import { useHandleOnBuy, useHandleOnSwap } from './useTokenAtomicActions';
 import { useAddNetwork } from '../../../hooks/useAddNetwork';
 import { TokenI } from '../../Tokens/types';
+import { selectHasEligibleSwapSource } from '../../../../selectors/assets/assets-list';
 
 const mockOnBuy = jest.fn();
 const mockOnSwap = jest.fn();
@@ -71,5 +72,11 @@ describe('useStickyTokenActions', () => {
       currentTokenBalance: '1.25',
       sourcePage: 'TokenDetails',
     });
+  });
+
+  it('selects swap eligibility without excluding the viewed token', () => {
+    renderHook(() => useStickyTokenActions({ token: defaultToken }));
+
+    expect(mockUseSelector).toHaveBeenCalledWith(selectHasEligibleSwapSource);
   });
 });

--- a/app/components/UI/TokenDetails/hooks/useStickyTokenActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useStickyTokenActions.ts
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux';
 import { useAddNetwork } from '../../../hooks/useAddNetwork';
 import { selectHasEligibleSwapSource } from '../../../../selectors/assets/assets-list';
-import type { RootState } from '../../../../reducers';
 import {
   TokenActionInput,
   useHandleOnBuy,
@@ -22,9 +21,7 @@ export const useStickyTokenActions = ({
   /** Page name sent with swap/bridge analytics. Defaults to `'MainView'`. */
   sourcePage?: string;
 }) => {
-  const hasEligibleSwapTokens = useSelector((state: RootState) =>
-    selectHasEligibleSwapSource(state, token.chainId, token.address),
-  );
+  const hasEligibleSwapTokens = useSelector(selectHasEligibleSwapSource);
 
   const onBuy = useHandleOnBuy({ token });
   const onSwap = useHandleOnSwap({ token, currentTokenBalance, sourcePage });

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -2281,10 +2281,8 @@ describe('selectAssetsByAccountGroupId', () => {
 describe('selectHasEligibleSwapSource', () => {
   const ETH_MAINNET = '0x1';
   const OPTIMISM = '0xa';
-  const SOLANA = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
   const DAI_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
   const USDC_ADDRESS = '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85';
-  const STETH_ADDRESS = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
 
   interface AssetFixture {
     assetId: string;
@@ -2315,193 +2313,68 @@ describe('selectHasEligibleSwapSource', () => {
    * Invokes the selector's pure result function so each test can focus on
    * behavior rather than rebuilding the full Redux state shape.
    */
-  const runSelector = (
-    assets: AssetFixture[],
-    excludedChainId?: string,
-    excludedAddress?: string,
-  ): boolean =>
-    selectHasEligibleSwapSource.resultFunc(
-      buildAssetsByChain(assets) as never,
-      excludedChainId,
-      excludedAddress,
-    );
+  const runSelector = (assets: AssetFixture[]): boolean =>
+    selectHasEligibleSwapSource.resultFunc(buildAssetsByChain(assets) as never);
 
-  describe('when no exclusion is provided', () => {
-    const noExclusionReturnsTrueCases = [
-      {
-        description: 'returns true when any asset has positive fiat balance',
-        getAssets: () => [buildAsset({ fiat: { balance: 50 } })],
-        expected: true,
-      },
-      {
-        description:
-          'returns true when at least one chain holds a positive-fiat asset',
-        getAssets: () => [
-          buildAsset({ chainId: ETH_MAINNET, fiat: { balance: 0 } }),
-          buildAsset({ chainId: OPTIMISM, fiat: { balance: 50 } }),
-        ],
-        expected: true,
-      },
-    ];
+  const returnsTrueCases = [
+    {
+      description: 'returns true when any asset has positive fiat balance',
+      getAssets: () => [buildAsset({ fiat: { balance: 50 } })],
+      expected: true,
+    },
+    {
+      description:
+        'returns true when at least one chain holds a positive-fiat asset',
+      getAssets: () => [
+        buildAsset({ chainId: ETH_MAINNET, fiat: { balance: 0 } }),
+        buildAsset({ chainId: OPTIMISM, fiat: { balance: 50 } }),
+      ],
+      expected: true,
+    },
+    {
+      description:
+        'returns true when the only funded asset is the currently-viewed token',
+      getAssets: () => [
+        buildAsset({ assetId: DAI_ADDRESS, fiat: { balance: 100 } }),
+      ],
+      expected: true,
+    },
+  ];
 
-    const noExclusionReturnsFalseCases = [
-      {
-        description: 'returns false when the asset map is empty',
-        getAssets: () => [] as AssetFixture[],
-        expected: false,
-      },
-      {
-        description: 'returns false when every asset has a zero fiat balance',
-        getAssets: () => [
-          buildAsset({ assetId: DAI_ADDRESS, fiat: { balance: 0 } }),
-          buildAsset({ assetId: USDC_ADDRESS, fiat: { balance: 0 } }),
-        ],
-        expected: false,
-      },
-      {
-        description:
-          'returns false when every asset has a negative fiat balance',
-        getAssets: () => [buildAsset({ fiat: { balance: -1 } })],
-        expected: false,
-      },
-      {
-        description: 'returns false when no asset has a fiat property',
-        getAssets: () => [buildAsset({ fiat: undefined })],
-        expected: false,
-      },
-    ];
+  const returnsFalseCases = [
+    {
+      description: 'returns false when the asset map is empty',
+      getAssets: () => [] as AssetFixture[],
+      expected: false,
+    },
+    {
+      description: 'returns false when every asset has a zero fiat balance',
+      getAssets: () => [
+        buildAsset({ assetId: DAI_ADDRESS, fiat: { balance: 0 } }),
+        buildAsset({ assetId: USDC_ADDRESS, fiat: { balance: 0 } }),
+      ],
+      expected: false,
+    },
+    {
+      description: 'returns false when every asset has a negative fiat balance',
+      getAssets: () => [buildAsset({ fiat: { balance: -1 } })],
+      expected: false,
+    },
+    {
+      description: 'returns false when no asset has a fiat property',
+      getAssets: () => [buildAsset({ fiat: undefined })],
+      expected: false,
+    },
+  ];
 
-    it.each([...noExclusionReturnsTrueCases, ...noExclusionReturnsFalseCases])(
-      '$description',
-      ({ getAssets, expected }) => {
-        expect(runSelector(getAssets())).toBe(expected);
-      },
-    );
-  });
+  it.each([...returnsTrueCases, ...returnsFalseCases])(
+    '$description',
+    ({ getAssets, expected }) => {
+      expect(runSelector(getAssets())).toBe(expected);
+    },
+  );
 
-  describe('when an excluded chainId and address are provided', () => {
-    type TestAsset = '0x1:DAI' | '0xa:DAI' | '0x1:USDC' | '0xa:USDC';
-    const buildAssets = (testAsset: TestAsset[]) =>
-      testAsset.map((asset) => {
-        const [chainId, testAssetName] = asset.split(':');
-
-        let assetId = DAI_ADDRESS;
-        if (testAssetName === 'USDC') {
-          assetId = USDC_ADDRESS;
-        } else if (testAssetName === 'DAI') {
-          assetId = DAI_ADDRESS;
-        }
-
-        return buildAsset({ assetId, chainId });
-      });
-
-    const buildOmitInput = (testAsset: TestAsset) => {
-      const [chainId, testAssetName] = testAsset.split(':');
-      const excludedChainId = chainId;
-      let assetId = DAI_ADDRESS;
-      if (testAssetName === 'USDC') {
-        assetId = USDC_ADDRESS;
-      } else if (testAssetName === 'DAI') {
-        assetId = DAI_ADDRESS;
-      }
-
-      return {
-        excludedChainId,
-        excludedAddress: assetId,
-      };
-    };
-
-    const exclusionProvidedCases = [
-      {
-        description:
-          'returns false when the only positive-fiat asset matches the exclusion',
-        getInputs: () => ({
-          assets: buildAssets(['0x1:DAI']),
-          ...buildOmitInput('0x1:DAI'), // 0x1:DAI is excluded
-        }),
-        assertResult: (result: boolean) => expect(result).toBe(false),
-      },
-      {
-        description:
-          'returns true when a non-excluded asset on another chain still qualifies',
-        getInputs: () => ({
-          assets: buildAssets(['0x1:DAI', '0xa:USDC']),
-          ...buildOmitInput('0x1:DAI'), // 0xa:USDC is still valid
-        }),
-        assertResult: (result: boolean) => expect(result).toBe(true),
-      },
-      {
-        description:
-          'returns true when the excluded chainId matches but the address differs',
-        getInputs: () => ({
-          assets: buildAssets(['0x1:DAI']),
-          ...buildOmitInput('0x1:USDC'), // 0x1:DAI is still valid
-        }),
-        assertResult: (result: boolean) => expect(result).toBe(true),
-      },
-      {
-        description:
-          'returns true when the excluded address matches but the chainId differs',
-        getInputs: () => ({
-          assets: buildAssets(['0xa:DAI']),
-          ...buildOmitInput('0x1:DAI'), // 0x1:DAI is still valid
-        }),
-        assertResult: (result: boolean) => expect(result).toBe(true),
-      },
-      {
-        description:
-          'skips assets with non-positive fiat before checking exclusion',
-        getInputs: () => {
-          const assets = buildAssets(['0x1:USDC', '0x1:DAI']);
-          assets[0].fiat = { balance: 0 };
-          return {
-            assets,
-            ...buildOmitInput('0x1:DAI'), // 0x1:USDC skipped, 0x1:DAI is excluded
-          };
-        },
-        assertResult: (result: boolean) => expect(result).toBe(false),
-      },
-    ];
-
-    it.each(exclusionProvidedCases)(
-      '$description',
-      ({ getInputs, assertResult }) => {
-        const { assets, excludedChainId, excludedAddress } = getInputs();
-        assertResult(runSelector(assets, excludedChainId, excludedAddress));
-      },
-    );
-  });
-
-  describe('integrated with Redux state', () => {
-    const integratedReturnsTrueCases = [
-      {
-        description:
-          'returns true for the default mockState since multiple positive-fiat assets exist',
-        excludedChainId: undefined,
-        excludedAddress: undefined,
-      },
-      {
-        description:
-          'returns true when one EVM asset is excluded but other positive-fiat assets remain',
-        excludedChainId: ETH_MAINNET,
-        excludedAddress: STETH_ADDRESS,
-      },
-      {
-        description:
-          'returns true when a non-EVM asset is the exclusion target',
-        excludedChainId: SOLANA,
-        excludedAddress: `${SOLANA}/slip44:501`,
-      },
-    ];
-
-    it.each(integratedReturnsTrueCases)(
-      '$description',
-      ({ excludedChainId, excludedAddress }) => {
-        const state = mockState();
-        expect(
-          selectHasEligibleSwapSource(state, excludedChainId, excludedAddress),
-        ).toBe(true);
-      },
-    );
+  it('returns true for the default mockState since positive-fiat assets exist', () => {
+    expect(selectHasEligibleSwapSource(mockState())).toBe(true);
   });
 });

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -161,26 +161,18 @@ export const selectAssetsBySelectedAccountGroup = createDeepEqualSelector(
 
 /**
  * Cheap boolean check: does the selected account group hold any
- * non-excluded positive-fiat-balance asset
+ * positive-fiat-balance asset.
+ *
+ * A held asset is itself a valid swap source (it can be swapped away), so the
+ * currently-viewed token is intentionally counted. This drives the Token
+ * Details footer's Swap / QuickBuy visibility and the Buy on-ramp fallback.
  */
 export const selectHasEligibleSwapSource = createSelector(
-  [
-    selectAssetsBySelectedAccountGroup,
-    (_state: RootState, excludedChainId?: string) => excludedChainId,
-    (_state: RootState, _excludedChainId?: string, excludedAddress?: string) =>
-      excludedAddress,
-  ],
-  (assetsByChain, excludedChainId, excludedAddress): boolean => {
+  [selectAssetsBySelectedAccountGroup],
+  (assetsByChain): boolean => {
     for (const chainAssets of Object.values(assetsByChain)) {
       for (const asset of chainAssets) {
-        if ((asset.fiat?.balance ?? 0) <= 0) continue;
-
-        const isExcludedToken =
-          asset.chainId === excludedChainId &&
-          excludedAddress !== undefined &&
-          asset.assetId.toLowerCase() === excludedAddress.toLowerCase();
-
-        if (!isExcludedToken) {
+        if ((asset.fiat?.balance ?? 0) > 0) {
           return true;
         }
       }

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -1,60 +1,60 @@
+import type { AccountGroupId } from '@metamask/account-api';
 import {
+  AccountGroupAssets,
   Asset,
+  AssetListState,
   selectAllAssets as _selectAllAssets,
   selectAssetsBySelectedAccountGroup as _selectAssetsBySelectedAccountGroup,
   getNativeTokenAddress,
-  AssetListState,
-  AccountGroupAssets,
 } from '@metamask/assets-controllers';
-import type { AccountGroupId } from '@metamask/account-api';
+import { toHex } from '@metamask/controller-utils';
 import {
   MULTICHAIN_NETWORK_DECIMAL_PLACES,
   toEvmCaipChainId,
 } from '@metamask/multichain-network-controller';
-import { toHex } from '@metamask/controller-utils';
 import { CaipChainId, Hex, hexToBigInt, isCaipChainId } from '@metamask/utils';
 import { createSelector } from 'reselect';
 
 import I18n from '../../../locales/i18n';
+import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
 import { TokenI } from '../../components/UI/Tokens/types';
-import { RootState } from '../../reducers';
-import { formatWithThreshold } from '../../util/assets';
-import { selectEvmNetworkConfigurationsByChainId } from '../networkController';
-import { selectEnabledNetworksByNamespace } from '../networkEnablementController';
-import { selectTokenSortConfig } from '../preferencesController';
-import { selectHideZeroBalanceTokens } from '../settings';
-import { createDeepEqualSelector } from '../util';
-import { fromWei, hexToBN, weiToFiatNumber } from '../../util/number';
-import {
-  selectCurrencyRates,
-  selectCurrentCurrency,
-} from '../currencyRateController';
-import { safeParseBigNumber } from '../../util/number/bignumber';
-import { selectAccountsByChainId } from '../accountTrackerController';
+import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
 import {
   TRON_SPECIAL_ASSET_SYMBOLS,
   TRON_SPECIAL_ASSET_SYMBOLS_SET,
   TronSpecialAssetSymbol,
 } from '../../core/Multichain/constants';
 import { isTronSpecialAsset } from '../../core/Multichain/utils';
-import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
-import { selectAllTokens } from '../tokensController';
+import { RootState } from '../../reducers';
+import { formatWithThreshold } from '../../util/assets';
+import { fromWei, hexToBN, weiToFiatNumber } from '../../util/number';
+import { safeParseBigNumber } from '../../util/number/bignumber';
 import { selectSelectedInternalAccountAddress } from '../accountsController';
-import { selectSelectedInternalAccountByScope } from '../multichainAccounts/accounts';
-import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
+import { selectAccountsByChainId } from '../accountTrackerController';
 import {
-  getMultichainAssetsRatesControllerConversionRates,
-  getTokenRatesControllerMarketData,
+  selectCurrencyRates,
+  selectCurrentCurrency,
+} from '../currencyRateController';
+import { selectSelectedInternalAccountByScope } from '../multichainAccounts/accounts';
+import { selectEvmNetworkConfigurationsByChainId } from '../networkController';
+import { selectEnabledNetworksByNamespace } from '../networkEnablementController';
+import { selectTokenSortConfig } from '../preferencesController';
+import { selectHideZeroBalanceTokens } from '../settings';
+import { selectAllTokens } from '../tokensController';
+import { createDeepEqualSelector } from '../util';
+import {
+  getAccountTrackerControllerAccountsByChainId,
   getCurrencyRateControllerCurrencyRates,
   getCurrencyRateControllerCurrentCurrency,
-  getTokensControllerAllTokens,
-  getTokensControllerAllIgnoredTokens,
-  getAccountTrackerControllerAccountsByChainId,
-  getTokenBalancesControllerTokenBalances,
-  getMultiChainBalancesControllerBalances,
   getMultiChainAssetsControllerAccountsAssets,
   getMultiChainAssetsControllerAllIgnoredAssets,
   getMultiChainAssetsControllerAssetsMetadata,
+  getMultiChainBalancesControllerBalances,
+  getMultichainAssetsRatesControllerConversionRates,
+  getTokenBalancesControllerTokenBalances,
+  getTokenRatesControllerMarketData,
+  getTokensControllerAllIgnoredTokens,
+  getTokensControllerAllTokens,
 } from './assets-migration';
 
 /**
@@ -166,12 +166,9 @@ export const selectAssetsBySelectedAccountGroup = createDeepEqualSelector(
 export const selectHasEligibleSwapSource = createSelector(
   [
     selectAssetsBySelectedAccountGroup,
-    (_state: RootState, excludedChainId: string | undefined) => excludedChainId,
-    (
-      _state: RootState,
-      _excludedChainId: string | undefined,
-      excludedAddress: string | undefined,
-    ) => excludedAddress,
+    (_state: RootState, excludedChainId?: string) => excludedChainId,
+    (_state: RootState, _excludedChainId?: string, excludedAddress?: string) =>
+      excludedAddress,
   ],
   (assetsByChain, excludedChainId, excludedAddress): boolean => {
     for (const chainAssets of Object.values(assetsByChain)) {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Token Details screen, the Swap button and the QuickBuy (lightning/flash) icon were both gated on `selectHasEligibleSwapSource`, which the footer called with the currently-viewed token **excluded**. As a result, **a user whose only funded asset was the token they were viewing (e.g. holding only ETH, on the ETH page) saw neither control, and only the fiat Buy fallback was shown**.

This is incorrect: the swap handler (`useHandleOnSwap`) already swaps the held token *away* when the user holds it, and QuickBuy's sell mode operates on the position token. So holding only the viewed token is a perfectly valid reason to surface Swap and QuickBuy.

The fix calls the selector with no exclusion args in `useStickyTokenActions`, so the viewed token counts as a fundable/swappable asset. The selector's optional `excludedChainId` / `excludedAddress` parameters are intentionally retained for any future caller that genuinely needs "any funded asset except X".

Behavioral delta: for a held token that is not fiat-buyable and with no other holdings, the Buy on-ramp fallback no longer shows; Swap is shown instead. For buyable tokens (e.g. ETH) both still show.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Swap and Quick Buy buttons not appearing on the token details screen when the only funded asset was the token being viewed.

## **Related issues**

Fixes: Issue where the Swap button wouldn't show, preventing me from swapping a token I actually hold.

## **Manual testing steps**

```gherkin
Feature: Token details trade actions for a single-asset wallet

  Scenario: User holding only the viewed token sees Swap and Quick Buy
    Given my wallet holds a positive balance of only one token (e.g. ETH)
    And I have no other funded assets
    When I open the Token Details screen for that token
    Then the Swap button is visible
    And the Quick Buy (lightning) icon is visible
    And tapping Quick Buy opens the QuickBuy sheet where I can sell the token
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1440" height="805" alt="image" src="https://github.com/user-attachments/assets/4e58144c-218a-473c-ad91-88c06c01499a" />

### **After**

<img width="694" height="919" alt="image" src="https://github.com/user-attachments/assets/b095e246-7584-41c1-a19f-01492669cd16" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to swap-eligibility gating and footer visibility on Token Details; no auth, payments, or data-layer changes.
> 
> **Overview**
> Fixes Token Details **Swap** and **Quick Buy** staying hidden when the user’s only funded asset is the token on screen.
> 
> `useStickyTokenActions` no longer passes the viewed token into `selectHasEligibleSwapSource` as an exclusion. **`selectHasEligibleSwapSource`** is simplified to a state-only check: any asset with positive fiat balance counts, including the current token, since that balance is a valid swap source.
> 
> Tests now assert the hook uses the selector without exclusions and that a single funded “viewed” token yields eligibility **true**. For wallets with only one non–fiat-buyable holding, the footer may show **Swap** instead of the Buy on-ramp fallback when swap eligibility is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5722fd1c856e89c57c2d282e3887fdee962867a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->