### PR TITLE
fix(notifications): suppress duplicate toasts for quickbuy trades

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -93,7 +93,11 @@ import {
   SocialLeaderboardEventValues,
 } from '../../../../analytics';
 import { buildQuickBuyToastOptions } from '../quickBuyToastOptions';
-import { trackQuickBuyTrade } from '../quickBuyTradeTracker';
+import {
+  trackQuickBuyTrade,
+  beginQuickBuySubmission,
+  endQuickBuySubmission,
+} from '../quickBuyTradeTracker';
 import { resolveQuickBuyTerminalToast } from '../resolveQuickBuyTerminalToast';
 
 export type QuickBuyButtonError =
@@ -1003,6 +1007,11 @@ export function useQuickBuyController(
       submitStartedAtRef.current ? Date.now() - submitStartedAtRef.current : 0;
 
     try {
+      // Mark a QuickBuy submission as in flight BEFORE submitTx so the generic
+      // transaction notification (which fires mid-submit, before the tx id is
+      // known) is suppressed. The id-based tracker takes over for the terminal
+      // notification once submitTx resolves.
+      beginQuickBuySubmission();
       dispatch(setIsSubmittingTx(true));
       const submitResult = await Engine.context.BridgeStatusController.submitTx(
         walletAddress,
@@ -1074,6 +1083,10 @@ export function useQuickBuyController(
         });
       }
     } finally {
+      // Cleared after `trackQuickBuyTrade` (in the try block) has registered the
+      // tx id, so the predicate transitions from marker-based to id-based
+      // suppression with no coverage gap.
+      endQuickBuySubmission();
       dispatch(setIsSubmittingTx(false));
     }
   }, [

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../../../../util/haptics';
 import { buildQuickBuyToastOptions } from '../quickBuyToastOptions';
 import {
+  clearSettledQuickBuyTrades,
   getTrackedQuickBuyTradeIds,
   isQuickBuyTransaction,
   trackQuickBuyTrade,
@@ -108,6 +109,7 @@ describe('useQuickBuyToastRegistrations', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
+    clearSettledQuickBuyTrades();
     Engine.context.MultichainTransactionsController.state.nonEvmTransactions =
       {};
   });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.test.tsx
@@ -9,11 +9,18 @@ import {
 import { buildQuickBuyToastOptions } from '../quickBuyToastOptions';
 import {
   getTrackedQuickBuyTradeIds,
+  isQuickBuyTransaction,
   trackQuickBuyTrade,
   untrackQuickBuyTrade,
   type TrackedQuickBuyTrade,
 } from '../quickBuyTradeTracker';
+import { registerNotificationSkipPredicate } from '../../../../../../../core/notificationSkipPredicates';
 import { useQuickBuyToastRegistrations } from './useQuickBuyToastRegistrations';
+
+jest.mock('../../../../../../../core/notificationSkipPredicates', () => ({
+  __esModule: true,
+  registerNotificationSkipPredicate: jest.fn(() => jest.fn()),
+}));
 
 jest.mock('../quickBuyToastOptions', () => ({
   buildQuickBuyToastOptions: jest.fn((kind: string) => ({ kind })),
@@ -103,6 +110,24 @@ describe('useQuickBuyToastRegistrations', () => {
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
     Engine.context.MultichainTransactionsController.state.nonEvmTransactions =
       {};
+  });
+
+  it('registers the QuickBuy notification skip predicate on mount and unregisters on unmount', () => {
+    const unregister = jest.fn();
+    (registerNotificationSkipPredicate as jest.Mock).mockReturnValue(
+      unregister,
+    );
+
+    const { unmount } = renderHook(() => useQuickBuyToastRegistrations());
+
+    expect(registerNotificationSkipPredicate).toHaveBeenCalledWith(
+      isQuickBuyTransaction,
+    );
+    expect(unregister).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unregister).toHaveBeenCalledTimes(1);
   });
 
   it('subscribes to both the bridge and multichain state change events', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyToastRegistrations.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { ToastRef } from '../../../../../../../component-library/components/Toast/Toast.types';
 import { useAppThemeFromContext } from '../../../../../../../util/theme';
+import { registerNotificationSkipPredicate } from '../../../../../../../core/notificationSkipPredicates';
 import type { ToastRegistration } from '../../../../../../Nav/App/ControllerEventToastBridge';
-import { getTrackedQuickBuyTradeIds } from '../quickBuyTradeTracker';
+import {
+  getTrackedQuickBuyTradeIds,
+  isQuickBuyTransaction,
+} from '../quickBuyTradeTracker';
 import { resolveQuickBuyTerminalToast } from '../resolveQuickBuyTerminalToast';
 
 /**
@@ -18,6 +22,11 @@ import { resolveQuickBuyTerminalToast } from '../resolveQuickBuyTerminalToast';
  */
 export const useQuickBuyToastRegistrations = (): ToastRegistration[] => {
   const theme = useAppThemeFromContext();
+
+  // Opt QuickBuy-initiated transactions out of the generic transaction
+  // notifications so the user only sees QuickBuy's own toasts. Registered at
+  // the app root so it covers submissions regardless of sheet lifecycle.
+  useEffect(() => registerNotificationSkipPredicate(isQuickBuyTransaction), []);
 
   // Shared by both controller subscriptions: `resolveQuickBuyTerminalToast`
   // checks each tracked trade against whichever controller is authoritative for

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.test.ts
@@ -4,11 +4,13 @@ import {
 } from '@metamask/transaction-controller';
 import {
   beginQuickBuySubmission,
+  clearSettledQuickBuyTrades,
   endQuickBuySubmission,
   getTrackedQuickBuyTrade,
   getTrackedQuickBuyTradeIds,
   hasPendingQuickBuySubmission,
   isQuickBuyTransaction,
+  markQuickBuyTradeSettled,
   trackQuickBuyTrade,
   untrackQuickBuyTrade,
   type TrackedQuickBuyTrade,
@@ -35,6 +37,7 @@ const sellTrade: TrackedQuickBuyTrade = {
 describe('quickBuyTradeTracker', () => {
   afterEach(() => {
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
+    clearSettledQuickBuyTrades();
     while (hasPendingQuickBuySubmission()) {
       endQuickBuySubmission();
     }
@@ -189,6 +192,55 @@ describe('quickBuyTradeTracker', () => {
           txMeta({ id: 'tx-9', type: TransactionType.swap }),
         ),
       ).toBe(false);
+    });
+
+    it('still matches a trade after it has settled (covers the delayed re-check)', () => {
+      trackQuickBuyTrade('tx-1', buyTrade);
+      markQuickBuyTradeSettled('tx-1');
+
+      expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+      expect(isQuickBuyTransaction(txMeta({ id: 'tx-1' }))).toBe(true);
+    });
+
+    it('stops matching a settled trade once it is explicitly untracked', () => {
+      trackQuickBuyTrade('tx-1', buyTrade);
+      markQuickBuyTradeSettled('tx-1');
+      untrackQuickBuyTrade('tx-1');
+
+      expect(isQuickBuyTransaction(txMeta({ id: 'tx-1' }))).toBe(false);
+    });
+  });
+
+  describe('markQuickBuyTradeSettled', () => {
+    it('removes the trade from the active registry so the terminal toast does not repeat', () => {
+      trackQuickBuyTrade('tx-1', buyTrade);
+
+      markQuickBuyTradeSettled('tx-1');
+
+      expect(getTrackedQuickBuyTrade('tx-1')).toBeUndefined();
+      expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+    });
+
+    it('evicts the oldest settled id once the retention cap is exceeded', () => {
+      for (let i = 0; i < 51; i += 1) {
+        markQuickBuyTradeSettled(`tx-${i}`);
+      }
+
+      expect(isQuickBuyTransaction(txMeta({ id: 'tx-0' }))).toBe(false);
+      expect(isQuickBuyTransaction(txMeta({ id: 'tx-1' }))).toBe(true);
+      expect(isQuickBuyTransaction(txMeta({ id: 'tx-50' }))).toBe(true);
+    });
+
+    it('refreshes a re-settled id so it survives further eviction', () => {
+      markQuickBuyTradeSettled('keep-me');
+      for (let i = 0; i < 49; i += 1) {
+        markQuickBuyTradeSettled(`tx-${i}`);
+      }
+      // Re-settle to move it to the newest position before overflowing.
+      markQuickBuyTradeSettled('keep-me');
+      markQuickBuyTradeSettled('overflow');
+
+      expect(isQuickBuyTransaction(txMeta({ id: 'keep-me' }))).toBe(true);
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.test.ts
@@ -1,10 +1,21 @@
 import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import {
+  beginQuickBuySubmission,
+  endQuickBuySubmission,
   getTrackedQuickBuyTrade,
   getTrackedQuickBuyTradeIds,
+  hasPendingQuickBuySubmission,
+  isQuickBuyTransaction,
   trackQuickBuyTrade,
   untrackQuickBuyTrade,
   type TrackedQuickBuyTrade,
 } from './quickBuyTradeTracker';
+
+const txMeta = (overrides: Partial<TransactionMeta>): TransactionMeta =>
+  overrides as TransactionMeta;
 
 const buyTrade: TrackedQuickBuyTrade = {
   tradeMode: 'buy',
@@ -24,6 +35,9 @@ const sellTrade: TrackedQuickBuyTrade = {
 describe('quickBuyTradeTracker', () => {
   afterEach(() => {
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
+    while (hasPendingQuickBuySubmission()) {
+      endQuickBuySubmission();
+    }
   });
 
   it('stores and returns a tracked trade by tx meta id', () => {
@@ -83,5 +97,98 @@ describe('quickBuyTradeTracker', () => {
 
     expect(() => untrackQuickBuyTrade('missing')).not.toThrow();
     expect(getTrackedQuickBuyTradeIds()).toEqual(['tx-1']);
+  });
+
+  describe('submission marker', () => {
+    it('reflects in-flight submissions via the counter', () => {
+      expect(hasPendingQuickBuySubmission()).toBe(false);
+
+      beginQuickBuySubmission();
+      expect(hasPendingQuickBuySubmission()).toBe(true);
+
+      endQuickBuySubmission();
+      expect(hasPendingQuickBuySubmission()).toBe(false);
+    });
+
+    it('stays active until all overlapping submissions end', () => {
+      beginQuickBuySubmission();
+      beginQuickBuySubmission();
+
+      endQuickBuySubmission();
+      expect(hasPendingQuickBuySubmission()).toBe(true);
+
+      endQuickBuySubmission();
+      expect(hasPendingQuickBuySubmission()).toBe(false);
+    });
+
+    it('never drops below zero on unbalanced ends', () => {
+      endQuickBuySubmission();
+
+      expect(hasPendingQuickBuySubmission()).toBe(false);
+
+      beginQuickBuySubmission();
+      expect(hasPendingQuickBuySubmission()).toBe(true);
+    });
+  });
+
+  describe('isQuickBuyTransaction', () => {
+    it('matches a transaction already tracked by id', () => {
+      trackQuickBuyTrade('tx-1', buyTrade);
+
+      expect(isQuickBuyTransaction(txMeta({ id: 'tx-1' }))).toBe(true);
+    });
+
+    it('matches an in-flight swap/bridge/batch transaction during submission', () => {
+      beginQuickBuySubmission();
+
+      expect(
+        isQuickBuyTransaction(
+          txMeta({ id: 'tx-9', type: TransactionType.batch }),
+        ),
+      ).toBe(true);
+      expect(
+        isQuickBuyTransaction(
+          txMeta({ id: 'tx-9', type: TransactionType.swap }),
+        ),
+      ).toBe(true);
+      expect(
+        isQuickBuyTransaction(
+          txMeta({ id: 'tx-9', type: TransactionType.bridge }),
+        ),
+      ).toBe(true);
+    });
+
+    it('matches a batch whose nested transaction is a swap during submission', () => {
+      beginQuickBuySubmission();
+
+      expect(
+        isQuickBuyTransaction(
+          txMeta({
+            id: 'tx-9',
+            type: TransactionType.batch,
+            nestedTransactions: [{ type: TransactionType.swap }],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any),
+        ),
+      ).toBe(true);
+    });
+
+    it('does not match an unrelated in-flight transaction type', () => {
+      beginQuickBuySubmission();
+
+      expect(
+        isQuickBuyTransaction(
+          txMeta({ id: 'tx-9', type: TransactionType.simpleSend }),
+        ),
+      ).toBe(false);
+    });
+
+    it('does not match when there is no marker and no tracked id', () => {
+      expect(
+        isQuickBuyTransaction(
+          txMeta({ id: 'tx-9', type: TransactionType.swap }),
+        ),
+      ).toBe(false);
+    });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
@@ -45,6 +45,30 @@ const trackedTrades = new Map<string, TrackedQuickBuyTrade>();
 /** Shared empty result so the common "nothing tracked" path allocates nothing. */
 const EMPTY_TRADE_IDS: string[] = [];
 
+/**
+ * Ids of QuickBuy trades that have reached a terminal state and been untracked.
+ *
+ * The terminal handler untracks a trade the instant the swap settles, but
+ * `NotificationManager` re-checks the skip predicates ~2s *after*
+ * `transactionConfirmed`/`transactionFailed` (a delayed `setTimeout`). For a
+ * fast-settling QuickBuy the trade would already be gone from `trackedTrades`
+ * by then, so the generic success/error toast would leak on top of QuickBuy's
+ * own terminal toast. Remembering recently-settled ids keeps suppression alive
+ * across that window.
+ *
+ * Bounded (insertion-ordered FIFO eviction) so it can never grow unbounded;
+ * QuickBuy ids are globally-unique tx meta ids, so retaining a small recent
+ * history is harmless.
+ */
+const settledTradeIds = new Set<string>();
+
+/**
+ * Upper bound on remembered settled ids. Comfortably larger than any realistic
+ * number of QuickBuy trades settling within the ~2s notification re-check
+ * window, while keeping memory trivially small.
+ */
+const SETTLED_TRADE_ID_LIMIT = 50;
+
 export function trackQuickBuyTrade(
   txMetaId: string,
   info: TrackedQuickBuyTrade,
@@ -70,6 +94,32 @@ export function getTrackedQuickBuyTradeIds(): string[] {
 
 export function untrackQuickBuyTrade(txMetaId: string): void {
   trackedTrades.delete(txMetaId);
+  settledTradeIds.delete(txMetaId);
+}
+
+/**
+ * Marks a trade as terminally settled: removes it from the active registry (so
+ * the terminal toast is not emitted twice) while remembering its id so the
+ * delayed generic-notification re-check still suppresses the leftover
+ * success/error toast.
+ */
+export function markQuickBuyTradeSettled(txMetaId: string): void {
+  trackedTrades.delete(txMetaId);
+
+  // Re-insert to refresh FIFO position, then evict the oldest if over the cap.
+  settledTradeIds.delete(txMetaId);
+  settledTradeIds.add(txMetaId);
+  if (settledTradeIds.size > SETTLED_TRADE_ID_LIMIT) {
+    const oldest = settledTradeIds.values().next().value;
+    if (oldest !== undefined) {
+      settledTradeIds.delete(oldest);
+    }
+  }
+}
+
+/** Clears all remembered settled ids. Intended for test isolation. */
+export function clearSettledQuickBuyTrades(): void {
+  settledTradeIds.clear();
 }
 
 /**
@@ -107,16 +157,22 @@ const QUICK_BUY_SUPPRESSED_TYPES: TransactionType[] = [
 
 /**
  * Predicate consumed by `NotificationManager` to skip the generic transaction
- * notification for QuickBuy-initiated trades. Matches either a transaction
- * already tracked by id (covers the later complete/confirmed notification) or,
- * while a submission is in flight, a swap/bridge/batch transaction (covers the
- * pending notification that fires before the id is known).
+ * notification for QuickBuy-initiated trades. Matches a transaction that is
+ * either currently tracked by id, recently settled by id (covers the delayed
+ * generic-toast re-check that fires after the trade is untracked), or — while a
+ * submission is in flight — a swap/bridge/batch transaction (covers the pending
+ * notification that fires before the id is known).
  */
 export function isQuickBuyTransaction(
   transactionMeta: TransactionMeta | undefined,
 ): boolean {
-  if (transactionMeta?.id && getTrackedQuickBuyTrade(transactionMeta.id)) {
-    return true;
+  if (transactionMeta?.id) {
+    if (getTrackedQuickBuyTrade(transactionMeta.id)) {
+      return true;
+    }
+    if (settledTradeIds.has(transactionMeta.id)) {
+      return true;
+    }
   }
 
   if (!hasPendingQuickBuySubmission()) {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/quickBuyTradeTracker.ts
@@ -1,3 +1,7 @@
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import type { QuickBuyTradeMode } from './types';
 
 export interface TrackedQuickBuyTrade {
@@ -66,4 +70,68 @@ export function getTrackedQuickBuyTradeIds(): string[] {
 
 export function untrackQuickBuyTrade(txMetaId: string): void {
   trackedTrades.delete(txMetaId);
+}
+
+/**
+ * Count of QuickBuy submissions currently in flight.
+ *
+ * The source transaction meta id is only known once `submitTx` resolves, but
+ * the generic transaction notification fires earlier (on `transactionApproved`,
+ * mid-submit). This marker lets us suppress that early notification before the
+ * id is registered. A counter (rather than a boolean) tolerates overlapping
+ * submissions without prematurely clearing the marker.
+ */
+let pendingSubmissions = 0;
+
+export function beginQuickBuySubmission(): void {
+  pendingSubmissions += 1;
+}
+
+export function endQuickBuySubmission(): void {
+  pendingSubmissions = Math.max(0, pendingSubmissions - 1);
+}
+
+export function hasPendingQuickBuySubmission(): boolean {
+  return pendingSubmissions > 0;
+}
+
+// Transaction types a QuickBuy submission can produce. Used to narrow the
+// marker window so an unrelated transaction approving mid-submit is not
+// suppressed. `batch` is the 7702 wrapper that triggers the duplicate
+// notification; swap/bridge cover the non-batched paths.
+const QUICK_BUY_SUPPRESSED_TYPES: TransactionType[] = [
+  TransactionType.batch,
+  TransactionType.swap,
+  TransactionType.bridge,
+];
+
+/**
+ * Predicate consumed by `NotificationManager` to skip the generic transaction
+ * notification for QuickBuy-initiated trades. Matches either a transaction
+ * already tracked by id (covers the later complete/confirmed notification) or,
+ * while a submission is in flight, a swap/bridge/batch transaction (covers the
+ * pending notification that fires before the id is known).
+ */
+export function isQuickBuyTransaction(
+  transactionMeta: TransactionMeta | undefined,
+): boolean {
+  if (transactionMeta?.id && getTrackedQuickBuyTrade(transactionMeta.id)) {
+    return true;
+  }
+
+  if (!hasPendingQuickBuySubmission()) {
+    return false;
+  }
+
+  const { type, nestedTransactions } = transactionMeta ?? {};
+
+  if (type && QUICK_BUY_SUPPRESSED_TYPES.includes(type)) {
+    return true;
+  }
+
+  return Boolean(
+    nestedTransactions?.some(
+      (tx) => tx.type && QUICK_BUY_SUPPRESSED_TYPES.includes(tx.type),
+    ),
+  );
 }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.test.ts
@@ -7,7 +7,9 @@ import {
 } from '../../../../../../util/haptics';
 import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
 import {
+  clearSettledQuickBuyTrades,
   getTrackedQuickBuyTradeIds,
+  isQuickBuyTransaction,
   trackQuickBuyTrade,
   untrackQuickBuyTrade,
   type TrackedQuickBuyTrade,
@@ -83,6 +85,7 @@ describe('resolveQuickBuyTerminalToast', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getTrackedQuickBuyTradeIds().forEach(untrackQuickBuyTrade);
+    clearSettledQuickBuyTrades();
     Engine.context.MultichainTransactionsController.state.nonEvmTransactions =
       {};
   });
@@ -158,6 +161,23 @@ describe('resolveQuickBuyTerminalToast', () => {
     expect(first).toBe(true);
     expect(second).toBe(false);
     expect(showToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the trade recognised as QuickBuy after settling so the delayed generic toast stays suppressed', () => {
+    trackQuickBuyTrade('tx-1', buyTrade);
+    mockGetHistoryItem.mockReturnValue(
+      historyItemWithStatus(StatusTypes.COMPLETE),
+    );
+
+    resolveQuickBuyTerminalToast('tx-1', jest.fn(), theme);
+
+    expect(getTrackedQuickBuyTradeIds()).toEqual([]);
+    expect(
+      isQuickBuyTransaction({
+        id: 'tx-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any),
+    ).toBe(true);
   });
 
   it('resolves a Solana swap to complete from the multichain controller when bridge status is absent', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/resolveQuickBuyTerminalToast.ts
@@ -10,7 +10,7 @@ import type { Theme } from '../../../../../../util/theme/models';
 import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
 import {
   getTrackedQuickBuyTrade,
-  untrackQuickBuyTrade,
+  markQuickBuyTradeSettled,
   type TrackedQuickBuyTrade,
 } from './quickBuyTradeTracker';
 
@@ -65,11 +65,13 @@ function resolveFromMultichain(signature: string): TerminalOutcome | undefined {
 }
 
 /**
- * Claims the trade atomically (untrack doubles as the dedupe), surfaces the
+ * Claims the trade atomically (settling doubles as the dedupe), surfaces the
  * matching `complete` / `failed` toast and fires the paired haptic. The first
- * caller to reach a terminal status removes the trade, so any later
+ * caller to reach a terminal status settles the trade, so any later
  * `stateChange` emission — or a concurrent resolve from the other controller —
- * becomes a no-op.
+ * becomes a no-op. Settling (rather than a plain untrack) keeps the id known to
+ * `isQuickBuyTransaction` so the delayed generic success/error toast is still
+ * suppressed.
  */
 function emitTerminalToast(
   txMetaId: string,
@@ -78,7 +80,7 @@ function emitTerminalToast(
   showToast: ToastRef['showToast'],
   theme: Theme,
 ): boolean {
-  untrackQuickBuyTrade(txMetaId);
+  markQuickBuyTradeSettled(txMetaId);
 
   const isComplete = outcome === 'complete';
   showToast(

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -40,7 +40,11 @@ import {
 import { useQuickBuySetup } from './hooks/useQuickBuySetup';
 import { useReceiveTokens } from './hooks/useReceiveTokens';
 import { buildQuickBuyToastOptions } from './quickBuyToastOptions';
-import { trackQuickBuyTrade } from './quickBuyTradeTracker';
+import {
+  trackQuickBuyTrade,
+  beginQuickBuySubmission,
+  endQuickBuySubmission,
+} from './quickBuyTradeTracker';
 import { resolveQuickBuyTerminalToast } from './resolveQuickBuyTerminalToast';
 import { positionToQuickBuyTarget } from './types';
 
@@ -233,6 +237,8 @@ jest.mock('./quickBuyTradeTracker', () => ({
   getTrackedQuickBuyTrade: jest.fn(),
   getTrackedQuickBuyTradeIds: jest.fn(() => []),
   untrackQuickBuyTrade: jest.fn(),
+  beginQuickBuySubmission: jest.fn(),
+  endQuickBuySubmission: jest.fn(),
 }));
 
 jest.mock('./quickBuyToastOptions', () => ({
@@ -2227,6 +2233,50 @@ describe('useQuickBuyController', () => {
         expect(mockShowToast).toHaveBeenCalledWith({ kind: 'failed' });
         expect(playErrorNotification).toHaveBeenCalledTimes(1);
         expect(trackQuickBuyTrade).not.toHaveBeenCalled();
+      });
+
+      it('marks the submission in flight before submit and clears it after success', async () => {
+        mockUsableQuote();
+        (
+          Engine.context.BridgeStatusController.submitTx as jest.Mock
+        ).mockResolvedValue({ id: 'tx-1', hash: '0xabc' });
+
+        const { result } = renderHook(() =>
+          useQuickBuyController(createTarget(), jest.fn()),
+        );
+
+        await act(async () => {
+          await result.current.handleConfirm();
+        });
+
+        expect(beginQuickBuySubmission).toHaveBeenCalledTimes(1);
+        expect(endQuickBuySubmission).toHaveBeenCalledTimes(1);
+        const beginOrder = (beginQuickBuySubmission as jest.Mock).mock
+          .invocationCallOrder[0];
+        const trackOrder = (trackQuickBuyTrade as jest.Mock).mock
+          .invocationCallOrder[0];
+        const endOrder = (endQuickBuySubmission as jest.Mock).mock
+          .invocationCallOrder[0];
+        expect(beginOrder).toBeLessThan(trackOrder);
+        expect(trackOrder).toBeLessThan(endOrder);
+      });
+
+      it('clears the in-flight submission marker when submit throws', async () => {
+        mockUsableQuote();
+        (
+          Engine.context.BridgeStatusController.submitTx as jest.Mock
+        ).mockRejectedValue(new Error('user rejected'));
+
+        const { result } = renderHook(() =>
+          useQuickBuyController(createTarget(), jest.fn()),
+        );
+
+        await act(async () => {
+          await result.current.handleConfirm();
+        });
+
+        expect(beginQuickBuySubmission).toHaveBeenCalledTimes(1);
+        expect(endQuickBuySubmission).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -21,6 +21,7 @@ import {
 import { endTrace, trace, TraceName } from '../util/trace';
 import { hasTransactionType } from '../components/Views/confirmations/utils/transaction';
 import TransactionTypes from './TransactionTypes';
+import { getNotificationSkipPredicates } from './notificationSkipPredicates';
 
 export const SKIP_NOTIFICATION_TRANSACTION_TYPES = [
   TransactionType.moneyAccountDeposit,
@@ -42,6 +43,14 @@ export const IN_PROGRESS_SKIP_STATUS = [
   TransactionStatus.signed,
   TransactionStatus.submitted,
 ];
+
+// Re-exported for convenience. The registry lives in its own dependency-free
+// module (`notificationSkipPredicates`) so feature code can register a predicate
+// without importing this heavy module and its transitive store/saga graph.
+export {
+  registerNotificationSkipPredicate,
+  clearNotificationSkipPredicates,
+} from './notificationSkipPredicates';
 
 export const constructTitleAndMessage = (notification) => {
   let title, message;
@@ -586,7 +595,24 @@ class NotificationManager {
         tx.batchId === transactionMeta?.batchId,
     );
 
-    return isSameBatch;
+    if (isSameBatch) {
+      return true;
+    }
+
+    // Feature-registered predicates (e.g. QuickBuy surfaces its own toasts and
+    // opts its transactions out of the generic notification). A throwing
+    // predicate must never break notifications.
+    for (const predicate of getNotificationSkipPredicates()) {
+      try {
+        if (predicate(transactionMeta)) {
+          return true;
+        }
+      } catch (error) {
+        Logger.error(error, 'Notification skip predicate threw');
+      }
+    }
+
+    return false;
   }
 }
 

--- a/app/core/NotificationsManager.test.ts
+++ b/app/core/NotificationsManager.test.ts
@@ -3,7 +3,9 @@ import { NotificationTransactionTypes } from '../util/notifications';
 import NotificationManager, {
   IN_PROGRESS_SKIP_STATUS,
   SKIP_NOTIFICATION_TRANSACTION_TYPES,
+  clearNotificationSkipPredicates,
   constructTitleAndMessage,
+  registerNotificationSkipPredicate,
 } from './NotificationManager';
 import { strings } from '../../locales/i18n';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller';
@@ -777,6 +779,84 @@ describe('NotificationManager', () => {
       });
 
       expect(showNotificationSpy).not.toHaveBeenCalled();
+    });
+
+    describe('notification skip predicates', () => {
+      afterEach(() => {
+        clearNotificationSkipPredicates();
+      });
+
+      it('does not show a notification when a registered predicate matches', () => {
+        registerNotificationSkipPredicate(() => true);
+
+        notificationManager.watchSubmittedTransaction({
+          id: '0x123',
+          txParams: { nonce: '0x1' },
+          silent: false,
+        });
+
+        expect(showNotificationSpy).not.toHaveBeenCalled();
+      });
+
+      it('shows a notification when no registered predicate matches', () => {
+        registerNotificationSkipPredicate(() => false);
+
+        notificationManager.watchSubmittedTransaction({
+          id: '0x123',
+          txParams: { nonce: '0x1' },
+          silent: false,
+        });
+
+        expect(showNotificationSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'pending' }),
+        );
+      });
+
+      it('ignores a throwing predicate and still shows the notification', () => {
+        registerNotificationSkipPredicate(() => {
+          throw new Error('predicate boom');
+        });
+
+        notificationManager.watchSubmittedTransaction({
+          id: '0x123',
+          txParams: { nonce: '0x1' },
+          silent: false,
+        });
+
+        expect(showNotificationSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'pending' }),
+        );
+      });
+
+      it('passes the transaction meta to the predicate', () => {
+        const predicate = jest.fn(() => false);
+        registerNotificationSkipPredicate(predicate);
+
+        notificationManager.watchSubmittedTransaction({
+          id: '0x123',
+          txParams: { nonce: '0x1' },
+          silent: false,
+        });
+
+        expect(predicate).toHaveBeenCalledWith(
+          expect.objectContaining({ id: '0x123' }),
+        );
+      });
+
+      it('stops showing notifications only while the predicate is registered', () => {
+        const unregister = registerNotificationSkipPredicate(() => true);
+        unregister();
+
+        notificationManager.watchSubmittedTransaction({
+          id: '0x123',
+          txParams: { nonce: '0x1' },
+          silent: false,
+        });
+
+        expect(showNotificationSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'pending' }),
+        );
+      });
     });
   });
 });

--- a/app/core/notificationSkipPredicates.ts
+++ b/app/core/notificationSkipPredicates.ts
@@ -1,0 +1,40 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+
+/**
+ * A predicate that, given a transaction, returns `true` when the generic
+ * transaction notification should be suppressed for it.
+ */
+export type NotificationSkipPredicate = (
+  transactionMeta: TransactionMeta | undefined,
+) => boolean;
+
+/**
+ * Registry of predicates that let feature code opt a transaction out of the
+ * generic transaction notifications, without `NotificationManager` (core)
+ * depending on any feature module.
+ *
+ * This lives in its own dependency-free module so feature code can register a
+ * predicate without importing the heavy `NotificationManager` module (and its
+ * transitive store/saga graph).
+ */
+const notificationSkipPredicates = new Set<NotificationSkipPredicate>();
+
+/**
+ * Register a predicate. Returns an unregister function.
+ */
+export function registerNotificationSkipPredicate(
+  predicate: NotificationSkipPredicate,
+): () => void {
+  notificationSkipPredicates.add(predicate);
+  return () => {
+    notificationSkipPredicates.delete(predicate);
+  };
+}
+
+export function clearNotificationSkipPredicates(): void {
+  notificationSkipPredicates.clear();
+}
+
+export function getNotificationSkipPredicates(): NotificationSkipPredicate[] {
+  return Array.from(notificationSkipPredicates);
+}


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

QuickBuy surfaces its own pending/complete/failed toasts. When a trade is submitted via an EIP-7702 smart account or a gas-included (`gasIncluded7702`) quote, `BridgeStatusController.submitTx` wraps the trade as a `TransactionType.batch` transaction. `batch` is in `REDESIGNED_TRANSACTION_TYPES`, so `NotificationManager` also fired the generic "Transaction submitted" and "Transaction #N complete" toasts on top of QuickBuy's own — the user saw **4 toasts instead of 2**. (This is why it doesn't reproduce on a plain EOA: those trades are typed `swap`/`bridge`, which are not redesigned types.)

This PR scopes the suppression strictly to QuickBuy via inversion of control, so the main Swap/Bridge flows are unaffected:

- New dependency-free module `app/core/notificationSkipPredicates.ts` holds a registry of "skip predicates". `NotificationManager.#shouldSkipNotification` consults it (guarded by try/catch so a throwing predicate can never break notifications). Keeping it in its own module means feature code can register without importing the heavy `NotificationManager` graph.
- QuickBuy registers a predicate at the app root (`useQuickBuyToastRegistrations`) that matches:
  - **tracked trade ids** — covers the terminal complete/failed toast, and
  - **in-flight submissions** via a pre-submit marker (`beginQuickBuySubmission`/`endQuickBuySubmission`) — covers the *pending* toast, which fires mid-`submitTx` before the tx id is known.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: Fixed QuickBuy showing duplicate transaction toasts for smart-account and gas-included trades

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-627

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: QuickBuy transaction toasts

  Scenario: User runs a QuickBuy with a smart (EIP-7702) account
    Given I have an EIP-7702 smart account enabled on the trade network
    And I open a token from the Social Leaderboard trader position view
    When I confirm a QuickBuy trade
    Then I see exactly one QuickBuy "Buying..." pending toast
    And after the trade settles I see exactly one QuickBuy "Bought" (or "Failed") toast
    And I do not see the generic "Transaction submitted" or "Transaction complete" toasts

  Scenario: User runs a QuickBuy on a plain EOA (regression)
    Given I have a standard externally-owned account
    When I confirm a QuickBuy trade
    Then I still see only the two QuickBuy toasts (pending, then terminal)

  Scenario: Main Swap/Bridge flows are unaffected (regression)
    Given I start a swap or bridge from the main Swap/Bridge UI
    When the transaction is submitted and confirmed
    Then the generic transaction toasts still appear as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

In some rare cases, this happens:

https://github.com/user-attachments/assets/838826be-99a7-4101-873e-88173059fbc1

### **After**

This is what we want in all cases:

https://github.com/user-attachments/assets/b49de0d5-a0e2-47cb-8eef-6b372ad0f79f



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global notification gating and briefly suppresses swap/bridge/batch notifications during QuickBuy submit; predicates are isolated and errors are caught so unrelated flows should still get generic toasts.
> 
> **Overview**
> Adds a **dependency-free notification skip registry** (`notificationSkipPredicates`) and wires **`NotificationManager`** to consult registered predicates (with try/catch) so feature flows can opt out of generic transaction toasts without core importing UI code.
> 
> **QuickBuy** registers `isQuickBuyTransaction` at the app root and extends the trade tracker with: a **ref-counted in-flight submission marker** (`begin`/`end` around `submitTx`) for pending notifications before the tx id exists; **tracked and recently-settled tx ids** so suppression still applies when `NotificationManager` re-checks ~2s after confirm/fail; and **type-narrowed matching** (swap/bridge/batch) during submission so unrelated txs are not hidden. Terminal handling now **settles** trades via `markQuickBuyTradeSettled` instead of a plain untrack so duplicate generic success/error toasts do not appear on top of QuickBuy’s own toasts (notably EIP-7702 `batch` trades).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270b0ec43c43219f46c381f075040f4d88860545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->