### PR TITLE
feat(ci): add per-directive blocking flag to PR template checks (MCWP-649)

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -19,7 +19,10 @@ markdown and must NOT be removed or edited without updating the validator regist
   type=manual-testing Section must have real testing steps or an explicit N/A.
   type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
   type=checklist      Section must have all checkboxes consciously checked.
-  required=true|false Whether a missing/invalid section blocks the PR check.
+  required=true|false Whether a missing/invalid section runs the validator at all.
+  blocking=true|false Whether a failure of this check fails the CI workflow.
+                      Default: false — failures are shown as warnings in the sticky
+                      comment but do not block the PR.
 
 Sections without a directive are checked for structural presence only.
 -->
@@ -36,7 +39,7 @@ Write a short description of the changes included in this pull request, also inc
 
 ## **Changelog**
 
-<!-- mms-check: type=changelog required=true -->
+<!-- mms-check: type=changelog required=true blocking=true -->
 
 <!--
 If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:

--- a/.github/scripts/check-template-and-add-labels.test.ts
+++ b/.github/scripts/check-template-and-add-labels.test.ts
@@ -172,5 +172,137 @@ describe('check-template-and-add-labels — base-branch guard', () => {
       // runAllChecks being called proves the base-branch guard did not short-circuit.
       expect(mockRunAllChecks).toHaveBeenCalled();
     });
+
+    it('warning-only failures: exits 0, posts sticky comment, removes label, calls core.warning not setFailed', async () => {
+      process.env.LABEL_TOKEN = 'test-token';
+      mockContextPayload.pull_request = {
+        number: 42,
+        base: { ref: 'main' },
+        draft: false,
+      };
+      mockRunAllChecks.mockReturnValue([
+        { ok: false, reason: 'Description is empty.', blocking: false },
+      ]);
+
+      await loadModule();
+
+      // With babel's transform-inline-environment-variables, process.env reads are
+      // compiled as their build-time values (undefined for LABEL_TOKEN in CI). The
+      // LABEL_TOKEN guard at the top of main() always calls setFailed('LABEL_TOKEN
+      // not found'), but code falls through (no early return there) to the actual
+      // check logic. We therefore assert that setFailed was NOT called with a blocking
+      // issue reason (which is what the warning path must never produce).
+      expect(mockSetFailed).not.toHaveBeenCalledWith(
+        expect.stringContaining('blocking issues'),
+      );
+      expect(mockCoreWarning).toHaveBeenCalledWith(
+        expect.stringContaining('Description is empty.'),
+      );
+      // Label removed because all section headings are present (template mock matches everything).
+      expect(mockRemoveLabelFromLabelableIfPresent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ name: 'INVALID-PR-TEMPLATE' }),
+      );
+      // Sticky comment is posted with a non-null body (renderFailureComment is mocked).
+      expect(mockUpsertStickyComment).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(String),
+      );
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('blocking failure: exits 1, posts sticky comment, removes label, calls setFailed not warning', async () => {
+      process.env.LABEL_TOKEN = 'test-token';
+      mockContextPayload.pull_request = {
+        number: 42,
+        base: { ref: 'main' },
+        draft: false,
+      };
+      mockRunAllChecks.mockReturnValue([
+        { ok: false, reason: 'Changelog section is missing.', blocking: true },
+      ]);
+
+      await loadModule();
+
+      expect(mockSetFailed).toHaveBeenCalledWith(
+        expect.stringContaining('Changelog section is missing.'),
+      );
+      expect(mockCoreWarning).not.toHaveBeenCalled();
+      // Label removed because all section headings are present.
+      expect(mockRemoveLabelFromLabelableIfPresent).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ name: 'INVALID-PR-TEMPLATE' }),
+      );
+      // Sticky comment is posted with a non-null body.
+      expect(mockUpsertStickyComment).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(String),
+      );
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('mixed blocking+warning failures: exits 1 driven by the blocking failure', async () => {
+      process.env.LABEL_TOKEN = 'test-token';
+      mockContextPayload.pull_request = {
+        number: 42,
+        base: { ref: 'main' },
+        draft: false,
+      };
+      mockRunAllChecks.mockReturnValue([
+        { ok: false, reason: 'Changelog missing.', blocking: true },
+        { ok: false, reason: 'Description empty.', blocking: false },
+      ]);
+
+      await loadModule();
+
+      expect(mockSetFailed).toHaveBeenCalledWith(
+        expect.stringContaining('Changelog missing.'),
+      );
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('draft PR with blocking failure: exits 1 (same rules as ready-for-review)', async () => {
+      process.env.LABEL_TOKEN = 'test-token';
+      mockContextPayload.pull_request = {
+        number: 42,
+        base: { ref: 'main' },
+        draft: true,
+      };
+      mockRunAllChecks.mockReturnValue([
+        { ok: false, reason: 'Changelog missing.', blocking: true },
+      ]);
+
+      await loadModule();
+
+      expect(mockSetFailed).toHaveBeenCalled();
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('draft PR with warning-only failures: exits 0 (informational, same as ready-for-review)', async () => {
+      process.env.LABEL_TOKEN = 'test-token';
+      mockContextPayload.pull_request = {
+        number: 42,
+        base: { ref: 'main' },
+        draft: true,
+      };
+      mockRunAllChecks.mockReturnValue([
+        { ok: false, reason: 'Description empty.', blocking: false },
+      ]);
+
+      await loadModule();
+
+      // Same comment as warning-only test above: LABEL_TOKEN is inlined as undefined
+      // so setFailed('LABEL_TOKEN not found') fires first, but code falls through.
+      // Assert the workflow-blocking path is NOT triggered.
+      expect(mockSetFailed).not.toHaveBeenCalledWith(
+        expect.stringContaining('blocking issues'),
+      );
+      expect(mockCoreWarning).toHaveBeenCalled();
+      expect(processExitSpy).toHaveBeenCalledWith(0);
+    });
   });
 });

--- a/.github/scripts/check-template-and-add-labels.ts
+++ b/.github/scripts/check-template-and-add-labels.ts
@@ -184,57 +184,62 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
-    // Draft PRs see the same checks but with informational status only, so
-    // authors can preview what to fix before flipping to "Ready for review".
-    // The check name stays identical in both states; branch protection can
-    // require it without extra wiring.
-    const isDraft = Boolean(context.payload.pull_request?.draft);
     const hasNoChangelogLabel = labelable.labels?.some(
       (label) => label.name === 'no-changelog',
     );
 
-    const failures: { ok: false; reason: string }[] = [];
+    // Section-heading check: every expected `## **…**` body heading must be present.
+    // The INVALID-PR-TEMPLATE label tracks this check only (pre-#30541 semantics) —
+    // semantic failures surface through the sticky comment and exit status instead.
+    const sectionHeadingsMissing = templateType !== TemplateType.PullRequest;
 
-    if (templateType !== TemplateType.PullRequest) {
+    if (sectionHeadingsMissing) {
+      await addLabelToLabelable(octokit, labelable, invalidPullRequestTemplateLabel);
+    } else {
+      await removeLabelFromLabelableIfPresent(octokit, labelable, invalidPullRequestTemplateLabel);
+    }
+
+    const failures: { ok: false; reason: string; blocking: boolean }[] = [];
+
+    if (sectionHeadingsMissing) {
+      // Section-heading mismatch is informational (non-blocking), matching pre-#30541 behavior.
       failures.push({
         ok: false,
         reason:
-          'PR body does not match `pull-request-template.md` (one or more section titles are missing). See https://github.com/MetaMask/metamask-mobile/blob/main/.github/scripts/shared/pr-template-checks.ts#L15-L23.',
+          'PR body does not match `pull-request-template.md` (one or more section headings are missing). See https://github.com/MetaMask/metamask-mobile/blob/main/.github/scripts/shared/pr-template-checks.ts#L15-L23.',
+        blocking: false,
       });
     } else {
       failures.push(...runAllChecks(labelable.body, Boolean(hasNoChangelogLabel)));
     }
 
     if (failures.length > 0) {
-      const bullets = failures.map((f) => `- ${f.reason}`).join('\n');
-      await addLabelToLabelable(
-        octokit,
-        labelable,
-        invalidPullRequestTemplateLabel,
-      );
+      const blockingFailures = failures.filter((f) => f.blocking);
+      const warningFailures = failures.filter((f) => !f.blocking);
+
       await upsertStickyComment(
         octokit,
         labelable,
-        renderFailureComment(failures.map((f) => f.reason), isDraft),
+        renderFailureComment({
+          blocking: blockingFailures.map((f) => f.reason),
+          warning: warningFailures.map((f) => f.reason),
+        }),
       );
 
-      if (isDraft) {
-        core.warning(
-          `PR template is not yet ready for review:\n${bullets}\n\nThis check is informational while the PR is in draft.`,
-        );
-        process.exit(0);
+      if (blockingFailures.length > 0) {
+        const bullets = blockingFailures.map((f) => `- ${f.reason}`).join('\n');
+        core.setFailed(`PR template has blocking issues:\n${bullets}`);
+        process.exit(1);
+        return;
       }
 
-      core.setFailed(`PR template is not ready for review:\n${bullets}`);
-      process.exit(1);
+      const bullets = warningFailures.map((f) => `- ${f.reason}`).join('\n');
+      core.warning(`PR template has warnings (informational, does not block merging):\n${bullets}`);
+      process.exit(0);
+      return;
     }
 
     console.log("PR matches 'pull-request-template.md' template and is materially complete.");
-    await removeLabelFromLabelableIfPresent(
-      octokit,
-      labelable,
-      invalidPullRequestTemplateLabel,
-    );
     await upsertStickyComment(octokit, labelable, null);
   } else {
     core.setFailed(

--- a/.github/scripts/shared/pr-template-checks.test.ts
+++ b/.github/scripts/shared/pr-template-checks.test.ts
@@ -559,8 +559,8 @@ describe('buildValidationPlan', () => {
     ].join('\n');
     const plan = buildValidationPlan(tokenize(md));
     expect(plan).toHaveLength(2);
-    expect(plan[0]).toEqual({ title: '## **Section A**', type: 'text', required: true });
-    expect(plan[1]).toEqual({ title: '## **Section B**', type: 'changelog', required: false });
+    expect(plan[0]).toEqual({ title: '## **Section A**', type: 'text', required: true, blocking: false });
+    expect(plan[1]).toEqual({ title: '## **Section B**', type: 'changelog', required: false, blocking: false });
   });
 
   it('skips sections that have no directive', () => {
@@ -614,6 +614,24 @@ describe('buildValidationPlan', () => {
     const plan = buildValidationPlan(tokenize(md));
     expect(plan[0].required).toBe(true);
   });
+
+  it('reads blocking=true from the directive', () => {
+    const md = '## **Section**\n<!-- mms-check: type=changelog required=true blocking=true -->';
+    const plan = buildValidationPlan(tokenize(md));
+    expect(plan[0].blocking).toBe(true);
+  });
+
+  it('reads blocking=false from the directive', () => {
+    const md = '## **Section**\n<!-- mms-check: type=text required=true blocking=false -->';
+    const plan = buildValidationPlan(tokenize(md));
+    expect(plan[0].blocking).toBe(false);
+  });
+
+  it('defaults blocking to false when the key is absent', () => {
+    const md = '## **Section**\n<!-- mms-check: type=text required=true -->';
+    const plan = buildValidationPlan(tokenize(md));
+    expect(plan[0].blocking).toBe(false);
+  });
 });
 
 // ─── validatePlanTypes ────────────────────────────────────────────────────────
@@ -622,12 +640,12 @@ describe('validatePlanTypes', () => {
   const registry = { text: () => ({ ok: true as const }) };
 
   it('does not throw when all types are present in the registry', () => {
-    const plan = [{ title: '## Foo', type: 'text', required: true }];
+    const plan = [{ title: '## Foo', type: 'text', required: true, blocking: false }];
     expect(() => validatePlanTypes(plan, registry)).not.toThrow();
   });
 
   it('throws for an unknown type', () => {
-    const plan = [{ title: '## Bar', type: 'unknown-type', required: true }];
+    const plan = [{ title: '## Bar', type: 'unknown-type', required: true, blocking: false }];
     expect(() => validatePlanTypes(plan, registry)).toThrow(
       /Unknown mms-check type "unknown-type" in section "## Bar"/,
     );
@@ -635,9 +653,157 @@ describe('validatePlanTypes', () => {
 
   it('throws for the first unknown type in a mixed plan', () => {
     const plan = [
-      { title: '## Good', type: 'text', required: true },
-      { title: '## Bad', type: 'typo-type', required: true },
+      { title: '## Good', type: 'text', required: true, blocking: false },
+      { title: '## Bad', type: 'typo-type', required: true, blocking: false },
     ];
     expect(() => validatePlanTypes(plan, registry)).toThrow(/typo-type/);
+  });
+});
+
+// ─── parseDirective — blocking key ────────────────────────────────────────────
+
+describe('parseDirective — blocking key', () => {
+  it('parses blocking=true', () => {
+    expect(parseDirective('mms-check: type=changelog required=true blocking=true')).toEqual({
+      type: 'changelog',
+      required: 'true',
+      blocking: 'true',
+    });
+  });
+
+  it('parses blocking=false', () => {
+    expect(parseDirective('mms-check: type=text required=true blocking=false')).toEqual({
+      type: 'text',
+      required: 'true',
+      blocking: 'false',
+    });
+  });
+
+  it('does not include a blocking key when the field is absent', () => {
+    const result = parseDirective('mms-check: type=text required=true');
+    expect(result).not.toHaveProperty('blocking');
+  });
+});
+
+// ─── runAllChecks — blocking flag stamping ────────────────────────────────────
+
+describe('runAllChecks — blocking flag on failures', () => {
+  it('stamps blocking:true on the changelog failure when template has blocking=true', () => {
+    // The real pull-request-template.md tags changelog with blocking=true.
+    const body = `
+## **Description**
+
+Real description.
+
+## **Changelog**
+
+CHANGELOG entry:
+
+## **Related issues**
+
+Fixes: #1
+
+## **Manual testing steps**
+
+\`\`\`gherkin
+Feature: ready for review
+
+  Scenario: user opens the PR
+    Given the author fills the PR
+    When user submits
+    Then the validator passes
+\`\`\`
+
+## **Screenshots/Recordings**
+
+### **Before**
+
+N/A
+
+### **After**
+
+N/A
+
+## **Pre-merge author checklist**
+
+- [x] Followed contributor docs
+- [x] Completed PR template
+- [x] Included tests if applicable
+- [x] Documented code with JSDoc if applicable
+- [x] Applied right labels
+
+#### Performance checks (if applicable)
+
+- [x] Tested on Android
+- [x] Tested with power user scenario
+- [x] Instrumented with Sentry traces if applicable
+
+## **Pre-merge reviewer checklist**
+
+- [ ] Reviewer item
+`.trim();
+
+    const failures = runAllChecks(body, false);
+    const changelogFailure = failures.find((f) => f.reason.includes('Changelog'));
+    expect(changelogFailure).toBeDefined();
+    expect(changelogFailure?.blocking).toBe(true);
+  });
+
+  it('stamps blocking:false on non-blocking failures', () => {
+    const body = `
+## **Description**
+
+## **Changelog**
+
+CHANGELOG entry: Real entry.
+
+## **Related issues**
+
+Fixes: #1
+
+## **Manual testing steps**
+
+\`\`\`gherkin
+Feature: ready for review
+
+  Scenario: user opens the PR
+    Given the author fills the PR
+    When user submits
+    Then the validator passes
+\`\`\`
+
+## **Screenshots/Recordings**
+
+### **Before**
+
+N/A
+
+### **After**
+
+N/A
+
+## **Pre-merge author checklist**
+
+- [x] Followed contributor docs
+- [x] Completed PR template
+- [x] Included tests if applicable
+- [x] Documented code with JSDoc if applicable
+- [x] Applied right labels
+
+#### Performance checks (if applicable)
+
+- [x] Tested on Android
+- [x] Tested with power user scenario
+- [x] Instrumented with Sentry traces if applicable
+
+## **Pre-merge reviewer checklist**
+
+- [ ] Reviewer item
+`.trim();
+
+    const failures = runAllChecks(body, false);
+    const descriptionFailure = failures.find((f) => f.reason.includes('Description'));
+    expect(descriptionFailure).toBeDefined();
+    expect(descriptionFailure?.blocking).toBe(false);
   });
 });

--- a/.github/scripts/shared/pr-template-checks.ts
+++ b/.github/scripts/shared/pr-template-checks.ts
@@ -14,7 +14,7 @@ import { tokenize, sectionTokens, Token } from './markdown-tokenizer';
 
 export type PrTemplateCheckResult =
   | { ok: true }
-  | { ok: false; reason: string };
+  | { ok: false; reason: string; blocking: boolean };
 
 // ─── Validation-plan types ───────────────────────────────────────────────────
 
@@ -24,6 +24,8 @@ interface ValidationPlanEntry {
   // Validator type key, must exist in VALIDATORS or module load throws.
   type: string;
   required: boolean;
+  // Whether a failure of this check fails the workflow. Default: false.
+  blocking: boolean;
 }
 
 type ValidatorContext = { hasNoChangelogLabel: boolean };
@@ -87,13 +89,15 @@ export function buildValidationPlan(tokens: Token[]): ValidationPlanEntry[] {
       !directiveFoundForCurrent
     ) {
       const directive = parseDirective(token.content);
-      if (directive?.type) {
-        plan.push({
-          title: currentHeading,
-          type: directive.type,
-          // Any value other than the explicit string "false" means required.
-          required: directive.required !== 'false',
-        });
+        if (directive?.type) {
+          plan.push({
+            title: currentHeading,
+            type: directive.type,
+            // Any value other than the explicit string "false" means required.
+            required: directive.required !== 'false',
+            // Only the explicit string "true" makes a check blocking; default is false.
+            blocking: directive.blocking === 'true',
+          });
         directiveFoundForCurrent = true;
       }
     }
@@ -442,14 +446,14 @@ export function hasChangelogEntry(
 export function runAllChecks(
   body: string,
   hasNoChangelogLabel: boolean,
-): { ok: false; reason: string }[] {
+): { ok: false; reason: string; blocking: boolean }[] {
   const ctx = { hasNoChangelogLabel };
-  const failures: { ok: false; reason: string }[] = [];
+  const failures: { ok: false; reason: string; blocking: boolean }[] = [];
   for (const entry of VALIDATION_PLAN) {
     if (!entry.required) continue;
     const section = extractSection(body, entry.title) ?? '';
     const result = VALIDATORS[entry.type](section, ctx);
-    if (!result.ok) failures.push(result);
+    if (!result.ok) failures.push({ ...result, blocking: entry.blocking });
   }
   return failures;
 }

--- a/.github/scripts/shared/pr-template-comment.test.ts
+++ b/.github/scripts/shared/pr-template-comment.test.ts
@@ -52,38 +52,67 @@ function makeOctokit(
 
 describe('renderFailureComment', () => {
   it('contains the static heading', () => {
-    const result = renderFailureComment(['Reason A'], false);
+    const result = renderFailureComment({ blocking: ['Reason A'], warning: [] });
     expect(result).toContain('PR template — items to address before');
   });
 
-  it('lists each reason as a bullet', () => {
-    const result = renderFailureComment(['First reason', 'Second reason'], false);
-    expect(result).toContain('- First reason');
-    expect(result).toContain('- Second reason');
-  });
-
   it('contains the ready-for-review doc link', () => {
-    const result = renderFailureComment(['x'], false);
+    const result = renderFailureComment({ blocking: [], warning: ['x'] });
     expect(result).toContain('ready-for-review.md');
   });
 
-  it('shows the blocking message when isDraft is false', () => {
-    const result = renderFailureComment(['x'], false);
-    expect(result).toContain('blocking');
-    expect(result).not.toContain('informational');
-  });
-
-  it('shows the informational message when isDraft is true', () => {
-    const result = renderFailureComment(['x'], true);
-    expect(result).toContain('informational');
-    // The draft note mentions "blocking" only in the future-tense clause
-    // ("will start blocking once…"), not as the primary description.
-    expect(result).not.toMatch(/^_This check is blocking\./m);
-  });
-
   it('does not prepend the sticky marker (that is done by upsertStickyComment)', () => {
-    const result = renderFailureComment(['x'], false);
+    const result = renderFailureComment({ blocking: ['x'], warning: [] });
     expect(result).not.toContain('<!-- pr-template-checks -->');
+  });
+
+  describe('blocking-only failures', () => {
+    it('shows the Blocking section with the reason', () => {
+      const result = renderFailureComment({ blocking: ['Missing changelog'], warning: [] });
+      expect(result).toContain('**Blocking**');
+      expect(result).toContain('- Missing changelog');
+    });
+
+    it('does not show the Warnings section when there are no warnings', () => {
+      const result = renderFailureComment({ blocking: ['x'], warning: [] });
+      expect(result).not.toContain('**Warnings**');
+    });
+  });
+
+  describe('warning-only failures', () => {
+    it('shows the Warnings section with the reason', () => {
+      const result = renderFailureComment({ blocking: [], warning: ['Missing description'] });
+      expect(result).toContain('**Warnings**');
+      expect(result).toContain('- Missing description');
+    });
+
+    it('does not show the Blocking section when there are no blocking failures', () => {
+      const result = renderFailureComment({ blocking: [], warning: ['x'] });
+      expect(result).not.toContain('**Blocking**');
+    });
+  });
+
+  describe('mixed failures', () => {
+    it('shows both Blocking and Warnings sections', () => {
+      const result = renderFailureComment({
+        blocking: ['Missing changelog'],
+        warning: ['Missing description'],
+      });
+      expect(result).toContain('**Blocking**');
+      expect(result).toContain('- Missing changelog');
+      expect(result).toContain('**Warnings**');
+      expect(result).toContain('- Missing description');
+    });
+
+    it('lists each reason as a bullet in the correct group', () => {
+      const result = renderFailureComment({
+        blocking: ['B1', 'B2'],
+        warning: ['W1'],
+      });
+      expect(result).toContain('- B1');
+      expect(result).toContain('- B2');
+      expect(result).toContain('- W1');
+    });
   });
 });
 

--- a/.github/scripts/shared/pr-template-comment.ts
+++ b/.github/scripts/shared/pr-template-comment.ts
@@ -10,22 +10,39 @@ const READY_FOR_REVIEW_DOC_URL =
   'https://github.com/MetaMask/metamask-mobile/blob/main/docs/readme/ready-for-review.md';
 
 /**
- * Build the markdown body of the sticky comment, given the aggregated failure
- * reasons and the draft flag. The marker is prepended by `upsertStickyComment`
- * so callers never need to think about it.
+ * Build the markdown body of the sticky comment from grouped failure reasons.
+ * Blocking failures fail the workflow; warning failures are informational.
+ * Groups with no entries are omitted so authors never see an empty section.
+ * The marker is prepended by `upsertStickyComment` so callers never need to
+ * think about it.
  */
-export function renderFailureComment(
-  reasons: string[],
-  isDraft: boolean,
-): string {
+export function renderFailureComment({
+  blocking,
+  warning,
+}: {
+  blocking: string[];
+  warning: string[];
+}): string {
   const heading =
     '### PR template — items to address before "Ready for review"';
-  const draftNote = isDraft
-    ? '_This check is informational while the PR is in draft. It will start blocking once you mark the PR as Ready for review._'
-    : '_This check is blocking. Address every item below, then push to re-run._';
-  const bullets = reasons.map((r) => `- ${r}`).join('\n');
   const footer = `See [docs/readme/ready-for-review.md](${READY_FOR_REVIEW_DOC_URL}) for the full Definition of Ready for Review.`;
-  return [heading, '', draftNote, '', bullets, '', footer].join('\n');
+
+  const sections: string[] = [heading, ''];
+
+  if (blocking.length > 0) {
+    sections.push('**Blocking** — these items fail the workflow until fixed:');
+    sections.push(blocking.map((r) => `- ${r}`).join('\n'));
+    sections.push('');
+  }
+
+  if (warning.length > 0) {
+    sections.push('**Warnings** — informational, address before merging:');
+    sections.push(warning.map((r) => `- ${r}`).join('\n'));
+    sections.push('');
+  }
+
+  sections.push(footer);
+  return sections.join('\n');
 }
 
 /**


### PR DESCRIPTION
## **Description**

Restores the blocking behavior that existed before [#30541](https://github.com/MetaMask/metamask-mobile/pull/30541): **only the `CHANGELOG entry:` check fails the CI workflow**. All other semantic checks (description, issue link, manual testing, screenshots, checklist) become informational warnings shown in the sticky comment without blocking the PR.

Adds a `blocking=true|false` key to the `mms-check` directive grammar (default `false`). Today only `type=changelog` is tagged `blocking=true`, matching pre-#30541 behavior. Draft and ready-for-review PRs follow identical rules (the `isDraft` preview behavior introduced by #30541 is removed).

**Behavior matrix after change:**

| Scenario | Exit | `INVALID-PR-TEMPLATE` label | Sticky comment |
|---|---|---|---|
| Non-`main` base | 0 | cleared | cleared |
| All headings present, no failures | 0 | removed | deleted |
| All headings present, warnings only | 0 | removed | Warnings section |
| All headings present, blocking failure | 1 | removed | Blocking + Warnings sections |
| Section heading missing | 0* | **added** | listed under Warnings |
| Section heading missing + blocking failure | 1 | **added** | Blocking + Warnings sections |
| Draft PR | same rules as ready-for-review | | |

\* Unless a blocking semantic failure also exists.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-649

## **Manual testing steps**

```gherkin
Feature: PR template CI check blocking behavior

  Scenario: missing CHANGELOG entry blocks the workflow
    Given a PR targeting main with no CHANGELOG entry line and no no-changelog label
    When the PR template check runs
    Then CI exits 1
    And the sticky comment shows a "Blocking" section with the changelog reason
    And the INVALID-PR-TEMPLATE label is not added

  Scenario: missing description is a warning only
    Given a PR targeting main with a valid CHANGELOG entry but an empty description
    When the PR template check runs
    Then CI exits 0
    And the sticky comment shows a "Warnings" section with the description reason
    And no INVALID-PR-TEMPLATE label is added

  Scenario: draft PR follows the same rules as ready-for-review
    Given a draft PR targeting main with a valid CHANGELOG entry but an empty description
    When the PR template check runs
    Then CI exits 0
    And the sticky comment shows a "Warnings" section (no special draft treatment)

  Scenario: PR targeting a non-main branch skips all checks
    Given a PR targeting a release branch
    When the PR template check runs
    Then CI exits 0 with no validation performed
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge gating and author-facing CI behavior for all PRs targeting main; misconfigured `blocking` directives could accidentally block or fail to block merges.
> 
> **Overview**
> Introduces a **`blocking`** flag on `mms-check` directives (default **`false`**) so each template section can either fail the workflow or only show up as a warning. **Changelog** is the only section tagged **`blocking=true`**, matching behavior before #30541; other semantic checks (description, issue link, manual testing, screenshots, checklist) are warnings that still appear in the sticky comment but do not fail CI.
> 
> The PR template check orchestrator **drops draft-only “informational” mode**—draft and ready-for-review PRs use the same rules. **`INVALID-PR-TEMPLATE`** is applied only when required **section headings** are missing; semantic issues no longer add that label. Exit status is driven by whether any **blocking** failure exists (`setFailed` / exit 1 vs `core.warning` / exit 0). Sticky comments are split into **Blocking** and **Warnings** sections instead of a single draft-dependent message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa07a089f3be2c2342a8df78e016c42e5ce5fdc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->