### PR TITLE
fix: update snaps test, add page objects for resusability and flakiness

### DIFF
--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -95,6 +95,18 @@ class TestSnaps {
     return Matchers.getIdentifier('snap-ui-renderer__scrollview');
   }
 
+  get dialogInput(): DetoxElement {
+    return Matchers.getElementByID('example-input-snap-ui-input');
+  }
+
+  get cancelButton(): DetoxElement {
+    return Matchers.getElementByText('Cancel');
+  }
+
+  get submitButton(): DetoxElement {
+    return Matchers.getElementByText('Submit');
+  }
+
   async checkResultSpan(
     selector: keyof typeof TestSnapResultSelectorWebIDS,
     expectedMessage: string,
@@ -252,9 +264,20 @@ class TestSnaps {
     });
   }
 
+  async openSnapDialog(
+    buttonKey: keyof typeof TestSnapViewSelectorWebIDS,
+  ): Promise<void> {
+    await this.tapButton(buttonKey);
+    await Assertions.expectElementToBeVisible(this.dialogInput, {
+      timeout: 10_000,
+      description: 'snap dialog fully rendered',
+    });
+  }
+
   async tapOkButton() {
-    const button = Matchers.getElementByText('OK');
-    await Gestures.waitAndTap(button);
+    await Gestures.waitAndTap(this.dateTimePickerOkButton, {
+      elemDescription: 'OK button',
+    });
   }
 
   async tapApproveButton() {
@@ -268,8 +291,10 @@ class TestSnaps {
   }
 
   async tapCancelButton() {
-    const button = Matchers.getElementByText('Cancel');
-    await Gestures.waitAndTap(button);
+    await Gestures.waitAndTap(this.cancelButton, {
+      checkStability: true,
+      elemDescription: 'Cancel button',
+    });
   }
 
   async tapFooterButton() {
@@ -277,8 +302,10 @@ class TestSnaps {
   }
 
   async tapSubmitButton() {
-    const button = Matchers.getElementByText('Submit');
-    await Gestures.waitAndTap(button);
+    await Gestures.waitAndTap(this.submitButton, {
+      checkStability: true,
+      elemDescription: 'Submit button',
+    });
   }
 
   async dismissAlert() {
@@ -329,6 +356,9 @@ class TestSnaps {
     const input = Matchers.getElementByID(`${name}-snap-ui-input`);
 
     await Gestures.typeText(input, text, { hideKeyboard: true });
+    if (device.getPlatform() === 'android') {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    }
   }
 
   async selectInNativeDropdown(
@@ -339,23 +369,31 @@ class TestSnaps {
       NativeDropdownSelectorWebIDS[selector],
     );
 
-    await Gestures.tap(dropdown);
+    await Gestures.tap(dropdown, {
+      elemDescription: `open dropdown ${selector}`,
+    });
 
     const selectorItem = element(
       by.text(text).withAncestor(by.id('snap-ui-renderer__selector-item')),
     ) as unknown as DetoxElement;
-    await Gestures.tap(selectorItem);
+    await Gestures.tap(selectorItem, {
+      elemDescription: `select "${text}" in dropdown`,
+    });
   }
 
   async selectRadioButton(text: string) {
     const radioButton = element(
       by.text(text).withAncestor(by.id('snap-ui-renderer__radio-button')),
     ) as unknown as DetoxElement;
-    await Gestures.tap(radioButton);
+    await Gestures.tap(radioButton, {
+      elemDescription: `radio button "${text}"`,
+    });
   }
 
   async tapCheckbox() {
-    await Gestures.tap(this.checkboxElement);
+    await Gestures.tap(this.checkboxElement, {
+      elemDescription: 'snap UI checkbox',
+    });
   }
 
   async selectDateInDateTimePicker() {

--- a/tests/smoke/snaps/test-snap-interactive-ui.spec.ts
+++ b/tests/smoke/snaps/test-snap-interactive-ui.spec.ts
@@ -37,7 +37,8 @@ describe(SmokeSnaps('Interactive UI Snap Tests'), () => {
         disableSynchronization: true,
       },
       async () => {
-        await TestSnaps.tapButton('createDialogButton');
+        await TestSnaps.navigateToTestSnap();
+        await TestSnaps.openSnapDialog('createDialogButton');
 
         // Create the expected date when the pickers are mounted.
         // This is needed to compare later with the values submitted by the snap.
@@ -83,7 +84,8 @@ describe(SmokeSnaps('Interactive UI Snap Tests'), () => {
         disableSynchronization: true,
       },
       async () => {
-        await TestSnaps.tapButton('createDialogDisabledButton');
+        await TestSnaps.navigateToTestSnap();
+        await TestSnaps.openSnapDialog('createDialogDisabledButton');
 
         const input = Matchers.getElementByID('example-input-snap-ui-input');
         await Assertions.expectElementToBeVisible(input);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Detox page objects and smoke specs; no production app logic is modified.
> 
> **Overview**
> Hardens **interactive Snap UI** Detox smoke coverage by centralizing dialog flow in `TestSnaps` and tightening gestures so dialogs are fully loaded before interaction.
> 
> The page object gains **`dialogInput`**, **Cancel/Submit** getters, and **`openSnapDialog`**, which taps the web button then waits up to 10s for the example input. **`test-snap-interactive-ui.spec.ts`** now calls **`navigateToTestSnap()`** plus **`openSnapDialog(...)`** instead of only **`tapButton`**. Several taps use shared getters, **`checkStability`**, and **`elemDescription`**; **`fillInput`** adds a short Android delay after typing; dropdown/radio/checkbox taps get clearer gesture metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664bf9f81b9951b7bb219283c51e7fec06d32d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->