### PR TITLE
feat(quickbuy): resolve terminal toast for same-chain Solana swaps

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -1,3 +1,5 @@
+import { isNonEvmChainId } from '@metamask/bridge-controller';
+import type { Hex } from '@metamask/utils';
 import {
   useCallback,
   useContext,
@@ -6,94 +8,93 @@ import {
   useRef,
   useState,
 } from 'react';
+import { TextInput } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectCurrentCurrency } from '../../../../../../../selectors/currencyRateController';
 import {
+  ImpactMoment,
   playErrorNotification,
   playImpact,
-  ImpactMoment,
 } from '../../../../../../../util/haptics';
-import { TextInput } from 'react-native';
-import { useSelector, useDispatch } from 'react-redux';
+import { getIntlNumberFormatter } from '../../../../../../../util/intl';
+import {
+  dotAndCommaDecimalFormatter,
+  isNumberValue,
+} from '../../../../../../../util/number/bigint';
+import { useDisplayCurrencyValue } from '../../../../../../UI/Bridge/hooks/useDisplayCurrencyValue';
+import { useFormattedNetworkFee } from '../../../../../../UI/Bridge/hooks/useFormattedNetworkFee';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import {
+  formatCurrency,
+  formatMinimumReceived,
+} from '../../../../../../UI/Bridge/utils/currencyUtils';
+import { isGaslessQuote } from '../../../../../../UI/Bridge/utils/isGaslessQuote';
+import { selectDefaultSourceToken } from '../../../../utils/tokenSelection';
 import type {
   QuickBuyAmountDisplayMode,
   QuickBuyAnalyticsContext,
   QuickBuyTarget,
   QuickBuyTradeMode,
 } from '../types';
-import { useQuickBuyAnalytics } from './useQuickBuyAnalytics';
 import { formatExchangeRate } from '../utils/formatExchangeRate';
 import { getMetamaskFeePercent } from '../utils/getMetamaskFeePercent';
-import type { Hex } from '@metamask/utils';
-import type { BridgeToken } from '../../../../../../UI/Bridge/types';
-import { selectDefaultSourceToken } from '../../../../utils/tokenSelection';
-import { useQuickBuySetup } from './useQuickBuySetup';
 import { usePayWithTokens } from './usePayWithTokens';
-import { useReceiveTokens } from './useReceiveTokens';
 import { usePositionTokenBalance } from './usePositionTokenBalance';
+import { useQuickBuyAnalytics } from './useQuickBuyAnalytics';
 import {
   useQuickBuyQuotes,
   type EnrichedQuickBuyQuote,
 } from './useQuickBuyQuotes';
-import { getIntlNumberFormatter } from '../../../../../../../util/intl';
-import { useDisplayCurrencyValue } from '../../../../../../UI/Bridge/hooks/useDisplayCurrencyValue';
-import {
-  formatMinimumReceived,
-  formatCurrency,
-} from '../../../../../../UI/Bridge/utils/currencyUtils';
-import { useFormattedNetworkFee } from '../../../../../../UI/Bridge/hooks/useFormattedNetworkFee';
-import { isGaslessQuote } from '../../../../../../UI/Bridge/utils/isGaslessQuote';
-import { selectCurrentCurrency } from '../../../../../../../selectors/currencyRateController';
-import {
-  isNumberValue,
-  dotAndCommaDecimalFormatter,
-} from '../../../../../../../util/number/bigint';
-import { isNonEvmChainId } from '@metamask/bridge-controller';
+import { useQuickBuySetup } from './useQuickBuySetup';
+import { useReceiveTokens } from './useReceiveTokens';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { useGasFeeEstimates } from '../../../../../confirmations/hooks/gas/useGasFeeEstimates';
+import I18n, { strings } from '../../../../../../../../locales/i18n';
+import { ToastContext } from '../../../../../../../component-library/components/Toast';
+import Engine from '../../../../../../../core/Engine';
 import {
-  setSourceAmount,
-  setSourceToken,
-  setDestToken,
-  selectIsSubmittingTx,
+  selectBridgeFeatureFlags,
   selectDestAddress,
-  selectSlippage,
   selectIsEvmNonEvmBridge,
   selectIsNonEvmNonEvmBridge,
   selectIsSolanaSourced,
-  selectBridgeFeatureFlags,
+  selectIsSubmittingTx,
+  selectSlippage,
+  setDestToken,
   setIsSubmittingTx,
+  setSourceAmount,
+  setSourceToken,
 } from '../../../../../../../core/redux/slices/bridge';
-import { useLatestBalance } from '../../../../../../UI/Bridge/hooks/useLatestBalance';
-import useIsInsufficientBalance from '../../../../../../UI/Bridge/hooks/useInsufficientBalance';
-import { useHasSufficientGas } from '../../../../../../UI/Bridge/hooks/useHasSufficientGas';
-import { useIsNetworkFeeUnavailable } from '../../../../../../UI/Bridge/hooks/useIsNetworkFeeUnavailable';
-import { useInitialSlippage } from '../../../../../../UI/Bridge/hooks/useInitialSlippage';
-import { usePriceImpactViewData } from '../../../../../../UI/Bridge/hooks/usePriceImpactViewData';
-import {
-  parsePriceImpact,
-  exceedsPriceImpactErrorThreshold,
-} from '../../../../../../UI/Bridge/utils/getPriceImpactViewData';
-import { selectShouldUseSmartTransaction } from '../../../../../../../selectors/smartTransactionsController';
-import { useRefreshSmartTransactionsLiveness } from '../../../../../../hooks/useRefreshSmartTransactionsLiveness';
-import { useIsGasIncludedSTXSendBundleSupported } from '../../../../../../UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported';
-import { useRecipientInitialization } from '../../../../../../UI/Bridge/hooks/useRecipientInitialization';
-import { selectSourceWalletAddress } from '../../../../../../../selectors/bridge';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../../selectors/accountsController';
+import { selectSourceWalletAddress } from '../../../../../../../selectors/bridge';
+import { selectShouldUseSmartTransaction } from '../../../../../../../selectors/smartTransactionsController';
 import { isHardwareAccount } from '../../../../../../../util/address';
-import Engine from '../../../../../../../core/Engine';
-import I18n, { strings } from '../../../../../../../../locales/i18n';
-import { calcTokenValue } from '../../../../../../../util/transactions';
 import Logger from '../../../../../../../util/Logger';
 import { buildSocialLoggerErrorOptions } from '../../../../../../../util/social/socialServiceTelemetry';
 import { useTheme } from '../../../../../../../util/theme';
-import { ToastContext } from '../../../../../../../component-library/components/Toast';
+import { calcTokenValue } from '../../../../../../../util/transactions';
+import { useRefreshSmartTransactionsLiveness } from '../../../../../../hooks/useRefreshSmartTransactionsLiveness';
+import { toAssetId } from '../../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import { useHasSufficientGas } from '../../../../../../UI/Bridge/hooks/useHasSufficientGas';
+import { useInitialSlippage } from '../../../../../../UI/Bridge/hooks/useInitialSlippage';
+import useIsInsufficientBalance from '../../../../../../UI/Bridge/hooks/useInsufficientBalance';
+import { useIsGasIncludedSTXSendBundleSupported } from '../../../../../../UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported';
+import { useIsNetworkFeeUnavailable } from '../../../../../../UI/Bridge/hooks/useIsNetworkFeeUnavailable';
+import { useLatestBalance } from '../../../../../../UI/Bridge/hooks/useLatestBalance';
+import { usePriceImpactViewData } from '../../../../../../UI/Bridge/hooks/usePriceImpactViewData';
+import { useRecipientInitialization } from '../../../../../../UI/Bridge/hooks/useRecipientInitialization';
+import {
+  exceedsPriceImpactErrorThreshold,
+  parsePriceImpact,
+} from '../../../../../../UI/Bridge/utils/getPriceImpactViewData';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { useGasFeeEstimates } from '../../../../../confirmations/hooks/gas/useGasFeeEstimates';
 import {
   SocialLeaderboardEventProperties,
   SocialLeaderboardEventValues,
 } from '../../../../analytics';
-import { trackQuickBuyTrade } from '../quickBuyTradeTracker';
 import { buildQuickBuyToastOptions } from '../quickBuyToastOptions';
+import { trackQuickBuyTrade } from '../quickBuyTradeTracker';
 import { resolveQuickBuyTerminalToast } from '../resolveQuickBuyTerminalToast';
-import { toAssetId } from '../../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 
 export type QuickBuyButtonError =
   | 'insufficient_balance'
@@ -966,6 +967,13 @@ export function useQuickBuyController(
     }
     markTradeSubmitted();
     submitStartedAtRef.current = Date.now();
+    // Same-chain Solana swaps never reach a terminal `BridgeStatusController`
+    // status, so the terminal toast must resolve from
+    // `MultichainTransactionsController` instead. Cross-chain bridges (incl.
+    // Solana → EVM) still settle via the bridge status path, so they are
+    // excluded here.
+    const isNonEvmSwap =
+      Boolean(isSolanaSourced) && !isEvmNonEvmBridge && !isNonEvmNonEvmBridge;
     // Captures the copy data for every swap-lifecycle toast so the pending,
     // complete and failed states read consistently — and so the app-root
     // watcher can render the terminal toast after the sheet has unmounted.
@@ -976,6 +984,7 @@ export function useQuickBuyController(
         (tradeMode === 'buy' ? sourceToken?.symbol : destToken?.symbol) ?? '',
       fiatAmountLabel: formatCurrency(usdAmountNumber, currentCurrency),
       rate: formattedRate,
+      isNonEvmSwap,
     };
     // Close the sheet and surface the pending toast immediately — the swap can
     // take minutes to settle (cross-chain), so the user gets instant feedback
@@ -1007,7 +1016,12 @@ export function useQuickBuyController(
           : undefined;
       const txMetaId = (submitResult as { id?: string } | undefined)?.id;
       if (txMetaId) {
-        trackQuickBuyTrade(txMetaId, tradeToastInfo);
+        // For Solana the tx signature (`hash`) is the id used to find the tx in
+        // `MultichainTransactionsController`; persist it for the fallback path.
+        trackQuickBuyTrade(txMetaId, {
+          ...tradeToastInfo,
+          txSignature: txHash,
+        });
         // The swap may already have settled by the time submitTx resolves, in
         // which case the terminal stateChange events fired before this id was
         // tracked and the app-root handler ignored them. Reconcile against the
@@ -1070,6 +1084,9 @@ export function useQuickBuyController(
     onClose,
     toastRef,
     theme,
+    isSolanaSourced,
+    isEvmNonEvmBridge,
+    isNonEvmNonEvmBridge,
     sourceToken?.chainId,
     destToken?.chainId,
     usdAmountNumber,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.test.tsx
@@ -1,18 +1,19 @@
-import { renderHook } from '@testing-library/react-native';
 import { StatusTypes } from '@metamask/bridge-controller';
-import { useQuickBuyToastRegistrations } from './useQuickBuyToastRegistrations';
+import { TransactionStatus as KeyringTransactionStatus } from '@metamask/keyring-api';
+import { renderHook } from '@testing-library/react-native';
+import Engine from '../../../../../../../core/Engine';
+import {
+  playErrorNotification,
+  playSuccessNotification,
+} from '../../../../../../../util/haptics';
+import { buildQuickBuyToastOptions } from '../quickBuyToastOptions';
 import {
   getTrackedQuickBuyTradeIds,
   trackQuickBuyTrade,
   untrackQuickBuyTrade,
   type TrackedQuickBuyTrade,
 } from '../quickBuyTradeTracker';
-import { buildQuickBuyToastOptions } from '../quickBuyToastOptions';
-import Engine from '../../../../../../../core/Engine';
-import {
-  playSuccessNotification,
-  playErrorNotification,
-} from '../../../../../../../util/haptics';
+import { useQuickBuyToastRegistrations } from './useQuickBuyToastRegistrations';
 
 jest.mock('../quickBuyToastOptions', () => ({
   buildQuickBuyToastOptions: jest.fn((kind: string) => ({ kind })),
@@ -39,12 +40,29 @@ jest.mock('../../../../../../../core/Engine', () => ({
       BridgeStatusController: {
         getBridgeHistoryItemByTxMetaId: jest.fn(),
       },
+      MultichainTransactionsController: {
+        state: { nonEvmTransactions: {} },
+      },
     },
   },
 }));
 
 const mockGetHistoryItem = Engine.context.BridgeStatusController
   .getBridgeHistoryItemByTxMetaId as jest.Mock;
+
+const setMultichainTransaction = (
+  id: string,
+  status: KeyringTransactionStatus,
+) => {
+  Engine.context.MultichainTransactionsController.state.nonEvmTransactions = {
+    'account-1': {
+      'solana:mainnet': {
+        transactions: [{ id, status }],
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+};
 
 const historyItemWithStatus = (status: StatusTypes) => ({
   status: { status },
@@ -65,6 +83,15 @@ const sellTrade: TrackedQuickBuyTrade = {
   fiatAmountLabel: '$25.00',
 };
 
+const solanaTrade: TrackedQuickBuyTrade = {
+  tradeMode: 'buy',
+  tokenSymbol: 'BONK',
+  counterTokenSymbol: 'SOL',
+  fiatAmountLabel: '$30.00',
+  isNonEvmSwap: true,
+  txSignature: 'sig-1',
+};
+
 const renderHandler = () => {
   const { result } = renderHook(() => useQuickBuyToastRegistrations());
   return result.current[0];
@@ -74,12 +101,17 @@ describe('useQuickBuyToastRegistrations', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
+    Engine.context.MultichainTransactionsController.state.nonEvmTransactions =
+      {};
   });
 
-  it('subscribes to the BridgeStatusController state change event', () => {
-    const registration = renderHandler();
+  it('subscribes to both the bridge and multichain state change events', () => {
+    const { result } = renderHook(() => useQuickBuyToastRegistrations());
 
-    expect(registration.eventName).toBe('BridgeStatusController:stateChange');
+    expect(result.current.map((r) => r.eventName)).toEqual([
+      'BridgeStatusController:stateChange',
+      'MultichainTransactionsController:stateChange',
+    ]);
   });
 
   it('shows a complete toast and untracks the trade when the swap completes', () => {
@@ -157,5 +189,44 @@ describe('useQuickBuyToastRegistrations', () => {
     registration.handler({}, showToast);
 
     expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a Solana swap from the multichain controller when bridge status is not terminal', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    setMultichainTransaction('sig-1', KeyringTransactionStatus.Confirmed);
+    const showToast = jest.fn();
+
+    const { result } = renderHook(() => useQuickBuyToastRegistrations());
+    result.current[1].handler({}, showToast);
+
+    expect(showToast).toHaveBeenCalledWith({ kind: 'complete' });
+    expect(playSuccessNotification).toHaveBeenCalledTimes(1);
+    expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+  });
+
+  it('shows a failed toast for a Solana swap that fails on-chain', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    setMultichainTransaction('sig-1', KeyringTransactionStatus.Failed);
+    const showToast = jest.fn();
+
+    renderHandler().handler({}, showToast);
+
+    expect(showToast).toHaveBeenCalledWith({ kind: 'failed' });
+    expect(playErrorNotification).toHaveBeenCalledTimes(1);
+    expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+  });
+
+  it('keeps tracking a Solana swap that has not yet confirmed', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    setMultichainTransaction('sig-1', KeyringTransactionStatus.Submitted);
+    const showToast = jest.fn();
+
+    renderHandler().handler({}, showToast);
+
+    expect(showToast).not.toHaveBeenCalled();
+    expect(getTrackedQuickBuyTradeIds()).toEqual(['sig-1']);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import type { ToastRef } from '../../../../../../../component-library/components/Toast/Toast.types';
-import type { ToastRegistration } from '../../../../../../Nav/App/ControllerEventToastBridge';
 import { useAppThemeFromContext } from '../../../../../../../util/theme';
+import type { ToastRegistration } from '../../../../../../Nav/App/ControllerEventToastBridge';
 import { getTrackedQuickBuyTradeIds } from '../quickBuyTradeTracker';
 import { resolveQuickBuyTerminalToast } from '../resolveQuickBuyTerminalToast';
 
@@ -13,12 +13,16 @@ import { resolveQuickBuyTerminalToast } from '../resolveQuickBuyTerminalToast';
  * toast fires even after the user navigates away (important for slow
  * cross-chain swaps). The handler is scoped to QuickBuy-initiated trades via
  * `quickBuyTradeTracker` and reads the authoritative lifecycle status from
- * `BridgeStatusController`.
+ * `BridgeStatusController` — falling back to `MultichainTransactionsController`
+ * for same-chain Solana swaps, which never reach a terminal bridge status.
  */
 export const useQuickBuyToastRegistrations = (): ToastRegistration[] => {
   const theme = useAppThemeFromContext();
 
-  const handleBridgeStatusChange = useCallback(
+  // Shared by both controller subscriptions: `resolveQuickBuyTerminalToast`
+  // checks each tracked trade against whichever controller is authoritative for
+  // it, so we can fan out the same scan regardless of which event fired.
+  const handleControllerStateChange = useCallback(
     (_payload: unknown, showToast: ToastRef['showToast']): void => {
       const trackedIds = getTrackedQuickBuyTradeIds();
       if (trackedIds.length === 0) {
@@ -38,9 +42,13 @@ export const useQuickBuyToastRegistrations = (): ToastRegistration[] => {
     () => [
       {
         eventName: 'BridgeStatusController:stateChange',
-        handler: handleBridgeStatusChange,
+        handler: handleControllerStateChange,
+      },
+      {
+        eventName: 'MultichainTransactionsController:stateChange',
+        handler: handleControllerStateChange,
       },
     ],
-    [handleBridgeStatusChange],
+    [handleControllerStateChange],
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.test.ts
@@ -36,6 +36,24 @@ describe('quickBuyTradeTracker', () => {
     expect(getTrackedQuickBuyTrade('missing')).toBeUndefined();
   });
 
+  it('returns the same empty array reference when nothing is tracked', () => {
+    const first = getTrackedQuickBuyTradeIds();
+    const second = getTrackedQuickBuyTradeIds();
+
+    expect(first).toEqual([]);
+    expect(second).toBe(first);
+  });
+
+  it('returns a freshly allocated array once a trade is tracked', () => {
+    const empty = getTrackedQuickBuyTradeIds();
+    trackQuickBuyTrade('tx-1', buyTrade);
+
+    const populated = getTrackedQuickBuyTradeIds();
+
+    expect(populated).toEqual(['tx-1']);
+    expect(populated).not.toBe(empty);
+  });
+
   it('lists all tracked tx meta ids', () => {
     trackQuickBuyTrade('tx-1', buyTrade);
     trackQuickBuyTrade('tx-2', sellTrade);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
@@ -10,6 +10,20 @@ export interface TrackedQuickBuyTrade {
   fiatAmountLabel: string;
   /** Formatted exchange rate quote (e.g. "1 ETH = 4,381.22 USDC"). */
   rate?: string;
+  /**
+   * True only for same-chain non-EVM (Solana) swaps. `BridgeStatusController`
+   * never marks these terminal (no polling, no `TransactionController`
+   * confirmation), so their complete/failed toast must be resolved from
+   * `MultichainTransactionsController` instead. EVM swaps and cross-chain
+   * bridges (incl. Solana → EVM) leave this falsy and stay on the bridge path.
+   */
+  isNonEvmSwap?: boolean;
+  /**
+   * Solana transaction signature (`submitTx` result `hash`) used to find the
+   * tx in `MultichainTransactionsController`. Only set for `isNonEvmSwap`
+   * trades; lookups fall back to the tracker key when absent.
+   */
+  txSignature?: string;
 }
 
 /**

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
@@ -38,6 +38,9 @@ export interface TrackedQuickBuyTrade {
  */
 const trackedTrades = new Map<string, TrackedQuickBuyTrade>();
 
+/** Shared empty result so the common "nothing tracked" path allocates nothing. */
+const EMPTY_TRADE_IDS: string[] = [];
+
 export function trackQuickBuyTrade(
   txMetaId: string,
   info: TrackedQuickBuyTrade,
@@ -52,6 +55,12 @@ export function getTrackedQuickBuyTrade(
 }
 
 export function getTrackedQuickBuyTradeIds(): string[] {
+  // Hot path: both controller `stateChange` handlers call this on every
+  // emission. Skip the array allocation entirely when nothing is tracked
+  // (the common case — no QuickBuy swap in flight).
+  if (trackedTrades.size === 0) {
+    return EMPTY_TRADE_IDS;
+  }
   return Array.from(trackedTrades.keys());
 }
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.test.ts
@@ -1,17 +1,18 @@
 import { StatusTypes } from '@metamask/bridge-controller';
-import { resolveQuickBuyTerminalToast } from './resolveQuickBuyTerminalToast';
+import { TransactionStatus as KeyringTransactionStatus } from '@metamask/keyring-api';
+import Engine from '../../../../../../core/Engine';
+import {
+  playErrorNotification,
+  playSuccessNotification,
+} from '../../../../../../util/haptics';
+import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
 import {
   getTrackedQuickBuyTradeIds,
   trackQuickBuyTrade,
   untrackQuickBuyTrade,
   type TrackedQuickBuyTrade,
 } from './quickBuyTradeTracker';
-import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
-import Engine from '../../../../../../core/Engine';
-import {
-  playSuccessNotification,
-  playErrorNotification,
-} from '../../../../../../util/haptics';
+import { resolveQuickBuyTerminalToast } from './resolveQuickBuyTerminalToast';
 
 jest.mock('./quickBuyToastOptions', () => ({
   buildQuickBuyToastOptions: jest.fn((kind: string) => ({ kind })),
@@ -29,12 +30,29 @@ jest.mock('../../../../../../core/Engine', () => ({
       BridgeStatusController: {
         getBridgeHistoryItemByTxMetaId: jest.fn(),
       },
+      MultichainTransactionsController: {
+        state: { nonEvmTransactions: {} },
+      },
     },
   },
 }));
 
 const mockGetHistoryItem = Engine.context.BridgeStatusController
   .getBridgeHistoryItemByTxMetaId as jest.Mock;
+
+const setMultichainTransaction = (
+  id: string,
+  status: KeyringTransactionStatus,
+) => {
+  Engine.context.MultichainTransactionsController.state.nonEvmTransactions = {
+    'account-1': {
+      'solana:mainnet': {
+        transactions: [{ id, status }],
+      },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+};
 
 const theme = { colors: {} } as unknown as Parameters<
   typeof resolveQuickBuyTerminalToast
@@ -52,10 +70,21 @@ const buyTrade: TrackedQuickBuyTrade = {
   rate: '1 USDC = 1,000 PEPE',
 };
 
+const solanaTrade: TrackedQuickBuyTrade = {
+  tradeMode: 'buy',
+  tokenSymbol: 'BONK',
+  counterTokenSymbol: 'SOL',
+  fiatAmountLabel: '$30.00',
+  isNonEvmSwap: true,
+  txSignature: 'sig-1',
+};
+
 describe('resolveQuickBuyTerminalToast', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
+    Engine.context.MultichainTransactionsController.state.nonEvmTransactions =
+      {};
   });
 
   it('shows the complete toast, plays success haptic, and untracks on COMPLETE', () => {
@@ -129,5 +158,76 @@ describe('resolveQuickBuyTerminalToast', () => {
     expect(first).toBe(true);
     expect(second).toBe(false);
     expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a Solana swap to complete from the multichain controller when bridge status is absent', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    setMultichainTransaction('sig-1', KeyringTransactionStatus.Confirmed);
+    const showToast = jest.fn();
+
+    const result = resolveQuickBuyTerminalToast('sig-1', showToast, theme);
+
+    expect(result).toBe(true);
+    expect(buildQuickBuyToastOptions).toHaveBeenCalledWith('complete', {
+      trade: solanaTrade,
+      theme,
+    });
+    expect(playSuccessNotification).toHaveBeenCalledTimes(1);
+    expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+  });
+
+  it('resolves a Solana swap to failed from the multichain controller', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    setMultichainTransaction('sig-1', KeyringTransactionStatus.Failed);
+    const showToast = jest.fn();
+
+    const result = resolveQuickBuyTerminalToast('sig-1', showToast, theme);
+
+    expect(result).toBe(true);
+    expect(showToast).toHaveBeenCalledWith({ kind: 'failed' });
+    expect(playErrorNotification).toHaveBeenCalledTimes(1);
+    expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+  });
+
+  it('keeps tracking a Solana swap whose multichain tx is not yet terminal', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    setMultichainTransaction('sig-1', KeyringTransactionStatus.Submitted);
+    const showToast = jest.fn();
+
+    const result = resolveQuickBuyTerminalToast('sig-1', showToast, theme);
+
+    expect(result).toBe(false);
+    expect(showToast).not.toHaveBeenCalled();
+    expect(getTrackedQuickBuyTradeIds()).toEqual(['sig-1']);
+  });
+
+  it('keeps tracking a Solana swap with no matching multichain tx yet', () => {
+    trackQuickBuyTrade('sig-1', solanaTrade);
+    mockGetHistoryItem.mockReturnValue(undefined);
+    const showToast = jest.fn();
+
+    const result = resolveQuickBuyTerminalToast('sig-1', showToast, theme);
+
+    expect(result).toBe(false);
+    expect(showToast).not.toHaveBeenCalled();
+    expect(getTrackedQuickBuyTradeIds()).toEqual(['sig-1']);
+  });
+
+  it('does not read the multichain controller for a non-Solana trade', () => {
+    trackQuickBuyTrade('tx-1', buyTrade);
+    mockGetHistoryItem.mockReturnValue(
+      historyItemWithStatus(StatusTypes.PENDING),
+    );
+    setMultichainTransaction('tx-1', KeyringTransactionStatus.Confirmed);
+    const showToast = jest.fn();
+
+    const result = resolveQuickBuyTerminalToast('tx-1', showToast, theme);
+
+    expect(result).toBe(false);
+    expect(showToast).not.toHaveBeenCalled();
+    expect(getTrackedQuickBuyTradeIds()).toEqual(['tx-1']);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.ts
@@ -1,56 +1,86 @@
 import { StatusTypes } from '@metamask/bridge-controller';
+import { TransactionStatus as KeyringTransactionStatus } from '@metamask/keyring-api';
 import type { ToastRef } from '../../../../../../component-library/components/Toast/Toast.types';
-import type { Theme } from '../../../../../../util/theme/models';
 import Engine from '../../../../../../core/Engine';
 import {
-  playSuccessNotification,
   playErrorNotification,
+  playSuccessNotification,
 } from '../../../../../../util/haptics';
+import type { Theme } from '../../../../../../util/theme/models';
+import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
 import {
   getTrackedQuickBuyTrade,
   untrackQuickBuyTrade,
+  type TrackedQuickBuyTrade,
 } from './quickBuyTradeTracker';
-import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
+
+type TerminalOutcome = 'complete' | 'failed';
 
 /**
- * Reconciles a single tracked QuickBuy trade against the authoritative
- * `BridgeStatusController` history and, if the swap has reached a terminal
- * state, surfaces the matching `complete` / `failed` toast (plus haptic) and
- * stops tracking it.
- *
- * `untrackQuickBuyTrade` doubles as the dedupe/claim: the first caller to see a
- * terminal status removes the trade, so any later `stateChange` emission — or
- * the controller's immediate post-submit reconcile — becomes a no-op. This lets
- * both entry points (the app-root `stateChange` handler and the controller,
- * right after it learns the tx meta id) share one code path without
- * double-firing.
- *
- * @returns `true` when a terminal toast was shown, `false` otherwise (untracked,
- * still pending, or no history yet).
+ * Authoritative terminal status from `BridgeStatusController`. Covers EVM swaps
+ * (marked `COMPLETE` on `TransactionController:transactionConfirmed`) and all
+ * cross-chain bridges, incl. Solana → EVM (settled via Bridge API polling).
  */
-export function resolveQuickBuyTerminalToast(
+function resolveFromBridgeStatus(
   txMetaId: string,
-  showToast: ToastRef['showToast'],
-  theme: Theme,
-): boolean {
-  const trade = getTrackedQuickBuyTrade(txMetaId);
-  if (!trade) {
-    return false;
-  }
-
+): TerminalOutcome | undefined {
   const historyItem =
     Engine.context.BridgeStatusController.getBridgeHistoryItemByTxMetaId(
       txMetaId,
     );
   const status = historyItem?.status?.status;
-  if (status !== StatusTypes.COMPLETE && status !== StatusTypes.FAILED) {
-    return false;
-  }
+  if (status === StatusTypes.COMPLETE) return 'complete';
+  if (status === StatusTypes.FAILED) return 'failed';
+  return undefined;
+}
 
-  // Claim the trade atomically so a concurrent path doesn't re-fire the toast.
+/**
+ * Terminal status for same-chain non-EVM (Solana) swaps. `BridgeStatusController`
+ * never terminalizes these (no polling, and the Solana tx is not tracked by
+ * `TransactionController` so `transactionConfirmed` never fires), so we read the
+ * authoritative confirmation from `MultichainTransactionsController` instead —
+ * the same signal `useCardDelegation` waits on. The multichain tx `id` equals
+ * the Solana signature returned from `submitTx`.
+ */
+function resolveFromMultichain(signature: string): TerminalOutcome | undefined {
+  const { nonEvmTransactions } =
+    Engine.context.MultichainTransactionsController.state;
+  for (const accountTransactions of Object.values(nonEvmTransactions)) {
+    for (const chainEntry of Object.values(accountTransactions)) {
+      const transaction = chainEntry?.transactions?.find(
+        (tx) => tx.id === signature,
+      );
+      if (!transaction) continue;
+      if (transaction.status === KeyringTransactionStatus.Confirmed) {
+        return 'complete';
+      }
+      if (transaction.status === KeyringTransactionStatus.Failed) {
+        return 'failed';
+      }
+      // Found but not yet terminal (e.g. submitted) — keep waiting.
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Claims the trade atomically (untrack doubles as the dedupe), surfaces the
+ * matching `complete` / `failed` toast and fires the paired haptic. The first
+ * caller to reach a terminal status removes the trade, so any later
+ * `stateChange` emission — or a concurrent resolve from the other controller —
+ * becomes a no-op.
+ */
+function emitTerminalToast(
+  txMetaId: string,
+  trade: TrackedQuickBuyTrade,
+  outcome: TerminalOutcome,
+  showToast: ToastRef['showToast'],
+  theme: Theme,
+): boolean {
   untrackQuickBuyTrade(txMetaId);
 
-  const isComplete = status === StatusTypes.COMPLETE;
+  const isComplete = outcome === 'complete';
   showToast(
     buildQuickBuyToastOptions(isComplete ? 'complete' : 'failed', {
       trade,
@@ -66,4 +96,39 @@ export function resolveQuickBuyTerminalToast(
   }
 
   return true;
+}
+
+/**
+ * Reconciles a single tracked QuickBuy trade against the authoritative
+ * lifecycle status and, if the swap has reached a terminal state, surfaces the
+ * matching `complete` / `failed` toast (plus haptic) and stops tracking it.
+ *
+ * `BridgeStatusController` is the source of truth for EVM swaps and every
+ * cross-chain bridge. Same-chain Solana swaps never reach a terminal status
+ * there, so those (`trade.isNonEvmSwap`) fall back to
+ * `MultichainTransactionsController`. See `quickBuyTradeTracker` and the bridge
+ * team thread on the upstream gap.
+ *
+ * @returns `true` when a terminal toast was shown, `false` otherwise (untracked,
+ * still pending, or no history yet).
+ */
+export function resolveQuickBuyTerminalToast(
+  txMetaId: string,
+  showToast: ToastRef['showToast'],
+  theme: Theme,
+): boolean {
+  const trade = getTrackedQuickBuyTrade(txMetaId);
+  if (!trade) {
+    return false;
+  }
+
+  let outcome = resolveFromBridgeStatus(txMetaId);
+  if (!outcome && trade.isNonEvmSwap) {
+    outcome = resolveFromMultichain(trade.txSignature ?? txMetaId);
+  }
+  if (!outcome) {
+    return false;
+  }
+
+  return emitTerminalToast(txMetaId, trade, outcome, showToast, theme);
 }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -1,48 +1,48 @@
-import { renderHook, act } from '@testing-library/react-native';
-import { useSelector, useDispatch } from 'react-redux';
+import { ChainId } from '@metamask/bridge-controller';
+import { TextColor } from '@metamask/design-system-react-native';
 import type { Position } from '@metamask/social-controllers';
-import { useQuickBuyController } from './hooks/useQuickBuyController';
-import { positionToQuickBuyTarget } from './types';
+import { act, renderHook } from '@testing-library/react-native';
+import { useDispatch, useSelector } from 'react-redux';
+import Engine from '../../../../../../core/Engine';
+import {
+  selectBridgeFeatureFlags,
+  selectDestAddress,
+  selectIsEvmNonEvmBridge,
+  selectIsNonEvmNonEvmBridge,
+  selectIsSolanaSourced,
+  selectIsSubmittingTx,
+  selectSlippage,
+} from '../../../../../../core/redux/slices/bridge';
+import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
+import { selectSourceWalletAddress } from '../../../../../../selectors/bridge';
+import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
+import { selectShouldUseSmartTransaction } from '../../../../../../selectors/smartTransactionsController';
+import {
+  ImpactMoment,
+  playErrorNotification,
+  playImpact,
+} from '../../../../../../util/haptics';
+import Logger from '../../../../../../util/Logger';
+import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
+import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
+import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
+import { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
+import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import { selectDefaultSourceToken } from '../../../utils/tokenSelection';
-import { useQuickBuySetup } from './hooks/useQuickBuySetup';
 import { usePayWithTokens } from './hooks/usePayWithTokens';
-import { useReceiveTokens } from './hooks/useReceiveTokens';
 import { usePositionTokenBalance } from './hooks/usePositionTokenBalance';
+import { useQuickBuyController } from './hooks/useQuickBuyController';
 import {
   useQuickBuyQuotes,
   type EnrichedQuickBuyQuote,
   type UseQuickBuyQuotesResult,
 } from './hooks/useQuickBuyQuotes';
-import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
-import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
-import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
-import { selectShouldUseSmartTransaction } from '../../../../../../selectors/smartTransactionsController';
-import Engine from '../../../../../../core/Engine';
-import {
-  selectIsSubmittingTx,
-  selectDestAddress,
-  selectSlippage,
-  selectIsEvmNonEvmBridge,
-  selectIsNonEvmNonEvmBridge,
-  selectIsSolanaSourced,
-  selectBridgeFeatureFlags,
-} from '../../../../../../core/redux/slices/bridge';
-import { selectSourceWalletAddress } from '../../../../../../selectors/bridge';
-import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
-import { selectCurrentCurrency } from '../../../../../../selectors/currencyRateController';
-import { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
-import { TextColor } from '@metamask/design-system-react-native';
-import type { BridgeToken } from '../../../../../UI/Bridge/types';
-import { ChainId } from '@metamask/bridge-controller';
-import Logger from '../../../../../../util/Logger';
-import { trackQuickBuyTrade } from './quickBuyTradeTracker';
+import { useQuickBuySetup } from './hooks/useQuickBuySetup';
+import { useReceiveTokens } from './hooks/useReceiveTokens';
 import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
+import { trackQuickBuyTrade } from './quickBuyTradeTracker';
 import { resolveQuickBuyTerminalToast } from './resolveQuickBuyTerminalToast';
-import {
-  playImpact,
-  playErrorNotification,
-  ImpactMoment,
-} from '../../../../../../util/haptics';
+import { positionToQuickBuyTarget } from './types';
 
 jest.mock('../../../../../../util/Logger', () => ({
   __esModule: true,
@@ -2110,6 +2110,74 @@ describe('useQuickBuyController', () => {
           theme: expect.any(Object),
         });
         expect(mockShowToast).toHaveBeenCalledWith({ kind: 'pending' });
+      });
+
+      it('tracks an EVM swap with isNonEvmSwap false and the tx hash as the signature', async () => {
+        mockUsableQuote();
+        (
+          Engine.context.BridgeStatusController.submitTx as jest.Mock
+        ).mockResolvedValue({ id: 'tx-1', hash: '0xabc' });
+
+        const { result } = renderHook(() =>
+          useQuickBuyController(createTarget(), jest.fn()),
+        );
+
+        await act(async () => {
+          await result.current.handleConfirm();
+        });
+
+        expect(trackQuickBuyTrade).toHaveBeenCalledWith(
+          'tx-1',
+          expect.objectContaining({
+            isNonEvmSwap: false,
+            txSignature: '0xabc',
+          }),
+        );
+      });
+
+      it('tracks a same-chain Solana swap with isNonEvmSwap true and the signature', async () => {
+        mockUsableQuote();
+        (selectIsSolanaSourced as unknown as jest.Mock).mockReturnValue(true);
+        (
+          Engine.context.BridgeStatusController.submitTx as jest.Mock
+        ).mockResolvedValue({ id: 'sig-1', hash: 'sig-1' });
+
+        const { result } = renderHook(() =>
+          useQuickBuyController(createTarget(), jest.fn()),
+        );
+
+        await act(async () => {
+          await result.current.handleConfirm();
+        });
+
+        expect(trackQuickBuyTrade).toHaveBeenCalledWith(
+          'sig-1',
+          expect.objectContaining({ isNonEvmSwap: true, txSignature: 'sig-1' }),
+        );
+      });
+
+      it('tracks a cross-chain Solana bridge with isNonEvmSwap false', async () => {
+        mockUsableQuote();
+        (selectIsSolanaSourced as unknown as jest.Mock).mockReturnValue(true);
+        (selectIsNonEvmNonEvmBridge as unknown as jest.Mock).mockReturnValue(
+          true,
+        );
+        (
+          Engine.context.BridgeStatusController.submitTx as jest.Mock
+        ).mockResolvedValue({ id: 'sig-1', hash: 'sig-1' });
+
+        const { result } = renderHook(() =>
+          useQuickBuyController(createTarget(), jest.fn()),
+        );
+
+        await act(async () => {
+          await result.current.handleConfirm();
+        });
+
+        expect(trackQuickBuyTrade).toHaveBeenCalledWith(
+          'sig-1',
+          expect.objectContaining({ isNonEvmSwap: false }),
+        );
       });
 
       it('reconciles against the current bridge status right after tracking', async () => {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

QuickBuy surfaces a pending toast on submit and a `complete`/`failed` toast once the swap settles. The terminal toast was resolved exclusively from `BridgeStatusController`, which works for EVM swaps and every cross-chain bridge (incl. Solana → EVM). Same-chain Solana swaps, however, never reach a terminal status there — there is no Bridge API polling and the Solana tx is not tracked by `TransactionController`, so `transactionConfirmed` never fires. As a result the pending toast for these swaps never transitioned to `complete` or `failed`.

This PR adds a fallback resolution path for same-chain non-EVM (Solana) swaps that reads the authoritative confirmation from `MultichainTransactionsController` (the same signal `useCardDelegation` waits on):

- `useQuickBuyController` flags same-chain Solana swaps with `isNonEvmSwap` and persists the Solana tx signature (`submitTx` result `hash`) on the tracked trade, since the signature — not the tx meta id — is the lookup key in `MultichainTransactionsController`.
- `resolveQuickBuyTerminalToast` is refactored into focused helpers: `resolveFromBridgeStatus` (source of truth for EVM + cross-chain), `resolveFromMultichain` (Solana same-chain fallback), and a shared `emitTerminalToast`. The multichain fallback only runs for `isNonEvmSwap` trades.
- `useQuickBuyToastRegistrations` now subscribes to `MultichainTransactionsController:stateChange` in addition to `BridgeStatusController:stateChange`, fanning both events into the same scan so a Solana swap that settles after the sheet unmounts still gets its terminal toast.
- `getTrackedQuickBuyTradeIds` returns a shared empty-array reference on the common "nothing tracked" path to avoid an allocation on every controller emission.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed QuickBuy success/failed toast not appearing for same-chain Solana swaps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TSA-644

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: QuickBuy terminal toast for same-chain Solana swaps

  Background:
    Given I am logged into MetaMask Mobile
    And I have a Solana account funded with SOL

  Scenario: same-chain Solana swap shows a success toast on confirmation
    Given I open QuickBuy for a Solana-based token
    And I enter an amount and confirm the swap

    When the QuickBuy sheet closes and the pending toast appears
    And the Solana transaction is confirmed on-chain
    Then a "complete" toast is shown
    And a success haptic is played

  Scenario: same-chain Solana swap shows a failed toast when the tx fails
    Given I open QuickBuy for a Solana-based token
    And I enter an amount and confirm the swap

    When the Solana transaction fails on-chain
    Then a "failed" toast is shown
    And an error haptic is played

  Scenario: terminal toast still fires after navigating away
    Given I confirm a same-chain Solana QuickBuy swap
    And I navigate away from the QuickBuy sheet

    When the Solana transaction reaches a terminal status
    Then the terminal toast is still shown from the app root

  Scenario: existing EVM and cross-chain flows are unaffected
    Given I confirm an EVM swap or a cross-chain (Solana → EVM) bridge

    When the swap settles via BridgeStatusController
    Then the complete/failed toast resolves from the bridge status path as before
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No "Complete" toast after a Solana-to-Solana swap

### **After**

<img width="430" height="900" alt="image" src="https://github.com/user-attachments/assets/927a3a06-fc5f-478b-bd95-fdf737adae19" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap lifecycle UX for Solana QuickBuy by adding a second controller source of truth, but EVM and cross-chain paths are gated and covered by new tests.
> 
> **Overview**
> Fixes QuickBuy **complete/failed** toasts stuck on **pending** for **same-chain Solana** swaps, which never reach a terminal status in `BridgeStatusController`.
> 
> On confirm, `useQuickBuyController` now marks those trades with **`isNonEvmSwap`** (Solana-sourced, not cross-chain) and stores the Solana **`txSignature`** when tracking. **`resolveQuickBuyTerminalToast`** is split into bridge vs multichain resolution: EVM and cross-chain bridges still use bridge history; **`isNonEvmSwap`** trades fall back to **`MultichainTransactionsController`** by signature. The app-root toast hook also listens to **`MultichainTransactionsController:stateChange`** alongside bridge state changes. **`getTrackedQuickBuyTradeIds`** reuses a shared empty array when nothing is in flight to avoid allocations on every controller emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725a680580f305262235e887b03fe0d9e2a18a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->