### PR TITLE
feat: improve notification settings toggles [GE-255]

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -254,6 +254,7 @@ describe('useNotificationAccountListProps', () => {
     });
     expect(hook.result.current.isAccountLoading(['id-0x123'])).toBe(true);
     expect(hook.result.current.isAccountLoading(['id-0x456'])).toBe(false);
+    expect(hook.result.current.isAnyAccountUpdating).toBe(true);
   });
 
   it('returns correct account enabled state', async () => {

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
@@ -58,6 +58,7 @@ export function useNotificationAccountListProps() {
     },
     [accountsBeingUpdated, getEvmAddressesFromAccountIds],
   );
+  const isAnyAccountUpdating = accountsBeingUpdated.length > 0;
 
   const isAccountEnabled = useCallback(
     (accountIds: string[]) => {
@@ -78,6 +79,7 @@ export function useNotificationAccountListProps() {
 
   return {
     shouldDisableSwitches,
+    isAnyAccountUpdating,
     refetchAccountSettings,
     isAccountLoading,
     isAccountEnabled,

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -8,10 +8,7 @@ import {
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar';
 // eslint-disable-next-line import-x/no-namespace
 import * as useSwitchNotificationsModule from '../../../../util/notifications/hooks/useSwitchNotifications';
-import {
-  NOTIFICATION_OPTIONS_TOGGLE_LOADING_TEST_ID,
-  NOTIFICATION_OPTIONS_TOGGLE_CONTAINER_TEST_ID,
-} from './NotificationOptionToggle';
+import { NOTIFICATION_OPTIONS_TOGGLE_CONTAINER_TEST_ID } from './NotificationOptionToggle';
 import { NotificationSettingsViewSelectorsIDs } from './NotificationSettingsView.testIds';
 import { toFormattedAddress } from '../../../../util/address';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
@@ -51,22 +48,12 @@ const ACCOUNT_1_TEST_ID = {
       CHECKSUMMED_ADDRESS_1,
     ),
   ),
-  itemLoading: NOTIFICATION_OPTIONS_TOGGLE_LOADING_TEST_ID(
-    NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
-      CHECKSUMMED_ADDRESS_1,
-    ),
-  ),
   itemSwitch: NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
     CHECKSUMMED_ADDRESS_1,
   ),
 };
 const ACCOUNT_2_TEST_ID = {
   item: NOTIFICATION_OPTIONS_TOGGLE_CONTAINER_TEST_ID(
-    NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
-      CHECKSUMMED_ADDRESS_2,
-    ),
-  ),
-  itemLoading: NOTIFICATION_OPTIONS_TOGGLE_LOADING_TEST_ID(
     NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
       CHECKSUMMED_ADDRESS_2,
     ),
@@ -202,6 +189,7 @@ describe('AccountList', () => {
     const mockRefetchAccountSettings = jest.fn();
     const notificationAccountListProps: NotificationAccountListProps = {
       shouldDisableSwitches: false,
+      isAnyAccountUpdating: false,
       refetchAccountSettings: mockRefetchAccountSettings,
       isAccountLoading: jest
         .fn()
@@ -254,20 +242,15 @@ describe('AccountList', () => {
 
   it('renders correctly', () => {
     const mocks = arrangeMocks();
-    const { getByTestId, queryByTestId } = renderAccountsList(mocks);
+    const { getByTestId } = renderAccountsList(mocks);
 
     // Assert - Items exist
     expect(getByTestId(ACCOUNT_1_TEST_ID.item)).toBeOnTheScreen();
     expect(getByTestId(ACCOUNT_2_TEST_ID.item)).toBeOnTheScreen();
     expect(getByTestId(ACCOUNT_3_TEST_ID.item)).toBeOnTheScreen();
 
-    // Assert - Item Loading
-    expect(getByTestId(ACCOUNT_1_TEST_ID.itemLoading)).toBeTruthy();
-
-    expect(queryByTestId(ACCOUNT_2_TEST_ID.itemLoading)).toBe(null);
-
     // Assert - Item Switch
-    expect(queryByTestId(ACCOUNT_1_TEST_ID.itemSwitch)).toBe(null); // We are loading, so this is null
+    expect(getByTestId(ACCOUNT_1_TEST_ID.itemSwitch).props.value).toBe(true);
     expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch).props.value).toBe(false); // The switch is set to false
   });
 
@@ -293,6 +276,26 @@ describe('AccountList', () => {
     );
   });
 
+  it('disables every switch while an account update is reported', () => {
+    const mocks = arrangeMocks();
+
+    const { getByTestId } = renderAccountsList(mocks, {
+      notificationAccountListProps: {
+        ...mocks.notificationAccountListProps,
+        isAnyAccountUpdating: true,
+      },
+    });
+
+    expect(getByTestId(ACCOUNT_1_TEST_ID.itemSwitch)).toHaveProp(
+      'disabled',
+      true,
+    );
+    expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch)).toHaveProp(
+      'disabled',
+      true,
+    );
+  });
+
   it('invokes switch toggle logic when clicked', async () => {
     const mocks = arrangeMocks();
 
@@ -306,11 +309,66 @@ describe('AccountList', () => {
 
     // Act
     const toggleSwitch = getByTestId(ACCOUNT_1_TEST_ID.itemSwitch);
-    fireEvent(toggleSwitch, 'onChange', { nativeEvent: { value: false } });
+    fireEvent(toggleSwitch, 'onValueChange', false);
 
     // Assert account was toggled, and we refetch all account notification toggles
     await waitFor(() => {
-      expect(mocks.mockOnToggle).toHaveBeenCalled();
+      expect(mocks.mockOnToggle).toHaveBeenCalledWith(
+        [CHECKSUMMED_ADDRESS_1],
+        false,
+      );
+      expect(mocks.mockRefetchAccountSettings).toHaveBeenCalled();
+    });
+  });
+
+  it('disables all switches immediately and ignores rapid second toggle', async () => {
+    const mocks = arrangeMocks();
+    let resolveToggle: () => void = () => undefined;
+    mocks.mockOnToggle.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveToggle = resolve;
+      }),
+    );
+
+    const { getByTestId } = renderAccountsList(mocks, {
+      notificationAccountListProps: {
+        ...mocks.notificationAccountListProps,
+        shouldDisableSwitches: false,
+        isAccountLoading: jest.fn().mockReturnValue(false),
+      },
+    });
+
+    const firstToggle = getByTestId(ACCOUNT_1_TEST_ID.itemSwitch);
+    const secondToggle = getByTestId(ACCOUNT_2_TEST_ID.itemSwitch);
+    fireEvent(firstToggle, 'onValueChange', false);
+    fireEvent(secondToggle, 'onValueChange', true);
+
+    expect(mocks.mockOnToggle).toHaveBeenCalledTimes(1);
+    expect(mocks.mockOnToggle).toHaveBeenCalledWith(
+      [CHECKSUMMED_ADDRESS_1],
+      false,
+    );
+    await waitFor(() => {
+      expect(getByTestId(ACCOUNT_1_TEST_ID.itemSwitch)).toHaveProp(
+        'value',
+        false,
+      );
+      expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch)).toHaveProp(
+        'value',
+        false,
+      );
+      expect(getByTestId(ACCOUNT_1_TEST_ID.itemSwitch)).toHaveProp(
+        'disabled',
+        true,
+      );
+      expect(getByTestId(ACCOUNT_2_TEST_ID.itemSwitch)).toHaveProp(
+        'disabled',
+        true,
+      );
+    });
+
+    resolveToggle();
+    await waitFor(() => {
       expect(mocks.mockRefetchAccountSettings).toHaveBeenCalled();
     });
   });

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
@@ -1,4 +1,9 @@
-import React, { useMemo } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { SectionList, View } from 'react-native';
 import type {
   useAccountProps,
@@ -10,6 +15,7 @@ import AccountListHeader from '../../../../component-library/components-temp/Mul
 import { useTheme } from '../../../../util/theme';
 import { useStyles } from '../../../../component-library/hooks';
 import styleSheet from './NotificationsSettings.styles';
+import { useAccountNotificationsToggle } from '../../../../util/notifications/hooks/useSwitchNotifications';
 
 export type AccountProps = ReturnType<typeof useAccountProps>;
 export type NotificationAccountListProps = ReturnType<
@@ -31,11 +37,40 @@ export const AccountsList = ({
   const { accountAvatarType, accountWalletGroups } = accountProps;
   const {
     shouldDisableSwitches,
-    isAccountLoading,
+    isAnyAccountUpdating,
     isAccountEnabled,
     refetchAccountSettings,
     getEvmAddress,
   } = notificationAccountListProps;
+  const { onToggle } = useAccountNotificationsToggle();
+  const [pendingAccountToggle, setPendingAccountToggle] = useState<{
+    address: string;
+    value: boolean;
+  } | null>(null);
+  const isUpdatingAccountRef = useRef(false);
+  const areSwitchesDisabled =
+    shouldDisableSwitches || isAnyAccountUpdating || pendingAccountToggle !== null;
+
+  const handleToggleAccountNotifications = useCallback(
+    async (evmAddress: string, nextValue: boolean) => {
+      if (isUpdatingAccountRef.current) {
+        return;
+      }
+
+      isUpdatingAccountRef.current = true;
+      setPendingAccountToggle({ address: evmAddress, value: nextValue });
+      try {
+        await onToggle([evmAddress], nextValue);
+        await refetchAccountSettings();
+      } catch {
+        // The toggle hook owns user-facing error state; keep this UI responsive.
+      } finally {
+        isUpdatingAccountRef.current = false;
+        setPendingAccountToggle(null);
+      }
+    },
+    [onToggle, refetchAccountSettings],
+  );
 
   const sections = useMemo(
     () =>
@@ -73,12 +108,16 @@ export const AccountsList = ({
             <NotificationOptionToggle
               key={item.id}
               item={item}
-              evmAddress={evmAddress}
               icon={accountAvatarType}
-              disabledSwitch={shouldDisableSwitches}
-              isLoading={isAccountLoading(item.accounts)}
-              isEnabled={isAccountEnabled(item.accounts)}
-              refetchNotificationAccounts={refetchAccountSettings}
+              disabledSwitch={areSwitchesDisabled}
+              isEnabled={
+                pendingAccountToggle?.address === evmAddress
+                  ? pendingAccountToggle.value
+                  : isAccountEnabled(item.accounts)
+              }
+              onToggle={(nextValue) =>
+                handleToggleAccountNotifications(evmAddress, nextValue)
+              }
               testID={NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATION_TOGGLE(
                 evmAddress,
               )}

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { SectionList, View } from 'react-native';
 import type {
   useAccountProps,
@@ -49,7 +44,9 @@ export const AccountsList = ({
   } | null>(null);
   const isUpdatingAccountRef = useRef(false);
   const areSwitchesDisabled =
-    shouldDisableSwitches || isAnyAccountUpdating || pendingAccountToggle !== null;
+    shouldDisableSwitches ||
+    isAnyAccountUpdating ||
+    pendingAccountToggle !== null;
 
   const handleToggleAccountNotifications = useCallback(
     async (evmAddress: string, nextValue: boolean) => {

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.test.tsx
@@ -1,3 +1,4 @@
+import { act, waitFor } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useMainNotificationToggle } from './MainNotificationToggle.hooks';
 import Routes from '../../../../constants/navigation/Routes';
@@ -73,15 +74,19 @@ describe('useMainNotificationToggle', () => {
     jest.clearAllMocks();
   });
 
-  it('toggles notifications from false to true', () => {
+  it('uses the explicit next value when toggling from enabled to disabled', async () => {
     const { mocks, result } = arrangeTest();
 
-    result.current.onToggle();
+    act(() => {
+      result.current.onToggle(false);
+    });
 
-    expect(mocks.switchNotifications).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(mocks.switchNotifications).toHaveBeenCalledWith(false);
+    });
   });
 
-  it('toggles from false to true', () => {
+  it('uses the explicit next value when toggling from disabled to enabled', async () => {
     const { mocks, result } = arrangeTest((m) => {
       mockUseNotificationsToggle.mockReturnValue({
         data: false,
@@ -91,9 +96,43 @@ describe('useMainNotificationToggle', () => {
       });
     });
 
-    result.current.onToggle();
+    act(() => {
+      result.current.onToggle(true);
+    });
 
-    expect(mocks.switchNotifications).toHaveBeenCalledWith(true);
+    await waitFor(() => {
+      expect(mocks.switchNotifications).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('serializes rapid toggle writes and preserves latest intent', async () => {
+    let resolveFirstToggle: () => void = () => undefined;
+    const firstTogglePromise = new Promise<void>((resolve) => {
+      resolveFirstToggle = resolve;
+    });
+    const { mocks, result } = arrangeTest((m) => {
+      m.switchNotifications
+        .mockReturnValueOnce(firstTogglePromise)
+        .mockResolvedValueOnce(undefined);
+    });
+
+    act(() => {
+      result.current.onToggle(false);
+      result.current.onToggle(true);
+    });
+
+    await waitFor(() => {
+      expect(mocks.switchNotifications).toHaveBeenCalledTimes(1);
+      expect(mocks.switchNotifications).toHaveBeenNthCalledWith(1, false);
+    });
+
+    await act(async () => {
+      resolveFirstToggle();
+      await firstTogglePromise;
+    });
+
+    expect(mocks.switchNotifications).toHaveBeenCalledTimes(2);
+    expect(mocks.switchNotifications).toHaveBeenNthCalledWith(2, true);
   });
 
   it('navigate to basic functionality screen when basicFunctionalityEnabled is false', () => {
@@ -101,7 +140,9 @@ describe('useMainNotificationToggle', () => {
       m.mockState.settings.basicFunctionalityEnabled = false;
     });
 
-    result.current.onToggle();
+    act(() => {
+      result.current.onToggle(false);
+    });
 
     expect(mocks.navigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.SHEET.BASIC_FUNCTIONALITY,

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.tsx
@@ -5,16 +5,18 @@ import { useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
 import { RootState } from '../../../../reducers';
 import { useNotificationsToggle } from '../../../../util/notifications/hooks/useSwitchNotifications';
+import { useOptimisticToggleValue } from './hooks/useOptimisticToggleValue';
 
 export function useMainNotificationToggle() {
-  const { data: currentVal, switchNotifications: onChange } =
+  const { data: notificationsEnabled, switchNotifications } =
     useNotificationsToggle();
+  const remoteValue = notificationsEnabled ?? false;
   const navigation = useNavigation();
   const basicFunctionalityEnabled = useSelector(
     (state: RootState) => state.settings.basicFunctionalityEnabled,
   );
 
-  const onToggle = useCallback(() => {
+  const onToggleBlocked = useCallback(() => {
     // Navigate to basic functionality if content is not set.
     if (!basicFunctionalityEnabled) {
       navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
@@ -23,12 +25,15 @@ export function useMainNotificationToggle() {
           caller: Routes.SETTINGS.NOTIFICATIONS,
         },
       });
-      return;
     }
+  }, [basicFunctionalityEnabled, navigation]);
 
-    const newVal = !currentVal;
-    onChange(newVal);
-  }, [basicFunctionalityEnabled, currentVal, navigation, onChange]);
+  const { value, onValueChange: onToggle } = useOptimisticToggleValue({
+    remoteValue,
+    onPersist: switchNotifications,
+    isToggleEnabled: () => basicFunctionalityEnabled,
+    onToggleBlocked,
+  });
 
-  return { onToggle, value: currentVal };
+  return { onToggle, value };
 }

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.tsx
@@ -28,13 +28,16 @@ export function useMainNotificationToggle() {
     }
   }, [basicFunctionalityEnabled, navigation]);
 
-  const { value, onValueChange: onToggle, pendingWrites } =
-    useOptimisticToggleValue({
-      remoteValue,
-      onPersist: switchNotifications,
-      isToggleEnabled: () => basicFunctionalityEnabled,
-      onToggleBlocked,
-    });
+  const {
+    value,
+    onValueChange: onToggle,
+    pendingWrites,
+  } = useOptimisticToggleValue({
+    remoteValue,
+    onPersist: switchNotifications,
+    isToggleEnabled: () => basicFunctionalityEnabled,
+    onToggleBlocked,
+  });
 
   return { onToggle, value, isUpdating: pendingWrites > 0 };
 }

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.hooks.tsx
@@ -28,12 +28,13 @@ export function useMainNotificationToggle() {
     }
   }, [basicFunctionalityEnabled, navigation]);
 
-  const { value, onValueChange: onToggle } = useOptimisticToggleValue({
-    remoteValue,
-    onPersist: switchNotifications,
-    isToggleEnabled: () => basicFunctionalityEnabled,
-    onToggleBlocked,
-  });
+  const { value, onValueChange: onToggle, pendingWrites } =
+    useOptimisticToggleValue({
+      remoteValue,
+      onPersist: switchNotifications,
+      isToggleEnabled: () => basicFunctionalityEnabled,
+      onToggleBlocked,
+    });
 
-  return { onToggle, value };
+  return { onToggle, value, isUpdating: pendingWrites > 0 };
 }

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.test.tsx
@@ -49,10 +49,10 @@ describe('MainNotificationToggle', () => {
       NotificationSettingsViewSelectorsIDs.NOTIFICATIONS_TOGGLE,
     );
 
-    fireEvent(toggleSwitch, 'onChange', { nativeEvent: { value: false } });
+    fireEvent(toggleSwitch, 'onValueChange', false);
 
     await waitFor(() => {
-      expect(mocks.mockOnToggle).toHaveBeenCalled();
+      expect(mocks.mockOnToggle).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.test.tsx
@@ -16,6 +16,7 @@ const arrangeToggleHook = () => {
     .mockReturnValue({
       onToggle: mockOnToggle,
       value: true,
+      isUpdating: false,
     });
 
   return {
@@ -54,5 +55,18 @@ describe('MainNotificationToggle', () => {
     await waitFor(() => {
       expect(mocks.mockOnToggle).toHaveBeenCalledWith(false);
     });
+  });
+
+  it('disables the switch while updating', () => {
+    arrangeMocks().mockUseMainNotificationToggle.mockReturnValue({
+      onToggle: jest.fn(),
+      value: true,
+      isUpdating: true,
+    });
+    const { getByTestId } = render(<MainNotificationToggle />);
+
+    expect(
+      getByTestId(NotificationSettingsViewSelectorsIDs.NOTIFICATIONS_TOGGLE),
+    ).toHaveProp('disabled', true);
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.tsx
@@ -40,7 +40,7 @@ export const MainNotificationToggle = () => {
         </Text>
         <Switch
           value={value}
-          onChange={onToggle}
+          onValueChange={onToggle}
           trackColor={{
             true: theme.colors.primary.default,
             false: theme.colors.border.muted,

--- a/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/MainNotificationToggle.tsx
@@ -20,7 +20,7 @@ export const MainNotificationToggle = () => {
   const theme = useTheme();
   const { styles } = useStyles(styleSheet, { theme });
 
-  const { onToggle, value } = useMainNotificationToggle();
+  const { onToggle, value, isUpdating } = useMainNotificationToggle();
 
   return (
     <>
@@ -40,6 +40,7 @@ export const MainNotificationToggle = () => {
         </Text>
         <Switch
           value={value}
+          disabled={isUpdating}
           onValueChange={onToggle}
           trackColor={{
             true: theme.colors.primary.default,

--- a/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationOptionToggle/index.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useState } from 'react';
-import { ActivityIndicator, Switch, View } from 'react-native';
+import React, { useCallback } from 'react';
+import { Switch, View } from 'react-native';
 import { createStyles } from './styles';
 import { useTheme } from '../../../../../util/theme';
 import { AvatarAccountType } from '../../../../../component-library/components/Avatars/Avatar';
-import { useAccountNotificationsToggle } from '../../../../../util/notifications/hooks/useSwitchNotifications';
 import { AccountGroupObject } from '@metamask/account-tree-controller';
 import AccountCell from '../../../../../component-library/components-temp/MultichainAccounts/AccountCell';
 
@@ -18,43 +17,12 @@ export const NOTIFICATION_OPTIONS_TOGGLE_LOADING_TEST_ID = (
 
 interface NotificationOptionsToggleProps {
   item: AccountGroupObject;
-  evmAddress?: string;
   icon: AvatarAccountType;
   testId?: string;
   disabledSwitch?: boolean;
-  isLoading?: boolean;
   isEnabled: boolean;
-  refetchNotificationAccounts: () => Promise<void>;
+  onToggle: (nextValue: boolean) => void;
   testID: string;
-}
-
-export function useUpdateAccountSetting(
-  address: string | undefined,
-  refetchAccountSettings: () => Promise<void>,
-) {
-  const { onToggle, error } = useAccountNotificationsToggle();
-
-  // Local states
-  const [loading, setLoading] = useState(false);
-
-  const toggleAccount = useCallback(
-    async (state: boolean) => {
-      if (!address) {
-        return;
-      }
-      setLoading(true);
-      try {
-        await onToggle([address], state);
-        await refetchAccountSettings();
-      } catch {
-        // Do nothing (we don't need to propagate this)
-      }
-      setLoading(false);
-    },
-    [address, onToggle, refetchAccountSettings],
-  );
-
-  return { toggleAccount, loading, error };
 }
 
 /**
@@ -63,28 +31,22 @@ export function useUpdateAccountSetting(
  */
 const NotificationOptionToggle = ({
   item,
-  evmAddress,
   icon,
   isEnabled,
   disabledSwitch,
-  isLoading,
-  refetchNotificationAccounts,
+  onToggle,
   testID,
 }: NotificationOptionsToggleProps) => {
   const theme = useTheme();
   const { colors } = theme;
   const styles = createStyles();
 
-  const { toggleAccount, loading: isUpdatingAccount } = useUpdateAccountSetting(
-    evmAddress,
-    refetchNotificationAccounts,
+  const handleToggleAccountNotifications = useCallback(
+    (nextValue: boolean) => {
+      onToggle(nextValue);
+    },
+    [onToggle],
   );
-
-  const loading = isLoading || isUpdatingAccount;
-
-  const handleToggleAccountNotifications = useCallback(async () => {
-    await toggleAccount(!isEnabled);
-  }, [isEnabled, toggleAccount]);
 
   return (
     <View testID={NOTIFICATION_OPTIONS_TOGGLE_CONTAINER_TEST_ID(testID)}>
@@ -92,25 +54,19 @@ const NotificationOptionToggle = ({
         accountGroup={item}
         avatarAccountType={icon}
         endContainer={
-          loading ? (
-            <ActivityIndicator
-              testID={NOTIFICATION_OPTIONS_TOGGLE_LOADING_TEST_ID(testID)}
-            />
-          ) : (
-            <Switch
-              style={styles.switch}
-              value={isEnabled}
-              onChange={handleToggleAccountNotifications}
-              trackColor={{
-                true: colors.primary.default,
-                false: colors.border.muted,
-              }}
-              thumbColor={theme.brandColors.white}
-              disabled={disabledSwitch}
-              ios_backgroundColor={colors.border.muted}
-              testID={testID}
-            />
-          )
+          <Switch
+            style={styles.switch}
+            value={isEnabled}
+            onValueChange={handleToggleAccountNotifications}
+            trackColor={{
+              true: colors.primary.default,
+              false: colors.border.muted,
+            }}
+            thumbColor={theme.brandColors.white}
+            disabled={disabledSwitch}
+            ios_backgroundColor={colors.border.muted}
+            testID={testID}
+          />
         }
       />
     </View>

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StackActions } from '@react-navigation/native';
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import Routes from '../../../../constants/navigation/Routes';
 import { NotificationSettingsViewSelectorsIDs } from './NotificationSettingsView.testIds';
@@ -10,7 +10,7 @@ import NotificationSettingsSection, {
 
 const mockDispatch = jest.fn();
 const mockGoBack = jest.fn();
-const mockUpdatePreference = jest.fn();
+const mockUpdateSectionChannel = jest.fn();
 const mockToggleAllAccounts = jest.fn();
 let mockIsMetamaskNotificationsEnabled = true;
 let mockHasEnabledAccount = true;
@@ -47,7 +47,7 @@ jest.mock('../../../../selectors/notifications', () => ({
 jest.mock('./hooks/useNotificationStoragePreferences', () => ({
   useNotificationStoragePreferences: () => ({
     preferences: mockPreferences,
-    updatePreference: mockUpdatePreference,
+    updateSectionChannel: mockUpdateSectionChannel,
   }),
 }));
 
@@ -95,6 +95,7 @@ const renderSection = (
 describe('NotificationSettingsSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUpdateSectionChannel.mockResolvedValue(undefined);
     mockIsMetamaskNotificationsEnabled = true;
     mockHasEnabledAccount = true;
     mockHasNotificationAccounts = true;
@@ -159,5 +160,74 @@ describe('NotificationSettingsSection', () => {
       );
     });
     expect(screen.queryByText('Trading Signals')).toBeNull();
+  });
+
+  it('uses explicit next value for push notifications toggle', async () => {
+    renderSection();
+
+    const pushToggle = screen.getByTestId(
+      NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+    );
+    await act(async () => {
+      fireEvent(pushToggle, 'onValueChange', false);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateSectionChannel).toHaveBeenCalledWith(
+        'socialAI',
+        'pushNotificationsEnabled',
+        false,
+      );
+    });
+  });
+
+  it('uses explicit next value for in-app notifications toggle', async () => {
+    renderSection();
+
+    const inAppToggle = screen.getByTestId(
+      NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE,
+    );
+    await act(async () => {
+      fireEvent(inAppToggle, 'onValueChange', false);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateSectionChannel).toHaveBeenCalledWith(
+        'socialAI',
+        'inAppNotificationsEnabled',
+        false,
+      );
+    });
+  });
+
+  it('forwards rapid toggle events in order', async () => {
+    renderSection();
+
+    const pushToggle = screen.getByTestId(
+      NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+    );
+    await act(async () => {
+      fireEvent(pushToggle, 'onValueChange', false);
+      fireEvent(pushToggle, 'onValueChange', true);
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateSectionChannel).toHaveBeenNthCalledWith(
+      1,
+      'socialAI',
+      'pushNotificationsEnabled',
+      false,
+    );
+    await waitFor(() => {
+      expect(mockUpdateSectionChannel).toHaveBeenCalledTimes(2);
+    });
+    expect(mockUpdateSectionChannel).toHaveBeenNthCalledWith(
+      2,
+      'socialAI',
+      'pushNotificationsEnabled',
+      true,
+    );
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -16,6 +16,7 @@ let mockIsMetamaskNotificationsEnabled = true;
 let mockHasEnabledAccount = true;
 let mockHasNotificationAccounts = true;
 let mockIsUpdatingAllAccounts = false;
+let mockIsUpdatingPreferences = false;
 
 const mockPreferences = {
   walletActivity: {
@@ -47,6 +48,7 @@ jest.mock('../../../../selectors/notifications', () => ({
 jest.mock('./hooks/useNotificationStoragePreferences', () => ({
   useNotificationStoragePreferences: () => ({
     preferences: mockPreferences,
+    isUpdatingPreferences: mockIsUpdatingPreferences,
     updateSectionChannel: mockUpdateSectionChannel,
   }),
 }));
@@ -100,6 +102,7 @@ describe('NotificationSettingsSection', () => {
     mockHasEnabledAccount = true;
     mockHasNotificationAccounts = true;
     mockIsUpdatingAllAccounts = false;
+    mockIsUpdatingPreferences = false;
   });
 
   it('renders section preferences when global notifications are enabled', () => {
@@ -202,32 +205,18 @@ describe('NotificationSettingsSection', () => {
     });
   });
 
-  it('forwards rapid toggle events in order', async () => {
+  it('disables channel toggles while preference save is in flight', () => {
+    mockIsUpdatingPreferences = true;
     renderSection();
 
     const pushToggle = screen.getByTestId(
       NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
     );
-    await act(async () => {
-      fireEvent(pushToggle, 'onValueChange', false);
-      fireEvent(pushToggle, 'onValueChange', true);
-      await Promise.resolve();
-    });
+    const inAppToggle = screen.getByTestId(
+      NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE,
+    );
 
-    expect(mockUpdateSectionChannel).toHaveBeenNthCalledWith(
-      1,
-      'socialAI',
-      'pushNotificationsEnabled',
-      false,
-    );
-    await waitFor(() => {
-      expect(mockUpdateSectionChannel).toHaveBeenCalledTimes(2);
-    });
-    expect(mockUpdateSectionChannel).toHaveBeenNthCalledWith(
-      2,
-      'socialAI',
-      'pushNotificationsEnabled',
-      true,
-    );
+    expect(pushToggle.props.disabled).toBe(true);
+    expect(inAppToggle.props.disabled).toBe(true);
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -205,7 +205,7 @@ describe('NotificationSettingsSection', () => {
     });
   });
 
-  it('disables channel toggles while preference save is in flight', () => {
+  it('keeps channel toggles enabled while preference save is in flight', () => {
     mockIsUpdatingPreferences = true;
     renderSection();
 
@@ -216,11 +216,11 @@ describe('NotificationSettingsSection', () => {
       NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE,
     );
 
-    expect(pushToggle.props.disabled).toBe(true);
-    expect(inAppToggle.props.disabled).toBe(true);
+    expect(pushToggle.props.disabled).not.toBe(true);
+    expect(inAppToggle.props.disabled).not.toBe(true);
   });
 
-  it('keeps channel toggle value optimistic while preference save is in flight', async () => {
+  it('keeps channel toggle value optimistic while preference save is in flight without disabling toggles', async () => {
     let resolveUpdate: () => void = () => undefined;
     mockUpdateSectionChannel.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -244,8 +244,8 @@ describe('NotificationSettingsSection', () => {
 
     await waitFor(() => {
       expect(pushToggle.props.value).toBe(false);
-      expect(pushToggle.props.disabled).toBe(true);
-      expect(inAppToggle.props.disabled).toBe(true);
+      expect(pushToggle.props.disabled).not.toBe(true);
+      expect(inAppToggle.props.disabled).not.toBe(true);
     });
     expect(mockUpdateSectionChannel).toHaveBeenCalledWith(
       'walletActivity',
@@ -255,6 +255,72 @@ describe('NotificationSettingsSection', () => {
 
     await act(async () => {
       resolveUpdate();
+      await Promise.resolve();
+    });
+  });
+
+  it('keeps the latest rapid channel toggle intent visible while writes are pending', async () => {
+    let resolveFirstUpdate: () => void = () => undefined;
+    mockUpdateSectionChannel
+      .mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveFirstUpdate = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(undefined);
+    renderSection({
+      type: 'walletActivity',
+      title: 'Wallet Activity',
+      description: 'Buy, sells, transfers, swaps and rewards',
+    });
+
+    fireEvent(
+      screen.getByTestId(
+        NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+      ),
+      'onValueChange',
+      false,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(
+          NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+        ).props.value,
+      ).toBe(false);
+    });
+
+    fireEvent(
+      screen.getByTestId(
+        NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+      ),
+      'onValueChange',
+      true,
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateSectionChannel).toHaveBeenCalledTimes(2);
+      expect(
+        screen.getByTestId(
+          NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+        ).props.value,
+      ).toBe(true);
+    });
+    expect(mockUpdateSectionChannel).toHaveBeenNthCalledWith(
+      1,
+      'walletActivity',
+      'pushNotificationsEnabled',
+      false,
+    );
+    expect(mockUpdateSectionChannel).toHaveBeenNthCalledWith(
+      2,
+      'walletActivity',
+      'pushNotificationsEnabled',
+      true,
+    );
+
+    await act(async () => {
+      resolveFirstUpdate();
       await Promise.resolve();
     });
   });

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -219,4 +219,43 @@ describe('NotificationSettingsSection', () => {
     expect(pushToggle.props.disabled).toBe(true);
     expect(inAppToggle.props.disabled).toBe(true);
   });
+
+  it('keeps channel toggle value optimistic while preference save is in flight', async () => {
+    let resolveUpdate: () => void = () => undefined;
+    mockUpdateSectionChannel.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+    renderSection({
+      type: 'walletActivity',
+      title: 'Wallet Activity',
+      description: 'Buy, sells, transfers, swaps and rewards',
+    });
+
+    const pushToggle = screen.getByTestId(
+      NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE,
+    );
+    const inAppToggle = screen.getByTestId(
+      NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE,
+    );
+
+    fireEvent(pushToggle, 'onValueChange', false);
+
+    await waitFor(() => {
+      expect(pushToggle.props.value).toBe(false);
+      expect(pushToggle.props.disabled).toBe(true);
+      expect(inAppToggle.props.disabled).toBe(true);
+    });
+    expect(mockUpdateSectionChannel).toHaveBeenCalledWith(
+      'walletActivity',
+      'pushNotificationsEnabled',
+      false,
+    );
+
+    await act(async () => {
+      resolveUpdate();
+      await Promise.resolve();
+    });
+  });
 });

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -4,7 +4,7 @@ import {
   RouteProp,
   StackActions,
 } from '@react-navigation/native';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ScrollView, Switch, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
@@ -160,6 +160,11 @@ const NotificationSettingsSection = ({
   );
   const { preferences, isUpdatingPreferences, updateSectionChannel } =
     useNotificationStoragePreferences();
+  const [pendingChannelToggle, setPendingChannelToggle] = useState<{
+    channel: NotificationPreferenceChannelKey;
+    value: boolean;
+  } | null>(null);
+  const isUpdatingChannelRef = useRef(false);
 
   useEffect(() => {
     if (!isMetamaskNotificationsEnabled) {
@@ -169,17 +174,28 @@ const NotificationSettingsSection = ({
 
   const handleChannelToggle = useCallback(
     (channel: NotificationPreferenceChannelKey, nextValue: boolean) => {
-      updateSectionChannel(type, channel, nextValue).catch(() => {
-        Logger.error(
-          new Error('Failed to update notification section channel'),
-          {
-            message: 'NotificationSettingsSection: update channel failed',
-            type,
-            channel,
-            nextValue,
-          },
-        );
-      });
+      if (isUpdatingChannelRef.current) {
+        return;
+      }
+
+      isUpdatingChannelRef.current = true;
+      setPendingChannelToggle({ channel, value: nextValue });
+      updateSectionChannel(type, channel, nextValue)
+        .catch(() => {
+          Logger.error(
+            new Error('Failed to update notification section channel'),
+            {
+              message: 'NotificationSettingsSection: update channel failed',
+              type,
+              channel,
+              nextValue,
+            },
+          );
+        })
+        .finally(() => {
+          isUpdatingChannelRef.current = false;
+          setPendingChannelToggle(null);
+        });
     },
     [type, updateSectionChannel],
   );
@@ -194,6 +210,8 @@ const NotificationSettingsSection = ({
   }
 
   const SectionContent = SECTION_CONTENT_BY_TYPE[type];
+  const areChannelSwitchesDisabled =
+    isUpdatingPreferences || pendingChannelToggle !== null;
 
   return (
     <SafeAreaView edges={['top']} style={styles.safeArea}>
@@ -223,8 +241,12 @@ const NotificationSettingsSection = ({
             {strings('app_settings.notifications_opts.push_recommended')}
           </Text>
           <Switch
-            value={sectionPrefs.pushNotificationsEnabled}
-            disabled={isUpdatingPreferences}
+            value={
+              pendingChannelToggle?.channel === 'pushNotificationsEnabled'
+                ? pendingChannelToggle.value
+                : sectionPrefs.pushNotificationsEnabled
+            }
+            disabled={areChannelSwitchesDisabled}
             onValueChange={(nextValue) =>
               handleChannelToggle('pushNotificationsEnabled', nextValue)
             }
@@ -250,8 +272,12 @@ const NotificationSettingsSection = ({
             {strings('app_settings.notifications_opts.in_app')}
           </Text>
           <Switch
-            value={sectionPrefs.inAppNotificationsEnabled}
-            disabled={isUpdatingPreferences}
+            value={
+              pendingChannelToggle?.channel === 'inAppNotificationsEnabled'
+                ? pendingChannelToggle.value
+                : sectionPrefs.inAppNotificationsEnabled
+            }
+            disabled={areChannelSwitchesDisabled}
             onValueChange={(nextValue) =>
               handleChannelToggle('inAppNotificationsEnabled', nextValue)
             }

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -4,7 +4,7 @@ import {
   RouteProp,
   StackActions,
 } from '@react-navigation/native';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { ScrollView, Switch, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
@@ -20,6 +20,7 @@ import {
 } from '@metamask/design-system-react-native';
 import {
   useNotificationStoragePreferences,
+  type NotificationStoragePreferenceChannelKey,
   type NotificationStoragePreferenceSection,
 } from './hooks/useNotificationStoragePreferences';
 import { AccountsList } from './AccountsList';
@@ -29,6 +30,7 @@ import { selectIsMetamaskNotificationsEnabled } from '../../../../selectors/noti
 import Routes from '../../../../constants/navigation/Routes';
 import { useWalletActivityAccountSelection } from './AccountsList.hooks';
 import { NotificationSettingsViewSelectorsIDs } from './NotificationSettingsView.testIds';
+import Logger from '../../../../util/Logger';
 
 type NotificationSettingsStyles = ReturnType<typeof styleSheet>;
 
@@ -156,7 +158,8 @@ const NotificationSettingsSection = ({
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
-  const { preferences, updatePreference } = useNotificationStoragePreferences();
+  const { preferences, updateSectionChannel } =
+    useNotificationStoragePreferences();
 
   useEffect(() => {
     if (!isMetamaskNotificationsEnabled) {
@@ -164,11 +167,33 @@ const NotificationSettingsSection = ({
     }
   }, [isMetamaskNotificationsEnabled, navigation]);
 
+  const handleChannelToggle = useCallback(
+    (channel: NotificationStoragePreferenceChannelKey, nextValue: boolean) => {
+      updateSectionChannel(type, channel, nextValue)
+        .catch(() => {
+          Logger.error(
+            new Error('Failed to update notification section channel'),
+            {
+              message: 'NotificationSettingsSection: update channel failed',
+              type,
+              channel,
+              nextValue,
+            },
+          );
+        });
+    },
+    [type, updateSectionChannel],
+  );
+
   if (!isMetamaskNotificationsEnabled || !preferences) {
     return null;
   }
 
   const sectionPrefs = preferences[type];
+  if (!sectionPrefs) {
+    return null;
+  }
+
   const SectionContent = SECTION_CONTENT_BY_TYPE[type];
 
   return (
@@ -200,12 +225,8 @@ const NotificationSettingsSection = ({
           </Text>
           <Switch
             value={sectionPrefs.pushNotificationsEnabled}
-            onChange={() =>
-              updatePreference(
-                type,
-                'pushNotificationsEnabled',
-                !sectionPrefs.pushNotificationsEnabled,
-              )
+            onValueChange={(nextValue) =>
+              handleChannelToggle('pushNotificationsEnabled', nextValue)
             }
             trackColor={{
               true: theme.colors.primary.default,
@@ -214,6 +235,9 @@ const NotificationSettingsSection = ({
             thumbColor={theme.brandColors.white}
             style={styles.switch}
             ios_backgroundColor={theme.colors.border.muted}
+            testID={
+              NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE
+            }
           />
         </View>
 
@@ -227,12 +251,8 @@ const NotificationSettingsSection = ({
           </Text>
           <Switch
             value={sectionPrefs.inAppNotificationsEnabled}
-            onChange={() =>
-              updatePreference(
-                type,
-                'inAppNotificationsEnabled',
-                !sectionPrefs.inAppNotificationsEnabled,
-              )
+            onValueChange={(nextValue) =>
+              handleChannelToggle('inAppNotificationsEnabled', nextValue)
             }
             trackColor={{
               true: theme.colors.primary.default,
@@ -241,6 +261,9 @@ const NotificationSettingsSection = ({
             thumbColor={theme.brandColors.white}
             style={styles.switch}
             ios_backgroundColor={theme.colors.border.muted}
+            testID={
+              NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE
+            }
           />
         </View>
 

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -20,8 +20,8 @@ import {
 } from '@metamask/design-system-react-native';
 import {
   useNotificationStoragePreferences,
-  type NotificationStoragePreferenceChannelKey,
-  type NotificationStoragePreferenceSection,
+  type NotificationPreferenceChannelKey,
+  type NotificationPreferenceSection,
 } from './hooks/useNotificationStoragePreferences';
 import { AccountsList } from './AccountsList';
 import { strings } from '../../../../../locales/i18n';
@@ -124,7 +124,7 @@ const MarketingSectionContent = ({ styles }: SectionContentProps) => (
 
 const SECTION_CONTENT_BY_TYPE: Partial<
   Record<
-    NotificationStoragePreferenceSection,
+    NotificationPreferenceSection,
     React.ComponentType<SectionContentProps>
   >
 > = {
@@ -138,7 +138,7 @@ export interface NotificationSettingsSectionProps {
   route: RouteProp<
     {
       params: {
-        type: NotificationStoragePreferenceSection;
+        type: NotificationPreferenceSection;
         title: string;
         description: string;
       };
@@ -158,7 +158,7 @@ const NotificationSettingsSection = ({
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
-  const { preferences, updateSectionChannel } =
+  const { preferences, isUpdatingPreferences, updateSectionChannel } =
     useNotificationStoragePreferences();
 
   useEffect(() => {
@@ -168,19 +168,18 @@ const NotificationSettingsSection = ({
   }, [isMetamaskNotificationsEnabled, navigation]);
 
   const handleChannelToggle = useCallback(
-    (channel: NotificationStoragePreferenceChannelKey, nextValue: boolean) => {
-      updateSectionChannel(type, channel, nextValue)
-        .catch(() => {
-          Logger.error(
-            new Error('Failed to update notification section channel'),
-            {
-              message: 'NotificationSettingsSection: update channel failed',
-              type,
-              channel,
-              nextValue,
-            },
-          );
-        });
+    (channel: NotificationPreferenceChannelKey, nextValue: boolean) => {
+      updateSectionChannel(type, channel, nextValue).catch(() => {
+        Logger.error(
+          new Error('Failed to update notification section channel'),
+          {
+            message: 'NotificationSettingsSection: update channel failed',
+            type,
+            channel,
+            nextValue,
+          },
+        );
+      });
     },
     [type, updateSectionChannel],
   );
@@ -225,6 +224,7 @@ const NotificationSettingsSection = ({
           </Text>
           <Switch
             value={sectionPrefs.pushNotificationsEnabled}
+            disabled={isUpdatingPreferences}
             onValueChange={(nextValue) =>
               handleChannelToggle('pushNotificationsEnabled', nextValue)
             }
@@ -251,6 +251,7 @@ const NotificationSettingsSection = ({
           </Text>
           <Switch
             value={sectionPrefs.inAppNotificationsEnabled}
+            disabled={isUpdatingPreferences}
             onValueChange={(nextValue) =>
               handleChannelToggle('inAppNotificationsEnabled', nextValue)
             }

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -158,13 +158,19 @@ const NotificationSettingsSection = ({
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );
-  const { preferences, isUpdatingPreferences, updateSectionChannel } =
+  const { preferences, updateSectionChannel } =
     useNotificationStoragePreferences();
-  const [pendingChannelToggle, setPendingChannelToggle] = useState<{
-    channel: NotificationPreferenceChannelKey;
-    value: boolean;
-  } | null>(null);
-  const isUpdatingChannelRef = useRef(false);
+  const [pendingChannelToggles, setPendingChannelToggles] = useState<
+    Partial<Record<NotificationPreferenceChannelKey, boolean>>
+  >({});
+  const channelGenerationsRef = useRef<
+    Record<NotificationPreferenceChannelKey, number>
+  >({
+    pushNotificationsEnabled: 0,
+    inAppNotificationsEnabled: 0,
+  });
+  const sectionPrefs = preferences?.[type];
+  const SectionContent = SECTION_CONTENT_BY_TYPE[type];
 
   useEffect(() => {
     if (!isMetamaskNotificationsEnabled) {
@@ -172,46 +178,70 @@ const NotificationSettingsSection = ({
     }
   }, [isMetamaskNotificationsEnabled, navigation]);
 
-  const handleChannelToggle = useCallback(
-    (channel: NotificationPreferenceChannelKey, nextValue: boolean) => {
-      if (isUpdatingChannelRef.current) {
-        return;
-      }
+  const clearPendingChannelToggle = useCallback(
+    (channel: NotificationPreferenceChannelKey) => {
+      setPendingChannelToggles((current) => {
+        if (current[channel] === undefined) {
+          return current;
+        }
 
-      isUpdatingChannelRef.current = true;
-      setPendingChannelToggle({ channel, value: nextValue });
-      updateSectionChannel(type, channel, nextValue)
-        .catch(() => {
-          Logger.error(
-            new Error('Failed to update notification section channel'),
-            {
-              message: 'NotificationSettingsSection: update channel failed',
-              type,
-              channel,
-              nextValue,
-            },
-          );
-        })
-        .finally(() => {
-          isUpdatingChannelRef.current = false;
-          setPendingChannelToggle(null);
-        });
+        const next = { ...current };
+        delete next[channel];
+        return next;
+      });
     },
-    [type, updateSectionChannel],
+    [],
   );
 
-  if (!isMetamaskNotificationsEnabled || !preferences) {
+  const handleChannelToggle = useCallback(
+    (channel: NotificationPreferenceChannelKey, nextValue: boolean) => {
+      channelGenerationsRef.current[channel] += 1;
+      const generation = channelGenerationsRef.current[channel];
+
+      setPendingChannelToggles((current) => ({
+        ...current,
+        [channel]: nextValue,
+      }));
+
+      updateSectionChannel(type, channel, nextValue).catch(() => {
+        Logger.error(
+          new Error('Failed to update notification section channel'),
+          {
+            message: 'NotificationSettingsSection: update channel failed',
+            type,
+            channel,
+            nextValue,
+          },
+        );
+
+        if (channelGenerationsRef.current[channel] === generation) {
+          clearPendingChannelToggle(channel);
+        }
+      });
+    },
+    [clearPendingChannelToggle, type, updateSectionChannel],
+  );
+
+  useEffect(() => {
+    if (!sectionPrefs) {
+      return;
+    }
+
+    (
+      [
+        'pushNotificationsEnabled',
+        'inAppNotificationsEnabled',
+      ] as NotificationPreferenceChannelKey[]
+    ).forEach((channel) => {
+      if (pendingChannelToggles[channel] === sectionPrefs[channel]) {
+        clearPendingChannelToggle(channel);
+      }
+    });
+  }, [clearPendingChannelToggle, pendingChannelToggles, sectionPrefs]);
+
+  if (!isMetamaskNotificationsEnabled || !sectionPrefs) {
     return null;
   }
-
-  const sectionPrefs = preferences[type];
-  if (!sectionPrefs) {
-    return null;
-  }
-
-  const SectionContent = SECTION_CONTENT_BY_TYPE[type];
-  const areChannelSwitchesDisabled =
-    isUpdatingPreferences || pendingChannelToggle !== null;
 
   return (
     <SafeAreaView edges={['top']} style={styles.safeArea}>
@@ -242,11 +272,9 @@ const NotificationSettingsSection = ({
           </Text>
           <Switch
             value={
-              pendingChannelToggle?.channel === 'pushNotificationsEnabled'
-                ? pendingChannelToggle.value
-                : sectionPrefs.pushNotificationsEnabled
+              pendingChannelToggles.pushNotificationsEnabled ??
+              sectionPrefs.pushNotificationsEnabled
             }
-            disabled={areChannelSwitchesDisabled}
             onValueChange={(nextValue) =>
               handleChannelToggle('pushNotificationsEnabled', nextValue)
             }
@@ -273,11 +301,9 @@ const NotificationSettingsSection = ({
           </Text>
           <Switch
             value={
-              pendingChannelToggle?.channel === 'inAppNotificationsEnabled'
-                ? pendingChannelToggle.value
-                : sectionPrefs.inAppNotificationsEnabled
+              pendingChannelToggles.inAppNotificationsEnabled ??
+              sectionPrefs.inAppNotificationsEnabled
             }
-            disabled={areChannelSwitchesDisabled}
             onValueChange={(nextValue) =>
               handleChannelToggle('inAppNotificationsEnabled', nextValue)
             }

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
@@ -4,7 +4,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { NotificationPreferences } from '@metamask/authenticated-user-storage';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
-import { useNotificationStoragePreferences } from './useNotificationStoragePreferences';
+import {
+  __resetNotificationStoragePreferencesModuleState,
+  useNotificationStoragePreferences,
+} from './useNotificationStoragePreferences';
 
 jest.mock('@metamask/react-data-query');
 
@@ -29,14 +32,20 @@ jest.mock('../../../../../util/Logger', () => ({
 const GET_ACTION = 'AuthenticatedUserStorageService:getNotificationPreferences';
 const PUT_ACTION = 'AuthenticatedUserStorageService:putNotificationPreferences';
 const CLIENT_TYPE = 'mobile';
+const RECONCILIATION_DELAY_MS = 60_000;
 
 const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
 const mockUseQueryClient = useQueryClient as jest.MockedFunction<
   typeof useQueryClient
 >;
 const mockSetQueryData = jest.fn();
+const mockGetQueryData = jest.fn();
+const mockCancelQueries = jest.fn();
+const mockInvalidateQueries = jest.fn();
 const mockRefetch = jest.fn();
 const mockCall = Engine.controllerMessenger.call as jest.Mock;
+
+let queryCache: NotificationPreferences | null | undefined;
 
 type QueryDataUpdater = (
   previousPreferences: NotificationPreferences | null | undefined,
@@ -84,13 +93,39 @@ const makeQueryResult = (
 
 describe('useNotificationStoragePreferences', () => {
   beforeEach(() => {
+    __resetNotificationStoragePreferencesModuleState();
     jest.clearAllMocks();
+    queryCache = undefined;
     mockUseQuery.mockReturnValue(makeQueryResult());
     mockUseQueryClient.mockReturnValue({
       setQueryData: mockSetQueryData,
+      getQueryData: mockGetQueryData,
+      cancelQueries: mockCancelQueries,
+      invalidateQueries: mockInvalidateQueries,
     } as unknown as ReturnType<typeof useQueryClient>);
-    mockCall.mockResolvedValue(undefined);
+    mockSetQueryData.mockImplementation(
+      (
+        _queryKey: readonly string[],
+        updaterOrValue:
+          | NotificationPreferences
+          | null
+          | undefined
+          | QueryDataUpdater,
+      ) => {
+        if (typeof updaterOrValue === 'function') {
+          queryCache = (updaterOrValue as QueryDataUpdater)(queryCache);
+          return queryCache;
+        }
+
+        queryCache = updaterOrValue;
+        return queryCache;
+      },
+    );
+    mockGetQueryData.mockImplementation(() => queryCache);
+    mockCancelQueries.mockResolvedValue(undefined);
+    mockInvalidateQueries.mockResolvedValue(undefined);
     mockRefetch.mockResolvedValue(undefined);
+    mockCall.mockResolvedValue(undefined);
   });
 
   it('scopes the query to the active account and exposes query state', () => {
@@ -105,6 +140,8 @@ describe('useNotificationStoragePreferences', () => {
     expect(mockUseQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: [GET_ACTION],
+        refetchOnMount: expect.any(Function),
+        refetchOnWindowFocus: expect.any(Function),
       }),
     );
     expect(result.current.preferences).toBe(preferences);
@@ -113,67 +150,42 @@ describe('useNotificationStoragePreferences', () => {
     expect(result.current.error).toBe(error);
   });
 
-  it('persists an updated channel key with a read-merge-write payload', async () => {
-    const cachedPreferences = buildPreferences();
-    const latestPreferences = buildPreferences({
-      walletActivity: {
-        inAppNotificationsEnabled: true,
-        pushNotificationsEnabled: true,
-        accounts: [{ address: '0xabc', enabled: true }],
-      },
-      marketing: {
-        inAppNotificationsEnabled: true,
-        pushNotificationsEnabled: true,
-      },
-    });
-    mockUseQuery.mockReturnValue(makeQueryResult({ data: cachedPreferences }));
-    mockCall.mockImplementation(async (action: string) => {
-      if (action === GET_ACTION) {
-        return latestPreferences;
-      }
-      return undefined;
-    });
+  it('optimistically updates cache and PUTs latest cached preferences', async () => {
+    queryCache = buildPreferences();
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
 
     const { result } = renderHook(() => useNotificationStoragePreferences());
 
     await act(async () => {
-      await result.current.updatePreference(
+      await result.current.updateSectionChannel(
         'perps',
         'pushNotificationsEnabled',
         false,
       );
     });
 
-    const [queryKey, updater] = mockSetQueryData.mock.calls[0];
-    expect(queryKey).toEqual([GET_ACTION]);
-    expect((updater as QueryDataUpdater)(latestPreferences)).toEqual({
-      ...latestPreferences,
-      perps: {
-        ...cachedPreferences.perps,
-        pushNotificationsEnabled: false,
-      },
+    expect(mockCancelQueries).toHaveBeenCalledWith({
+      queryKey: [GET_ACTION],
     });
-    expect(mockCall).toHaveBeenCalledWith(GET_ACTION);
+    expect(queryCache?.perps.pushNotificationsEnabled).toBe(false);
     expect(mockCall).toHaveBeenCalledWith(
       PUT_ACTION,
-      {
-        ...latestPreferences,
-        perps: {
-          ...cachedPreferences.perps,
+      expect.objectContaining({
+        perps: expect.objectContaining({
           pushNotificationsEnabled: false,
-        },
-      },
+        }),
+      }),
       CLIENT_TYPE,
     );
+    expect(mockCall).not.toHaveBeenCalledWith(GET_ACTION);
   });
 
-  it('refetches and rethrows when persistence fails', async () => {
+  it('rolls back cache when latest write fails', async () => {
+    const initialPreferences = buildPreferences();
+    queryCache = initialPreferences;
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
     const persistError = new Error('network down');
-    mockUseQuery.mockReturnValue(makeQueryResult({ data: buildPreferences() }));
     mockCall.mockImplementation(async (action: string) => {
-      if (action === GET_ACTION) {
-        return buildPreferences();
-      }
       if (action === PUT_ACTION) {
         throw persistError;
       }
@@ -184,7 +196,7 @@ describe('useNotificationStoragePreferences', () => {
 
     await act(async () => {
       try {
-        await result.current.updatePreference(
+        await result.current.updateSectionChannel(
           'marketing',
           'inAppNotificationsEnabled',
           true,
@@ -195,10 +207,82 @@ describe('useNotificationStoragePreferences', () => {
     });
 
     expect(thrownError).toBe(persistError);
-    expect(mockRefetch).toHaveBeenCalledTimes(1);
+    expect(queryCache).toEqual(initialPreferences);
     expect(Logger.error).toHaveBeenCalledWith(
       persistError,
       'Failed to persist notification preferences',
     );
+  });
+
+  it('serializes rapid writes and preserves latest payload intent', async () => {
+    queryCache = buildPreferences();
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
+
+    let resolveFirstPut: () => void = () => undefined;
+    const firstPut = new Promise<void>((resolve) => {
+      resolveFirstPut = resolve;
+    });
+    const putPayloads: NotificationPreferences[] = [];
+    let putCount = 0;
+    mockCall.mockImplementation(async (action: string, payload: unknown) => {
+      if (action !== PUT_ACTION) {
+        return undefined;
+      }
+
+      putCount += 1;
+      putPayloads.push(payload as NotificationPreferences);
+      if (putCount === 1) {
+        await firstPut;
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useNotificationStoragePreferences());
+
+    let firstWrite: Promise<void> | undefined;
+    let secondWrite: Promise<void> | undefined;
+    await act(async () => {
+      firstWrite = result.current.updateSectionChannel(
+        'walletActivity',
+        'pushNotificationsEnabled',
+        false,
+      );
+      secondWrite = result.current.updateSectionChannel(
+        'walletActivity',
+        'pushNotificationsEnabled',
+        true,
+      );
+      resolveFirstPut();
+      await Promise.all([firstWrite, secondWrite]);
+    });
+
+    expect(putPayloads).toHaveLength(2);
+    expect(putPayloads[1].walletActivity.pushNotificationsEnabled).toBe(true);
+  });
+
+  it('invalidates once writes are idle and refetch suppression window passes', async () => {
+    jest.useFakeTimers();
+    queryCache = buildPreferences();
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
+
+    const { result } = renderHook(() => useNotificationStoragePreferences());
+
+    await act(async () => {
+      await result.current.updateSectionChannel(
+        'perps',
+        'inAppNotificationsEnabled',
+        false,
+      );
+    });
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    await act(async () => {
+      jest.advanceTimersByTime(RECONCILIATION_DELAY_MS);
+    });
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: [GET_ACTION],
+    });
+
+    jest.useRealTimers();
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
@@ -4,10 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { NotificationPreferences } from '@metamask/authenticated-user-storage';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
-import {
-  __resetNotificationStoragePreferencesModuleState,
-  useNotificationStoragePreferences,
-} from './useNotificationStoragePreferences';
+import { useNotificationStoragePreferences } from './useNotificationStoragePreferences';
 
 jest.mock('@metamask/react-data-query');
 
@@ -32,7 +29,6 @@ jest.mock('../../../../../util/Logger', () => ({
 const GET_ACTION = 'AuthenticatedUserStorageService:getNotificationPreferences';
 const PUT_ACTION = 'AuthenticatedUserStorageService:putNotificationPreferences';
 const CLIENT_TYPE = 'mobile';
-const RECONCILIATION_DELAY_MS = 60_000;
 
 const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
 const mockUseQueryClient = useQueryClient as jest.MockedFunction<
@@ -41,7 +37,6 @@ const mockUseQueryClient = useQueryClient as jest.MockedFunction<
 const mockSetQueryData = jest.fn();
 const mockGetQueryData = jest.fn();
 const mockCancelQueries = jest.fn();
-const mockInvalidateQueries = jest.fn();
 const mockRefetch = jest.fn();
 const mockCall = Engine.controllerMessenger.call as jest.Mock;
 
@@ -93,7 +88,6 @@ const makeQueryResult = (
 
 describe('useNotificationStoragePreferences', () => {
   beforeEach(() => {
-    __resetNotificationStoragePreferencesModuleState();
     jest.clearAllMocks();
     queryCache = undefined;
     mockUseQuery.mockReturnValue(makeQueryResult());
@@ -101,7 +95,6 @@ describe('useNotificationStoragePreferences', () => {
       setQueryData: mockSetQueryData,
       getQueryData: mockGetQueryData,
       cancelQueries: mockCancelQueries,
-      invalidateQueries: mockInvalidateQueries,
     } as unknown as ReturnType<typeof useQueryClient>);
     mockSetQueryData.mockImplementation(
       (
@@ -123,7 +116,6 @@ describe('useNotificationStoragePreferences', () => {
     );
     mockGetQueryData.mockImplementation(() => queryCache);
     mockCancelQueries.mockResolvedValue(undefined);
-    mockInvalidateQueries.mockResolvedValue(undefined);
     mockRefetch.mockResolvedValue(undefined);
     mockCall.mockResolvedValue(undefined);
   });
@@ -140,13 +132,13 @@ describe('useNotificationStoragePreferences', () => {
     expect(mockUseQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: [GET_ACTION],
-        refetchOnMount: expect.any(Function),
-        refetchOnWindowFocus: expect.any(Function),
+        refetchOnWindowFocus: false,
       }),
     );
     expect(result.current.preferences).toBe(preferences);
     expect(result.current.hasNotificationPreferences).toBe(true);
     expect(result.current.isLoading).toBe(true);
+    expect(result.current.isUpdatingPreferences).toBe(false);
     expect(result.current.error).toBe(error);
   });
 
@@ -214,7 +206,7 @@ describe('useNotificationStoragePreferences', () => {
     );
   });
 
-  it('serializes rapid writes and preserves latest payload intent', async () => {
+  it('ignores overlapping writes while a preference save is in flight', async () => {
     queryCache = buildPreferences();
     mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
 
@@ -256,33 +248,7 @@ describe('useNotificationStoragePreferences', () => {
       await Promise.all([firstWrite, secondWrite]);
     });
 
-    expect(putPayloads).toHaveLength(2);
-    expect(putPayloads[1].walletActivity.pushNotificationsEnabled).toBe(true);
-  });
-
-  it('invalidates once writes are idle and refetch suppression window passes', async () => {
-    jest.useFakeTimers();
-    queryCache = buildPreferences();
-    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
-
-    const { result } = renderHook(() => useNotificationStoragePreferences());
-
-    await act(async () => {
-      await result.current.updateSectionChannel(
-        'perps',
-        'inAppNotificationsEnabled',
-        false,
-      );
-    });
-
-    expect(mockInvalidateQueries).not.toHaveBeenCalled();
-    await act(async () => {
-      jest.advanceTimersByTime(RECONCILIATION_DELAY_MS);
-    });
-    expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: [GET_ACTION],
-    });
-
-    jest.useRealTimers();
+    expect(putPayloads).toHaveLength(1);
+    expect(putPayloads[0].walletActivity.pushNotificationsEnabled).toBe(false);
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
@@ -172,6 +172,41 @@ describe('useNotificationStoragePreferences', () => {
     expect(mockCall).not.toHaveBeenCalledWith(GET_ACTION);
   });
 
+  it('accepts a section updater that receives the latest cached section', async () => {
+    queryCache = buildPreferences({
+      socialAI: {
+        inAppNotificationsEnabled: true,
+        pushNotificationsEnabled: true,
+        txAmountLimit: 500,
+        mutedTraderProfileIds: ['trader-1'],
+      },
+    });
+    mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
+
+    const { result } = renderHook(() => useNotificationStoragePreferences());
+
+    await act(async () => {
+      await result.current.updatePreferencesSection('socialAI', (previous) => ({
+        ...previous,
+        mutedTraderProfileIds: [...previous.mutedTraderProfileIds, 'trader-2'],
+      }));
+    });
+
+    expect(queryCache?.socialAI.mutedTraderProfileIds).toEqual([
+      'trader-1',
+      'trader-2',
+    ]);
+    expect(mockCall).toHaveBeenCalledWith(
+      PUT_ACTION,
+      expect.objectContaining({
+        socialAI: expect.objectContaining({
+          mutedTraderProfileIds: ['trader-1', 'trader-2'],
+        }),
+      }),
+      CLIENT_TYPE,
+    );
+  });
+
   it('rolls back cache when latest write fails', async () => {
     const initialPreferences = buildPreferences();
     queryCache = initialPreferences;

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.test.ts
@@ -206,7 +206,7 @@ describe('useNotificationStoragePreferences', () => {
     );
   });
 
-  it('ignores overlapping writes while a preference save is in flight', async () => {
+  it('serializes overlapping writes and preserves the latest preference intent', async () => {
     queryCache = buildPreferences();
     mockUseQuery.mockReturnValue(makeQueryResult({ data: queryCache }));
 
@@ -248,7 +248,9 @@ describe('useNotificationStoragePreferences', () => {
       await Promise.all([firstWrite, secondWrite]);
     });
 
-    expect(putPayloads).toHaveLength(1);
+    expect(putPayloads).toHaveLength(2);
     expect(putPayloads[0].walletActivity.pushNotificationsEnabled).toBe(false);
+    expect(putPayloads[1].walletActivity.pushNotificationsEnabled).toBe(true);
+    expect(queryCache?.walletActivity.pushNotificationsEnabled).toBe(true);
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery } from '@metamask/react-data-query';
 import { useQueryClient } from '@tanstack/react-query';
 import type {
@@ -62,13 +62,33 @@ export const useNotificationStoragePreferences =
         refetchOnWindowFocus: false,
       });
     const queryClient = useQueryClient();
-    const [isUpdatingPreferences, setIsUpdatingPreferences] = useState(false);
-    const isUpdatingPreferencesRef = useRef(false);
+    const [pendingWrites, setPendingWrites] = useState(0);
+    const pendingWritesRef = useRef(0);
+    const writeChainRef = useRef<Promise<void>>(Promise.resolve());
+    const generationRef = useRef(0);
+    const lastConfirmedPreferencesRef =
+      useRef<NotificationPreferencesQueryData>(undefined);
     const getCachedPreferences = useCallback(
       () =>
         queryClient.getQueryData(QUERY_KEY) as NotificationPreferencesQueryData,
       [queryClient],
     );
+
+    useEffect(() => {
+      if (pendingWritesRef.current === 0 && data) {
+        lastConfirmedPreferencesRef.current = data;
+      }
+    }, [data]);
+
+    const beginWrite = useCallback(() => {
+      pendingWritesRef.current += 1;
+      setPendingWrites(pendingWritesRef.current);
+    }, []);
+
+    const finishWrite = useCallback(() => {
+      pendingWritesRef.current = Math.max(0, pendingWritesRef.current - 1);
+      setPendingWrites(pendingWritesRef.current);
+    }, []);
 
     const updatePreferencesSection = useCallback(
       async <PreferenceType extends NotificationPreferenceSection>(
@@ -86,10 +106,6 @@ export const useNotificationStoragePreferences =
           return;
         }
 
-        if (isUpdatingPreferencesRef.current) {
-          return;
-        }
-
         const currentPreferences =
           latestCachedPreferences as NotificationPreferences;
         const previousSnapshot = getCachedPreferences() ?? currentPreferences;
@@ -98,37 +114,52 @@ export const useNotificationStoragePreferences =
           [type]: nextSectionPreferences,
         };
 
-        isUpdatingPreferencesRef.current = true;
-        setIsUpdatingPreferences(true);
-        try {
-          await queryClient.cancelQueries({
-            queryKey: QUERY_KEY,
-          });
-          queryClient.setQueryData<NotificationPreferencesQueryData>(
-            QUERY_KEY,
-            nextPreferences,
-          );
+        if (pendingWritesRef.current === 0) {
+          lastConfirmedPreferencesRef.current = previousSnapshot;
+        }
+
+        generationRef.current += 1;
+        const writeGeneration = generationRef.current;
+        beginWrite();
+
+        const cancelQueriesPromise = queryClient.cancelQueries({
+          queryKey: QUERY_KEY,
+        });
+        queryClient.setQueryData<NotificationPreferencesQueryData>(
+          QUERY_KEY,
+          nextPreferences,
+        );
+
+        const persistWrite = writeChainRef.current.then(async () => {
+          await cancelQueriesPromise;
           await Engine.controllerMessenger.call(
             PUT_ACTION,
             nextPreferences,
             CLIENT_TYPE,
           );
+        });
+        writeChainRef.current = persistWrite.catch(() => undefined);
+
+        try {
+          await persistWrite;
+          lastConfirmedPreferencesRef.current = nextPreferences;
         } catch (err) {
           Logger.error(
             err as Error,
             'Failed to persist notification preferences',
           );
-          queryClient.setQueryData<NotificationPreferencesQueryData>(
-            QUERY_KEY,
-            previousSnapshot,
-          );
+          if (generationRef.current === writeGeneration) {
+            queryClient.setQueryData<NotificationPreferencesQueryData>(
+              QUERY_KEY,
+              lastConfirmedPreferencesRef.current ?? previousSnapshot,
+            );
+          }
           throw err;
         } finally {
-          isUpdatingPreferencesRef.current = false;
-          setIsUpdatingPreferences(false);
+          finishWrite();
         }
       },
-      [data, getCachedPreferences, queryClient],
+      [beginWrite, data, finishWrite, getCachedPreferences, queryClient],
     );
 
     const updateSectionChannel = useCallback(
@@ -178,7 +209,7 @@ export const useNotificationStoragePreferences =
       preferences: data as NotificationPreferencesResult,
       hasNotificationPreferences: data !== null && data !== undefined,
       isLoading,
-      isUpdatingPreferences,
+      isUpdatingPreferences: pendingWrites > 0,
       error,
       updatePreference,
       updateSectionChannel,

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -26,6 +26,16 @@ export type NotificationPreferenceSection = keyof NotificationPreferences;
 export type NotificationPreferenceChannelKey =
   | 'pushNotificationsEnabled'
   | 'inAppNotificationsEnabled';
+type NotificationPreferenceSectionUpdater<
+  PreferenceType extends NotificationPreferenceSection,
+> = (
+  currentSectionPreferences: NotificationPreferences[PreferenceType],
+) => NotificationPreferences[PreferenceType];
+type NotificationPreferenceSectionUpdate<
+  PreferenceType extends NotificationPreferenceSection,
+> =
+  | NotificationPreferences[PreferenceType]
+  | NotificationPreferenceSectionUpdater<PreferenceType>;
 
 export interface UseNotificationStoragePreferencesResult {
   preferences: NotificationPreferencesQueryData;
@@ -47,7 +57,7 @@ export interface UseNotificationStoragePreferencesResult {
     PreferenceType extends NotificationPreferenceSection,
   >(
     type: PreferenceType,
-    nextSectionPreferences: NotificationPreferences[PreferenceType],
+    sectionUpdate: NotificationPreferenceSectionUpdate<PreferenceType>,
   ) => Promise<void>;
   refetch: () => Promise<unknown>;
 }
@@ -93,7 +103,7 @@ export const useNotificationStoragePreferences =
     const updatePreferencesSection = useCallback(
       async <PreferenceType extends NotificationPreferenceSection>(
         type: PreferenceType,
-        nextSectionPreferences: NotificationPreferences[PreferenceType],
+        sectionUpdate: NotificationPreferenceSectionUpdate<PreferenceType>,
       ) => {
         const latestCachedPreferences = getCachedPreferences() ?? data;
 
@@ -108,6 +118,16 @@ export const useNotificationStoragePreferences =
 
         const currentPreferences =
           latestCachedPreferences as NotificationPreferences;
+        const currentSectionPreferences = currentPreferences[type];
+        const nextSectionPreferences =
+          typeof sectionUpdate === 'function'
+            ? sectionUpdate(currentSectionPreferences)
+            : sectionUpdate;
+
+        if (nextSectionPreferences === currentSectionPreferences) {
+          return;
+        }
+
         const previousSnapshot = getCachedPreferences() ?? currentPreferences;
         const nextPreferences: NotificationPreferences = {
           ...currentPreferences,
@@ -168,30 +188,18 @@ export const useNotificationStoragePreferences =
         key: NotificationPreferenceChannelKey,
         value: boolean,
       ) => {
-        const latestCachedPreferences = getCachedPreferences() ?? data;
+        await updatePreferencesSection(type, (currentSectionPreferences) => {
+          if (currentSectionPreferences[key] === value) {
+            return currentSectionPreferences;
+          }
 
-        if (!latestCachedPreferences) {
-          Logger.error(
-            new Error(
-              'No notification preferences found when updating preference, enable notifications first',
-            ),
-          );
-          return;
-        }
-
-        const currentPreferences =
-          latestCachedPreferences as NotificationPreferences;
-
-        if (currentPreferences[type][key] === value) {
-          return;
-        }
-
-        await updatePreferencesSection(type, {
-          ...currentPreferences[type],
-          [key]: value,
+          return {
+            ...currentSectionPreferences,
+            [key]: value,
+          };
         });
       },
-      [data, getCachedPreferences, updatePreferencesSection],
+      [updatePreferencesSection],
     );
 
     const updatePreference = useCallback(

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -1,7 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useQuery } from '@metamask/react-data-query';
-import { type QueryClient, useQueryClient } from '@tanstack/react-query';
-import type { AuthenticatedUserStorageServiceGetNotificationPreferencesAction } from '@metamask/authenticated-user-storage';
+import { useQueryClient } from '@tanstack/react-query';
+import type {
+  AuthenticatedUserStorageServiceGetNotificationPreferencesAction,
+  NotificationPreferences,
+} from '@metamask/authenticated-user-storage';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
 
@@ -11,232 +14,178 @@ const GET_ACTION =
 const PUT_ACTION =
   'AuthenticatedUserStorageService:putNotificationPreferences' as const;
 
-type NotificationStoragePreferencesResult = Awaited<
+type NotificationPreferencesResult = Awaited<
   ReturnType<
     AuthenticatedUserStorageServiceGetNotificationPreferencesAction['handler']
   >
 >;
-export type NotificationStoragePreferences =
-  NonNullable<NotificationStoragePreferencesResult>;
-export type NotificationStoragePreferenceSection =
-  keyof NotificationStoragePreferences;
-export type NotificationStoragePreferenceChannelKey =
+type NotificationPreferencesQueryData =
+  | NotificationPreferencesResult
+  | undefined;
+export type NotificationPreferenceSection = keyof NotificationPreferences;
+export type NotificationPreferenceChannelKey =
   | 'pushNotificationsEnabled'
   | 'inAppNotificationsEnabled';
 
 export interface UseNotificationStoragePreferencesResult {
-  preferences: NotificationStoragePreferencesResult;
+  preferences: NotificationPreferencesQueryData;
   hasNotificationPreferences: boolean;
   isLoading: boolean;
+  isUpdatingPreferences: boolean;
   error: unknown;
   updatePreference: (
-    type: NotificationStoragePreferenceSection,
-    key: NotificationStoragePreferenceChannelKey,
+    type: NotificationPreferenceSection,
+    key: NotificationPreferenceChannelKey,
     value: boolean,
   ) => Promise<void>;
   updateSectionChannel: (
-    type: NotificationStoragePreferenceSection,
-    key: NotificationStoragePreferenceChannelKey,
+    type: NotificationPreferenceSection,
+    key: NotificationPreferenceChannelKey,
     value: boolean,
   ) => Promise<void>;
-  updatePreferencesSection: <PreferenceType extends NotificationStoragePreferenceSection>(
+  updatePreferencesSection: <
+    PreferenceType extends NotificationPreferenceSection,
+  >(
     type: PreferenceType,
-    nextSectionPreferences: NotificationStoragePreferences[PreferenceType],
+    nextSectionPreferences: NotificationPreferences[PreferenceType],
   ) => Promise<void>;
   refetch: () => Promise<unknown>;
 }
 
-const QUERY_KEY = [GET_ACTION] as const;
-const RECONCILIATION_DELAY_MS = 60_000;
-
-let pendingWrites = 0;
-let writeChain: Promise<void> = Promise.resolve();
-let suppressAutoRefetchUntil = 0;
-let reconcileTimer: ReturnType<typeof setTimeout> | undefined;
-const sectionGenerations: Partial<
-  Record<NotificationStoragePreferenceSection, number>
-> = {};
-
-const shouldAllowAutomaticRefetch = () =>
-  pendingWrites === 0 && Date.now() >= suppressAutoRefetchUntil;
-
-const enqueueWrite = (task: () => Promise<void>) => {
-  const next = writeChain.then(task);
-  // Keep the chain alive after failures so future writes are not blocked.
-  writeChain = next.catch(() => undefined);
-  return next;
-};
-
-const scheduleIdleReconcile = (queryClient: QueryClient) => {
-  if (reconcileTimer) {
-    clearTimeout(reconcileTimer);
-  }
-
-  const delay = Math.max(suppressAutoRefetchUntil - Date.now(), 0);
-  reconcileTimer = setTimeout(() => {
-    void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
-  }, delay);
-};
-
-export const __resetNotificationStoragePreferencesModuleState = () => {
-  pendingWrites = 0;
-  writeChain = Promise.resolve();
-  suppressAutoRefetchUntil = 0;
-  if (reconcileTimer) {
-    clearTimeout(reconcileTimer);
-    reconcileTimer = undefined;
-  }
-  (Object.keys(sectionGenerations) as NotificationStoragePreferenceSection[]).forEach(
-    (key) => {
-      delete sectionGenerations[key];
-    },
-  );
-};
+const QUERY_KEY: [typeof GET_ACTION] = [GET_ACTION];
 
 export const useNotificationStoragePreferences =
   (): UseNotificationStoragePreferencesResult => {
-  const { data, isLoading, error, refetch } =
-    useQuery<NotificationStoragePreferencesResult>({
-      queryKey: QUERY_KEY,
-      refetchOnMount: () => shouldAllowAutomaticRefetch(),
-      refetchOnWindowFocus: () => shouldAllowAutomaticRefetch(),
-    });
-  const queryClient = useQueryClient();
-
-  const updatePreferencesSection = useCallback(
-    async <PreferenceType extends NotificationStoragePreferenceSection>(
-      type: PreferenceType,
-      nextSectionPreferences: NotificationStoragePreferences[PreferenceType],
-    ) => {
-      const latestCachedPreferences =
-        queryClient.getQueryData<NotificationStoragePreferencesResult>(
-          QUERY_KEY,
-        ) ?? data;
-
-      if (!latestCachedPreferences) {
-        Logger.error(
-          new Error(
-            `No notification preferences found when updating ${type} section, enable notifications first`,
-          ),
-        );
-        return;
-      }
-
-      const previousSnapshot =
-        queryClient.getQueryData<NotificationStoragePreferencesResult>(
-          QUERY_KEY,
-        ) ?? latestCachedPreferences;
-      const optimisticPreferences: NotificationStoragePreferences = {
-        ...(latestCachedPreferences as NotificationStoragePreferences),
-        [type]: nextSectionPreferences,
-      };
-
-      sectionGenerations[type] = (sectionGenerations[type] ?? 0) + 1;
-      const myGeneration = sectionGenerations[type];
-      pendingWrites += 1;
-      // The backing storage service has internal caching; avoid stale refetches
-      // overriding optimistic values until writes settle and reconciliation runs.
-      suppressAutoRefetchUntil = Date.now() + RECONCILIATION_DELAY_MS;
-
-      const cancelQueriesPromise = queryClient.cancelQueries({
+    const { data, isLoading, error, refetch } =
+      useQuery<NotificationPreferencesResult>({
         queryKey: QUERY_KEY,
+        refetchOnWindowFocus: false,
       });
-      queryClient.setQueryData<NotificationStoragePreferencesResult>(
-        QUERY_KEY,
-        (currentPreferences) => {
-          const currentBase =
-            (currentPreferences ?? latestCachedPreferences) as NotificationStoragePreferences;
-          return {
-            ...currentBase,
-            [type]: nextSectionPreferences,
-          } as NotificationStoragePreferences;
-        },
-      );
+    const queryClient = useQueryClient();
+    const [isUpdatingPreferences, setIsUpdatingPreferences] = useState(false);
+    const isUpdatingPreferencesRef = useRef(false);
+    const getCachedPreferences = useCallback(
+      () =>
+        queryClient.getQueryData(
+          QUERY_KEY,
+        ) as NotificationPreferencesQueryData,
+      [queryClient],
+    );
 
-      try {
-        await cancelQueriesPromise;
-        await enqueueWrite(async () => {
-          const preferencesToPersist =
-            (queryClient.getQueryData<NotificationStoragePreferencesResult>(
-              QUERY_KEY,
-            ) ?? optimisticPreferences) as NotificationStoragePreferences;
+    const updatePreferencesSection = useCallback(
+      async <PreferenceType extends NotificationPreferenceSection>(
+        type: PreferenceType,
+        nextSectionPreferences: NotificationPreferences[PreferenceType],
+      ) => {
+        const latestCachedPreferences = getCachedPreferences() ?? data;
 
+        if (!latestCachedPreferences) {
+          Logger.error(
+            new Error(
+              `No notification preferences found when updating ${type} section, enable notifications first`,
+            ),
+          );
+          return;
+        }
+
+        if (isUpdatingPreferencesRef.current) {
+          return;
+        }
+
+        const currentPreferences =
+          latestCachedPreferences as NotificationPreferences;
+        const previousSnapshot =
+          getCachedPreferences() ?? currentPreferences;
+        const nextPreferences: NotificationPreferences = {
+          ...currentPreferences,
+          [type]: nextSectionPreferences,
+        };
+
+        isUpdatingPreferencesRef.current = true;
+        setIsUpdatingPreferences(true);
+        try {
+          await queryClient.cancelQueries({
+            queryKey: QUERY_KEY,
+          });
+          queryClient.setQueryData<NotificationPreferencesQueryData>(
+            QUERY_KEY,
+            nextPreferences,
+          );
           await Engine.controllerMessenger.call(
             PUT_ACTION,
-            preferencesToPersist,
+            nextPreferences,
             CLIENT_TYPE,
           );
-        });
-      } catch (err) {
-        Logger.error(err as Error, 'Failed to persist notification preferences');
-        if (sectionGenerations[type] === myGeneration) {
-          queryClient.setQueryData<NotificationStoragePreferencesResult>(
+        } catch (err) {
+          Logger.error(
+            err as Error,
+            'Failed to persist notification preferences',
+          );
+          queryClient.setQueryData<NotificationPreferencesQueryData>(
             QUERY_KEY,
             previousSnapshot,
           );
+          throw err;
+        } finally {
+          isUpdatingPreferencesRef.current = false;
+          setIsUpdatingPreferences(false);
         }
-        throw err;
-      } finally {
-        pendingWrites = Math.max(0, pendingWrites - 1);
-        if (pendingWrites === 0) {
-          scheduleIdleReconcile(queryClient);
+      },
+      [data, getCachedPreferences, queryClient],
+    );
+
+    const updateSectionChannel = useCallback(
+      async (
+        type: NotificationPreferenceSection,
+        key: NotificationPreferenceChannelKey,
+        value: boolean,
+      ) => {
+        const latestCachedPreferences = getCachedPreferences() ?? data;
+
+        if (!latestCachedPreferences) {
+          Logger.error(
+            new Error(
+              'No notification preferences found when updating preference, enable notifications first',
+            ),
+          );
+          return;
         }
-      }
-    },
-    [data, queryClient],
-  );
 
-  const updateSectionChannel = useCallback(
-    async (
-      type: NotificationStoragePreferenceSection,
-      key: NotificationStoragePreferenceChannelKey,
-      value: boolean,
-    ) => {
-      const latestCachedPreferences =
-        queryClient.getQueryData<NotificationStoragePreferencesResult>(
-          QUERY_KEY,
-        ) ?? data;
+        const currentPreferences =
+          latestCachedPreferences as NotificationPreferences;
 
-      if (!latestCachedPreferences) {
-        Logger.error(
-          new Error(
-            'No notification preferences found when updating preference, enable notifications first',
-          ),
-        );
-        return;
-      }
+        if (currentPreferences[type][key] === value) {
+          return;
+        }
 
-      if (latestCachedPreferences[type][key] === value) {
-        return;
-      }
+        await updatePreferencesSection(type, {
+          ...currentPreferences[type],
+          [key]: value,
+        });
+      },
+      [data, getCachedPreferences, updatePreferencesSection],
+    );
 
-      await updatePreferencesSection(type, {
-        ...latestCachedPreferences[type],
-        [key]: value,
-      });
-    },
-    [data, queryClient, updatePreferencesSection],
-  );
+    const updatePreference = useCallback(
+      async (
+        type: NotificationPreferenceSection,
+        key: NotificationPreferenceChannelKey,
+        value: boolean,
+      ) => {
+        await updateSectionChannel(type, key, value);
+      },
+      [updateSectionChannel],
+    );
 
-  const updatePreference = useCallback(
-    async (
-      type: NotificationStoragePreferenceSection,
-      key: NotificationStoragePreferenceChannelKey,
-      value: boolean,
-    ) => {
-      await updateSectionChannel(type, key, value);
-    },
-    [updateSectionChannel],
-  );
-
-  return {
-    preferences: data as NotificationStoragePreferencesResult,
-    hasNotificationPreferences: data !== null && data !== undefined,
-    isLoading,
-    error,
-    updatePreference,
-    updateSectionChannel,
-    updatePreferencesSection,
-    refetch,
+    return {
+      preferences: data as NotificationPreferencesResult,
+      hasNotificationPreferences: data !== null && data !== undefined,
+      isLoading,
+      isUpdatingPreferences,
+      error,
+      updatePreference,
+      updateSectionChannel,
+      updatePreferencesSection,
+      refetch,
+    };
   };
-};

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -66,9 +66,7 @@ export const useNotificationStoragePreferences =
     const isUpdatingPreferencesRef = useRef(false);
     const getCachedPreferences = useCallback(
       () =>
-        queryClient.getQueryData(
-          QUERY_KEY,
-        ) as NotificationPreferencesQueryData,
+        queryClient.getQueryData(QUERY_KEY) as NotificationPreferencesQueryData,
       [queryClient],
     );
 
@@ -94,8 +92,7 @@ export const useNotificationStoragePreferences =
 
         const currentPreferences =
           latestCachedPreferences as NotificationPreferences;
-        const previousSnapshot =
-          getCachedPreferences() ?? currentPreferences;
+        const previousSnapshot = getCachedPreferences() ?? currentPreferences;
         const nextPreferences: NotificationPreferences = {
           ...currentPreferences,
           [type]: nextSectionPreferences,

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useNotificationStoragePreferences.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useQuery } from '@metamask/react-data-query';
-import { useQueryClient } from '@tanstack/react-query';
+import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import type { AuthenticatedUserStorageServiceGetNotificationPreferencesAction } from '@metamask/authenticated-user-storage';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
@@ -24,52 +24,96 @@ export type NotificationStoragePreferenceChannelKey =
   | 'pushNotificationsEnabled'
   | 'inAppNotificationsEnabled';
 
-export const useNotificationStoragePreferences = () => {
+export interface UseNotificationStoragePreferencesResult {
+  preferences: NotificationStoragePreferencesResult;
+  hasNotificationPreferences: boolean;
+  isLoading: boolean;
+  error: unknown;
+  updatePreference: (
+    type: NotificationStoragePreferenceSection,
+    key: NotificationStoragePreferenceChannelKey,
+    value: boolean,
+  ) => Promise<void>;
+  updateSectionChannel: (
+    type: NotificationStoragePreferenceSection,
+    key: NotificationStoragePreferenceChannelKey,
+    value: boolean,
+  ) => Promise<void>;
+  updatePreferencesSection: <PreferenceType extends NotificationStoragePreferenceSection>(
+    type: PreferenceType,
+    nextSectionPreferences: NotificationStoragePreferences[PreferenceType],
+  ) => Promise<void>;
+  refetch: () => Promise<unknown>;
+}
+
+const QUERY_KEY = [GET_ACTION] as const;
+const RECONCILIATION_DELAY_MS = 60_000;
+
+let pendingWrites = 0;
+let writeChain: Promise<void> = Promise.resolve();
+let suppressAutoRefetchUntil = 0;
+let reconcileTimer: ReturnType<typeof setTimeout> | undefined;
+const sectionGenerations: Partial<
+  Record<NotificationStoragePreferenceSection, number>
+> = {};
+
+const shouldAllowAutomaticRefetch = () =>
+  pendingWrites === 0 && Date.now() >= suppressAutoRefetchUntil;
+
+const enqueueWrite = (task: () => Promise<void>) => {
+  const next = writeChain.then(task);
+  // Keep the chain alive after failures so future writes are not blocked.
+  writeChain = next.catch(() => undefined);
+  return next;
+};
+
+const scheduleIdleReconcile = (queryClient: QueryClient) => {
+  if (reconcileTimer) {
+    clearTimeout(reconcileTimer);
+  }
+
+  const delay = Math.max(suppressAutoRefetchUntil - Date.now(), 0);
+  reconcileTimer = setTimeout(() => {
+    void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+  }, delay);
+};
+
+export const __resetNotificationStoragePreferencesModuleState = () => {
+  pendingWrites = 0;
+  writeChain = Promise.resolve();
+  suppressAutoRefetchUntil = 0;
+  if (reconcileTimer) {
+    clearTimeout(reconcileTimer);
+    reconcileTimer = undefined;
+  }
+  (Object.keys(sectionGenerations) as NotificationStoragePreferenceSection[]).forEach(
+    (key) => {
+      delete sectionGenerations[key];
+    },
+  );
+};
+
+export const useNotificationStoragePreferences =
+  (): UseNotificationStoragePreferencesResult => {
   const { data, isLoading, error, refetch } =
     useQuery<NotificationStoragePreferencesResult>({
-      queryKey: [GET_ACTION],
+      queryKey: QUERY_KEY,
+      refetchOnMount: () => shouldAllowAutomaticRefetch(),
+      refetchOnWindowFocus: () => shouldAllowAutomaticRefetch(),
     });
   const queryClient = useQueryClient();
-
-  const enqueuePersist = useCallback(
-    async <
-      PreferenceType extends
-        NotificationStoragePreferenceSection = NotificationStoragePreferenceSection,
-    >(
-      nextPreferences: NotificationStoragePreferences,
-      updatedType?: PreferenceType,
-    ) => {
-      try {
-        const latest = await Engine.controllerMessenger.call(GET_ACTION);
-        const preferencesToPersist: NotificationStoragePreferences = {
-          ...(latest ?? nextPreferences),
-          ...(updatedType
-            ? { [updatedType]: nextPreferences[updatedType] }
-            : nextPreferences),
-        };
-
-        await Engine.controllerMessenger.call(
-          PUT_ACTION,
-          preferencesToPersist,
-          CLIENT_TYPE,
-        );
-      } catch (err) {
-        Logger.error(
-          err as Error,
-          'Failed to persist notification preferences',
-        );
-        throw err;
-      }
-    },
-    [],
-  );
 
   const updatePreferencesSection = useCallback(
     async <PreferenceType extends NotificationStoragePreferenceSection>(
       type: PreferenceType,
       nextSectionPreferences: NotificationStoragePreferences[PreferenceType],
     ) => {
-      if (!data) {
+      const latestCachedPreferences =
+        queryClient.getQueryData<NotificationStoragePreferencesResult>(
+          QUERY_KEY,
+        ) ?? data;
+
+      if (!latestCachedPreferences) {
         Logger.error(
           new Error(
             `No notification preferences found when updating ${type} section, enable notifications first`,
@@ -78,37 +122,82 @@ export const useNotificationStoragePreferences = () => {
         return;
       }
 
-      const nextPreferences = {
-        ...data,
+      const previousSnapshot =
+        queryClient.getQueryData<NotificationStoragePreferencesResult>(
+          QUERY_KEY,
+        ) ?? latestCachedPreferences;
+      const optimisticPreferences: NotificationStoragePreferences = {
+        ...(latestCachedPreferences as NotificationStoragePreferences),
         [type]: nextSectionPreferences,
-      } as NotificationStoragePreferences;
+      };
 
+      sectionGenerations[type] = (sectionGenerations[type] ?? 0) + 1;
+      const myGeneration = sectionGenerations[type];
+      pendingWrites += 1;
+      // The backing storage service has internal caching; avoid stale refetches
+      // overriding optimistic values until writes settle and reconciliation runs.
+      suppressAutoRefetchUntil = Date.now() + RECONCILIATION_DELAY_MS;
+
+      const cancelQueriesPromise = queryClient.cancelQueries({
+        queryKey: QUERY_KEY,
+      });
       queryClient.setQueryData<NotificationStoragePreferencesResult>(
-        [GET_ACTION],
-        (previousPreferences) =>
-          ({
-            ...(previousPreferences ?? nextPreferences),
+        QUERY_KEY,
+        (currentPreferences) => {
+          const currentBase =
+            (currentPreferences ?? latestCachedPreferences) as NotificationStoragePreferences;
+          return {
+            ...currentBase,
             [type]: nextSectionPreferences,
-          }) as NotificationStoragePreferences,
+          } as NotificationStoragePreferences;
+        },
       );
 
       try {
-        await enqueuePersist(nextPreferences, type);
+        await cancelQueriesPromise;
+        await enqueueWrite(async () => {
+          const preferencesToPersist =
+            (queryClient.getQueryData<NotificationStoragePreferencesResult>(
+              QUERY_KEY,
+            ) ?? optimisticPreferences) as NotificationStoragePreferences;
+
+          await Engine.controllerMessenger.call(
+            PUT_ACTION,
+            preferencesToPersist,
+            CLIENT_TYPE,
+          );
+        });
       } catch (err) {
-        refetch();
+        Logger.error(err as Error, 'Failed to persist notification preferences');
+        if (sectionGenerations[type] === myGeneration) {
+          queryClient.setQueryData<NotificationStoragePreferencesResult>(
+            QUERY_KEY,
+            previousSnapshot,
+          );
+        }
         throw err;
+      } finally {
+        pendingWrites = Math.max(0, pendingWrites - 1);
+        if (pendingWrites === 0) {
+          scheduleIdleReconcile(queryClient);
+        }
       }
     },
-    [data, enqueuePersist, queryClient, refetch],
+    [data, queryClient],
   );
 
-  const updatePreference = useCallback(
+  const updateSectionChannel = useCallback(
     async (
       type: NotificationStoragePreferenceSection,
       key: NotificationStoragePreferenceChannelKey,
       value: boolean,
     ) => {
-      if (!data) {
+      const latestCachedPreferences =
+        queryClient.getQueryData<NotificationStoragePreferencesResult>(
+          QUERY_KEY,
+        ) ?? data;
+
+      if (!latestCachedPreferences) {
         Logger.error(
           new Error(
             'No notification preferences found when updating preference, enable notifications first',
@@ -117,20 +206,37 @@ export const useNotificationStoragePreferences = () => {
         return;
       }
 
+      if (latestCachedPreferences[type][key] === value) {
+        return;
+      }
+
       await updatePreferencesSection(type, {
-        ...data[type],
+        ...latestCachedPreferences[type],
         [key]: value,
       });
     },
-    [data, updatePreferencesSection],
+    [data, queryClient, updatePreferencesSection],
+  );
+
+  const updatePreference = useCallback(
+    async (
+      type: NotificationStoragePreferenceSection,
+      key: NotificationStoragePreferenceChannelKey,
+      value: boolean,
+    ) => {
+      await updateSectionChannel(type, key, value);
+    },
+    [updateSectionChannel],
   );
 
   return {
-    preferences: data,
+    preferences: data as NotificationStoragePreferencesResult,
     hasNotificationPreferences: data !== null && data !== undefined,
     isLoading,
     error,
     updatePreference,
+    updateSectionChannel,
     updatePreferencesSection,
+    refetch,
   };
 };

--- a/app/components/Views/Settings/NotificationsSettings/hooks/useOptimisticToggleValue.ts
+++ b/app/components/Views/Settings/NotificationsSettings/hooks/useOptimisticToggleValue.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseOptimisticToggleValueParams {
+  remoteValue: boolean;
+  onPersist: (nextValue: boolean) => Promise<void>;
+  isToggleEnabled?: (nextValue: boolean) => boolean;
+  onToggleBlocked?: (nextValue: boolean) => void;
+}
+
+export interface UseOptimisticToggleValueResult {
+  value: boolean;
+  onValueChange: (nextValue: boolean) => void;
+  pendingWrites: number;
+}
+
+export const useOptimisticToggleValue = ({
+  remoteValue,
+  onPersist,
+  isToggleEnabled,
+  onToggleBlocked,
+}: UseOptimisticToggleValueParams): UseOptimisticToggleValueResult => {
+  const [overlayValue, setOverlayValue] = useState<boolean | undefined>(
+    undefined,
+  );
+  const [pendingWrites, setPendingWrites] = useState(0);
+
+  const displayedValue = overlayValue ?? remoteValue;
+  const writeChainRef = useRef<Promise<void>>(Promise.resolve());
+  const generationRef = useRef(0);
+  const displayedValueRef = useRef(displayedValue);
+  displayedValueRef.current = displayedValue;
+  const remoteValueRef = useRef(remoteValue);
+  remoteValueRef.current = remoteValue;
+
+  const enqueuePersist = useCallback(
+    (nextValue: boolean) => {
+      const next = writeChainRef.current.then(() => onPersist(nextValue));
+      // Keep the queue alive even if one mutation fails.
+      writeChainRef.current = next.catch(() => undefined);
+      return next;
+    },
+    [onPersist],
+  );
+
+  useEffect(() => {
+    if (
+      overlayValue !== undefined &&
+      pendingWrites === 0 &&
+      overlayValue === remoteValue
+    ) {
+      setOverlayValue(undefined);
+    }
+  }, [overlayValue, pendingWrites, remoteValue]);
+
+  const onValueChange = useCallback(
+    (nextValue: boolean) => {
+      if (nextValue === displayedValueRef.current) {
+        return;
+      }
+
+      if (isToggleEnabled && !isToggleEnabled(nextValue)) {
+        onToggleBlocked?.(nextValue);
+        return;
+      }
+
+      generationRef.current += 1;
+      const writeGeneration = generationRef.current;
+      displayedValueRef.current = nextValue;
+      setOverlayValue(nextValue);
+      setPendingWrites((count) => count + 1);
+
+      enqueuePersist(nextValue)
+        .catch(() => {
+          // Roll back only if no newer mutation has been queued.
+          if (generationRef.current === writeGeneration) {
+            displayedValueRef.current = remoteValueRef.current;
+            setOverlayValue(undefined);
+          }
+        })
+        .finally(() => {
+          setPendingWrites((count) => Math.max(0, count - 1));
+        });
+    },
+    [enqueuePersist, isToggleEnabled, onToggleBlocked],
+  );
+
+  return {
+    value: displayedValue,
+    onValueChange,
+    pendingWrites,
+  };
+};

--- a/app/components/Views/Settings/NotificationsSettings/index.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.test.tsx
@@ -82,8 +82,6 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../UI/Notification/SwitchLoadingModal', () => () => null);
-
 jest.mock('./hooks/useNotificationStoragePreferences', () => ({
   useNotificationStoragePreferences: () => ({
     preferences: {

--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -8,7 +8,6 @@ import { useTheme } from '../../../../util/theme';
 
 import { useStyles } from '../../../../component-library/hooks';
 import HeaderCompactStandard from '../../../../component-library/components-temp/HeaderCompactStandard';
-import SwitchLoadingModal from '../../../UI/Notification/SwitchLoadingModal';
 import { Props } from './NotificationsSettings.types';
 
 import { selectIsMetamaskNotificationsEnabled } from '../../../../selectors/notifications';
@@ -16,7 +15,6 @@ import { selectSocialLeaderboardEnabled } from '../../../../selectors/featureFla
 
 import Routes from '../../../../constants/navigation/Routes';
 
-import { useSwitchNotificationLoadingText } from '../../../../util/notifications/hooks/useSwitchNotifications';
 import { MainNotificationToggle } from './MainNotificationToggle';
 import styleSheet from './NotificationsSettings.styles';
 import {
@@ -101,7 +99,6 @@ const NotificationsSettings = ({ navigation }: Props) => {
     selectSocialLeaderboardEnabled,
   );
 
-  const loadingText = useSwitchNotificationLoadingText();
   const { preferences } = useNotificationStoragePreferences();
 
   const navigateToSection = (
@@ -190,10 +187,6 @@ const NotificationsSettings = ({ navigation }: Props) => {
             />
           </>
         )}
-        <SwitchLoadingModal
-          loading={!!loadingText}
-          loadingText={loadingText ?? ''}
-        />
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/components/Views/Settings/NotificationsSettings/index.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/index.tsx
@@ -21,8 +21,7 @@ import { MainNotificationToggle } from './MainNotificationToggle';
 import styleSheet from './NotificationsSettings.styles';
 import {
   useNotificationStoragePreferences,
-  type NotificationStoragePreferences,
-  type NotificationStoragePreferenceSection,
+  type NotificationPreferenceSection,
 } from './hooks/useNotificationStoragePreferences';
 
 import {
@@ -36,6 +35,7 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
 } from '@metamask/design-system-react-native';
+import { NotificationPreferences } from '@metamask/authenticated-user-storage';
 
 interface NotificationRowProps {
   title: string;
@@ -75,7 +75,7 @@ const NotificationRow = ({
 };
 
 type NotificationPreferenceStatus =
-  NotificationStoragePreferences[NotificationStoragePreferenceSection];
+  NotificationPreferences[NotificationPreferenceSection];
 
 const getStatusText = (prefs?: NotificationPreferenceStatus | null) => {
   const active = [];
@@ -105,7 +105,7 @@ const NotificationsSettings = ({ navigation }: Props) => {
   const { preferences } = useNotificationStoragePreferences();
 
   const navigateToSection = (
-    type: NotificationStoragePreferenceSection,
+    type: NotificationPreferenceSection,
     title: string,
     description: string,
   ) => {

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -83,7 +83,9 @@ describe('useNotificationPreferences', () => {
 
     expect(result.current.preferences.pushNotificationsEnabled).toBe(true);
     expect(result.current.preferences.inAppNotificationsEnabled).toBe(true);
-    expect(result.current.preferences.txAmountLimit).toBe(DEFAULT_TX_AMOUNT_LIMIT);
+    expect(result.current.preferences.txAmountLimit).toBe(
+      DEFAULT_TX_AMOUNT_LIMIT,
+    );
     expect(result.current.preferences.mutedTraderProfileIds).toEqual([]);
     expect(result.current.hasNotificationPreferences).toBe(false);
   });
@@ -113,7 +115,9 @@ describe('useNotificationPreferences', () => {
       txAmountLimit: 100,
       mutedTraderProfileIds: ['trader-muted'],
     });
-    expect(result.current.isTraderNotificationEnabled('trader-muted')).toBe(false);
+    expect(result.current.isTraderNotificationEnabled('trader-muted')).toBe(
+      false,
+    );
   });
 
   it('setPushNotificationsEnabled delegates to updateSectionChannel', async () => {

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -177,10 +177,9 @@ describe('useNotificationPreferences', () => {
     const { socialAI: _socialAI, ...preferencesWithoutSocialAI } =
       buildStoragePreferences();
     mockUseNotificationStoragePreferences.mockReturnValue({
-      preferences:
-        preferencesWithoutSocialAI as unknown as ReturnType<
-          typeof useNotificationStoragePreferences
-        >['preferences'],
+      preferences: preferencesWithoutSocialAI as unknown as ReturnType<
+        typeof useNotificationStoragePreferences
+      >['preferences'],
       hasNotificationPreferences: true,
       isLoading: false,
       error: null,

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -144,6 +144,10 @@ describe('useNotificationPreferences', () => {
 
       expect(mockUpdatePreferencesSection).toHaveBeenCalledWith(
         'socialAI',
+        expect.any(Function),
+      );
+      const updater = mockUpdatePreferencesSection.mock.calls[0][1];
+      expect(updater(buildStoragePreferences().socialAI)).toEqual(
         expect.objectContaining({
           txAmountLimit: threshold,
         }),
@@ -159,6 +163,10 @@ describe('useNotificationPreferences', () => {
 
     expect(mockUpdatePreferencesSection).toHaveBeenCalledWith(
       'socialAI',
+      expect.any(Function),
+    );
+    const updater = mockUpdatePreferencesSection.mock.calls[0][1];
+    expect(updater(buildStoragePreferences().socialAI)).toEqual(
       expect.objectContaining({
         mutedTraderProfileIds: ['trader-1'],
       }),
@@ -177,13 +185,23 @@ describe('useNotificationPreferences', () => {
     expect(mockUpdatePreferencesSection).toHaveBeenNthCalledWith(
       1,
       'socialAI',
-      expect.objectContaining({
-        mutedTraderProfileIds: ['trader-1'],
-      }),
+      expect.any(Function),
     );
     expect(mockUpdatePreferencesSection).toHaveBeenNthCalledWith(
       2,
       'socialAI',
+      expect.any(Function),
+    );
+
+    const firstUpdater = mockUpdatePreferencesSection.mock.calls[0][1];
+    const secondUpdater = mockUpdatePreferencesSection.mock.calls[1][1];
+    const firstPreferences = firstUpdater(buildStoragePreferences().socialAI);
+    expect(firstPreferences).toEqual(
+      expect.objectContaining({
+        mutedTraderProfileIds: ['trader-1'],
+      }),
+    );
+    expect(secondUpdater(firstPreferences)).toEqual(
       expect.objectContaining({
         mutedTraderProfileIds: ['trader-1', 'trader-2'],
       }),

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -173,6 +173,37 @@ describe('useNotificationPreferences', () => {
     );
   });
 
+  it('applies default socialAI preferences when stored preferences omit the section', async () => {
+    const { socialAI: _socialAI, ...preferencesWithoutSocialAI } =
+      buildStoragePreferences();
+    mockUseNotificationStoragePreferences.mockReturnValue({
+      preferences:
+        preferencesWithoutSocialAI as unknown as ReturnType<
+          typeof useNotificationStoragePreferences
+        >['preferences'],
+      hasNotificationPreferences: true,
+      isLoading: false,
+      error: null,
+      updatePreferencesSection: mockUpdatePreferencesSection,
+      updateSectionChannel: mockUpdateSectionChannel,
+      updatePreference: jest.fn(),
+      isUpdatingPreferences: false,
+      refetch: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useNotificationPreferences());
+    await act(async () => {
+      await result.current.toggleTraderNotification('trader-1');
+    });
+
+    const updater = mockUpdatePreferencesSection.mock.calls[0][1];
+    expect(updater(undefined)).toEqual(
+      expect.objectContaining({
+        mutedTraderProfileIds: ['trader-1'],
+      }),
+    );
+  });
+
   it('chains rapid trader toggles without losing prior muted ids', async () => {
     const { result } = renderHook(() => useNotificationPreferences());
 

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -161,6 +161,31 @@ describe('useNotificationPreferences', () => {
     );
   });
 
+  it('chains rapid trader toggles without losing prior muted ids', async () => {
+    const { result } = renderHook(() => useNotificationPreferences());
+
+    await act(async () => {
+      const firstToggle = result.current.toggleTraderNotification('trader-1');
+      const secondToggle = result.current.toggleTraderNotification('trader-2');
+      await Promise.all([firstToggle, secondToggle]);
+    });
+
+    expect(mockUpdatePreferencesSection).toHaveBeenNthCalledWith(
+      1,
+      'socialAI',
+      expect.objectContaining({
+        mutedTraderProfileIds: ['trader-1'],
+      }),
+    );
+    expect(mockUpdatePreferencesSection).toHaveBeenNthCalledWith(
+      2,
+      'socialAI',
+      expect.objectContaining({
+        mutedTraderProfileIds: ['trader-1', 'trader-2'],
+      }),
+    );
+  });
+
   it('returns user-facing error when preferences are missing and mutator is called', async () => {
     mockUseNotificationStoragePreferences.mockReturnValue({
       preferences: undefined,

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -1,46 +1,30 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { useQuery } from '@metamask/react-data-query';
-import { useQueryClient } from '@tanstack/react-query';
-import type { NotificationPreferences } from '@metamask/authenticated-user-storage';
-import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller/notification-services';
-import Engine from '../../../../../core/Engine';
+import { renderHook, act } from '@testing-library/react-native';
 import Logger from '../../../../../util/Logger';
 import {
+  DEFAULT_TX_AMOUNT_LIMIT,
   useNotificationPreferences,
   TX_AMOUNT_THRESHOLDS,
 } from './useNotificationPreferences';
+import { useNotificationStoragePreferences } from '../../../Settings/NotificationsSettings/hooks/useNotificationStoragePreferences';
 
 jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
-jest.mock('../../../../../core/Engine', () => ({
-  controllerMessenger: {
-    call: jest.fn(),
-  },
-}));
+jest.mock(
+  '../../../Settings/NotificationsSettings/hooks/useNotificationStoragePreferences',
+  () => ({
+    useNotificationStoragePreferences: jest.fn(),
+  }),
+);
 
-jest.mock('@metamask/react-data-query');
+const mockUseNotificationStoragePreferences = jest.mocked(
+  useNotificationStoragePreferences,
+);
+const mockUpdatePreferencesSection = jest.fn();
+const mockUpdateSectionChannel = jest.fn();
 
-jest.mock('@tanstack/react-query', () => ({
-  useQueryClient: jest.fn(),
-}));
-
-const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
-const mockUseQueryClient = useQueryClient as jest.MockedFunction<
-  typeof useQueryClient
->;
-const mockRefetch = jest.fn().mockResolvedValue(undefined);
-const mockSetQueryData = jest.fn();
-const mockCall = Engine.controllerMessenger.call as jest.Mock;
-
-const GET_ACTION = 'AuthenticatedUserStorageService:getNotificationPreferences';
-const PUT_ACTION = 'AuthenticatedUserStorageService:putNotificationPreferences';
-const CLIENT_TYPE = 'mobile';
-
-const buildRemote = (
-  overrides: Partial<NotificationPreferences> = {},
-): NotificationPreferences => ({
+const buildStoragePreferences = (socialAIOverrides = {}) => ({
   walletActivity: {
     inAppNotificationsEnabled: true,
     pushNotificationsEnabled: true,
@@ -55,591 +39,168 @@ const buildRemote = (
     pushNotificationsEnabled: true,
   },
   socialAI: {
-    ...DEFAULT_SOCIAL_AI_PREFERENCES,
-    mutedTraderProfileIds: [
-      ...DEFAULT_SOCIAL_AI_PREFERENCES.mutedTraderProfileIds,
-    ],
+    pushNotificationsEnabled: true,
+    inAppNotificationsEnabled: true,
+    txAmountLimit: DEFAULT_TX_AMOUNT_LIMIT,
+    mutedTraderProfileIds: [],
+    ...socialAIOverrides,
   },
-  ...overrides,
+  marketing: {
+    inAppNotificationsEnabled: false,
+    pushNotificationsEnabled: false,
+  },
 });
-
-const makeQueryResult = (
-  overrides: Partial<ReturnType<typeof useQuery>> = {},
-): ReturnType<typeof useQuery> =>
-  ({
-    data: undefined,
-    isLoading: false,
-    error: null,
-    refetch: mockRefetch,
-    ...overrides,
-  }) as ReturnType<typeof useQuery>;
 
 describe('useNotificationPreferences', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseQuery.mockReturnValue(makeQueryResult());
-    mockCall.mockResolvedValue(undefined);
-    mockRefetch.mockResolvedValue(undefined);
-    mockUseQueryClient.mockReturnValue({
-      setQueryData: mockSetQueryData,
-    } as unknown as ReturnType<typeof useQueryClient>);
-  });
-
-  describe('query configuration', () => {
-    it('uses the shared notification storage queryKey', () => {
-      renderHook(() => useNotificationPreferences());
-
-      expect(mockUseQuery).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: [GET_ACTION] }),
-      );
+    mockUpdatePreferencesSection.mockResolvedValue(undefined);
+    mockUpdateSectionChannel.mockResolvedValue(undefined);
+    mockUseNotificationStoragePreferences.mockReturnValue({
+      preferences: buildStoragePreferences(),
+      hasNotificationPreferences: true,
+      isLoading: false,
+      error: null,
+      updatePreferencesSection: mockUpdatePreferencesSection,
+      updateSectionChannel: mockUpdateSectionChannel,
+      updatePreference: jest.fn(),
+      refetch: jest.fn(),
     });
   });
 
-  describe('initial state', () => {
-    it('seeds defaults when the query returns no data yet', () => {
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      expect(result.current.preferences.pushNotificationsEnabled).toBe(true);
-      expect(result.current.preferences.inAppNotificationsEnabled).toBe(true);
-      expect(result.current.preferences.txAmountLimit).toBe(500);
-      expect(result.current.preferences.mutedTraderProfileIds).toEqual([]);
-      expect(result.current.hasNotificationPreferences).toBe(false);
+  it('seeds defaults when storage preferences are missing', () => {
+    mockUseNotificationStoragePreferences.mockReturnValue({
+      preferences: undefined,
+      hasNotificationPreferences: false,
+      isLoading: false,
+      error: null,
+      updatePreferencesSection: mockUpdatePreferencesSection,
+      updateSectionChannel: mockUpdateSectionChannel,
+      updatePreference: jest.fn(),
+      refetch: jest.fn(),
     });
 
-    it('reflects the remote socialAI slice when the query resolves', () => {
-      mockUseQuery.mockReturnValue(
-        makeQueryResult({
-          data: buildRemote({
-            socialAI: {
-              pushNotificationsEnabled: false,
-              inAppNotificationsEnabled: true,
-              txAmountLimit: 100,
-              mutedTraderProfileIds: ['trader-muted'],
-            },
-          }),
-        }),
-      );
+    const { result } = renderHook(() => useNotificationPreferences());
 
-      const { result } = renderHook(() => useNotificationPreferences());
+    expect(result.current.preferences.pushNotificationsEnabled).toBe(true);
+    expect(result.current.preferences.inAppNotificationsEnabled).toBe(true);
+    expect(result.current.preferences.txAmountLimit).toBe(DEFAULT_TX_AMOUNT_LIMIT);
+    expect(result.current.preferences.mutedTraderProfileIds).toEqual([]);
+    expect(result.current.hasNotificationPreferences).toBe(false);
+  });
 
-      expect(result.current.preferences).toEqual({
+  it('reflects socialAI preferences from shared storage', () => {
+    mockUseNotificationStoragePreferences.mockReturnValue({
+      preferences: buildStoragePreferences({
         pushNotificationsEnabled: false,
-        inAppNotificationsEnabled: true,
+        inAppNotificationsEnabled: false,
         txAmountLimit: 100,
         mutedTraderProfileIds: ['trader-muted'],
-      });
-      expect(result.current.hasNotificationPreferences).toBe(true);
+      }),
+      hasNotificationPreferences: true,
+      isLoading: false,
+      error: null,
+      updatePreferencesSection: mockUpdatePreferencesSection,
+      updateSectionChannel: mockUpdateSectionChannel,
+      updatePreference: jest.fn(),
+      refetch: jest.fn(),
     });
 
-    it('forwards the useQuery loading state', () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ isLoading: true }));
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      expect(result.current.isLoading).toBe(true);
+    const { result } = renderHook(() => useNotificationPreferences());
+    expect(result.current.preferences).toEqual({
+      pushNotificationsEnabled: false,
+      inAppNotificationsEnabled: false,
+      txAmountLimit: 100,
+      mutedTraderProfileIds: ['trader-muted'],
     });
-
-    it('forwards useQuery errors as string via the error field', () => {
-      mockUseQuery.mockReturnValue(
-        makeQueryResult({ error: new Error('boom') }),
-      );
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      expect(result.current.error).toBe('boom');
-      expect(Logger.error).toHaveBeenCalled();
-    });
+    expect(result.current.isTraderNotificationEnabled('trader-muted')).toBe(false);
   });
 
-  describe('isTraderNotificationEnabled', () => {
-    it('returns true when the trader is NOT in the muted list (opt-out)', () => {
-      mockUseQuery.mockReturnValue(
-        makeQueryResult({
-          data: buildRemote({
-            socialAI: {
-              inAppNotificationsEnabled: true,
-              pushNotificationsEnabled: true,
-              txAmountLimit: 500,
-              mutedTraderProfileIds: ['muted-1'],
-            },
-          }),
-        }),
-      );
+  it('setPushNotificationsEnabled delegates to updateSectionChannel', async () => {
+    const { result } = renderHook(() => useNotificationPreferences());
 
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      expect(result.current.isTraderNotificationEnabled('trader-1')).toBe(true);
-      expect(result.current.isTraderNotificationEnabled('muted-1')).toBe(false);
-    });
-  });
-
-  describe('toggleTraderNotification', () => {
-    it('adds the trader id to the muted list when muting', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.toggleTraderNotification('trader-1');
-      });
-
-      expect(result.current.preferences.mutedTraderProfileIds).toContain(
-        'trader-1',
-      );
-      expect(result.current.isTraderNotificationEnabled('trader-1')).toBe(
-        false,
-      );
+    await act(async () => {
+      await result.current.setPushNotificationsEnabled(false);
     });
 
-    it('removes the trader id from the muted list when unmuting', async () => {
-      mockUseQuery.mockReturnValue(
-        makeQueryResult({
-          data: buildRemote({
-            socialAI: {
-              inAppNotificationsEnabled: true,
-              pushNotificationsEnabled: true,
-              txAmountLimit: 500,
-              mutedTraderProfileIds: ['trader-1'],
-            },
-          }),
-        }),
-      );
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.toggleTraderNotification('trader-1');
-      });
-
-      expect(result.current.preferences.mutedTraderProfileIds).not.toContain(
-        'trader-1',
-      );
-      expect(result.current.isTraderNotificationEnabled('trader-1')).toBe(true);
-    });
-
-    it('does not affect other traders when muting one', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.toggleTraderNotification('trader-1');
-      });
-
-      expect(result.current.isTraderNotificationEnabled('trader-2')).toBe(true);
-      expect(result.current.isTraderNotificationEnabled('trader-3')).toBe(true);
-    });
-  });
-
-  describe('setPushNotificationsEnabled', () => {
-    it('flips pushNotificationsEnabled locally before the server catches up', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      expect(result.current.preferences.pushNotificationsEnabled).toBe(false);
-    });
-  });
-
-  describe('setTxAmountLimit', () => {
-    it.each(TX_AMOUNT_THRESHOLDS)(
-      'updates txAmountLimit to %s',
-      async (threshold) => {
-        mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-
-        const { result } = renderHook(() => useNotificationPreferences());
-
-        await act(async () => {
-          await result.current.setTxAmountLimit(threshold);
-        });
-
-        expect(result.current.preferences.txAmountLimit).toBe(threshold);
-      },
+    expect(mockUpdateSectionChannel).toHaveBeenCalledWith(
+      'socialAI',
+      'pushNotificationsEnabled',
+      false,
     );
   });
 
-  describe('persistence (read-merge-write)', () => {
-    it('GETs the latest preferences right before PUTting', async () => {
-      const cached = buildRemote();
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: cached }));
-
-      // Concurrent writer updated the walletActivity slice on the server.
-      const latest = buildRemote({
-        walletActivity: {
-          inAppNotificationsEnabled: true,
-          pushNotificationsEnabled: true,
-          accounts: [{ address: '0xabc', enabled: true }],
-        },
-      });
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return latest;
-        return undefined;
-      });
-
+  it.each(TX_AMOUNT_THRESHOLDS)(
+    'setTxAmountLimit delegates updated section for threshold %s',
+    async (threshold) => {
       const { result } = renderHook(() => useNotificationPreferences());
-
       await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
+        await result.current.setTxAmountLimit(threshold);
       });
 
-      const calls = mockCall.mock.calls;
-      const getIdx = calls.findIndex((c) => c[0] === GET_ACTION);
-      const putIdx = calls.findIndex((c) => c[0] === PUT_ACTION);
-
-      expect(getIdx).toBeGreaterThanOrEqual(0);
-      expect(putIdx).toBeGreaterThanOrEqual(0);
-      expect(getIdx).toBeLessThan(putIdx);
-    });
-
-    it('PUTs a merged payload that preserves other slices and overrides socialAI', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      const latest = buildRemote({
-        walletActivity: {
-          inAppNotificationsEnabled: true,
-          pushNotificationsEnabled: true,
-          accounts: [{ address: '0xabc', enabled: true }],
-        },
-        marketing: {
-          inAppNotificationsEnabled: true,
-          pushNotificationsEnabled: true,
-        },
-      });
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return latest;
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.toggleTraderNotification('trader-1');
-      });
-
-      expect(mockCall).toHaveBeenCalledWith(
-        PUT_ACTION,
+      expect(mockUpdatePreferencesSection).toHaveBeenCalledWith(
+        'socialAI',
         expect.objectContaining({
-          walletActivity: latest.walletActivity,
-          marketing: latest.marketing,
-          perps: latest.perps,
-          socialAI: expect.objectContaining({
-            mutedTraderProfileIds: ['trader-1'],
-          }),
-        }),
-        CLIENT_TYPE,
-      );
-    });
-
-    it('does not initialize preferences when the server has nothing stored', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: null }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return null;
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      expect(mockCall).not.toHaveBeenCalled();
-      expect(result.current.error).toBe(
-        'No notification preferences found when updating social AI preferences, enable notifications first',
-      );
-      expect(Logger.error).toHaveBeenCalledWith(
-        expect.any(Error),
-        'useNotificationPreferences: persist skipped',
-      );
-    });
-
-    it('rolls back the optimistic overlay and surfaces an error on PUT failure', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return buildRemote();
-        if (action === PUT_ACTION) throw new Error('network down');
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      await waitFor(() => {
-        expect(result.current.preferences.pushNotificationsEnabled).toBe(true);
-      });
-      expect(result.current.error).toBe('network down');
-      expect(Logger.error).toHaveBeenCalled();
-    });
-
-    it('does not refetch the query after a successful PUT', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return buildRemote();
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      expect(mockRefetch).not.toHaveBeenCalled();
-    });
-
-    it('does not roll back or set an error when persist succeeds', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return buildRemote();
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      // The mutation was saved — optimistic overlay must remain (push disabled).
-      expect(result.current.preferences.pushNotificationsEnabled).toBe(false);
-      expect(result.current.error).toBeNull();
-    });
-
-    it('primes the TanStack cache with the updated socialAI slice', async () => {
-      const latest = buildRemote({
-        walletActivity: {
-          inAppNotificationsEnabled: true,
-          pushNotificationsEnabled: true,
-          accounts: [{ address: '0xabc', enabled: true }],
-        },
-      });
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return latest;
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      expect(mockSetQueryData).toHaveBeenCalledTimes(1);
-      const [keyArg, updaterArg] = mockSetQueryData.mock.calls[0];
-      expect(keyArg).toEqual([GET_ACTION]);
-      // The updater merges socialAI on top of the previous cached value.
-      const merged = (updaterArg as CallableFunction)(latest);
-      expect(merged).toEqual(
-        expect.objectContaining({
-          walletActivity: latest.walletActivity,
-          socialAI: expect.objectContaining({
-            pushNotificationsEnabled: false,
-          }),
+          txAmountLimit: threshold,
         }),
       );
+    },
+  );
+
+  it('toggleTraderNotification adds trader to muted list when not muted', async () => {
+    const { result } = renderHook(() => useNotificationPreferences());
+    await act(async () => {
+      await result.current.toggleTraderNotification('trader-1');
     });
 
-    it('keeps the optimistic overlay while a PUT is in flight even if the query data momentarily reports the pre-PUT value (no snap-back)', async () => {
-      // Simulate a stale refetch landing between the optimistic cache write
-      // and the PUT resolving: the second render of the hook receives query
-      // data that no longer matches the optimistic overlay.
-      const remoteWithMute = buildRemote({
-        socialAI: {
-          ...DEFAULT_SOCIAL_AI_PREFERENCES,
-          mutedTraderProfileIds: ['trader-x'],
-        },
-      });
-      const remoteWithoutMute = buildRemote();
-
-      mockUseQuery.mockReturnValue(
-        makeQueryResult({ data: remoteWithoutMute }),
-      );
-
-      let resolvePut: () => void = () => undefined;
-      const putPromise = new Promise<void>((resolve) => {
-        resolvePut = resolve;
-      });
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return remoteWithoutMute;
-        if (action === PUT_ACTION) return putPromise;
-        return undefined;
-      });
-
-      const { result, rerender } = renderHook(() =>
-        useNotificationPreferences(),
-      );
-
-      act(() => {
-        result.current.toggleTraderNotification('trader-x');
-      });
-
-      expect(result.current.isTraderNotificationEnabled('trader-x')).toBe(
-        false,
-      );
-
-      mockUseQuery.mockReturnValue(
-        makeQueryResult({ data: remoteWithoutMute }),
-      );
-      rerender({});
-
-      expect(result.current.isTraderNotificationEnabled('trader-x')).toBe(
-        false,
-      );
-
-      await act(async () => {
-        resolvePut();
-        await putPromise;
-      });
-
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: remoteWithMute }));
-      rerender({});
-
-      await waitFor(() => {
-        expect(result.current.isTraderNotificationEnabled('trader-x')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('rolls back from the optimistic cache update when the PUT fails', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return buildRemote();
-        if (action === PUT_ACTION) throw new Error('network down');
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        await result.current.setPushNotificationsEnabled(false);
-      });
-
-      expect(mockSetQueryData).toHaveBeenCalledTimes(1);
-      expect(mockRefetch).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not corrupt state when a first rapid mutation fails but a second succeeds', async () => {
-      // Remote: enabled=true, txAmountLimit=500
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-
-      let putCount = 0;
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return buildRemote();
-        if (action === PUT_ACTION) {
-          putCount += 1;
-          // First PUT (from setPushNotificationsEnabled) fails; second
-          // (from setTxAmountLimit) succeeds.
-          if (putCount === 1) throw new Error('first PUT failed');
-          return undefined;
-        }
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        const first = result.current.setPushNotificationsEnabled(false);
-        const second = result.current.setTxAmountLimit(100);
-        await Promise.all([first, second]);
-      });
-
-      // The second mutation's overlay must survive the first mutation's rollback.
-      // B built its nextSocialAI on top of A's pending state
-      // (pushNotificationsEnabled:false, txAmountLimit:100), and its PUT
-      // succeeded, so both changes are on the server.
-      expect(result.current.preferences.pushNotificationsEnabled).toBe(false);
-      expect(result.current.preferences.txAmountLimit).toBe(100);
-      // A's failure was swallowed because a newer mutation was in flight.
-      expect(result.current.error).toBeNull();
-    });
+    expect(mockUpdatePreferencesSection).toHaveBeenCalledWith(
+      'socialAI',
+      expect.objectContaining({
+        mutedTraderProfileIds: ['trader-1'],
+      }),
+    );
   });
 
-  describe('write serialization', () => {
-    it('processes back-to-back toggles sequentially without overlapping GETs and PUTs', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-
-      const order: string[] = [];
-      let resolveFirstPut: () => void = () => undefined;
-      const firstPutBlocker = new Promise<void>((r) => {
-        resolveFirstPut = r;
-      });
-
-      let putCount = 0;
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) {
-          order.push('GET');
-          return buildRemote();
-        }
-        if (action === PUT_ACTION) {
-          putCount += 1;
-          order.push(`PUT-${putCount}-start`);
-          if (putCount === 1) {
-            await firstPutBlocker;
-          }
-          order.push(`PUT-${putCount}-end`);
-          return undefined;
-        }
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        const first = result.current.setPushNotificationsEnabled(false);
-        const second = result.current.setTxAmountLimit(100);
-        // Release the first PUT only after both calls have been initiated.
-        // If writes weren't serialized, the second GET would fire before the
-        // first PUT resolved.
-        setTimeout(() => resolveFirstPut(), 0);
-        await Promise.all([first, second]);
-      });
-
-      // Expected strict interleaving: GET → PUT-1-start → PUT-1-end → GET → PUT-2-start → PUT-2-end
-      expect(order).toEqual([
-        'GET',
-        'PUT-1-start',
-        'PUT-1-end',
-        'GET',
-        'PUT-2-start',
-        'PUT-2-end',
-      ]);
+  it('returns user-facing error when preferences are missing and mutator is called', async () => {
+    mockUseNotificationStoragePreferences.mockReturnValue({
+      preferences: undefined,
+      hasNotificationPreferences: false,
+      isLoading: false,
+      error: null,
+      updatePreferencesSection: mockUpdatePreferencesSection,
+      updateSectionChannel: mockUpdateSectionChannel,
+      updatePreference: jest.fn(),
+      refetch: jest.fn(),
     });
 
-    it('chains rapid successive mutations so the second PUT reflects both changes', async () => {
-      mockUseQuery.mockReturnValue(makeQueryResult({ data: buildRemote() }));
-      mockCall.mockImplementation(async (action: string) => {
-        if (action === GET_ACTION) return buildRemote();
-        return undefined;
-      });
-
-      const { result } = renderHook(() => useNotificationPreferences());
-
-      await act(async () => {
-        // Fire both mutations without awaiting — simulates rapid user interaction
-        // before React can re-render with the new overlay.
-        const first = result.current.setPushNotificationsEnabled(false);
-        const second = result.current.setTxAmountLimit(100);
-        await Promise.all([first, second]);
-      });
-
-      // There must be exactly two PUTs (one per mutation, serialized).
-      const putCalls = mockCall.mock.calls.filter((c) => c[0] === PUT_ACTION);
-      expect(putCalls).toHaveLength(2);
-
-      // The second PUT must carry BOTH mutations — not the stale socialAI base
-      // from the first render (which would have re-applied push: true).
-      expect(putCalls[1][1].socialAI).toMatchObject({
-        pushNotificationsEnabled: false,
-        txAmountLimit: 100,
-      });
+    const { result } = renderHook(() => useNotificationPreferences());
+    await act(async () => {
+      await result.current.setPushNotificationsEnabled(false);
     });
+
+    expect(result.current.error).toBe(
+      'No notification preferences found when updating social AI preferences, enable notifications first',
+    );
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      'useNotificationPreferences: persist skipped',
+    );
+  });
+
+  it('surfaces storage query errors', () => {
+    mockUseNotificationStoragePreferences.mockReturnValue({
+      preferences: buildStoragePreferences(),
+      hasNotificationPreferences: true,
+      isLoading: false,
+      error: new Error('boom'),
+      updatePreferencesSection: mockUpdatePreferencesSection,
+      updateSectionChannel: mockUpdateSectionChannel,
+      updatePreference: jest.fn(),
+      refetch: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useNotificationPreferences());
+    expect(result.current.error).toBe('boom');
+    expect(Logger.error).toHaveBeenCalled();
   });
 });

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.test.ts
@@ -5,6 +5,7 @@ import {
   useNotificationPreferences,
   TX_AMOUNT_THRESHOLDS,
 } from './useNotificationPreferences';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useNotificationStoragePreferences } from '../../../Settings/NotificationsSettings/hooks/useNotificationStoragePreferences';
 
 jest.mock('../../../../../util/Logger', () => ({
@@ -45,10 +46,6 @@ const buildStoragePreferences = (socialAIOverrides = {}) => ({
     mutedTraderProfileIds: [],
     ...socialAIOverrides,
   },
-  marketing: {
-    inAppNotificationsEnabled: false,
-    pushNotificationsEnabled: false,
-  },
 });
 
 describe('useNotificationPreferences', () => {
@@ -64,6 +61,7 @@ describe('useNotificationPreferences', () => {
       updatePreferencesSection: mockUpdatePreferencesSection,
       updateSectionChannel: mockUpdateSectionChannel,
       updatePreference: jest.fn(),
+      isUpdatingPreferences: false,
       refetch: jest.fn(),
     });
   });
@@ -77,6 +75,7 @@ describe('useNotificationPreferences', () => {
       updatePreferencesSection: mockUpdatePreferencesSection,
       updateSectionChannel: mockUpdateSectionChannel,
       updatePreference: jest.fn(),
+      isUpdatingPreferences: false,
       refetch: jest.fn(),
     });
 
@@ -103,6 +102,7 @@ describe('useNotificationPreferences', () => {
       updatePreferencesSection: mockUpdatePreferencesSection,
       updateSectionChannel: mockUpdateSectionChannel,
       updatePreference: jest.fn(),
+      isUpdatingPreferences: false,
       refetch: jest.fn(),
     });
 
@@ -195,6 +195,7 @@ describe('useNotificationPreferences', () => {
       updatePreferencesSection: mockUpdatePreferencesSection,
       updateSectionChannel: mockUpdateSectionChannel,
       updatePreference: jest.fn(),
+      isUpdatingPreferences: false,
       refetch: jest.fn(),
     });
 
@@ -221,6 +222,7 @@ describe('useNotificationPreferences', () => {
       updatePreferencesSection: mockUpdatePreferencesSection,
       updateSectionChannel: mockUpdateSectionChannel,
       updatePreference: jest.fn(),
+      isUpdatingPreferences: false,
       refetch: jest.fn(),
     });
 

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { SocialAIPreference } from '@metamask/authenticated-user-storage';
 import Logger from '../../../../../util/Logger';
 import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller';
@@ -64,6 +64,8 @@ export const useNotificationPreferences =
 
     const socialAI: SocialAIPreference =
       storagePreferences?.socialAI ?? DEFAULT_SOCIAL_AI;
+    const currentSocialAIRef = useRef<SocialAIPreference>(socialAI);
+    currentSocialAIRef.current = socialAI;
 
     const applyChange = useCallback(
       async (updater: (prev: SocialAIPreference) => SocialAIPreference) => {
@@ -76,12 +78,14 @@ export const useNotificationPreferences =
           return;
         }
 
-        const nextSocialAI = updater(storagePreferences.socialAI);
+        const nextSocialAI = updater(currentSocialAIRef.current);
+        currentSocialAIRef.current = nextSocialAI;
         setPersistError(null);
 
         try {
           await updatePreferencesSection('socialAI', nextSocialAI);
         } catch (err) {
+          currentSocialAIRef.current = storagePreferences.socialAI;
           Logger.error(
             err as Error,
             'useNotificationPreferences: persist failed',

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
@@ -93,7 +93,11 @@ export const useNotificationPreferences =
           setPersistError(toErrorMessage(err));
         }
       },
-      [hasNotificationPreferences, storagePreferences, updatePreferencesSection],
+      [
+        hasNotificationPreferences,
+        storagePreferences,
+        updatePreferencesSection,
+      ],
     );
 
     const setPushNotificationsEnabled = useCallback(

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { SocialAIPreference } from '@metamask/authenticated-user-storage';
 import Logger from '../../../../../util/Logger';
 import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller';
@@ -64,12 +64,10 @@ export const useNotificationPreferences =
 
     const socialAI: SocialAIPreference =
       storagePreferences?.socialAI ?? DEFAULT_SOCIAL_AI;
-    const currentSocialAIRef = useRef<SocialAIPreference>(socialAI);
-    currentSocialAIRef.current = socialAI;
 
     const applyChange = useCallback(
       async (updater: (prev: SocialAIPreference) => SocialAIPreference) => {
-        if (!hasNotificationPreferences || !storagePreferences) {
+        if (!hasNotificationPreferences) {
           const err = new Error(
             'No notification preferences found when updating social AI preferences, enable notifications first',
           );
@@ -78,14 +76,11 @@ export const useNotificationPreferences =
           return;
         }
 
-        const nextSocialAI = updater(currentSocialAIRef.current);
-        currentSocialAIRef.current = nextSocialAI;
         setPersistError(null);
 
         try {
-          await updatePreferencesSection('socialAI', nextSocialAI);
+          await updatePreferencesSection('socialAI', updater);
         } catch (err) {
-          currentSocialAIRef.current = storagePreferences.socialAI;
           Logger.error(
             err as Error,
             'useNotificationPreferences: persist failed',
@@ -93,11 +88,7 @@ export const useNotificationPreferences =
           setPersistError(toErrorMessage(err));
         }
       },
-      [
-        hasNotificationPreferences,
-        storagePreferences,
-        updatePreferencesSection,
-      ],
+      [hasNotificationPreferences, updatePreferencesSection],
     );
 
     const setPushNotificationsEnabled = useCallback(

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
@@ -79,7 +79,9 @@ export const useNotificationPreferences =
         setPersistError(null);
 
         try {
-          await updatePreferencesSection('socialAI', updater);
+          await updatePreferencesSection('socialAI', (prev) =>
+            updater(prev ?? getDefaultSocialAIPreferences()),
+          );
         } catch (err) {
           Logger.error(
             err as Error,

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useNotificationPreferences.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { SocialAIPreference } from '@metamask/authenticated-user-storage';
 import Logger from '../../../../../util/Logger';
 import { DEFAULT_SOCIAL_AI_PREFERENCES } from '@metamask/notification-services-controller';
@@ -41,41 +41,13 @@ const toErrorMessage = (err: unknown): string => {
 };
 
 /**
- * True once the remote query reflects the optimistic overlay — the signal to
- * drop the overlay. Muted IDs are compared as sets (order-independent and
- * duplicate-safe).
- */
-const hasRemoteCaughtUp = (
-  overlay: SocialAIPreference,
-  remote: SocialAIPreference,
-): boolean => {
-  if (overlay === remote) return true;
-  if (
-    overlay.pushNotificationsEnabled !== remote.pushNotificationsEnabled ||
-    overlay.inAppNotificationsEnabled !== remote.inAppNotificationsEnabled
-  ) {
-    return false;
-  }
-  if (overlay.txAmountLimit !== remote.txAmountLimit) return false;
-  const overlaySet = new Set(overlay.mutedTraderProfileIds);
-  const remoteSet = new Set(remote.mutedTraderProfileIds);
-  if (overlaySet.size !== remoteSet.size) return false;
-  for (const id of overlaySet) {
-    if (!remoteSet.has(id)) return false;
-  }
-  return true;
-};
-
-/**
  * Notification preferences for the Top Traders feature, backed by
  * the shared notification preferences stored in
  * `AuthenticatedUserStorageService`.
  *
- * The UI renders `overlay ?? remote`: an optimistic overlay flips the toggles
- * instantly on tap, while a read-merge-write PUT runs in the background and
- * the overlay is dropped once the shared preferences query reflects the new
- * value. Failed PUTs roll the overlay back — unless a newer mutation already
- * owns it (tracked via `generationRef`).
+ * Optimistic updates and write serialization are centralized in
+ * `useNotificationStoragePreferences`. This hook only derives the socialAI
+ * slice and exposes Social Leaderboard specific mutators/selectors.
  */
 export const useNotificationPreferences =
   (): UseNotificationPreferencesResult => {
@@ -85,55 +57,43 @@ export const useNotificationPreferences =
       isLoading,
       error: queryError,
       updatePreferencesSection,
+      updateSectionChannel,
     } = useNotificationStoragePreferences();
 
-    const [overlay, setOverlay] = useState<SocialAIPreference | undefined>(
-      undefined,
-    );
-    // Number of in-flight PUTs. The overlay is only allowed to drop once this
-    // is 0, so a refetch landing mid-flight cannot snap the UI back to the
-    // pre-PUT value via the react-query cache. Bumped synchronously in
-    // applyChange (before await) and decremented when the PUT settles.
-    const [pendingWrites, setPendingWrites] = useState(0);
     const [persistError, setPersistError] = useState<string | null>(null);
 
-    const remoteSocialAI: SocialAIPreference =
+    const socialAI: SocialAIPreference =
       storagePreferences?.socialAI ?? DEFAULT_SOCIAL_AI;
-    const socialAI: SocialAIPreference = overlay ?? remoteSocialAI;
-
-    // Refs mirrored during render so async code never reads stale closures.
-    // Safe because each write is idempotent for the same render input.
-
-    // Serializes writes: rapid taps chain instead of interleaving GETs/PUTs.
-    const writeChainRef = useRef<Promise<unknown>>(Promise.resolve());
-
-    // Latest *intended* socialAI — updated synchronously in `applyChange`
-    // so rapid successive calls chain off each other's output.
-    const currentSocialAIRef = useRef<SocialAIPreference>(socialAI);
-    currentSocialAIRef.current = socialAI;
-
-    // Latest remote value for the rollback path.
-    const remoteRef = useRef<SocialAIPreference>(remoteSocialAI);
-    remoteRef.current = remoteSocialAI;
-
-    // Each mutation captures its generation; only rolls back if still current.
-    const generationRef = useRef(0);
-
-    const enqueuePersist = useCallback(
-      (nextSocialAI: SocialAIPreference) => {
-        const next = writeChainRef.current.then(async () => {
-          await updatePreferencesSection('socialAI', nextSocialAI);
-        });
-        // Swallow the chain's error so one failure doesn't jam subsequent
-        // writes. The returned promise still rejects for the caller.
-        writeChainRef.current = next.catch(() => undefined);
-        return next;
-      },
-      [updatePreferencesSection],
-    );
 
     const applyChange = useCallback(
       async (updater: (prev: SocialAIPreference) => SocialAIPreference) => {
+        if (!hasNotificationPreferences || !storagePreferences) {
+          const err = new Error(
+            'No notification preferences found when updating social AI preferences, enable notifications first',
+          );
+          Logger.error(err, 'useNotificationPreferences: persist skipped');
+          setPersistError(toErrorMessage(err));
+          return;
+        }
+
+        const nextSocialAI = updater(storagePreferences.socialAI);
+        setPersistError(null);
+
+        try {
+          await updatePreferencesSection('socialAI', nextSocialAI);
+        } catch (err) {
+          Logger.error(
+            err as Error,
+            'useNotificationPreferences: persist failed',
+          );
+          setPersistError(toErrorMessage(err));
+        }
+      },
+      [hasNotificationPreferences, storagePreferences, updatePreferencesSection],
+    );
+
+    const setPushNotificationsEnabled = useCallback(
+      async (value: boolean) => {
         if (!hasNotificationPreferences) {
           const err = new Error(
             'No notification preferences found when updating social AI preferences, enable notifications first',
@@ -143,53 +103,22 @@ export const useNotificationPreferences =
           return;
         }
 
-        generationRef.current += 1;
-        const myGeneration = generationRef.current;
-
-        const nextSocialAI = updater(currentSocialAIRef.current);
-        currentSocialAIRef.current = nextSocialAI;
-        setOverlay(nextSocialAI);
-        setPendingWrites((count) => count + 1);
         setPersistError(null);
-
         try {
-          await enqueuePersist(nextSocialAI);
+          await updateSectionChannel(
+            'socialAI',
+            'pushNotificationsEnabled',
+            value,
+          );
         } catch (err) {
           Logger.error(
             err as Error,
             'useNotificationPreferences: persist failed',
           );
-          // Skip rollback if a newer mutation now owns the overlay.
-          if (generationRef.current === myGeneration) {
-            currentSocialAIRef.current = remoteRef.current;
-            setOverlay(undefined);
-            setPersistError(toErrorMessage(err));
-          }
-          return;
-        } finally {
-          setPendingWrites((count) => Math.max(0, count - 1));
+          setPersistError(toErrorMessage(err));
         }
       },
-      [enqueuePersist, hasNotificationPreferences],
-    );
-
-    useEffect(() => {
-      if (
-        overlay &&
-        pendingWrites === 0 &&
-        hasRemoteCaughtUp(overlay, remoteSocialAI)
-      ) {
-        setOverlay(undefined);
-      }
-    }, [overlay, pendingWrites, remoteSocialAI]);
-
-    const setPushNotificationsEnabled = useCallback(
-      (value: boolean) =>
-        applyChange((prev) => ({
-          ...prev,
-          pushNotificationsEnabled: value,
-        })),
-      [applyChange],
+      [hasNotificationPreferences, updateSectionChannel],
     );
 
     const setTxAmountLimit = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR improves notification toggles, making them reliable and showing a faster UI response. This is done by using useNotificationStoragePreferences as single source of truth with serialized writes, optimistic cache updates, rollback safety, and refetch protection.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/GE-255

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

- Make sure notification settings toggle behave correctly, especially when triggering them quickly on/off
- Toggle on/off some toggles in a notification section like Wallet activity, then go back to the previous screen. The `In App, Push` text should be aligned with what you toggled

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A

### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/2b344d85-930b-4852-aaf7-79caac5b6ae8



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how notification preferences are persisted and cached across settings and Social Leaderboard; incorrect rollback or write ordering could desync UI from server state, though behavior is heavily covered by new tests.
> 
> **Overview**
> Notification settings toggles now update **optimistically** and **serialize writes** so rapid taps don’t race or snap back. **`useNotificationStoragePreferences`** is the shared persistence layer: it optimistically updates the React Query cache, chains PUTs, rolls back on failure, and exposes **`updateSectionChannel`** plus **`isUpdatingPreferences`** instead of read-merge-write GET-before-PUT.
> 
> **Main** and **per-account** switches use explicit **`onValueChange`** values, show pending state on the switch (no per-row loading spinners), and **disable all account switches** while any account update is in flight. **`useOptimisticToggleValue`** powers the main notifications toggle (disabled while a write is pending). Section **push/in-app** toggles keep switches enabled during saves but show optimistic values via local pending state.
> 
> **Social Leaderboard** `useNotificationPreferences` drops its own overlay/write queue and delegates to the shared storage hook. **`SwitchLoadingModal`** is removed from the notifications settings screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db9f38c406cb7c198b863458f6a5b3c2546364de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->