### PR TITLE
feat(analytics): add QR Code Viewed event for receive QR sheets (TMCU-444)

### DIFF
--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -364,6 +364,7 @@ jest.mock('../../../selectors/networkController', () => ({
 jest.mock('../../../util/address', () => ({
   ...jest.requireActual('../../../util/address'),
   getInternalAccountByAddress: () => mockAccount,
+  getAddressAccountType: jest.fn().mockReturnValue('MetaMask'),
 }));
 
 jest.mock('../../../components/hooks/useAsyncResult', () => ({

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
@@ -667,6 +667,7 @@ describe('useTokenAtomicActions - useHandleOnReceive', () => {
           chainId: '0x1',
           groupId: 'group-1',
           location: 'asset-details',
+          account: mockAccount,
         },
       },
     );

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.test.ts
@@ -666,6 +666,7 @@ describe('useTokenAtomicActions - useHandleOnReceive', () => {
           networkName: 'Ethereum Mainnet',
           chainId: '0x1',
           groupId: 'group-1',
+          location: 'asset-details',
         },
       },
     );

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
@@ -478,6 +478,7 @@ export const useHandleOnReceive = ({
           chainId,
           groupId: selectedAccountGroup.id,
           location: 'asset-details',
+          account: accountForChain,
         },
       });
     } else {

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
@@ -477,6 +477,7 @@ export const useHandleOnReceive = ({
           networkName: networkName || 'Unknown Network',
           chainId,
           groupId: selectedAccountGroup.id,
+          location: 'asset-details',
         },
       });
     } else {

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -265,6 +265,7 @@ describe('AddressList', () => {
           chainId: 'eip155:1',
           groupId: ACCOUNT_GROUP_ID,
           location: 'address-list',
+          account: expect.objectContaining({ id: mockEthEoaAccount.id }),
         },
       },
     );

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -264,6 +264,7 @@ describe('AddressList', () => {
           networkName: 'Ethereum',
           chainId: 'eip155:1',
           groupId: ACCOUNT_GROUP_ID,
+          location: 'address-list',
         },
       },
     );

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -92,6 +92,7 @@ export const AddressList = () => {
                       networkName: item.networkName,
                       chainId: item.scope,
                       groupId,
+                      location: 'address-list',
                     },
                   },
                 );

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -93,6 +93,7 @@ export const AddressList = () => {
                       chainId: item.scope,
                       groupId,
                       location: 'address-list',
+                      account: item.account,
                     },
                   },
                 );

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx
@@ -76,10 +76,14 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock('../../../../../util/analytics/qrCodeViewedTracking', () => ({
+  ...jest.requireActual('../../../../../util/analytics/qrCodeViewedTracking'),
+  getQrCodeViewedAccountType: jest.fn().mockReturnValue('MetaMask'),
+}));
+
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   renderAccountName: jest.fn().mockReturnValue('Test Account'),
-  getAddressAccountType: jest.fn().mockReturnValue('MetaMask'),
 }));
 
 jest.mock('../../../../../core/Multichain/networks', () => ({

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx
@@ -79,6 +79,7 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   renderAccountName: jest.fn().mockReturnValue('Test Account'),
+  getAddressAccountType: jest.fn().mockReturnValue('MetaMask'),
 }));
 
 jest.mock('../../../../../core/Multichain/networks', () => ({
@@ -108,6 +109,16 @@ jest.mock('../../../../../core/Engine', () => {
       NetworkController: {
         getNetworkConfigurationsByCaipChainId: jest.fn(),
       },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: 'HD Key Tree',
+              accounts: [mockAccountEngine.address],
+            },
+          ],
+        },
+      },
       AccountsController: {
         internalAccounts: {
           accounts: {
@@ -119,6 +130,17 @@ jest.mock('../../../../../core/Engine', () => {
     },
   };
 });
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(() => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: jest.requireActual(
+      '../../../../../util/analytics/AnalyticsEventBuilder',
+    ).AnalyticsEventBuilder.createEventBuilder,
+  })),
+}));
 
 // Mock QRCode component to render something visible
 jest.mock('react-native-qrcode-svg', () => {
@@ -194,7 +216,29 @@ describe('ShareAddress', () => {
     jest.clearAllMocks();
     mockGoBack.mockClear();
     mockNavigate.mockClear();
+    mockTrackEvent.mockClear();
     mockAccount = internalAccount1; // Reset to default
+  });
+
+  it('tracks QR Code Viewed on render without chain_id_caip', () => {
+    render();
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'QR Code Viewed',
+        properties: expect.objectContaining({
+          location: 'account-details',
+          account_type: 'MetaMask',
+        }),
+      }),
+    );
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.not.objectContaining({
+          chain_id_caip: expect.anything(),
+        }),
+      }),
+    );
   });
 
   it('displays title and QR account information', () => {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -27,6 +27,9 @@ import { getFormattedAddressFromInternalAccount } from '../../../../../core/Mult
 import { getMultichainBlockExplorer } from '../../../../../core/Multichain/networks';
 import { ShareAddressIds } from './ShareAddress.testIds';
 import PNG_MM_LOGO_PATH from '../../../../../images/branding/fox.png';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { trackQrCodeViewed } from '../../../../../util/analytics/qrCodeViewedTracking';
+import { getAddressAccountType } from '../../../../../util/address';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddress: {
@@ -42,6 +45,7 @@ export const ShareAddress = () => {
   const route = useRoute<ShareAddressRouteProp>();
   const { account } = route.params;
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const formattedAddress = getFormattedAddressFromInternalAccount(account);
 
   const blockExplorer:
@@ -51,6 +55,13 @@ export const ShareAddress = () => {
         blockExplorerName: string;
       }
     | undefined = useMemo(() => getMultichainBlockExplorer(account), [account]);
+
+  useEffect(() => {
+    trackQrCodeViewed(trackEvent, createEventBuilder, {
+      location: 'account-details',
+      account_type: getAddressAccountType(account.address),
+    });
+  }, [account.address, createEventBuilder, trackEvent]);
 
   const handleExplorerLinkPress = useCallback(() => {
     if (blockExplorer) {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.tsx
@@ -28,8 +28,10 @@ import { getMultichainBlockExplorer } from '../../../../../core/Multichain/netwo
 import { ShareAddressIds } from './ShareAddress.testIds';
 import PNG_MM_LOGO_PATH from '../../../../../images/branding/fox.png';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackQrCodeViewed } from '../../../../../util/analytics/qrCodeViewedTracking';
-import { getAddressAccountType } from '../../../../../util/address';
+import {
+  getQrCodeViewedAccountType,
+  trackQrCodeViewed,
+} from '../../../../../util/analytics/qrCodeViewedTracking';
 
 interface RootNavigationParamList extends ParamListBase {
   ShareAddress: {
@@ -59,9 +61,9 @@ export const ShareAddress = () => {
   useEffect(() => {
     trackQrCodeViewed(trackEvent, createEventBuilder, {
       location: 'account-details',
-      account_type: getAddressAccountType(account.address),
+      account_type: getQrCodeViewedAccountType(account),
     });
-  }, [account.address, createEventBuilder, trackEvent]);
+  }, [account, createEventBuilder, trackEvent]);
 
   const handleExplorerLinkPress = useCallback(() => {
     if (blockExplorer) {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
@@ -119,6 +119,7 @@ jest.mock('@react-navigation/native', () => ({
       chainId: '0x1',
       groupId: 'test-group-id',
       location: 'address-list',
+      account: mockAccount,
     },
   }),
 }));
@@ -134,10 +135,14 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   })),
 }));
 
+jest.mock('../../../../../util/analytics/qrCodeViewedTracking', () => ({
+  ...jest.requireActual('../../../../../util/analytics/qrCodeViewedTracking'),
+  getQrCodeViewedAccountType: jest.fn().mockReturnValue('MetaMask'),
+}));
+
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   renderAccountName: jest.fn().mockReturnValue('Test Account'),
-  getAddressAccountType: jest.fn().mockReturnValue('MetaMask'),
 }));
 
 // Mock the selectAccountGroupById selector

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
@@ -118,13 +118,26 @@ jest.mock('@react-navigation/native', () => ({
       accountName: mockAccount?.metadata?.name || 'Test Account',
       chainId: '0x1',
       groupId: 'test-group-id',
+      location: 'address-list',
     },
   }),
+}));
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(() => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: jest.requireActual(
+      '../../../../../util/analytics/AnalyticsEventBuilder',
+    ).AnalyticsEventBuilder.createEventBuilder,
+  })),
 }));
 
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   renderAccountName: jest.fn().mockReturnValue('Test Account'),
+  getAddressAccountType: jest.fn().mockReturnValue('MetaMask'),
 }));
 
 // Mock the selectAccountGroupById selector
@@ -172,6 +185,16 @@ jest.mock('../../../../../core/Engine', () => {
     context: {
       NetworkController: {
         getNetworkConfigurationsByCaipChainId: jest.fn(),
+      },
+      KeyringController: {
+        state: {
+          keyrings: [
+            {
+              type: 'HD Key Tree',
+              accounts: [mockAccountEngine.address],
+            },
+          ],
+        },
       },
       AccountsController: {
         internalAccounts: {
@@ -237,8 +260,24 @@ describe('ShareAddressQR', () => {
     jest.clearAllMocks();
     mockGoBack.mockClear();
     mockNavigate.mockClear();
+    mockTrackEvent.mockClear();
     mockAccount = internalAccount1;
     mockNetworkName = 'Ethereum Mainnet';
+  });
+
+  it('tracks QR Code Viewed on render', () => {
+    render();
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'QR Code Viewed',
+        properties: expect.objectContaining({
+          location: 'address-list',
+          chain_id_caip: 'eip155:1',
+          account_type: 'MetaMask',
+        }),
+      }),
+    );
   });
 
   it('displays title and QR code with account information', () => {

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -30,8 +30,11 @@ import QRAccountDisplay from '../../../QRAccountDisplay';
 import QRCode from 'react-native-qrcode-svg';
 import useBlockExplorer from '../../../../hooks/useBlockExplorer';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { trackQrCodeViewed } from '../../../../../util/analytics/qrCodeViewedTracking';
-import { getAddressAccountType } from '../../../../../util/address';
+import {
+  getQrCodeViewedAccountType,
+  trackQrCodeViewed,
+} from '../../../../../util/analytics/qrCodeViewedTracking';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from './ShareAddressQR.testIds';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -43,6 +46,7 @@ export interface ShareAddressQRParams {
   chainId: string;
   groupId: AccountGroupId;
   location: string;
+  account: InternalAccount;
 }
 
 interface RootNavigationParamList extends ParamListBase {
@@ -58,7 +62,8 @@ export const ShareAddressQR = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const tw = useTailwind();
   const route = useRoute<ShareAddressQRRouteProp>();
-  const { address, networkName, chainId, groupId, location } = route.params;
+  const { address, networkName, chainId, groupId, location, account } =
+    route.params;
   const accountGroup = useSelector((state: RootState) =>
     selectAccountGroupById(state, groupId),
   );
@@ -72,10 +77,10 @@ export const ShareAddressQR = () => {
   useEffect(() => {
     trackQrCodeViewed(trackEvent, createEventBuilder, {
       location,
-      account_type: getAddressAccountType(address),
+      account_type: getQrCodeViewedAccountType(account),
       chain_id_caip: formatChainIdToCaip(chainId),
     });
-  }, [address, chainId, createEventBuilder, location, trackEvent]);
+  }, [account, chainId, createEventBuilder, location, trackEvent]);
 
   const handleOnBack = useCallback(() => {
     navigation.goBack();

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { strings } from '../../../../../../locales/i18n';
 import {
   ParamListBase,
@@ -28,6 +29,9 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import QRAccountDisplay from '../../../QRAccountDisplay';
 import QRCode from 'react-native-qrcode-svg';
 import useBlockExplorer from '../../../../hooks/useBlockExplorer';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { trackQrCodeViewed } from '../../../../../util/analytics/qrCodeViewedTracking';
+import { getAddressAccountType } from '../../../../../util/address';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { ShareAddressQRIds } from './ShareAddressQR.testIds';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -38,6 +42,7 @@ export interface ShareAddressQRParams {
   networkName: string;
   chainId: string;
   groupId: AccountGroupId;
+  location: string;
 }
 
 interface RootNavigationParamList extends ParamListBase {
@@ -53,15 +58,24 @@ export const ShareAddressQR = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const tw = useTailwind();
   const route = useRoute<ShareAddressQRRouteProp>();
-  const { address, networkName, chainId, groupId } = route.params;
+  const { address, networkName, chainId, groupId, location } = route.params;
   const accountGroup = useSelector((state: RootState) =>
     selectAccountGroupById(state, groupId),
   );
   const accountGroupName = accountGroup?.metadata.name;
 
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { toBlockExplorer, getBlockExplorerName } = useBlockExplorer(chainId);
   const networkImageSource = getNetworkImageSource({ chainId });
+
+  useEffect(() => {
+    trackQrCodeViewed(trackEvent, createEventBuilder, {
+      location,
+      account_type: getAddressAccountType(address),
+      chain_id_caip: formatChainIdToCaip(chainId),
+    });
+  }, [address, chainId, createEventBuilder, location, trackEvent]);
 
   const handleOnBack = useCallback(() => {
     navigation.goBack();

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -81,6 +81,7 @@ enum EVENT_NAME {
   // Wallet
   WALLET_OPENED = 'Wallet Opened',
   ADDRESS_COPIED = 'Address Copied',
+  QR_CODE_VIEWED = 'QR Code Viewed',
   TOKEN_ADDED = 'Token Added',
   COLLECTIBLE_ADDED = 'Collectible Added',
   NFT_DETAILS_OPENED = 'NFT Details Opened',
@@ -892,6 +893,7 @@ const events = {
 
   WALLET_OPENED: generateOpt(EVENT_NAME.WALLET_OPENED),
   ADDRESS_COPIED: generateOpt(EVENT_NAME.ADDRESS_COPIED),
+  QR_CODE_VIEWED: generateOpt(EVENT_NAME.QR_CODE_VIEWED),
   TOKEN_ADDED: generateOpt(EVENT_NAME.TOKEN_ADDED),
   COLLECTIBLE_ADDED: generateOpt(EVENT_NAME.COLLECTIBLE_ADDED),
   NFT_DETAILS_OPENED: generateOpt(EVENT_NAME.NFT_DETAILS_OPENED),

--- a/app/util/analytics/qrCodeViewedTracking.test.ts
+++ b/app/util/analytics/qrCodeViewedTracking.test.ts
@@ -1,0 +1,81 @@
+import {
+  trackQrCodeViewed,
+  QrCodeViewedProperties,
+} from './qrCodeViewedTracking';
+import { MetaMetricsEvents } from '../../core/Analytics';
+import { ITrackingEvent } from './analytics.types';
+
+jest.mock('../../core/Analytics');
+
+describe('qrCodeViewedTracking', () => {
+  const mockTrackEvent = jest.fn();
+  const mockCreateEventBuilder = jest.fn();
+  const mockAddProperties = jest.fn();
+  const mockBuild = jest.fn();
+
+  const mockProperties: QrCodeViewedProperties = {
+    location: 'address-list',
+    account_type: 'MetaMask',
+    chain_id_caip: 'eip155:1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    mockAddProperties.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    mockBuild.mockReturnValue({
+      name: 'QR Code Viewed',
+      properties: mockProperties,
+      sensitiveProperties: {},
+      saveDataRecording: false,
+      isAnonymous: false,
+      hasProperties: true,
+    } as ITrackingEvent);
+  });
+
+  describe('trackQrCodeViewed', () => {
+    it('creates event with QR_CODE_VIEWED', () => {
+      trackQrCodeViewed(mockTrackEvent, mockCreateEventBuilder, mockProperties);
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.QR_CODE_VIEWED,
+      );
+    });
+
+    it('adds link properties to the event builder', () => {
+      trackQrCodeViewed(mockTrackEvent, mockCreateEventBuilder, mockProperties);
+
+      expect(mockAddProperties).toHaveBeenCalledWith(mockProperties);
+    });
+
+    it('omits chain_id_caip when not provided', () => {
+      trackQrCodeViewed(mockTrackEvent, mockCreateEventBuilder, {
+        location: 'account-details',
+        account_type: 'MetaMask',
+      });
+
+      expect(mockAddProperties).toHaveBeenCalledWith({
+        location: 'account-details',
+        account_type: 'MetaMask',
+      });
+    });
+
+    it('builds and tracks the event', () => {
+      trackQrCodeViewed(mockTrackEvent, mockCreateEventBuilder, mockProperties);
+
+      expect(mockBuild).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'QR Code Viewed',
+        }),
+      );
+    });
+  });
+});

--- a/app/util/analytics/qrCodeViewedTracking.test.ts
+++ b/app/util/analytics/qrCodeViewedTracking.test.ts
@@ -1,11 +1,25 @@
+import { KeyringTypes } from '@metamask/keyring-controller';
 import {
+  getQrCodeViewedAccountType,
   trackQrCodeViewed,
   QrCodeViewedProperties,
 } from './qrCodeViewedTracking';
+import {
+  createMockSnapInternalAccount,
+  internalAccount1,
+  internalSolanaAccount1,
+} from '../../util/test/accountsControllerTestUtils';
+import { getAddressAccountType } from '../address';
 import { MetaMetricsEvents } from '../../core/Analytics';
 import { ITrackingEvent } from './analytics.types';
 
 jest.mock('../../core/Analytics');
+jest.mock('../address', () => ({
+  ...jest.requireActual('../address'),
+  getAddressAccountType: jest.fn(),
+}));
+
+const mockGetAddressAccountType = jest.mocked(getAddressAccountType);
 
 describe('qrCodeViewedTracking', () => {
   const mockTrackEvent = jest.fn();
@@ -38,6 +52,37 @@ describe('qrCodeViewedTracking', () => {
       isAnonymous: false,
       hasProperties: true,
     } as ITrackingEvent);
+  });
+
+  describe('getQrCodeViewedAccountType', () => {
+    it('returns keyring metadata for non-EVM addresses', () => {
+      expect(getQrCodeViewedAccountType(internalSolanaAccount1)).toBe(
+        KeyringTypes.snap,
+      );
+      expect(mockGetAddressAccountType).not.toHaveBeenCalled();
+    });
+
+    it('returns getAddressAccountType for EVM addresses when available', () => {
+      mockGetAddressAccountType.mockReturnValue('MetaMask');
+
+      expect(getQrCodeViewedAccountType(internalAccount1)).toBe('MetaMask');
+      expect(mockGetAddressAccountType).toHaveBeenCalledWith(
+        internalAccount1.address,
+      );
+    });
+
+    it('falls back to keyring metadata when getAddressAccountType throws', () => {
+      mockGetAddressAccountType.mockImplementation(() => {
+        throw new Error('The address is not imported');
+      });
+
+      const snapAccount = createMockSnapInternalAccount(
+        internalAccount1.address,
+        'Snap Account',
+      );
+
+      expect(getQrCodeViewedAccountType(snapAccount)).toBe(KeyringTypes.snap);
+    });
   });
 
   describe('trackQrCodeViewed', () => {

--- a/app/util/analytics/qrCodeViewedTracking.ts
+++ b/app/util/analytics/qrCodeViewedTracking.ts
@@ -1,11 +1,37 @@
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { isCaipAccountId } from '@metamask/utils';
 import { MetaMetricsEvents } from '../../core/Analytics';
+import { getAddressAccountType, isValidHexAddress } from '../address';
 import { IMetaMetricsEvent, JsonMap } from './analytics.types';
+
+/**
+ * Resolve account_type for QR Code Viewed without crashing on non-EVM addresses.
+ * Prefers getAddressAccountType for hex/CAIP account IDs; falls back to keyring metadata.
+ *
+ * @param account - Internal account shown in the QR sheet
+ * @returns Account type string for analytics
+ */
+export const getQrCodeViewedAccountType = (
+  account: InternalAccount,
+): string => {
+  const keyringType = account.metadata?.keyring?.type ?? 'MetaMask';
+
+  if (isValidHexAddress(account.address) || isCaipAccountId(account.address)) {
+    try {
+      return getAddressAccountType(account.address);
+    } catch {
+      return keyringType;
+    }
+  }
+
+  return keyringType;
+};
 
 /**
  * Properties for QR Code Viewed tracking.
  *
  * @property location - Entry point in kebab-case (e.g. address-list)
- * @property account_type - Account type from getAddressAccountType
+ * @property account_type - Account type from getQrCodeViewedAccountType
  * @property chain_id_caip - Optional CAIP-2 chain ID when a specific chain is shown
  */
 export interface QrCodeViewedProperties extends JsonMap {

--- a/app/util/analytics/qrCodeViewedTracking.ts
+++ b/app/util/analytics/qrCodeViewedTracking.ts
@@ -1,0 +1,49 @@
+import { MetaMetricsEvents } from '../../core/Analytics';
+import { IMetaMetricsEvent, JsonMap } from './analytics.types';
+
+/**
+ * Properties for QR Code Viewed tracking.
+ *
+ * @property location - Entry point in kebab-case (e.g. address-list)
+ * @property account_type - Account type from getAddressAccountType
+ * @property chain_id_caip - Optional CAIP-2 chain ID when a specific chain is shown
+ */
+export interface QrCodeViewedProperties extends JsonMap {
+  location: string;
+  account_type: string;
+  chain_id_caip?: string;
+}
+
+type QrCodeViewedEventFactory<TEvent> = (event: IMetaMetricsEvent) => {
+  addProperties: (properties: QrCodeViewedProperties) => {
+    build: () => TEvent;
+  };
+};
+
+/**
+ * Track QR Code Viewed with the mobile analytics schema.
+ * Generic over the event type so callers using either MetricsEventBuilder
+ * (ITrackingEvent) or AnalyticsEventBuilder (AnalyticsTrackingEvent) are
+ * both accepted without a lossy union parameter.
+ *
+ * @param trackEvent - trackEvent function (MetaMetrics or useAnalytics)
+ * @param createEventBuilder - createEventBuilder function (MetricsEventBuilder or AnalyticsEventBuilder)
+ * @param properties - QR code view properties
+ */
+export const trackQrCodeViewed = <TEvent>(
+  trackEvent: (event: TEvent) => void,
+  createEventBuilder: QrCodeViewedEventFactory<TEvent>,
+  properties: QrCodeViewedProperties,
+): void => {
+  const { location, account_type, chain_id_caip } = properties;
+
+  trackEvent(
+    createEventBuilder(MetaMetricsEvents.QR_CODE_VIEWED)
+      .addProperties({
+        location,
+        account_type,
+        ...(chain_id_caip !== undefined && { chain_id_caip }),
+      })
+      .build(),
+  );
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds mobile instrumentation for the `QR Code Viewed` Segment event ([TMCU-444](https://consensyssoftware.atlassian.net/browse/TMCU-444)), aligned with the schema in [Consensys/segment-schema#604](https://github.com/Consensys/segment-schema/pull/604).

The event fires when a user opens a receive-address QR bottom sheet:

- **`ShareAddressQR`** (per-chain QR) from Address List (`location: address-list`) and Token Details Receive (`location: asset-details`), with optional `chain_id_caip`
- **`ShareAddress`** (account QR) from Account Details (`location: account-details`), without `chain_id_caip`

Implementation adds `QR_CODE_VIEWED` to MetaMetrics, a shared `trackQrCodeViewed` helper, and unit tests for the helper and both sheets.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-444

Related schema PR: https://github.com/Consensys/segment-schema/pull/604

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — analytics instrumentation only. Verified with unit tests:

```bash
yarn run jest app/util/analytics/qrCodeViewedTracking.test.ts app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx app/components/Views/MultichainAccounts/sheets/ShareAddress/ShareAddress.test.tsx app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
```

Optional manual verification (with analytics debugging enabled):

1. Open Account → Addresses → tap QR on a network row → confirm `QR Code Viewed` with `location: address-list` and `chain_id_caip`
2. Open Token Details → Receive → confirm `location: asset-details`
3. Open Account Details → tap account address → confirm `location: account-details` without `chain_id_caip`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no user-facing UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-444]: https://consensyssoftware.atlassian.net/browse/TMCU-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation with no user-facing behavior changes; navigation adds required params only on updated entry points covered by tests.
> 
> **Overview**
> Adds **QR Code Viewed** analytics when users open receive-address QR bottom sheets, aligned with the Segment schema (TMCU-444).
> 
> Registers `QR_CODE_VIEWED` in MetaMetrics and introduces shared helpers `trackQrCodeViewed` and `getQrCodeViewedAccountType` (EVM account type via `getAddressAccountType`, with safe fallback to keyring metadata for non-EVM). **`ShareAddress`** fires on mount with `location: account-details` and no `chain_id_caip`. **`ShareAddressQR`** fires with the passed-through `location`, optional CAIP chain id, and `account_type`.
> 
> Call sites now supply analytics context: Address List and Token Details Receive navigate to `ShareAddressQR` with `location` (`address-list` / `asset-details`) and the `InternalAccount`; `ShareAddressQRParams` types those fields as required. Unit tests cover the helper and both sheets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2c2559e6452f228159e64931af62fc4990ba45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
