### PR TITLE
fix(quickbuy): spend exact balance when selling all to avoid false insufficient funds

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -753,6 +753,15 @@ export function useQuickBuyController(
           ? ''
           : ((maxSpendUsd * rounded) / 100).toFixed(2);
 
+      // Flag max BEFORE the dedup guard. lastCommittedUsdRef is also written by
+      // typed input and the price-migration effect, so releasing the slider at
+      // 100% can match the ref and return early (e.g. user typed the exact max,
+      // then slid to 100% to "sell all"). If setIsMaxSourceAmount ran after the
+      // guard, sourceTokenAmount would fall back to the cent-rounded fiat
+      // reconstruction and falsely trip insufficient-funds on sell-all. Setting
+      // it here is idempotent, so the dedup path is unaffected.
+      setIsMaxSourceAmount(rounded >= 100);
+
       // Deduplicate: Tap + Pan can both fire onEnd for a pure tap gesture.
       if (nextUsd === lastCommittedUsdRef.current) {
         return;
@@ -767,9 +776,6 @@ export function useQuickBuyController(
       setSliderPercent(rounded);
       lastSliderPercentRef.current = rounded;
       setUsdAmount(nextUsd);
-      // Priced path commits here: flag max so sourceTokenAmount spends the
-      // exact balance instead of the cent-rounded fiat reconstruction.
-      setIsMaxSourceAmount(rounded >= 100);
 
       setQuotedUsdAmount(nextUsd);
       const numericUsd = Number(nextUsd);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -231,6 +231,12 @@ export function useQuickBuyController(
   const [tradeMode, setTradeMode] = useState<QuickBuyTradeMode>('buy');
   const [usdAmount, setUsdAmount] = useState('');
   const [sourceAmountTokens, setSourceAmountTokens] = useState('');
+  // True when the user has committed the slider to 100% ("sell all"). In this
+  // mode `sourceTokenAmount` spends the exact on-chain balance rather than a
+  // value reconstructed from the fiat round-trip / float math, either of which
+  // can land just above the real balance and falsely trip the insufficient-
+  // funds gate. Reset on any other amount input.
+  const [isMaxSourceAmount, setIsMaxSourceAmount] = useState(false);
   // Drives quote re-fetching. Updated only when the user commits a value
   // (slider drag end, tap, or text input) — NOT on every drag tick. This
   // prevents spamming quote requests while the thumb is moving.
@@ -403,7 +409,22 @@ export function useQuickBuyController(
     sourceToken?.currencyExchangeRate && sourceToken.currencyExchangeRate > 0,
   );
 
+  const latestSourceBalance = useLatestBalance({
+    address: sourceToken?.address,
+    decimals: sourceToken?.decimals,
+    chainId: sourceToken?.chainId,
+    balance: sourceToken?.balance,
+  });
+
   const sourceTokenAmount = useMemo(() => {
+    // Max ("sell all"): spend the exact on-chain balance. `displayBalance` is
+    // `formatUnits(atomicBalance)`, so it round-trips back to the precise
+    // atomic balance — unlike the fiat (priced) or float (unpriced) paths
+    // below, which can reconstruct a value fractionally above the real balance
+    // and falsely block the trade with "Insufficient funds".
+    if (isMaxSourceAmount && latestSourceBalance?.displayBalance) {
+      return latestSourceBalance.displayBalance;
+    }
     if (hasSourcePrice) {
       if (!quotedUsdAmount || !sourceToken?.currencyExchangeRate) {
         return undefined;
@@ -419,6 +440,8 @@ export function useQuickBuyController(
     return sourceAmountTokens;
   }, [
     hasSourcePrice,
+    isMaxSourceAmount,
+    latestSourceBalance?.displayBalance,
     quotedUsdAmount,
     sourceAmountTokens,
     sourceToken?.currencyExchangeRate,
@@ -431,13 +454,6 @@ export function useQuickBuyController(
       dispatch(setSourceAmount(undefined));
     }
   }, [sourceTokenAmount, dispatch]);
-
-  const latestSourceBalance = useLatestBalance({
-    address: sourceToken?.address,
-    decimals: sourceToken?.decimals,
-    chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
-  });
 
   // Used for analytics passed to useQuickBuyQuotes. Must derive from
   // quotedUsdAmount (not usdAmount) so that mid-drag display updates don't
@@ -697,11 +713,15 @@ export function useQuickBuyController(
       setSliderPercent(rounded);
 
       // ── Unpriced path: drive token-amount state directly. ───────────────
+      // This branch commits on every tick (no separate drag-end commit), so the
+      // max sentinel is set here rather than in handleSliderDragEnd.
       if (!hasSourcePrice) {
         if (maxSpendTokens <= 0) {
           setSourceAmountTokens('');
+          setIsMaxSourceAmount(false);
           return;
         }
+        setIsMaxSourceAmount(rounded >= 100);
         const nextTokens =
           rounded === 0 ? '' : ((maxSpendTokens * rounded) / 100).toString();
         setSourceAmountTokens(nextTokens);
@@ -747,6 +767,9 @@ export function useQuickBuyController(
       setSliderPercent(rounded);
       lastSliderPercentRef.current = rounded;
       setUsdAmount(nextUsd);
+      // Priced path commits here: flag max so sourceTokenAmount spends the
+      // exact balance instead of the cent-rounded fiat reconstruction.
+      setIsMaxSourceAmount(rounded >= 100);
 
       setQuotedUsdAmount(nextUsd);
       const numericUsd = Number(nextUsd);
@@ -792,6 +815,7 @@ export function useQuickBuyController(
     setUsdAmount('');
     setQuotedUsdAmount('');
     setSourceAmountTokens('');
+    setIsMaxSourceAmount(false);
     setSliderPercent(0);
     lastSliderPercentRef.current = 0;
     lastCommittedUsdRef.current = '';
@@ -882,6 +906,7 @@ export function useQuickBuyController(
       }
       lastSliderPercentRef.current = 0;
       setSliderPercent(0);
+      setIsMaxSourceAmount(false);
     },
     [hasSourcePrice, sourceToken?.decimals, lastInputMethodRef],
   );

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -587,6 +587,93 @@ describe('useQuickBuyController', () => {
     });
   });
 
+  describe('max ("sell all") source amount', () => {
+    // A near-$1 stablecoin whose rate is fractionally below 1. The fiat
+    // round-trip (balance → cent-rounded USD → tokens) reconstructs an amount
+    // slightly ABOVE the real balance, which previously tripped the
+    // insufficient-funds gate when selling the entire balance.
+    const NEAR_DOLLAR_RATE = 0.9997;
+    const FULL_BALANCE = '0.10003';
+
+    const renderWithStablecoin = () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: FULL_BALANCE,
+        atomicBalance: '100030000000000000',
+      });
+      const stablecoin = createSourceToken({
+        symbol: 'MUSD',
+        currencyExchangeRate: NEAR_DOLLAR_RATE,
+        balance: FULL_BALANCE,
+      });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [stablecoin],
+      });
+      return renderHook(() => useQuickBuyController(createTarget(), jest.fn()));
+    };
+
+    it('spends the exact on-chain balance instead of the fiat round-trip at 100%', () => {
+      const { result } = renderWithStablecoin();
+
+      act(() => {
+        result.current.handleSliderChange(100);
+      });
+      act(() => {
+        result.current.handleSliderDragEnd(100);
+      });
+
+      // Exact balance — not `usd / rate`, which would exceed FULL_BALANCE.
+      expect(result.current.sourceTokenAmount).toBe(FULL_BALANCE);
+    });
+
+    it('passes the exact balance to the insufficient-balance check at 100%', () => {
+      const { result } = renderWithStablecoin();
+
+      act(() => {
+        result.current.handleSliderChange(100);
+      });
+      act(() => {
+        result.current.handleSliderDragEnd(100);
+      });
+
+      expect(useIsInsufficientBalance).toHaveBeenLastCalledWith(
+        expect.objectContaining({ amount: FULL_BALANCE }),
+      );
+    });
+
+    it('still derives the amount from fiat below 100%', () => {
+      const { result } = renderWithStablecoin();
+
+      act(() => {
+        result.current.handleSliderChange(50);
+      });
+      act(() => {
+        result.current.handleSliderDragEnd(50);
+      });
+
+      expect(result.current.sourceTokenAmount).not.toBe(FULL_BALANCE);
+      expect(Number(result.current.sourceTokenAmount)).toBeCloseTo(0.05, 2);
+    });
+
+    it('clears the max flag once the user types a custom amount', () => {
+      const { result } = renderWithStablecoin();
+
+      act(() => {
+        result.current.handleSliderChange(100);
+      });
+      act(() => {
+        result.current.handleSliderDragEnd(100);
+      });
+      expect(result.current.sourceTokenAmount).toBe(FULL_BALANCE);
+
+      act(() => {
+        result.current.handleAmountChange('0.05');
+      });
+
+      expect(result.current.sourceTokenAmount).not.toBe(FULL_BALANCE);
+      expect(Number(result.current.sourceTokenAmount)).toBeCloseTo(0.05, 2);
+    });
+  });
+
   describe('handleSelectSourceToken', () => {
     it('updates the selected token and resets amount + slider state', () => {
       (useLatestBalance as jest.Mock).mockReturnValue({


### PR DESCRIPTION
## **Description**

When selling the **entire** balance of a near-$1 source token (e.g. mUSD) via QuickBuy's "Sell" flow, the trade was incorrectly blocked with an **"Insufficient funds"** button state.

**Root cause:** the QuickBuy "Sell" flow is fiat-first. When the slider is dragged to 100%, the committed amount was reconstructed through a lossy fiat round-trip: `balance → USD (rounded to 2 decimals via .toFixed(2)) → tokens (usd / currencyExchangeRate)`. Because the exchange rate of these tokens is fractionally below `1`, dividing the cent-rounded USD value back into tokens yields an amount **slightly larger** than the actual on-chain balance (e.g. `0.10003 MUSD` balance → `$0.10` → `0.10003001… MUSD`). `useIsInsufficientBalance` then compared this inflated amount against the true atomic balance and flagged the trade. The unpriced slider path had the same class of issue via `parseFloat` reconstruction.

**Fix:** an `isMaxSourceAmount` sentinel. When the slider is committed at 100% ("sell all"), `sourceTokenAmount` now returns the exact `latestSourceBalance.displayBalance` (which is `formatUnits(atomicBalance, decimals)` and therefore round-trips back to the precise atomic balance) instead of the reconstructed value. The flag is set at the priced commit (`handleSliderDragEnd`) and the unpriced commit (`handleSliderChange`), and cleared on custom typed input and on amount reset (token switch / mode flip). This fixes both the priced (reported mUSD) and unpriced paths.

## **Changelog**

CHANGELOG entry: Fixed a bug where selling your entire balance of a token in QuickBuy could be incorrectly blocked with an "Insufficient funds" error.

## **Related issues**

Fixes: TSA-650

## **Manual testing steps**

```gherkin
Feature: QuickBuy sell-all does not falsely report insufficient funds

  Scenario: Selling the entire balance of a near-$1 token
    Given I hold a small balance of a near-$1 token (e.g. mUSD) whose exchange rate is fractionally below 1
    And I open the QuickBuy sheet and select the "Sell" tab
    And I have selected a token to receive (e.g. ETH)

    When I drag the amount slider all the way to 100% (sell all)
    Then the headline shows my full balance and its fiat value
    And the confirm button is enabled (NOT "Insufficient funds")
    And submitting the trade sells the exact on-chain balance

  Scenario: Selling a partial amount still works
    When I drag the slider to a value below 100%
    Then the amount is derived from the fiat value as before
    And the confirm button reflects the correct sufficient/insufficient state
```

## **Screenshots/Recordings**

### **Before**

<!-- See linked ticket: dragging the slider to 100% ("sell all") on a near-$1 token shows "Insufficient funds" and blocks the trade. -->

### **After**

<!-- Slider at 100% spends the exact balance; the confirm button is enabled. Verified via unit tests in useQuickBuyController.test.ts (66/66 passing, incl. 4 new cases). On-device recording N/A for this logic-only fix. -->

N/A — logic-only fix covered by unit tests; no visual change beyond the button no longer being erroneously disabled.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized QuickBuy amount derivation and balance checks; no auth or payment-rail changes, with new unit tests covering the regression.
> 
> **Overview**
> Fixes QuickBuy **sell-all** falsely showing **Insufficient funds** when the slider is committed at **100%**.
> 
> The change adds an **`isMaxSourceAmount`** flag so **`sourceTokenAmount`** uses **`latestSourceBalance.displayBalance`** (exact on-chain balance) instead of amounts rebuilt from **cent-rounded USD** or **float slider math**, which could exceed the real balance for near-$1 tokens. The flag is set on **priced** slider commit (`handleSliderDragEnd`, including **before** the USD dedup guard so typed-max then slide-to-100% still works) and on the **unpriced** path (`handleSliderChange`), and cleared on **reset**, **custom input**, and non-100% slider moves. **`useLatestBalance`** is moved earlier so max mode can use it in the memo. **Four unit tests** cover the stablecoin round-trip scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903b931c29485795d787a7943f3104da8740d93f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->