### PR TITLE
fix: add Solana, Tron and Bitcoin chips to the Quick Buy receive view (TSA-657)

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.test.tsx
@@ -19,8 +19,14 @@ jest.mock('../../../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('@metamask/bridge-controller', () => ({
-  formatChainIdToHex: () => '0x1',
-  isNonEvmChainId: () => false,
+  formatChainIdToHex: (caipChainId: string) => {
+    const [namespace, reference] = caipChainId.split(':');
+    if (namespace !== 'eip155') {
+      throw new Error(`unsupported chain ${caipChainId}`);
+    }
+    return `0x${parseInt(reference, 10).toString(16)}`;
+  },
+  isNonEvmChainId: (chainId: string) => chainId.startsWith('solana:'),
   isNativeAddress: () => false,
   getNativeAssetForChainId: () => undefined,
 }));
@@ -39,11 +45,18 @@ const createToken = (overrides: Partial<BridgeToken> = {}): BridgeToken => ({
   ...overrides,
 });
 
+const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
 const usdcToken = createToken({ symbol: 'USDC', chainId: '0x1' });
 const usdtToken = createToken({
   symbol: 'USDT',
   chainId: '0x1',
   address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+});
+const solanaUsdcToken = createToken({
+  symbol: 'USDC',
+  chainId: SOLANA_CHAIN_ID,
+  address: `${SOLANA_CHAIN_ID}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
 });
 
 const buildContext = (overrides: Record<string, unknown> = {}) => ({
@@ -120,5 +133,43 @@ describe('QuickBuyReceiveScreen', () => {
     expect(
       screen.getByText('social_leaderboard.quick_buy.receive_with_no_tokens'),
     ).toBeOnTheScreen();
+  });
+
+  it('renders a Solana network chip when Solana receive options exist', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({
+        sellDestTokenOptions: [usdcToken, solanaUsdcToken],
+        handleSelectDestStable,
+        setActiveScreen,
+      }),
+    );
+
+    render(<QuickBuyReceiveScreen />);
+
+    expect(
+      screen.getByTestId(`quick-buy-chain-filter-${SOLANA_CHAIN_ID}`),
+    ).toBeOnTheScreen();
+  });
+
+  it('defaults the chain filter to Solana when the position is on Solana', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({
+        target: {
+          chain: SOLANA_CHAIN_ID,
+          tokenAddress: `${SOLANA_CHAIN_ID}/slip44:501`,
+          tokenSymbol: 'SOL',
+          tokenName: 'Solana',
+        },
+        sellDestTokenOptions: [usdcToken, solanaUsdcToken],
+        selectedDestStable: solanaUsdcToken,
+        handleSelectDestStable,
+        setActiveScreen,
+      }),
+    );
+
+    render(<QuickBuyReceiveScreen />);
+
+    expect(screen.getByTestId(getRowTestId(solanaUsdcToken))).toBeOnTheScreen();
+    expect(screen.queryByTestId(getRowTestId(usdcToken))).toBeNull();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.test.tsx
@@ -26,7 +26,8 @@ jest.mock('@metamask/bridge-controller', () => ({
     }
     return `0x${parseInt(reference, 10).toString(16)}`;
   },
-  isNonEvmChainId: (chainId: string) => chainId.startsWith('solana:'),
+  isNonEvmChainId: (chainId: string) =>
+    !chainId.startsWith('0x') && !chainId.startsWith('eip155:'),
   isNativeAddress: () => false,
   getNativeAssetForChainId: () => undefined,
 }));
@@ -46,6 +47,8 @@ const createToken = (overrides: Partial<BridgeToken> = {}): BridgeToken => ({
 });
 
 const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const TRON_CHAIN_ID = 'tron:728126428';
+const BITCOIN_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93';
 
 const usdcToken = createToken({ symbol: 'USDC', chainId: '0x1' });
 const usdtToken = createToken({
@@ -57,6 +60,18 @@ const solanaUsdcToken = createToken({
   symbol: 'USDC',
   chainId: SOLANA_CHAIN_ID,
   address: `${SOLANA_CHAIN_ID}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
+});
+const tronNativeToken = createToken({
+  symbol: 'TRX',
+  name: 'Tron',
+  chainId: TRON_CHAIN_ID,
+  address: `${TRON_CHAIN_ID}/slip44:195`,
+});
+const bitcoinNativeToken = createToken({
+  symbol: 'BTC',
+  name: 'Bitcoin',
+  chainId: BITCOIN_CHAIN_ID,
+  address: `${BITCOIN_CHAIN_ID}/slip44:0`,
 });
 
 const buildContext = (overrides: Record<string, unknown> = {}) => ({
@@ -135,10 +150,15 @@ describe('QuickBuyReceiveScreen', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders a Solana network chip when Solana receive options exist', () => {
+  it('renders Solana, Tron and Bitcoin network chips when receive options exist on those chains', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue(
       buildContext({
-        sellDestTokenOptions: [usdcToken, solanaUsdcToken],
+        sellDestTokenOptions: [
+          usdcToken,
+          solanaUsdcToken,
+          tronNativeToken,
+          bitcoinNativeToken,
+        ],
         handleSelectDestStable,
         setActiveScreen,
       }),
@@ -148,6 +168,12 @@ describe('QuickBuyReceiveScreen', () => {
 
     expect(
       screen.getByTestId(`quick-buy-chain-filter-${SOLANA_CHAIN_ID}`),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(`quick-buy-chain-filter-${TRON_CHAIN_ID}`),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(`quick-buy-chain-filter-${BITCOIN_CHAIN_ID}`),
     ).toBeOnTheScreen();
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.tsx
@@ -30,15 +30,20 @@ const QuickBuyReceiveScreen: React.FC = () => {
     // `target.chain` is already a CAIP id — `positionToQuickBuyTarget` does the
     // chain-name → CAIP conversion when the target is built.
     const caip = target.chain as CaipChainId;
-    if (isNonEvmChainId(caip)) return null;
-    let hexChainId: string;
-    try {
-      hexChainId = formatChainIdToHex(caip);
-    } catch {
-      return null;
+    // Receive candidates carry hex chain ids on EVM and CAIP ids on non-EVM
+    // (e.g. Solana), so the filter id must match the candidate format.
+    let chainFilterId: string;
+    if (isNonEvmChainId(caip)) {
+      chainFilterId = caip;
+    } else {
+      try {
+        chainFilterId = formatChainIdToHex(caip);
+      } catch {
+        return null;
+      }
     }
-    return sellDestTokenOptions.some((t) => t.chainId === hexChainId)
-      ? hexChainId
+    return sellDestTokenOptions.some((t) => t.chainId === chainFilterId)
+      ? chainFilterId
       : null;
   }, [target.chain, sellDestTokenOptions]);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/enrichTokenBalance.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/enrichTokenBalance.test.ts
@@ -232,4 +232,99 @@ describe('enrichTokenBalance', () => {
       });
     });
   });
+
+  describe('Tron and Bitcoin', () => {
+    const trxAssetId = 'tron:728126428/slip44:195';
+    const tronScope = 'tron:728126428';
+    const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0';
+    const bitcoinScope = 'bip122:000000000019d6689c085ae165831e93';
+    const tronAccount = { id: 'tron-account-id' };
+    const bitcoinAccount = { id: 'bitcoin-account-id' };
+
+    it('prices a held TRX balance using the Tron account multichain data', () => {
+      const deps = baseDeps({
+        tronAccount,
+        multichainBalances: {
+          [tronAccount.id]: { [trxAssetId]: { amount: '100' } },
+        },
+        multichainRates: { [trxAssetId]: { rate: '0.25' } },
+      });
+
+      const result = enrichTokenBalance(
+        token({ address: trxAssetId, chainId: tronScope, symbol: 'TRX' }),
+        deps,
+      );
+
+      expect(result).toEqual({
+        balance: '100',
+        balanceFiat: '$25.00',
+        tokenFiatAmount: 25,
+        currencyExchangeRate: 0.25,
+      });
+    });
+
+    it('prices a held BTC balance using the Bitcoin account multichain data', () => {
+      const deps = baseDeps({
+        bitcoinAccount,
+        multichainBalances: {
+          [bitcoinAccount.id]: { [btcAssetId]: { amount: '0.5' } },
+        },
+        multichainRates: { [btcAssetId]: { rate: '100000' } },
+      });
+
+      const result = enrichTokenBalance(
+        token({ address: btcAssetId, chainId: bitcoinScope, symbol: 'BTC' }),
+        deps,
+      );
+
+      expect(result).toEqual({
+        balance: '0.5',
+        balanceFiat: '$50000.00',
+        tokenFiatAmount: 50000,
+        currencyExchangeRate: 100000,
+      });
+    });
+
+    it('returns null when there is no account for the candidate chain (strict)', () => {
+      const result = enrichTokenBalance(
+        token({ address: trxAssetId, chainId: tronScope, symbol: 'TRX' }),
+        baseDeps(),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns a zero enrichment when there is no account for the chain and lenient', () => {
+      const result = enrichTokenBalance(
+        token({ address: btcAssetId, chainId: bitcoinScope, symbol: 'BTC' }),
+        baseDeps(),
+        { includeZeroBalance: true },
+      );
+
+      expect(result).toEqual({
+        balance: '0',
+        balanceFiat: '$0.00',
+        tokenFiatAmount: 0,
+        currencyExchangeRate: undefined,
+      });
+    });
+
+    it('does not read another chain account for a non-EVM candidate (Solana account does not price TRX)', () => {
+      const solanaAccount = { id: 'solana-account-id' };
+      const deps = baseDeps({
+        solanaAccount,
+        multichainBalances: {
+          [solanaAccount.id]: { [trxAssetId]: { amount: '100' } },
+        },
+        multichainRates: { [trxAssetId]: { rate: '0.25' } },
+      });
+
+      const result = enrichTokenBalance(
+        token({ address: trxAssetId, chainId: tronScope, symbol: 'TRX' }),
+        deps,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/enrichTokenBalance.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/enrichTokenBalance.ts
@@ -1,6 +1,11 @@
 import type { Hex } from '@metamask/utils';
 import { formatUnits } from 'ethers/lib/utils';
-import { isSolanaChainId, isNativeAddress } from '@metamask/bridge-controller';
+import {
+  isNonEvmChainId,
+  isSolanaChainId,
+  isNativeAddress,
+} from '@metamask/bridge-controller';
+import { BtcScope, TrxScope } from '@metamask/keyring-api';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 import { addCurrencySymbol } from '../../../../../../../util/number/bigint';
 import type { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
@@ -41,6 +46,8 @@ export interface TokenBalanceDeps {
   currencyRates: ReturnType<typeof selectCurrencyRates>;
   allNetworkConfigs?: Record<string, { nativeCurrency?: string } | undefined>;
   solanaAccount?: { id: string };
+  tronAccount?: { id: string };
+  bitcoinAccount?: { id: string };
   multichainBalances?: Record<
     string,
     Record<string, { amount?: string } | undefined> | undefined
@@ -173,20 +180,36 @@ const enrichEvmTokenBalance = (
   return priced(displayBalance, exchangeRate, balanceNum);
 };
 
-const enrichSolanaTokenBalance = (
+/**
+ * Resolves the non-EVM account whose multichain balances cover the candidate's
+ * chain. Multichain balances/rates are keyed by account id + CAIP asset id, so
+ * each non-EVM chain needs the matching account from the selected group.
+ */
+const getNonEvmAccount = (
+  chainId: BridgeToken['chainId'],
+  deps: TokenBalanceDeps,
+): { id: string } | undefined => {
+  if (isSolanaChainId(chainId)) return deps.solanaAccount;
+  if (chainId === TrxScope.Mainnet) return deps.tronAccount;
+  if (chainId === BtcScope.Mainnet) return deps.bitcoinAccount;
+  return undefined;
+};
+
+const enrichNonEvmTokenBalance = (
   candidate: BridgeToken,
   deps: TokenBalanceDeps,
   options: EnrichTokenBalanceOptions,
 ): TokenBalanceEnrichment | null => {
   const { includeZeroBalance } = options;
-  const { solanaAccount, multichainBalances, multichainRates } = deps;
+  const { multichainBalances, multichainRates } = deps;
 
   const dropOrZero = () => (includeZeroBalance ? zeroEnrichment() : null);
 
-  if (!solanaAccount) return dropOrZero();
+  const nonEvmAccount = getNonEvmAccount(candidate.chainId, deps);
+  if (!nonEvmAccount) return dropOrZero();
 
   const amountStr =
-    multichainBalances?.[solanaAccount.id]?.[candidate.address]?.amount;
+    multichainBalances?.[nonEvmAccount.id]?.[candidate.address]?.amount;
   if (!amountStr) return dropOrZero();
 
   const balanceNum = parseFloat(amountStr);
@@ -207,14 +230,15 @@ const enrichSolanaTokenBalance = (
 /**
  * Prices a single token candidate from cached Redux balances, returning the
  * shared balance fields (or `null` when the token should be omitted). Handles
- * EVM natives, EVM ERC-20s, and Solana assets, keeping the USD exchange-rate
- * semantics QuickBuy's amount math depends on.
+ * EVM natives, EVM ERC-20s, and non-EVM assets (Solana, Tron, Bitcoin) via the
+ * multichain balance/rate controllers, keeping the USD exchange-rate semantics
+ * QuickBuy's amount math depends on.
  */
 export const enrichTokenBalance = (
   candidate: BridgeToken,
   deps: TokenBalanceDeps,
   options: EnrichTokenBalanceOptions = {},
 ): TokenBalanceEnrichment | null =>
-  isSolanaChainId(candidate.chainId)
-    ? enrichSolanaTokenBalance(candidate, deps, options)
+  isNonEvmChainId(candidate.chainId)
+    ? enrichNonEvmTokenBalance(candidate, deps, options)
     : enrichEvmTokenBalance(candidate, deps, options);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import { SolScope } from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import type { RootState } from '../../../../../../../reducers';
 import { selectSelectedInternalAccountByScope } from '../../../../../../../selectors/multichainAccounts/accounts';
 import { useReceiveTokens } from './useReceiveTokens';
@@ -117,6 +117,24 @@ jest.mock('../../../../../../UI/Bridge/utils/tokenUtils', () => ({
         chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       };
     }
+    if (chainId === 'tron:728126428') {
+      return {
+        symbol: 'TRX',
+        name: 'Tron',
+        address: 'tron:728126428/slip44:195',
+        decimals: 6,
+        chainId: 'tron:728126428',
+      };
+    }
+    if (chainId === 'bip122:000000000019d6689c085ae165831e93') {
+      return {
+        symbol: 'BTC',
+        name: 'Bitcoin',
+        address: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        decimals: 8,
+        chainId: 'bip122:000000000019d6689c085ae165831e93',
+      };
+    }
     throw new Error(`unsupported chain ${chainId}`);
   }),
 }));
@@ -128,6 +146,8 @@ const mockSelectSelectedInternalAccountByScope =
   selectSelectedInternalAccountByScope as unknown as jest.Mock;
 
 const SOLANA_CHAIN_ID = SolScope.Mainnet;
+const TRON_CHAIN_ID = TrxScope.Mainnet;
+const BITCOIN_CHAIN_ID = BtcScope.Mainnet;
 
 const MOCK_STATE = {
   engine: {
@@ -137,17 +157,30 @@ const MOCK_STATE = {
   },
 } as unknown as RootState;
 
-const SOLANA_ACCOUNT = {
-  id: 'solana-account-id',
-  address: 'So1anaAddre55111111111111111111111111111111',
+const NON_EVM_ACCOUNTS: Record<string, { id: string; address: string }> = {
+  [SOLANA_CHAIN_ID]: {
+    id: 'solana-account-id',
+    address: 'So1anaAddre55111111111111111111111111111111',
+  },
+  [TRON_CHAIN_ID]: {
+    id: 'tron-account-id',
+    address: 'TTronAddre55xxxxxxxxxxxxxxxxxxxxxx',
+  },
+  [BITCOIN_CHAIN_ID]: {
+    id: 'bitcoin-account-id',
+    address: 'bc1qbitcoinaddre55xxxxxxxxxxxxxxxxxxxxx',
+  },
+};
+
+/** Makes the selected account group expose addresses for the given scopes. */
+const givenAccountsForScopes = (scopes: string[]) => {
+  mockSelectSelectedInternalAccountByScope.mockReturnValue((scope: string) =>
+    scopes.includes(scope) ? NON_EVM_ACCOUNTS[scope] : undefined,
+  );
 };
 
 /** Makes the selected account group expose a Solana address. */
-const givenSolanaAccount = () => {
-  mockSelectSelectedInternalAccountByScope.mockReturnValue((scope: string) =>
-    scope === SOLANA_CHAIN_ID ? SOLANA_ACCOUNT : undefined,
-  );
-};
+const givenSolanaAccount = () => givenAccountsForScopes([SOLANA_CHAIN_ID]);
 
 describe('useReceiveTokens', () => {
   beforeEach(() => {
@@ -278,15 +311,6 @@ describe('useReceiveTokens', () => {
       expect(chainIds).toContain('0x1');
     });
 
-    it('never offers unsupported non-EVM chains (e.g. Tron) even with a Solana account', () => {
-      givenSolanaAccount();
-
-      const { result } = renderHook(() => useReceiveTokens(undefined));
-
-      const chainIds = result.current.map((t) => t.chainId);
-      expect(chainIds).not.toContain('tron:728126428');
-    });
-
     it('sorts Solana candidates to the front when the preferred chain is Solana', () => {
       givenSolanaAccount();
 
@@ -304,7 +328,80 @@ describe('useReceiveTokens', () => {
       expect(mockEnrich).toHaveBeenCalledWith(
         expect.objectContaining({ chainId: SOLANA_CHAIN_ID }),
         expect.objectContaining({
-          solanaAccount: expect.objectContaining({ id: SOLANA_ACCOUNT.id }),
+          solanaAccount: expect.objectContaining({
+            id: NON_EVM_ACCOUNTS[SOLANA_CHAIN_ID].id,
+          }),
+        }),
+        { includeZeroBalance: true },
+      );
+    });
+  });
+
+  describe('Tron and Bitcoin candidates', () => {
+    it('offers native TRX when the account has a Tron address, but never TRC-20 stablecoins', () => {
+      givenAccountsForScopes([TRON_CHAIN_ID]);
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const tronTokens = result.current.filter(
+        (t) => t.chainId === TRON_CHAIN_ID,
+      );
+      // Native-only: useAssetMetadata cannot resolve Tron token addresses
+      // (e.g. TRC-20 USDT), so only the native asset is offered.
+      expect(tronTokens.map((t) => t.symbol)).toEqual(['TRX']);
+    });
+
+    it('offers native BTC when the account has a Bitcoin address', () => {
+      givenAccountsForScopes([BITCOIN_CHAIN_ID]);
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const bitcoinTokens = result.current.filter(
+        (t) => t.chainId === BITCOIN_CHAIN_ID,
+      );
+      expect(bitcoinTokens.map((t) => t.symbol)).toEqual(['BTC']);
+    });
+
+    it('omits Tron and Bitcoin candidates when the account lacks those addresses', () => {
+      givenSolanaAccount();
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const chainIds = result.current.map((t) => t.chainId);
+      expect(chainIds).toContain(SOLANA_CHAIN_ID);
+      expect(chainIds).not.toContain(TRON_CHAIN_ID);
+      expect(chainIds).not.toContain(BITCOIN_CHAIN_ID);
+    });
+
+    it('drops Tron and Bitcoin candidates when those networks are not enabled', () => {
+      givenAccountsForScopes([TRON_CHAIN_ID, BITCOIN_CHAIN_ID]);
+      mockUseNetworkEnabledPredicate.mockReturnValue(
+        (chainId: string | undefined) =>
+          chainId !== TRON_CHAIN_ID && chainId !== BITCOIN_CHAIN_ID,
+      );
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const chainIds = result.current.map((t) => t.chainId);
+      expect(chainIds).not.toContain(TRON_CHAIN_ID);
+      expect(chainIds).not.toContain(BITCOIN_CHAIN_ID);
+      expect(chainIds).toContain('0x1');
+    });
+
+    it('passes the Tron and Bitcoin accounts to balance enrichment so their holdings are priced', () => {
+      givenAccountsForScopes([TRON_CHAIN_ID, BITCOIN_CHAIN_ID]);
+
+      renderHook(() => useReceiveTokens(undefined));
+
+      expect(mockEnrich).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: TRON_CHAIN_ID }),
+        expect.objectContaining({
+          tronAccount: expect.objectContaining({
+            id: NON_EVM_ACCOUNTS[TRON_CHAIN_ID].id,
+          }),
+          bitcoinAccount: expect.objectContaining({
+            id: NON_EVM_ACCOUNTS[BITCOIN_CHAIN_ID].id,
+          }),
         }),
         { includeZeroBalance: true },
       );

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.test.ts
@@ -1,14 +1,43 @@
 import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { SolScope } from '@metamask/keyring-api';
+import type { RootState } from '../../../../../../../reducers';
+import { selectSelectedInternalAccountByScope } from '../../../../../../../selectors/multichainAccounts/accounts';
 import { useReceiveTokens } from './useReceiveTokens';
 import { enrichTokenBalance } from './enrichTokenBalance';
 import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
 
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => undefined),
+  useSelector: jest.fn(),
 }));
 
 jest.mock('./useNetworkEnabledPredicate', () => ({
   useNetworkEnabledPredicate: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/accountTrackerController', () => ({
+  selectAccountsByChainId: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/tokenBalancesController', () => ({
+  selectTokensBalances: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/currencyRateController', () => ({
+  selectCurrencyRates: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/multichain/multichain', () => ({
+  selectMultichainBalances: jest.fn(() => ({})),
+  selectMultichainAssetsRates: jest.fn(() => ({})),
 }));
 
 jest.mock(
@@ -35,6 +64,21 @@ jest.mock(
         chainId: '0x1',
         decimals: 18,
         name: 'Wrapped Ether',
+      },
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+        symbol: 'USDC',
+        address:
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        decimals: 6,
+        name: 'USD Coin',
+      },
+      'tron:728126428': {
+        symbol: 'USDT',
+        address: 'tron:728126428/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        chainId: 'tron:728126428',
+        decimals: 6,
+        name: 'Tether USD',
       },
     },
   }),
@@ -64,17 +108,56 @@ jest.mock('../../../../../../UI/Bridge/utils/tokenUtils', () => ({
         chainId: '0x89',
       };
     }
+    if (chainId === 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp') {
+      return {
+        symbol: 'SOL',
+        name: 'Solana',
+        address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        decimals: 9,
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      };
+    }
     throw new Error(`unsupported chain ${chainId}`);
   }),
 }));
 
 const mockEnrich = enrichTokenBalance as jest.Mock;
 const mockUseNetworkEnabledPredicate = useNetworkEnabledPredicate as jest.Mock;
+const mockUseSelector = useSelector as unknown as jest.Mock;
+const mockSelectSelectedInternalAccountByScope =
+  selectSelectedInternalAccountByScope as unknown as jest.Mock;
+
+const SOLANA_CHAIN_ID = SolScope.Mainnet;
+
+const MOCK_STATE = {
+  engine: {
+    backgroundState: {
+      NetworkController: { networkConfigurationsByChainId: {} },
+    },
+  },
+} as unknown as RootState;
+
+const SOLANA_ACCOUNT = {
+  id: 'solana-account-id',
+  address: 'So1anaAddre55111111111111111111111111111111',
+};
+
+/** Makes the selected account group expose a Solana address. */
+const givenSolanaAccount = () => {
+  mockSelectSelectedInternalAccountByScope.mockReturnValue((scope: string) =>
+    scope === SOLANA_CHAIN_ID ? SOLANA_ACCOUNT : undefined,
+  );
+};
 
 describe('useReceiveTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseNetworkEnabledPredicate.mockReturnValue(() => true);
+    // No account in the selected group resolves for any scope by default.
+    mockSelectSelectedInternalAccountByScope.mockReturnValue(() => undefined);
+    mockUseSelector.mockImplementation(
+      (selector: (state: RootState) => unknown) => selector(MOCK_STATE),
+    );
     mockEnrich.mockReturnValue({
       balance: '0',
       balanceFiat: '$0.00',
@@ -159,5 +242,72 @@ describe('useReceiveTokens', () => {
     const chainIds = result.current.map((t) => t.chainId);
     expect(chainIds).toContain('0x1');
     expect(chainIds).not.toContain('0x89');
+  });
+
+  describe('Solana candidates', () => {
+    it('includes Solana stablecoin and native candidates when the account has a Solana address', () => {
+      givenSolanaAccount();
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const solanaTokens = result.current.filter(
+        (t) => t.chainId === SOLANA_CHAIN_ID,
+      );
+      expect(solanaTokens.map((t) => t.symbol)).toEqual(
+        expect.arrayContaining(['USDC', 'SOL']),
+      );
+    });
+
+    it('omits Solana candidates when the account has no Solana address', () => {
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const chainIds = result.current.map((t) => t.chainId);
+      expect(chainIds).not.toContain(SOLANA_CHAIN_ID);
+    });
+
+    it('drops Solana candidates when the Solana network is not enabled', () => {
+      givenSolanaAccount();
+      mockUseNetworkEnabledPredicate.mockReturnValue(
+        (chainId: string | undefined) => chainId !== SOLANA_CHAIN_ID,
+      );
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const chainIds = result.current.map((t) => t.chainId);
+      expect(chainIds).not.toContain(SOLANA_CHAIN_ID);
+      expect(chainIds).toContain('0x1');
+    });
+
+    it('never offers unsupported non-EVM chains (e.g. Tron) even with a Solana account', () => {
+      givenSolanaAccount();
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const chainIds = result.current.map((t) => t.chainId);
+      expect(chainIds).not.toContain('tron:728126428');
+    });
+
+    it('sorts Solana candidates to the front when the preferred chain is Solana', () => {
+      givenSolanaAccount();
+
+      const { result } = renderHook(() => useReceiveTokens(SOLANA_CHAIN_ID));
+
+      expect(result.current[0].chainId).toBe(SOLANA_CHAIN_ID);
+      expect(result.current[0].symbol).toBe('USDC');
+    });
+
+    it('passes the Solana account to balance enrichment so Solana holdings are priced', () => {
+      givenSolanaAccount();
+
+      renderHook(() => useReceiveTokens(undefined));
+
+      expect(mockEnrich).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: SOLANA_CHAIN_ID }),
+        expect.objectContaining({
+          solanaAccount: expect.objectContaining({ id: SOLANA_ACCOUNT.id }),
+        }),
+        { includeZeroBalance: true },
+      );
+    });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { isSolanaChainId } from '@metamask/bridge-controller';
-import { SolScope } from '@metamask/keyring-api';
+import { isNonEvmChainId, isSolanaChainId } from '@metamask/bridge-controller';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
+import type { CaipChainId } from '@metamask/utils';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 import type { RootState } from '../../../../../../../reducers';
 import { selectAccountsByChainId } from '../../../../../../../selectors/accountTrackerController';
@@ -33,9 +34,12 @@ import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
  * Optimism, USDC on Polygon, etc.) without disturbing the existing default
  * ordering. Duplicates are removed by stable token identity (`address:chainId`).
  *
- * Chains are limited to the ones QuickBuy can actually quote and price: EVM
- * (hex chain ids) and Solana (the only non-EVM chain `enrichTokenBalance` and
- * the quote flow support). Other non-EVM entries (e.g. Tron) are excluded.
+ * Stablecoin candidates are limited to the chains whose token addresses
+ * QuickBuy can actually resolve as destinations: EVM (hex chain ids) and
+ * Solana. `useAssetMetadata` only resolves Solana base58 / EVM hex token
+ * addresses, so non-native tokens on other non-EVM chains (e.g. TRC-20 USDT on
+ * Tron) cannot be quoted and are excluded — those chains are offered as
+ * native-only via `NATIVE_ONLY_NON_EVM_CHAINS` instead.
  */
 const STABLECOIN_CANDIDATES: BridgeToken[] = (() => {
   const primaries = Object.values(DefaultSwapDestTokens).filter(
@@ -52,14 +56,29 @@ const STABLECOIN_CANDIDATES: BridgeToken[] = (() => {
 })();
 
 /**
- * Native token candidates for the Sell "Receive" picker, one per chain already
- * covered by `STABLECOIN_CANDIDATES`. Built via `getNativeSourceToken` so each
- * native uses the bridge-expected address (zero address on EVM). Chains the
- * helper can't resolve are skipped. Together with the stablecoins, these are
- * the tokens a user can receive when selling a position.
+ * Non-EVM chains offered as native-asset-only receive candidates (TRX, BTC).
+ * Their native assets resolve through the bridge native-asset registry
+ * (`getNativeSourceToken`), unlike their non-native tokens which
+ * `useAssetMetadata` cannot resolve (see `STABLECOIN_CANDIDATES`).
+ */
+const NATIVE_ONLY_NON_EVM_CHAINS: CaipChainId[] = [
+  TrxScope.Mainnet,
+  BtcScope.Mainnet,
+];
+
+/**
+ * Native token candidates for the Sell "Receive" picker: one per chain already
+ * covered by `STABLECOIN_CANDIDATES`, plus the native-only non-EVM chains
+ * (TRX, BTC). Built via `getNativeSourceToken` so each native uses the
+ * bridge-expected address (zero address on EVM, CAIP asset id on non-EVM).
+ * Chains the helper can't resolve are skipped. Together with the stablecoins,
+ * these are the tokens a user can receive when selling a position.
  */
 const NATIVE_CANDIDATES: BridgeToken[] = Array.from(
-  new Set(STABLECOIN_CANDIDATES.map((token) => token.chainId)),
+  new Set<BridgeToken['chainId']>([
+    ...STABLECOIN_CANDIDATES.map((token) => token.chainId),
+    ...NATIVE_ONLY_NON_EVM_CHAINS,
+  ]),
 ).reduce<BridgeToken[]>((acc, chainId) => {
   try {
     acc.push(getNativeSourceToken(chainId));
@@ -96,36 +115,51 @@ const getReceiveTokenCandidates = (
  * unheld ones show "$0.00". Candidates on `preferredChainId` are sorted to the
  * top, stablecoins before natives.
  *
- * Solana candidates are only offered when the selected account actually has a
- * Solana address (multichain account groups may lack one), mirroring how the
- * rest of the app gates Solana visibility via
- * `selectSelectedInternalAccountByScope(SolScope.Mainnet)`.
+ * Non-EVM candidates (Solana, Tron, Bitcoin) are only offered when the
+ * selected account actually has an address on that chain (multichain account
+ * groups may lack one), mirroring how the rest of the app gates non-EVM
+ * visibility via `selectSelectedInternalAccountByScope(scope)`.
  */
 export const useReceiveTokens = (
   preferredChainId: string | undefined,
 ): BridgeToken[] => {
   const isChainEnabled = useNetworkEnabledPredicate();
 
-  const solanaAccount = useSelector((state: RootState) =>
-    selectSelectedInternalAccountByScope(state)(SolScope.Mainnet),
+  const selectAccountByScope = useSelector(
+    selectSelectedInternalAccountByScope,
   );
-  const hasSolanaAccount = Boolean(solanaAccount);
+  const solanaAccount = selectAccountByScope(SolScope.Mainnet);
+  const tronAccount = selectAccountByScope(TrxScope.Mainnet);
+  const bitcoinAccount = selectAccountByScope(BtcScope.Mainnet);
+
+  // Non-EVM accounts in the selected group, keyed by the CAIP chain id the
+  // receive candidates carry. A missing entry means the user has no address on
+  // that chain and cannot receive there.
+  const nonEvmAccountByChainId = useMemo(
+    () => ({
+      [SolScope.Mainnet]: solanaAccount,
+      [TrxScope.Mainnet]: tronAccount,
+      [BtcScope.Mainnet]: bitcoinAccount,
+    }),
+    [solanaAccount, tronAccount, bitcoinAccount],
+  );
 
   const candidates = useMemo(
     () =>
-      getReceiveTokenCandidates(preferredChainId).filter(
-        (candidate) =>
-          isChainEnabled(candidate.chainId) &&
-          // Without a Solana address the user cannot receive on Solana.
-          (hasSolanaAccount || !isSolanaChainId(candidate.chainId)),
-      ),
-    [preferredChainId, isChainEnabled, hasSolanaAccount],
+      getReceiveTokenCandidates(preferredChainId).filter((candidate) => {
+        if (!isChainEnabled(candidate.chainId)) return false;
+        if (!isNonEvmChainId(candidate.chainId)) return true;
+        // Without an address on the non-EVM chain the user cannot receive there.
+        return Boolean(
+          nonEvmAccountByChainId[
+            candidate.chainId as keyof typeof nonEvmAccountByChainId
+          ],
+        );
+      }),
+    [preferredChainId, isChainEnabled, nonEvmAccountByChainId],
   );
 
-  const accountAddress = useSelector(
-    (state: RootState) =>
-      selectSelectedInternalAccountByScope(state)(EVM_SCOPE)?.address,
-  );
+  const accountAddress = selectAccountByScope(EVM_SCOPE)?.address;
   const accountsByChainId = useSelector(selectAccountsByChainId);
   const tokenBalances = useSelector(selectTokensBalances);
   const tokenMarketData = useSelector(selectTokenMarketData);
@@ -151,6 +185,8 @@ export const useReceiveTokens = (
             currencyRates,
             allNetworkConfigs,
             solanaAccount: solanaAccount ?? undefined,
+            tronAccount: tronAccount ?? undefined,
+            bitcoinAccount: bitcoinAccount ?? undefined,
             multichainBalances,
             multichainRates: multichainRates as Record<
               string,
@@ -172,6 +208,8 @@ export const useReceiveTokens = (
       currencyRates,
       allNetworkConfigs,
       solanaAccount,
+      tronAccount,
+      bitcoinAccount,
       multichainBalances,
       multichainRates,
     ],

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useReceiveTokens.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { isSolanaChainId } from '@metamask/bridge-controller';
+import { SolScope } from '@metamask/keyring-api';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 import type { RootState } from '../../../../../../../reducers';
 import { selectAccountsByChainId } from '../../../../../../../selectors/accountTrackerController';
@@ -7,6 +9,10 @@ import { selectSelectedInternalAccountByScope } from '../../../../../../../selec
 import { selectTokensBalances } from '../../../../../../../selectors/tokenBalancesController';
 import { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
 import { selectCurrencyRates } from '../../../../../../../selectors/currencyRateController';
+import {
+  selectMultichainBalances,
+  selectMultichainAssetsRates,
+} from '../../../../../../../selectors/multichain/multichain';
 import { DefaultSwapDestTokens } from '../../../../../../UI/Bridge/constants/default-swap-dest-tokens';
 import { EVM_SCOPE } from '../../../../../../UI/Earn/constants/networks';
 import { getNativeSourceToken } from '../../../../../../UI/Bridge/utils/tokenUtils';
@@ -17,22 +23,26 @@ import { RECEIVE_STABLECOIN_CANDIDATES } from './receiveStablecoinCandidates';
 import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
 
 /**
- * Static EVM stablecoin candidates for the Sell "Receive" picker.
+ * Static stablecoin candidates for the Sell "Receive" picker (EVM + Solana).
  *
  * `DefaultSwapDestTokens` carries a single stablecoin per chain (which sets the
- * per-chain default selection — e.g. mUSD on mainnet/Linea), so we keep those
- * as the leading entries and then append the canonical USDC/USDT set from
- * `RECEIVE_STABLECOIN_CANDIDATES`. The append guarantees both major stablecoins
- * show on every supported chain (previously USDT was missing on Optimism,
- * USDC on Polygon, etc.) without disturbing the existing default ordering.
- * Duplicates are removed by stable token identity (`address:chainId`).
+ * per-chain default selection — e.g. mUSD on mainnet/Linea, USDC on Solana), so
+ * we keep those as the leading entries and then append the canonical USDC/USDT
+ * set from `RECEIVE_STABLECOIN_CANDIDATES`. The append guarantees both major
+ * stablecoins show on every supported chain (previously USDT was missing on
+ * Optimism, USDC on Polygon, etc.) without disturbing the existing default
+ * ordering. Duplicates are removed by stable token identity (`address:chainId`).
+ *
+ * Chains are limited to the ones QuickBuy can actually quote and price: EVM
+ * (hex chain ids) and Solana (the only non-EVM chain `enrichTokenBalance` and
+ * the quote flow support). Other non-EVM entries (e.g. Tron) are excluded.
  */
 const STABLECOIN_CANDIDATES: BridgeToken[] = (() => {
   const primaries = Object.values(DefaultSwapDestTokens).filter(
     (token) =>
       isStablecoinSymbol(token.symbol) &&
       typeof token.chainId === 'string' &&
-      token.chainId.startsWith('0x'),
+      (token.chainId.startsWith('0x') || isSolanaChainId(token.chainId)),
   );
   const seen = new Set(primaries.map(getTokenKey));
   const extras = RECEIVE_STABLECOIN_CANDIDATES.filter(
@@ -85,17 +95,31 @@ const getReceiveTokenCandidates = (
  * a token they don't yet hold). Held tokens are enriched with balance + fiat;
  * unheld ones show "$0.00". Candidates on `preferredChainId` are sorted to the
  * top, stablecoins before natives.
+ *
+ * Solana candidates are only offered when the selected account actually has a
+ * Solana address (multichain account groups may lack one), mirroring how the
+ * rest of the app gates Solana visibility via
+ * `selectSelectedInternalAccountByScope(SolScope.Mainnet)`.
  */
 export const useReceiveTokens = (
   preferredChainId: string | undefined,
 ): BridgeToken[] => {
   const isChainEnabled = useNetworkEnabledPredicate();
+
+  const solanaAccount = useSelector((state: RootState) =>
+    selectSelectedInternalAccountByScope(state)(SolScope.Mainnet),
+  );
+  const hasSolanaAccount = Boolean(solanaAccount);
+
   const candidates = useMemo(
     () =>
-      getReceiveTokenCandidates(preferredChainId).filter((candidate) =>
-        isChainEnabled(candidate.chainId),
+      getReceiveTokenCandidates(preferredChainId).filter(
+        (candidate) =>
+          isChainEnabled(candidate.chainId) &&
+          // Without a Solana address the user cannot receive on Solana.
+          (hasSolanaAccount || !isSolanaChainId(candidate.chainId)),
       ),
-    [preferredChainId, isChainEnabled],
+    [preferredChainId, isChainEnabled, hasSolanaAccount],
   );
 
   const accountAddress = useSelector(
@@ -106,6 +130,8 @@ export const useReceiveTokens = (
   const tokenBalances = useSelector(selectTokensBalances);
   const tokenMarketData = useSelector(selectTokenMarketData);
   const currencyRates = useSelector(selectCurrencyRates);
+  const multichainBalances = useSelector(selectMultichainBalances);
+  const multichainRates = useSelector(selectMultichainAssetsRates);
   const allNetworkConfigs = useSelector(
     (state: RootState) =>
       state.engine.backgroundState.NetworkController
@@ -124,6 +150,12 @@ export const useReceiveTokens = (
             tokenMarketData,
             currencyRates,
             allNetworkConfigs,
+            solanaAccount: solanaAccount ?? undefined,
+            multichainBalances,
+            multichainRates: multichainRates as Record<
+              string,
+              { rate?: string } | undefined
+            >,
           },
           {
             includeZeroBalance: true,
@@ -139,6 +171,9 @@ export const useReceiveTokens = (
       tokenMarketData,
       currencyRates,
       allNetworkConfigs,
+      solanaAccount,
+      multichainBalances,
+      multichainRates,
     ],
   );
 };


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The Quick Buy "Receive" view (sell flow) was missing the Solana, Tron, and BTC network chips, so users couldn't select those chains to receive on — breaking parity with the other supported networks.

Root cause: the receive-token candidates in `useReceiveTokens` were built EVM-only — the stablecoin curation filtered `DefaultSwapDestTokens` with `chainId.startsWith('0x')`, silently dropping non-EVM (CAIP) chain ids. Since chips are derived from the candidates' chain ids, no non-EVM candidates meant no chips. All surrounding infrastructure (chain-filter display, enabled-network gating, quote flow) already supported non-EVM chains.

Changes:

- **Solana:** SOL native and Solana USDC are now receive candidates.
- **Tron / Bitcoin:** native TRX and BTC are now receive candidates via the bridge native-asset registry. Non-native tokens on these chains (e.g. TRC-20 USDT) are deliberately excluded: `useAssetMetadata` can only resolve Solana base58 / EVM hex addresses, so they cannot resolve as Quick Buy destinations (see TSA-659).
- Each non-EVM chip is gated on the selected account actually having an address on that chain (`selectSelectedInternalAccountByScope` per scope), matching app-wide gating.
- `enrichSolanaTokenBalance` generalized to `enrichNonEvmTokenBalance` so Tron/BTC holdings get correct balance/fiat enrichment (previously Solana-only).
- The chain filter defaults to the position's CAIP chain for non-EVM positions (previously fell back to "All").

Jira: [TSA-657](https://consensyssoftware.atlassian.net/browse/TSA-657)

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Added Solana, Tron and Bitcoin network options to the Quick Buy receive view

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [TSA-657](https://consensyssoftware.atlassian.net/browse/TSA-657)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy receive view network chips

  Scenario: user with a multichain account opens the receive picker
    Given the selected account has Solana, Tron and Bitcoin addresses
    And the user is selling a token via Quick Buy

    When the user opens the "Receive" token picker
    Then Solana, Tron and Bitcoin chips appear alongside the EVM network chips
    And selecting Tron offers native TRX as the receive option
    And selecting Bitcoin offers native BTC as the receive option
    And selecting Solana offers SOL and Solana USDC

  Scenario: account without non-EVM addresses
    Given the selected account has no Tron or Bitcoin address

    When the user opens the "Receive" token picker
    Then the Tron and Bitcoin chips are not shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<img width="393" height="417" alt="image" src="https://github.com/user-attachments/assets/414fe115-f979-4b8c-9ef2-6d7dfca49b1f" />

### **After**

<img width="437" height="423" alt="image" src="https://github.com/user-attachments/assets/5cbf55a1-74ea-409d-aa22-6e6058a49b11" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TSA-657]: https://consensyssoftware.atlassian.net/browse/TSA-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sell-flow receive token selection and balance/fiat enrichment across multichain accounts; wrong gating or chain-id mismatches could hide options or misprice rows, but changes are scoped to Quick Buy with broad test coverage.
> 
> **Overview**
> Fixes the Quick Buy **Receive** picker (sell flow) so **Solana, Tron, and Bitcoin** network chips and tokens appear when the user’s account and enabled networks allow it.
> 
> **Receive candidates (`useReceiveTokens`):** Stablecoin curation no longer drops non-EVM chains—**Solana USDC** is included alongside EVM stables. **Native TRX and BTC** are added via `NATIVE_ONLY_NON_EVM_CHAINS` (TRC-20 stables on Tron stay excluded because destinations can’t be resolved). Non-EVM options are gated on **`selectSelectedInternalAccountByScope`** per chain and existing network-enabled checks; multichain balances/rates are wired into enrichment.
> 
> **Balances (`enrichTokenBalance`):** Solana-specific enrichment is generalized to **`enrichNonEvmTokenBalance`** with Tron/Bitcoin accounts so held TRX/BTC/SOL show correct fiat in the list.
> 
> **UI filter (`QuickBuyReceiveScreen`):** The default chain filter uses the position’s **CAIP chain id** for non-EVM positions (matching candidate `chainId` format) instead of skipping non-EVM and falling back to “All”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c8ac7505490c27a0381b0af385d428fc9988ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->