### PR TITLE
refactor(perps): migrate Text to MMDS in order, position, and UI components (pt3)

### DIFF
--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -7,14 +7,18 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   Card,
-} from '@metamask/design-system-react-native';
-import Text, {
-  TextColor,
+  FontWeight,
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
 import SensitiveText, {
   SensitiveTextLength,
 } from '../../../../../component-library/components/Texts/SensitiveText';
+import {
+  TextVariant as LegacyTextVariant,
+  TextColor as LegacyTextColor,
+} from '../../../../../component-library/components/Texts/Text';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
@@ -49,7 +53,7 @@ interface CardDisplayData {
   secondaryText: string;
   valueText: string;
   labelText: string;
-  valueColor: TextColor;
+  valueColor: LegacyTextColor;
 }
 
 const getPositionDisplayData = (position: Position): CardDisplayData => {
@@ -65,7 +69,8 @@ const getPositionDisplayData = (position: Position): CardDisplayData => {
   });
   const roeValue = parseFloat(position.returnOnEquity) * 100;
   const labelText = `${formatPnl(pnlValue)} (${formatPercentage(roeValue, 1)})`;
-  const valueColor = pnlValue >= 0 ? TextColor.Success : TextColor.Error;
+  const valueColor =
+    pnlValue >= 0 ? LegacyTextColor.Success : LegacyTextColor.Error;
 
   return { primaryText, secondaryText, valueText, labelText, valueColor };
 };
@@ -88,7 +93,7 @@ const getOrderDisplayData = (order: Order): CardDisplayData => {
     secondaryText,
     valueText,
     labelText,
-    valueColor: TextColor.Alternative,
+    valueColor: LegacyTextColor.Alternative,
   };
 };
 
@@ -189,10 +194,17 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
             </Box>
           )}
           <Box twClassName="flex-1">
-            <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextDefault}
+            >
               {displayData?.primaryText ?? ''}
             </Text>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
               {displayData?.secondaryText ?? ''}
             </Text>
           </Box>
@@ -201,19 +213,19 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
         {/* Right side: Value and label */}
         <Box alignItems={BoxAlignItems.End}>
           <SensitiveText
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Default}
+            variant={LegacyTextVariant.BodyMD}
+            color={LegacyTextColor.Default}
             isHidden={privacyMode}
             length={SensitiveTextLength.Short}
           >
             {displayData?.valueText ?? ''}
           </SensitiveText>
           <SensitiveText
-            variant={TextVariant.BodySM}
+            variant={LegacyTextVariant.BodySM}
             color={
               privacyMode && !!position
-                ? TextColor.Default
-                : (displayData?.valueColor ?? TextColor.Default)
+                ? LegacyTextColor.Default
+                : (displayData?.valueColor ?? LegacyTextColor.Default)
             }
             isHidden={privacyMode && !!position}
             length={SensitiveTextLength.Short}

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -92,7 +92,9 @@ jest.mock('../../../../../component-library/components/Buttons/Button', () => {
 jest.mock('@metamask/design-system-react-native', () => {
   const { TouchableOpacity, Text } = jest.requireActual('react-native');
   return {
+    ...jest.requireActual('@metamask/design-system-react-native'),
     __esModule: true,
+    Text,
     Button: ({
       label,
       onPress,
@@ -124,25 +126,6 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 // Mock Text component
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    default: ({ children, ...props }: any) => (
-      <Text {...props}>{children}</Text>
-    ),
-    TextVariant: {
-      HeadingLG: 'HeadingLG',
-      BodyMD: 'BodyMD',
-      BodySM: 'BodySM',
-    },
-    TextColor: {
-      Error: 'Error',
-      Muted: 'Muted',
-    },
-  };
-});
 
 // Mock usePerpsEventTracking
 const mockTrack = jest.fn();

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -5,16 +5,16 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  FontWeight,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -82,8 +82,9 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
         />
 
         <Text
-          variant={TextVariant.BodyMDMedium}
-          color={TextColor.Default}
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
           style={styles.errorTitle}
         >
           {strings('perps.errors.connectionFailed.title')}
@@ -92,8 +93,8 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
         {/* Only show debug details in development */}
         {shouldShowDebugDetails && (
           <Text
-            variant={TextVariant.BodySM}
-            color={TextColor.Muted}
+            variant={TextVariant.BodySm}
+            color={TextColor.TextMuted}
             style={styles.debugMessage}
           >
             Debug: {error instanceof Error ? error.message : error}

--- a/app/components/UI/Perps/components/PerpsCrossMarginWarningBottomSheet/PerpsCrossMarginWarningBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCrossMarginWarningBottomSheet/PerpsCrossMarginWarningBottomSheet.test.tsx
@@ -129,37 +129,10 @@ jest.mock('../../../../../component-library/components/Buttons/Button', () => ({
   },
 }));
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-
-  const MockText = ({
-    children,
-    variant,
-    color: _color,
-    style,
-  }: {
-    children: React.ReactNode;
-    variant?: string;
-    color?: string;
-    style?: React.ComponentProps<typeof Text>['style'];
-  }) => (
-    <Text style={style} testID={`text-${variant || 'default'}`}>
-      {children}
-    </Text>
-  );
-
-  return {
-    __esModule: true,
-    default: MockText,
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodyMD: 'BodyMD',
-    },
-    TextColor: {
-      Alternative: 'Alternative',
-    },
-  };
-});
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();

--- a/app/components/UI/Perps/components/PerpsCrossMarginWarningBottomSheet/PerpsCrossMarginWarningBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsCrossMarginWarningBottomSheet/PerpsCrossMarginWarningBottomSheet.tsx
@@ -1,5 +1,10 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useRef } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import BottomSheet, {
@@ -9,10 +14,6 @@ import BottomSheetHeader from '../../../../../component-library/components/Botto
 import BottomSheetFooter, {
   ButtonsAlignment,
 } from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import {
   ButtonSize,
   ButtonVariants,
@@ -53,12 +54,12 @@ const PerpsCrossMarginWarningBottomSheet: React.FC<
       onClose={handleClose}
     >
       <BottomSheetHeader onClose={handleClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.crossMargin.title')}
         </Text>
       </BottomSheetHeader>
       <View style={styles.contentContainer}>
-        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
           {strings('perps.crossMargin.message')}
         </Text>
       </View>

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsDeveloperOptionsSection.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsDeveloperOptionsSection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Text, {
-  TextColor,
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { View, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../hooks/useStyles';
@@ -28,8 +29,8 @@ export const PerpsDeveloperOptionsSection = () => {
   return (
     <View style={styles.container}>
       <Text
-        color={TextColor.Default}
-        variant={TextVariant.HeadingLG}
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingLg}
         style={styles.heading}
       >
         {strings('perps.perps_trading')}

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsProviderToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsProviderToggle.tsx
@@ -3,11 +3,12 @@ import {
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
 import React, { useState, useContext, useMemo, useCallback } from 'react';
-import { useSelector } from 'react-redux';
-import Text, {
-  TextColor,
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { useSelector } from 'react-redux';
 import { View, Switch, ActivityIndicator, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -81,7 +82,7 @@ const PerpsProviderToggleContent = () => {
       style={styles.container}
       testID={PerpsProviderToggleSelectorsIDs.ROOT}
     >
-      <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+      <Text color={TextColor.TextAlternative} variant={TextVariant.BodyMd}>
         {strings('perps.developer_options.provider_mode_toggle')}
       </Text>
       <Switch
@@ -97,7 +98,7 @@ const PerpsProviderToggleContent = () => {
           testID={PerpsProviderToggleSelectorsIDs.LOADING_INDICATOR}
         />
       ) : (
-        <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+        <Text color={TextColor.TextAlternative} variant={TextVariant.BodyMd}>
           {currentProvider}
         </Text>
       )}

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.tsx
@@ -3,10 +3,11 @@ import {
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
 import React, { useState, useContext, useMemo } from 'react';
-import Text, {
-  TextColor,
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { View, Switch, ActivityIndicator, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -67,7 +68,7 @@ export const PerpsTestnetToggle = () => {
 
   return (
     <View style={styles.container} testID={PerpsTestnetToggleSelectorsIDs.ROOT}>
-      <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+      <Text color={TextColor.TextAlternative} variant={TextVariant.BodyMd}>
         {strings('perps.developer_options.hyperliquid_network_toggle')}
       </Text>
       <Switch
@@ -82,7 +83,7 @@ export const PerpsTestnetToggle = () => {
           testID={PerpsTestnetToggleSelectorsIDs.LOADING_INDICATOR}
         />
       ) : (
-        <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+        <Text color={TextColor.TextAlternative} variant={TextVariant.BodyMd}>
           {isTestnetEnabled
             ? strings('perps.testnet')
             : strings('perps.mainnet')}

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -5,16 +5,15 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './PerpsErrorState.styles';
 
@@ -91,16 +90,16 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
           style={styles.icon}
         />
         <Text
-          variant={TextVariant.HeadingMD}
-          color={TextColor.Default}
+          variant={TextVariant.HeadingSm}
+          color={TextColor.TextDefault}
           style={styles.title}
         >
           {errorContent.title}
         </Text>
         {errorContent.description && (
           <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Muted}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextMuted}
             style={styles.description}
           >
             {errorContent.description}

--- a/app/components/UI/Perps/components/PerpsFillTag/PerpsFillTag.tsx
+++ b/app/components/UI/Perps/components/PerpsFillTag/PerpsFillTag.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react';
+import {
+  FontWeight,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { View, TouchableOpacity, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import TagBase, {
   TagSeverity,
   TagShape,
@@ -60,7 +62,7 @@ const PerpsFillTag: React.FC<PerpsFillTagProps> = ({
       [FillType.AutoDeleveraging]: {
         label: strings('perps.transactions.order.auto_deleveraging'),
         severity: TagSeverity.Info,
-        textColor: TextColor.Default,
+        textColor: TextColor.TextDefault,
         includesBorder: false,
         testID: PerpsTransactionSelectorsIDs.FILL_TAG_ADL,
       },
@@ -73,21 +75,21 @@ const PerpsFillTag: React.FC<PerpsFillTagProps> = ({
           fill.liquidation.liquidatedUser === selectedAccount.address,
         label: strings('perps.transactions.order.liquidated'),
         severity: TagSeverity.Danger,
-        textColor: TextColor.Error,
+        textColor: TextColor.ErrorDefault,
         includesBorder: false,
         testID: PerpsTransactionSelectorsIDs.FILL_TAG_LIQUIDATED,
       },
       [FillType.TakeProfit]: {
         label: strings('perps.transactions.order.take_profit'),
         severity: TagSeverity.Default,
-        textColor: TextColor.Alternative,
+        textColor: TextColor.TextAlternative,
         includesBorder: true,
         testID: PerpsTransactionSelectorsIDs.FILL_TAG_TAKE_PROFIT,
       },
       [FillType.StopLoss]: {
         label: strings('perps.transactions.order.stop_loss'),
         severity: TagSeverity.Default,
-        textColor: TextColor.Alternative,
+        textColor: TextColor.TextAlternative,
         includesBorder: true,
         testID: PerpsTransactionSelectorsIDs.FILL_TAG_STOP_LOSS,
       },
@@ -106,7 +108,11 @@ const PerpsFillTag: React.FC<PerpsFillTagProps> = ({
           severity={tagConfig.severity}
           includesBorder={tagConfig.includesBorder}
         >
-          <Text variant={TextVariant.BodyXSMedium} color={tagConfig.textColor}>
+          <Text
+            variant={TextVariant.BodyXs}
+            fontWeight={FontWeight.Medium}
+            color={tagConfig.textColor}
+          >
             {tagConfig.label}
           </Text>
         </TagBase>

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
@@ -217,31 +217,6 @@ jest.mock(
   },
 );
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const ReactModule = jest.requireActual('react');
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: function MockText({
-      children,
-      testID,
-    }: {
-      children: React.ReactNode;
-      testID?: string;
-    }) {
-      return ReactModule.createElement(Text, { testID }, children);
-    },
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodyMD: 'BodyMD',
-    },
-    TextColor: {
-      Default: 'Default',
-      Alternative: 'Alternative',
-    },
-  };
-});
-
 jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
   __esModule: true,
   default: () => null,

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
@@ -1,5 +1,10 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useState } from 'react';
+import {
+  FontWeight,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { Image, View, useColorScheme } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
@@ -9,9 +14,6 @@ import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -115,13 +117,13 @@ const PerpsGTMModal = () => {
       <View style={styles.headerContainer}>
         <Text
           style={styles.title}
-          variant={TextVariant.HeadingLG}
+          variant={TextVariant.HeadingLg}
           onLayout={handleTitleLayout}
         >
           {titleText}
         </Text>
         <Text
-          variant={TextVariant.BodyMD}
+          variant={TextVariant.BodyMd}
           style={styles.titleDescription}
           onLayout={handleSubtitleLayout}
         >
@@ -145,7 +147,8 @@ const PerpsGTMModal = () => {
           activeOpacity={0.6}
           label={
             <Text
-              variant={TextVariant.BodyMDMedium}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
               style={styles.tryNowButtonText}
             >
               {strings('perps.gtm_content.try_now')}
@@ -162,7 +165,8 @@ const PerpsGTMModal = () => {
           activeOpacity={0.6}
           label={
             <Text
-              variant={TextVariant.BodyMDMedium}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
               style={styles.notNowButtonText}
             >
               {strings('perps.gtm_content.not_now')}

--- a/app/components/UI/Perps/components/PerpsLeverage/PerpsLeverage.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverage/PerpsLeverage.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { View } from 'react-native';
-import Text, {
-  TextColor,
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { View } from 'react-native';
 import styleSheet from './PerpsLeverage.styles';
 import { useStyles } from '../../../../hooks/useStyles';
 
@@ -20,7 +21,7 @@ const PerpsLeverage = ({
 
   return (
     <View style={styles.maxLeverage} testID={testID}>
-      <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+      <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
         {maxLeverage}
       </Text>
     </View>

--- a/app/components/UI/Perps/components/PerpsLoader/PerpsLoader.tsx
+++ b/app/components/UI/Perps/components/PerpsLoader/PerpsLoader.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { ActivityIndicator, View } from 'react-native';
-import Text, {
-  TextColor,
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { ActivityIndicator, View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import ScreenView from '../../../../Base/ScreenView';
 import { createStyles } from './PerpsLoader.styles';
@@ -36,8 +37,8 @@ const PerpsLoader: React.FC<PerpsLoaderProps> = ({
         testID={PerpsLoaderSelectorsIDs.SPINNER}
       />
       <Text
-        variant={TextVariant.BodyMD}
-        color={TextColor.Muted}
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextMuted}
         style={styles.loadingText}
         testID={PerpsLoaderSelectorsIDs.TEXT}
       >

--- a/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.test.tsx
@@ -51,15 +51,9 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
     Primary: 'Primary',
   },
 }));
-jest.mock('../../../../../component-library/components/Texts/Text', () => ({
-  __esModule: true,
-  default: 'Text',
-  TextVariant: {
-    BodyMD: 'BodyMD',
-  },
-  TextColor: {
-    Default: 'Default',
-  },
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
 }));
 
 describe('PerpsNavigationCard', () => {

--- a/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.tsx
+++ b/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import ListItem from '../../../../../component-library/components/List/ListItem';
 import ListItemColumn, {
@@ -9,10 +14,6 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './PerpsNavigationCard.styles';
 
@@ -92,7 +93,10 @@ const PerpsNavigationCard: React.FC<PerpsNavigationCardProps> = ({ items }) => {
                 />
               )}
               <ListItemColumn widthType={WidthType.Fill}>
-                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                >
                   {item.label}
                 </Text>
               </ListItemColumn>

--- a/app/components/UI/Perps/components/PerpsOICapWarning/PerpsOICapWarning.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOICapWarning/PerpsOICapWarning.test.tsx
@@ -3,7 +3,12 @@ import { render } from '@testing-library/react-native';
 import PerpsOICapWarning from './PerpsOICapWarning';
 import { usePerpsOICap } from '../../hooks/usePerpsOICap';
 import { strings } from '../../../../../../locales/i18n';
-import { TextVariant } from '../../../../../component-library/components/Texts/Text';
+import { TextVariant } from '@metamask/design-system-react-native';
+
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 jest.mock('../../hooks/usePerpsOICap');
 
@@ -86,8 +91,8 @@ describe('PerpsOICapWarning', () => {
         <PerpsOICapWarning symbol="BTC" />,
       );
 
-      UNSAFE_getByProps({ variant: TextVariant.BodySM });
-      expect(UNSAFE_queryByProps({ variant: TextVariant.BodyMD })).toBeNull();
+      UNSAFE_getByProps({ variant: TextVariant.BodySm });
+      expect(UNSAFE_queryByProps({ variant: TextVariant.BodyMd })).toBeNull();
     });
 
     it('should render banner variant when specified', () => {
@@ -95,8 +100,8 @@ describe('PerpsOICapWarning', () => {
         <PerpsOICapWarning symbol="BTC" variant="banner" />,
       );
 
-      UNSAFE_getByProps({ variant: TextVariant.BodyMD });
-      expect(UNSAFE_queryByProps({ variant: TextVariant.BodySM })).toBeNull();
+      UNSAFE_getByProps({ variant: TextVariant.BodyMd });
+      expect(UNSAFE_queryByProps({ variant: TextVariant.BodySm })).toBeNull();
     });
 
     it('should render inline variant when specified', () => {
@@ -104,8 +109,8 @@ describe('PerpsOICapWarning', () => {
         <PerpsOICapWarning symbol="BTC" variant="inline" />,
       );
 
-      UNSAFE_getByProps({ variant: TextVariant.BodySM });
-      expect(UNSAFE_queryByProps({ variant: TextVariant.BodyMD })).toBeNull();
+      UNSAFE_getByProps({ variant: TextVariant.BodySm });
+      expect(UNSAFE_queryByProps({ variant: TextVariant.BodyMd })).toBeNull();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsOICapWarning/PerpsOICapWarning.tsx
+++ b/app/components/UI/Perps/components/PerpsOICapWarning/PerpsOICapWarning.tsx
@@ -1,10 +1,11 @@
 import React, { memo } from 'react';
-import { View } from 'react-native';
-import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { View } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
 import Icon, {
   IconName,
   IconSize,
@@ -61,8 +62,8 @@ const PerpsOICapWarning: React.FC<PerpsOICapWarningProps> = memo(
         />
         <View style={styles.textContainer}>
           <Text
-            variant={isBanner ? TextVariant.BodyMD : TextVariant.BodySM}
-            color={TextColor.Default}
+            variant={isBanner ? TextVariant.BodyMd : TextVariant.BodySm}
+            color={TextColor.TextDefault}
           >
             {strings('perps.order.validation.oi_cap_reached')}
           </Text>

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -10,19 +10,23 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  FontWeight,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconColor,
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import SensitiveText, {
   SensitiveTextLength,
 } from '../../../../../component-library/components/Texts/SensitiveText';
+import {
+  TextVariant as LegacyTextVariant,
+  TextColor as LegacyTextColor,
+} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import {
@@ -138,14 +142,14 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
   const isNearZeroFunding = Math.abs(fundingSinceOpen) < 0.005; // Threshold: |value| < $0.005 -> display $0.00
 
   // Keep original color logic: exact zero = neutral, positive = cost (Error), negative = payment (Success)
-  let fundingColorFromValue = TextColor.Default;
+  let fundingColorFromValue = LegacyTextColor.Default;
   if (fundingSinceOpen > 0) {
-    fundingColorFromValue = TextColor.Error;
+    fundingColorFromValue = LegacyTextColor.Error;
   } else if (fundingSinceOpen < 0) {
-    fundingColorFromValue = TextColor.Success;
+    fundingColorFromValue = LegacyTextColor.Success;
   }
   const fundingColor = isNearZeroFunding
-    ? TextColor.Default
+    ? LegacyTextColor.Default
     : fundingColorFromValue;
 
   const fundingSignPrefix = fundingSinceOpen >= 0 ? '-' : '+';
@@ -233,21 +237,21 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
       secondaryLabel = showTpSlSkeleton ? (
         <View style={styles.tpSlSkeleton} testID="tp-sl-skeleton" />
       ) : (
-        <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {tpSlLabel ?? strings('homepage.sections.positions.no_tp_sl')}
         </Text>
       );
       secondaryValue = (
         <SensitiveText
-          variant={TextVariant.BodySM}
+          variant={LegacyTextVariant.BodySM}
           color={
             privacyMode
-              ? TextColor.Default
+              ? LegacyTextColor.Default
               : hasValidRoe
                 ? roeRaw >= 0
-                  ? TextColor.Success
-                  : TextColor.Error
-                : TextColor.Alternative
+                  ? LegacyTextColor.Success
+                  : LegacyTextColor.Error
+                : LegacyTextColor.Alternative
           }
           isHidden={privacyMode}
           length={SensitiveTextLength.Short}
@@ -258,8 +262,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
     } else {
       secondaryLabel = (
         <SensitiveText
-          variant={TextVariant.BodySM}
-          color={TextColor.Alternative}
+          variant={LegacyTextVariant.BodySM}
+          color={LegacyTextColor.Alternative}
           isHidden={privacyMode}
           length={SensitiveTextLength.Short}
         >
@@ -268,13 +272,13 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
       );
       secondaryValue = (
         <SensitiveText
-          variant={TextVariant.BodySM}
+          variant={LegacyTextVariant.BodySM}
           color={
             privacyMode
-              ? TextColor.Default
+              ? LegacyTextColor.Default
               : pnlNum >= 0
-                ? TextColor.Success
-                : TextColor.Error
+                ? LegacyTextColor.Success
+                : LegacyTextColor.Error
           }
           isHidden={privacyMode}
           length={SensitiveTextLength.Short}
@@ -299,8 +303,9 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             <View style={styles.compactInfo}>
               <View style={styles.compactNameRow}>
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Default}
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
                 >
                   {directionLabel} {displaySymbol}
                 </Text>
@@ -311,8 +316,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           </View>
           <View style={styles.compactRight}>
             <SensitiveText
-              variant={TextVariant.BodyMDMedium}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodyMD}
+              color={LegacyTextColor.Default}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
             >
@@ -331,7 +336,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
     <View style={styles.container} testID={PerpsPositionCardSelectorsIDs.CARD}>
       {/* Header Section */}
       <View style={styles.header} testID={PerpsPositionCardSelectorsIDs.HEADER}>
-        <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+        <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
           {strings('perps.position.card.position_title')}
         </Text>
         {onSharePress && (
@@ -350,17 +355,17 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           style={[styles.pnlCard, styles.pnlCardLeft]}
           testID={PerpsPositionCardSelectorsIDs.PNL_CARD}
         >
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {strings('perps.position.card.pnl_label')}
           </Text>
           <SensitiveText
-            variant={TextVariant.BodyMD}
+            variant={LegacyTextVariant.BodyMD}
             color={
               privacyMode
-                ? TextColor.Default
+                ? LegacyTextColor.Default
                 : pnlNum >= 0
-                  ? TextColor.Success
-                  : TextColor.Error
+                  ? LegacyTextColor.Success
+                  : LegacyTextColor.Error
             }
             testID={PerpsPositionCardSelectorsIDs.PNL_VALUE}
             isHidden={privacyMode}
@@ -374,17 +379,17 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           style={[styles.pnlCard, styles.pnlCardRight]}
           testID={PerpsPositionCardSelectorsIDs.RETURN_CARD}
         >
-          <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {strings('perps.position.card.return_label')}
           </Text>
           <SensitiveText
-            variant={TextVariant.BodyMD}
+            variant={LegacyTextVariant.BodyMD}
             color={
               privacyMode
-                ? TextColor.Default
+                ? LegacyTextColor.Default
                 : roe >= 0
-                  ? TextColor.Success
-                  : TextColor.Error
+                  ? LegacyTextColor.Success
+                  : LegacyTextColor.Error
             }
             testID={PerpsPositionCardSelectorsIDs.RETURN_VALUE}
             isHidden={privacyMode}
@@ -404,12 +409,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           testID={PerpsPositionCardSelectorsIDs.SIZE_CONTAINER}
         >
           <View style={styles.sizeLeftContent}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
               {strings('perps.position.card.size_label')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodyMD}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodyMD}
+              color={LegacyTextColor.Default}
               testID={PerpsPositionCardSelectorsIDs.SIZE_VALUE}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
@@ -440,12 +448,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
           testID={PerpsPositionCardSelectorsIDs.MARGIN_CONTAINER}
         >
           <View style={styles.marginLeftContent}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
               {strings('perps.position.card.margin_label')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodyMD}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodyMD}
+              color={LegacyTextColor.Default}
               testID={PerpsPositionCardSelectorsIDs.MARGIN_VALUE}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
@@ -479,7 +490,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         testID={PerpsPositionCardSelectorsIDs.AUTO_CLOSE_TOGGLE}
       >
         <View style={styles.autoCloseTextContainer}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {strings('perps.auto_close.title')}
           </Text>
           {(() => {
@@ -532,8 +543,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
               return (
                 <SensitiveText
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Default}
+                  variant={LegacyTextVariant.BodyMD}
+                  color={LegacyTextColor.Default}
                   isHidden={privacyMode}
                   length={SensitiveTextLength.Short}
                 >
@@ -543,7 +554,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             }
 
             return (
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {strings('perps.auto_close.description')}
               </Text>
             );
@@ -569,8 +580,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
         testID={PerpsPositionCardSelectorsIDs.DETAILS_SECTION}
       >
         <Text
-          variant={TextVariant.HeadingMD}
-          color={TextColor.Default}
+          variant={TextVariant.HeadingSm}
+          color={TextColor.TextDefault}
           style={styles.detailsTitle}
         >
           {strings('perps.position.card.details_title')}
@@ -578,14 +589,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
         <View style={[styles.detailRow, styles.detailRowFirst]}>
           <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('perps.position.card.direction_label')}
           </Text>
           <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Default}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
             testID={PerpsPositionCardSelectorsIDs.DIRECTION_VALUE}
           >
             {direction === 'long'
@@ -597,14 +609,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
         <View style={styles.detailRow}>
           <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('perps.position.card.entry_label')}
           </Text>
           <SensitiveText
-            variant={TextVariant.BodyMD}
-            color={TextColor.Default}
+            variant={LegacyTextVariant.BodyMD}
+            color={LegacyTextColor.Default}
             isHidden={privacyMode}
             length={SensitiveTextLength.Short}
             testID={PerpsPositionCardSelectorsIDs.ENTRY_VALUE}
@@ -617,15 +630,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
         <View style={styles.detailRow}>
           <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('perps.position.card.liquidation_price_label')}
           </Text>
           <View style={styles.liquidationPriceValue}>
             <SensitiveText
-              variant={TextVariant.BodyMD}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodyMD}
+              color={LegacyTextColor.Default}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
               testID={PerpsPositionCardSelectorsIDs.LIQUIDATION_PRICE_VALUE}
@@ -640,8 +654,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
             {liquidationDistance !== null && !privacyMode && (
               <>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {' '}
                   {Math.round(liquidationDistance)}%
@@ -658,14 +672,15 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
         <View style={[styles.detailRow, styles.detailRowLast]}>
           <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('perps.position.card.funding_payments_label')}
           </Text>
           <SensitiveText
-            variant={TextVariant.BodyMD}
-            color={privacyMode ? TextColor.Default : fundingColor}
+            variant={LegacyTextVariant.BodyMD}
+            color={privacyMode ? LegacyTextColor.Default : fundingColor}
             isHidden={privacyMode}
             length={SensitiveTextLength.Short}
             testID={PerpsPositionCardSelectorsIDs.FUNDING_PAYMENTS_VALUE}

--- a/app/components/UI/Perps/components/PerpsPriceDeviationWarning/PerpsPriceDeviationWarning.tsx
+++ b/app/components/UI/Perps/components/PerpsPriceDeviationWarning/PerpsPriceDeviationWarning.tsx
@@ -1,10 +1,11 @@
 import React, { memo } from 'react';
-import { View } from 'react-native';
-import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { View } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
 import Icon, {
   IconName,
   IconSize,
@@ -39,7 +40,7 @@ const PerpsPriceDeviationWarning: React.FC<PerpsPriceDeviationWarningProps> =
           style={styles.icon}
         />
         <View style={styles.textContainer}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {strings('perps.price_deviation_warning.message')}
           </Text>
         </View>

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.test.tsx
@@ -28,19 +28,10 @@ jest.mock('../../../../../component-library/hooks', () => ({
   }),
 }));
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text: RNText } = jest.requireActual('react-native');
-  const MockText = ({ children, ...props }: Record<string, unknown>) => (
-    <RNText {...props}>{children}</RNText>
-  );
-  MockText.displayName = 'Text';
-  return {
-    __esModule: true,
-    default: MockText,
-    TextVariant: { BodySM: 'BodySM' },
-    TextColor: { Alternative: 'Alternative', Warning: 'Warning' },
-  };
-});
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 jest.mock('../../../../../component-library/components/Icons/Icon', () => {
   const { View } = jest.requireActual('react-native');

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import Icon, {
   IconName,
   IconSize,
@@ -61,8 +62,8 @@ const PerpsProviderSelectorBadge: React.FC<PerpsProviderSelectorBadgeProps> = ({
     >
       {isTestnet && <View style={styles.testnetDot} />}
       <Text
-        variant={TextVariant.BodySM}
-        color={isTestnet ? TextColor.Warning : TextColor.Alternative}
+        variant={TextVariant.BodySm}
+        color={isTestnet ? TextColor.WarningDefault : TextColor.TextAlternative}
         style={styles.badgeText}
       >
         {currentProvider.name}

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.test.tsx
@@ -27,25 +27,10 @@ jest.mock('../../../../../component-library/hooks', () => ({
   }),
 }));
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text: RNText } = jest.requireActual('react-native');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const MockText = ({ children, ...props }: any) => (
-    <RNText {...props}>{children}</RNText>
-  );
-  MockText.displayName = 'Text';
-  return {
-    __esModule: true,
-    default: MockText,
-    TextVariant: {
-      HeadingMD: 'HeadingMD',
-      BodyMDMedium: 'BodyMDMedium',
-      BodyXS: 'BodyXS',
-      BodySM: 'BodySM',
-    },
-    TextColor: { Alternative: 'Alternative', Warning: 'Warning' },
-  };
-});
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 jest.mock('../../../../../component-library/components/Icons/Icon', () => {
   const { View } = jest.requireActual('react-native');

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.tsx
@@ -1,10 +1,12 @@
 import React, { useRef, useEffect, useCallback, useMemo } from 'react';
-import { TouchableOpacity, View } from 'react-native';
-import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
+import {
+  FontWeight,
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { TouchableOpacity, View } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
 import Icon, {
   IconName,
   IconSize,
@@ -79,7 +81,7 @@ const PerpsProviderSelectorSheet: React.FC<PerpsProviderSelectorSheetProps> = ({
       testID={testID}
     >
       <BottomSheetHeader onClose={onClose}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.provider_selector.title')}
         </Text>
       </BottomSheetHeader>
@@ -100,7 +102,8 @@ const PerpsProviderSelectorSheet: React.FC<PerpsProviderSelectorSheetProps> = ({
               <View style={styles.optionContent}>
                 <View style={styles.optionNameRow}>
                   <Text
-                    variant={TextVariant.BodyMDMedium}
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
                     style={styles.optionName}
                   >
                     {option.name}
@@ -109,24 +112,24 @@ const PerpsProviderSelectorSheet: React.FC<PerpsProviderSelectorSheetProps> = ({
                     <View style={styles.testnetTag}>
                       <View style={styles.testnetDot} />
                       <Text
-                        variant={TextVariant.BodyXS}
-                        color={TextColor.Warning}
+                        variant={TextVariant.BodyXs}
+                        color={TextColor.WarningDefault}
                       >
                         {option.network}
                       </Text>
                     </View>
                   ) : (
                     <Text
-                      variant={TextVariant.BodyXS}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextAlternative}
                     >
                       {option.network}
                     </Text>
                   )}
                 </View>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
                 >
                   {option.description}
                 </Text>

--- a/app/components/UI/Perps/components/PerpsQuoteDetailsCard/PerpsQuoteDetailsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsQuoteDetailsCard/PerpsQuoteDetailsCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { strings } from '../../../../../../locales/i18n';
-import { TextVariant } from '../../../../../component-library/components/Texts/Text';
+import { TextVariant as LegacyTextVariant } from '../../../../../component-library/components/Texts/Text';
 import { Box } from '../../../Box/Box';
 import KeyValueRow from '../../../../../component-library/components-temp/KeyValueRow';
 import { TooltipSizes } from '../../../../../component-library/components-temp/KeyValueRow/KeyValueRow.types';
@@ -32,13 +32,13 @@ const PerpsQuoteDetailsCard: React.FC<PerpsQuoteDetailsCardProps> = ({
         field={{
           label: {
             text: strings('perps.quote.network_fee'),
-            variant: TextVariant.BodyMDMedium,
+            variant: LegacyTextVariant.BodyMD,
           },
         }}
         value={{
           label: {
             text: networkFee,
-            variant: TextVariant.BodyMD,
+            variant: LegacyTextVariant.BodyMD,
           },
         }}
         style={styles.quoteRow}
@@ -48,7 +48,7 @@ const PerpsQuoteDetailsCard: React.FC<PerpsQuoteDetailsCardProps> = ({
         field={{
           label: {
             text: strings('perps.quote.metamask_fee'),
-            variant: TextVariant.BodyMDMedium,
+            variant: LegacyTextVariant.BodyMD,
           },
           tooltip: {
             title: strings('perps.quote.metamask_fee'),
@@ -59,7 +59,7 @@ const PerpsQuoteDetailsCard: React.FC<PerpsQuoteDetailsCardProps> = ({
         value={{
           label: {
             text: metamaskFee,
-            variant: TextVariant.BodyMD,
+            variant: LegacyTextVariant.BodyMD,
           },
         }}
         style={styles.quoteRow}
@@ -70,13 +70,13 @@ const PerpsQuoteDetailsCard: React.FC<PerpsQuoteDetailsCardProps> = ({
           field={{
             label: {
               text: strings('perps.quote.estimated_time'),
-              variant: TextVariant.BodyMDMedium,
+              variant: LegacyTextVariant.BodyMD,
             },
           }}
           value={{
             label: {
               text: estimatedTime,
-              variant: TextVariant.BodyMD,
+              variant: LegacyTextVariant.BodyMD,
             },
           }}
           style={styles.quoteRow}
@@ -87,13 +87,13 @@ const PerpsQuoteDetailsCard: React.FC<PerpsQuoteDetailsCardProps> = ({
         field={{
           label: {
             text: strings('perps.quote.rate'),
-            variant: TextVariant.BodyMDMedium,
+            variant: LegacyTextVariant.BodyMD,
           },
         }}
         value={{
           label: {
             text: rate,
-            variant: TextVariant.BodyMD,
+            variant: LegacyTextVariant.BodyMD,
           },
         }}
         style={styles.quoteRow}

--- a/app/components/UI/Perps/components/PerpsQuoteExpiredModal/PerpsQuoteExpiredModal.tsx
+++ b/app/components/UI/Perps/components/PerpsQuoteExpiredModal/PerpsQuoteExpiredModal.tsx
@@ -7,10 +7,9 @@ import {
   BottomSheetFooter,
   BottomSheetHeader,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Text, {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import createStyles from './PerpsQuoteExpiredModal.styles';
 import { DEPOSIT_CONFIG } from '@metamask/perps-controller';
@@ -31,12 +30,12 @@ const PerpsQuoteExpiredModal = () => {
   return (
     <BottomSheet goBack={navigation.goBack} twClassName={surfaceClass}>
       <BottomSheetHeader onClose={navigation.goBack}>
-        <Text variant={TextVariant.HeadingMD}>
+        <Text variant={TextVariant.HeadingSm}>
           {strings('perps.deposit.quote_expired_modal.title')}
         </Text>
       </BottomSheetHeader>
       <View style={styles.container}>
-        <Text variant={TextVariant.BodyMD}>
+        <Text variant={TextVariant.BodyMd}>
           {strings('perps.deposit.quote_expired_modal.description', {
             refreshRate,
           })}

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
@@ -35,35 +35,10 @@ jest.mock('../../../../../component-library/hooks', () => ({
   }),
 }));
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const ReactLib = jest.requireActual('react');
-  const { Text: ReactNativeText } = jest.requireActual('react-native');
-
-  const MockText = ({
-    children,
-    ...props
-  }: {
-    children?: React.ReactNode;
-    [key: string]: unknown;
-  }) => ReactLib.createElement(ReactNativeText, props, children);
-
-  return {
-    __esModule: true,
-    default: MockText,
-    TextVariant: {
-      HeadingSM: 'HeadingSM',
-      BodyMD: 'BodyMD',
-      BodyMDMedium: 'BodyMDMedium',
-      BodySM: 'BodySM',
-    },
-    TextColor: {
-      Default: 'Default',
-      Alternative: 'Alternative',
-      Success: 'Success',
-      Error: 'Error',
-    },
-  };
-});
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 jest.mock('../PerpsTokenLogo', () => {
   const { View: RNView, Text: RNText } = jest.requireActual('react-native');

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback } from 'react';
-import { View, TouchableOpacity, FlatList } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import Text, {
+import {
+  FontWeight,
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { View, TouchableOpacity, FlatList } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import Icon, {
   IconName,
   IconSize,
@@ -85,10 +87,14 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
     if (!transaction.fill) return null;
 
     const pnlColor = transaction.fill.isPositive
-      ? TextColor.Success
-      : TextColor.Error;
+      ? TextColor.SuccessDefault
+      : TextColor.ErrorDefault;
     return (
-      <Text variant={TextVariant.BodyMDMedium} color={pnlColor}>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        color={pnlColor}
+      >
         {transaction.fill.amount}
       </Text>
     );
@@ -115,8 +121,9 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
             <View style={styles.activityInfo}>
               <View style={styles.activityTitleRow}>
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Default}
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
                   style={styles.activityType}
                 >
                   {item.title}
@@ -128,7 +135,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
               </View>
               {!!item.subtitle && (
                 <Text
-                  variant={TextVariant.BodySM}
+                  variant={TextVariant.BodySm}
                   style={styles.activityAmount}
                 >
                   {getPerpsDisplaySymbol(item.subtitle)}
@@ -147,7 +154,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
     return (
       <View style={styles.container}>
         <View style={styles.header}>
-          <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
             {strings('perps.home.recent_activity')}
           </Text>
         </View>
@@ -164,7 +171,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
     <View style={styles.container}>
       <TouchableOpacity style={styles.header} onPress={handleSeeAll}>
         <View style={styles.titleRow}>
-          <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
             {strings('perps.home.recent_activity')}
           </Text>
           <Icon

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.test.tsx
@@ -36,13 +36,10 @@ jest.mock('../../../../../component-library/hooks', () => ({
 }));
 
 // Mock component library Text component
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  return (props: {
-    children: React.ReactNode;
-    style?: React.ComponentProps<typeof Text>['style'];
-  }) => <Text {...props}>{props.children}</Text>;
-});
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 
 describe('PerpsSlider', () => {
   const defaultProps = {

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
+import { Text } from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import {
   Gesture,
@@ -18,7 +19,6 @@ import {
   type HapticImpactMoment,
 } from '../../../../../util/haptics';
 import LinearGradient from 'react-native-linear-gradient';
-import Text from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import styleSheet from './PerpsSlider.styles';
 

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
@@ -1,14 +1,13 @@
 import React, { memo, useCallback, useEffect, useRef } from 'react';
 import { View, Animated } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
 import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Text,
+  TextVariant,
+  TextColor,
 } from '@metamask/design-system-react-native';
 import Icon, {
   IconName,
@@ -140,14 +139,17 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
           >
             <View style={styles.addMarginRow}>
               <View style={styles.addMarginTextContainer}>
-                <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextDefault}
+                >
                   {strings('perps.stop_loss_prompt.near_liquidation_title', {
                     distance: roundedDistance,
                   })}
                 </Text>
                 <Text
-                  variant={TextVariant.BodySM}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.stop_loss_prompt.near_liquidation_subtitle')}
                 </Text>
@@ -176,10 +178,13 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
         >
           <View style={styles.stopLossRow}>
             <View style={styles.stopLossTextContainer}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {strings('perps.stop_loss_prompt.protect_losses_title')}
               </Text>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.stop_loss_prompt.set_stop_loss_subtitle', {
                   price: formattedStopLossPrice,
                   percent: formattedPercent,

--- a/app/components/UI/Perps/components/PerpsTransactionDetailAssetHero/PerpsTransactionDetailAssetHero.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionDetailAssetHero/PerpsTransactionDetailAssetHero.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
 import { View } from 'react-native';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { PerpsTransactionSelectorsIDs } from '../../Perps.testIds';
 import { PerpsTransaction } from '../../types/transactionHistory';
 import PerpsTokenLogo from '../PerpsTokenLogo';
@@ -26,7 +24,7 @@ const PerpsTransactionDetailAssetHero: React.FC<
     >
       <PerpsTokenLogo symbol={transaction.asset} size={44} />
     </View>
-    <Text variant={TextVariant.HeadingLG} style={styles.assetAmount}>
+    <Text variant={TextVariant.HeadingLg} style={styles.assetAmount}>
       {transaction.subtitle}
     </Text>
   </View>

--- a/app/components/UI/Perps/components/PerpsTransactionItem/PerpsTransactionItem.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionItem/PerpsTransactionItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Text } from '@metamask/design-system-react-native';
 import { View, TouchableOpacity, ViewStyle, TextStyle } from 'react-native';
-import Text from '../../../../../component-library/components/Texts/Text';
 import { PerpsTransactionSelectorsIDs } from '../../Perps.testIds';
 import { PERPS_TRANSACTIONS_HISTORY_CONSTANTS } from '@metamask/perps-controller';
 import { PerpsTransaction } from '../../types/transactionHistory';

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -24,11 +24,11 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Text, {
-  TextColor,
+  FontWeight,
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
 import NavigationService from '../../../../../core/NavigationService';
@@ -433,23 +433,23 @@ const PerpsTutorialCarousel: React.FC = () => {
                   {/* Header Section - Now flexible height */}
                   <View>
                     <Text
-                      variant={TextVariant.HeadingLG}
-                      color={TextColor.Default}
+                      variant={TextVariant.HeadingLg}
+                      color={TextColor.TextDefault}
                       style={styles.title}
                     >
                       {screen.title}
                     </Text>
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
                       style={styles.description}
                     >
                       {screen.description}
                     </Text>
                     {screen.subtitle && (
                       <Text
-                        variant={TextVariant.BodyMD}
-                        color={TextColor.Alternative}
+                        variant={TextVariant.BodyMd}
+                        color={TextColor.TextAlternative}
                         style={styles.subtitle}
                       >
                         {screen.subtitle}
@@ -479,8 +479,8 @@ const PerpsTutorialCarousel: React.FC = () => {
                 {screen.footerText && (
                   <View style={styles.footerTextContainer}>
                     <Text
-                      variant={TextVariant.BodySM}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodySm}
+                      color={TextColor.TextAlternative}
                       style={styles.footerText}
                     >
                       {screen.footerText}
@@ -524,8 +524,9 @@ const PerpsTutorialCarousel: React.FC = () => {
                 testID={PerpsTutorialSelectorsIDs.SKIP_BUTTON}
               >
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.tutorial.skip')}
                 </Text>

--- a/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.test.tsx
+++ b/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.test.tsx
@@ -21,18 +21,6 @@ jest.mock('../../../../../component-library/hooks', () => ({
   }),
 }));
 
-jest.mock('../../../../../component-library/components/Texts/Text', () => {
-  const { Text } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ children, ...props }: { children: React.ReactNode }) => (
-      <Text {...props}>{children}</Text>
-    ),
-    TextVariant: { BodyMD: 'BodyMD', BodySM: 'BodySM' },
-    TextColor: { Default: 'Default', Alternative: 'Alternative' },
-  };
-});
-
 jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
   __esModule: true,
   default: () => null,
@@ -42,6 +30,8 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
 }));
 
 jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
   IconColor: { PrimaryDefault: 'PrimaryDefault' },
   IconSize: { Md: 'Md' },
   Spinner: () => null,

--- a/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.tsx
+++ b/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.tsx
@@ -11,12 +11,11 @@ import {
   IconColor as ReactNativeDsIconColor,
   IconSize as ReactNativeDsIconSize,
   Spinner,
-} from '@metamask/design-system-react-native';
-import { useStyles } from '../../../../../component-library/hooks';
-import Text, {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { useStyles } from '../../../../../component-library/hooks';
 import Icon, {
   IconName,
   IconSize,
@@ -264,10 +263,13 @@ const PerpsWebSocketHealthToast: React.FC = memo(() => {
 
             {/* Text Content */}
             <View style={styles.textContainer}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
                 {toastConfig.title}
               </Text>
-              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
                 {toastConfig.description}
               </Text>
             </View>
@@ -280,7 +282,10 @@ const PerpsWebSocketHealthToast: React.FC = memo(() => {
                   onPress={onRetry}
                   testID={PerpsWebSocketHealthToastSelectorsIDs.RETRY_BUTTON}
                 >
-                  <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
                     {strings('perps.connection.websocket_retry')}
                   </Text>
                 </TouchableOpacity>


### PR DESCRIPTION
## Summary

- Migrates 36 Perps component files from deprecated `component-library/components/Texts/Text` to `@metamask/design-system-react-native` Text
- Renames `TextVariant`/`TextColor` values to MMDS equivalents (e.g. `BodyMD` → `BodyMd`, `Default` → `TextDefault`)
- Replaces weight-bearing variants (`BodyMDMedium`, etc.) with base variant + `FontWeight` enum
- Uses `LegacyTextVariant`/`LegacyTextColor` aliases at call sites for unmigrated consumer components (`KeyValueRow`, `SensitiveText`, `LivePriceDisplay`) that still use old component-library Text internally

## Test plan

- [ ] All 26 affected test suites pass (393 tests)
- [ ] No TypeScript errors (`yarn lint:tsc`)
- [ ] Part of a series: PR1 #31439 → PR2 #31442 → **this PR** → PT4 (pending)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical typography and import changes across Perps UI with no trading, auth, or data-flow changes; main risk is subtle visual regressions from variant/color mapping.
> 
> **Overview**
> **Part 3 of the Perps MMDS Text migration** moves dozens of Perps UI components off deprecated `component-library` `Text` onto `@metamask/design-system-react-native`, aligning typography with the MetaMask Design System.
> 
> Direct `Text` usage now follows MMDS naming (`BodyMd`, `TextDefault`, `TextAlternative`, `TextMuted`, `SuccessDefault`/`ErrorDefault`/`WarningDefault`) and replaces weight-specific variants like `BodyMDMedium` with `BodyMd` plus `FontWeight.Medium`. Several headings shift to smaller MMDS steps (e.g. `HeadingMD` → `HeadingSm`, `HeadingLG` → `HeadingLg`).
> 
> **Unmigrated consumers** (`SensitiveText`, `KeyValueRow` in quote details) still expect the legacy API, so those call sites use `LegacyTextVariant` / `LegacyTextColor` aliases while labels and static copy use MMDS `Text`.
> 
> **Tests** drop bespoke `Text` mocks in favor of `jest.requireActual('@metamask/design-system-react-native')` with React Native `Text`, and assertions update to the new variant enum values (e.g. `BodySm` vs `BodySM`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc750167675f4073ca560e4dddf12233adbdb02f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->