### PR TITLE
refactor: update useHasNativeFiatProvider to gate native

### DIFF
--- a/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.test.ts
+++ b/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.test.ts
@@ -11,35 +11,36 @@ describe('useHasNativeFiatProvider', () => {
     jest.resetAllMocks();
   });
 
-  function mockProviders(providers: unknown[]) {
+  function mockSelection(selectedProvider: unknown, providers: unknown[] = []) {
     useRampsProvidersMock.mockReturnValue({
       providers,
+      selectedProvider,
     } as unknown as ReturnType<typeof useRampsProviders>);
   }
 
-  it('returns true when a native provider exists', () => {
-    mockProviders([
-      { id: '/providers/transak', type: 'aggregator' },
-      { id: '/providers/transak-native', type: 'native' },
-    ]);
+  it('returns true when the selected (preferred) provider is native', () => {
+    mockSelection({ id: '/providers/transak-native', type: 'native' });
     const { result } = renderHook(() => useHasNativeFiatProvider());
     expect(result.current).toBe(true);
   });
 
-  it('returns false when only aggregator providers exist', () => {
-    mockProviders([{ id: '/providers/transak', type: 'aggregator' }]);
+  it('returns false when the selected provider is an aggregator, even if a native provider exists in the region', () => {
+    mockSelection({ id: '/providers/transak', type: 'aggregator' }, [
+      { id: '/providers/transak', type: 'aggregator' },
+      { id: '/providers/transak-native', type: 'native' },
+    ]);
     const { result } = renderHook(() => useHasNativeFiatProvider());
     expect(result.current).toBe(false);
   });
 
-  it('returns false when the provider list is empty', () => {
-    mockProviders([]);
+  it('returns false when no provider is selected', () => {
+    mockSelection(null, [{ id: '/providers/transak-native', type: 'native' }]);
     const { result } = renderHook(() => useHasNativeFiatProvider());
     expect(result.current).toBe(false);
   });
 
-  it('returns false when provider type is absent (pre-v2 catalog)', () => {
-    mockProviders([{ id: '/providers/transak' }]);
+  it('returns false when the selected provider has no type (pre-v2 catalog)', () => {
+    mockSelection({ id: '/providers/transak' });
     const { result } = renderHook(() => useHasNativeFiatProvider());
     expect(result.current).toBe(false);
   });

--- a/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts
+++ b/app/components/UI/Ramp/hooks/useHasNativeFiatProvider.ts
@@ -1,19 +1,28 @@
 import { useRampsProviders } from './useRampsProviders';
 
 /**
- * Returns whether the user's region has at least one NATIVE fiat on-ramp
- * provider (e.g. Transak Native).
+ * Returns whether the fiat deposit flow will run on a NATIVE provider
+ * (e.g. Transak Native).
  *
- * Headless fiat deposit (MM Pay / Money Account, Perps, Predict) is only
- * supported on native providers for v0, so consumers use this to gate the
- * fiat payment option where no native provider serves the region (e.g.
- * Brazil, which only exposes the aggregator). Read-only — it never mutates
- * provider selection or any controller state, so it has no effect on the
- * standalone Buy flows.
+ * Headless fiat deposit (MM Pay / Money Account, Perps, Predict) is native-only
+ * for v0. It is NOT enough for a native provider to merely exist in the region:
+ * what matters is the PREFERRED provider that gets selected. The headless quote
+ * auto-selects with `restrictToKnownOrNativeProviders`, but `RampsController`
+ * resolves the currently selected provider first (see
+ * `resolveProviderIdsForQuote`), so an aggregator preferred provider — carried
+ * over from order history, or the aggregator `/providers/transak` matched by the
+ * loose "transak" name check in `determinePreferredProvider` — would run a
+ * non-native deposit experience.
+ *
+ * Therefore we gate on the selected (preferred) provider being native, and block
+ * the flow whenever the preferred provider is an aggregator or none is native.
+ *
+ * Read-only — never mutates provider selection or controller state, so it has no
+ * effect on the standalone Buy flows.
  */
 export function useHasNativeFiatProvider(): boolean {
-  const { providers } = useRampsProviders();
-  return providers.some((provider) => provider.type === 'native');
+  const { selectedProvider } = useRampsProviders();
+  return selectedProvider?.type === 'native';
 }
 
 export default useHasNativeFiatProvider;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This is a follow-up refinement to the native fiat deposit gating introduced in #31209.

`useHasNativeFiatProvider` previously returned `true` whenever **any** native provider merely existed in the user's region (`providers.some((p) => p.type === 'native')`). That is not the condition that actually determines the deposit experience.

Headless fiat deposit (MM Pay / Money Account, Perps, Predict) is native-only for v0, but `RampsController` resolves the **currently selected (preferred) provider** first (see `resolveProviderIdsForQuote`) rather than relying on the headless quote's `restrictToKnownOrNativeProviders` auto-selection. As a result, an aggregator preferred provider — carried over from order history, or the aggregator `/providers/transak` matched by the loose `"transak"` name check in `determinePreferredProvider` — could run a **non-native** deposit experience even though the gate said a native provider was available.

This change gates on the **selected** provider's type instead (`selectedProvider?.type === 'native'`), so the flow is correctly blocked whenever the preferred provider is an aggregator or no native provider is selected. The hook remains read-only — it never mutates provider selection or controller state, so the standalone Buy flows are unaffected. The accompanying unit test was updated to assert against the selected-provider behavior.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: null

<!--
Internal refinement of an unreleased v0 gating hook (follow-up to #31209); no
user-visible change on its own. If release engineering would rather track it,
swap to:
CHANGELOG entry: Fixed native fiat deposit gating to key off the selected provider, so the cash deposit option no longer appears when an aggregator provider would handle the deposit.
-->

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3615

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Native fiat deposit gating

  Scenario: Preferred provider is an aggregator
    Given the user's region resolves a native provider
    And the user's selected/preferred provider is an aggregator (e.g. carried over from a previous order)
    When the user opens the cash deposit / add money flow (MM Pay, Money Account, Perps or Predict)
    Then the native fiat deposit option is not offered

  Scenario: Preferred provider is native
    Given the user's selected/preferred provider is a native provider (e.g. Transak Native)
    When the user opens the cash deposit / add money flow
    Then the native fiat deposit option is offered

  Scenario: No provider selected
    Given the user has no selected provider
    When the user opens the cash deposit / add money flow
    Then the native fiat deposit option is not offered
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — logic-only change to a read-only gating hook; there is no visual change beyond whether the existing option is offered. Behavior is covered by `app/components/UI/Ramp/hooks/useHasNativeFiatProvider.test.ts`.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes money/deposit UX gating logic; wrong behavior could hide or show fiat deposit incorrectly, but the hook stays read-only and scope is limited to one boolean gate.
> 
> **Overview**
> **`useHasNativeFiatProvider`** no longer treats “a native provider exists in the region” as sufficient for headless fiat deposit (MM Pay, Money Account, Perps, Predict). It now returns **`true` only when the selected/preferred provider’s `type` is `native`**, matching how `RampsController` resolves quotes so aggregator preferences (e.g. from order history or loose Transak matching) do not incorrectly expose the deposit path.
> 
> Unit tests were reworked to mock **`selectedProvider`** (not just the provider list), including the case where a native provider is available but an aggregator is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e01e31f31863c1f40187666928f426c119fa94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->