### PR TITLE
feat: keep asset ordering between screens in batch sell the same

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -874,4 +874,68 @@ describe('BatchSellTokenSelect', () => {
     });
     expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.BATCH_SELL_REVIEW);
   });
+
+  it('persists the descending sort order regardless of selection order', () => {
+    const stablecoinAssetId =
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
+    const highToken = createToken({
+      symbol: 'HIGH',
+      address: '0x1111111111111111111111111111111111111111',
+      tokenFiatAmount: 10,
+    });
+    const lowToken = createToken({
+      symbol: 'LOW',
+      address: '0x2222222222222222222222222222222222222222',
+      tokenFiatAmount: 1,
+    });
+    mockDestinationStablecoins = [BridgeTokenMetadata[stablecoinAssetId]];
+    mockWalletTokens = [highToken, lowToken];
+
+    const { getByTestId, getByText } = render(<BatchSellTokenSelect />);
+
+    // Select in ascending-value order to prove handoff uses sort order, not tap order.
+    fireEvent.press(getByText('LOW'));
+    fireEvent.press(getByText('HIGH'));
+
+    mockDispatch.mockClear();
+    fireEvent.press(getByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON));
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'bridge/setBatchSellSourceTokens',
+      payload: [highToken, lowToken],
+    });
+  });
+
+  it('persists the ascending sort order when the user toggles sorting', () => {
+    const stablecoinAssetId =
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CaipAssetType;
+    const highToken = createToken({
+      symbol: 'HIGH',
+      address: '0x1111111111111111111111111111111111111111',
+      tokenFiatAmount: 10,
+    });
+    const lowToken = createToken({
+      symbol: 'LOW',
+      address: '0x2222222222222222222222222222222222222222',
+      tokenFiatAmount: 1,
+    });
+    mockDestinationStablecoins = [BridgeTokenMetadata[stablecoinAssetId]];
+    mockWalletTokens = [highToken, lowToken];
+
+    const { getByTestId, getByText } = render(<BatchSellTokenSelect />);
+
+    fireEvent.press(
+      getByTestId(BatchSellTokenSelectSelectorsIDs.BALANCE_SORT_BUTTON),
+    );
+    fireEvent.press(getByText('HIGH'));
+    fireEvent.press(getByText('LOW'));
+
+    mockDispatch.mockClear();
+    fireEvent.press(getByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON));
+
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+      type: 'bridge/setBatchSellSourceTokens',
+      payload: [lowToken, highToken],
+    });
+  });
 });

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -255,25 +255,38 @@ export function BatchSellTokenSelect() {
       return;
     }
 
-    dispatch(setBatchSellSourceTokens(selectedTokens));
+    const orderedSelectedTokens = sortBatchSellTokens(
+      selectedTokens,
+      tokenSortDirection,
+    );
+
+    dispatch(setBatchSellSourceTokens(orderedSelectedTokens));
     dispatch(
       setBatchSellSourceTokenAmounts(
-        getDefaultBatchSellSourceTokenAmounts(selectedTokens),
+        getDefaultBatchSellSourceTokenAmounts(orderedSelectedTokens),
       ),
     );
     dispatch(
       setBatchSellDestToken(
         getBatchSellDestinationToken(
-          selectedTokens[0].chainId,
+          orderedSelectedTokens[0].chainId,
           destinationStablecoins,
         ),
       ),
     );
     dispatch(
-      setBatchSellTokenSlippages(getDefaultBatchSellSlippages(selectedTokens)),
+      setBatchSellTokenSlippages(
+        getDefaultBatchSellSlippages(orderedSelectedTokens),
+      ),
     );
     navigation.navigate(Routes.BRIDGE.BATCH_SELL_REVIEW);
-  }, [destinationStablecoins, dispatch, navigation, selectedTokens]);
+  }, [
+    destinationStablecoins,
+    dispatch,
+    navigation,
+    selectedTokens,
+    tokenSortDirection,
+  ]);
 
   const handleExploreTokensPress = useCallback(() => {
     navigation.navigate(Routes.TRENDING_VIEW, {


### PR DESCRIPTION
## **Description**

When a user changes the token sort order on the Batch Sell token selection screen and then taps **Continue**, the chosen order was not persisted to the quotes screen or the final review modal. This happened because the selected tokens were dispatched to Redux in tap order (the order in which the user clicked each row), which is independent of the sort direction displayed on screen.

This PR fixes the bug by sorting the selected tokens according to the active `tokenSortDirection` (ascending or descending) in `handleNextPress` before dispatching them to Redux via `setBatchSellSourceTokens`. Because both the quotes screen and the review modal derive their display order from the `sourceTokens` slice, a single sort at hand-off propagates the user's preference across the entire journey:

| Sort | Token Selection | Quotes Screen | Review Modal |
|------|----------------|---------------|--------------|
| **DESC** | ETH → AAVE → LINK | ETH → AAVE → LINK | ETH → AAVE → LINK |
| **ASC** | LINK → AAVE → ETH | LINK → AAVE → ETH | LINK → AAVE → ETH |

Two unit tests were added to cover the descending (default) and ascending cases.

## **Changelog**

CHANGELOG entry:  keep asset ordering between screens in batch sell the same

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4582

## **Manual testing steps**

```gherkin
Feature: Batch Sell token sort order persistence

  Scenario: User sorts tokens descending and continues to quotes
    Given the user has multiple tokens with different USD values on one chain
      And the Batch Sell token selection screen is open (default DESC sort)

    When the user selects the tokens in any order (e.g. lowest value first)
     And taps "Continue with (N) tokens"
    Then the quotes screen shows tokens ordered highest → lowest value
     And the final review modal shows the same highest → lowest order

  Scenario: User switches to ascending sort before continuing
    Given the user has multiple tokens with different USD values on one chain
      And the Batch Sell token selection screen is open

    When the user taps the sort toggle to switch to ASC order
     And selects the tokens in any order
     And taps "Continue with (N) tokens"
    Then the quotes screen shows tokens ordered lowest → highest value
     And the final review modal shows the same lowest → highest order
```

## **Screenshots/Recordings**

N/A — the change affects token ordering in the Redux store, not visual styling. The existing token-row UI is unchanged.

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/d237e34c-90e3-4feb-bea0-385a68cd58e4


N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized batch-sell handoff ordering with tests; no auth, payments, or broad Redux refactors.
> 
> **Overview**
> Fixes batch sell so **Continue** stores source tokens in the same order as the on-screen balance sort (asc/desc), not in tap order.
> 
> On multi-token continue, `handleNextPress` now runs `sortBatchSellTokens` with `tokenSortDirection` before Redux handoff (`setBatchSellSourceTokens`, amounts, destination token, slippages), so quotes and review follow the user's sort.
> 
> Two unit tests cover default descending and toggled ascending persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90b37c396a66d196f67f904414a1943203f67ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->