### PR TITLE
feat: MUSD-954 add "Paid by MetaMask" for Money account deposits when fees are subsidized

### DIFF
--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -214,6 +214,18 @@ describe('BridgeFeeRow', () => {
       expect(queryByTestId('transaction-fee')).toBeNull();
     });
 
+    it('renders paid by MetaMask label for Money Account Deposit with all-zero fees and quotes', () => {
+      useTransactionTotalsMock.mockReturnValue(zeroFeesTotals);
+      useIsPaidByMetaMaskMock.mockReturnValue(true);
+
+      const { getByText, queryByTestId } = render({
+        type: TransactionType.moneyAccountDeposit,
+      });
+
+      expect(getByText('Paid by MetaMask')).toBeOnTheScreen();
+      expect(queryByTestId('transaction-fee')).toBeNull();
+    });
+
     it('hides the tooltip icon when paid by MetaMask is shown', () => {
       useTransactionTotalsMock.mockReturnValue(zeroFeesTotals);
       useIsPaidByMetaMaskMock.mockReturnValue(true);

--- a/app/components/Views/confirmations/hooks/pay/useIsPaidByMetaMask.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsPaidByMetaMask.test.ts
@@ -3,6 +3,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import {
+  TransactionFiatPayment,
   TransactionPayQuote,
   TransactionPayTotals,
 } from '@metamask/transaction-pay-controller';
@@ -12,6 +13,7 @@ import { Json } from '@metamask/utils';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { useIsPaidByMetaMask } from './useIsPaidByMetaMask';
 import {
+  useTransactionPayFiatPayment,
   useTransactionPayQuotes,
   useTransactionPayTotals,
 } from './useTransactionPayData';
@@ -54,12 +56,16 @@ function runHook({ type }: { type?: TransactionType } = {}) {
 }
 
 describe('useIsPaidByMetaMask', () => {
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
   const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
 
   beforeEach(() => {
     jest.resetAllMocks();
 
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
     useTransactionPayQuotesMock.mockReturnValue([
       {} as TransactionPayQuote<Json>,
     ]);
@@ -84,6 +90,16 @@ describe('useIsPaidByMetaMask', () => {
 
   it('returns false when the transaction type is not musdConversion', () => {
     const { result } = runHook({ type: TransactionType.perpsDeposit });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when a fiat payment method is selected', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'apple-pay',
+    } as TransactionFiatPayment);
+
+    const { result } = runHook({ type: TransactionType.moneyAccountDeposit });
 
     expect(result.current).toBe(false);
   });

--- a/app/components/Views/confirmations/hooks/pay/useIsPaidByMetaMask.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsPaidByMetaMask.ts
@@ -3,6 +3,7 @@ import { BigNumber } from 'bignumber.js';
 import { hasTransactionType } from '../../utils/transaction';
 import { useTransactionMetadataOrThrow } from '../transactions/useTransactionMetadataRequest';
 import {
+  useTransactionPayFiatPayment,
   useTransactionPayQuotes,
   useTransactionPayTotals,
 } from './useTransactionPayData';
@@ -13,6 +14,7 @@ const SUPPORTED_TYPES = [
 ];
 
 export function useIsPaidByMetaMask(): boolean {
+  const { selectedPaymentMethodId } = useTransactionPayFiatPayment() || {};
   const totals = useTransactionPayTotals();
   const quotes = useTransactionPayQuotes();
   const transactionMetadata = useTransactionMetadataOrThrow();
@@ -20,7 +22,8 @@ export function useIsPaidByMetaMask(): boolean {
   if (
     !quotes?.length ||
     !totals?.fees ||
-    !hasTransactionType(transactionMetadata, SUPPORTED_TYPES)
+    !hasTransactionType(transactionMetadata, SUPPORTED_TYPES) ||
+    selectedPaymentMethodId
   ) {
     return false;
   }

--- a/app/components/Views/confirmations/hooks/pay/useIsPaidByMetaMask.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsPaidByMetaMask.ts
@@ -7,7 +7,10 @@ import {
   useTransactionPayTotals,
 } from './useTransactionPayData';
 
-const SUPPORTED_TYPES = [TransactionType.musdConversion];
+const SUPPORTED_TYPES = [
+  TransactionType.musdConversion,
+  TransactionType.moneyAccountDeposit,
+];
 
 export function useIsPaidByMetaMask(): boolean {
   const totals = useTransactionPayTotals();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Adds the "Paid by MetaMask" tag for Money account deposits when fees are subsidized.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added paid by metamask tag for Money account deposits when fees are subsidized.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-954: Add "Paid by MetaMask" for subsidized Money account deposits](https://consensyssoftware.atlassian.net/browse/MUSD-954)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Paid by MetaMask tag for subsidized Money account deposits

  Scenario: Paid By MetaMask tag displayed on Money account deposit screen
    Given user has money account
    AND user has "no fee" token

    When user selects a token in the "Earn on your crypto" section that has a "no fee" token
    Then on Money account deposit screen the "Paid by MetaMask" tag is displayed next to the transaction fee
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A - We showed `Transaction Fee: $0`
### **After**

<!-- [screenshots/recordings] -->
<img width="505" height="1010" alt="image" src="https://github.com/user-attachments/assets/90143fc4-3766-401b-8ee0-45e61d9c3fc9" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small confirmation UI and hook logic change with tests; no auth or payment execution paths modified.
> 
> **Overview**
> Extends **"Paid by MetaMask"** on the confirmation fee row to **Money account deposits** when all pay fees are zero and quotes exist—the same subsidized-fee behavior already used for mUSD conversion.
> 
> `useIsPaidByMetaMask` now treats `TransactionType.moneyAccountDeposit` as supported and **returns false** when a fiat payment method is selected (`selectedPaymentMethodId` from `useTransactionPayFiatPayment`), so Apple Pay and similar flows do not show the subsidized label. Tests cover the new deposit type in `bridge-fee-row` and the fiat-payment guard in the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e02bc6b62702d13cf1f2b5b20f61d573b288b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->