### PR TITLE
feat: show verified USDC and USDT on all chains in QuickBuy sell receive list (TSA-645)

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/receiveStablecoinCandidates.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/receiveStablecoinCandidates.ts
@@ -1,0 +1,158 @@
+import type { Hex } from '@metamask/utils';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import { NETWORK_CHAIN_ID } from '../../../../../../../util/networks/customNetworks';
+
+/**
+ * Canonical USDC / USDT deployments per EVM chain for the Sell "Receive" picker.
+ *
+ * `DefaultSwapDestTokens` only carries a single stablecoin per chain (USDC *or*
+ * USDT, never both), which is why USDT was missing on Optimism (and USDC on
+ * Polygon, etc.). This table lets `useReceiveTokens` offer *both* major
+ * stablecoins on every supported chain.
+ *
+ * Addresses are the canonical Circle / Tether deployments and mirror the
+ * stablecoin source-of-truth in `useStablecoinsDefaultSlippage`. Chains where
+ * Tether has no canonical USDT (Base, Monad, HyperEVM) list USDC only.
+ *
+ * The set is curated against the token-alerts security API: only assets it
+ * returns as `Verified` are listed. Entries that came back non-`Verified` were
+ * dropped — Linea USDC/USDT and zkSync USDT (all `Benign`) — as was Sei USDC,
+ * which the API did not confirm as `Verified`.
+ */
+type StableSymbol = 'USDC' | 'USDT';
+
+const STABLE_NAMES: Record<StableSymbol, string> = {
+  USDC: 'USD Coin',
+  USDT: 'Tether USD',
+};
+
+// Token icons follow a predictable CDN path keyed by decimal chain id and
+// lower-cased address, so we derive them rather than hand-maintaining URLs.
+const tokenIconUrl = (chainId: Hex, address: string): string =>
+  `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/${parseInt(
+    chainId,
+    16,
+  )}/erc20/${address.toLowerCase()}.png`;
+
+const makeStable = (
+  chainId: Hex,
+  symbol: StableSymbol,
+  address: string,
+  decimals: number,
+): BridgeToken => ({
+  symbol,
+  name: STABLE_NAMES[symbol],
+  address,
+  decimals,
+  image: tokenIconUrl(chainId, address),
+  chainId,
+});
+
+export const RECEIVE_STABLECOIN_CANDIDATES: BridgeToken[] = [
+  // Ethereum
+  makeStable(
+    NETWORK_CHAIN_ID.MAINNET,
+    'USDC',
+    '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    6,
+  ),
+  makeStable(
+    NETWORK_CHAIN_ID.MAINNET,
+    'USDT',
+    '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    6,
+  ),
+  // Polygon
+  makeStable(
+    NETWORK_CHAIN_ID.POLYGON,
+    'USDC',
+    '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+    6,
+  ),
+  makeStable(
+    NETWORK_CHAIN_ID.POLYGON,
+    'USDT',
+    '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
+    6,
+  ),
+  // Arbitrum
+  makeStable(
+    NETWORK_CHAIN_ID.ARBITRUM,
+    'USDC',
+    '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    6,
+  ),
+  makeStable(
+    NETWORK_CHAIN_ID.ARBITRUM,
+    'USDT',
+    '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+    6,
+  ),
+  // Base (no canonical USDT)
+  makeStable(
+    NETWORK_CHAIN_ID.BASE,
+    'USDC',
+    '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    6,
+  ),
+  // Optimism
+  makeStable(
+    NETWORK_CHAIN_ID.OPTIMISM,
+    'USDC',
+    '0x0b2c639c533813f4aa9d7837caf62653d097ff85',
+    6,
+  ),
+  makeStable(
+    NETWORK_CHAIN_ID.OPTIMISM,
+    'USDT',
+    '0x94b008aa00579c1307b0ef2c499ad98a8ce58e58',
+    6,
+  ),
+  // BNB Smart Chain (stablecoins use 18 decimals here)
+  makeStable(
+    NETWORK_CHAIN_ID.BSC,
+    'USDC',
+    '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
+    18,
+  ),
+  makeStable(
+    NETWORK_CHAIN_ID.BSC,
+    'USDT',
+    '0x55d398326f99059ff775485246999027b3197955',
+    18,
+  ),
+  // Avalanche
+  makeStable(
+    NETWORK_CHAIN_ID.AVALANCHE,
+    'USDC',
+    '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+    6,
+  ),
+  makeStable(
+    NETWORK_CHAIN_ID.AVALANCHE,
+    'USDT',
+    '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7',
+    6,
+  ),
+  // zkSync Era (USDT omitted — token-alerts API returns it as Benign, not Verified)
+  makeStable(
+    NETWORK_CHAIN_ID.ZKSYNC_ERA,
+    'USDC',
+    '0x1d17cbcf0d6d143135ae902365d2e5e2a16538d4',
+    6,
+  ),
+  // Monad (no canonical USDT)
+  makeStable(
+    NETWORK_CHAIN_ID.MONAD,
+    'USDC',
+    '0x754704bc059f8c67012fed69bc8a327a5aafb603',
+    6,
+  ),
+  // HyperEVM (no canonical USDT)
+  makeStable(
+    NETWORK_CHAIN_ID.HYPE,
+    'USDC',
+    '0xb88339cb7199b77e23db6e890353e22632ba630f',
+    6,
+  ),
+];

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.test.ts
@@ -37,21 +37,8 @@ jest.mock(
         name: 'Wrapped Ether',
       },
     },
-    Bip44TokensForDefaultPairs: {
-      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': {
-        symbol: 'USDC',
-        address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        chainId: '0x1',
-        decimals: 6,
-        name: 'USD Coin',
-      },
-    },
   }),
 );
-
-jest.mock('../../../../../../../constants/bridge', () => ({
-  ETH_USDT_ADDRESS: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-}));
 
 jest.mock('./enrichTokenBalance', () => ({
   enrichTokenBalance: jest.fn(),
@@ -141,6 +128,25 @@ describe('useReceiveTokens', () => {
       expect.any(Object),
       { includeZeroBalance: true },
     );
+  });
+
+  it('offers both USDC and USDT on every chain with a canonical deployment (e.g. Optimism)', () => {
+    const { result } = renderHook(() => useReceiveTokens(undefined));
+
+    const optimismSymbols = result.current
+      .filter((t) => t.chainId === '0xa')
+      .map((t) => t.symbol);
+    expect(optimismSymbols).toContain('USDC');
+    expect(optimismSymbols).toContain('USDT');
+  });
+
+  it('does not list the same token identity twice when merging the curated set', () => {
+    const { result } = renderHook(() => useReceiveTokens(undefined));
+
+    const keys = result.current.map(
+      (t) => `${t.address.toLowerCase()}:${t.chainId}`,
+    );
+    expect(new Set(keys).size).toBe(keys.length);
   });
 
   it('drops candidates on networks the user has not enabled', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.ts
@@ -7,48 +7,39 @@ import { selectSelectedInternalAccountByScope } from '../../../../../../../selec
 import { selectTokensBalances } from '../../../../../../../selectors/tokenBalancesController';
 import { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
 import { selectCurrencyRates } from '../../../../../../../selectors/currencyRateController';
-import {
-  DefaultSwapDestTokens,
-  Bip44TokensForDefaultPairs,
-} from '../../../../../../UI/Bridge/constants/default-swap-dest-tokens';
-import { ETH_USDT_ADDRESS } from '../../../../../../../constants/bridge';
-import { NETWORK_CHAIN_ID } from '../../../../../../../util/networks/customNetworks';
+import { DefaultSwapDestTokens } from '../../../../../../UI/Bridge/constants/default-swap-dest-tokens';
 import { EVM_SCOPE } from '../../../../../../UI/Earn/constants/networks';
 import { getNativeSourceToken } from '../../../../../../UI/Bridge/utils/tokenUtils';
+import { getTokenKey } from '../tokenKey';
 import { enrichTokenBalance } from './enrichTokenBalance';
 import { isStablecoinSymbol } from './stablecoins';
+import { RECEIVE_STABLECOIN_CANDIDATES } from './receiveStablecoinCandidates';
 import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
 
 /**
- * Static EVM stablecoin candidates for the Sell "Receive" picker, extracted
- * from `DefaultSwapDestTokens` and filtered to mUSD, USDC, and USDT on EVM
- * chains.
+ * Static EVM stablecoin candidates for the Sell "Receive" picker.
+ *
+ * `DefaultSwapDestTokens` carries a single stablecoin per chain (which sets the
+ * per-chain default selection — e.g. mUSD on mainnet/Linea), so we keep those
+ * as the leading entries and then append the canonical USDC/USDT set from
+ * `RECEIVE_STABLECOIN_CANDIDATES`. The append guarantees both major stablecoins
+ * show on every supported chain (previously USDT was missing on Optimism,
+ * USDC on Polygon, etc.) without disturbing the existing default ordering.
+ * Duplicates are removed by stable token identity (`address:chainId`).
  */
-const STABLECOIN_CANDIDATES: BridgeToken[] = Object.values(
-  DefaultSwapDestTokens,
-)
-  .filter(
+const STABLECOIN_CANDIDATES: BridgeToken[] = (() => {
+  const primaries = Object.values(DefaultSwapDestTokens).filter(
     (token) =>
       isStablecoinSymbol(token.symbol) &&
       typeof token.chainId === 'string' &&
       token.chainId.startsWith('0x'),
-  )
-  // Add mainnet USDC from Bip44TokensForDefaultPairs (DefaultSwapDestTokens has mUSD for mainnet)
-  .concat(
-    Bip44TokensForDefaultPairs[
-      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-    ],
-  )
-  // Add mainnet USDT (not in DefaultSwapDestTokens)
-  .concat({
-    symbol: 'USDT',
-    name: 'Tether USD',
-    address: ETH_USDT_ADDRESS,
-    decimals: 6,
-    image:
-      'https://static.cx.metamask.io/api/v1/tokenIcons/1/0xdac17f958d2ee523a2206206994597c13d831ec7.png',
-    chainId: NETWORK_CHAIN_ID.MAINNET,
-  });
+  );
+  const seen = new Set(primaries.map(getTokenKey));
+  const extras = RECEIVE_STABLECOIN_CANDIDATES.filter(
+    (token) => !seen.has(getTokenKey(token)),
+  );
+  return [...primaries, ...extras];
+})();
 
 /**
  * Native token candidates for the Sell "Receive" picker, one per chain already


### PR DESCRIPTION
## **Description**

In QuickBuy **Sell** mode, the "Receive" token picker was seeded only from `DefaultSwapDestTokens`, which carries a single stablecoin per chain (e.g. USDC on Optimism, USDT on Polygon). As a result users could not choose to receive into the *other* major stablecoin on most chains — for example, USDT was missing on Optimism.

This PR adds a curated USDC/USDT-per-chain table (`receiveStablecoinCandidates.ts`) that is merged into the receive candidates in `useReceiveTokens`. The merge:

- Keeps the existing `DefaultSwapDestTokens` entries as the leading per-chain defaults (so the default selection per chain is unchanged, e.g. mUSD on mainnet/Linea).
- Appends the canonical USDC/USDT set, deduped by stable token identity (`address:chainId`).
- Is curated against the **token-alerts security API** (`/token/v1/scan-bulk`): only assets returned as `Verified` are listed. Entries that came back non-`Verified` were dropped — Linea USDC/USDT, zkSync USDT (all `Benign`), and Sei USDC (not confirmed `Verified`).

Addresses mirror the existing stablecoin source-of-truth in `useStablecoinsDefaultSlippage`, and icons are derived from the standard MetaMask token-icon CDN rather than hand-maintained URLs.

<img width="393" height="805" alt="image" src="https://github.com/user-attachments/assets/1413ee25-5d6e-40bc-8b00-ff5e19474e6e" />


Jira: [TSA-645](https://consensyssoftware.atlassian.net/browse/TSA-645)

## **Changelog**

CHANGELOG entry: Added USDC and USDT receive options on all supported networks in the QuickBuy sell flow.

## **Related issues**

Fixes: [TSA-645](https://consensyssoftware.atlassian.net/browse/TSA-645)

## **Manual testing steps**

```gherkin
Feature: QuickBuy sell receive token list

  Scenario: User can receive both USDC and USDT when selling on Optimism
    Given I open a trader position on Optimism
    And I switch QuickBuy to "Sell" mode
    When I open the "Receive" token picker
    And I filter to the Optimism network
    Then I see both USDC and USDT listed

  Scenario: Non-verified stablecoins are not offered
    Given I open the "Receive" token picker in Sell mode
    When I filter to Linea or zkSync Era
    Then I do not see the stablecoins the token-alerts API marks as non-Verified
    (Linea USDC/USDT, zkSync USDT)
```

## **Screenshots/Recordings**

N/A — this change only affects which stablecoins populate the existing Sell "Receive" list (data/list contents); no UI layout or component changes.

### **Before**

USDT missing on Optimism (and USDC missing on Polygon, etc.) in the Sell "Receive" picker.

### **After**

Both USDC and USDT shown on every supported chain that the security API marks `Verified`.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TSA-645]: https://consensyssoftware.atlassian.net/browse/TSA-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ERC-20 contracts users can select when receiving proceeds from a sell; risk is mitigated by verified-only curation and canonical addresses, but a wrong entry would affect swap/settlement routing.
> 
> **Overview**
> QuickBuy **Sell** “Receive” picker now merges existing per-chain defaults from `DefaultSwapDestTokens` with a new curated **`RECEIVE_STABLECOIN_CANDIDATES`** list so **both USDC and USDT** appear on chains where each is deployed (e.g. USDT on Optimism), without changing which token stays first per chain.
> 
> `useReceiveTokens` builds stablecoin candidates by keeping filtered `DefaultSwapDestTokens` entries, then appending extras from `receiveStablecoinCandidates.ts` deduped via `getTokenKey` (`address:chainId`). The old one-off mainnet USDC/USDT wiring (`Bip44TokensForDefaultPairs`, `ETH_USDT_ADDRESS`) is removed. The new table uses canonical contract addresses (aligned with slippage defaults), CDN-derived icons, and omits stables not marked **Verified** by token-alerts (e.g. Linea, zkSync USDT).
> 
> Tests assert Optimism lists both stables and that merged identities are not duplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 046d79420bbb44f6732ef45fd6fd873680b258cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->