### PR TITLE
fix: simplify `useClearConfirmationOnBackSwipe` to reliably reject on back swipe

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -42,7 +42,6 @@ import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTr
 import { useTokenFiatRates } from '../../../hooks/tokens/useTokenFiatRates';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionAccountOverride } from '../../../hooks/transactions/useTransactionAccountOverride';
-import Engine from '../../../../../../core/Engine';
 import Logger from '../../../../../../util/Logger';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 
@@ -81,9 +80,6 @@ jest.mock('../../../../../../core/Engine', () => ({
   context: {
     TransactionPayController: {
       updateFiatPayment: jest.fn(),
-    },
-    PredictController: {
-      clearPendingDeposit: jest.fn(),
     },
   },
 }));
@@ -334,84 +330,10 @@ describe('CustomAmountInfo', () => {
     expect(getByText('0 TST')).toBeDefined();
   });
 
-  it('rejects predict deposit confirmations on beforeRemove', () => {
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.predictDeposit }],
-      txParams: { from: '0x123' },
-    } as never);
-
+  it('sets up back swipe rejection', () => {
     render();
 
-    expect(useClearConfirmationOnBackSwipeMock).toHaveBeenCalledWith({
-      rejectOnBeforeRemove: true,
-      rejectOnBeforeRemoveWithoutGesture: true,
-      skipNavigationOnGestureEnd: true,
-      onBeforeReject: expect.any(Function),
-    });
-  });
-
-  it('rejects money account deposit confirmations on beforeRemove', () => {
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
-      txParams: { from: '0x123' },
-    } as never);
-
-    render();
-
-    expect(useClearConfirmationOnBackSwipeMock).toHaveBeenCalledWith({
-      rejectOnBeforeRemove: true,
-      rejectOnBeforeRemoveWithoutGesture: true,
-      skipNavigationOnGestureEnd: true,
-      onBeforeReject: undefined,
-    });
-  });
-
-  it('rejects money account withdraw confirmations on beforeRemove', () => {
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.moneyAccountWithdraw }],
-      txParams: { from: '0x123' },
-    } as never);
-
-    render();
-
-    expect(useClearConfirmationOnBackSwipeMock).toHaveBeenCalledWith({
-      rejectOnBeforeRemove: true,
-      rejectOnBeforeRemoveWithoutGesture: true,
-      skipNavigationOnGestureEnd: true,
-      onBeforeReject: undefined,
-    });
-  });
-
-  it('clears pending predict deposit before rejecting the confirmation', () => {
-    useTransactionMetadataRequestMock.mockReturnValue({
-      type: TransactionType.batch,
-      nestedTransactions: [{ type: TransactionType.predictDeposit }],
-      txParams: { from: '0x123' },
-    } as never);
-
-    render();
-
-    const options = useClearConfirmationOnBackSwipeMock.mock.calls[0]?.[0];
-
-    options?.onBeforeReject?.();
-
-    expect(
-      Engine.context.PredictController.clearPendingDeposit,
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not reject non-predict deposit confirmations on beforeRemove', () => {
-    render();
-
-    expect(useClearConfirmationOnBackSwipeMock).toHaveBeenCalledWith({
-      rejectOnBeforeRemove: false,
-      rejectOnBeforeRemoveWithoutGesture: false,
-      skipNavigationOnGestureEnd: false,
-      onBeforeReject: undefined,
-    });
+    expect(useClearConfirmationOnBackSwipeMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not render payment token if disablePay', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -123,29 +123,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     supportAccountSelection,
   }) => {
     const transactionMeta = useTransactionMetadataRequest();
-    const isPredictDeposit = hasTransactionType(transactionMeta, [
-      TransactionType.predictDeposit,
-    ]);
     const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
       TransactionType.moneyAccountDeposit,
     ]);
-    const isMoneyAccountTransfer =
-      isMoneyAccountDeposit ||
-      hasTransactionType(transactionMeta, [
-        TransactionType.moneyAccountWithdraw,
-      ]);
-    const shouldRejectOnBackSwipe = isPredictDeposit || isMoneyAccountTransfer;
 
-    const clearPendingPredictDeposit = useCallback(() => {
-      Engine.context.PredictController.clearPendingDeposit();
-    }, []);
-
-    useClearConfirmationOnBackSwipe({
-      rejectOnBeforeRemove: shouldRejectOnBackSwipe,
-      rejectOnBeforeRemoveWithoutGesture: shouldRejectOnBackSwipe,
-      skipNavigationOnGestureEnd: shouldRejectOnBackSwipe,
-      onBeforeReject: isPredictDeposit ? clearPendingPredictDeposit : undefined,
-    });
+    useClearConfirmationOnBackSwipe();
 
     const { canSelectWithdrawToken } = useTransactionPayWithdraw();
 

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import { PredictClaimInfo } from './predict-claim-info';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
-import Engine from '../../../../../../core/Engine';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
 
@@ -18,14 +17,6 @@ jest.mock('../../../hooks/useConfirmActions', () => ({
   useConfirmActions: () => ({
     onReject: jest.fn(),
   }),
-}));
-
-jest.mock('../../../../../../core/Engine', () => ({
-  context: {
-    PredictController: {
-      clearPendingClaim: jest.fn(),
-    },
-  },
 }));
 
 jest.mock('../../predict-confirmations/predict-claim-amount', () => ({
@@ -62,23 +53,9 @@ describe('PredictClaimInfo', () => {
     (useClearConfirmationOnBackSwipe as jest.Mock).mockReturnValue(jest.fn());
   });
 
-  it('clears the confirmation when dismissed with a back gesture', () => {
+  it('sets up back swipe rejection', () => {
     render(<PredictClaimInfo />);
 
     expect(useClearConfirmationOnBackSwipe).toHaveBeenCalledTimes(1);
-    expect(useClearConfirmationOnBackSwipe).toHaveBeenCalledWith({
-      rejectOnBeforeRemove: true,
-      skipNavigationOnGestureEnd: false,
-      rejectOnBeforeRemoveWithoutGesture: true,
-      onBeforeReject: expect.any(Function),
-    });
-    const options = (useClearConfirmationOnBackSwipe as jest.Mock).mock
-      .calls[0][0];
-
-    options.onBeforeReject();
-
-    expect(
-      Engine.context.PredictController.clearPendingClaim,
-    ).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
@@ -13,21 +13,12 @@ import { IconName } from '../../../../../../component-library/components/Icons/I
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './predict-claim-info.styles';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
-import Engine from '../../../../../../core/Engine';
 
 export function PredictClaimInfo() {
   useModalNavbar();
   usePredictClaimConfirmationMetrics();
-  const clearPendingClaim = useCallback(() => {
-    Engine.context.PredictController.clearPendingClaim();
-  }, []);
 
-  const rejectConfirmation = useClearConfirmationOnBackSwipe({
-    rejectOnBeforeRemove: true,
-    rejectOnBeforeRemoveWithoutGesture: true,
-    skipNavigationOnGestureEnd: false,
-    onBeforeReject: clearPendingClaim,
-  });
+  const rejectConfirmation = useClearConfirmationOnBackSwipe();
 
   return (
     <>

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useNavigation } from '@react-navigation/native';
 import { BackHandler } from 'react-native';
 import Device from '../../../../../util/device';
-import Logger from '../../../../../util/Logger';
 import { useConfirmActions } from '../useConfirmActions';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
 import useClearConfirmationOnBackSwipe from './useClearConfirmationOnBackSwipe';
@@ -27,13 +26,6 @@ jest.mock('./useFullScreenConfirmation', () => ({
 
 jest.mock('../../context/confirmation-context', () => ({
   useConfirmationContext: jest.fn(),
-}));
-
-jest.mock('../../../../../util/Logger', () => ({
-  __esModule: true,
-  default: {
-    error: jest.fn(),
-  },
 }));
 
 describe('useClearConfirmationOnBackSwipe', () => {
@@ -62,7 +54,7 @@ describe('useClearConfirmationOnBackSwipe', () => {
     });
   });
 
-  it('does not set up back handler if confirmation is not standalone', () => {
+  it('does not set up listeners if confirmation is not full screen', () => {
     (useFullScreenConfirmation as jest.Mock).mockReturnValue({
       isFullScreenConfirmation: false,
     });
@@ -82,65 +74,20 @@ describe('useClearConfirmationOnBackSwipe', () => {
       });
     });
 
-    it('adds a gestureEnd listener when mounted', () => {
+    it('adds a beforeRemove listener when mounted', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
       expect(mockAddListener).toHaveBeenCalledTimes(1);
       expect(mockAddListener).toHaveBeenCalledWith(
-        'gestureEnd',
+        'beforeRemove',
         expect.any(Function),
       );
     });
 
-    it('calls onReject when gestureEnd event is triggered', () => {
+    it('calls onReject with skipNavigation when beforeRemove is triggered', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
-      const gestureEndCallback = mockAddListener.mock.calls[0][1];
-      gestureEndCallback();
-
-      expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith();
-    });
-
-    it('calls onReject with skipNavigation when beforeRemove follows a gestureStart event', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({ rejectOnBeforeRemove: true }),
-      );
-      const gestureStartCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureStart',
-      )?.[1];
       const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
-      )?.[1];
-
-      gestureStartCallback();
-      beforeRemoveCallback();
-
-      expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith(undefined, true);
-    });
-
-    it('does not reject on beforeRemove without a gestureStart event', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({ rejectOnBeforeRemove: true }),
-      );
-      const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
-      )?.[1];
-
-      beforeRemoveCallback();
-
-      expect(mockOnReject).not.toHaveBeenCalled();
-    });
-
-    it('calls onReject with skipNavigation on beforeRemove without gesture when configured', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          rejectOnBeforeRemoveWithoutGesture: true,
-        }),
-      );
-      const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
+        ([eventName]: [string]) => eventName === 'beforeRemove',
       )?.[1];
 
       beforeRemoveCallback();
@@ -153,39 +100,14 @@ describe('useClearConfirmationOnBackSwipe', () => {
       (useConfirmationContext as jest.Mock).mockReturnValue({
         isConfirmationSubmittingRef: { current: true },
       });
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          rejectOnBeforeRemoveWithoutGesture: true,
-        }),
-      );
+
+      renderHook(() => useClearConfirmationOnBackSwipe());
       const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
+        ([eventName]: [string]) => eventName === 'beforeRemove',
       )?.[1];
 
       beforeRemoveCallback();
 
-      expect(mockOnReject).not.toHaveBeenCalled();
-    });
-
-    it('does not reject on gestureEnd when confirmation is submitting', () => {
-      const mockOnBeforeReject = jest.fn();
-      (useConfirmationContext as jest.Mock).mockReturnValue({
-        isConfirmationSubmittingRef: { current: true },
-      });
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          onBeforeReject: mockOnBeforeReject,
-        }),
-      );
-      const gestureEndCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureEnd',
-      )?.[1];
-
-      gestureEndCallback();
-
-      expect(mockOnBeforeReject).not.toHaveBeenCalled();
       expect(mockOnReject).not.toHaveBeenCalled();
     });
 
@@ -194,14 +116,10 @@ describe('useClearConfirmationOnBackSwipe', () => {
       (useConfirmationContext as jest.Mock).mockReturnValue({
         isConfirmationSubmittingRef,
       });
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          rejectOnBeforeRemoveWithoutGesture: true,
-        }),
-      );
+
+      renderHook(() => useClearConfirmationOnBackSwipe());
       const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
+        ([eventName]: [string]) => eventName === 'beforeRemove',
       )?.[1];
 
       isConfirmationSubmittingRef.current = true;
@@ -210,132 +128,16 @@ describe('useClearConfirmationOnBackSwipe', () => {
       expect(mockOnReject).not.toHaveBeenCalled();
     });
 
-    it('does not reject on beforeRemove after a gestureCancel event', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({ rejectOnBeforeRemove: true }),
-      );
-      const gestureStartCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureStart',
-      )?.[1];
-      const gestureCancelCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureCancel',
-      )?.[1];
+    it('does not reject twice when beforeRemove fires multiple times', () => {
+      renderHook(() => useClearConfirmationOnBackSwipe());
       const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
+        ([eventName]: [string]) => eventName === 'beforeRemove',
       )?.[1];
 
-      gestureStartCallback();
-      gestureCancelCallback();
       beforeRemoveCallback();
-
-      expect(mockOnReject).not.toHaveBeenCalled();
-    });
-
-    it('does not reject twice when multiple dismissal events are triggered', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({ rejectOnBeforeRemove: true }),
-      );
-      const gestureStartCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureStart',
-      )?.[1];
-      const gestureEndCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureEnd',
-      )?.[1];
-      const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
-      )?.[1];
-
-      gestureStartCallback();
-      beforeRemoveCallback();
-      gestureEndCallback();
-
-      expect(mockOnReject).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls onReject without skipNavigation when gestureEnd is triggered for rejectOnBeforeRemove by default', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({ rejectOnBeforeRemove: true }),
-      );
-      const gestureEndCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureEnd',
-      )?.[1];
-      const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
-      )?.[1];
-
-      gestureEndCallback();
       beforeRemoveCallback();
 
       expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith(undefined, false);
-    });
-
-    it('calls onReject with skipNavigation when gestureEnd is configured to skip navigation', () => {
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          skipNavigationOnGestureEnd: true,
-        }),
-      );
-      const gestureEndCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureEnd',
-      )?.[1];
-      const beforeRemoveCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'beforeRemove',
-      )?.[1];
-
-      gestureEndCallback();
-      beforeRemoveCallback();
-
-      expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith(undefined, true);
-    });
-
-    it('logs onBeforeReject errors and still rejects the confirmation', () => {
-      const mockError = new Error('cleanup failed');
-      const mockOnBeforeReject = jest.fn(() => {
-        throw mockError;
-      });
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          onBeforeReject: mockOnBeforeReject,
-        }),
-      );
-      const gestureEndCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureEnd',
-      )?.[1];
-
-      gestureEndCallback();
-
-      expect(Logger.error).toHaveBeenCalledTimes(1);
-      expect(Logger.error).toHaveBeenCalledWith(
-        mockError,
-        'useClearConfirmationOnBackSwipe: onBeforeReject failed',
-      );
-      expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith(undefined, false);
-    });
-
-    it('calls onBeforeReject before rejecting the confirmation', () => {
-      const mockOnBeforeReject = jest.fn();
-      renderHook(() =>
-        useClearConfirmationOnBackSwipe({
-          rejectOnBeforeRemove: true,
-          onBeforeReject: mockOnBeforeReject,
-        }),
-      );
-      const gestureEndCallback = mockAddListener.mock.calls.find(
-        ([eventName]) => eventName === 'gestureEnd',
-      )?.[1];
-
-      gestureEndCallback();
-
-      expect(mockOnBeforeReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnBeforeReject.mock.invocationCallOrder[0]).toBeLessThan(
-        mockOnReject.mock.invocationCallOrder[0],
-      );
     });
 
     it('calls unsubscribe when unmounted', () => {
@@ -377,8 +179,21 @@ describe('useClearConfirmationOnBackSwipe', () => {
       const result = backHandlerCallback();
 
       expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith();
+      expect(mockOnReject).toHaveBeenCalledWith(undefined, false);
       expect(result).toBe(true);
+    });
+
+    it('does not reject on hardware back when confirmation is submitting', () => {
+      (useConfirmationContext as jest.Mock).mockReturnValue({
+        isConfirmationSubmittingRef: { current: true },
+      });
+
+      renderHook(() => useClearConfirmationOnBackSwipe());
+      const backHandlerCallback = (BackHandler.addEventListener as jest.Mock)
+        .mock.calls[0][1];
+      backHandlerCallback();
+
+      expect(mockOnReject).not.toHaveBeenCalled();
     });
 
     it('removes back handler listener when unmounted', () => {
@@ -388,23 +203,25 @@ describe('useClearConfirmationOnBackSwipe', () => {
       expect(mockBackHandlerRemove).toHaveBeenCalledTimes(1);
     });
 
-    it('adds a gestureEnd listener when mounted', () => {
+    it('adds a beforeRemove listener when mounted', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
-      expect(mockAddListener).toHaveBeenCalledTimes(1);
       expect(mockAddListener).toHaveBeenCalledWith(
-        'gestureEnd',
+        'beforeRemove',
         expect.any(Function),
       );
     });
 
-    it('calls onReject when gestureEnd event is triggered', () => {
+    it('calls onReject with skipNavigation when beforeRemove is triggered', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
-      const gestureEndCallback = mockAddListener.mock.calls[0][1];
-      gestureEndCallback();
+      const beforeRemoveCallback = mockAddListener.mock.calls.find(
+        ([eventName]: [string]) => eventName === 'beforeRemove',
+      )?.[1];
+
+      beforeRemoveCallback();
 
       expect(mockOnReject).toHaveBeenCalledTimes(1);
-      expect(mockOnReject).toHaveBeenCalledWith();
+      expect(mockOnReject).toHaveBeenCalledWith(undefined, true);
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
@@ -3,32 +3,17 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { useCallback, useEffect, useRef } from 'react';
 import { BackHandler } from 'react-native';
 import Device from '../../../../../util/device';
-import Logger from '../../../../../util/Logger';
-import { ensureError } from '../../../../../util/errorUtils';
 import { useConfirmActions } from '../useConfirmActions';
 import { useFullScreenConfirmation } from './useFullScreenConfirmation';
 import type { RootStackParamList } from '../../../../../core/NavigationService/types';
 import { useConfirmationContext } from '../../context/confirmation-context';
 
-interface UseClearConfirmationOnBackSwipeOptions {
-  rejectOnBeforeRemove?: boolean;
-  rejectOnBeforeRemoveWithoutGesture?: boolean;
-  skipNavigationOnGestureEnd?: boolean;
-  onBeforeReject?: () => void;
-}
-
-const useClearConfirmationOnBackSwipe = ({
-  rejectOnBeforeRemove = false,
-  rejectOnBeforeRemoveWithoutGesture = false,
-  skipNavigationOnGestureEnd = false,
-  onBeforeReject,
-}: UseClearConfirmationOnBackSwipeOptions = {}) => {
+const useClearConfirmationOnBackSwipe = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const { onReject } = useConfirmActions();
   const { isConfirmationSubmittingRef } = useConfirmationContext();
   const hasRejectedRef = useRef(false);
-  const isGestureInProgressRef = useRef(false);
 
   const rejectConfirmation = useCallback(
     (skipNavigation = false) => {
@@ -36,113 +21,30 @@ const useClearConfirmationOnBackSwipe = ({
         return;
       }
 
-      try {
-        onBeforeReject?.();
-      } catch (error) {
-        Logger.error(
-          ensureError(error),
-          'useClearConfirmationOnBackSwipe: onBeforeReject failed',
-        );
-      }
-
       hasRejectedRef.current = true;
       onReject(undefined, skipNavigation);
     },
-    [isConfirmationSubmittingRef, onBeforeReject, onReject],
+    [isConfirmationSubmittingRef, onReject],
   );
 
   useEffect(() => {
-    if (isFullScreenConfirmation) {
-      const unsubscribe = navigation.addListener('gestureEnd', () => {
-        isGestureInProgressRef.current = false;
-        if (rejectOnBeforeRemove) {
-          rejectConfirmation(skipNavigationOnGestureEnd);
-          return;
-        }
-
-        onReject();
-      });
-
-      return () => {
-        if (typeof unsubscribe === 'function') {
-          unsubscribe();
-        }
-      };
+    if (!isFullScreenConfirmation) {
+      return;
     }
-  }, [
-    isFullScreenConfirmation,
-    navigation,
-    onReject,
-    rejectConfirmation,
-    rejectOnBeforeRemove,
-    skipNavigationOnGestureEnd,
-  ]);
 
-  useEffect(() => {
-    if (isFullScreenConfirmation && rejectOnBeforeRemove) {
-      const unsubscribeGestureStart = navigation.addListener(
-        'gestureStart',
-        () => {
-          isGestureInProgressRef.current = true;
-        },
-      );
-      const unsubscribeGestureCancel = navigation.addListener(
-        'gestureCancel',
-        () => {
-          isGestureInProgressRef.current = false;
-        },
-      );
-      const unsubscribeBeforeRemove = navigation.addListener(
-        'beforeRemove',
-        () => {
-          const shouldRejectBeforeRemove =
-            isGestureInProgressRef.current ||
-            rejectOnBeforeRemoveWithoutGesture;
+    const unsubscribe = navigation.addListener('beforeRemove', () => {
+      rejectConfirmation(true);
+    });
 
-          if (
-            isConfirmationSubmittingRef.current ||
-            !shouldRejectBeforeRemove
-          ) {
-            return;
-          }
-
-          isGestureInProgressRef.current = false;
-          rejectConfirmation(true);
-        },
-      );
-
-      return () => {
-        if (typeof unsubscribeGestureStart === 'function') {
-          unsubscribeGestureStart();
-        }
-        if (typeof unsubscribeGestureCancel === 'function') {
-          unsubscribeGestureCancel();
-        }
-        if (typeof unsubscribeBeforeRemove === 'function') {
-          unsubscribeBeforeRemove();
-        }
-      };
-    }
-  }, [
-    isFullScreenConfirmation,
-    navigation,
-    rejectConfirmation,
-    rejectOnBeforeRemove,
-    rejectOnBeforeRemoveWithoutGesture,
-    isConfirmationSubmittingRef,
-  ]);
+    return () => unsubscribe?.();
+  }, [isFullScreenConfirmation, navigation, rejectConfirmation]);
 
   useEffect(() => {
     if (isFullScreenConfirmation && Device.isAndroid()) {
       const backHandlerSubscription = BackHandler.addEventListener(
         'hardwareBackPress',
         () => {
-          if (rejectOnBeforeRemove) {
-            rejectConfirmation();
-          } else {
-            onReject();
-          }
-
+          rejectConfirmation();
           return true;
         },
       );
@@ -151,12 +53,7 @@ const useClearConfirmationOnBackSwipe = ({
         backHandlerSubscription.remove();
       };
     }
-  }, [
-    isFullScreenConfirmation,
-    onReject,
-    rejectConfirmation,
-    rejectOnBeforeRemove,
-  ]);
+  }, [isFullScreenConfirmation, rejectConfirmation]);
 
   return rejectConfirmation;
 };


### PR DESCRIPTION
## **Description**

Back swipe on full-screen confirmations was not rejecting the pending approval transaction. The root cause was in `useClearConfirmationOnBackSwipe`: the default code path (used by 5 of 7 call sites) called `onReject()` directly on `gestureEnd`, bypassing the `hasRejectedRef` guard and racing with navigation lifecycle — by the time the rejection runs, the approval may already be gone from the Redux store.

This PR simplifies the hook from a complex 4-option configuration to a zero-config hook:

- **Replaced** gesture event tracking (`gestureStart`/`gestureEnd`/`gestureCancel`) with a single `beforeRemove` listener that reliably fires on any screen removal (gesture, `goBack()`, or stack reset)
- **Removed** all boolean options (`rejectOnBeforeRemove`, `rejectOnBeforeRemoveWithoutGesture`, `skipNavigationOnGestureEnd`) — `beforeRemove` always rejects with `skipNavigation=true` since navigation is already happening
- **Removed** `onBeforeReject` callback — `PredictController` already handles cleanup internally on rejection
- **All rejections** now go through the guarded `rejectConfirmation` path (no double-rejection, respects `isConfirmationSubmitting`)
- **Net result**: 164 → 61 lines in the hook, 467 lines removed across 6 files

## **Changelog**

CHANGELOG entry: Fixed back swipe not rejecting confirmation transactions on full-screen confirmations

## **Related issues**

Fixes: CONF-1517

## **Manual testing steps**

```gherkin
Feature: Back swipe rejects confirmation

  Scenario: user swipes back on a full-screen confirmation (iOS)
    Given user is on a full-screen confirmation (e.g. simple send, staking deposit)

    When user swipes back (iOS back gesture)
    Then the pending approval is rejected and user returns to previous screen

  Scenario: user presses hardware back on a full-screen confirmation (Android)
    Given user is on a full-screen confirmation

    When user presses the hardware back button
    Then the pending approval is rejected and user returns to previous screen

  Scenario: user confirms a transaction (no false rejection)
    Given user is on a full-screen confirmation

    When user presses the confirm button
    Then the transaction is submitted without being rejected by back-swipe logic
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

Perps Deposit:

https://github.com/user-attachments/assets/99ffca70-bfee-46e1-b783-214c7e72e1e5



Perps Withdraw:


https://github.com/user-attachments/assets/db6517d7-cb60-4d25-96a9-ffd1311c67fa



Predict Deposit:


https://github.com/user-attachments/assets/e6e03ded-25ea-45da-8fc0-f998caf2c70b



Predict Withdraw:


https://github.com/user-attachments/assets/1e6e3726-911c-489d-a9d6-fb3eabffebb9



Predict Claim:



https://github.com/user-attachments/assets/4cb518f2-3600-4baf-80f8-82876de08895



Money Account Deposit:



https://github.com/user-attachments/assets/e760e85e-2617-49dd-9932-9c8f35812aaa



Money Account Withdraw:


https://github.com/user-attachments/assets/6124ae90-77b9-425f-9f5d-a2a263527956




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.