### PR TITLE
fix: force batch sell to use control variant for balance layout

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
@@ -30,6 +30,10 @@ import { strings } from '../../../../../../locales/i18n';
 import { formatPriceWithSubscriptNotation } from '../../../Predict/utils/format';
 import { useTokenPricePercentageChange } from '../../../Tokens/hooks/useTokenPricePercentageChange';
 import { TokenSelectorItem } from '../../components/TokenSelectorItem';
+import {
+  TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  TokenSelectorBalanceLayoutVariant,
+} from '../../components/TokenSelectorItem.abTestConfig';
 import { BridgeToken } from '../../types';
 
 const styles = StyleSheet.create({
@@ -211,6 +215,11 @@ export function BatchSellTokenRow({
       shouldChangeSelectedStyle={false}
       shouldShowNetworkIcon={false}
       secondaryRowContent={secondaryRowContent}
+      balanceLayoutConfigOverride={
+        TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
+          TokenSelectorBalanceLayoutVariant.Control
+        ]
+      }
       tokenBalanceTextProps={{
         textVariant: ComponentLibraryTextVariant.BodySMMedium,
         textColor: ComponentLibraryTextColor.Alternative,

--- a/app/components/UI/Bridge/components/TokenSelectorItem.abTestConfig.ts
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.abTestConfig.ts
@@ -10,7 +10,7 @@ export enum TokenSelectorBalanceLayoutVariant {
   Treatment = 'treatment',
 }
 
-interface TokenSelectorBalanceLayoutConfig {
+export interface TokenSelectorBalanceLayoutConfig {
   showTokenBalanceFirst: boolean;
   removeTickerFromTokenBalance: boolean;
 }

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -49,6 +49,7 @@ import { useABTest } from '../../../../hooks';
 import {
   TOKEN_SELECTOR_BALANCE_LAYOUT_AB_KEY,
   TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
+  TokenSelectorBalanceLayoutConfig,
   TokenSelectorBalanceLayoutVariant,
 } from './TokenSelectorItem.abTestConfig';
 import {
@@ -174,6 +175,7 @@ interface TokenSelectorItemProps {
   isNoFeeAsset?: boolean;
   secondaryRowContent?: React.ReactNode;
   tokenBalanceTextProps?: Partial<BalanceTextProps>;
+  balanceLayoutConfigOverride?: TokenSelectorBalanceLayoutConfig;
   shouldChangeSelectedStyle?: boolean;
   shouldShowNetworkIcon?: boolean;
 }
@@ -278,6 +280,7 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
   isNoFeeAsset = false,
   secondaryRowContent,
   tokenBalanceTextProps,
+  balanceLayoutConfigOverride,
   shouldChangeSelectedStyle = true,
   shouldShowNetworkIcon = true,
 }) => {
@@ -298,6 +301,7 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
   const fiatValue = token.balanceFiat;
 
   const selectedVariant =
+    balanceLayoutConfigOverride ??
     variant ??
     TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
       TokenSelectorBalanceLayoutVariant.Control


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Batch Sell token rows reuse `TokenSelectorItem`, which applies the swaps balance-layout A/B test (`swapsSWAPS4242AbtestTokenSelectorBalanceLayout`). In the treatment variant, token balance renders above fiat — the opposite of the Batch Sell design.

**Why:** Users in the treatment bucket saw flipped balance/fiat order and mismatched typography on the Batch Sell token select screen.

**What changed:**

- Add optional `balanceLayoutConfigOverride` to `TokenSelectorItem` so callers can bypass the A/B test layout when needed.
- Export `TokenSelectorBalanceLayoutConfig` from `TokenSelectorItem.abTestConfig.ts`.
- In `BatchSellTokenRow`, pass the control layout override (`showTokenBalanceFirst: false`) so fiat stays on top and token balance stays below, regardless of A/B assignment.

Regular swaps token selector behavior is unchanged; only Batch Sell opts into the override.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Fixed flipped fiat and token balance order on the Batch Sell token select screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [SWAPS-4602](https://consensyssoftware.atlassian.net/browse/SWAPS-4602)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch Sell token select balance layout

  Scenario: Fiat value appears above token balance on Batch Sell token select
    Given Batch Sell is enabled in the build
    And I have multiple tokens with non-zero balances on a supported chain
    And I am assigned to the token selector balance-layout A/B treatment variant (showTokenBalanceFirst: true)
    When I open Batch Sell and view the token list
    Then each token row shows fiat value on the top-right
    And each token row shows token balance (amount + symbol) on the bottom-right

  Scenario: Swaps token selector still respects the balance-layout A/B test
    Given I open the regular Unified Swap/Bridge token selector
    When I view token rows
    Then balance layout still follows the active A/B test variant (no override applied)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2026-06-09 at 12 56 12 PM" src="https://github.com/user-attachments/assets/5a67931e-0024-4ab3-b8bd-2f3d431569bf" />


### **After**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2026-06-09 at 1 21 22 PM" src="https://github.com/user-attachments/assets/e4c9b386-351b-42bb-b967-81f6d93a307a" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4602]: https://consensyssoftware.atlassian.net/browse/SWAPS-4602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI layout override for Batch Sell only; swaps token selector A/B behavior is unchanged.
> 
> **Overview**
> **Batch Sell** token rows now pin the balance layout to the **control** variant (fiat on top, token amount + symbol below) even when the swaps token-selector balance-layout A/B test assigns **treatment**.
> 
> `TokenSelectorItem` gains an optional **`balanceLayoutConfigOverride`** that wins over `useABTest` when choosing `showTokenBalanceFirst` / `removeTickerFromTokenBalance`. **`TokenSelectorBalanceLayoutConfig`** is exported from the A/B config module so callers can pass a fixed layout. **`BatchSellTokenRow`** passes the control config override; the regular swaps/bridge token selector still follows the A/B test with no override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b577496eb7894a910edca33d68c0d40c97008ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->