### PR TITLE
fix: batch sell tx bridge status bump (#31098)

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts
@@ -760,6 +760,23 @@ describe('Transaction Controller Init', () => {
         expect(result).toEqual({ transactionHash: '0xde702' });
       });
 
+      it('prioritizes Delegation7702PublishHook over STX when isGasFeeIncluded is true', async () => {
+        submitSmartTransactionHookMock.mockResolvedValue({
+          transactionHash: '0xsmarthash',
+        });
+
+        const hooks = testConstructorOption('hooks');
+        const result = await hooks?.publish?.({
+          ...MOCK_TRANSACTION_META,
+          chainId: '0x13',
+          isGasFeeIncluded: true,
+        });
+
+        expect(mockDelegation7702Hook).toHaveBeenCalled();
+        expect(submitSmartTransactionHookMock).not.toHaveBeenCalled();
+        expect(result).toEqual({ transactionHash: '0xde702' });
+      });
+
       it('publishes via Smart Transactions when supported and returns its transactionHash', async () => {
         submitSmartTransactionHookMock.mockResolvedValue({
           transactionHash: '0xsmarthash',

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -265,10 +265,15 @@ async function publishHook({
     keyringController,
   );
 
+  const isSwapGasIncluded7702 = Boolean(transactionMeta.isGasFeeIncluded);
+
   if (
     keyringSupports7702 &&
     !isRevokeDelegation &&
-    (!shouldUseSmartTransaction || !sendBundleSupport || isExternalSign)
+    (isSwapGasIncluded7702 ||
+      !shouldUseSmartTransaction ||
+      !sendBundleSupport ||
+      isExternalSign)
   ) {
     const hook = new Delegation7702PublishHook({
       isAtomicBatchSupported: transactionController.isAtomicBatchSupported.bind(

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.12.0",
     "@metamask/bridge-controller": "^73.2.0",
-    "@metamask/bridge-status-controller": "^72.0.0",
+    "@metamask/bridge-status-controller": "^72.0.2",
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/chomp-api-service": "^3.1.0",
     "@metamask/client-controller": "^1.0.1",

--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -201,7 +201,7 @@ export const dismissDeveloperMenuPlaywright = async (): Promise<void> => {
  * @throws {Error} Throws an error if app fails to stabilize within timeout
  */
 export const waitForAppReady = async (
-  timeout: number = 20000,
+  timeout: number = 60000,
 ): Promise<void> => {
   const startTime = Date.now();
 

--- a/tests/helpers/swap/smart-transactions-mocks.ts
+++ b/tests/helpers/swap/smart-transactions-mocks.ts
@@ -71,7 +71,7 @@ export async function setupSmartTransactionsMocks(
   // Mock POST /getFees – returns a single fee tier so createSignedTransactions
   // produces a non-empty rawTxs array that can be forwarded to Anvil.
   await setupMockRequest(mockServer, {
-    url: /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/getFees/,
+    url: /\.api\.cx\.metamask\.io\/(v\d+\/)?networks\/\d+\/getFees/,
     response: GET_FEES_RESPONSE,
     requestMethod: 'POST',
     responseCode: 200,
@@ -83,7 +83,7 @@ export async function setupSmartTransactionsMocks(
     .forPost('/proxy')
     .matching((request) => {
       const url = getDecodedProxiedURL(request.url);
-      return /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/submitTransactions/.test(
+      return /\.api\.cx\.metamask\.io\/(v\d+\/)?networks\/\d+\/submitTransactions/.test(
         url,
       );
     })
@@ -150,11 +150,117 @@ export async function setupSmartTransactionsMocks(
   };
 
   await setupMockRequest(mockServer, {
-    url: /transaction\.api\.cx\.metamask\.io\/networks\/\d+\/batchStatus/,
+    url: /\.api\.cx\.metamask\.io\/(v\d+\/)?networks\/\d+\/batchStatus/,
     response: GET_BATCH_STATUS_SUCCESS,
     requestMethod: 'GET',
     responseCode: 200,
   });
+
+  // -- 7702 Relay mocks --
+  // When a quote has gasIncluded7702: true the delegation-7702-publish hook
+  // bypasses STX and submits through the Sentinel relay API instead.
+  // We mock both the submit (JSON-RPC POST) and polling (GET) endpoints,
+  // and send a simple tx to Anvil so TransactionController finds a receipt.
+
+  const RELAY_UUID = 'relay-7702-e2e-uuid';
+  let relayTxHash: string | undefined;
+
+  // Mock POST eth_sendRelayTransaction – JSON-RPC to sentinel root URL.
+  await mockServer
+    .forPost('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      // Relay submit goes to the root sentinel URL (no path beyond /)
+      return /tx-sentinel[^/]*\.api\.cx\.metamask\.io\/?$/.test(url);
+    })
+    .asPriority(1000)
+    .thenCallback(async (request) => {
+      let rpcId: unknown = 1;
+      try {
+        const bodyText = await request.body.getText();
+        const body = JSON.parse(bodyText ?? '{}');
+        rpcId = body?.id ?? 1;
+      } catch {
+        // Ignore parse errors
+      }
+
+      // Impersonate the test wallet and send a dummy tx to Anvil so a real
+      // receipt exists when TransactionController polls eth_getTransactionReceipt.
+      const walletAddress = '0x76cf1CdD1fcC252442b50D6e97207228aA4aefC3';
+      try {
+        const anvilUrl = getActualAnvilRpcUrl();
+
+        await fetch(anvilUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'anvil_impersonateAccount',
+            params: [walletAddress],
+            id: 1,
+          }),
+        });
+
+        const txResp = await fetch(anvilUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'eth_sendTransaction',
+            params: [{ from: walletAddress, to: walletAddress, value: '0x0' }],
+            id: 2,
+          }),
+        });
+
+        const txResult = await txResp.json();
+        relayTxHash = txResult?.result;
+
+        await fetch(anvilUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'anvil_stopImpersonatingAccount',
+            params: [walletAddress],
+            id: 3,
+          }),
+        });
+      } catch {
+        // Non-fatal: the relay UUID is still returned.
+      }
+
+      return {
+        statusCode: 200,
+        json: {
+          jsonrpc: '2.0',
+          result: { uuid: RELAY_UUID },
+          id: rpcId,
+        },
+      };
+    });
+
+  // Mock GET /smart-transactions/{uuid} – relay polling endpoint.
+  // waitForRelayResult polls this until status !== PENDING.
+  await mockServer
+    .forGet('/proxy')
+    .matching((request) => {
+      const url = getDecodedProxiedURL(request.url);
+      return /tx-sentinel[^/]*\.api\.cx\.metamask\.io.*\/smart-transactions\//.test(
+        url,
+      );
+    })
+    .asPriority(1000)
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        transactions: [
+          {
+            hash: relayTxHash,
+            status: 'VALIDATED',
+          },
+        ],
+      },
+    }));
 
   // Mock GET /getTxStatus – fallback for same-chain swap tests.
   // Registered at priority 1 so bridge-mocks.ts (priority 999) always wins

--- a/tests/page-objects/Browser/TestSnaps.ts
+++ b/tests/page-objects/Browser/TestSnaps.ts
@@ -374,7 +374,6 @@ class TestSnaps {
     });
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton, {
-      checkStability: true,
       elemDescription: 'date-time picker OK',
     });
 
@@ -391,7 +390,6 @@ class TestSnaps {
     });
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton, {
-      checkStability: true,
       elemDescription: 'date picker OK',
     });
   }
@@ -403,7 +401,6 @@ class TestSnaps {
     });
 
     await Gestures.waitAndTap(this.dateTimePickerOkButton, {
-      checkStability: true,
       elemDescription: 'time picker OK',
     });
   }

--- a/tests/smoke/ramps/onramp-unified-buy.spec.ts
+++ b/tests/smoke/ramps/onramp-unified-buy.spec.ts
@@ -16,7 +16,7 @@ import {
   setupDepositOnRampMocks,
   setupBuyOnRampMocks,
 } from '../../api-mocking/mock-responses/ramps/ramps-mocks';
-import { remoteFeatureFlagRampsUnifiedEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { remoteFeatureFlagRampsUnifiedMatrixForE2E } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
 import { ONRAMP_PERSONA } from '../../api-mocking/mock-responses/ramps/onramp-persona-data';
 
@@ -32,7 +32,7 @@ const selectedRegion = RampsRegions[RampsRegionsEnum.UNITED_STATES];
 
 const newUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
-    ...remoteFeatureFlagRampsUnifiedEnabled(true),
+    ...remoteFeatureFlagRampsUnifiedMatrixForE2E(true, true),
     depositConfig: {
       active: true,
       providerApiKey: 'DUMMY_VALUE_FOR_TESTING',
@@ -46,7 +46,7 @@ const newUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
 const returningUserUnifiedBuyV2Mocks = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(
     mockServer,
-    remoteFeatureFlagRampsUnifiedEnabled(true),
+    remoteFeatureFlagRampsUnifiedMatrixForE2E(true, true),
   );
   await setupBuyOnRampMocks(mockServer, selectedRegion);
 };
@@ -81,6 +81,7 @@ describe(SmokeMoney('Onramp Unified Buy'), () => {
         fixture: new FixtureBuilder()
           .withNetworkController(CustomNetworks.Tenderly.Mainnet.providerConfig)
           .withRampsSelectedRegion(selectedRegion)
+          .withRampsUnifiedBuyRemoteFlagsSeededForE2E()
           .withMetaMetricsOptIn()
           .build(),
         restartDevice: true,
@@ -148,6 +149,7 @@ describe(SmokeMoney('Onramp Unified Buy'), () => {
         fixture: new FixtureBuilder()
           .withNetworkController(CustomNetworks.Tenderly.Mainnet.providerConfig)
           .withRampsSelectedRegion(selectedRegion)
+          .withRampsUnifiedBuyRemoteFlagsSeededForE2E()
           .withMetaMetricsOptIn()
           .build(),
         restartDevice: true,

--- a/tests/smoke/stake/stake-action-smoke.spec.ts
+++ b/tests/smoke/stake/stake-action-smoke.spec.ts
@@ -135,7 +135,7 @@ describe(SmokeStake('Stake from Actions'), (): void => {
         await loginToApp();
 
         await Assertions.expectElementToBeVisible(WalletView.earnButton, {
-          timeout: 45000,
+          timeout: 60000,
           description:
             'Earn button should be visible after balance loads from fixture state',
         });

--- a/tests/smoke/swap/bridge-action-smoke.spec.ts
+++ b/tests/smoke/swap/bridge-action-smoke.spec.ts
@@ -84,11 +84,11 @@ describe(SmokeSwap('Bridge functionality'), () => {
         // Open keypad by tapping source amount input (keypad is in BottomSheet, closed after token selection)
         await QuoteView.tapSourceAmountInput();
         await QuoteView.enterAmount(quantity);
-        await QuoteView.dismissKeypad();
         await Assertions.expectElementToBeVisible(QuoteView.networkFeeLabel, {
           timeout: 60000,
           description: 'Network fee label visible',
         });
+        await QuoteView.dismissKeypad();
         await Assertions.expectElementToBeVisible(QuoteView.confirmBridge, {
           description: 'Confirm bridge button visible',
         });

--- a/tests/smoke/swap/gasless-swap.spec.ts
+++ b/tests/smoke/swap/gasless-swap.spec.ts
@@ -28,7 +28,7 @@ describe(SmokeSwap('Gasless Swap - '), (): void => {
     jest.setTimeout(180000);
   });
 
-  it.skip('completes a gasless ETH to MUSD swap', async (): Promise<void> => {
+  it('completes a gasless ETH to MUSD swap', async (): Promise<void> => {
     await withFixtures(
       {
         fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {
@@ -107,7 +107,7 @@ describe(SmokeSwap('Gasless Swap - '), (): void => {
     );
   });
 
-  it.skip('completes a gasless USDC to MUSD swap (ERC-20 source with approval)', async (): Promise<void> => {
+  it('completes a gasless USDC to MUSD swap (ERC-20 source with approval)', async (): Promise<void> => {
     await withFixtures(
       {
         fixture: ({ localNodes }: { localNodes?: LocalNode[] }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7762,16 +7762,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^7.2.0, @metamask/account-tree-controller@npm:^7.5.0":
-  version: 7.5.0
-  resolution: "@metamask/account-tree-controller@npm:7.5.0"
+"@metamask/account-tree-controller@npm:^7.2.0, @metamask/account-tree-controller@npm:^7.5.1":
+  version: 7.5.1
+  resolution: "@metamask/account-tree-controller@npm:7.5.1"
   dependencies:
-    "@metamask/accounts-controller": "npm:^38.1.2"
+    "@metamask/accounts-controller": "npm:^39.0.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/multichain-account-service": "npm:^10.0.1"
+    "@metamask/multichain-account-service": "npm:^10.0.2"
     "@metamask/profile-sync-controller": "npm:^28.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
@@ -7783,7 +7783,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/b7d6f1505d3ae07304649c3d922e5275270a83bbb97391dd47d776656ad3b22b6926d75f3925e22b28dde7c6e713f23fd6a4de7f20c2d02a9eece27cd1b10f9f
+  checksum: 10/e037c51b800f4c63fbb6ca17d2e2c5f606e5b2456b3435d8e58358e83791c598f2a80d789799371029b7db539baf29b6fe8ef6cb6db12bcf2bba2bf7f71670cf
   languageName: node
   linkType: hard
 
@@ -7879,20 +7879,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^8.1.0, @metamask/assets-controller@npm:^8.2.0, @metamask/assets-controller@npm:^8.3.1":
-  version: 8.3.1
-  resolution: "@metamask/assets-controller@npm:8.3.1"
+"@metamask/assets-controller@npm:^8.2.0, @metamask/assets-controller@npm:^8.3.1, @metamask/assets-controller@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "@metamask/assets-controller@npm:8.3.2"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/account-tree-controller": "npm:^7.5.0"
-    "@metamask/accounts-controller": "npm:^38.1.2"
-    "@metamask/assets-controllers": "npm:^108.4.0"
+    "@metamask/account-tree-controller": "npm:^7.5.1"
+    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/assets-controllers": "npm:^108.5.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/client-controller": "npm:^1.0.1"
     "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/core-backend": "npm:^6.3.1"
+    "@metamask/core-backend": "npm:^6.3.2"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
@@ -7906,19 +7906,19 @@ __metadata:
     "@metamask/preferences-controller": "npm:^23.1.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
     "@metamask/utils": "npm:^11.9.0"
     async-mutex: "npm:^0.5.0"
     bignumber.js: "npm:^9.1.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/c2f327294320bb73260b1e9f64c2860bff6d549c17dc92e35f036f555f65ae10bcb6bbdcc08fd84cb8a69e503a2f15b4c4ca865bcc6fce4d909c94a82b18199f
+  checksum: 10/8a1fac3cb15503059ef297b9e4868e38d4571297017745d2341413389c49a1fd8b24c8c3a4f55e82be3485c2a1bb7e8e36bb5f93b6d44f19e29e7ade89584535
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^108.2.0, @metamask/assets-controllers@npm:^108.3.0, @metamask/assets-controllers@npm:^108.4.0":
-  version: 108.4.0
-  resolution: "@metamask/assets-controllers@npm:108.4.0"
+"@metamask/assets-controllers@npm:^108.3.0, @metamask/assets-controllers@npm:^108.4.0, @metamask/assets-controllers@npm:^108.5.0":
+  version: 108.5.0
+  resolution: "@metamask/assets-controllers@npm:108.5.0"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -7927,19 +7927,19 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^7.5.0"
-    "@metamask/accounts-controller": "npm:^38.1.2"
+    "@metamask/account-tree-controller": "npm:^7.5.1"
+    "@metamask/accounts-controller": "npm:^39.0.0"
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/core-backend": "npm:^6.3.1"
+    "@metamask/core-backend": "npm:^6.3.2"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^10.0.1"
+    "@metamask/multichain-account-service": "npm:^10.0.2"
     "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/network-enablement-controller": "npm:^5.2.0"
     "@metamask/permission-controller": "npm:^13.1.1"
@@ -7952,7 +7952,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
     "@metamask/storage-service": "npm:^1.0.1"
-    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
     "@metamask/utils": "npm:^11.9.0"
     "@tanstack/query-core": "npm:^5.62.16"
     "@types/bn.js": "npm:^5.1.5"
@@ -7969,7 +7969,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/d43d8690c1aca32270d749d687f44aa97cc92c509f62ed387e065852d21a2fe4eea33dd3a2c0029a9776619316511e055d285e9d0d8f33cea3f3a4cb06440538
+  checksum: 10/724c5b0a15d74fb3e28842003c4806a287b3fc31acd68dd40b6fb3eda30e70150d35dc391bd3690c4a0b413a4f215c77af04446bb8f2a348952224bc85541938
   languageName: node
   linkType: hard
 
@@ -8081,46 +8081,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^73.2.0":
-  version: 73.2.0
-  resolution: "@metamask/bridge-controller@npm:73.2.0"
+"@metamask/bridge-controller@npm:^73.2.0, @metamask/bridge-controller@npm:^73.2.1":
+  version: 73.2.1
+  resolution: "@metamask/bridge-controller@npm:73.2.1"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
     "@ethersproject/constants": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^38.1.2"
-    "@metamask/assets-controller": "npm:^8.1.0"
-    "@metamask/assets-controllers": "npm:^108.2.0"
+    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/assets-controller": "npm:^8.3.2"
+    "@metamask/assets-controllers": "npm:^108.5.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-network-controller": "npm:^3.1.2"
+    "@metamask/multichain-network-controller": "npm:^3.1.3"
     "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/polling-controller": "npm:^16.0.6"
     "@metamask/profile-sync-controller": "npm:^28.1.1"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.1"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/7d093196ce31e6644d31d3c1f047245b1142ef6c7248c058b9906c07505b716ca131c73b67659b684e0f1e9b371e6e2beb2ecb348ee3e1f7e63214f6c0aa03d8
+  checksum: 10/d1a540ace86ed9226ae5f02a65b6f00ab97d22a82fa14d766e2bebe9e4cc14ba6cbc36d965636916e136a17a9c85aa22ccb286425a760c9327de429230704a50
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^72.0.0":
-  version: 72.0.0
-  resolution: "@metamask/bridge-status-controller@npm:72.0.0"
+"@metamask/bridge-status-controller@npm:^72.0.0, @metamask/bridge-status-controller@npm:^72.0.2":
+  version: 72.0.2
+  resolution: "@metamask/bridge-status-controller@npm:72.0.2"
   dependencies:
-    "@metamask/accounts-controller": "npm:^38.1.2"
+    "@metamask/accounts-controller": "npm:^39.0.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^73.2.0"
+    "@metamask/bridge-controller": "npm:^73.2.1"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
     "@metamask/keyring-controller": "npm:^26.0.0"
@@ -8130,11 +8130,11 @@ __metadata:
     "@metamask/profile-sync-controller": "npm:^28.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/transaction-controller": "npm:^66.0.1"
     "@metamask/utils": "npm:^11.9.0"
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
-  checksum: 10/123fec19759bd56988e937c7edb7e72cdfa1acd26d8b3870338d320dfc64b1f52d8d540b5e41cdabe06f147a035f3f71f0d46ad8063045fc825f417a61b43cbf
+  checksum: 10/60f2849e351bfa39c60f18bf30056e0720ad39fce4982a70bdf85b71e85a7da71e9174ea93c3bbf69fa65618ae27ea9fc55ea0e9cfae14b79b7445509e962260
   languageName: node
   linkType: hard
 
@@ -8294,11 +8294,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:^6.3.0, @metamask/core-backend@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@metamask/core-backend@npm:6.3.1"
+"@metamask/core-backend@npm:^6.3.0, @metamask/core-backend@npm:^6.3.2":
+  version: 6.3.2
+  resolution: "@metamask/core-backend@npm:6.3.2"
   dependencies:
-    "@metamask/accounts-controller": "npm:^38.1.2"
+    "@metamask/accounts-controller": "npm:^39.0.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^1.2.0"
@@ -8307,7 +8307,7 @@ __metadata:
     "@tanstack/query-core": "npm:^5.62.16"
     async-mutex: "npm:^0.5.0"
     uuid: "npm:^8.3.2"
-  checksum: 10/f267e17202738f6190da8edc7eeeb49941b76ba893d33c8e07fb2010bf0f9c44f360556199b2e5bc08db4e66296efec377b8d06cb7fabba2be99bf7c2a6d21c9
+  checksum: 10/97965ba67fc3574b857a8f18b66450e141d3ee58afe0a2788d08e55253183692421373c0c076ae75e5763f5206eb7be1af4235d4ab480881a9b80fcec6538541
   languageName: node
   linkType: hard
 
@@ -9262,12 +9262,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-account-service@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "@metamask/multichain-account-service@npm:10.0.1"
+"@metamask/multichain-account-service@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@metamask/multichain-account-service@npm:10.0.2"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
-    "@metamask/accounts-controller": "npm:^38.1.2"
+    "@metamask/accounts-controller": "npm:^39.0.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/eth-snap-keyring": "npm:^22.0.1"
     "@metamask/key-tree": "npm:^10.1.1"
@@ -9277,7 +9277,7 @@ __metadata:
     "@metamask/keyring-snap-client": "npm:^9.0.2"
     "@metamask/keyring-utils": "npm:^3.2.1"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/snap-account-service": "npm:^0.2.1"
+    "@metamask/snap-account-service": "npm:^0.3.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
@@ -9289,7 +9289,7 @@ __metadata:
     "@metamask/account-api": ^1.0.4
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/e522b621aa939f2cd3e8733574c137951275d2b209369e6765e005d26cc9a3b63842ce66bab8c705c78ee19f74cfcc14f59d1b3970e5bda1278efdbf2fc12f18
+  checksum: 10/14ed586988071cbfca53b6d5d263b391f1818e762eb1af175da33ddca38020eb82cdfcded3578093192c891e84ab7232112e8129cd2f98f10cce2d8c1f8d4b48
   languageName: node
   linkType: hard
 
@@ -9351,7 +9351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-network-controller@npm:^3.1.0, @metamask/multichain-network-controller@npm:^3.1.2, @metamask/multichain-network-controller@npm:^3.1.3":
+"@metamask/multichain-network-controller@npm:^3.1.0, @metamask/multichain-network-controller@npm:^3.1.3":
   version: 3.1.3
   resolution: "@metamask/multichain-network-controller@npm:3.1.3"
   dependencies:
@@ -10025,20 +10025,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snap-account-service@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@metamask/snap-account-service@npm:0.2.1"
+"@metamask/snap-account-service@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@metamask/snap-account-service@npm:0.3.0"
   dependencies:
     "@metamask/account-api": "npm:^1.0.4"
-    "@metamask/account-tree-controller": "npm:^7.5.0"
+    "@metamask/account-tree-controller": "npm:^7.5.1"
     "@metamask/eth-snap-keyring": "npm:^22.0.1"
+    "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/keyring-snap-sdk": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/utils": "npm:^11.9.0"
     lodash: "npm:^4.17.21"
-  checksum: 10/ab6b412b1bda09d2299ff97e24dacbf58ae6faafdc13ead7f4fe0b875472f9495811d59a48195259515d8057911900da184d37e5f285ad1732b189a359bb32d7
+  checksum: 10/b7088073cab6d3c208c33f16b14e7a2a047152efa1c432dd03702e0f4c67c8ca1fe40111f01ccfd6f77052fe9a8d79957a51a1d8272f27dd5ffa3e1d9b6cdc1d
   languageName: node
   linkType: hard
 
@@ -35353,7 +35355,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
     "@metamask/bridge-controller": "npm:^73.2.0"
-    "@metamask/bridge-status-controller": "npm:^72.0.0"
+    "@metamask/bridge-status-controller": "npm:^72.0.2"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.3.0"
     "@metamask/build-utils": "npm:^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9840,16 +9840,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/remote-feature-flag-controller@npm:^4.2.0, @metamask/remote-feature-flag-controller@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "@metamask/remote-feature-flag-controller@npm:4.2.1"
+"@metamask/remote-feature-flag-controller@npm:^4.2.0, @metamask/remote-feature-flag-controller@npm:^4.2.1, @metamask/remote-feature-flag-controller@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "@metamask/remote-feature-flag-controller@npm:4.2.2"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.0.0"
+    "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/utils": "npm:^11.9.0"
     uuid: "npm:^8.3.2"
-  checksum: 10/b789836eb03dfe45374a86209d00fad4b1e2284bd61fa7e0342504f577b2227336db01da67063b0166ece24edee7cb0482f63512143f0bbd5710942fba9b1d60
+  checksum: 10/ed03ff1ba63c7a0f2b221c3514eb71a8be4200ec543b90676a44930dc731920ac2c92dcc2b13a32ed4e4e8e7e7b28a26db443af9f4bf30f5e2b5785580b286ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fixes Batch Sell (and other gasless EIP-7702) transaction submission when Smart Transactions (STX) and send bundle are both enabled.

**Problem:** Quotes with `gasIncluded7702: true` must be published via the EIP-7702 delegation relay (`Delegation7702PublishHook`). When STX and send bundle were enabled, `publishHook` skipped the 7702 path and submitted via STX instead, causing transaction failures.

**Changes:**

1. **`@metamask/bridge-status-controller` `^72.0.0` → `^72.0.2`** — picks up the controller fix for the batch-sell submission edge case when `gasIncluded7702=true` and STX is enabled (see package changelog for parameter changes).
2. **`TransactionController` `publishHook`** — when `transactionMeta.isGasFeeIncluded` is true (set by bridge-status-controller for gasless-7702 quotes), attempt `Delegation7702PublishHook` before STX even if STX and send bundle are supported. Aligns with extension client behavior (`isSwapGasIncluded7702`).

**Motivation:** The quote/backend contract requires 7702 processing; routing through STX was incorrect for this case.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Batch Sell transactions failing to submit when gas-included EIP-7702 quotes were used with Smart Transactions enabled

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/issues/31484

## **Manual testing steps**

```gherkin
Feature: Batch Sell gas-included 7702 submission with Smart Transactions

  Scenario: Batch Sell submits successfully when gas is included via 7702 and STX is enabled
    Given I have an EVM account that supports EIP-7702
    And Smart Transactions are enabled on a chain that supports send bundle
    And Batch Sell is available with multiple eligible source tokens
    And quotes return with gas included via 7702 (network fee shown as included / gasIncluded7702)

    When I complete Batch Sell review and submit Sell All
    Then transactions submit without failure
    And I am not blocked by incorrect STX-only submission for gasless-7702 quotes

  Scenario: Normal STX gas-included swap still uses Smart Transactions when isGasFeeIncluded is not set
    Given Smart Transactions and send bundle are enabled
    And I initiate a swap with STX gas-included (not gasIncluded7702 / no isGasFeeIncluded on tx meta)

    When I confirm and submit the transaction
    Then submission still goes through the Smart Transactions path as before
```

**Commands run locally:**

```bash
yarn jest app/core/Engine/controllers/transaction-controller/transaction-controller-init.test.ts -t "7702 delegation hook"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which publish path runs for gas-included transactions when STX is enabled—a core submission decision—but scope is gated on `isGasFeeIncluded` with new unit and E2E coverage.
> 
> **Overview**
> Fixes **Batch Sell** and other **gas-included EIP-7702** flows that were incorrectly published through **Smart Transactions** when STX and send bundle were enabled.
> 
> **Transaction publish routing** now treats `transactionMeta.isGasFeeIncluded` as **gas-included 7702** (`isSwapGasIncluded7702`) and runs **`Delegation7702PublishHook` (Sentinel relay)** before STX, even when STX + send bundle would otherwise win. A unit test asserts STX is **not** called when that flag is set.
> 
> **`@metamask/bridge-status-controller`** is bumped to **`^72.0.2`** so tx meta gets the right gas-included-7702 signaling (with related lockfile/controller dependency updates).
> 
> **E2E/support:** STX HTTP mocks accept versioned `*.api.cx.metamask.io` paths; **7702 relay** submit/poll mocks were added (Anvil-backed receipt). Gasless swap smoke tests are **re-enabled**; ramps unified-buy fixtures/flags, longer app-ready/stake timeouts, bridge quote keypad timing, and minor TestSnaps tap stability tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6309f0300cb2be01c595584c0eaf5a76feda2440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->