### PR TITLE
fix: reserve gas buffer in Quick Buy max amount for native pay tokens (TSA-605)

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -90,6 +90,7 @@ import { useHasSufficientGas } from '../../../../../../UI/Bridge/hooks/useHasSuf
 import { useInitialSlippage } from '../../../../../../UI/Bridge/hooks/useInitialSlippage';
 import useIsInsufficientBalance from '../../../../../../UI/Bridge/hooks/useInsufficientBalance';
 import { useIsGasIncludedSTXSendBundleSupported } from '../../../../../../UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported';
+import { useIsNetworkGasSponsored } from '../../../../../../UI/Bridge/hooks/useIsNetworkGasSponsored';
 import { useIsNetworkFeeUnavailable } from '../../../../../../UI/Bridge/hooks/useIsNetworkFeeUnavailable';
 import { useLatestBalance } from '../../../../../../UI/Bridge/hooks/useLatestBalance';
 import { usePriceImpactViewData } from '../../../../../../UI/Bridge/hooks/usePriceImpactViewData';
@@ -100,6 +101,9 @@ import {
 } from '../../../../../../UI/Bridge/utils/getPriceImpactViewData';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useGasFeeEstimates } from '../../../../../confirmations/hooks/gas/useGasFeeEstimates';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { GasFeeEstimatesType } from '../../../../../confirmations/utils/estimated-total-gas';
+import { getSpendableSourceBalance } from '../utils/getSpendableSourceBalance';
 import {
   SocialLeaderboardEventProperties,
   SocialLeaderboardEventValues,
@@ -503,7 +507,9 @@ export function useQuickBuyController(
       return undefined;
     }
   }, [sourceChainId]);
-  useGasFeeEstimates(sourceNetworkClientId);
+  // Polled estimates double as the native-source gas reserve for the slider
+  // max (see `maxSpendTokens` below).
+  const { gasFeeEstimates } = useGasFeeEstimates(sourceNetworkClientId);
 
   useRefreshSmartTransactionsLiveness(sourceChainId);
   useIsGasIncludedSTXSendBundleSupported(sourceChainId);
@@ -846,17 +852,46 @@ export function useQuickBuyController(
   // pass it straight through rather than re-deriving it from a token amount.
   const destBalanceFiat = liveSelectedDestBalance?.balanceFiat;
 
-  const maxSpendFiat = sourceBalanceFiatValue;
+  const isSourceNetworkGasSponsored = useIsNetworkGasSponsored(sourceChainId);
 
-  // Token-amount-based gate: used for sources we can't price. Mirrors how the
-  // Bridge / asset list keep unpriceable tokens usable as long as the user
-  // actually holds a positive balance.
-  const maxSpendTokens = useMemo(() => {
-    const raw = latestSourceBalance?.displayBalance;
-    if (!raw) return 0;
-    const parsed = parseFloat(raw);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-  }, [latestSourceBalance?.displayBalance]);
+  // Token-amount spend ceiling (display units). For EVM-native pay tokens the
+  // swap's gas comes out of the same balance being spent, so the slider's 100%
+  // must leave room for it — otherwise quoting/execution fails on the full
+  // balance (TSA-605). `getSpendableSourceBalance` reuses the Send flow's
+  // `getEstimatedTotalGas` reserve and clamps at zero; ERC-20 and non-EVM
+  // sources keep the full balance. Also gates the slider for sources we can't
+  // price, mirroring how the Bridge / asset list keep unpriceable tokens
+  // usable as long as the user actually holds a positive balance.
+  const maxSpendTokens = useMemo(
+    () =>
+      getSpendableSourceBalance({
+        displayBalance: latestSourceBalance?.displayBalance,
+        token: sourceToken,
+        gasFeeEstimates: gasFeeEstimates as unknown as
+          | GasFeeEstimatesType
+          | undefined,
+        isGasSponsored: isSourceNetworkGasSponsored && !isHardwareAddress,
+      }),
+    [
+      latestSourceBalance?.displayBalance,
+      sourceToken,
+      gasFeeEstimates,
+      isSourceNetworkGasSponsored,
+      isHardwareAddress,
+    ],
+  );
+
+  // Fiat spend ceiling for the slider, derived from the same gas-reserved
+  // token max so both input paths agree on what "100%" means. Note the
+  // headline balance figures above intentionally keep showing the full
+  // balance — only the spendable max is reduced.
+  const maxSpendFiat = useMemo(() => {
+    if (!sourceToken?.currencyExchangeRate) {
+      return 0;
+    }
+    const fiat = maxSpendTokens * sourceToken.currencyExchangeRate;
+    return Number.isFinite(fiat) && fiat > 0 ? fiat : 0;
+  }, [maxSpendTokens, sourceToken?.currencyExchangeRate]);
 
   const isSliderDisabled = hasSourcePrice
     ? maxSpendFiat <= 0

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -30,7 +30,10 @@ import {
 import Logger from '../../../../../../util/Logger';
 import { useHasSufficientGas } from '../../../../../UI/Bridge/hooks/useHasSufficientGas';
 import useIsInsufficientBalance from '../../../../../UI/Bridge/hooks/useInsufficientBalance';
+import { useIsNetworkGasSponsored } from '../../../../../UI/Bridge/hooks/useIsNetworkGasSponsored';
 import { useLatestBalance } from '../../../../../UI/Bridge/hooks/useLatestBalance';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { useGasFeeEstimates } from '../../../../confirmations/hooks/gas/useGasFeeEstimates';
 import { usePriceImpactViewData } from '../../../../../UI/Bridge/hooks/usePriceImpactViewData';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import {
@@ -159,6 +162,10 @@ jest.mock('../../../../../hooks/useRefreshSmartTransactionsLiveness', () => ({
 
 jest.mock('../../../../confirmations/hooks/gas/useGasFeeEstimates', () => ({
   useGasFeeEstimates: jest.fn(),
+}));
+
+jest.mock('../../../../../UI/Bridge/hooks/useIsNetworkGasSponsored', () => ({
+  useIsNetworkGasSponsored: jest.fn(() => false),
 }));
 
 jest.mock('../../../../../../core/Engine', () => ({
@@ -429,6 +436,10 @@ const setupDefaultMocks = () => {
 
   (useIsInsufficientBalance as jest.Mock).mockReturnValue(false);
   (useHasSufficientGas as jest.Mock).mockReturnValue(true);
+  (useGasFeeEstimates as jest.Mock).mockReturnValue({
+    gasFeeEstimates: undefined,
+  });
+  (useIsNetworkGasSponsored as jest.Mock).mockReturnValue(false);
   (selectShouldUseSmartTransaction as unknown as jest.Mock).mockReturnValue(
     false,
   );
@@ -680,6 +691,120 @@ describe('useQuickBuyController', () => {
       // still formats via Intl as whole yen.
       expect(result.current.fiatAmount).toBe('33.00');
       expect(result.current.fiatAmountLabel).toBe('¥33');
+    });
+  });
+
+  describe('maxSpendFiat (native gas reserve, TSA-605)', () => {
+    // 10 gwei medium maxFeePerGas x 21000 native-transfer gas = 0.00021 ETH.
+    const gasFeeEstimates = { medium: { suggestedMaxFeePerGas: 10 } };
+
+    it('reserves a gas buffer when the pay token is the chain native asset', () => {
+      // Arrange: native ETH source (zero address) with 1 ETH at $2000 and
+      // gas estimates available for the source chain.
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '1',
+        atomicBalance: '1000000000000000000',
+      });
+      (useGasFeeEstimates as jest.Mock).mockReturnValue({ gasFeeEstimates });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [createSourceToken()],
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      // Assert: max = (1 - 0.00021) ETH x $2000 = $1999.58, not $2000.
+      expect(result.current.maxSpendFiat).toBeCloseTo(1999.58, 2);
+    });
+
+    it('keeps the full balance for ERC-20 pay tokens', () => {
+      // Arrange: USDC source with 100 USDC at $1 and gas estimates available.
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '100',
+        atomicBalance: '100000000',
+      });
+      (useGasFeeEstimates as jest.Mock).mockReturnValue({ gasFeeEstimates });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [
+          createSourceToken({
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            symbol: 'USDC',
+            decimals: 6,
+            currencyExchangeRate: 1,
+          }),
+        ],
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      // Assert: ERC-20 gas is paid from the native balance, so no reserve.
+      expect(result.current.maxSpendFiat).toBe(100);
+    });
+
+    it('clamps the max at zero and disables the slider when the native balance is below the gas buffer', () => {
+      // Arrange: 0.0001 ETH balance, below the 0.00021 ETH gas buffer.
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '0.0001',
+        atomicBalance: '100000000000000',
+      });
+      (useGasFeeEstimates as jest.Mock).mockReturnValue({ gasFeeEstimates });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [createSourceToken()],
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      // Assert
+      expect(result.current.maxSpendFiat).toBe(0);
+      expect(result.current.isSliderDisabled).toBe(true);
+    });
+
+    it('keeps the full native balance when gas estimates are unavailable', () => {
+      // Arrange: native source, but no estimates yet (default mock).
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '1',
+        atomicBalance: '1000000000000000000',
+      });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [createSourceToken()],
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      // Assert: falls back to the previous full-balance behavior.
+      expect(result.current.maxSpendFiat).toBe(2000);
+    });
+
+    it('keeps the full native balance on gas-sponsored networks', () => {
+      // Arrange: native source on a network that sponsors gas.
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '1',
+        atomicBalance: '1000000000000000000',
+      });
+      (useGasFeeEstimates as jest.Mock).mockReturnValue({ gasFeeEstimates });
+      (useIsNetworkGasSponsored as jest.Mock).mockReturnValue(true);
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [createSourceToken()],
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      // Assert
+      expect(result.current.maxSpendFiat).toBe(2000);
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getSpendableSourceBalance.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getSpendableSourceBalance.test.ts
@@ -1,0 +1,156 @@
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { GasFeeEstimatesType } from '../../../../../confirmations/utils/estimated-total-gas';
+import { getSpendableSourceBalance } from './getSpendableSourceBalance';
+
+const NATIVE_ETH: Pick<BridgeToken, 'address' | 'chainId' | 'decimals'> = {
+  address: '0x0000000000000000000000000000000000000000',
+  chainId: '0x1',
+  decimals: 18,
+};
+
+const USDC: Pick<BridgeToken, 'address' | 'chainId' | 'decimals'> = {
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  chainId: '0x1',
+  decimals: 6,
+};
+
+const SOL_NATIVE: Pick<BridgeToken, 'address' | 'chainId' | 'decimals'> = {
+  address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  decimals: 9,
+};
+
+// 10 gwei medium maxFeePerGas x 21000 native-transfer gas = 0.00021 ETH.
+const gasFeeEstimates: GasFeeEstimatesType = {
+  medium: { suggestedMaxFeePerGas: 10 },
+};
+
+describe('getSpendableSourceBalance', () => {
+  it('subtracts the estimated gas buffer for an EVM-native pay token', () => {
+    // Arrange
+    const params = {
+      displayBalance: '1',
+      token: NATIVE_ETH,
+      gasFeeEstimates,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBeCloseTo(0.99979, 10);
+  });
+
+  it('returns the full balance for an ERC-20 pay token', () => {
+    // Arrange
+    const params = {
+      displayBalance: '100',
+      token: USDC,
+      gasFeeEstimates,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(100);
+  });
+
+  it('clamps at zero when the native balance is smaller than the gas buffer', () => {
+    // Arrange: 0.0001 ETH < 0.00021 ETH buffer.
+    const params = {
+      displayBalance: '0.0001',
+      token: NATIVE_ETH,
+      gasFeeEstimates,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(0);
+  });
+
+  it('returns the full native balance when gas estimates are unavailable', () => {
+    // Arrange
+    const params = {
+      displayBalance: '1',
+      token: NATIVE_ETH,
+      gasFeeEstimates: undefined,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(1);
+  });
+
+  it('returns the full native balance when the network sponsors gas', () => {
+    // Arrange
+    const params = {
+      displayBalance: '1',
+      token: NATIVE_ETH,
+      gasFeeEstimates,
+      isGasSponsored: true,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(1);
+  });
+
+  it('returns the full balance for a non-EVM native token (no EVM gas estimates apply)', () => {
+    // Arrange
+    const params = {
+      displayBalance: '2.5',
+      token: SOL_NATIVE,
+      gasFeeEstimates,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(2.5);
+  });
+
+  it('returns the full balance when no token is selected yet', () => {
+    // Arrange
+    const params = {
+      displayBalance: '3',
+      token: undefined,
+      gasFeeEstimates,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(3);
+  });
+
+  it.each([
+    ['undefined balance', undefined],
+    ['empty balance', ''],
+    ['non-numeric balance', 'abc'],
+    ['zero balance', '0'],
+    ['negative balance', '-1'],
+  ])('returns zero for %s', (_label, displayBalance) => {
+    // Arrange
+    const params = {
+      displayBalance,
+      token: NATIVE_ETH,
+      gasFeeEstimates,
+    };
+
+    // Act
+    const spendable = getSpendableSourceBalance(params);
+
+    // Assert
+    expect(spendable).toBe(0);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getSpendableSourceBalance.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getSpendableSourceBalance.ts
@@ -1,0 +1,71 @@
+import { isNativeAddress, isNonEvmChainId } from '@metamask/bridge-controller';
+import { BigNumber } from 'bignumber.js';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import {
+  getEstimatedTotalGas,
+  type GasFeeEstimatesType,
+  // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+} from '../../../../../confirmations/utils/estimated-total-gas';
+
+interface GetSpendableSourceBalanceParams {
+  /** Source token balance in display (decimal token) units, e.g. "1.5". */
+  displayBalance: string | undefined;
+  /** The selected "Pay with" token. */
+  token: Pick<BridgeToken, 'address' | 'chainId' | 'decimals'> | undefined;
+  /** Current gas fee estimates for the source chain (EVM only). */
+  gasFeeEstimates: GasFeeEstimatesType | undefined;
+  /** True when the source network sponsors gas, so no reserve is needed. */
+  isGasSponsored?: boolean;
+}
+
+/**
+ * Returns the amount of the source token (in display units) the user can
+ * actually spend in a QuickBuy trade.
+ *
+ * For EVM-native pay tokens (ETH, POL, BNB, …) gas is paid from the same
+ * balance being spent, so offering the entire balance as "max" produces
+ * quotes/transactions that cannot pay for gas (TSA-605). We reserve an
+ * estimated gas amount by reusing the Send flow's `getEstimatedTotalGas`
+ * (the same reserve its percentage/Max buttons apply) and clamp at zero.
+ *
+ * ERC-20 tokens keep the full balance — their gas is checked separately
+ * against the native balance (see `useHasSufficientGas`). Non-EVM natives
+ * (SOL, BTC) are excluded too: their reserves are enforced elsewhere
+ * (`minSolBalance` rent exemption in `useIsInsufficientBalance`, BTC reserve
+ * in `useInsufficientNativeReserveError`) and EVM gas estimates do not apply.
+ */
+export const getSpendableSourceBalance = ({
+  displayBalance,
+  token,
+  gasFeeEstimates,
+  isGasSponsored = false,
+}: GetSpendableSourceBalanceParams): number => {
+  if (!displayBalance) {
+    return 0;
+  }
+  const balance = parseFloat(displayBalance);
+  if (!Number.isFinite(balance) || balance <= 0) {
+    return 0;
+  }
+
+  const isEvmNativeSource = Boolean(
+    token &&
+      isNativeAddress(token.address) &&
+      token.chainId &&
+      !isNonEvmChainId(token.chainId),
+  );
+
+  if (!token || !isEvmNativeSource || isGasSponsored || !gasFeeEstimates) {
+    return balance;
+  }
+
+  const estimatedTotalGasWei = getEstimatedTotalGas(gasFeeEstimates, '0x0');
+  const gasBuffer = new BigNumber(estimatedTotalGasWei.toString())
+    .shiftedBy(-token.decimals)
+    .toNumber();
+  if (!Number.isFinite(gasBuffer) || gasBuffer <= 0) {
+    return balance;
+  }
+
+  return Math.max(balance - gasBuffer, 0);
+};

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
@@ -3,9 +3,12 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { useCallback } from 'react';
 
-import { hexToBN } from '../../../../../util/number';
 import { useAsyncResult } from '../../../../hooks/useAsyncResult';
 import { AssetType } from '../../types/token';
+import {
+  getEstimatedTotalGas,
+  type GasFeeEstimatesType,
+} from '../../utils/estimated-total-gas';
 import { fromBNWithDecimals, getLayer1GasFeeForSend } from '../../utils/send';
 import { useSendContext } from '../../context/send-context';
 import { useBalance } from './useBalance';
@@ -14,28 +17,10 @@ import { useSendType } from './useSendType';
 import { useIsNetworkGasSponsored } from '../../../../UI/Bridge/hooks/useIsNetworkGasSponsored';
 import { isHardwareAccount } from '../../../../../util/address';
 
-export interface GasFeeEstimatesType {
-  medium: {
-    suggestedMaxFeePerGas: number;
-  };
-}
-
-const NATIVE_TRANSFER_GAS_LIMIT = 21000;
-const GWEI_TO_WEI_CONVERSION_RATE = 1e9;
-
-export const getEstimatedTotalGas = (
-  gasFeeEstimates: GasFeeEstimatesType,
-  layer1GasFee: Hex,
-) => {
-  if (!gasFeeEstimates) {
-    return new BN(0);
-  }
-  const suggestedMaxFeePerGas =
-    gasFeeEstimates?.medium?.suggestedMaxFeePerGas ?? '0';
-  const totalGas = new BN(suggestedMaxFeePerGas * NATIVE_TRANSFER_GAS_LIMIT);
-  const conversionrate = new BN(GWEI_TO_WEI_CONVERSION_RATE);
-  return totalGas.mul(conversionrate).add(hexToBN(layer1GasFee));
-};
+// Re-exported from their extracted leaf module (`utils/estimated-total-gas`)
+// so existing consumers of this hook module keep working.
+export { getEstimatedTotalGas };
+export type { GasFeeEstimatesType };
 
 export const getPercentageValueFn = ({
   asset,

--- a/app/components/Views/confirmations/utils/estimated-total-gas.ts
+++ b/app/components/Views/confirmations/utils/estimated-total-gas.ts
@@ -1,0 +1,34 @@
+import BN from 'bnjs4';
+import { hexToBN } from '@metamask/controller-utils';
+import { Hex } from '@metamask/utils';
+
+export interface GasFeeEstimatesType {
+  medium: {
+    suggestedMaxFeePerGas: number;
+  };
+}
+
+export const NATIVE_TRANSFER_GAS_LIMIT = 21000;
+const GWEI_TO_WEI_CONVERSION_RATE = 1e9;
+
+/**
+ * Estimates the total gas (in wei) a native-asset transfer needs, used to
+ * reserve a portion of the native balance when computing "max" amounts —
+ * shared by the Send flow's percentage/Max buttons (`usePercentageAmount`)
+ * and the QuickBuy slider max (`getSpendableSourceBalance`).
+ */
+export const getEstimatedTotalGas = (
+  gasFeeEstimates: GasFeeEstimatesType,
+  layer1GasFee: Hex,
+) => {
+  if (!gasFeeEstimates) {
+    return new BN(0);
+  }
+  const suggestedMaxFeePerGas =
+    gasFeeEstimates?.medium?.suggestedMaxFeePerGas ?? '0';
+  const totalGas = new BN(suggestedMaxFeePerGas * NATIVE_TRANSFER_GAS_LIMIT);
+  const conversionrate = new BN(GWEI_TO_WEI_CONVERSION_RATE);
+  return totalGas
+    .mul(conversionrate)
+    .add(new BN(hexToBN(layer1GasFee).toString()));
+};


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

In the Quick Buy sheet, the spend slider's maximum for a native pay token (e.g. ETH) was the entire balance. Since gas is paid from that same balance, committing 100% produced an amount the wallet couldn't cover once gas was added — the insufficient-balance check (which adds the quote's gas for native sources) then flagged "insufficient funds" and quoting/execution failed.

Fix:

- New pure util `getSpendableSourceBalance`: for an EVM-native pay token, spendable = `max(balance − estimated gas, 0)`; ERC-20s, non-EVM natives (SOL/BTC have their own reserve mechanisms), gas-sponsored networks, and missing estimates keep the full balance.
- The gas reserve reuses the Send flow's `getEstimatedTotalGas` (medium `suggestedMaxFeePerGas` × 21000 + L1 fee). It was extracted verbatim into a leaf module (`app/components/Views/confirmations/utils/estimated-total-gas.ts`) and re-exported from `usePercentageAmount` for compatibility — importing it via the hook dragged the whole send-context graph into Quick Buy. The only behavioral delta is `hexToBN` now imported from `@metamask/controller-utils` (the old path is lint-restricted for new files).
- `useQuickBuyController` derives `maxSpendTokens`/`maxSpendUsd` from the gas-reserved spendable balance, using the already-polled `useGasFeeEstimates` and gas-sponsorship parity with Send. Headline balance displays and the insufficient-funds validation path are unchanged.

Known limitation (same as Send): the reserve is sized for a 21000-gas transfer; on mainnet a swap can cost more, in which case the existing insufficient-funds CTA still catches the exact-100% edge — strictly better than offering the full balance.

Jira: [TSA-605](https://consensyssoftware.atlassian.net/browse/TSA-605)

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Fixed the Quick Buy max amount offering the full native token balance without leaving room for gas fees

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [TSA-605](https://consensyssoftware.atlassian.net/browse/TSA-605)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy max amount with native pay token

  Scenario: user maxes the slider paying with ETH
    Given the user opens Quick Buy paying with ETH on Base

    When the user drags the amount slider to 100%
    Then the committed amount is the ETH balance minus an estimated gas reserve
    And quotes load successfully without an "insufficient funds" error

  Scenario: user maxes the slider paying with an ERC-20
    Given the user opens Quick Buy paying with USDC on Base

    When the user drags the amount slider to 100%
    Then the committed amount is the full USDC balance

  Scenario: balance smaller than the gas reserve
    Given the user's ETH balance is below the estimated gas reserve

    When the user opens Quick Buy paying with ETH
    Then the maximum spendable amount is zero and the slider is disabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TSA-605]: https://consensyssoftware.atlassian.net/browse/TSA-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ