### PR TITLE
feat: improve batch sell slider styling

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.styles.ts
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.styles.ts
@@ -1,0 +1,61 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../util/theme/models';
+
+const HANDLE_SIZE = 32;
+const TRACK_HEIGHT = 8;
+const MARKER_SIZE = 4;
+
+const styleSheet = (params: { theme: Theme }) => {
+  const { colors } = params.theme;
+
+  return StyleSheet.create({
+    container: { width: '100%', paddingVertical: 8 },
+    trackContainer: { position: 'relative' },
+    gestureArea: {
+      height: HANDLE_SIZE,
+      width: '100%',
+      justifyContent: 'center',
+    },
+    track: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      height: TRACK_HEIGHT,
+      borderRadius: TRACK_HEIGHT / 2,
+      backgroundColor: colors.border.muted,
+    },
+    progress: {
+      position: 'absolute',
+      left: 0,
+      height: TRACK_HEIGHT,
+      borderRadius: TRACK_HEIGHT / 2,
+      backgroundColor: colors.icon.alternative,
+    },
+    thumb: {
+      position: 'absolute',
+      top: 0,
+      width: HANDLE_SIZE,
+      height: HANDLE_SIZE,
+      borderRadius: HANDLE_SIZE / 2,
+      backgroundColor: colors.icon.defaultPressed,
+      elevation: 4,
+    },
+    dot: {
+      position: 'absolute',
+      width: MARKER_SIZE,
+      height: MARKER_SIZE,
+      borderRadius: MARKER_SIZE / 2,
+      backgroundColor: colors.text.muted,
+      top: (HANDLE_SIZE - MARKER_SIZE) / 2,
+      transform: [{ translateX: -MARKER_SIZE / 2 }],
+      zIndex: -1,
+    },
+    dot0: { left: '2%' },
+    dot25: { left: '25%' },
+    dot50: { left: '50%' },
+    dot75: { left: '75%' },
+    dot100: { left: '98%' },
+  });
+};
+
+export default styleSheet;

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.test.tsx
@@ -4,15 +4,14 @@ import { fireEvent, render } from '@testing-library/react-native';
 import {
   BatchSellPercentageSlider,
   clampToPercentage,
+  snapToStep,
   MARKER_POINTS,
 } from './BatchSellPercentageSlider';
 
 const SLIDER_TEST_ID = 'batch-sell-percentage-slider';
 
-jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => ({
-    style: () => ({}),
-  }),
+jest.mock('../../../../../component-library/hooks', () => ({
+  useStyles: () => ({ styles: {} }),
 }));
 
 jest.mock('react-native-gesture-handler', () => {
@@ -52,7 +51,28 @@ describe('BatchSellPercentageSlider', () => {
     expect(result).toBe(expectedValue);
   });
 
-  it('increments accessibility value by one percentage point', () => {
+  it.each([
+    [-10, 0],
+    [0, 0],
+    [12, 0],
+    [12.4, 0],
+    [12.5, 25],
+    [24, 25],
+    [37.4, 25],
+    [37.5, 50],
+    [50, 50],
+    [62.4, 50],
+    [62.5, 75],
+    [75, 75],
+    [87.4, 75],
+    [87.5, 100],
+    [100, 100],
+    [120, 100],
+  ])('snaps %s to the nearest step %s', (value, expectedValue) => {
+    expect(snapToStep(value)).toBe(expectedValue);
+  });
+
+  it('increments accessibility value to the next step', () => {
     const onValueChange = jest.fn();
     const { getByTestId } = render(
       <BatchSellPercentageSlider
@@ -66,10 +86,10 @@ describe('BatchSellPercentageSlider', () => {
       nativeEvent: { actionName: 'increment' },
     });
 
-    expect(onValueChange).toHaveBeenCalledWith(51);
+    expect(onValueChange).toHaveBeenCalledWith(75);
   });
 
-  it('decrements accessibility value by one percentage point', () => {
+  it('decrements accessibility value to the previous step', () => {
     const onValueChange = jest.fn();
     const { getByTestId } = render(
       <BatchSellPercentageSlider
@@ -83,7 +103,7 @@ describe('BatchSellPercentageSlider', () => {
       nativeEvent: { actionName: 'decrement' },
     });
 
-    expect(onValueChange).toHaveBeenCalledWith(49);
+    expect(onValueChange).toHaveBeenCalledWith(25);
   });
 
   it('does not decrement below 0%', () => {
@@ -101,6 +121,23 @@ describe('BatchSellPercentageSlider', () => {
     });
 
     expect(onValueChange).toHaveBeenCalledWith(0);
+  });
+
+  it('does not increment above 100%', () => {
+    const onValueChange = jest.fn();
+    const { getByTestId } = render(
+      <BatchSellPercentageSlider
+        value={100}
+        onValueChange={onValueChange}
+        testID={SLIDER_TEST_ID}
+      />,
+    );
+
+    fireEvent(getByTestId(SLIDER_TEST_ID), 'accessibilityAction', {
+      nativeEvent: { actionName: 'increment' },
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith(100);
   });
 
   it('renders muted marker dots for each marker point', () => {

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.test.tsx
@@ -4,7 +4,6 @@ import { fireEvent, render } from '@testing-library/react-native';
 import {
   BatchSellPercentageSlider,
   clampToPercentage,
-  snapToStep,
   MARKER_POINTS,
 } from './BatchSellPercentageSlider';
 
@@ -51,28 +50,7 @@ describe('BatchSellPercentageSlider', () => {
     expect(result).toBe(expectedValue);
   });
 
-  it.each([
-    [-10, 0],
-    [0, 0],
-    [12, 0],
-    [12.4, 0],
-    [12.5, 25],
-    [24, 25],
-    [37.4, 25],
-    [37.5, 50],
-    [50, 50],
-    [62.4, 50],
-    [62.5, 75],
-    [75, 75],
-    [87.4, 75],
-    [87.5, 100],
-    [100, 100],
-    [120, 100],
-  ])('snaps %s to the nearest step %s', (value, expectedValue) => {
-    expect(snapToStep(value)).toBe(expectedValue);
-  });
-
-  it('increments accessibility value to the next step', () => {
+  it('increments accessibility value by one percentage point', () => {
     const onValueChange = jest.fn();
     const { getByTestId } = render(
       <BatchSellPercentageSlider
@@ -86,10 +64,10 @@ describe('BatchSellPercentageSlider', () => {
       nativeEvent: { actionName: 'increment' },
     });
 
-    expect(onValueChange).toHaveBeenCalledWith(75);
+    expect(onValueChange).toHaveBeenCalledWith(51);
   });
 
-  it('decrements accessibility value to the previous step', () => {
+  it('decrements accessibility value by one percentage point', () => {
     const onValueChange = jest.fn();
     const { getByTestId } = render(
       <BatchSellPercentageSlider
@@ -103,7 +81,7 @@ describe('BatchSellPercentageSlider', () => {
       nativeEvent: { actionName: 'decrement' },
     });
 
-    expect(onValueChange).toHaveBeenCalledWith(25);
+    expect(onValueChange).toHaveBeenCalledWith(49);
   });
 
   it('does not decrement below 0%', () => {
@@ -121,23 +99,6 @@ describe('BatchSellPercentageSlider', () => {
     });
 
     expect(onValueChange).toHaveBeenCalledWith(0);
-  });
-
-  it('does not increment above 100%', () => {
-    const onValueChange = jest.fn();
-    const { getByTestId } = render(
-      <BatchSellPercentageSlider
-        value={100}
-        onValueChange={onValueChange}
-        testID={SLIDER_TEST_ID}
-      />,
-    );
-
-    fireEvent(getByTestId(SLIDER_TEST_ID), 'accessibilityAction', {
-      nativeEvent: { actionName: 'increment' },
-    });
-
-    expect(onValueChange).toHaveBeenCalledWith(100);
   });
 
   it('renders muted marker dots for each marker point', () => {

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
@@ -27,29 +27,6 @@ export function clampToPercentage(value: number): number {
   return Math.max(MIN_PERCENTAGE, Math.min(MAX_PERCENTAGE, Math.round(value)));
 }
 
-/**
- * Snaps a raw percentage value to the nearest entry in PERCENTAGE_STEPS.
- * Ties (exact midpoint) snap to the higher step.
- * Marked as a worklet so it can be called directly from gesture callbacks
- * on the UI thread without bridge overhead.
- */
-export function snapToStep(rawPercentage: number): number {
-  'worklet';
-  // Inline the step values so the worklet does not need to capture the
-  // module-level `as const` tuple across the JS/UI thread boundary.
-  const steps = [0, 25, 50, 75, 100];
-  let closest = steps[0];
-  let minDiff = Math.abs(rawPercentage - closest);
-  for (let i = 1; i < steps.length; i++) {
-    const diff = Math.abs(rawPercentage - steps[i]);
-    if (diff <= minDiff) {
-      minDiff = diff;
-      closest = steps[i];
-    }
-  }
-  return closest;
-}
-
 interface BatchSellPercentageSliderProps {
   value: number;
   onValueChange: (value: number) => void;
@@ -82,7 +59,9 @@ export function BatchSellPercentageSlider({
       }
 
       const clampedPosition = Math.max(0, Math.min(position, width));
-      const nextValue = snapToStep((clampedPosition / width) * MAX_PERCENTAGE);
+      const nextValue = clampToPercentage(
+        (clampedPosition / width) * MAX_PERCENTAGE,
+      );
 
       updatePosition(nextValue, width);
       onValueChange(nextValue);
@@ -147,14 +126,12 @@ export function BatchSellPercentageSlider({
 
   const handleAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
-      const steps = [...PERCENTAGE_STEPS] as number[];
-      const currentIndex = steps.indexOf(snapToStep(clampedValue));
-      const nextIndex =
+      const nextValue =
         event.nativeEvent.actionName === 'increment'
-          ? Math.min(currentIndex + 1, steps.length - 1)
-          : Math.max(currentIndex - 1, 0);
+          ? clampToPercentage(clampedValue + 1)
+          : clampToPercentage(clampedValue - 1);
 
-      onValueChange(PERCENTAGE_STEPS[nextIndex]);
+      onValueChange(nextValue);
     },
     [onValueChange, clampedValue],
   );

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
@@ -114,7 +114,6 @@ export function BatchSellPercentageSlider({
         }
 
         // Track finger position at 1 % granularity while dragging.
-        // Snapping to a step only happens when the finger lifts (onEnd).
         const rawPos = Math.max(0, Math.min(event.x, width));
         const pct = Math.round((rawPos / width) * MAX_PERCENTAGE);
         translateX.value = (pct / MAX_PERCENTAGE) * width;

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { AccessibilityActionEvent, LayoutChangeEvent } from 'react-native';
+import {
+  AccessibilityActionEvent,
+  LayoutChangeEvent,
+  View,
+} from 'react-native';
 import {
   Gesture,
   GestureDetector,
@@ -10,17 +14,40 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useStyles } from '../../../../../component-library/hooks';
+import styleSheet from './BatchSellPercentageSlider.styles';
 
-const HANDLE_SIZE = 24;
-const MARKER_SIZE = 4;
-const ACCESSIBILITY_STEP = 1;
+const HANDLE_SIZE = 32;
+const PERCENTAGE_STEPS = [0, 25, 50, 75, 100] as const;
 export const MARKER_POINTS = [25, 50, 75, 100];
 const MIN_PERCENTAGE = 0;
 const MAX_PERCENTAGE = 100;
 
 export function clampToPercentage(value: number): number {
   return Math.max(MIN_PERCENTAGE, Math.min(MAX_PERCENTAGE, Math.round(value)));
+}
+
+/**
+ * Snaps a raw percentage value to the nearest entry in PERCENTAGE_STEPS.
+ * Ties (exact midpoint) snap to the higher step.
+ * Marked as a worklet so it can be called directly from gesture callbacks
+ * on the UI thread without bridge overhead.
+ */
+export function snapToStep(rawPercentage: number): number {
+  'worklet';
+  // Inline the step values so the worklet does not need to capture the
+  // module-level `as const` tuple across the JS/UI thread boundary.
+  const steps = [0, 25, 50, 75, 100];
+  let closest = steps[0];
+  let minDiff = Math.abs(rawPercentage - closest);
+  for (let i = 1; i < steps.length; i++) {
+    const diff = Math.abs(rawPercentage - steps[i]);
+    if (diff <= minDiff) {
+      minDiff = diff;
+      closest = steps[i];
+    }
+  }
+  return closest;
 }
 
 interface BatchSellPercentageSliderProps {
@@ -34,7 +61,7 @@ export function BatchSellPercentageSlider({
   onValueChange,
   testID,
 }: BatchSellPercentageSliderProps) {
-  const tw = useTailwind();
+  const { styles } = useStyles(styleSheet, {});
   const clampedValue = clampToPercentage(value);
   const sliderWidth = useSharedValue(0);
   const translateX = useSharedValue(0);
@@ -55,9 +82,7 @@ export function BatchSellPercentageSlider({
       }
 
       const clampedPosition = Math.max(0, Math.min(position, width));
-      const nextValue = clampToPercentage(
-        (clampedPosition / width) * MAX_PERCENTAGE,
-      );
+      const nextValue = snapToStep((clampedPosition / width) * MAX_PERCENTAGE);
 
       updatePosition(nextValue, width);
       onValueChange(nextValue);
@@ -109,7 +134,11 @@ export function BatchSellPercentageSlider({
           return;
         }
 
-        translateX.value = Math.max(0, Math.min(event.x, width));
+        // Track finger position at 1 % granularity while dragging.
+        // Snapping to a step only happens when the finger lifts (onEnd).
+        const rawPos = Math.max(0, Math.min(event.x, width));
+        const pct = Math.round((rawPos / width) * MAX_PERCENTAGE);
+        translateX.value = (pct / MAX_PERCENTAGE) * width;
       })
       .onEnd((event) => {
         runOnJS(commitValueFromPosition)(event.x, sliderWidth.value);
@@ -118,12 +147,14 @@ export function BatchSellPercentageSlider({
 
   const handleAccessibilityAction = useCallback(
     (event: AccessibilityActionEvent) => {
-      const nextValue =
+      const steps = [...PERCENTAGE_STEPS] as number[];
+      const currentIndex = steps.indexOf(snapToStep(clampedValue));
+      const nextIndex =
         event.nativeEvent.actionName === 'increment'
-          ? clampToPercentage(clampedValue + ACCESSIBILITY_STEP)
-          : clampToPercentage(clampedValue - ACCESSIBILITY_STEP);
+          ? Math.min(currentIndex + 1, steps.length - 1)
+          : Math.max(currentIndex - 1, 0);
 
-      onValueChange(nextValue);
+      onValueChange(PERCENTAGE_STEPS[nextIndex]);
     },
     [onValueChange, clampedValue],
   );
@@ -140,48 +171,30 @@ export function BatchSellPercentageSlider({
       }}
       accessibilityActions={[{ name: 'increment' }, { name: 'decrement' }]}
       onAccessibilityAction={handleAccessibilityAction}
-      style={tw.style('h-6 w-full')}
+      style={styles.container}
     >
-      <GestureDetector gesture={gesture}>
-        <Animated.View
-          onLayout={handleLayout}
-          style={tw.style('h-6 w-full justify-center')}
-        >
-          <Animated.View
-            style={tw.style(
-              'absolute left-0 right-0 h-1 rounded-full bg-icon-muted',
-            )}
+      <View style={styles.trackContainer}>
+        <GestureDetector gesture={gesture}>
+          <Animated.View onLayout={handleLayout} style={styles.gestureArea}>
+            <Animated.View style={styles.track} />
+            <Animated.View style={[styles.progress, progressStyle]} />
+            <Animated.View style={[styles.thumb, handleStyle]} />
+          </Animated.View>
+        </GestureDetector>
+
+        {PERCENTAGE_STEPS.map((percent) => (
+          <View
+            key={`dot-${percent}`}
+            pointerEvents="none"
+            testID={
+              testID && MARKER_POINTS.includes(percent)
+                ? `${testID}-marker-point-${percent}`
+                : undefined
+            }
+            style={[styles.dot, styles[`dot${percent}` as keyof typeof styles]]}
           />
-          <Animated.View
-            style={[
-              tw.style('absolute left-0 h-1 rounded-full bg-icon-default'),
-              progressStyle,
-            ]}
-          />
-          {MARKER_POINTS.map((markerPoint) => (
-            <Animated.View
-              key={markerPoint}
-              pointerEvents="none"
-              testID={
-                testID ? `${testID}-marker-point-${markerPoint}` : undefined
-              }
-              style={[
-                tw.style('absolute h-1 w-1 rounded-full bg-icon-muted'),
-                {
-                  left: `${markerPoint}%`,
-                  transform: [{ translateX: -MARKER_SIZE / 2 }],
-                },
-              ]}
-            />
-          ))}
-          <Animated.View
-            style={[
-              tw.style('absolute h-6 w-6 rounded-full bg-icon-default'),
-              handleStyle,
-            ]}
-          />
-        </Animated.View>
-      </GestureDetector>
+        ))}
+      </View>
     </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION

## **Description**

Refactors `BatchSellPercentageSlider` to align its visual design with `PerpsSlider` and improves its interaction model.

**Why:** The slider's appearance was inconsistent with the rest of the app's slider components (thin track, small thumb, no theming), and its interaction model allowed any arbitrary integer percentage rather than the discrete values the batch-sell feature actually supports.

**What changed:**
- Styles are now driven by the theme (via `useStyles` / `BatchSellPercentageSlider.styles.ts`) instead of Tailwind, matching `PerpsSlider`'s visual design: 32 px thumb, 8 px track, themed colours for track, progress fill, and marker dots.
- Percentage label presets (0 %, 25 %, 50 %, 75 %, 100 %) are no longer rendered — they are not needed by the batch-sell UX.
- Dragging the thumb now tracks finger position at 1 % granularity for smooth visual feedback; the committed value snaps to the nearest `PERCENTAGE_STEPS` entry (0, 25, 50, 75, 100) when the finger lifts or the user taps the track.
- Accessibility increment/decrement now navigates between steps instead of ±1 %.

## **Changelog**

CHANGELOG entry: improve batch sell slider styling to match that of perps slider

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4572

## **Manual testing steps**

```gherkin
Feature: BatchSellPercentageSlider

  Scenario: user drags the slider
    Given the Batch Sell review screen is open with multiple tokens selected
    When user drags the slider thumb left or right
    Then the thumb follows the finger smoothly at 1 % granularity
    And when the finger lifts the thumb snaps to the nearest step (0 / 25 / 50 / 75 / 100 %)
    And the parent onValueChange is called with the snapped step value

  Scenario: user taps the track
    Given the Batch Sell review screen is open
    When user taps anywhere on the track
    Then the thumb jumps to the nearest step position
    And onValueChange is called with that step value

  Scenario: user adjusts via accessibility controls
    Given the slider is focused by the screen reader at 50 %
    When user triggers the increment action
    Then the value becomes 75 %
    When user triggers the decrement action
    Then the value becomes back to 50 %
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/5d99b6b8-1a46-47e9-9bd2-b3d3fefb149c



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Bridge batch-sell UI and interaction tweaks; no auth, persistence, or payment logic changes.
> 
> **Overview**
> **Batch Sell percentage slider** is restyled to match other app sliders: Tailwind is replaced with themed `useStyles` and a new stylesheet (32px thumb, 8px track, themed track/progress/thumb, marker dots at 0/25/50/75/100).
> 
> The layout splits the gesture area from static markers (dots sit in `trackContainer` beside the draggable track). **While dragging**, thumb position updates in **1% steps** instead of following the finger continuously; tap/pan end still commits via the existing rounded-percentage helper. Unit tests now mock `useStyles` instead of the design-system Tailwind preset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11421afbc8e32938a35f26f44ab042a1138a4e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->