### PR TITLE
feat: update World Cup event count in PredictionsSection and related components

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -245,6 +245,11 @@ jest.mock('@tanstack/react-query', () => {
   const actual = jest.requireActual('@tanstack/react-query');
   return {
     ...actual,
+    useQuery: jest.fn(() => ({
+      data: 510,
+      isLoading: false,
+      refetch: jest.fn().mockResolvedValue(undefined),
+    })),
     useQueryClient: jest.fn(() => ({
       invalidateQueries: jest.fn(() => Promise.resolve()),
     })),

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -52,6 +52,15 @@ const worldCupHomepageMarketsMock = (
   fetchMore: jest.fn(),
 });
 
+const worldCupEventCountMock = (
+  eventCount: number | undefined = 510,
+  opts: { isFetching?: boolean } = {},
+) => ({
+  eventCount,
+  isFetching: opts.isFetching ?? false,
+  refetch: jest.fn(),
+});
+
 const HOMEPAGE_DISCOVERY_WINNER_MARKET = {
   id: 'market-1',
   title: '2026 FIFA World Cup Winner',
@@ -204,6 +213,7 @@ jest.mock('./hooks', () => {
   const worldCupMock = jest.fn(() =>
     worldCupMarketsWithDiscoveryChampionship(),
   );
+  const worldCupEventCount = jest.fn(() => worldCupEventCountMock());
   const nbaMock = jest.fn(() =>
     worldCupHomepageMarketsMock([HOMEPAGE_DISCOVERY_NBA_CHAMPION_PARENT]),
   );
@@ -222,6 +232,7 @@ jest.mock('./hooks', () => {
       refetch: jest.fn(),
     })),
     useHomepagePredictWorldCupMarkets: worldCupMock,
+    useHomepagePredictWorldCupEventCount: worldCupEventCount,
     useHomepagePredictTaggedMarkets: jest.fn(
       ({ customQueryParams }: { customQueryParams: string }) =>
         customQueryParams === tagQueries.nbaChampion
@@ -229,6 +240,7 @@ jest.mock('./hooks', () => {
           : worldCupHomepageMarketsMock([]),
     ),
     __mockUsePredictWorldCupHomepageMarkets: worldCupMock,
+    __mockUsePredictWorldCupEventCount: worldCupEventCount,
     __mockUsePredictNbaChampionHomepageMarkets: nbaMock,
   };
 });
@@ -254,6 +266,8 @@ const mockUsePredictPositionsForHomepage =
   jest.requireMock('./hooks').usePredictPositionsForHomepage;
 const mockUsePredictWorldCupHomepageMarkets = jest.requireMock('./hooks')
   .__mockUsePredictWorldCupHomepageMarkets as jest.Mock;
+const mockUsePredictWorldCupEventCount = jest.requireMock('./hooks')
+  .__mockUsePredictWorldCupEventCount as jest.Mock;
 const mockUsePredictNbaChampionHomepageMarkets = jest.requireMock('./hooks')
   .__mockUsePredictNbaChampionHomepageMarkets as jest.Mock;
 const mockSelectPrivacyMode = jest.requireMock(
@@ -386,6 +400,7 @@ describe('PredictionsSection', () => {
     mockUsePredictWorldCupHomepageMarkets.mockReturnValue(
       worldCupMarketsWithDiscoveryChampionship(),
     );
+    mockUsePredictWorldCupEventCount.mockReturnValue(worldCupEventCountMock());
     mockUsePredictNbaChampionHomepageMarkets.mockReturnValue(
       worldCupHomepageMarketsMock([HOMEPAGE_DISCOVERY_NBA_CHAMPION_PARENT]),
     );
@@ -858,6 +873,27 @@ describe('PredictionsSection', () => {
 
       expect(toJSON()).not.toBeNull();
       expect(screen.getByText('Predictions')).toBeOnTheScreen();
+    });
+
+    it('shows the World Cup API total with a plus sign in the discovery row', () => {
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: [],
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      mockUsePredictWorldCupHomepageMarkets.mockReturnValue(
+        worldCupHomepageMarketsMock([HOMEPAGE_DISCOVERY_WINNER_MARKET]),
+      );
+      mockUsePredictWorldCupEventCount.mockReturnValue(
+        worldCupEventCountMock(48),
+      );
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      expect(screen.getByText('48+ events in total')).toBeOnTheScreen();
     });
 
     it('still renders treatment discovery when trending markets fail', async () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -26,6 +26,7 @@ import {
   usePredictPositionsForHomepage,
   useHomepagePredictTaggedMarkets,
   useHomepagePredictWorldCupMarkets,
+  useHomepagePredictWorldCupEventCount,
   HOMEPAGE_PREDICT_TAG_QUERIES,
   usePredictHomepageDiscoveryExperiment,
 } from './hooks';
@@ -54,6 +55,7 @@ import type { TransactionActiveAbTestEntry } from '../../../../../util/transacti
 /** Loads both feeds the World Cup discovery rail needs (World Cup tag + NBA Champion event). */
 const useWorldCupDiscoveryFeeds = (enabled: boolean) => ({
   worldCup: useHomepagePredictWorldCupMarkets({ enabled }),
+  worldCupEventCount: useHomepagePredictWorldCupEventCount({ enabled }),
   nbaChampion: useHomepagePredictTaggedMarkets({
     enabled,
     customQueryParams: HOMEPAGE_PREDICT_TAG_QUERIES.nbaChampion,
@@ -336,14 +338,17 @@ const PredictionsSectionDefault = forwardRef<
 
     const {
       worldCup: worldCupHomepageMarkets,
+      worldCupEventCount,
       nbaChampion: nbaChampionHomepageMarkets,
     } = useWorldCupDiscoveryFeeds(isPredictEnabled && isTreatmentDiscovery);
     const { refetch: refetchWorldCupHomepageMarkets } = worldCupHomepageMarkets;
+    const { refetch: refetchWorldCupEventCount } = worldCupEventCount;
     const { refetch: refetchNbaChampionHomepageMarkets } =
       nbaChampionHomepageMarkets;
     const isLoadingWorldCupHomepage = useTreatmentDiscoveryFeedsLoading({
       isTreatmentDiscovery,
-      isWorldCupFetching: worldCupHomepageMarkets.isFetching,
+      isWorldCupFetching:
+        worldCupHomepageMarkets.isFetching || worldCupEventCount.isFetching,
       isNbaChampionFetching: nbaChampionHomepageMarkets.isFetching,
     });
 
@@ -410,6 +415,7 @@ const PredictionsSectionDefault = forwardRef<
       const tasks: Promise<unknown>[] = [refreshPositions(), refetchMarkets()];
       if (isTreatmentDiscovery) {
         tasks.push(refetchWorldCupHomepageMarkets());
+        tasks.push(refetchWorldCupEventCount());
         tasks.push(refetchNbaChampionHomepageMarkets());
       }
       await Promise.all(tasks);
@@ -418,6 +424,7 @@ const PredictionsSectionDefault = forwardRef<
       refetchMarkets,
       isTreatmentDiscovery,
       refetchWorldCupHomepageMarkets,
+      refetchWorldCupEventCount,
       refetchNbaChampionHomepageMarkets,
     ]);
 
@@ -458,6 +465,7 @@ const PredictionsSectionDefault = forwardRef<
                   markets={markets}
                   transactionActiveAbTests={discoveryTransactionActiveAbTests}
                   worldCupHomepage={worldCupHomepageMarkets}
+                  worldCupEventCount={worldCupEventCount.eventCount}
                   nbaChampionHomepage={nbaChampionHomepageMarkets}
                   emptyStateTransactionActiveAbTests={
                     discoveryTransactionActiveAbTests
@@ -495,6 +503,7 @@ const PredictionsSectionDefault = forwardRef<
               markets={markets}
               transactionActiveAbTests={discoveryTransactionActiveAbTests}
               worldCupHomepage={worldCupHomepageMarkets}
+              worldCupEventCount={worldCupEventCount.eventCount}
               nbaChampionHomepage={nbaChampionHomepageMarkets}
               emptyStateTransactionActiveAbTests={
                 discoveryTransactionActiveAbTests
@@ -626,9 +635,11 @@ const PredictionsSectionTrendingOnly = forwardRef<
     const isListLayout = discoveryLayout === 'list';
     const {
       worldCup: worldCupHomepageMarkets,
+      worldCupEventCount,
       nbaChampion: nbaChampionHomepageMarkets,
     } = useWorldCupDiscoveryFeeds(isPredictEnabled && isListLayout);
     const { refetch: refetchWorldCupHomepageMarkets } = worldCupHomepageMarkets;
+    const { refetch: refetchWorldCupEventCount } = worldCupEventCount;
     const { refetch: refetchNbaChampionHomepageMarkets } =
       nbaChampionHomepageMarkets;
 
@@ -641,6 +652,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
       const tasks: Promise<unknown>[] = [refetchMarkets()];
       if (isListLayout) {
         tasks.push(refetchWorldCupHomepageMarkets());
+        tasks.push(refetchWorldCupEventCount());
         tasks.push(refetchNbaChampionHomepageMarkets());
       }
       await Promise.all(tasks);
@@ -648,6 +660,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
       refetchMarkets,
       isListLayout,
       refetchWorldCupHomepageMarkets,
+      refetchWorldCupEventCount,
       refetchNbaChampionHomepageMarkets,
     ]);
 
@@ -663,6 +676,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
         isLoading={
           isListLayout
             ? worldCupHomepageMarkets.isFetching ||
+              worldCupEventCount.isFetching ||
               nbaChampionHomepageMarkets.isFetching
             : isLoadingMarkets
         }
@@ -685,6 +699,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
               trendingTransactionActiveAbTests
             }
             worldCupHomepage={worldCupHomepageMarkets}
+            worldCupEventCount={worldCupEventCount.eventCount}
             nbaChampionHomepage={nbaChampionHomepageMarkets}
           />
         </Box>
@@ -717,18 +732,25 @@ const PredictionsSectionSportsOnly = forwardRef<
 
     const {
       worldCup: worldCupHomepageMarkets,
+      worldCupEventCount,
       nbaChampion: nbaChampionHomepageMarkets,
     } = useWorldCupDiscoveryFeeds(isPredictEnabled);
     const { refetch: refetchWorldCupHomepageMarkets } = worldCupHomepageMarkets;
+    const { refetch: refetchWorldCupEventCount } = worldCupEventCount;
     const { refetch: refetchNbaChampionHomepageMarkets } =
       nbaChampionHomepageMarkets;
 
     const refresh = useCallback(async () => {
       await Promise.all([
         refetchWorldCupHomepageMarkets(),
+        refetchWorldCupEventCount(),
         refetchNbaChampionHomepageMarkets(),
       ]);
-    }, [refetchWorldCupHomepageMarkets, refetchNbaChampionHomepageMarkets]);
+    }, [
+      refetchWorldCupHomepageMarkets,
+      refetchWorldCupEventCount,
+      refetchNbaChampionHomepageMarkets,
+    ]);
 
     return (
       <PredictionsSectionShell
@@ -738,6 +760,7 @@ const PredictionsSectionSportsOnly = forwardRef<
         refresh={refresh}
         isLoading={
           worldCupHomepageMarkets.isFetching ||
+          worldCupEventCount.isFetching ||
           nbaChampionHomepageMarkets.isFetching
         }
         isEmpty={false}
@@ -752,6 +775,7 @@ const PredictionsSectionSportsOnly = forwardRef<
             onViewAll={handleViewAllPredictions}
             headerTestIdKey="trending-predictions"
             worldCup={worldCupHomepageMarkets}
+            worldCupEventCount={worldCupEventCount.eventCount}
             nbaChampion={nbaChampionHomepageMarkets}
           />
         </Box>

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingMarkets.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingMarkets.tsx
@@ -20,6 +20,7 @@ export interface HomepagePredictTrendingMarketsProps {
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   /** Required when `discoveryLayout` is `list` (World Cup discovery rail). */
   worldCupHomepage?: UseHomepagePredictWorldCupMarketsResult;
+  worldCupEventCount?: number;
   /** Required when `discoveryLayout` is `list` (NBA champion event, separate from World Cup tag). */
   nbaChampionHomepage?: UseHomepagePredictTaggedMarketsResult;
   emptyStateTransactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -38,6 +39,7 @@ const HomepagePredictTrendingMarkets = ({
   markets,
   transactionActiveAbTests,
   worldCupHomepage,
+  worldCupEventCount,
   nbaChampionHomepage,
   emptyStateTransactionActiveAbTests,
   onEmptyStateTreatmentCtaClick,
@@ -65,6 +67,7 @@ const HomepagePredictTrendingMarkets = ({
       onViewAll={onViewAll}
       headerTestIdKey={headerTestIdKey}
       worldCup={worldCupHomepage}
+      worldCupEventCount={worldCupEventCount}
       nbaChampion={nbaChampionHomepage}
       transactionActiveAbTests={emptyStateTransactionActiveAbTests}
       onTreatmentCtaClick={onEmptyStateTreatmentCtaClick}

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/MensWorldCupRow.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/MensWorldCupRow.tsx
@@ -17,7 +17,7 @@ import HomepagePredictDiscoveryMaterialGlyph from './HomepagePredictDiscoveryMat
 
 interface MensWorldCupRowProps {
   onPress: () => void;
-  eventCountLabel: string;
+  eventCountLabel?: string;
 }
 
 const MensWorldCupRow = ({
@@ -48,13 +48,15 @@ const MensWorldCupRow = ({
         >
           {strings('predict.homepage_discovery.fifa_world_cup_2026_title')}
         </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          color={TextColor.TextAlternative}
-          numberOfLines={1}
-        >
-          {eventCountLabel}
-        </Text>
+        {eventCountLabel ? (
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            numberOfLines={1}
+          >
+            {eventCountLabel}
+          </Text>
+        ) : null}
       </Box>
       <Icon
         name={IconName.ArrowRight}

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -47,6 +47,7 @@ export interface HomepagePredictWorldCupDiscoveryProps {
   ) => void;
   headerTestIdKey: PredictionsTrendingHeaderTestId;
   worldCup: UseHomepagePredictWorldCupMarketsResult;
+  worldCupEventCount?: number;
   nbaChampion: UseHomepagePredictTaggedMarketsResult;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   onTreatmentCtaClick?: (
@@ -62,6 +63,7 @@ const HomepagePredictWorldCupDiscovery: React.FC<
   onViewAll,
   headerTestIdKey,
   worldCup,
+  worldCupEventCount,
   nbaChampion,
   transactionActiveAbTests,
   onTreatmentCtaClick,
@@ -93,7 +95,7 @@ const HomepagePredictWorldCupDiscovery: React.FC<
       ? WORLD_CUP_CTA_CATEGORY_NAME
       : 'nba';
 
-  const { marketData, isFetching, hasMore } = worldCup;
+  const { marketData, isFetching } = worldCup;
   const { marketData: nbaMarketData, isFetching: isNbaFetching } = nbaChampion;
 
   const isInitialLoad = isFetching && marketData.length === 0;
@@ -102,14 +104,15 @@ const HomepagePredictWorldCupDiscovery: React.FC<
     isNbaFetching &&
     nbaMarketData.length === 0;
 
-  const eventCountLabel = useMemo(() => {
-    const n = marketData.length;
-    const i18nKey =
-      n > 0 && hasMore
-        ? 'predict.homepage_discovery.events_in_total_overflow'
-        : 'predict.homepage_discovery.events_in_total';
-    return strings(i18nKey, { count: n });
-  }, [marketData.length, hasMore]);
+  const eventCountLabel = useMemo(
+    () =>
+      worldCupEventCount === undefined
+        ? undefined
+        : strings('predict.homepage_discovery.events_in_total_overflow', {
+            count: worldCupEventCount,
+          }),
+    [worldCupEventCount],
+  );
 
   const championshipRow: ChampionshipRowState = useMemo(() => {
     if (championshipRowKind === 'nba') {

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.test.ts
@@ -46,7 +46,7 @@ describe('useHomepagePredictWorldCupMarkets', () => {
     });
   });
 
-  it('fetches the homepage World Cup event count directly from pagination metadata', async () => {
+  it('fetches the homepage World Cup event count using the configured World Cup tag', async () => {
     mockUseSelector.mockReturnValue({
       ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
       tagSlug: 'remote-configured-world-cup-tag',
@@ -66,8 +66,44 @@ describe('useHomepagePredictWorldCupMarkets', () => {
     await waitFor(() => expect(result.current.eventCount).toBe(48));
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://gamma-api.polymarket.com/events/pagination?tag_slug=fifa-world-cup&limit=1&active=true&closed=false&archived=false',
+      'https://gamma-api.polymarket.com/events/pagination?tag_slug=remote-configured-world-cup-tag&limit=1&active=true&closed=false&archived=false',
     );
+  });
+
+  it('omits the event count when pagination metadata is missing', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        pagination: {},
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.eventCount).toBeUndefined();
+  });
+
+  it('omits the event count when pagination totalResults is not a number', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        pagination: { totalResults: '48' },
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.eventCount).toBeUndefined();
   });
 
   it('does not fall back to the loaded market count while the event count is loading', () => {

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.test.ts
@@ -1,0 +1,113 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../../../../../UI/Predict/constants/flags';
+import { usePredictWorldCupMarkets } from '../../../../../UI/Predict/hooks/usePredictWorldCup';
+import {
+  useHomepagePredictWorldCupEventCount,
+  useHomepagePredictWorldCupMarkets,
+} from './useHomepagePredictWorldCupMarkets';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../UI/Predict/hooks/usePredictWorldCup', () => ({
+  usePredictWorldCupMarkets: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.Mock;
+const mockUsePredictWorldCupMarkets = jest.mocked(usePredictWorldCupMarkets);
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { cacheTime: Infinity, retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+};
+
+describe('useHomepagePredictWorldCupMarkets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(DEFAULT_PREDICT_WORLD_CUP_FLAG);
+    mockUsePredictWorldCupMarkets.mockReturnValue({
+      marketData: [{ id: 'market-1' }] as never,
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+  });
+
+  it('fetches the homepage World Cup event count directly from pagination metadata', async () => {
+    mockUseSelector.mockReturnValue({
+      ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      tagSlug: 'remote-configured-world-cup-tag',
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        pagination: { totalResults: 48 },
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.eventCount).toBe(48));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://gamma-api.polymarket.com/events/pagination?tag_slug=fifa-world-cup&limit=1&active=true&closed=false&archived=false',
+    );
+  });
+
+  it('does not fall back to the loaded market count while the event count is loading', () => {
+    mockUsePredictWorldCupMarkets.mockReturnValue({
+      marketData: Array.from({ length: 19 }, (_, index) => ({
+        id: `market-${index}`,
+      })) as never,
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+    mockFetch.mockReturnValue(new Promise(() => undefined));
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.eventCount).toBeUndefined();
+    expect(result.current.isFetching).toBe(true);
+  });
+
+  it('does not request the event count when the homepage query is disabled', () => {
+    renderHook(() => useHomepagePredictWorldCupEventCount({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps the market hook scoped to market data only', () => {
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupMarkets({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current).not.toHaveProperty('eventCount');
+    expect(result.current).not.toHaveProperty('totalResults');
+  });
+});

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
@@ -4,7 +4,6 @@ import { usePredictWorldCupMarkets } from '../../../../../UI/Predict/hooks/usePr
 import type { UsePredictMarketDataResult } from '../../../../../UI/Predict/hooks/usePredictMarketData';
 import { PREDICT_WORLD_CUP_TAB_KEYS } from '../../../../../UI/Predict/constants/worldCupTabs';
 import { selectPredictWorldCupConfig } from '../../../../../UI/Predict/selectors/featureFlags';
-import { PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG } from '../../../../../UI/Predict/constants/flags';
 import { getPolymarketEndpoints } from '../../../../../UI/Predict/providers/polymarket/utils';
 
 interface UseHomepagePredictWorldCupMarketsArgs {
@@ -32,9 +31,11 @@ const homepagePredictWorldCupEventCountKeys = {
     ] as const,
 };
 
-const buildHomepagePredictWorldCupEventCountQuery = (): string => {
+const buildHomepagePredictWorldCupEventCountQuery = (
+  tagSlug: string,
+): string => {
   const queryParams = new URLSearchParams();
-  queryParams.set('tag_slug', PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG);
+  queryParams.set('tag_slug', tagSlug);
   queryParams.set(
     'limit',
     String(HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_LIMIT),
@@ -46,9 +47,10 @@ const buildHomepagePredictWorldCupEventCountQuery = (): string => {
   return queryParams.toString();
 };
 
-const fetchHomepagePredictWorldCupEventCount = async (): Promise<number> => {
+const fetchHomepagePredictWorldCupEventCount = async (
+  queryParams: string,
+): Promise<number | null> => {
   const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
-  const queryParams = buildHomepagePredictWorldCupEventCountQuery();
 
   const response = await fetch(
     `${GAMMA_API_ENDPOINT}/events/pagination?${queryParams}`,
@@ -61,7 +63,7 @@ const fetchHomepagePredictWorldCupEventCount = async (): Promise<number> => {
   const data = await response.json();
   const totalResults = data?.pagination?.totalResults;
 
-  return typeof totalResults === 'number' ? totalResults : 0;
+  return typeof totalResults === 'number' ? totalResults : null;
 };
 
 /**
@@ -72,10 +74,14 @@ const fetchHomepagePredictWorldCupEventCount = async (): Promise<number> => {
 export function useHomepagePredictWorldCupEventCount({
   enabled,
 }: UseHomepagePredictWorldCupMarketsArgs): UseHomepagePredictWorldCupEventCountResult {
-  const eventCountQueryParams = buildHomepagePredictWorldCupEventCountQuery();
+  const config = useSelector(selectPredictWorldCupConfig);
+  const eventCountQueryParams = buildHomepagePredictWorldCupEventCountQuery(
+    config.tagSlug,
+  );
   const eventCountQuery = useQuery({
     queryKey: homepagePredictWorldCupEventCountKeys.all(eventCountQueryParams),
-    queryFn: fetchHomepagePredictWorldCupEventCount,
+    queryFn: () =>
+      fetchHomepagePredictWorldCupEventCount(eventCountQueryParams),
     staleTime: HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_STALE_TIME,
     enabled,
   });
@@ -84,7 +90,7 @@ export function useHomepagePredictWorldCupEventCount({
   };
 
   return {
-    eventCount: eventCountQuery.data,
+    eventCount: eventCountQuery.data ?? undefined,
     isFetching: eventCountQuery.isLoading,
     refetch,
   };

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
@@ -1,20 +1,102 @@
 import { useSelector } from 'react-redux';
+import { useQuery } from '@tanstack/react-query';
 import { usePredictWorldCupMarkets } from '../../../../../UI/Predict/hooks/usePredictWorldCup';
 import type { UsePredictMarketDataResult } from '../../../../../UI/Predict/hooks/usePredictMarketData';
 import { PREDICT_WORLD_CUP_TAB_KEYS } from '../../../../../UI/Predict/constants/worldCupTabs';
 import { selectPredictWorldCupConfig } from '../../../../../UI/Predict/selectors/featureFlags';
+import { PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG } from '../../../../../UI/Predict/constants/flags';
+import { getPolymarketEndpoints } from '../../../../../UI/Predict/providers/polymarket/utils';
 
 interface UseHomepagePredictWorldCupMarketsArgs {
   enabled: boolean;
 }
 
+interface UseHomepagePredictWorldCupEventCountResult {
+  eventCount?: number;
+  isFetching: boolean;
+  refetch: () => Promise<void>;
+}
+
+const HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_LIMIT = 1;
+const HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_STALE_TIME = 10_000;
+
+const homepagePredictWorldCupEventCountKeys = {
+  all: (queryParams: string) =>
+    [
+      'homepage',
+      'predict',
+      'worldCup',
+      'eventCount',
+      'paginationTotalResults',
+      queryParams,
+    ] as const,
+};
+
+const buildHomepagePredictWorldCupEventCountQuery = (): string => {
+  const queryParams = new URLSearchParams();
+  queryParams.set('tag_slug', PREDICT_WORLD_CUP_DEFAULT_TAG_SLUG);
+  queryParams.set(
+    'limit',
+    String(HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_LIMIT),
+  );
+  queryParams.set('active', 'true');
+  queryParams.set('closed', 'false');
+  queryParams.set('archived', 'false');
+
+  return queryParams.toString();
+};
+
+const fetchHomepagePredictWorldCupEventCount = async (): Promise<number> => {
+  const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
+  const queryParams = buildHomepagePredictWorldCupEventCountQuery();
+
+  const response = await fetch(
+    `${GAMMA_API_ENDPOINT}/events/pagination?${queryParams}`,
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to get homepage World Cup event count');
+  }
+
+  const data = await response.json();
+  const totalResults = data?.pagination?.totalResults;
+
+  return typeof totalResults === 'number' ? totalResults : 0;
+};
+
 /**
  * Homepage discovery: loads World Cup markets using the same ALL-tab query path
- * as the dedicated World Cup screen (`buildPredictWorldCupAllQuery` → keyset API).
+ * as the dedicated World Cup screen, but keeps its event-count query private to
+ * this hook so `/events/pagination` is only requested by the homepage row.
+ */
+export function useHomepagePredictWorldCupEventCount({
+  enabled,
+}: UseHomepagePredictWorldCupMarketsArgs): UseHomepagePredictWorldCupEventCountResult {
+  const eventCountQueryParams = buildHomepagePredictWorldCupEventCountQuery();
+  const eventCountQuery = useQuery({
+    queryKey: homepagePredictWorldCupEventCountKeys.all(eventCountQueryParams),
+    queryFn: fetchHomepagePredictWorldCupEventCount,
+    staleTime: HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_STALE_TIME,
+    enabled,
+  });
+  const refetch = async () => {
+    await eventCountQuery.refetch();
+  };
+
+  return {
+    eventCount: eventCountQuery.data,
+    isFetching: eventCountQuery.isLoading,
+    refetch,
+  };
+}
+
+/**
+ * Homepage discovery: loads World Cup markets using the same ALL-tab query path
+ * as the dedicated World Cup screen.
  */
 export function useHomepagePredictWorldCupMarkets({
   enabled,
-}: UseHomepagePredictWorldCupMarketsArgs): UsePredictMarketDataResult {
+}: UseHomepagePredictWorldCupMarketsArgs): UseHomepagePredictWorldCupMarketsResult {
   const config = useSelector(selectPredictWorldCupConfig);
 
   return usePredictWorldCupMarkets({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates the homepage Predictions World Cup discovery row so the “events in total” count comes from Polymarket’s lightweight pagination endpoint instead of the loaded World Cup market list.
The row now uses:
`https://gamma-api.polymarket.com/events/pagination?tag_slug=fifa-world-cup&limit=1&active=true&closed=false&archived=false`
and reads `pagination.totalResults`.
This prevents the UI from showing partial loaded counts like `19+` or `20+` when the real total is much higher. The `+` suffix is preserved.


## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the World Cup events count shown in the homepage Predictions discovery row.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage Predictions World Cup event count

  Scenario: user views the World Cup discovery row in Predictions
    Given Predict is enabled
    And the homepage Predictions discovery layout is shown

    When the user views the FIFA World Cup 2026 row
    Then the row shows the total event count from the Polymarket pagination API
    And the count keeps the plus suffix
    And the row does not show a partial loaded market count such as "19+" or "20+"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="387" height="335" alt="Screenshot 2026-06-10 at 13 07 25" src="https://github.com/user-attachments/assets/16df1441-1e94-4bd5-a395-ba56e9aceab6" />

<!-- [screenshots/recordings] -->

### **After**
<img width="391" height="337" alt="Screenshot 2026-06-10 at 12 59 32" src="https://github.com/user-attachments/assets/c163ed17-a4c7-4710-9cb5-f3ca1d2f404b" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI and a lightweight external count API; no auth, payments, or data writes.
> 
> **Overview**
> Fixes the homepage Predictions **FIFA World Cup 2026** row so “events in total” reflects Polymarket’s full catalog instead of how many markets are already loaded.
> 
> A new **`useHomepagePredictWorldCupEventCount`** hook calls Gamma **`/events/pagination`** with `limit=1` and the remote-configured World Cup tag, then surfaces **`pagination.totalResults`** via React Query (with refetch on section pull-to-refresh). **`PredictionsSection`** loads that count alongside existing World Cup/NBA discovery feeds and treats event-count fetching as part of discovery loading.
> 
> **`HomepagePredictWorldCupDiscovery`** stops deriving the label from `marketData.length` / `hasMore` and always formats the API total with the overflow copy (e.g. `48+ events in total`). **`MensWorldCupRow`** hides the subtitle until a count is available so partial loaded counts are not shown while the pagination request is in flight.
> 
> Hook and section tests cover the pagination URL, invalid/missing totals, disabled queries, and the new UI assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a68d99b7002e912549ea9419cbccf4205244ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->