### PR TITLE
refactor: Refactor accounts-related controllers to remove duplicate messenger types

### DIFF
--- a/app/core/Engine/messengers/accounts-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/accounts-controller-messenger/index.ts
@@ -1,5 +1,5 @@
 import { AccountsControllerMessenger } from '@metamask/accounts-controller';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   SnapKeyringAccountAssetListUpdatedEvent,
   SnapKeyringAccountBalancesUpdatedEvent,
@@ -21,19 +21,17 @@ export * from './types';
  * @returns The AccountsControllerMessenger.
  */
 export function getAccountsControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): AccountsControllerMessenger {
-  const messenger = new Messenger<
-    'AccountsController',
+  rootMessenger: RootMessenger<
     MessengerActions<AccountsControllerMessenger>,
-    MessengerEvents<AccountsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AccountsControllerMessenger>
+  >,
+): AccountsControllerMessenger {
+  const messenger: AccountsControllerMessenger = new Messenger({
     namespace: 'AccountsController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
 
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'KeyringController:getState',
       'KeyringController:getKeyringsByType',

--- a/app/core/Engine/messengers/identity/authentication-controller-messenger.ts
+++ b/app/core/Engine/messengers/identity/authentication-controller-messenger.ts
@@ -16,14 +16,12 @@ const name = 'AuthenticationController';
  * @returns The AuthenticationControllerMessenger.
  */
 export function getAuthenticationControllerMessenger(
-  rootMessenger: RootMessenger,
-): AuthenticationControllerMessenger {
-  const messenger = new Messenger<
-    typeof name,
+  rootMessenger: RootMessenger<
     MessengerActions<AuthenticationControllerMessenger>,
-    MessengerEvents<AuthenticationControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AuthenticationControllerMessenger>
+  >,
+): AuthenticationControllerMessenger {
+  const messenger: AuthenticationControllerMessenger = new Messenger({
     namespace: name,
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/identity/user-storage-controller-messenger.ts
+++ b/app/core/Engine/messengers/identity/user-storage-controller-messenger.ts
@@ -15,14 +15,12 @@ import { AnalyticsControllerActions } from '@metamask/analytics-controller';
  * @returns The UserStorageControllerMessenger.
  */
 export function getUserStorageControllerMessenger(
-  rootMessenger: RootMessenger,
-): UserStorageControllerMessenger {
-  const messenger = new Messenger<
-    'UserStorageController',
+  rootMessenger: RootMessenger<
     MessengerActions<UserStorageControllerMessenger>,
-    MessengerEvents<UserStorageControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<UserStorageControllerMessenger>
+  >,
+): UserStorageControllerMessenger {
+  const messenger: UserStorageControllerMessenger = new Messenger({
     namespace: 'UserStorageController',
     parent: rootMessenger,
   });
@@ -58,24 +56,19 @@ type UserStorageControllerInitMessengerActions = AnalyticsControllerActions;
  * @param rootMessenger - The root messenger.
  * @returns The UserStorageControllerInitMessenger.
  */
-export type UserStorageControllerInitMessenger = ReturnType<
-  typeof getUserStorageControllerInitMessenger
+export type UserStorageControllerInitMessenger = Messenger<
+  'UserStorageControllerInit',
+  UserStorageControllerInitMessengerActions,
+  never
 >;
 
 export function getUserStorageControllerInitMessenger(
-  rootMessenger: RootMessenger,
-): Messenger<
-  'UserStorageControllerInit',
-  UserStorageControllerInitMessengerActions,
-  never,
-  RootMessenger
-> {
-  const messenger = new Messenger<
-    'UserStorageControllerInit',
-    UserStorageControllerInitMessengerActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<UserStorageControllerInitMessenger>,
+    MessengerEvents<UserStorageControllerInitMessenger>
+  >,
+): UserStorageControllerInitMessenger {
+  const messenger: UserStorageControllerInitMessenger = new Messenger({
     namespace: 'UserStorageControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/multichain-account-service-messenger/multichain-account-service-messenger.ts
+++ b/app/core/Engine/messengers/multichain-account-service-messenger/multichain-account-service-messenger.ts
@@ -17,14 +17,12 @@ import { RootMessenger } from '../../types';
  * @returns The MultichainAccountServiceMessenger.
  */
 export function getMultichainAccountServiceMessenger(
-  rootMessenger: RootMessenger,
-): MultichainAccountServiceMessenger {
-  const messenger = new Messenger<
-    'MultichainAccountService',
+  rootMessenger: RootMessenger<
     MessengerActions<MultichainAccountServiceMessenger>,
-    MessengerEvents<MultichainAccountServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MultichainAccountServiceMessenger>
+  >,
+): MultichainAccountServiceMessenger {
+  const messenger: MultichainAccountServiceMessenger = new Messenger({
     namespace: 'MultichainAccountService',
     parent: rootMessenger,
   });
@@ -59,10 +57,10 @@ export function getMultichainAccountServiceMessenger(
 type AllowedInitializationEvents =
   MultichainAccountServiceMultichainAccountGroupUpdatedEvent;
 
-type AllowedInitializationActions = never;
-
-export type MultichainAccountServiceInitMessenger = ReturnType<
-  typeof getMultichainAccountServiceInitMessenger
+export type MultichainAccountServiceInitMessenger = Messenger<
+  'MultichainAccountServiceInit',
+  never,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -73,14 +71,12 @@ export type MultichainAccountServiceInitMessenger = ReturnType<
  * @returns The MultichainAccountServiceInitMessenger.
  */
 export function getMultichainAccountServiceInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'MultichainAccountServiceInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<MultichainAccountServiceInitMessenger>,
+    MessengerEvents<MultichainAccountServiceInitMessenger>
+  >,
+): MultichainAccountServiceInitMessenger {
+  const messenger: MultichainAccountServiceInitMessenger = new Messenger({
     namespace: 'MultichainAccountServiceInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -714,7 +714,10 @@ export const getRootExtendedMessenger = (): RootExtendedMessenger =>
  * Type definition for the root messenger used in the Engine.
  * It extends the root messenger with global actions and events.
  */
-export type RootMessenger = Messenger<'Root', GlobalActions, GlobalEvents>;
+export type RootMessenger<
+  AllowedActions extends GlobalActions = GlobalActions,
+  AllowedEvents extends GlobalEvents = GlobalEvents,
+> = Messenger<'Root', AllowedActions, AllowedEvents>;
 
 export const getRootMessenger = (): RootMessenger =>
   new Messenger<'Root', GlobalActions, GlobalEvents>({


### PR DESCRIPTION
## **Description**

Makes `RootMessenger` a generic type that accepts optional `AllowedActions` and `AllowedEvents` type parameters. Messenger factory functions are updated to accept `RootMessenger<AllowedActions, AllowedEvents>` instead of the broader `RootExtendedMessenger`, eliminating duplicate type declarations across accounts-related controller messengers.

Also converts `ReturnType<typeof getXMessenger>` aliases to explicit `Messenger<...>` definitions for `UserStorageControllerInitMessenger` and `MultichainAccountServiceInitMessenger`, which makes the types self-contained and consistent with the rest of the messenger type patterns.

No runtime behavior changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behavior changes.

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no runtime or delegation changes; default `RootMessenger` still matches full global actions/events.
> 
> **Overview**
> **`RootMessenger`** is now generic over optional `AllowedActions` and `AllowedEvents` (defaulting to the full global sets), so factory helpers can require a **narrowed** root parent instead of the broader **`RootExtendedMessenger`**.
> 
> Accounts-related messenger factories (`AccountsController`, authentication, user storage, multichain account service, and their init messengers) now take `RootMessenger<MessengerActions<…>, MessengerEvents<…>>`, use simpler `new Messenger({ … })` construction with explicit return types, and replace `ReturnType<typeof get…>` init aliases with explicit `Messenger<namespace, actions, events>` types.
> 
> No changes to `delegate` wiring or runtime messenger behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfea2e4015ab7e3efe59c791099db75bec1e3a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->