### PR TITLE
fix: default QuickBuy sell receive token to chain native instead of the sold token

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -38,6 +38,7 @@ import type {
 } from '../types';
 import { formatExchangeRate } from '../utils/formatExchangeRate';
 import { getMetamaskFeePercent } from '../utils/getMetamaskFeePercent';
+import { selectDefaultReceiveToken } from '../utils/selectDefaultReceiveToken';
 import { usePayWithTokens } from './usePayWithTokens';
 import { usePositionTokenBalance } from './usePositionTokenBalance';
 import { useQuickBuyAnalytics } from './useQuickBuyAnalytics';
@@ -355,13 +356,28 @@ export function useQuickBuyController(
     BridgeToken | undefined
   >(undefined);
 
-  // Auto-select default dest stable: prefer a token the user already holds on
-  // the position chain; fall back to the first candidate (USDC on position chain).
+  // Auto-select the default receive token. Prefer the native token of the
+  // position's chain (e.g. selling USDC on Base defaults to ETH on Base) and
+  // never the same token being sold — see `selectDefaultReceiveToken`.
+  //
+  // Wait for `!isSetupLoading` so the sold token's address is normalised before
+  // the (one-shot) selection runs. The sold token's identity is read from
+  // `positionTokenFromSetup` (which carries the normalised address/chainId)
+  // rather than the balance-enriched `positionToken`, so the exclusion still
+  // works even when the balance is still resolving.
   useEffect(() => {
+    if (isSetupLoading) return;
     if (sellDestTokenOptions.length > 0 && !selectedDestStable) {
-      setSelectedDestStable(sellDestTokenOptions[0]);
+      setSelectedDestStable(
+        selectDefaultReceiveToken(sellDestTokenOptions, positionTokenFromSetup),
+      );
     }
-  }, [sellDestTokenOptions, selectedDestStable]);
+  }, [
+    isSetupLoading,
+    sellDestTokenOptions,
+    selectedDestStable,
+    positionTokenFromSetup,
+  ]);
 
   // ─── Source / dest resolution (mode-dependent) ─────────────────────────
   const sourceToken = tradeMode === 'buy' ? selectedSourceToken : positionToken;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -36,6 +36,7 @@ import type {
   QuickBuyTarget,
   QuickBuyTradeMode,
 } from '../types';
+import { getTokenKey } from '../tokenKey';
 import { formatExchangeRate } from '../utils/formatExchangeRate';
 import { getMetamaskFeePercent } from '../utils/getMetamaskFeePercent';
 import { selectDefaultReceiveToken } from '../utils/selectDefaultReceiveToken';
@@ -349,9 +350,19 @@ export function useQuickBuyController(
   const positionToken = usePositionTokenBalance(target, positionTokenFromSetup);
 
   // ─── Sell "Receive" options (stablecoins) ──────────────────────────────
-  const sellDestTokenOptions = useReceiveTokens(
+  const receiveTokenOptions = useReceiveTokens(
     destChainId as string | undefined,
   );
+  // Exclude the token being sold from the "Receive" list entirely — receiving
+  // the same token you're selling is a no-op, so it must not be selectable.
+  // Identity comes from `positionTokenFromSetup` (normalised address/chainId).
+  const sellDestTokenOptions = useMemo(() => {
+    if (!positionTokenFromSetup) return receiveTokenOptions;
+    const soldKey = getTokenKey(positionTokenFromSetup);
+    return receiveTokenOptions.filter(
+      (token) => getTokenKey(token) !== soldKey,
+    );
+  }, [receiveTokenOptions, positionTokenFromSetup]);
   const [selectedDestStable, setSelectedDestStable] = useState<
     BridgeToken | undefined
   >(undefined);

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/tokenKey.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/tokenKey.ts
@@ -6,5 +6,6 @@ import type { BridgeToken } from '../../../../../UI/Bridge/types';
  * both the "Pay with" (buy) and "Receive" (sell) flows so row keys and
  * selection comparisons behave identically.
  */
-export const getTokenKey = (token: BridgeToken): string =>
-  `${token.address.toLowerCase()}:${token.chainId}`;
+export const getTokenKey = (
+  token: Pick<BridgeToken, 'address' | 'chainId'>,
+): string => `${token.address.toLowerCase()}:${token.chainId}`;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -1424,6 +1424,87 @@ describe('useQuickBuyController', () => {
     });
   });
 
+  describe('receive token auto-selection', () => {
+    const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
+    const USDC_DEST = '0xDEST'; // matches the default-mock position token
+
+    it('defaults the receive token to the chain native instead of the token being sold', () => {
+      // Selling 0xDEST on chain 0x1. The receive options are stablecoins-first,
+      // so options[0] is the very token being sold — the default must skip it
+      // and pick the chain's native token instead.
+      const usdcDest = createSourceToken({
+        address: USDC_DEST,
+        chainId: '0x1',
+        symbol: 'USDC',
+      });
+      const nativeDest = createSourceToken({
+        address: NATIVE_ADDRESS,
+        chainId: '0x1',
+        symbol: 'ETH',
+      });
+      (useReceiveTokens as jest.Mock).mockReturnValue([usdcDest, nativeDest]);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.selectedDestStable?.symbol).toBe('ETH');
+    });
+
+    it('falls back to the first non-sold candidate when selling the native token', () => {
+      (useQuickBuySetup as jest.Mock).mockReturnValue({
+        chainId: '0x1',
+        destToken: {
+          address: NATIVE_ADDRESS,
+          chainId: '0x1',
+          decimals: 18,
+          symbol: 'ETH',
+          name: 'Ether',
+        },
+        isLoading: false,
+        isUnsupportedChain: false,
+      });
+      const nativeDest = createSourceToken({
+        address: NATIVE_ADDRESS,
+        chainId: '0x1',
+        symbol: 'ETH',
+      });
+      const usdcDest = createSourceToken({
+        address: USDC_DEST,
+        chainId: '0x1',
+        symbol: 'USDC',
+      });
+      (useReceiveTokens as jest.Mock).mockReturnValue([nativeDest, usdcDest]);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.selectedDestStable?.symbol).toBe('USDC');
+    });
+
+    it('does not auto-select while setup is still loading', () => {
+      (useQuickBuySetup as jest.Mock).mockReturnValue({
+        chainId: '0x1',
+        destToken: undefined,
+        isLoading: true,
+        isUnsupportedChain: false,
+      });
+      const usdcDest = createSourceToken({
+        address: USDC_DEST,
+        chainId: '0x1',
+        symbol: 'USDC',
+      });
+      (useReceiveTokens as jest.Mock).mockReturnValue([usdcDest]);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.selectedDestStable).toBeUndefined();
+    });
+  });
+
   describe('selectDefaultSourceToken', () => {
     const native = (chainId: string, fiat = 1000): BridgeToken =>
       createSourceToken({

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -1483,6 +1483,28 @@ describe('useQuickBuyController', () => {
       expect(result.current.selectedDestStable?.symbol).toBe('USDC');
     });
 
+    it('excludes the token being sold from the receive options entirely', () => {
+      const usdcDest = createSourceToken({
+        address: USDC_DEST,
+        chainId: '0x1',
+        symbol: 'USDC',
+      });
+      const nativeDest = createSourceToken({
+        address: NATIVE_ADDRESS,
+        chainId: '0x1',
+        symbol: 'ETH',
+      });
+      (useReceiveTokens as jest.Mock).mockReturnValue([usdcDest, nativeDest]);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      const symbols = result.current.sellDestTokenOptions.map((t) => t.symbol);
+      expect(symbols).not.toContain('USDC');
+      expect(symbols).toEqual(['ETH']);
+    });
+
     it('does not auto-select while setup is still loading', () => {
       (useQuickBuySetup as jest.Mock).mockReturnValue({
         chainId: '0x1',

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/selectDefaultReceiveToken.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/selectDefaultReceiveToken.test.ts
@@ -1,0 +1,73 @@
+import type { Hex } from '@metamask/utils';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import { selectDefaultReceiveToken } from './selectDefaultReceiveToken';
+
+const BASE = '0x2105' as Hex;
+const POLYGON = '0x89' as Hex;
+const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
+const USDC_BASE = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const USDC_POLYGON = '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359';
+const USDT_POLYGON = '0xc2132d05d31c914a87c6611c10748aeb04b58e8f';
+
+const token = (symbol: string, address: string, chainId: Hex): BridgeToken =>
+  ({
+    symbol,
+    address,
+    chainId,
+    decimals: 6,
+  }) as BridgeToken;
+
+const usdcBase = token('USDC', USDC_BASE, BASE);
+const ethBase = token('ETH', NATIVE_ADDRESS, BASE);
+const usdcPolygon = token('USDC', USDC_POLYGON, POLYGON);
+const usdtPolygon = token('USDT', USDT_POLYGON, POLYGON);
+const polPolygon = token('POL', NATIVE_ADDRESS, POLYGON);
+
+describe('selectDefaultReceiveToken', () => {
+  it('returns undefined when there are no options', () => {
+    expect(selectDefaultReceiveToken([], usdcBase)).toBeUndefined();
+  });
+
+  it('returns the first option when the sold token is unknown', () => {
+    const options = [usdcBase, ethBase];
+    expect(selectDefaultReceiveToken(options, undefined)).toBe(usdcBase);
+  });
+
+  it('defaults to the native token of the chain when selling a stablecoin', () => {
+    // Receive options are ordered stablecoins-first on the position chain, so a
+    // naive options[0] would return USDC — the very token being sold.
+    const options = [usdcBase, ethBase, usdcPolygon];
+    expect(selectDefaultReceiveToken(options, usdcBase)).toBe(ethBase);
+  });
+
+  it('matches the sold token case-insensitively before excluding it', () => {
+    const options = [usdcBase, ethBase];
+    const soldUpperCase = token('USDC', USDC_BASE.toUpperCase(), BASE);
+    expect(selectDefaultReceiveToken(options, soldUpperCase)).toBe(ethBase);
+  });
+
+  it('falls back to the first eligible candidate when selling the native token', () => {
+    // Selling ETH on Base: native preference would re-select ETH, so we fall
+    // through to the first non-ETH candidate.
+    const options = [ethBase, usdcBase];
+    expect(selectDefaultReceiveToken(options, ethBase)).toBe(usdcBase);
+  });
+
+  it('falls back to the first eligible candidate when the native token is not an option', () => {
+    // No native candidate present for the sold token's chain.
+    const options = [usdcPolygon, usdtPolygon];
+    expect(selectDefaultReceiveToken(options, usdcPolygon)).toBe(usdtPolygon);
+  });
+
+  it('only prefers the native token on the sold token chain', () => {
+    // Native ETH/Base must not be chosen when selling on Polygon — the native
+    // preference is scoped to the sold token's own chain.
+    const options = [usdcPolygon, polPolygon, ethBase];
+    expect(selectDefaultReceiveToken(options, usdcPolygon)).toBe(polPolygon);
+  });
+
+  it('returns the first option when every candidate is the sold token', () => {
+    const options = [usdcBase];
+    expect(selectDefaultReceiveToken(options, usdcBase)).toBe(usdcBase);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/selectDefaultReceiveToken.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/selectDefaultReceiveToken.ts
@@ -1,0 +1,48 @@
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import { getNativeSourceToken } from '../../../../../../UI/Bridge/utils/tokenUtils';
+import { getTokenKey } from '../tokenKey';
+
+/**
+ * Picks the default "Receive" token for QuickBuy Sell mode.
+ *
+ * The receive options are ordered stablecoins-first on the position's chain, so
+ * naively taking the first entry can default to the *same* token the user is
+ * selling (e.g. selling USDC on Base would default to receiving USDC, which is a
+ * no-op). To keep the default sensible this excludes the token being sold and
+ * then prefers the native token of the sold token's chain (e.g. ETH on Base) so
+ * a sale defaults to cashing out into the chain's native asset. When the user is
+ * already selling the native token, or no native option exists, it falls back to
+ * the first remaining candidate (a stablecoin on the position chain).
+ *
+ * @param options - The ordered receive-token candidates.
+ * @param soldToken - The token being sold (Sell mode source), if known.
+ * @returns The token to preselect, or `undefined` when there are no options.
+ */
+export const selectDefaultReceiveToken = (
+  options: BridgeToken[],
+  soldToken: Pick<BridgeToken, 'address' | 'chainId'> | undefined,
+): BridgeToken | undefined => {
+  if (options.length === 0) return undefined;
+  if (!soldToken) return options[0];
+
+  const soldKey = getTokenKey(soldToken);
+  const eligible = options.filter((token) => getTokenKey(token) !== soldKey);
+  // Every option matched the sold token (shouldn't happen in practice) — fall
+  // back to the first so we always return something selectable.
+  if (eligible.length === 0) return options[0];
+
+  let nativeKey: string | undefined;
+  try {
+    nativeKey = getTokenKey(getNativeSourceToken(soldToken.chainId));
+  } catch {
+    // Native asset can't be resolved for this chain — skip the native
+    // preference and fall through to the first eligible candidate.
+  }
+
+  if (nativeKey && nativeKey !== soldKey) {
+    const native = eligible.find((token) => getTokenKey(token) === nativeKey);
+    if (native) return native;
+  }
+
+  return eligible[0];
+};


### PR DESCRIPTION
## **Description**

When selling a token in QuickBuy, the **receive** token list could contain — and default to — the **same token being sold**, which is a no-op (e.g. selling USDC on Base offered/defaulted to receiving USDC).

The receive options are built stablecoins-first and sorted with the position's chain first, so the previous logic — which simply preselected `sellDestTokenOptions[0]` — landed on the very token being sold whenever the position was a stablecoin that also appears in the curated stablecoin list. The token was also still selectable in the picker.

This PR fixes both the default and the list:

- **Excludes the token being sold from the receive list entirely**, so it can't be selected at all (receiving the same token you're selling is a no-op).
- Introduces `selectDefaultReceiveToken`, which prefers the **native token of the sold token's chain** as the default (e.g. selling USDC on Base now defaults to ETH on Base), falling back to the first remaining candidate when the user is already selling the native token or when no native option is available.

The auto-select effect is gated on `!isSetupLoading` and reads the sold token's identity from the normalised `positionTokenFromSetup` (rather than the balance-enriched `positionToken`), so both the exclusion and the default are correct even before the balance resolves — closing a race where the default could still be set to the sold token.

<img width="973" height="1066" alt="image" src="https://github.com/user-attachments/assets/48caf26e-1e30-44e3-8919-d47b5c9e9c69" />


## **Changelog**

CHANGELOG entry: Fixed QuickBuy so selling a token no longer lists or defaults the receive token to the same token; the sold token is removed from the receive options and the default is now the chain's native token (e.g. selling USDC on Base defaults to ETH).

## **Related issues**

Fixes: N/A — internal bug report (QuickBuy sell default/listing of receive token).

## **Manual testing steps**

```gherkin
Feature: QuickBuy sell receive token

  Scenario: The token being sold is not offered as a receive option
    Given I hold USDC on Base
    And I open the QuickBuy sheet for that position
    When I switch to "Sell" mode
    And I open the "Receive" token picker
    Then USDC on Base is not listed as a receive option

  Scenario: Selling a stablecoin defaults to the chain native token
    Given I hold USDC on Base
    And I open the QuickBuy sheet for that position
    When I switch to "Sell" mode
    Then the default "Receive" token is ETH on Base
    And it is never USDC (the token being sold)

  Scenario: Selling the native token defaults to a stablecoin
    Given I hold ETH on Base
    And I open the QuickBuy sheet for that position
    When I switch to "Sell" mode
    Then the default "Receive" token is a stablecoin on Base (not ETH)
```

## **Screenshots/Recordings**

### **Before**

<!-- Selling USDC on Base listed and defaulted the receive token to USDC. -->

N/A — logic-only change; behavior covered by unit tests.

### **After**

<!-- Selling USDC on Base removes USDC from the receive list and defaults to ETH. -->

N/A — logic-only change; behavior covered by unit tests.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

