### PR TITLE
refactor(perps): migrate Text to MMDS in FundingCountdown, LivePriceDisplay, and PerpsPositionsView (pt4)

### DIFF
--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.tsx
@@ -1,5 +1,11 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { useMemo } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react-native';
 import { ScrollView, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
@@ -10,13 +16,13 @@ import {
   IconColor,
   IconName,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import SensitiveText, {
   SensitiveTextLength,
 } from '../../../../../component-library/components/Texts/SensitiveText';
+import {
+  TextVariant as LegacyTextVariant,
+  TextColor as LegacyTextColor,
+} from '../../../../../component-library/components/Texts/Text';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { useStyles } from '../../../../../component-library/hooks';
 import PerpsPositionCard from '../../components/PerpsPositionCard';
@@ -72,7 +78,7 @@ const PerpsPositionsView: React.FC = () => {
     if (isInitialLoading) {
       return (
         <View style={styles.loadingContainer}>
-          <Text variant={TextVariant.BodyMD} color={TextColor.Muted}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextMuted}>
             {strings('perps.position.list.loading')}
           </Text>
         </View>
@@ -82,10 +88,10 @@ const PerpsPositionsView: React.FC = () => {
     if (error) {
       return (
         <View style={styles.errorContainer}>
-          <Text variant={TextVariant.HeadingSM} color={TextColor.Error}>
+          <Text variant={TextVariant.HeadingSm} color={TextColor.ErrorDefault}>
             {strings('perps.position.list.error_title')}
           </Text>
-          <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
             {error}
           </Text>
         </View>
@@ -95,10 +101,10 @@ const PerpsPositionsView: React.FC = () => {
     if (positions.length === 0) {
       return (
         <View style={styles.emptyContainer}>
-          <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
             {strings('perps.position.list.empty_title')}
           </Text>
-          <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
             {strings('perps.position.list.empty_description')}
           </Text>
         </View>
@@ -111,10 +117,10 @@ const PerpsPositionsView: React.FC = () => {
         testID={PerpsPositionsViewSelectorsIDs.POSITIONS_SECTION}
       >
         <View style={styles.sectionHeader}>
-          <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+          <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
             {strings('perps.position.list.open_positions')}
           </Text>
-          <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
             {positionCountText}
           </Text>
         </View>
@@ -143,7 +149,7 @@ const PerpsPositionsView: React.FC = () => {
           onPress={handleBackPress}
           testID={PerpsPositionsViewSelectorsIDs.BACK_BUTTON}
         />
-        <Text variant={TextVariant.HeadingSM} color={TextColor.Default}>
+        <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
           {strings('perps.position.title')}
         </Text>
         <View style={styles.headerPlaceholder} />
@@ -152,17 +158,21 @@ const PerpsPositionsView: React.FC = () => {
       <ScrollView style={styles.container}>
         {/* Account Summary */}
         <View style={styles.accountSummary}>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+          >
             {strings('perps.position.account.summary_title')}
           </Text>
 
           <View style={styles.summaryRow}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+            <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
               {strings('perps.position.account.total_balance')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodySMMedium}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodySM}
+              color={LegacyTextColor.Default}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
             >
@@ -176,12 +186,12 @@ const PerpsPositionsView: React.FC = () => {
           </View>
 
           <View style={styles.summaryRow}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+            <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
               {strings('perps.position.account.available_balance')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodySMMedium}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodySM}
+              color={LegacyTextColor.Default}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
             >
@@ -195,12 +205,12 @@ const PerpsPositionsView: React.FC = () => {
           </View>
 
           <View style={styles.summaryRow}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+            <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
               {strings('perps.position.account.margin_used')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodySMMedium}
-              color={TextColor.Default}
+              variant={LegacyTextVariant.BodySM}
+              color={LegacyTextColor.Default}
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}
             >
@@ -213,17 +223,17 @@ const PerpsPositionsView: React.FC = () => {
           </View>
 
           <View style={styles.summaryRow}>
-            <Text variant={TextVariant.BodySM} color={TextColor.Muted}>
+            <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
               {strings('perps.position.account.total_unrealized_pnl')}
             </Text>
             <SensitiveText
-              variant={TextVariant.BodySMMedium}
+              variant={LegacyTextVariant.BodySM}
               color={
                 privacyMode
-                  ? TextColor.Default
+                  ? LegacyTextColor.Default
                   : totalUnrealizedPnl >= 0
-                    ? TextColor.Success
-                    : TextColor.Error
+                    ? LegacyTextColor.Success
+                    : LegacyTextColor.Error
               }
               isHidden={privacyMode}
               length={SensitiveTextLength.Short}

--- a/app/components/UI/Perps/components/FundingCountdown/FundingCountdown.test.tsx
+++ b/app/components/UI/Perps/components/FundingCountdown/FundingCountdown.test.tsx
@@ -93,6 +93,9 @@ describe('FundingCountdown', () => {
     );
 
     const element = getByTestId('styled-countdown');
-    expect(element.props.style).toEqual(expect.objectContaining(customStyle));
+    const styles = ([] as object[]).concat(element.props.style);
+    expect(styles).toEqual(
+      expect.arrayContaining([expect.objectContaining(customStyle)]),
+    );
   });
 });

--- a/app/components/UI/Perps/components/FundingCountdown/FundingCountdown.tsx
+++ b/app/components/UI/Perps/components/FundingCountdown/FundingCountdown.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, memo } from 'react';
-import type { TextStyle } from 'react-native';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import type { TextStyle } from 'react-native';
 import { calculateFundingCountdown } from '@metamask/perps-controller';
 
 interface FundingCountdownProps {
@@ -27,8 +28,8 @@ interface FundingCountdownProps {
  * Supports market-specific funding times when provided.
  */
 const FundingCountdown: React.FC<FundingCountdownProps> = ({
-  variant = TextVariant.BodySM,
-  color = TextColor.Default,
+  variant = TextVariant.BodySm,
+  color = TextColor.TextDefault,
   style,
   testID,
   nextFundingTime,

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceDisplay.test.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceDisplay.test.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import LivePriceDisplay from './LivePriceDisplay';
 import { usePerpsLivePrices } from '../../hooks/stream';
-import {
-  TextVariant,
-  TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+import { TextVariant, TextColor } from '@metamask/design-system-react-native';
 
 jest.mock('../../hooks/stream');
 
@@ -115,8 +112,9 @@ describe('LivePriceDisplay', () => {
       <LivePriceDisplay
         symbol="AVAX"
         testID="custom-price"
-        variant={TextVariant.BodyLGMedium}
-        color={TextColor.Primary}
+        variant={TextVariant.BodyLg}
+        fontWeight="medium"
+        color={TextColor.PrimaryDefault}
       />,
     );
 

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceDisplay.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceDisplay.tsx
@@ -1,9 +1,10 @@
 import React, { memo } from 'react';
-import { View } from 'react-native';
-import Text, {
+import {
+  Text,
   TextVariant,
   TextColor,
-} from '../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { View } from 'react-native';
 import { usePerpsLivePrices } from '../../hooks/stream';
 import {
   formatPerpsFiat,
@@ -26,8 +27,8 @@ interface LivePriceDisplayProps {
  */
 const LivePriceDisplay: React.FC<LivePriceDisplayProps> = ({
   symbol,
-  variant = TextVariant.BodyMD,
-  color = TextColor.Default,
+  variant = TextVariant.BodyMd,
+  color = TextColor.TextDefault,
   showChange = false,
   testID,
   throttleMs = 1000, // Default to 1 second updates for price displays
@@ -51,13 +52,14 @@ const LivePriceDisplay: React.FC<LivePriceDisplayProps> = ({
   const change = parseFloat(priceData.percentChange24h || '0');
 
   if (showChange) {
-    const changeColor = change >= 0 ? TextColor.Success : TextColor.Error;
+    const changeColor =
+      change >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault;
     return (
       <View>
         <Text variant={variant} color={color} testID={testID}>
           {formatPerpsFiat(price, { ranges: PRICE_RANGES_UNIVERSAL })}
         </Text>
-        <Text variant={TextVariant.BodySM} color={changeColor}>
+        <Text variant={TextVariant.BodySm} color={changeColor}>
           {formatPercentage(change)}
         </Text>
       </View>

--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.test.tsx
@@ -10,6 +10,10 @@ const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockCanGoBack = jest.fn();
 
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Text: jest.requireActual('react-native').Text,
+}));
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
   return {

--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
@@ -1,4 +1,9 @@
 import React, { useMemo } from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import Icon, {
@@ -6,11 +11,8 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import KeyValueRow from '../../../../../component-library/components-temp/KeyValueRow';
+import { TextVariant as LegacyTextVariant } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './PerpsMarketStatisticsCard.styles';
 import type { PerpsMarketStatisticsCardProps } from './PerpsMarketStatisticsCard.types';
@@ -76,7 +78,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
     }
 
     // Determine color based on value
-    const color = fundingValue >= 0 ? TextColor.Success : TextColor.Error;
+    const color =
+      fundingValue >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault;
 
     return {
       value: fundingValue,
@@ -89,12 +92,12 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
   const fundingValueContent = useMemo(
     () => (
       <View style={styles.fundingRateContainer}>
-        <Text variant={TextVariant.BodyMD} color={fundingRateData.color}>
+        <Text variant={TextVariant.BodyMd} color={fundingRateData.color}>
           {fundingRateData.displayText}
         </Text>
         <FundingCountdown
-          variant={TextVariant.BodySM}
-          color={TextColor.Alternative}
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
           style={styles.fundingCountdown}
           nextFundingTime={nextFundingTime}
           fundingIntervalHours={fundingIntervalHours}
@@ -117,7 +120,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
     <View style={styles.container}>
       {/* Header with title with DEX badge */}
       <View style={styles.header}>
-        <Text variant={TextVariant.HeadingMD} color={TextColor.Default}>
+        <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
           {strings('perps.market.stats')}
         </Text>
         {dexName && <Tag label={dexName.toUpperCase()} style={styles.dexTag} />}
@@ -133,7 +136,10 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             testID={PerpsOrderBookViewSelectorsIDs.CONTAINER}
           >
             <View style={styles.orderBookRowContent}>
-              <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
                 {strings('perps.market.order_book')}
               </Text>
             </View>
@@ -150,15 +156,15 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
           field={{
             label: {
               text: strings('perps.market.24h_volume'),
-              variant: TextVariant.BodyMD,
-              color: TextColor.Alternative,
+              variant: LegacyTextVariant.BodyMD,
+              color: TextColor.TextAlternative,
             },
           }}
           value={{
             label: {
               text: marketStats.volume24h,
-              variant: TextVariant.BodyMD,
-              color: TextColor.Default,
+              variant: LegacyTextVariant.BodyMD,
+              color: TextColor.TextDefault,
             },
           }}
           style={[styles.statsRow, !onOrderBookPress && styles.statsRowFirst]}
@@ -170,8 +176,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             label: (
               <View style={styles.labelWithIcon}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.market.open_interest')}
                 </Text>
@@ -191,8 +197,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
           value={{
             label: {
               text: marketStats.openInterest,
-              variant: TextVariant.BodyMD,
-              color: TextColor.Default,
+              variant: LegacyTextVariant.BodyMD,
+              color: TextColor.TextDefault,
             },
           }}
           style={styles.statsRow}
@@ -204,8 +210,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             label: (
               <View style={styles.labelWithIcon}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.market.funding_rate')}
                 </Text>
@@ -234,8 +240,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             label: (
               <View style={styles.labelWithIcon}>
                 <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('perps.market.oracle_price')}
                 </Text>
@@ -255,8 +261,8 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
           value={{
             label: (
               <Text
-                variant={TextVariant.BodyMD}
-                color={TextColor.Default}
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
                 testID={
                   PerpsMarketDetailsViewSelectorsIDs.STATISTICS_ORACLE_PRICE
                 }


### PR DESCRIPTION
## Summary

- Migrates the remaining deferred Perps files to `@metamask/design-system-react-native` Text
- **`FundingCountdown`** — migrated from old Text to MMDS; now accepts MMDS `TextVariant`/`TextColor` in its props interface
- **`LivePriceDisplay`** — migrated from old Text to MMDS; now accepts MMDS `TextVariant`/`TextColor` in its props interface  
- **`PerpsPositionsView`** — migrated MMDS Text for direct uses; `SensitiveText` call sites use `LegacyTextVariant`/`LegacyTextColor` aliases until `SensitiveText` itself is migrated
- **`PerpsMarketStatisticsCard`** — updated to pass MMDS variants to the now-migrated `FundingCountdown`; `KeyValueRow` call sites retain `LegacyTextVariant` until `KeyValueRow` is migrated

## Notes

> This PR overlaps with PR2 (#31442) on `PerpsMarketStatisticsCard.tsx`. Whichever merges second will need a trivial rebase.

## Test plan

- [ ] All 5 affected test suites pass (71 tests)
- [ ] No TypeScript errors (`yarn lint:tsc`)
- [ ] Completes the series: PR1 #31439 → PR2 #31442 → PR3 #31445 → **this PR**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only typography and import changes in Perps screens with no auth, data, or payment logic touched.
> 
> **Overview**
> Continues the Perps **MMDS Text migration** by swapping component-library `Text` for `@metamask/design-system-react-native` in **`FundingCountdown`**, **`LivePriceDisplay`**, **`PerpsPositionsView`**, and related **`PerpsMarketStatisticsCard`** call sites.
> 
> Typography tokens are updated to MMDS names (e.g. `BodySm` / `TextMuted` / `SuccessDefault`), and **`PerpsPositionsView`** uses **`FontWeight.Medium`** where the old `BodyMDMedium` variant applied. **`SensitiveText`** and **`KeyValueRow`** still take **`LegacyTextVariant`** / **`LegacyTextColor`** until those components migrate.
> 
> Tests were adjusted for MMDS defaults (including **`FundingCountdown`** style arrays and a **`PerpsMarketStatisticsCard`** mock that maps MMDS `Text` to React Native `Text`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3238c4e4df06223c41e0748cda07017e43557199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->