### PR TITLE
fix: prevent Token Details scroll jump when a non-EVM transaction confirms (TSA-656)

### DIFF
--- a/app/components/UI/TokenDetails/Views/TokenDetails.test.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.test.tsx
@@ -193,11 +193,15 @@ jest.mock('../../Transactions', () => ({
   default: ({ header }: { header?: React.ReactNode }) => header ?? null,
 }));
 
+const mockMultichainTransactionsView = jest.fn(
+  (_props: Record<string, unknown>) => null,
+);
 jest.mock(
   '../../../Views/MultichainTransactionsView/MultichainTransactionsView',
   () => ({
     __esModule: true,
-    default: () => null,
+    default: (props: Record<string, unknown>) =>
+      mockMultichainTransactionsView(props),
   }),
 );
 
@@ -362,6 +366,55 @@ describe('TokenDetails', () => {
     const { UNSAFE_getByType } = render(<TokenDetails />);
 
     expect(UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+  });
+
+  describe('non-EVM asset header stability (TSA-656)', () => {
+    const getLastMultichainViewProps = () =>
+      mockMultichainTransactionsView.mock.calls[
+        mockMultichainTransactionsView.mock.calls.length - 1
+      ][0];
+
+    it('keeps the same header element when the transaction list updates', () => {
+      mockUseTokenTransactions.mockReturnValue({
+        ...defaultUseTokenTransactionsReturn,
+        isNonEvmAsset: true,
+        transactions: [{ id: 'tx-1' }],
+      });
+
+      const { rerender } = render(<TokenDetails />);
+      const initialHeader = getLastMultichainViewProps().header;
+
+      mockUseTokenTransactions.mockReturnValue({
+        ...defaultUseTokenTransactionsReturn,
+        isNonEvmAsset: true,
+        transactions: [{ id: 'tx-1' }, { id: 'tx-2' }],
+      });
+      rerender(<TokenDetails />);
+
+      expect(initialHeader).toBeDefined();
+      expect(getLastMultichainViewProps().header).toBe(initialHeader);
+    });
+
+    it('recreates the header element when transactions first appear', () => {
+      mockUseTokenTransactions.mockReturnValue({
+        ...defaultUseTokenTransactionsReturn,
+        isNonEvmAsset: true,
+        transactions: [],
+      });
+
+      const { rerender } = render(<TokenDetails />);
+      const initialHeader = getLastMultichainViewProps().header;
+
+      mockUseTokenTransactions.mockReturnValue({
+        ...defaultUseTokenTransactionsReturn,
+        isNonEvmAsset: true,
+        transactions: [{ id: 'tx-1' }],
+      });
+      rerender(<TokenDetails />);
+
+      expect(initialHeader).toBeDefined();
+      expect(getLastMultichainViewProps().header).not.toBe(initialHeader);
+    });
   });
 
   describe('Swap/Buy sticky buttons', () => {

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -291,52 +291,93 @@ const TokenDetails: React.FC<{
     submittedTxs.length > 0 ||
     confirmedTxs.length > 0;
 
-  const renderHeader = () => (
-    <>
-      <AssetOverviewContent
-        token={token}
-        balance={balance}
-        mainBalance={fiatBalance ?? ''}
-        secondaryBalance={tokenFormattedBalance}
-        currentPrice={currentPrice}
-        priceDiff={priceDiff}
-        comparePrice={comparePrice}
-        prices={prices}
-        isLoading={isLoading}
-        timePeriod={timePeriod}
-        setTimePeriod={setTimePeriod}
-        chartNavigationButtons={chartNavigationButtons}
-        isPerpsEnabled={isPerpsEnabled}
-        currentCurrency={currentCurrency}
-        onBuy={handleBuy}
-        onSend={handleSend}
-        onReceive={onReceive}
-        onMarketInsightsDisplayResolved={onMarketInsightsDisplayResolved}
-        onMarketInsightsDisclaimerPress={() =>
-          setIsInsightsDisclaimerVisible(true)
-        }
-        securityData={securityData}
-        isSecurityDataLoading={isSecurityDataLoading}
-        hasSecurityDataError={Boolean(securityDataError)}
-        onPriceDirectionChange={handlePriceDirectionChange}
-        useAmbientColor={useAmbientColor}
-        onExitAction={onCtaClicked}
-        isPricePositive={chartPricePositive}
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
-        stakedTrxAsset={stakedTrxAsset}
-        inLockPeriodBalance={inLockPeriodBalance}
-        readyForWithdrawalBalance={readyForWithdrawalBalance}
-        ///: END:ONLY_INCLUDE_IF
-      />
-      {(txLoading || hasTransactions) && (
-        <ActivityHeader
-          asset={{
-            ...token,
-            hasBalanceError: token.hasBalanceError ?? false,
-          }}
+  // The header element must keep a stable identity across renders: it is
+  // passed to a FlashList `ListHeaderComponent` and recreating it on every
+  // render (e.g. when a non-EVM transaction confirms and the activity list
+  // updates) makes FlashList remount/remeasure the large header (chart +
+  // balances) and jump the scroll position back to the top (TSA-656).
+  const header = useMemo(
+    () => (
+      <>
+        <AssetOverviewContent
+          token={token}
+          balance={balance}
+          mainBalance={fiatBalance ?? ''}
+          secondaryBalance={tokenFormattedBalance}
+          currentPrice={currentPrice}
+          priceDiff={priceDiff}
+          comparePrice={comparePrice}
+          prices={prices}
+          isLoading={isLoading}
+          timePeriod={timePeriod}
+          setTimePeriod={setTimePeriod}
+          chartNavigationButtons={chartNavigationButtons}
+          isPerpsEnabled={isPerpsEnabled}
+          currentCurrency={currentCurrency}
+          onBuy={handleBuy}
+          onSend={handleSend}
+          onReceive={onReceive}
+          onMarketInsightsDisplayResolved={onMarketInsightsDisplayResolved}
+          onMarketInsightsDisclaimerPress={() =>
+            setIsInsightsDisclaimerVisible(true)
+          }
+          securityData={securityData}
+          isSecurityDataLoading={isSecurityDataLoading}
+          hasSecurityDataError={Boolean(securityDataError)}
+          onPriceDirectionChange={handlePriceDirectionChange}
+          useAmbientColor={useAmbientColor}
+          onExitAction={onCtaClicked}
+          isPricePositive={chartPricePositive}
+          ///: BEGIN:ONLY_INCLUDE_IF(tron)
+          stakedTrxAsset={stakedTrxAsset}
+          inLockPeriodBalance={inLockPeriodBalance}
+          readyForWithdrawalBalance={readyForWithdrawalBalance}
+          ///: END:ONLY_INCLUDE_IF
         />
-      )}
-    </>
+        {(txLoading || hasTransactions) && (
+          <ActivityHeader
+            asset={{
+              ...token,
+              hasBalanceError: token.hasBalanceError ?? false,
+            }}
+          />
+        )}
+      </>
+    ),
+    [
+      token,
+      balance,
+      fiatBalance,
+      tokenFormattedBalance,
+      currentPrice,
+      priceDiff,
+      comparePrice,
+      prices,
+      isLoading,
+      timePeriod,
+      setTimePeriod,
+      chartNavigationButtons,
+      isPerpsEnabled,
+      currentCurrency,
+      handleBuy,
+      handleSend,
+      onReceive,
+      onMarketInsightsDisplayResolved,
+      securityData,
+      isSecurityDataLoading,
+      securityDataError,
+      handlePriceDirectionChange,
+      useAmbientColor,
+      onCtaClicked,
+      chartPricePositive,
+      ///: BEGIN:ONLY_INCLUDE_IF(tron)
+      stakedTrxAsset,
+      inLockPeriodBalance,
+      readyForWithdrawalBalance,
+      ///: END:ONLY_INCLUDE_IF
+      txLoading,
+      hasTransactions,
+    ],
   );
 
   const renderLoader = () => (
@@ -356,7 +397,7 @@ const TokenDetails: React.FC<{
         renderLoader()
       ) : txIsNonEvmAsset ? (
         <MultichainTransactionsView
-          header={renderHeader()}
+          header={header}
           transactions={transactions}
           navigation={navigation}
           selectedAddress={selectedAddress}
@@ -367,7 +408,7 @@ const TokenDetails: React.FC<{
         />
       ) : (
         <Transactions
-          header={renderHeader()}
+          header={header}
           assetSymbol={token.symbol}
           navigation={navigation}
           transactions={transactions}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On the Token Details page for a non-EVM asset (e.g. Solana), the whole page jumped back to the top whenever a transaction confirmed — most visible when a Quick Buy swap settled and the success toast appeared (the toast is not the cause; both are triggered by the same `MultichainTransactionsController:stateChange`).

Root cause: `TokenDetails` passed `header={renderHeader()}` to `MultichainTransactionsView`, which feeds it straight into FlashList's `ListHeaderComponent`. `renderHeader()` created a brand-new element on every render, so when a confirmed transaction updated the activity list, FlashList received a new header element, remounted/remeasured the large header (chart + balances), and the list jumped to the top.

Fix: the header element is now memoized with `useMemo` (same hook-order position; the component has no early returns, so hook rules hold for both EVM and non-EVM paths) and the stable reference is passed to both `MultichainTransactionsView` (non-EVM) and `Transactions` (EVM). The dependency array covers every value used in the header, with Tron-only deps kept inside the existing `///: BEGIN:ONLY_INCLUDE_IF(tron)` code-fence pattern. The header is still legitimately recreated when `hasTransactions` first flips (ActivityHeader appearing).

Includes two regression tests: header reference unchanged across transaction-list updates, and recreated when transactions first appear.

Jira: [TSA-656](https://consensyssoftware.atlassian.net/browse/TSA-656)

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Fixed the token details page scrolling back to the top when a transaction confirms

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [TSA-656](https://consensyssoftware.atlassian.net/browse/TSA-656)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token Details scroll stability

  Scenario: a transaction confirms while the user has scrolled down
    Given the user is on the Token Details page of a Solana asset
    And the user has scrolled down the page
    And a Quick Buy swap on that asset is settling

    When the transaction confirms and the success toast appears
    Then the page keeps its scroll position and does not jump to the top
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TSA-656]: https://consensyssoftware.atlassian.net/browse/TSA-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ