### PR TITLE
feat: show transak data in money activity list

### DIFF
--- a/app/components/UI/Money/constants/mockActivityData.ts
+++ b/app/components/UI/Money/constants/mockActivityData.ts
@@ -1,4 +1,5 @@
 import {
+  CHAIN_IDS,
   type TransactionMeta,
   type TransactionParams,
   TransactionStatus,
@@ -35,9 +36,13 @@ export type MoneyActivityTransactionMeta = TransactionMeta & {
   moneyActivityTitleKey?: MoneyActivityTitleKey;
 };
 
-export const MOCK_CHAIN_ID = '0x1' as Hex;
+// The Money Account lives on Monad — mock rows MUST be on this chain so the
+// mUSD display path (`isMusdOnMoneyAccountChain`) resolves their amounts.
+// Using mainnet here is what previously left every transferInformation-backed
+// mock row blank.
+export const MOCK_CHAIN_ID = CHAIN_IDS.MONAD as Hex;
 
-export const MOCK_NETWORK_CLIENT_ID = 'mainnet';
+export const MOCK_NETWORK_CLIENT_ID = 'monad';
 
 const defaultTxParams = {
   from: '0x0000000000000000000000000000000000000001',
@@ -84,7 +89,68 @@ function makeMoneyTx(config: {
   };
 }
 
+/** USD value → mUSD minimal units (6dp) as Hex, matching `requiredAssets[0].amount`. */
+const usdToRequiredAssetHex = (usd: number): Hex =>
+  `0x${Math.round(usd * 1e6).toString(16)}` as Hex;
+
+/**
+ * Builds a {@link TransactionType.moneyAccountDeposit} that mirrors a REAL MM Pay
+ * deposit: NO `transferInformation` (that field is only populated by incoming
+ * polling), with the USD-denominated (6dp) deposit target carried on
+ * `requiredAssets[0].amount` and an optional `metamaskPay.targetFiat`. Use this
+ * to reproduce the blank "Deposited" rows that appear when the pay-token
+ * symbol/price can't be resolved.
+ */
+function makeMoneyDepositTx(config: {
+  id: string;
+  timestampSec: number;
+  usdValue: number;
+  status?: TransactionStatus;
+  targetFiat?: string;
+}): MoneyActivityTransactionMeta {
+  const {
+    id,
+    timestampSec,
+    usdValue,
+    status = TransactionStatus.confirmed,
+    targetFiat,
+  } = config;
+
+  return {
+    id,
+    chainId: MOCK_CHAIN_ID,
+    networkClientId: MOCK_NETWORK_CLIENT_ID,
+    status,
+    time: timestampSec * 1000,
+    txParams: defaultTxParams,
+    type: TransactionType.moneyAccountDeposit,
+    requiredAssets: [
+      {
+        address: MUSD_TOKEN_ADDRESS,
+        amount: usdToRequiredAssetHex(usdValue),
+        standard: 'erc20',
+      },
+    ],
+    ...(targetFiat !== undefined ? { metamaskPay: { targetFiat } } : {}),
+  };
+}
+
 const MOCK_MONEY_TRANSACTIONS: MoneyActivityTransactionMeta[] = [
+  // Realistic MM Pay deposit: no `transferInformation`, value only on
+  // `requiredAssets`, pay-token symbol/price unavailable. Renders blank before
+  // the requiredAssets fallback in useMoneyTransactionDisplayInfo.
+  makeMoneyDepositTx({
+    id: 'money-tx-deposit-no-transfer-info',
+    timestampSec: 1747095600,
+    usdValue: 42.5,
+  }),
+  // Failed deposit with no resolved amount — renders with no value (expected).
+  makeMoneyDepositTx({
+    id: 'money-tx-deposit-failed',
+    timestampSec: 1747095000,
+    usdValue: 0,
+    status: TransactionStatus.failed,
+  }),
   makeMoneyTx({
     id: 'money-tx-1',
     timestampSec: 1747094400,

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -475,15 +475,16 @@ describe('useMoneyTransactionDisplayInfo — ERC-20 (stablecoin) primary amount'
     expect(result.current.primaryAmount).toBe('+1.25 USDC');
   });
 
-  it('leaves primaryAmount empty when stablecoin market data is unavailable', () => {
-    // No peg fallback: without market data we cannot price USDC, so we show
-    // nothing rather than a misleading "+1.00 USDC". The fiat line still renders.
+  it('falls back to the mUSD deposit amount when stablecoin market data is unavailable', () => {
+    // Without market data we cannot price the pay token (USDC), so we never show
+    // a misleading "+1.00 USDC". Instead we fall back to the mUSD deposit value
+    // carried on requiredAssets ($1.00) rather than leaving the row blank.
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(makeUsdcDepositTx(), undefined),
       { state: makeUsdcState({}) },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
   });
 });
 
@@ -578,38 +579,38 @@ describe('useMoneyTransactionDisplayInfo — non-stable ERC-20 primary amount', 
     expect(result.current.primaryAmount).toBe('+0.02 LINK');
   });
 
-  it('leaves primaryAmount empty (not +0.00) when market data is unavailable', () => {
-    // No market data and no ETH rate → we cannot price LINK, so we must show
-    // nothing rather than a misleading "+0.00 LINK". Fiat still renders from
-    // its own pipeline.
+  it('falls back to the mUSD deposit amount (not +0.00 LINK) when market data is unavailable', () => {
+    // No market data and no ETH rate → we cannot price LINK, so we never show a
+    // misleading "+0.00 LINK". We fall back to the mUSD deposit value ($0.50)
+    // rather than leaving the row blank.
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
       { state: makeLinkState({}) },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.primaryAmount).toBe('+0.50 mUSD');
   });
 
-  it('leaves primaryAmount empty when token→ETH price exists but ETH→USD rate is missing', () => {
+  it('falls back to the mUSD deposit amount when token→ETH price exists but ETH→USD rate is missing', () => {
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
       { state: makeLinkState({ tokenToEthPrice: 0.01 }) },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.primaryAmount).toBe('+0.50 mUSD');
   });
 
-  it('leaves primaryAmount empty (not +0) when the token amount underflows 6 decimals', () => {
+  it('falls back to the mUSD deposit amount (not +0 LINK) when the pay-token amount underflows 6 decimals', () => {
     // High-unit-value token: token→ETH 400 × ETH→USD 2500 = $1,000,000 per token.
-    // $0.50 / $1,000,000 = 0.0000005, which rounds down to "0.000000" at 6
-    // decimals. We must show nothing rather than a misleading "+0 LINK" — this
-    // is the same class of bug MUSD-857 fixed, just one decimal place over.
+    // $0.50 / $1,000,000 = 0.0000005, which would round down to "+0 LINK" — a
+    // misleading zero (the MUSD-857 class of bug). Instead of the underflowing
+    // pay-token amount we show the mUSD deposit value ($0.50).
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
       { state: makeLinkState({ tokenToEthPrice: 400, ethUsdRate: 2500 }) },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.primaryAmount).toBe('+0.50 mUSD');
   });
 });
 
@@ -671,7 +672,7 @@ describe('useMoneyTransactionDisplayInfo — native token (ETH) primary amount',
     expect(result.current.primaryAmount).toBe('+0.000445 ETH');
   });
 
-  it('leaves primaryAmount empty when exchange rate is unavailable', () => {
+  it('falls back to the mUSD deposit amount when exchange rate is unavailable', () => {
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: ETH_ADDRESS, chainId: CHAIN_ID },
       requiredAssets: [{ address: ETH_ADDRESS, amount: '998537' }],
@@ -682,7 +683,9 @@ describe('useMoneyTransactionDisplayInfo — native token (ETH) primary amount',
       { state: makeState({ currencyRates: {} }) },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    // Pay token (ETH) can't be priced → fall back to the mUSD deposit value
+    // ($0.998537 → 1.00 at 2dp) rather than leaving the row blank.
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
   });
 });
 
@@ -708,13 +711,53 @@ describe('useMoneyTransactionDisplayInfo — fiat amount fallback', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Deposit with no pay-token metadata at all (the blank-row bug)
+// ---------------------------------------------------------------------------
+
+describe('useMoneyTransactionDisplayInfo — deposit without pay-token metadata', () => {
+  it('shows the mUSD amount and fiat from requiredAssets when there is no metamaskPay', () => {
+    // Mirrors a real moneyAccountDeposit that never got pay-token enrichment:
+    // no transferInformation, no metamaskPay, value only on requiredAssets.
+    // Previously rendered fully blank.
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      requiredAssets: [{ address: MUSD_TOKEN_ADDRESS, amount: '42500000' }],
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState({ currentCurrency: 'usd' }) },
+    );
+
+    expect(result.current.primaryAmount).toBe('+42.50 mUSD');
+    expect(result.current.fiatAmount).toBeTruthy();
+    expect(result.current.fiatAmount.startsWith('+')).toBe(true);
+  });
+
+  it('leaves the row value-less when the deposit has a zero requiredAssets amount', () => {
+    // e.g. a deposit that failed before any amount was encoded.
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      requiredAssets: [{ address: MUSD_TOKEN_ADDRESS, amount: '0x0' }],
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState({ currentCurrency: 'usd' }) },
+    );
+
+    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.fiatAmount).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Token resolution — catch branch and no-token fallback
 // ---------------------------------------------------------------------------
 
 describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () => {
-  it('leaves primaryAmount empty when token is not in state and address is not native', () => {
-    // USDC address but NOT present in TokensController state → not native, not erc-20
-    // → sourceTokenSymbol is undefined → primaryAmount stays empty
+  it('falls back to the mUSD deposit amount when the pay token is not in state and not native', () => {
+    // USDC address but NOT present in TokensController state → not native, not
+    // erc-20 → sourceTokenSymbol is undefined, so the pay-token amount can't be
+    // resolved. We fall back to the mUSD deposit value ($1.00).
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
       requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000' }],
@@ -726,10 +769,10 @@ describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () =>
       { state: makeState() },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
   });
 
-  it('leaves primaryAmount empty when getNativeTokenAddress throws for unknown chainId', () => {
+  it('falls back to the mUSD deposit amount when getNativeTokenAddress throws for unknown chainId', () => {
     // Use a chainId our mock does not support → isNativeTokenAddress catch → returns false.
     // We also include the chain in networkConfigurationsByChainId so that
     // selectTickerByChainId does not error if the reselect stability check
@@ -761,7 +804,7 @@ describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () =>
       { state: stateWithPolygon },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
   });
 });
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -30,7 +30,7 @@ import {
   type TokenMarketDataMap,
 } from '../utils/moneyActivityFiat';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
-import { isMusdToken } from '../../Earn/constants/musd';
+import { isMusdToken, MUSD_TOKEN } from '../../Earn/constants/musd';
 import { ETH_TICKER } from '../constants/moneyTokens';
 import type {
   MoneyActivityTitleKey,
@@ -397,6 +397,25 @@ export function useMoneyTransactionDisplayInfo(
       }
     }
 
+    // Final fallback: a money-account deposit always lands as mUSD in the vault,
+    // and `requiredAssets[0].amount` is the USD-denominated (6dp) deposit
+    // target. When neither the mUSD transfer meta nor a pay-token amount could
+    // be resolved (e.g. the pay token is missing from the registry or has no
+    // price), show the mUSD amount rather than leaving the row blank.
+    if (!primaryAmount) {
+      const requiredAsset = getRequiredAsset(tx);
+      if (requiredAsset) {
+        const musdAmount = new BigNumber(requiredAsset.amount).dividedBy(1e6);
+        if (musdAmount.isGreaterThan(0)) {
+          primaryAmount = formatPrimaryTokenAmount(
+            musdAmount,
+            MUSD_TOKEN.symbol,
+            true,
+          );
+        }
+      }
+    }
+
     // --- Fiat amount ---
     // Prefer calculated market-rate value.
     let fiatAmount = buildMoneyActivityFiatLine(
@@ -409,6 +428,16 @@ export function useMoneyTransactionDisplayInfo(
       const rawFiat = Number(tx.metamaskPay?.targetFiat);
       if (!isNaN(rawFiat) && rawFiat > 0) {
         fiatAmount = `+${moneyFormatFiat(new BigNumber(rawFiat), currentCurrency)}`;
+      } else {
+        // Fall back to the mUSD deposit target (USD-denominated, 6dp) when no
+        // explicit fiat figure is present, so the row isn't left value-less.
+        const requiredAsset = getRequiredAsset(tx);
+        if (requiredAsset) {
+          const usdValue = new BigNumber(requiredAsset.amount).dividedBy(1e6);
+          if (usdValue.isGreaterThan(0)) {
+            fiatAmount = `+${moneyFormatFiat(usdValue, currentCurrency)}`;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
