### PR TITLE
fix: vip badge text

### DIFF
--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -8454,7 +8454,7 @@
     "main_title": "Belohnungen",
     "vip": {
       "bps_unit": "Basispunkte",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -8454,7 +8454,7 @@
     "main_title": "Ανταμοιβές",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8754,7 +8754,7 @@
     "vip": {
       "progress_to_next_tier": "{{pointsRemaining}} points to next tier",
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "points_label": "Points",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -8454,7 +8454,7 @@
     "main_title": "Recompensas",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Canjes",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -8453,7 +8453,7 @@
     "main_title": "Récompenses",
     "vip": {
       "bps_unit": "points de base",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Échanges",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -8454,7 +8454,7 @@
     "main_title": "पुरस्कार",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -8454,7 +8454,7 @@
     "main_title": "Reward",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -8454,7 +8454,7 @@
     "main_title": "報酬",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -8454,7 +8454,7 @@
     "main_title": "보상",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -8454,7 +8454,7 @@
     "main_title": "Recompensas",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Trocas",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -8454,7 +8454,7 @@
     "main_title": "Награды",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -8454,7 +8454,7 @@
     "main_title": "Mga Reward",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Mga Swap",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -8454,7 +8454,7 @@
     "main_title": "Ödüller",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -8454,7 +8454,7 @@
     "main_title": "Phần thưởng",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -8454,7 +8454,7 @@
     "main_title": "奖励",
     "vip": {
       "bps_unit": "bps",
-      "badge_label": "VIP Fox {{tier}}",
+      "badge_label": "VIP {{tier}}",
       "swaps_label": "Swaps",
       "perps_label": "Perps",
       "error_title": "We couldn’t load your VIP dashboard",


### PR DESCRIPTION
## **Description**

The VIP rewards badge currently renders as `VIP Fox <tier>` (e.g. `VIP Fox 1`). Product/design wants the label to be `VIP <tier>` so it reads cleanly as `VIP 1`, `VIP 2`, etc., next to the existing fox icon (which already conveys the "Fox" branding). The extra "Fox" word was redundant with the icon and made the badge wider than designed.

This PR updates the `rewards.vip.badge_label` localization key in every supported locale to drop "Fox" from the badge label so the rendered string matches the design across all languages.

The string is consumed by `RewardsVipBadge` ([`app/components/UI/Rewards/components/RewardsVipBadge/RewardsVipBadge.tsx`](https://github.com/MetaMask/metamask-mobile/blob/main/app/components/UI/Rewards/components/RewardsVipBadge/RewardsVipBadge.tsx)) via `strings('rewards.vip.badge_label', { tier })`. No component, logic, or test changes are required — the test still asserts on the interpolated tier value.

## **Changelog**

CHANGELOG entry: Fixed the VIP rewards badge label so it now reads `VIP <tier>` instead of `VIP Fox <tier>`.

## **Related issues**

Fixes: N/A — copy-only fix flagged by design.

## **Manual testing steps**

```gherkin
Feature: VIP rewards badge label

  Scenario: VIP user sees the corrected badge text
    Given the wallet is opened with an account that has an active VIP tier
    And the rewards feature is enabled

    When the user navigates to a screen that renders the RewardsVipBadge (e.g. the Rewards entry point)
    Then the badge text reads "VIP <tier>" (e.g. "VIP 1")
    And it no longer reads "VIP Fox <tier>"
    And the fox icon remains visible to the left of the text

  Scenario: Label is correct in non-English locales
    Given the device language is changed to a supported locale (e.g. es, fr, ja, zh)

    When the user opens the same Rewards screen
    Then the badge still reads "VIP <tier>" in that locale (the word "Fox" is gone in every language)
```

## **Screenshots/Recordings**

### **Before**

N/A
<!-- VIP Fox 1 -->

### **After**

N/A
<!-- VIP 1 -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [\`trace()\`](/app/util/trace.ts) for usage and [\`addToken\`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

N/A — this PR only changes localized strings, with no rendering, navigation, or runtime work added.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.