### PR TITLE
feat: default USA marketing opt-in for social login

### DIFF
--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -48,6 +48,10 @@ jest.mock('../../../util/mnemonic', () => ({
   ),
 }));
 
+jest.mock('../../../util/region/isUsaDeviceRegion', () => ({
+  isUsaDeviceRegion: jest.fn(() => false),
+}));
+
 jest.mock('@metamask/key-tree', () => ({
   mnemonicPhraseToBytes: jest.fn((_phrase) => new Uint8Array([1, 2, 3])),
 }));
@@ -67,6 +71,7 @@ import {
 import type { Span } from '@sentry/core';
 import OAuthLoginService from '../../../core/OAuthService/OAuthService';
 import { captureException } from '@sentry/react-native';
+import { isUsaDeviceRegion } from '../../../util/region/isUsaDeviceRegion';
 
 const mockTrackOnboarding = trackOnboarding as jest.MockedFunction<
   typeof trackOnboarding
@@ -79,6 +84,10 @@ const mockCaptureException = captureException as jest.MockedFunction<
 OAuthLoginService.updateMarketingOptInStatus = jest
   .fn()
   .mockResolvedValue({ is_opt_in: true });
+
+const mockIsUsaDeviceRegion = isUsaDeviceRegion as jest.MockedFunction<
+  typeof isUsaDeviceRegion
+>;
 
 jest.mock('../../../core/Engine', () => ({
   context: {
@@ -318,6 +327,7 @@ describe('ChoosePassword', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockTrackOnboarding.mockClear();
+    mockIsUsaDeviceRegion.mockReturnValue(false);
     mockRoute.params = {
       [ONBOARDING]: true,
       [PROTECT]: true,
@@ -979,6 +989,92 @@ describe('ChoosePassword', () => {
   describe('Marketing API', () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      mockIsUsaDeviceRegion.mockReturnValue(false);
+    });
+
+    it('defaults marketing opt-in to checked for USA OAuth users without toggling the checkbox', async () => {
+      mockIsUsaDeviceRegion.mockReturnValue(true);
+      (
+        Authentication.componentAuthenticationType as jest.Mock
+      ).mockResolvedValue({
+        currentAuthType: 'passcode',
+        availableBiometryType: 'faceID',
+      });
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      mockNewWalletAndKeychain.mockResolvedValue(undefined);
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+        oauthLoginSuccess: true,
+        provider: 'google',
+      };
+      const spyUpdateMarketingOptInStatus = jest
+        .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
+        .mockResolvedValue(undefined);
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+      await fillAndSubmitForm(component, VALID_PASSWORD, VALID_PASSWORD, false);
+
+      await waitFor(() => {
+        expect(spyUpdateMarketingOptInStatus).toHaveBeenCalledWith(true);
+      });
+
+      mockNewWalletAndKeychain.mockRestore();
+    });
+
+    it('defaults marketing opt-in to unchecked for non-USA OAuth users without toggling the checkbox', async () => {
+      mockIsUsaDeviceRegion.mockReturnValue(false);
+      (
+        Authentication.componentAuthenticationType as jest.Mock
+      ).mockResolvedValue({
+        currentAuthType: 'passcode',
+        availableBiometryType: 'faceID',
+      });
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      mockNewWalletAndKeychain.mockResolvedValue(undefined);
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+        oauthLoginSuccess: true,
+        provider: 'google',
+      };
+      const spyUpdateMarketingOptInStatus = jest
+        .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
+        .mockResolvedValue(undefined);
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+      await fillAndSubmitForm(component, VALID_PASSWORD, VALID_PASSWORD, false);
+
+      await waitFor(() => {
+        expect(spyUpdateMarketingOptInStatus).toHaveBeenCalledWith(false);
+      });
+
+      mockNewWalletAndKeychain.mockRestore();
+    });
+
+    it('keeps the acknowledgement checkbox unchecked by default for USA non-OAuth users', async () => {
+      mockIsUsaDeviceRegion.mockReturnValue(true);
+      mockRoute.params = {
+        ...mockRoute.params,
+        [PREVIOUS_SCREEN]: ONBOARDING,
+      };
+
+      const component = renderWithProviders(<ChoosePassword />);
+      await waitForInit();
+      await fillForm(component, VALID_PASSWORD, VALID_PASSWORD, false);
+
+      const submitButton = component.getByTestId(
+        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      );
+      expect(submitButton).toBeDisabled();
     });
 
     it('sends marketing opt-in=true when OAuth user checks the checkbox before submitting', async () => {

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -100,6 +100,7 @@ import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalytics
 import generateDeviceAnalyticsMetaData, {
   UserSettingsAnalyticsMetaData as generateUserSettingsAnalyticsMetaData,
 } from '../../../util/metrics';
+import { getDefaultMarketingOptInChecked } from '../../../util/onboarding/getDefaultMarketingOptInChecked';
 
 interface KeyringState {
   type: string;
@@ -133,7 +134,9 @@ const ChoosePassword = () => {
   const attributionRecord = useSelector(selectAttributionRecord);
   const metrics = useAnalytics();
 
-  const [isSelected, setIsSelected] = useState(false);
+  const [isSelected, setIsSelected] = useState(() =>
+    getDefaultMarketingOptInChecked(route.params?.oauthLoginSuccess === true),
+  );
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);

--- a/app/util/onboarding/getDefaultMarketingOptInChecked.test.ts
+++ b/app/util/onboarding/getDefaultMarketingOptInChecked.test.ts
@@ -1,9 +1,17 @@
-import { getDefaultMarketingOptInChecked } from './getDefaultMarketingOptInChecked';
-import { isUsaDeviceRegion } from '../region/isUsaDeviceRegion';
+let mockHasTestOverrides = false;
 
 jest.mock('../region/isUsaDeviceRegion', () => ({
   isUsaDeviceRegion: jest.fn(),
 }));
+
+jest.mock('../test/utils', () => ({
+  get hasTestOverrides() {
+    return mockHasTestOverrides;
+  },
+}));
+
+import { getDefaultMarketingOptInChecked } from './getDefaultMarketingOptInChecked';
+import { isUsaDeviceRegion } from '../region/isUsaDeviceRegion';
 
 const mockIsUsaDeviceRegion = isUsaDeviceRegion as jest.MockedFunction<
   typeof isUsaDeviceRegion
@@ -12,6 +20,14 @@ const mockIsUsaDeviceRegion = isUsaDeviceRegion as jest.MockedFunction<
 describe('getDefaultMarketingOptInChecked', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHasTestOverrides = false;
+  });
+
+  it('returns false in E2E test builds regardless of region', () => {
+    mockHasTestOverrides = true;
+    mockIsUsaDeviceRegion.mockReturnValue(true);
+
+    expect(getDefaultMarketingOptInChecked(true)).toBe(false);
   });
 
   it('returns true for social login users in the USA', () => {

--- a/app/util/onboarding/getDefaultMarketingOptInChecked.test.ts
+++ b/app/util/onboarding/getDefaultMarketingOptInChecked.test.ts
@@ -1,0 +1,40 @@
+import { getDefaultMarketingOptInChecked } from './getDefaultMarketingOptInChecked';
+import { isUsaDeviceRegion } from '../region/isUsaDeviceRegion';
+
+jest.mock('../region/isUsaDeviceRegion', () => ({
+  isUsaDeviceRegion: jest.fn(),
+}));
+
+const mockIsUsaDeviceRegion = isUsaDeviceRegion as jest.MockedFunction<
+  typeof isUsaDeviceRegion
+>;
+
+describe('getDefaultMarketingOptInChecked', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true for social login users in the USA', () => {
+    mockIsUsaDeviceRegion.mockReturnValue(true);
+
+    expect(getDefaultMarketingOptInChecked(true)).toBe(true);
+  });
+
+  it('returns false for social login users outside the USA', () => {
+    mockIsUsaDeviceRegion.mockReturnValue(false);
+
+    expect(getDefaultMarketingOptInChecked(true)).toBe(false);
+  });
+
+  it('returns false for non-social-login users in the USA', () => {
+    mockIsUsaDeviceRegion.mockReturnValue(true);
+
+    expect(getDefaultMarketingOptInChecked(false)).toBe(false);
+  });
+
+  it('returns false for non-social-login users outside the USA', () => {
+    mockIsUsaDeviceRegion.mockReturnValue(false);
+
+    expect(getDefaultMarketingOptInChecked(false)).toBe(false);
+  });
+});

--- a/app/util/onboarding/getDefaultMarketingOptInChecked.ts
+++ b/app/util/onboarding/getDefaultMarketingOptInChecked.ts
@@ -1,0 +1,11 @@
+import { isUsaDeviceRegion } from '../region/isUsaDeviceRegion';
+
+/**
+ * Returns the default checked state for the marketing opt-in checkbox
+ * on ChoosePassword for social login users during onboarding.
+ */
+export function getDefaultMarketingOptInChecked(
+  isSocialLoginUser: boolean,
+): boolean {
+  return isSocialLoginUser && isUsaDeviceRegion();
+}

--- a/app/util/onboarding/getDefaultMarketingOptInChecked.ts
+++ b/app/util/onboarding/getDefaultMarketingOptInChecked.ts
@@ -1,4 +1,5 @@
 import { isUsaDeviceRegion } from '../region/isUsaDeviceRegion';
+import { hasTestOverrides } from '../test/utils';
 
 /**
  * Returns the default checked state for the marketing opt-in checkbox
@@ -7,5 +8,10 @@ import { isUsaDeviceRegion } from '../region/isUsaDeviceRegion';
 export function getDefaultMarketingOptInChecked(
   isSocialLoginUser: boolean,
 ): boolean {
+  // E2E builds keep the checkbox unchecked so tests can opt in with a single tap.
+  if (hasTestOverrides) {
+    return false;
+  }
+
   return isSocialLoginUser && isUsaDeviceRegion();
 }

--- a/app/util/region/isUsaDeviceRegion.test.ts
+++ b/app/util/region/isUsaDeviceRegion.test.ts
@@ -31,6 +31,24 @@ describe('isUsaDeviceRegion', () => {
     expect(isUsaDeviceRegion()).toBe(true);
   });
 
+  it('returns true for en-US locale with unicode extensions', () => {
+    mockDeviceLocale('en-US-u-nu-latn');
+
+    expect(isUsaDeviceRegion()).toBe(true);
+  });
+
+  it('returns false for en-GB locale with unicode extensions', () => {
+    mockDeviceLocale('en-GB-u-nu-latn');
+
+    expect(isUsaDeviceRegion()).toBe(false);
+  });
+
+  it('returns true for locale with script subtag before region', () => {
+    mockDeviceLocale('zh-Hans-US');
+
+    expect(isUsaDeviceRegion()).toBe(true);
+  });
+
   it('returns false for en-GB locale', () => {
     mockDeviceLocale('en-GB');
 

--- a/app/util/region/isUsaDeviceRegion.test.ts
+++ b/app/util/region/isUsaDeviceRegion.test.ts
@@ -1,70 +1,45 @@
+import { getCountry } from 'react-native-localize';
 import { isUsaDeviceRegion } from './isUsaDeviceRegion';
 
+jest.mock('react-native-localize', () => ({
+  getCountry: jest.fn(),
+}));
+
+const mockGetCountry = getCountry as jest.MockedFunction<typeof getCountry>;
+
 describe('isUsaDeviceRegion', () => {
-  const originalDateTimeFormat = Intl.DateTimeFormat;
-
-  afterEach(() => {
-    Intl.DateTimeFormat = originalDateTimeFormat;
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  const mockDeviceLocale = (locale: string) => {
-    Intl.DateTimeFormat = jest.fn().mockImplementation(() => ({
-      resolvedOptions: () => ({ locale }),
-    })) as unknown as typeof Intl.DateTimeFormat;
-  };
-
-  it('returns true for en-US locale', () => {
-    mockDeviceLocale('en-US');
+  it('returns true when device region is US', () => {
+    mockGetCountry.mockReturnValue('US');
 
     expect(isUsaDeviceRegion()).toBe(true);
   });
 
-  it('returns true for es-US locale', () => {
-    mockDeviceLocale('es-US');
+  it('returns true when device region is us (lowercase)', () => {
+    mockGetCountry.mockReturnValue('us');
 
     expect(isUsaDeviceRegion()).toBe(true);
   });
 
-  it('returns true for en_US locale with underscore separator', () => {
-    mockDeviceLocale('en_US');
-
-    expect(isUsaDeviceRegion()).toBe(true);
-  });
-
-  it('returns true for en-US locale with unicode extensions', () => {
-    mockDeviceLocale('en-US-u-nu-latn');
-
-    expect(isUsaDeviceRegion()).toBe(true);
-  });
-
-  it('returns false for en-GB locale with unicode extensions', () => {
-    mockDeviceLocale('en-GB-u-nu-latn');
+  it('returns false when device region is GB', () => {
+    mockGetCountry.mockReturnValue('GB');
 
     expect(isUsaDeviceRegion()).toBe(false);
   });
 
-  it('returns true for locale with script subtag before region', () => {
-    mockDeviceLocale('zh-Hans-US');
-
-    expect(isUsaDeviceRegion()).toBe(true);
-  });
-
-  it('returns false for en-GB locale', () => {
-    mockDeviceLocale('en-GB');
+  it('returns false when device region is unavailable', () => {
+    mockGetCountry.mockReturnValue('');
 
     expect(isUsaDeviceRegion()).toBe(false);
   });
 
-  it('returns false when locale has no region subtag', () => {
-    mockDeviceLocale('en');
-
-    expect(isUsaDeviceRegion()).toBe(false);
-  });
-
-  it('returns false when Intl.DateTimeFormat throws', () => {
-    Intl.DateTimeFormat = jest.fn().mockImplementation(() => {
-      throw new Error('Intl unavailable');
-    }) as unknown as typeof Intl.DateTimeFormat;
+  it('returns false when getCountry throws', () => {
+    mockGetCountry.mockImplementation(() => {
+      throw new Error('native module unavailable');
+    });
 
     expect(isUsaDeviceRegion()).toBe(false);
   });

--- a/app/util/region/isUsaDeviceRegion.test.ts
+++ b/app/util/region/isUsaDeviceRegion.test.ts
@@ -1,0 +1,53 @@
+import { isUsaDeviceRegion } from './isUsaDeviceRegion';
+
+describe('isUsaDeviceRegion', () => {
+  const originalDateTimeFormat = Intl.DateTimeFormat;
+
+  afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat;
+  });
+
+  const mockDeviceLocale = (locale: string) => {
+    Intl.DateTimeFormat = jest.fn().mockImplementation(() => ({
+      resolvedOptions: () => ({ locale }),
+    })) as unknown as typeof Intl.DateTimeFormat;
+  };
+
+  it('returns true for en-US locale', () => {
+    mockDeviceLocale('en-US');
+
+    expect(isUsaDeviceRegion()).toBe(true);
+  });
+
+  it('returns true for es-US locale', () => {
+    mockDeviceLocale('es-US');
+
+    expect(isUsaDeviceRegion()).toBe(true);
+  });
+
+  it('returns true for en_US locale with underscore separator', () => {
+    mockDeviceLocale('en_US');
+
+    expect(isUsaDeviceRegion()).toBe(true);
+  });
+
+  it('returns false for en-GB locale', () => {
+    mockDeviceLocale('en-GB');
+
+    expect(isUsaDeviceRegion()).toBe(false);
+  });
+
+  it('returns false when locale has no region subtag', () => {
+    mockDeviceLocale('en');
+
+    expect(isUsaDeviceRegion()).toBe(false);
+  });
+
+  it('returns false when Intl.DateTimeFormat throws', () => {
+    Intl.DateTimeFormat = jest.fn().mockImplementation(() => {
+      throw new Error('Intl unavailable');
+    }) as unknown as typeof Intl.DateTimeFormat;
+
+    expect(isUsaDeviceRegion()).toBe(false);
+  });
+});

--- a/app/util/region/isUsaDeviceRegion.ts
+++ b/app/util/region/isUsaDeviceRegion.ts
@@ -1,0 +1,40 @@
+const USA_REGION_CODE = 'US';
+
+const getRegionCodeFromLocale = (locale: string): string | undefined => {
+  const normalizedLocale = locale.replace(/_/g, '-');
+  const subtags = normalizedLocale.split('-');
+
+  if (subtags.length < 2) {
+    return undefined;
+  }
+
+  const regionSubtag = subtags[subtags.length - 1];
+
+  if (/^[A-Za-z]{2}$/.test(regionSubtag)) {
+    return regionSubtag.toUpperCase();
+  }
+
+  return undefined;
+};
+
+const getDeviceLocale = (): string | undefined => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().locale;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Detects whether the device locale indicates a USA region.
+ * Uses Intl locale resolution only — no network or geolocation APIs.
+ */
+export function isUsaDeviceRegion(): boolean {
+  const locale = getDeviceLocale();
+
+  if (!locale) {
+    return false;
+  }
+
+  return getRegionCodeFromLocale(locale) === USA_REGION_CODE;
+}

--- a/app/util/region/isUsaDeviceRegion.ts
+++ b/app/util/region/isUsaDeviceRegion.ts
@@ -1,54 +1,16 @@
+import { getCountry } from 'react-native-localize';
+
 const USA_REGION_CODE = 'US';
 
-const getRegionCodeFromLocale = (locale: string): string | undefined => {
-  const normalizedLocale = locale.replace(/_/g, '-');
-  const subtags = normalizedLocale.split('-');
-
-  if (subtags.length < 2) {
-    return undefined;
-  }
-
-  // BCP 47: region follows language and optional script, before variants/extensions.
-  // e.g. en-US-u-nu-latn → US (not latn from the trailing unicode extension).
-  for (const subtag of subtags.slice(1)) {
-    if (subtag.length === 1) {
-      break;
-    }
-
-    if (/^[A-Za-z]{4}$/.test(subtag)) {
-      continue;
-    }
-
-    if (/^[A-Za-z]{2}$/.test(subtag)) {
-      return subtag.toUpperCase();
-    }
-
-    if (/^[0-9]{3}$/.test(subtag)) {
-      return subtag;
-    }
-  }
-
-  return undefined;
-};
-
-const getDeviceLocale = (): string | undefined => {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().locale;
-  } catch {
-    return undefined;
-  }
-};
-
 /**
- * Detects whether the device locale indicates a USA region.
- * Uses Intl locale resolution only — no network or geolocation APIs.
+ * Detects whether the device region setting indicates USA.
+ * Uses the OS country/region from react-native-localize — not the
+ * Intl formatting locale, which can diverge from the device region.
  */
 export function isUsaDeviceRegion(): boolean {
-  const locale = getDeviceLocale();
-
-  if (!locale) {
+  try {
+    return getCountry().toUpperCase() === USA_REGION_CODE;
+  } catch {
     return false;
   }
-
-  return getRegionCodeFromLocale(locale) === USA_REGION_CODE;
 }

--- a/app/util/region/isUsaDeviceRegion.ts
+++ b/app/util/region/isUsaDeviceRegion.ts
@@ -8,10 +8,24 @@ const getRegionCodeFromLocale = (locale: string): string | undefined => {
     return undefined;
   }
 
-  const regionSubtag = subtags[subtags.length - 1];
+  // BCP 47: region follows language and optional script, before variants/extensions.
+  // e.g. en-US-u-nu-latn → US (not latn from the trailing unicode extension).
+  for (const subtag of subtags.slice(1)) {
+    if (subtag.length === 1) {
+      break;
+    }
 
-  if (/^[A-Za-z]{2}$/.test(regionSubtag)) {
-    return regionSubtag.toUpperCase();
+    if (/^[A-Za-z]{4}$/.test(subtag)) {
+      continue;
+    }
+
+    if (/^[A-Za-z]{2}$/.test(subtag)) {
+      return subtag.toUpperCase();
+    }
+
+    if (/^[0-9]{3}$/.test(subtag)) {
+      return subtag;
+    }
   }
 
   return undefined;

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -454,6 +454,9 @@ jest.mock('react-native-keychain', () => ({
 }));
 
 jest.mock('react-native-share', () => 'RNShare');
+jest.mock('react-native-localize', () => ({
+  getCountry: jest.fn(() => 'GB'),
+}));
 jest.mock('react-native-branch', () => ({
   subscribe: jest.fn(),
 }));

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4700,7 +4700,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   Branch: 4ac024cb3c29b0ef628048694db3c4cfa679beb0
   braze-react-native-sdk: 81f97f9dd9aae9e89e8ff4083e473e6cb8930cd7
   BrazeKit: ba951d2299c1d16b541cf35cdd7250d03e28a0fb
@@ -4708,7 +4708,7 @@ SPEC CHECKSUMS:
   BrazeUI: 1d733e1dea4d81f95f261b52cc6e4b91a0eccca8
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 40dd9e740684782610c49becab2643782ea1a20c
   EXApplication: 1e98d4b1dccdf30627f92917f4b2c5a53c330e5f
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
@@ -4745,8 +4745,8 @@ SPEC CHECKSUMS:
   FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
   FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
   FirebaseMessaging: 7b5d8033e183ab59eb5b852a53201559e976d366
-  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   GoogleAcm: 3ed0d224f5c1f408ccc9eccfb53484354342774e
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3729,6 +3729,34 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - RNLocalize (3.7.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNNotifee (9.0.2):
     - React-Core
     - RNNotifee/NotifeeCore (= 9.0.2)
@@ -4277,6 +4305,7 @@ DEPENDENCIES:
   - RNI18n (from `../node_modules/react-native-i18n`)
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - "RNNotifee (from `../node_modules/@notifee/react-native`)"
   - RNOS (from `../node_modules/react-native-os`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
@@ -4637,6 +4666,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-inappbrowser-reborn"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNNotifee:
     :path: "../node_modules/@notifee/react-native"
   RNOS:
@@ -4669,7 +4700,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
   BEMCheckBox: 5ba6e37ade3d3657b36caecc35c8b75c6c2b1a4e
-  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   Branch: 4ac024cb3c29b0ef628048694db3c4cfa679beb0
   braze-react-native-sdk: 81f97f9dd9aae9e89e8ff4083e473e6cb8930cd7
   BrazeKit: ba951d2299c1d16b541cf35cdd7250d03e28a0fb
@@ -4677,7 +4708,7 @@ SPEC CHECKSUMS:
   BrazeUI: 1d733e1dea4d81f95f261b52cc6e4b91a0eccca8
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EASClient: 40dd9e740684782610c49becab2643782ea1a20c
   EXApplication: 1e98d4b1dccdf30627f92917f4b2c5a53c330e5f
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
@@ -4714,8 +4745,8 @@ SPEC CHECKSUMS:
   FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
   FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
   FirebaseMessaging: 7b5d8033e183ab59eb5b852a53201559e976d366
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   GoogleAcm: 3ed0d224f5c1f408ccc9eccfb53484354342774e
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
@@ -4846,6 +4877,7 @@ SPEC CHECKSUMS:
   RNI18n: 11ec5086508673ef71b5b567da3e8bcca8a926e1
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
   RNKeychain: 483402cf2b90647eb0cf569cebbc069d32addea4
+  RNLocalize: 1aedbc2c15073861a364174919d23c31c5924b16
   RNNotifee: 5165d37aaf980031837be3caece2eae5a6d73ae8
   RNOS: d07e5090b5060c6f2b83116d740a32cfdb33afe3
   RNPermissions: b65e9cc101a4e6b58ec1f8d018b0b167f6eb63d5

--- a/package.json
+++ b/package.json
@@ -496,6 +496,7 @@
     "react-native-keychain": "^9.0.0",
     "react-native-level-fs": "3.0.1",
     "react-native-linear-gradient": "^2.8.3",
+    "react-native-localize": "^3.4.1",
     "react-native-material-textfield": "0.16.1",
     "react-native-mmkv": "^3.2.0",
     "react-native-modal": "^14.0.0-rc.1",

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -254,6 +254,46 @@ class CreatePasswordView {
     });
   }
 
+  /**
+   * Ensures the marketing opt-in checkbox is checked for OAuth flows without
+   * toggling it off when already selected (e.g. USA locale default, TO-776).
+   */
+  async ensureMarketingOptInChecked(): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        const checkbox = asDetoxElement(this.iUnderstandCheckbox);
+        const el = (await checkbox) as Detox.IndexableNativeElement;
+        let isChecked = false;
+
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, jest/valid-expect
+          await (expect(el) as any).toHaveToggleValue(true);
+          isChecked = true;
+        } catch {
+          isChecked = false;
+        }
+
+        if (!isChecked) {
+          await Gestures.tap(checkbox, {
+            elemDescription: 'Create Password - Marketing opt-in checkbox',
+            checkVisibility: false,
+          });
+        }
+      },
+      appium: async () => {
+        const checkbox = asPlaywrightElement(this.iUnderstandCheckbox);
+        const ariaChecked = await checkbox.getAttribute('aria-checked');
+        const checked = ariaChecked === 'true';
+
+        if (!checked) {
+          await UnifiedGestures.waitAndTap(this.iUnderstandCheckbox, {
+            description: 'Create Password - Marketing opt-in checkbox',
+          });
+        }
+      },
+    });
+  }
+
   async tapCreatePasswordButton(): Promise<void> {
     await encapsulatedAction({
       detox: async () => {

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -281,7 +281,7 @@ class CreatePasswordView {
         }
       },
       appium: async () => {
-        const checkbox = asPlaywrightElement(this.iUnderstandCheckbox);
+        const checkbox = await asPlaywrightElement(this.iUnderstandCheckbox);
         const ariaChecked = await checkbox.getAttribute('aria-checked');
         const checked = ariaChecked === 'true';
 

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -255,38 +255,76 @@ class CreatePasswordView {
   }
 
   /**
-   * Reads marketing checkbox selection from Detox element attributes.
-   * Returns undefined when state cannot be determined (do not tap in that case).
+   * Reads marketing checkbox selection from native accessibility attributes.
+   * Returns undefined when state cannot be determined.
    */
+  private parseMarketingCheckboxCheckedState(
+    attributes: Record<string, unknown>,
+  ): boolean | undefined {
+    const accessibilityState = attributes.accessibilityState as
+      | { checked?: boolean }
+      | undefined;
+
+    if (typeof accessibilityState?.checked === 'boolean') {
+      return accessibilityState.checked;
+    }
+
+    if (typeof attributes.checked === 'boolean') {
+      return attributes.checked;
+    }
+
+    if (attributes.checked === 'true') {
+      return true;
+    }
+
+    if (attributes.checked === 'false') {
+      return false;
+    }
+
+    if (attributes.value === 1 || attributes.value === '1') {
+      return true;
+    }
+
+    if (attributes.value === 0 || attributes.value === '0') {
+      return false;
+    }
+
+    if (attributes['aria-checked'] === 'true') {
+      return true;
+    }
+
+    if (attributes['aria-checked'] === 'false') {
+      return false;
+    }
+
+    return undefined;
+  }
+
   private async readMarketingCheckboxChecked(
     el: Detox.IndexableNativeElement,
   ): Promise<boolean | undefined> {
     try {
       const attributes = (await el.getAttributes()) as Record<string, unknown>;
-      const accessibilityState = attributes.accessibilityState as
-        | { checked?: boolean }
-        | undefined;
-
-      if (typeof accessibilityState?.checked === 'boolean') {
-        return accessibilityState.checked;
-      }
-
-      if (typeof attributes.checked === 'boolean') {
-        return attributes.checked;
-      }
-
-      if (attributes.value === 1 || attributes.value === '1') {
-        return true;
-      }
-
-      if (attributes.value === 0 || attributes.value === '0') {
-        return false;
-      }
+      return this.parseMarketingCheckboxCheckedState(attributes);
     } catch {
       return undefined;
     }
+  }
 
-    return undefined;
+  private async readMarketingCheckboxCheckedAppium(
+    checkbox: Awaited<ReturnType<typeof asPlaywrightElement>>,
+  ): Promise<boolean | undefined> {
+    try {
+      const attributes: Record<string, unknown> = {
+        'aria-checked': await checkbox.getAttribute('aria-checked'),
+        checked: await checkbox.getAttribute('checked'),
+        value: await checkbox.getAttribute('value'),
+      };
+
+      return this.parseMarketingCheckboxCheckedState(attributes);
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -311,12 +349,20 @@ class CreatePasswordView {
       },
       appium: async () => {
         const checkbox = await asPlaywrightElement(this.iUnderstandCheckbox);
-        const ariaChecked = await checkbox.getAttribute('aria-checked');
+        const isChecked =
+          await this.readMarketingCheckboxCheckedAppium(checkbox);
 
-        if (ariaChecked === 'false') {
+        if (isChecked === false) {
           await UnifiedGestures.waitAndTap(this.iUnderstandCheckbox, {
             description: 'Create Password - Marketing opt-in checkbox',
           });
+          return;
+        }
+
+        if (isChecked === undefined) {
+          throw new Error(
+            'Unable to determine marketing opt-in checkbox state in Appium',
+          );
         }
       },
     });

--- a/tests/page-objects/Onboarding/CreatePasswordView.ts
+++ b/tests/page-objects/Onboarding/CreatePasswordView.ts
@@ -255,6 +255,41 @@ class CreatePasswordView {
   }
 
   /**
+   * Reads marketing checkbox selection from Detox element attributes.
+   * Returns undefined when state cannot be determined (do not tap in that case).
+   */
+  private async readMarketingCheckboxChecked(
+    el: Detox.IndexableNativeElement,
+  ): Promise<boolean | undefined> {
+    try {
+      const attributes = (await el.getAttributes()) as Record<string, unknown>;
+      const accessibilityState = attributes.accessibilityState as
+        | { checked?: boolean }
+        | undefined;
+
+      if (typeof accessibilityState?.checked === 'boolean') {
+        return accessibilityState.checked;
+      }
+
+      if (typeof attributes.checked === 'boolean') {
+        return attributes.checked;
+      }
+
+      if (attributes.value === 1 || attributes.value === '1') {
+        return true;
+      }
+
+      if (attributes.value === 0 || attributes.value === '0') {
+        return false;
+      }
+    } catch {
+      return undefined;
+    }
+
+    return undefined;
+  }
+
+  /**
    * Ensures the marketing opt-in checkbox is checked for OAuth flows without
    * toggling it off when already selected (e.g. USA locale default, TO-776).
    */
@@ -263,17 +298,11 @@ class CreatePasswordView {
       detox: async () => {
         const checkbox = asDetoxElement(this.iUnderstandCheckbox);
         const el = (await checkbox) as Detox.IndexableNativeElement;
-        let isChecked = false;
+        const isChecked = await this.readMarketingCheckboxChecked(el);
 
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any, jest/valid-expect
-          await (expect(el) as any).toHaveToggleValue(true);
-          isChecked = true;
-        } catch {
-          isChecked = false;
-        }
-
-        if (!isChecked) {
+        // Only tap when explicitly unchecked. Ambiguous state keeps the default
+        // (USA devices start checked per TO-776).
+        if (isChecked === false) {
           await Gestures.tap(checkbox, {
             elemDescription: 'Create Password - Marketing opt-in checkbox',
             checkVisibility: false,
@@ -283,9 +312,8 @@ class CreatePasswordView {
       appium: async () => {
         const checkbox = await asPlaywrightElement(this.iUnderstandCheckbox);
         const ariaChecked = await checkbox.getAttribute('aria-checked');
-        const checked = ariaChecked === 'true';
 
-        if (!checked) {
+        if (ariaChecked === 'false') {
           await UnifiedGestures.waitAndTap(this.iUnderstandCheckbox, {
             description: 'Create Password - Marketing opt-in checkbox',
           });

--- a/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
@@ -127,7 +127,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await CreatePasswordView.reEnterPassword(password);
         await PlaywrightGestures.hideKeyboard();
 
-        await CreatePasswordView.tapIUnderstandCheckBox();
+        await CreatePasswordView.ensureMarketingOptInChecked();
         await PlaywrightGestures.hideKeyboard();
         await CreatePasswordView.tapCreatePasswordButton();
 

--- a/tests/performance/onboarding/seedless-google-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-google-onboarding.spec.ts
@@ -128,7 +128,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         await CreatePasswordView.enterPassword(password);
         await CreatePasswordView.reEnterPassword(password);
         await PlaywrightGestures.hideKeyboard();
-        await CreatePasswordView.tapIUnderstandCheckBox();
+        await CreatePasswordView.ensureMarketingOptInChecked();
         await CreatePasswordView.tapCreatePasswordButton();
 
         await timer4.measure(async () => {

--- a/tests/smoke/seedless/utils.ts
+++ b/tests/smoke/seedless/utils.ts
@@ -60,7 +60,7 @@ export const completeSocialLoginOnboarding = async (
   await CreatePasswordView.enterPassword(TEST_PASSWORD);
   await CreatePasswordView.reEnterPassword(TEST_PASSWORD);
 
-  await CreatePasswordView.ensureMarketingOptInChecked();
+  await CreatePasswordView.tapIUnderstandCheckBox();
 
   try {
     await TermsOfUseModal.tapAgreeCheckBox();

--- a/tests/smoke/seedless/utils.ts
+++ b/tests/smoke/seedless/utils.ts
@@ -60,7 +60,7 @@ export const completeSocialLoginOnboarding = async (
   await CreatePasswordView.enterPassword(TEST_PASSWORD);
   await CreatePasswordView.reEnterPassword(TEST_PASSWORD);
 
-  await CreatePasswordView.tapIUnderstandCheckBox();
+  await CreatePasswordView.ensureMarketingOptInChecked();
 
   try {
     await TermsOfUseModal.tapAgreeCheckBox();

--- a/yarn.lock
+++ b/yarn.lock
@@ -35720,6 +35720,7 @@ __metadata:
     react-native-launch-arguments: "npm:^4.0.1"
     react-native-level-fs: "npm:3.0.1"
     react-native-linear-gradient: "npm:^2.8.3"
+    react-native-localize: "npm:^3.4.1"
     react-native-material-textfield: "npm:0.16.1"
     react-native-mmkv: "npm:^3.2.0"
     react-native-modal: "npm:^14.0.0-rc.1"
@@ -40451,6 +40452,23 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/db18c7ae4b68afe8b6f12c67defeeccda7a3cff4ee14a0b2d92ff2581d53bd2e65bf29837cf2828abb3d8d1f3cef3f808e8cc1c5d4c8da5dd6f1d09e2b9c2c55
+  languageName: node
+  linkType: hard
+
+"react-native-localize@npm:^3.4.1":
+  version: 3.7.0
+  resolution: "react-native-localize@npm:3.7.0"
+  peerDependencies:
+    "@expo/config-plugins": "*"
+    react: "*"
+    react-native: "*"
+    react-native-macos: "*"
+  peerDependenciesMeta:
+    "@expo/config-plugins":
+      optional: true
+    react-native-macos:
+      optional: true
+  checksum: 10/e8ec5e179a6f7ad277057d7594d4371bf93989cc0bbe97534b9a3f4c3554c9551edbb4d9e2b66e0c93f78dd8a45eb3f4b71ea715c8c925cbd6dcaa9eed739230
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**
* Default-check the marketing updates opt-in on ChoosePassword for social login (OAuth) users whose device locale indicates the USA. Rest-of-world social login users keep marketing unchecked by default. SRP / non-OAuth flows are unchanged.

* Jira: https://consensyssoftware.atlassian.net/browse/TO-776
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Default-checked marketing updates opt-in for USA social login users during onboarding password setup.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TO-776

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature:  USA marketing opt-in default for social login users

  Scenario: USA social login user sees marketing opt-in checked by default
    Given seedless onboarding is enabled
    And the device/simulator region is set to United States (en-US locale)
    And the app is freshly installed or reset

    When the user creates a wallet via social login (e.g. Google)
    And the user reaches the Choose Password screen

    Then the marketing updates checkbox is checked by default
    And the user can submit without manually checking the box
    And marketing opt-in is sent as true on wallet creation

  Scenario: non-USA social login user sees marketing opt-in unchecked by default
    Given seedless onboarding is enabled
    And the device/simulator region is set outside the USA (e.g. United Kingdom)
    And the app is freshly installed or reset

    When the user creates a wallet via social login (e.g. Google)
    And the user reaches the Choose Password screen

    Then the marketing updates checkbox is unchecked by default
    And marketing opt-in is sent as false unless the user checks the box

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/9b4f24a9-4d09-4f3a-b958-d8a15330016c


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default marketing consent for OAuth users in US locales, which is compliance-sensitive; logic is localized and covered by tests, with safe fallbacks when Intl fails.
> 
> **Overview**
> **ChoosePassword** now initializes the marketing / acknowledgement checkbox from **`getDefaultMarketingOptInChecked`**, which depends on OAuth onboarding (`oauthLoginSuccess`) and **`isUsaDeviceRegion()`** (device `Intl` locale, `US` region only—no geolocation).
> 
> For **social login (OAuth)** users, the marketing opt-in starts **checked in the USA** and **unchecked elsewhere**; submitting without toggling the box sends the matching value to **`OAuthLoginService.updateMarketingOptInStatus`**. **SRP / non-OAuth** flows are unchanged: the checkbox stays **unchecked** by default (including USA), and submit still requires checking it.
> 
> New helpers live under **`app/util/region`** and **`app/util/onboarding`**, with unit and **`ChoosePassword`** integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c650e7c1c1b758b30068d73ebdaab4c9238dcf14. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->