### PR TITLE
feat(card): make MoneyAccount the default spending source on Card

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
@@ -350,7 +350,6 @@ describe('SpendingLimit Component', () => {
     canShowMoneyAccountCta: false,
     selectMoneyAccountAsSource: mockSelectMoneyAccountAsSource,
     moneyAccountTotalFiatFormatted: undefined as string | undefined,
-    isMoneyAccountBalanceLoading: false,
     canLinkMoneyAccount: true,
     moneyAccountApyPercent: 4 as number | undefined,
     hasMetalCard: false,
@@ -1173,7 +1172,7 @@ describe('SpendingLimit Component', () => {
       expect(mockSelectMoneyAccountAsSource).toHaveBeenCalledTimes(1);
     });
 
-    it('does NOT render the switch-back CTA when canShowMoneyAccountCta is false (e.g. balance is zero)', () => {
+    it('does NOT render the switch-back CTA when canShowMoneyAccountCta is false', () => {
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1223,7 +1222,7 @@ describe('SpendingLimit Component', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('renders the Money Account CTA in the enable flow when canShowMoneyAccountCta is true (NotEnabled token + funded)', () => {
+    it('renders the Money Account CTA in the enable flow when canShowMoneyAccountCta is true (NotEnabled token)', () => {
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1252,71 +1251,6 @@ describe('SpendingLimit Component', () => {
         screen.queryByTestId('use-money-account-cta'),
       ).not.toBeOnTheScreen();
       expect(screen.getByTestId('account-row')).toBeOnTheScreen();
-    });
-
-    it('shows the onboarding loading state while the Money Account balance is still resolving', () => {
-      mockUseSpendingLimitData.mockReturnValue({
-        availableTokens: [mockPriorityToken, mockMUSDToken],
-        delegationSettings: null,
-        isLoading: false,
-        error: null,
-        fetchData: mockFetchSpendingLimitData,
-      });
-      mockUseSpendingLimit.mockReturnValue({
-        ...getDefaultUseSpendingLimitMock(),
-        isMoneyAccountBalanceLoading: true,
-      });
-
-      render({ params: { flow: 'onboarding' } });
-
-      expect(
-        screen.getByTestId('spending-limit-loading-indicator'),
-      ).toBeOnTheScreen();
-      expect(screen.queryByTestId('account-row')).not.toBeOnTheScreen();
-    });
-
-    it('does not block the manage flow UI on the Money Account balance when the user cannot link a Money Account', () => {
-      mockUseSpendingLimit.mockReturnValue({
-        ...getDefaultUseSpendingLimitMock(),
-        isMoneyAccountBalanceLoading: true,
-        canLinkMoneyAccount: false,
-      });
-
-      render({ params: { flow: 'manage' } });
-
-      expect(
-        screen.queryByTestId('spending-limit-loading-indicator'),
-      ).not.toBeOnTheScreen();
-      expect(screen.getByTestId('account-row')).toBeOnTheScreen();
-    });
-
-    it('does NOT block the manage flow UI on the Money Account balance even when linking is possible', () => {
-      mockUseSpendingLimit.mockReturnValue({
-        ...getDefaultUseSpendingLimitMock(),
-        isMoneyAccountBalanceLoading: true,
-        canLinkMoneyAccount: true,
-      });
-
-      render({ params: { flow: 'manage' } });
-
-      expect(
-        screen.queryByTestId('spending-limit-loading-indicator'),
-      ).not.toBeOnTheScreen();
-      expect(screen.getByTestId('account-row')).toBeOnTheScreen();
-    });
-
-    it('shows the loading state on the enable_card flow while the Money Account balance is still resolving', () => {
-      mockUseSpendingLimit.mockReturnValue({
-        ...getDefaultUseSpendingLimitMock(),
-        isMoneyAccountBalanceLoading: true,
-        canLinkMoneyAccount: true,
-      });
-
-      render({ params: { flow: 'enable_card' } });
-
-      expect(
-        screen.getByTestId('spending-limit-loading-indicator'),
-      ).toBeOnTheScreen();
     });
 
     it('renders a pressable (NOT locked) Money Account row and hides the Token row on the enable_card flow when Money Account is the source', () => {

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -118,9 +118,6 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     isMoneyAccountLocked,
     canShowMoneyAccountCta,
     selectMoneyAccountAsSource,
-    moneyAccountTotalFiatFormatted,
-    isMoneyAccountBalanceLoading,
-    canLinkMoneyAccount,
     moneyAccountApyPercent,
   } = useSpendingLimit({
     flow,
@@ -166,12 +163,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     return customLimit || '0';
   }, [limitType, customLimit]);
 
-  const shouldWaitForMoneyAccountBalance =
-    (flow === 'onboarding' || flow === 'enable_card') && canLinkMoneyAccount;
-  if (
-    (isOnboardingFlow && isLoadingHookData) ||
-    (shouldWaitForMoneyAccountBalance && isMoneyAccountBalanceLoading)
-  ) {
+  if (isOnboardingFlow && isLoadingHookData) {
     return (
       <SafeAreaView
         style={tw.style('flex-1 bg-background-default')}

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -535,31 +535,7 @@ describe('useSpendingLimit', () => {
       expect(result.current.selectedToken?.symbol).toBe('mUSD');
     });
 
-    it('defaults to mUSD on Linea when all tokens have zero fiat balance', () => {
-      const musdToken = createMockToken({
-        symbol: 'mUSD',
-        address: '0xmusd',
-        caipChainId: LINEA_CAIP_CHAIN_ID,
-        fundingStatus: FundingStatus.NotEnabled,
-      });
-      const usdcToken = createMockToken({
-        symbol: 'USDC',
-        address: '0xusdc',
-        fundingStatus: FundingStatus.NotEnabled,
-      });
-
-      (useTokensWithBalance as jest.Mock).mockReturnValue([]);
-
-      const { result } = renderHook(() =>
-        useSpendingLimit(
-          createDefaultParams({ allTokens: [usdcToken, musdToken] }),
-        ),
-      );
-
-      expect(result.current.selectedToken?.symbol).toBe('mUSD');
-    });
-
-    it('falls back to first sorted token when mUSD on Linea is not present', () => {
+    it('falls back to the first sorted token when all balances are zero', () => {
       const usdcToken = createMockToken({
         symbol: 'USDC',
         address: '0xusdc',
@@ -1693,7 +1669,7 @@ describe('useSpendingLimit', () => {
       expect(result.current.canShowMoneyAccountCta).toBe(false);
     });
 
-    it('does NOT preselect Money Account when balance is zero', () => {
+    it('preselects Money Account on the onboarding flow even when balance is zero', () => {
       mockUseMoneyAccountCardLinkage.mockReturnValue(
         buildLinkageReturn({
           hasMoneyAccountRequirements: true,
@@ -1710,8 +1686,101 @@ describe('useSpendingLimit', () => {
         useSpendingLimit(createDefaultParams({ flow: 'onboarding' })),
       );
 
+      expect(result.current.isMoneyAccountSource).toBe(true);
+      expect(result.current.selectedToken).toEqual(MONEY_ACCOUNT_TOKEN);
+    });
+
+    it('preselects Money Account on the enable_card flow even when balance is zero', () => {
+      mockUseMoneyAccountCardLinkage.mockReturnValue(
+        buildLinkageReturn({
+          hasMoneyAccountRequirements: true,
+          isCardAuthenticated: true,
+          moneyAccountCardToken: MONEY_ACCOUNT_TOKEN,
+          canLink: true,
+        }),
+      );
+      mockUseMoneyAccountBalance.mockReturnValue(
+        buildBalanceReturn({ tokenTotal: new BigNumber(0) }),
+      );
+
+      const { result } = renderHook(() =>
+        useSpendingLimit(createDefaultParams({ flow: 'enable_card' })),
+      );
+
+      expect(result.current.isMoneyAccountSource).toBe(true);
+      expect(result.current.selectedToken).toEqual(MONEY_ACCOUNT_TOKEN);
+    });
+
+    it('preselects Money Account on the enable_card flow even when mUSD-on-Linea exists with zero balance', () => {
+      mockUseMoneyAccountCardLinkage.mockReturnValue(
+        buildLinkageReturn({
+          hasMoneyAccountRequirements: true,
+          isCardAuthenticated: true,
+          moneyAccountCardToken: MONEY_ACCOUNT_TOKEN,
+          canLink: true,
+        }),
+      );
+      mockUseMoneyAccountBalance.mockReturnValue(
+        buildBalanceReturn({ tokenTotal: new BigNumber(0) }),
+      );
+      const musdOnLinea = createMockToken({
+        symbol: 'mUSD',
+        address: '0xmusd',
+        caipChainId: LINEA_CAIP_CHAIN_ID,
+        fundingStatus: FundingStatus.NotEnabled,
+      });
+      const usdcToken = createMockToken({
+        symbol: 'USDC',
+        address: '0xusdc',
+        fundingStatus: FundingStatus.NotEnabled,
+      });
+
+      const { result } = renderHook(() =>
+        useSpendingLimit(
+          createDefaultParams({
+            flow: 'enable_card',
+            allTokens: [usdcToken, musdOnLinea],
+          }),
+        ),
+      );
+
+      expect(result.current.isMoneyAccountSource).toBe(true);
+      expect(result.current.selectedToken).toEqual(MONEY_ACCOUNT_TOKEN);
+    });
+
+    it('falls through to highest-balance selection when canLinkMoneyAccount is false on enable_card', () => {
+      mockUseMoneyAccountCardLinkage.mockReturnValue(
+        buildLinkageReturn({
+          moneyAccountCardToken: MONEY_ACCOUNT_TOKEN,
+          canLink: false,
+        }),
+      );
+      const usdcToken = createMockToken({
+        symbol: 'USDC',
+        address: '0xusdc',
+        fundingStatus: FundingStatus.NotEnabled,
+      });
+      const daiToken = createMockToken({
+        symbol: 'DAI',
+        address: '0xdai',
+        fundingStatus: FundingStatus.NotEnabled,
+      });
+      (useTokensWithBalance as jest.Mock).mockReturnValue([
+        { address: '0xusdc', chainId: '0xe708', tokenFiatAmount: 50 },
+        { address: '0xdai', chainId: '0xe708', tokenFiatAmount: 200 },
+      ]);
+
+      const { result } = renderHook(() =>
+        useSpendingLimit(
+          createDefaultParams({
+            flow: 'enable_card',
+            allTokens: [usdcToken, daiToken],
+          }),
+        ),
+      );
+
       expect(result.current.isMoneyAccountSource).toBe(false);
-      expect(result.current.canShowMoneyAccountCta).toBe(false);
+      expect(result.current.selectedToken?.symbol).toBe('DAI');
     });
 
     it('locks the manage flow to Money Account when the priority token has isMoneyAccountEntry (even with zero balance)', () => {
@@ -1821,7 +1890,7 @@ describe('useSpendingLimit', () => {
       expect(result.current.canShowMoneyAccountCta).toBe(false);
     });
 
-    it('shows the Money Account CTA in the enable flow when the initial token is NotEnabled and Money Account is funded', () => {
+    it('shows the Money Account CTA in the enable flow when the initial token is NotEnabled', () => {
       setupFunded();
       const initialToken = createMockToken({
         symbol: 'USDC',

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -100,7 +100,6 @@ export interface UseSpendingLimitReturn {
   canShowMoneyAccountCta: boolean;
   selectMoneyAccountAsSource: () => void;
   moneyAccountTotalFiatFormatted: string | undefined;
-  isMoneyAccountBalanceLoading: boolean;
   canLinkMoneyAccount: boolean;
   moneyAccountApyPercent: number | undefined;
   hasMetalCard: boolean;
@@ -180,12 +179,9 @@ const useSpendingLimit = ({
     canLink: canLinkMoneyAccount,
   } = useMoneyAccountCardLinkage();
   const {
-    tokenTotal: moneyAccountTokenTotal,
     totalFiatFormatted: moneyAccountTotalFiatFormatted,
-    isAggregatedBalanceLoading: isMoneyAccountBalanceLoading,
     apyPercent: moneyAccountApyPercent,
   } = useMoneyAccountBalance();
-  const isMoneyAccountFunded = Boolean(moneyAccountTokenTotal?.gt(0));
 
   const { data: cardHomeData } = useCardHomeData();
   const hasMetalCard = cardHomeData?.card?.type === CardType.METAL;
@@ -362,17 +358,13 @@ const useSpendingLimit = ({
     if (
       isMoneyAccountPreselectAllowed &&
       canLinkMoneyAccount &&
-      !hasUserExitedMoneyAccountSourceRef.current
+      !hasUserExitedMoneyAccountSourceRef.current &&
+      moneyAccountCardToken
     ) {
-      if (isMoneyAccountBalanceLoading) {
-        return;
-      }
-      if (isMoneyAccountFunded && moneyAccountCardToken) {
-        setIsMoneyAccountSource(true);
-        applySelectedToken(moneyAccountCardToken);
-        setHasInitialized(true);
-        return;
-      }
+      setIsMoneyAccountSource(true);
+      applySelectedToken(moneyAccountCardToken);
+      setHasInitialized(true);
+      return;
     }
 
     if (!selectedToken && priorityToken) {
@@ -416,15 +408,7 @@ const useSpendingLimit = ({
           return { token, fiat: walletToken?.tokenFiatAmount ?? 0 };
         })
         .sort((a, b) => b.fiat - a.fiat);
-      const topEntry = sorted[0];
-      const defaultToken =
-        topEntry.fiat > 0
-          ? topEntry.token
-          : (tokensToSearch.find(
-              (t) =>
-                t.symbol?.toUpperCase() === 'MUSD' &&
-                t.caipChainId === LINEA_CAIP_CHAIN_ID,
-            ) ?? topEntry.token);
+      const defaultToken = sorted[0]?.token;
       if (defaultToken) {
         applySelectedToken(defaultToken);
         setHasInitialized(true);
@@ -443,8 +427,6 @@ const useSpendingLimit = ({
     isManageFlow,
     isMoneyAccountPreselectAllowed,
     canLinkMoneyAccount,
-    isMoneyAccountBalanceLoading,
-    isMoneyAccountFunded,
     moneyAccountCardToken,
   ]);
 
@@ -554,7 +536,6 @@ const useSpendingLimit = ({
   const canShowMoneyAccountCta =
     (isOnboardingLikeFlow || isEnablingNotEnabledToken) &&
     !isMoneyAccountSource &&
-    isMoneyAccountFunded &&
     canLinkMoneyAccount;
 
   const isMoneyAccountLocked = Boolean(
@@ -787,7 +768,6 @@ const useSpendingLimit = ({
     canShowMoneyAccountCta,
     selectMoneyAccountAsSource,
     moneyAccountTotalFiatFormatted,
-    isMoneyAccountBalanceLoading,
     canLinkMoneyAccount,
     moneyAccountApyPercent,
     hasMetalCard,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Reason for the change:** Previously, the Money Account was only preselected as the Card spending source when it already had a non-zero balance. New and unfunded users were instead defaulted to a token-based source, which hid the Money Account behind a balance requirement and forced an extra step (and a balance-loading gate) before they could use it. This also meant the spending limit screen blocked rendering on the onboarding / enable-card flows while the Money Account balance was still resolving.

**Improvement/solution:** Make the Money Account the default spending source on the `onboarding` and `enable_card` flows regardless of its balance, as long as the user can link a Money Account (`canLinkMoneyAccount`) and hasn't explicitly opted out. As a result:

- Money Account is now preselected even when its balance is zero (it only requires a valid `moneyAccountCardToken`).
- Removed the `isMoneyAccountFunded` / balance-loading dependency from the preselect logic, the `canShowMoneyAccountCta` gate, and the screen-level loading gate, so the UI no longer waits on the Money Account balance to render.
- Removed the now-unused `isMoneyAccountBalanceLoading` field from `UseSpendingLimitReturn` and its consumer in `SpendingLimit.tsx`.
- Simplified the zero-balance token fallback to the first sorted token (dropped the special-case mUSD-on-Linea fallback, which is now superseded by the Money Account default).
- When `canLinkMoneyAccount` is false, the flow still falls through to the highest-balance token selection as before.

Tests in `useSpendingLimit.test.ts` and `SpendingLimit.test.tsx` were updated to cover the new zero-balance preselect behavior and to remove the obsolete balance-loading and funded-only assertions.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Made the Money Account the default spending source on the Card onboarding and enable-card flows, even before it is funded.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: CARD-427

<!-- Tracked by Jira ticket CARD-427. No matching GitHub issue found. -->

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account default spending source on Card

  Scenario: New user with an empty Money Account onboards to Card
    Given the user can link a Money Account
    And the user's Money Account balance is zero
    When the user opens the Card spending limit screen on the onboarding flow
    Then the spending limit screen renders without waiting on the Money Account balance
    And the Money Account is preselected as the spending source

  Scenario: User enables a NotEnabled token via the enable_card flow
    Given the user can link a Money Account
    And the user's Money Account balance is zero
    When the user opens the spending limit screen on the enable_card flow
    Then the Money Account is preselected as the spending source

  Scenario: User cannot link a Money Account
    Given the user cannot link a Money Account
    And the user holds multiple funded tokens
    When the user opens the spending limit screen on the enable_card flow
    Then the highest-balance token is selected as the spending source
    And the Money Account is not preselected

  Scenario: User opts out of the Money Account source
    Given the Money Account is preselected as the spending source
    When the user switches to a token-based source
    Then the Money Account is no longer reselected on subsequent renders
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default funding source and promo CTA visibility for onboarding/enable_card flows; incorrect preselect when linkage is mis-detected could steer users to Money Account before they intend to use tokens.
> 
> **Overview**
> **Money Account becomes the default Card spending source** on `onboarding` and `enable_card` when the user can link (`canLinkMoneyAccount`) and has a `moneyAccountCardToken`, **without requiring a positive balance** or waiting on balance aggregation.
> 
> In **`useSpendingLimit`**, preselect no longer gates on `isMoneyAccountFunded` or `isMoneyAccountBalanceLoading`; **`canShowMoneyAccountCta`** no longer requires a funded account; the hook API drops **`isMoneyAccountBalanceLoading`**. Zero-balance token fallback is simplified to the **first fiat-sorted token** (the special **mUSD-on-Linea** default is removed).
> 
> **`SpendingLimit`** only blocks on onboarding **token/delegation** loading—not Money Account balance—so **`enable_card`** no longer shows a balance-driven loading gate.
> 
> Tests are updated for zero-balance preselect, unlink fallback, and removed balance-loading UI cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31458f41cbad5515849d41f030f0bfd462b22c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->