### PR TITLE
refactor(perps): migrate Text to MMDS in bottom sheets and market components (pt2)

### DIFF
--- a/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.tsx
@@ -1,10 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -18,7 +14,13 @@ import {
   PERPS_EVENT_VALUE,
 } from '@metamask/perps-controller';
 import { getPerpsCandlePeriodBottomSheetSelector } from '../../Perps.testIds';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import styleSheet from './PerpsCandlePeriodBottomSheet.styles';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
@@ -127,7 +129,7 @@ const PerpsCandlePeriodBottomSheet: React.FC<
       testID={testID}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.chart.candle_intervals')}
         </Text>
       </BottomSheetHeader>
@@ -139,8 +141,9 @@ const PerpsCandlePeriodBottomSheet: React.FC<
               style={sectionIndex > 0 ? styles.sectionSpacing : undefined}
             >
               <Text
-                variant={TextVariant.BodyMDBold}
-                color={TextColor.Alternative}
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Bold}
+                color={TextColor.TextAlternative}
                 style={styles.sectionTitle}
               >
                 {section.title}
@@ -167,13 +170,13 @@ const PerpsCandlePeriodBottomSheet: React.FC<
                     <Text
                       variant={
                         selectedPeriod === period.value
-                          ? TextVariant.BodyMDBold
-                          : TextVariant.BodySMMedium
+                          ? TextVariant.BodyMd
+                          : TextVariant.BodySm
                       }
                       color={
                         selectedPeriod === period.value
-                          ? TextColor.Inverse
-                          : TextColor.Default
+                          ? TextColor.PrimaryInverse
+                          : TextColor.TextDefault
                       }
                     >
                       {period.label}
@@ -205,13 +208,13 @@ const PerpsCandlePeriodBottomSheet: React.FC<
                 <Text
                   variant={
                     selectedPeriod === period.value
-                      ? TextVariant.BodyMDBold
-                      : TextVariant.BodySMMedium
+                      ? TextVariant.BodyMd
+                      : TextVariant.BodySm
                   }
                   color={
                     selectedPeriod === period.value
-                      ? TextColor.Inverse
-                      : TextColor.Default
+                      ? TextColor.PrimaryInverse
+                      : TextColor.TextDefault
                   }
                 >
                   {period.label}

--- a/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlestickChartIntervalSelector/PerpsCandlestickChartIntervalSelector.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, ScrollView } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { CANDLE_PERIODS, CandlePeriod } from '@metamask/perps-controller';
 import { PERPS_CHART_CONFIG } from '../../constants/chartConfig';
 import { selectorStyleSheet } from './PerpsCandlestickChartIntervalSelector.styles.ts';
@@ -43,11 +44,11 @@ const PerpsCandlestickChartIntervalSelector: React.FC<
           testID={`${testID}-${interval.value}`}
         >
           <Text
-            variant={TextVariant.BodySM}
+            variant={TextVariant.BodySm}
             color={
               selectedInterval === interval.value
-                ? TextColor.Default
-                : TextColor.Muted
+                ? TextColor.TextDefault
+                : TextColor.TextMuted
             }
             style={[
               styles.intervalTabText,

--- a/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.tsx
+++ b/app/components/UI/Perps/components/PerpsCompactOrderRow/PerpsCompactOrderRow.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
   formatPositionSize,
@@ -85,10 +86,10 @@ const PerpsCompactOrderRow: React.FC<PerpsCompactOrderRowProps> = ({
 
         {/* Order info */}
         <View style={styles.infoContainer}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {orderInfo.orderTypeDisplay}
           </Text>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {orderInfo.formattedSize} {orderInfo.symbol}
           </Text>
         </View>
@@ -96,15 +97,15 @@ const PerpsCompactOrderRow: React.FC<PerpsCompactOrderRowProps> = ({
 
       <View style={styles.rightSection}>
         <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Default}
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextDefault}
           style={styles.priceText}
         >
           {orderInfo.formattedPrice}
         </Text>
         <Text
-          variant={TextVariant.BodySM}
-          color={TextColor.Alternative}
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
           style={styles.labelText}
         >
           {orderInfo.orderTypeLabel}

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
@@ -247,27 +247,10 @@ jest.mock(
 );
 
 // Mock component library Text component
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: (props: { children: React.ReactNode }) => (
-      <Text {...props}>{props.children}</Text>
-    ),
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodyMD: 'BodyMD',
-      BodyLGMedium: 'BodyLGMedium',
-      BodySM: 'BodySM',
-    },
-    TextColor: {
-      Default: 'Default',
-      Alternative: 'Alternative',
-      Error: 'Error',
-      Inverse: 'Inverse',
-    },
-  };
-});
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 // Mock Button enums
 jest.mock('../../../../../component-library/components/Buttons/Button', () => ({

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, memo } from 'react';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
 import { TouchableOpacity, View, Animated } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -11,9 +12,6 @@ import {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
 import Keypad from '../../../../Base/Keypad';
 import {
@@ -336,7 +334,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
       onClose={onClose}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.order.limit_price_modal.title')}
         </Text>
       </BottomSheetHeader>
@@ -390,7 +388,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
               }
             }}
           >
-            <Text variant={TextVariant.BodyMD}>
+            <Text variant={TextVariant.BodyMd}>
               {strings('perps.order.limit_price_modal.mid_price')}
             </Text>
           </TouchableOpacity>
@@ -415,7 +413,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
                   }
                 }}
               >
-                <Text variant={TextVariant.BodyMD}>
+                <Text variant={TextVariant.BodyMd}>
                   {strings('perps.order.limit_price_modal.bid_price')}
                 </Text>
               </TouchableOpacity>
@@ -442,7 +440,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
                     }
                   }}
                 >
-                  <Text variant={TextVariant.BodyMD}>
+                  <Text variant={TextVariant.BodyMd}>
                     {percentage > 0 ? '+' : ''}
                     {percentage}%
                   </Text>
@@ -469,7 +467,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
                   }
                 }}
               >
-                <Text variant={TextVariant.BodyMD}>
+                <Text variant={TextVariant.BodyMd}>
                   {strings('perps.order.limit_price_modal.ask_price')}
                 </Text>
               </TouchableOpacity>
@@ -496,7 +494,7 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
                     }
                   }}
                 >
-                  <Text variant={TextVariant.BodyMD}>
+                  <Text variant={TextVariant.BodyMd}>
                     {percentage > 0 ? '+' : ''}
                     {percentage}%
                   </Text>

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -8,14 +8,18 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-} from '@metamask/design-system-react-native';
-import Text, {
+  Text,
   TextVariant,
+  FontWeight,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
 import SensitiveText, {
   SensitiveTextLength,
 } from '../../../../../component-library/components/Texts/SensitiveText';
+import {
+  TextVariant as LegacyTextVariant,
+  TextColor as LegacyTextColor,
+} from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useColorPulseAnimation, useBalanceComparison } from '../../hooks';
@@ -217,16 +221,17 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
           <Box twClassName="p-4">
             <Box twClassName="w-full flex-row justify-between">
               <Text
-                variant={TextVariant.BodySMMedium}
-                color={TextColor.Default}
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
               >
                 {statusText}
               </Text>
               {/* Only show dollar value when there's a single transaction in progress */}
               {shouldShowDollarAmount && (
                 <SensitiveText
-                  variant={TextVariant.BodySMMedium}
-                  color={TextColor.Default}
+                  variant={LegacyTextVariant.BodySM}
+                  color={LegacyTextColor.Default}
                   isHidden={privacyMode}
                   length={SensitiveTextLength.Short}
                 >
@@ -285,8 +290,8 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
             <Box twClassName="px-4 pt-2 pb-4">
               <Animated.View style={[getBalanceAnimatedStyle]}>
                 <SensitiveText
-                  variant={TextVariant.DisplayLG}
-                  color={TextColor.Default}
+                  variant={LegacyTextVariant.DisplayLG}
+                  color={LegacyTextColor.Default}
                   testID={PerpsMarketBalanceActionsSelectorsIDs.BALANCE_VALUE}
                   isHidden={privacyMode}
                   length={SensitiveTextLength.Medium}
@@ -302,16 +307,16 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
                 }
               >
                 <SensitiveText
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={LegacyTextVariant.BodyMD}
+                  color={LegacyTextColor.Alternative}
                   isHidden={privacyMode}
                   length={SensitiveTextLength.Short}
                 >
                   {formatPerpsBalance(spendableBalance)}
                 </SensitiveText>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {' '}
                   {strings('perps.available')}

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import { PerpsMarketHeaderSelectorsIDs } from '../../Perps.testIds';
 import ButtonIcon, {
@@ -9,10 +14,6 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
   getPerpsDisplaySymbol,
@@ -70,8 +71,8 @@ const PerpsMarketHeader: React.FC<PerpsMarketHeaderProps> = ({
       <View style={styles.leftSection}>
         <View style={styles.assetRow}>
           <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Default}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
             style={styles.assetName}
           >
             {getPerpsDisplaySymbol(market.symbol)}-USD

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from 'react';
-import { View } from 'react-native';
-import { FlashList } from '@shopify/flash-list';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { View } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
 import PerpsMarketRowItem from '../PerpsMarketRowItem';
@@ -66,7 +67,7 @@ const PerpsMarketList: React.FC<PerpsMarketListProps> = ({
   const renderEmpty = useCallback(
     () => (
       <View style={styles.emptyContainer} testID={`${testID}-empty`}>
-        <Text variant={TextVariant.BodyMD} color={TextColor.Muted}>
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextMuted}>
           {emptyMessage}
         </Text>
       </View>

--- a/app/components/UI/Perps/components/PerpsMarketListHeader/PerpsMarketListHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketListHeader/PerpsMarketListHeader.test.tsx
@@ -60,22 +60,6 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => {
   };
 });
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: Text,
-    TextVariant: {
-      BodyMD: 'BodyMD',
-      HeadingLG: 'HeadingLG',
-      HeadingMD: 'HeadingMD',
-    },
-    TextColor: {
-      Default: 'Default',
-    },
-  };
-});
-
 jest.mock('../../../../../component-library/hooks', () => ({
   useStyles: () => ({
     styles: {

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -1,16 +1,16 @@
 import React, { useMemo } from 'react';
 import { getPerpsMarketRowItemSelector } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
   Card,
+  Text,
+  TextVariant,
+  FontWeight,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import {
   PERPS_CONSTANTS,
@@ -182,7 +182,11 @@ const PerpsMarketRowItem = ({
             alignItems={BoxAlignItems.Center}
             gap={2}
           >
-            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
               {getPerpsDisplaySymbol(displayMarket.symbol)}
             </Text>
             <PerpsLeverage maxLeverage={displayMarket.maxLeverage} />
@@ -196,8 +200,8 @@ const PerpsMarketRowItem = ({
             twClassName="mt-0.5"
           >
             <Text
-              variant={TextVariant.BodySM}
-              color={TextColor.Alternative}
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
               numberOfLines={1}
             >
               {displayText}
@@ -221,12 +225,18 @@ const PerpsMarketRowItem = ({
         gap={1}
         twClassName="flex-1"
       >
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+        >
           {displayMarket.price}
         </Text>
         <Text
-          variant={TextVariant.BodySM}
-          color={isPositiveChange ? TextColor.Success : TextColor.Error}
+          variant={TextVariant.BodySm}
+          color={
+            isPositiveChange ? TextColor.SuccessDefault : TextColor.ErrorDefault
+          }
         >
           {displayMarket.change24hPercent}
         </Text>

--- a/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
@@ -21,26 +21,13 @@ jest.mock('../../../../../component-library/hooks', () => ({
 jest.mock('@metamask/design-system-react-native', () => {
   const { View } = jest.requireActual('react-native');
   return {
+    ...jest.requireActual('@metamask/design-system-react-native'),
     Box: View,
+    Text: jest.requireActual('react-native').Text,
   };
 });
 
 // Mock component-library Text component
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ children, ...props }: { children?: React.ReactNode }) => (
-      <Text {...props}>{children}</Text>
-    ),
-    TextColor: {
-      Default: 'Default',
-    },
-    TextVariant: {
-      BodySM: 'BodySM',
-    },
-  };
-});
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string) => {

--- a/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
 import { Pressable } from 'react-native';
-import { Box } from '@metamask/design-system-react-native';
-import Text, {
-  TextColor,
+import {
+  Box,
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
 import Icon, {
@@ -61,7 +62,7 @@ const PerpsMarketSortDropdowns: React.FC<PerpsMarketSortDropdownsProps> = ({
         onPress={onSortPress}
         testID={`${testID}-sort-field`}
       >
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {sortLabel}
         </Text>
         <Icon

--- a/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortFieldBottomSheet/PerpsMarketSortFieldBottomSheet.tsx
@@ -1,10 +1,12 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import { TouchableOpacity, View } from 'react-native';
-import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
+import {
+  FontWeight,
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { TouchableOpacity, View } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
 import Icon, {
   IconName,
   IconSize,
@@ -124,7 +126,7 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
       testID={testID}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.sort.sort_by')}
         </Text>
       </BottomSheetHeader>
@@ -140,7 +142,7 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
               onPress={() => handleOptionPress(option.id)}
               testID={testID ? `${testID}-option-${option.id}` : undefined}
             >
-              <Text variant={TextVariant.BodyMD}>
+              <Text variant={TextVariant.BodyMd}>
                 {strings(option.labelKey)}
               </Text>
               {isSelected && (
@@ -149,8 +151,9 @@ const PerpsMarketSortFieldBottomSheet: React.FC<
                   testID={testID ? `${testID}-direction-indicator` : undefined}
                 >
                   <Text
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                    color={TextColor.TextAlternative}
                     testID={testID ? `${testID}-direction-text` : undefined}
                   >
                     {sortDirection === 'asc'

--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.test.tsx
@@ -10,6 +10,10 @@ const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockCanGoBack = jest.fn();
 
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
   return {

--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
@@ -1,4 +1,13 @@
 import React, { useMemo } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import {
+  TextVariant as LegacyTextVariant,
+  TextColor as LegacyTextColor,
+} from '../../../../../component-library/components/Texts/Text';
 import { TouchableOpacity, View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Icon, {
@@ -6,10 +15,6 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import KeyValueRow from '../../../../../component-library/components-temp/KeyValueRow';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './PerpsMarketStatisticsCard.styles';
@@ -76,7 +81,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
     }
 
     // Determine color based on value
-    const color = fundingValue >= 0 ? TextColor.Success : TextColor.Error;
+    const color =
+      fundingValue >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault;
 
     return {
       value: fundingValue,
@@ -89,12 +95,12 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
   const fundingValueContent = useMemo(
     () => (
       <View style={styles.fundingRateContainer}>
-        <Text variant={TextVariant.BodyMD} color={fundingRateData.color}>
+        <Text variant={TextVariant.BodyMd} color={fundingRateData.color}>
           {fundingRateData.displayText}
         </Text>
         <FundingCountdown
-          variant={TextVariant.BodySM}
-          color={TextColor.Alternative}
+          variant={LegacyTextVariant.BodySM}
+          color={LegacyTextColor.Alternative}
           style={styles.fundingCountdown}
           nextFundingTime={nextFundingTime}
           fundingIntervalHours={fundingIntervalHours}
@@ -117,7 +123,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
     <View style={styles.container}>
       {/* Header with title with DEX badge */}
       <View style={styles.header}>
-        <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+        <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
           {strings('perps.market.stats')}
         </Text>
         {dexName && <Tag label={dexName.toUpperCase()} style={styles.dexTag} />}
@@ -133,7 +139,10 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             testID={PerpsOrderBookViewSelectorsIDs.CONTAINER}
           >
             <View style={styles.orderBookRowContent}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.market.order_book')}
               </Text>
             </View>
@@ -150,15 +159,15 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
           field={{
             label: {
               text: strings('perps.market.24h_volume'),
-              variant: TextVariant.BodyMD,
-              color: TextColor.Alternative,
+              variant: LegacyTextVariant.BodyMD,
+              color: TextColor.TextAlternative,
             },
           }}
           value={{
             label: {
               text: marketStats.volume24h,
-              variant: TextVariant.BodyMD,
-              color: TextColor.Default,
+              variant: LegacyTextVariant.BodyMD,
+              color: TextColor.TextDefault,
             },
           }}
           style={[styles.statsRow, !onOrderBookPress && styles.statsRowFirst]}
@@ -170,8 +179,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             label: (
               <View style={styles.labelWithIcon}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.market.open_interest')}
                 </Text>
@@ -191,8 +200,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
           value={{
             label: {
               text: marketStats.openInterest,
-              variant: TextVariant.BodyMD,
-              color: TextColor.Default,
+              variant: LegacyTextVariant.BodyMD,
+              color: TextColor.TextDefault,
             },
           }}
           style={styles.statsRow}
@@ -204,8 +213,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             label: (
               <View style={styles.labelWithIcon}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.market.funding_rate')}
                 </Text>
@@ -234,8 +243,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             label: (
               <View style={styles.labelWithIcon}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.market.oracle_price')}
                 </Text>
@@ -255,8 +264,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
           value={{
             label: (
               <Text
-                variant={TextVariant.BodyMD}
-                color={TextColor.Default}
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
                 testID={
                   PerpsMarketDetailsViewSelectorsIDs.STATISTICS_ORACLE_PRICE
                 }

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.test.tsx
@@ -10,6 +10,10 @@ import {
 
 const mockNavigate = jest.fn();
 
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
@@ -5,11 +5,12 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
-import { useNavigation } from '@react-navigation/native';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { useNavigation } from '@react-navigation/native';
 import Icon, {
   IconName,
   IconSize,
@@ -126,13 +127,13 @@ const OrdersTabContent = React.memo<OrdersTabContentProps>(
             <Icon
               name={IconName.Book}
               size={IconSize.Xl}
-              color={TextColor.Muted}
+              color={TextColor.TextMuted}
               style={styles.emptyStateIcon}
               testID={PerpsMarketTabsSelectorsIDs.ORDERS_EMPTY_ICON}
             />
             <Text
-              variant={TextVariant.BodyMD}
-              color={TextColor.Muted}
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextMuted}
               style={styles.emptyStateText}
               testID={PerpsMarketTabsSelectorsIDs.ORDERS_EMPTY_TEXT}
             >
@@ -760,8 +761,8 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
     return (
       <View style={styles.singleTabContainer}>
         <Text
-          variant={TextVariant.HeadingSM}
-          color={TextColor.Default}
+          variant={TextVariant.HeadingSm}
+          color={TextColor.TextDefault}
           style={styles.statisticsTitle}
           testID={PerpsMarketTabsSelectorsIDs.STATISTICS_ONLY_TITLE}
         >

--- a/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
@@ -89,32 +89,16 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
 }));
 
 // Mock Text component
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const ReactModule = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: function MockText({ children }: { children: React.ReactNode }) {
-      return ReactModule.createElement(Text, null, children);
-    },
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodyMDBold: 'BodyMDBold',
-      BodySM: 'BodySM',
-    },
-    TextColor: {
-      Alternative: 'Alternative',
-    },
-  };
-});
 
 // Mock Box component
 jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
   Box: function MockBox({ children }: { children: React.ReactNode }) {
     const ReactModule = jest.requireActual('react');
     const { View } = jest.requireActual('react-native');
     return ReactModule.createElement(View, null, children);
   },
+  Text: jest.requireActual('react-native').Text,
 }));
 
 describe('PerpsModifyActionSheet', () => {

--- a/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.tsx
@@ -1,10 +1,6 @@
 import React, { useRef, useEffect, useCallback } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -13,7 +9,13 @@ import Icon, {
   IconSize,
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import styleSheet from './PerpsModifyActionSheet.styles';
 import type { ModifyAction } from './PerpsModifyActionSheet.types';
@@ -108,7 +110,7 @@ const PerpsModifyActionSheet: React.FC<PerpsModifyActionSheetProps> = ({
       testID={testID}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.modify.title')}
         </Text>
       </BottomSheetHeader>
@@ -131,8 +133,13 @@ const PerpsModifyActionSheet: React.FC<PerpsModifyActionSheetProps> = ({
               />
             </View>
             <View style={styles.actionTextContainer}>
-              <Text variant={TextVariant.BodyMDBold}>{option.label}</Text>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
+                {option.label}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {option.description}
               </Text>
             </View>

--- a/app/components/UI/Perps/components/PerpsNotificationBottomSheet/PerpsNotificationBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsNotificationBottomSheet/PerpsNotificationBottomSheet.tsx
@@ -3,14 +3,13 @@ import { View } from 'react-native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
@@ -64,13 +63,13 @@ const PerpsNotificationBottomSheet: React.FC<
     >
       <View style={styles.container}>
         <View style={styles.header}>
-          <Text variant={TextVariant.HeadingMD} style={styles.title}>
+          <Text variant={TextVariant.HeadingSm} style={styles.title}>
             {strings('perps.tooltips.notifications.title')}
           </Text>
         </View>
         <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Alternative}
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
           style={styles.description}
         >
           {strings('perps.tooltips.notifications.description')}

--- a/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
+++ b/app/components/UI/Perps/components/PerpsOHLCVBar/PerpsOHLCVBar.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo } from 'react';
+import { Text, TextColor } from '@metamask/design-system-react-native';
 import { View } from 'react-native';
-import Text, {
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import {
   formatPerpsFiat,
@@ -90,7 +88,7 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
         <View style={styles.column}>
           <Text
             style={styles.valueText}
-            color={TextColor.Default}
+            color={TextColor.TextDefault}
             numberOfLines={1}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
@@ -101,7 +99,7 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
         <View style={styles.column}>
           <Text
             style={styles.valueText}
-            color={TextColor.Default}
+            color={TextColor.TextDefault}
             numberOfLines={1}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
@@ -112,7 +110,7 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
         <View style={styles.column}>
           <Text
             style={styles.valueText}
-            color={TextColor.Default}
+            color={TextColor.TextDefault}
             numberOfLines={1}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
@@ -123,7 +121,7 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
         <View style={styles.column}>
           <Text
             style={styles.valueText}
-            color={TextColor.Default}
+            color={TextColor.TextDefault}
             numberOfLines={1}
             adjustsFontSizeToFit
             minimumFontScale={0.7}
@@ -135,7 +133,7 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
           <View style={styles.column}>
             <Text
               style={styles.valueText}
-              color={TextColor.Default}
+              color={TextColor.TextDefault}
               numberOfLines={1}
               adjustsFontSizeToFit
               minimumFontScale={0.7}
@@ -149,28 +147,28 @@ const PerpsOHLCVBar: React.FC<PerpsOHLCVBarProps> = ({
       {/* Labels Row */}
       <View style={styles.labelsRow}>
         <View style={styles.column}>
-          <Text style={styles.labelText} color={TextColor.Alternative}>
+          <Text style={styles.labelText} color={TextColor.TextAlternative}>
             {strings('perps.chart.ohlc.open')}
           </Text>
         </View>
         <View style={styles.column}>
-          <Text style={styles.labelText} color={TextColor.Alternative}>
+          <Text style={styles.labelText} color={TextColor.TextAlternative}>
             {strings('perps.chart.ohlc.close')}
           </Text>
         </View>
         <View style={styles.column}>
-          <Text style={styles.labelText} color={TextColor.Alternative}>
+          <Text style={styles.labelText} color={TextColor.TextAlternative}>
             {strings('perps.chart.ohlc.high')}
           </Text>
         </View>
         <View style={styles.column}>
-          <Text style={styles.labelText} color={TextColor.Alternative}>
+          <Text style={styles.labelText} color={TextColor.TextAlternative}>
             {strings('perps.chart.ohlc.low')}
           </Text>
         </View>
         {formattedValues.volume && (
           <View style={styles.column}>
-            <Text style={styles.labelText} color={TextColor.Alternative}>
+            <Text style={styles.labelText} color={TextColor.TextAlternative}>
               {strings('perps.chart.ohlc.volume')}
             </Text>
           </View>

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
@@ -4,11 +4,10 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Text, {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
@@ -208,7 +207,7 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
         <View style={styles.headerLeft}>
           <View style={styles.headerRow}>
             {/* Show order type or direction */}
-            <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+            <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
               {order.detailedOrderType === 'Limit'
                 ? derivedData.direction
                 : order.detailedOrderType || derivedData.direction}
@@ -221,8 +220,8 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                     style={[styles.activeChartIndicator, styles.tpIndicator]}
                   >
                     <Text
-                      variant={TextVariant.BodyXS}
-                      color={TextColor.Inverse}
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.PrimaryInverse}
                     >
                       {strings('perps.tp_on_chart')}
                     </Text>
@@ -233,8 +232,8 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                     style={[styles.activeChartIndicator, styles.slIndicator]}
                   >
                     <Text
-                      variant={TextVariant.BodyXS}
-                      color={TextColor.Default}
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextDefault}
                     >
                       {strings('perps.sl_on_chart')}
                     </Text>
@@ -253,8 +252,8 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                     style={styles.fillBadgeIcon}
                   />
                   <Text
-                    variant={TextVariant.BodyXS}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodyXs}
+                    color={TextColor.TextAlternative}
                   >
                     {derivedData.fillPercentage.toFixed(0)}%{' '}
                     {strings('perps.order.filled')}
@@ -262,20 +261,20 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                 </View>
               )}
           </View>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {formatOrderCardDate(order.timestamp)}
           </Text>
         </View>
 
         <View style={styles.headerRight}>
           <View style={styles.headerRow}>
-            <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+            <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
               {formatPerpsFiat(derivedData.sizeInUSD, {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
               })}
             </Text>
           </View>
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {formatPositionSize(order.originalSize)}{' '}
             {getPerpsDisplaySymbol(order.symbol)}
           </Text>
@@ -292,12 +291,15 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
         <View style={styles.body}>
           <View style={styles.bodyRow}>
             <View style={styles.bodyItem}>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {order.isTrigger
                   ? strings('perps.order.trigger_price')
                   : strings('perps.order.limit_price')}
               </Text>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {formatPerpsFiat(order.price, {
                   ranges: PRICE_RANGES_UNIVERSAL,
                 })}
@@ -308,12 +310,15 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
               <>
                 <View style={styles.bodyItem}>
                   <Text
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
                   >
                     {strings('perps.order.take_profit')}
                   </Text>
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {order.takeProfitPrice !== undefined &&
                     order.takeProfitPrice !== null
                       ? formatPerpsFiat(order.takeProfitPrice, {
@@ -324,12 +329,15 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                 </View>
                 <View style={styles.bodyItem}>
                   <Text
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Alternative}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
                   >
                     {strings('perps.order.stop_loss')}
                   </Text>
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {order.stopLossPrice !== undefined &&
                     order.stopLossPrice !== null
                       ? formatPerpsFiat(order.stopLossPrice, {
@@ -344,12 +352,15 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
             {order.isTrigger && order.reduceOnly && (
               <View style={[styles.bodyItem, styles.bodyItemReduceOnly]}>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.order.reduce_only')}
                 </Text>
-                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                >
                   {strings('perps.order.yes')}
                 </Text>
               </View>

--- a/app/components/UI/Perps/components/PerpsOrderBookDepthChart/PerpsOrderBookDepthChart.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderBookDepthChart/PerpsOrderBookDepthChart.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { View } from 'react-native';
 import Svg, { Path, Defs, LinearGradient, Stop } from 'react-native-svg';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../hooks/useStyles';
 import type { OrderBookData } from '../../hooks/stream/usePerpsLiveOrderBook';
 import styleSheet from './PerpsOrderBookDepthChart.styles';
@@ -135,13 +136,13 @@ const PerpsOrderBookDepthChart: React.FC<PerpsOrderBookDepthChartProps> = ({
       <View style={styles.legendContainer}>
         <View style={styles.legendItem}>
           <View style={[styles.legendDot, styles.bidDot]} />
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('perps.order_book.bids')}
           </Text>
         </View>
         <View style={styles.legendItem}>
           <View style={[styles.legendDot, styles.askDot]} />
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('perps.order_book.asks')}
           </Text>
         </View>
@@ -208,10 +209,10 @@ const PerpsOrderBookDepthChart: React.FC<PerpsOrderBookDepthChartProps> = ({
 
       {/* Price labels - min and max only, no mid-price */}
       <View style={styles.labelContainer}>
-        <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
           {formatPrice(priceRange.min)}
         </Text>
-        <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
           {formatPrice(priceRange.max)}
         </Text>
       </View>

--- a/app/components/UI/Perps/components/PerpsOrderBookTable/PerpsOrderBookTable.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderBookTable/PerpsOrderBookTable.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useCallback } from 'react';
-import { View } from 'react-native';
-import Text, {
-  TextColor,
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { View } from 'react-native';
 import { useStyles } from '../../../../hooks/useStyles';
 import { strings } from '../../../../../../locales/i18n';
 import type {
@@ -119,14 +120,17 @@ const PerpsOrderBookTable: React.FC<PerpsOrderBookTableProps> = ({
 
           {/* Total (left for bids) */}
           <View style={styles.totalColumn}>
-            <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
               {formatTotal(level)}
             </Text>
           </View>
 
           {/* Price (right for bids, colored green) */}
           <View style={styles.priceColumnBid}>
-            <Text variant={TextVariant.BodyXS} color={TextColor.Success}>
+            <Text variant={TextVariant.BodyXs} color={TextColor.SuccessDefault}>
               {formatPrice(level.price)}
             </Text>
           </View>
@@ -160,14 +164,17 @@ const PerpsOrderBookTable: React.FC<PerpsOrderBookTableProps> = ({
 
           {/* Price (left for asks, colored red) */}
           <View style={styles.priceColumnAsk}>
-            <Text variant={TextVariant.BodyXS} color={TextColor.Error}>
+            <Text variant={TextVariant.BodyXs} color={TextColor.ErrorDefault}>
               {formatPrice(level.price)}
             </Text>
           </View>
 
           {/* Total (right for asks) */}
           <View style={styles.totalColumnRight}>
-            <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
               {formatTotal(level)}
             </Text>
           </View>
@@ -195,7 +202,7 @@ const PerpsOrderBookTable: React.FC<PerpsOrderBookTableProps> = ({
   if (isLoading || !orderBook) {
     return (
       <View style={styles.emptyState} testID={testID}>
-        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
           {isLoading
             ? strings('perps.order_book.loading')
             : strings('perps.order_book.no_data')}
@@ -209,22 +216,22 @@ const PerpsOrderBookTable: React.FC<PerpsOrderBookTableProps> = ({
       {/* Column Headers */}
       <View style={styles.header}>
         <View style={styles.headerColumn}>
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('perps.order_book.total')} ({unitLabel})
           </Text>
         </View>
         <View style={styles.headerColumnCenter}>
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('perps.order_book.price')}
           </Text>
         </View>
         <View style={styles.headerColumnCenter}>
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('perps.order_book.price')}
           </Text>
         </View>
         <View style={styles.headerColumnRight}>
-          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {strings('perps.order_book.total')} ({unitLabel})
           </Text>
         </View>

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -1,5 +1,10 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PerpsOrderHeaderSelectorsIDs } from '../../Perps.testIds';
@@ -11,10 +16,6 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
 import {
   PERPS_CONSTANTS,
@@ -117,7 +118,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
       />
       <View style={styles.headerLeft}>
         <Text
-          variant={TextVariant.HeadingMD}
+          variant={TextVariant.HeadingSm}
           style={styles.headerTitle}
           testID={PerpsOrderHeaderSelectorsIDs.ASSET_TITLE}
         >
@@ -129,13 +130,17 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
             } ${getPerpsDisplaySymbol(asset)}`}
         </Text>
         <View style={styles.priceRow}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {formattedPrice}
           </Text>
           {price > 0 && (
             <Text
-              variant={TextVariant.BodyMD}
-              color={priceChange >= 0 ? TextColor.Success : TextColor.Error}
+              variant={TextVariant.BodyMd}
+              color={
+                priceChange >= 0
+                  ? TextColor.SuccessDefault
+                  : TextColor.ErrorDefault
+              }
             >
               {formattedChange}
             </Text>
@@ -149,7 +154,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
           testID={PerpsOrderHeaderSelectorsIDs.ORDER_TYPE_BUTTON}
           disabled={isLoading}
         >
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {orderType === 'market'
               ? strings('perps.order.market')
               : strings('perps.order.limit')}

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -118,37 +118,24 @@ jest.mock(
   },
 );
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-
+jest.mock('@metamask/design-system-react-native', () => {
+  const { Text: RNText } = jest.requireActual('react-native');
   const MockText = ({
     children,
     variant,
-    color: _color,
     style,
   }: {
     children: React.ReactNode;
     variant?: string;
-    color?: string;
-    style?: React.ComponentProps<typeof Text>['style'];
+    style?: object;
   }) => (
-    <Text style={style} testID={`text-${variant || 'default'}`}>
+    <RNText style={style} testID={`text-${variant ?? 'default'}`}>
       {children}
-    </Text>
+    </RNText>
   );
-
   return {
-    __esModule: true,
-    default: MockText,
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodyLGMedium: 'BodyLGMedium',
-      BodyMD: 'BodyMD',
-    },
-    TextColor: {
-      Default: 'Default',
-      Alternative: 'Alternative',
-    },
+    ...jest.requireActual('@metamask/design-system-react-native'),
+    Text: MockText,
   };
 });
 

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
@@ -1,14 +1,16 @@
 import React, { useRef, useEffect, memo } from 'react';
+import {
+  FontWeight,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { View, TouchableOpacity } from 'react-native';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import { useTheme } from '../../../../../util/theme';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import { createStyles } from './PerpsOrderTypeBottomSheet.styles';
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -93,7 +95,7 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
   return (
     <BottomSheet ref={sheetRef} shouldNavigateBack={false} onClose={onClose}>
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.order.type.title')}
         </Text>
       </BottomSheetHeader>
@@ -112,15 +114,16 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
             <View style={styles.optionHeader}>
               <View style={styles.optionContent}>
                 <Text
-                  variant={TextVariant.BodyLGMedium}
-                  color={TextColor.Default}
+                  variant={TextVariant.BodyLg}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
                   style={styles.optionTitle}
                 >
                   {title}
                 </Text>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {description}
                 </Text>

--- a/app/components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx
@@ -3,6 +3,9 @@ import {
   ButtonIconSize,
   ButtonIconVariant,
   IconName,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Animated, View } from 'react-native';
@@ -16,10 +19,6 @@ import {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
 import Keypad from '../../../../Base/Keypad';
 import {
@@ -154,7 +153,7 @@ const PerpsCustomSlippageBottomSheet: React.FC<
       onClose={onClose}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.slippage.use_custom_title')}
         </Text>
       </BottomSheetHeader>
@@ -194,8 +193,8 @@ const PerpsCustomSlippageBottomSheet: React.FC<
         {showError && (
           <Text
             testID={PerpsCustomSlippageBottomSheetSelectorsIDs.ERROR}
-            variant={TextVariant.BodySM}
-            color={TextColor.Error}
+            variant={TextVariant.BodySm}
+            color={TextColor.ErrorDefault}
             style={styles.errorText}
           >
             {strings('perps.slippage.out_of_range', {

--- a/app/components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsSlippageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsSlippageBottomSheet.test.tsx
@@ -90,6 +90,8 @@ jest.mock(
 jest.mock('@metamask/design-system-react-native', () => {
   const { TouchableOpacity, Text, View } = jest.requireActual('react-native');
   return {
+    ...jest.requireActual('@metamask/design-system-react-native'),
+    Text,
     ButtonBaseSize: { Sm: 'sm', Md: 'md', Lg: 'lg' },
     ButtonFilter: ({
       children,
@@ -162,31 +164,6 @@ jest.mock('./PerpsCustomSlippageBottomSheet', () => {
           />
         </View>
       ) : null,
-  };
-});
-
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  const MockText = ({ children, testID, ...rest }: Record<string, unknown>) => (
-    <Text testID={testID as string} {...rest}>
-      {children as React.ReactNode}
-    </Text>
-  );
-  MockText.displayName = 'MockText';
-  return {
-    __esModule: true,
-    default: MockText,
-    TextColor: {
-      Alternative: 'Alternative',
-      Error: 'Error',
-      Default: 'Default',
-      Inverse: 'Inverse',
-    },
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodySM: 'BodySM',
-      BodyLGMedium: 'BodyLGMedium',
-    },
   };
 });
 

--- a/app/components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsSlippageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsSlippageBottomSheet.tsx
@@ -2,6 +2,9 @@ import {
   ButtonBaseSize,
   ButtonFilter,
   IconName,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
@@ -15,10 +18,6 @@ import {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
 import {
   PERPS_SLIPPAGE_QUICK_PICKS_BPS,
@@ -118,15 +117,15 @@ const PerpsSlippageBottomSheet: React.FC<PerpsSlippageBottomSheetProps> = ({
       onClose={onClose}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.slippage.config_title')}
         </Text>
       </BottomSheetHeader>
 
       <View style={styles.container}>
         <Text
-          variant={TextVariant.BodySM}
-          color={TextColor.Alternative}
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
           style={styles.description}
         >
           {strings('perps.slippage.config_description')}

--- a/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.tsx
+++ b/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback } from 'react';
-import { FlatList, View, type StyleProp, type ViewStyle } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import Text, {
+import {
+  FontWeight,
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { FlatList, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 import {
@@ -95,7 +97,11 @@ const PerpsWatchlistMarkets: React.FC<PerpsWatchlistMarketsProps> = ({
   const SectionHeader = useCallback(
     () => (
       <View style={[styles.header, headerStyle]}>
-        <Text variant={TextVariant.BodyLGMedium} color={TextColor.Default}>
+        <Text
+          variant={TextVariant.BodyLg}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+        >
           {strings('perps.home.watchlist')}
         </Text>
       </View>


### PR DESCRIPTION
## Summary

- Migrates 30 Perps component files from deprecated `component-library/components/Texts/Text` to `@metamask/design-system-react-native` Text
- Renames `TextVariant`/`TextColor` values to MMDS equivalents (e.g. `BodyMD` → `BodyMd`, `Default` → `TextDefault`)
- Replaces weight-bearing variants (`BodyMDMedium`, `BodyMDBold`) with base variant + `FontWeight` enum
- Uses `LegacyTextVariant`/`LegacyTextColor` aliases at call sites for unmigrated consumer components (`KeyValueRow`, `FundingCountdown`, `SensitiveText`) that still use old component-library Text internally

## Test plan

- [ ] All 24 affected test suites pass (`543` tests)
- [ ] No TypeScript errors (`yarn lint:tsc`)
- [ ] Part of a series: PR1 #31439 → **this PR** → PT3 (pending) → PT4 (pending)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3b5bc64c0e00498867dc19f0b8a215f8406bb9d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->