### PR TITLE
feat(analytics): track Address List Viewed event (TMCU-858)

### DIFF
--- a/app/components/UI/AddressCopy/AddressCopy.tsx
+++ b/app/components/UI/AddressCopy/AddressCopy.tsx
@@ -17,6 +17,7 @@ import { useStyles } from '../../../component-library/hooks';
 import { WalletViewSelectorsIDs } from '../../Views/Wallet/WalletView.testIds';
 import { selectSelectedAccountGroupId } from '../../../selectors/multichainAccounts/accountTreeController';
 import { createAddressListNavigationDetails } from '../../Views/MultichainAccounts/AddressList';
+import { AddressListViewedSource } from '../../../util/analytics/addressListViewedTracking';
 
 // Internal dependencies
 import styleSheet from './AddressCopy.styles';
@@ -51,6 +52,7 @@ const AddressCopy = ({ iconColor, hitSlop, testID }: AddressCopyProps) => {
         title: `${strings(
           'multichain_accounts.address_list.receiving_address',
         )}`,
+        source: AddressListViewedSource.COPY_BUTTON,
         onLoad: () => {
           endTrace({ name: TraceName.ShowAccountAddressList });
         },

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.test.tsx
@@ -362,6 +362,7 @@ describe('AccountGroupDetails', () => {
     expect(mockNavigate).toHaveBeenCalledWith(expect.any(String), {
       groupId: mockAccountGroup.id,
       title: `Addresses / ${mockAccountGroup.metadata.name}`,
+      source: 'account_details',
       onLoad: expect.any(Function),
     });
   });

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
@@ -44,6 +44,7 @@ import {
 import { selectInternalAccountsById } from '../../../../selectors/accountsController';
 import { SecretRecoveryPhrase, Wallet, RemoveAccount } from './components';
 import { createAddressListNavigationDetails } from '../AddressList';
+import { AddressListViewedSource } from '../../../../util/analytics/addressListViewedTracking';
 import { createPrivateKeyListNavigationDetails } from '../PrivateKeyList/PrivateKeyList';
 import { selectSeedlessOnboardingLoginFlow } from '../../../../selectors/seedlessOnboardingController';
 import {
@@ -139,6 +140,7 @@ export const AccountGroupDetails = () => {
         title: `${strings('multichain_accounts.address_list.addresses')} / ${
           metadata.name
         }`,
+        source: AddressListViewedSource.ACCOUNT_DETAILS,
         onLoad: () => {
           endTrace({ name: TraceName.ShowAccountAddressList });
         },

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.view.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.view.test.tsx
@@ -112,6 +112,9 @@ describeForPlatforms('Multichain account group details', () => {
       expect(getByTestId(addressListRouteParamsTestId).props.children).toEqual(
         expect.stringContaining(fixture.groups.account1.id),
       );
+      expect(getByTestId(addressListRouteParamsTestId).props.children).toEqual(
+        expect.stringContaining('account_details'),
+      );
     });
   });
 

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -379,8 +379,9 @@ describe('AddressList', () => {
 
       await new Promise(process.nextTick);
 
-      // Access the first call from this test (now properly cleared between tests)
-      const addPropertiesCall = mockAddProperties.mock.calls[0][0];
+      const addPropertiesCall = mockAddProperties.mock.calls.find(
+        ([properties]) => properties.location === 'address-list',
+      )?.[0];
 
       expect(addPropertiesCall).toHaveProperty('location', 'address-list');
     });

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx
@@ -11,6 +11,7 @@ import { AddressList } from './AddressList';
 import { MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID } from '../../../../component-library/components-temp/MultichainAccounts/MultichainAddressRow';
 import { toFormattedAddress } from '../../../../util/address';
 import { EVENT_NAME } from '../../../../core/Analytics/MetaMetrics.events';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { strings } from '../../../../../locales/i18n';
 import { AddressListIds } from './AddressList.testIds';
 
@@ -35,6 +36,7 @@ jest.mock('../../../../util/navigation/navUtils', () => ({
   useParams: jest.fn().mockReturnValue({
     title: TITLE,
     groupId: ACCOUNT_GROUP_ID,
+    source: 'copy_button',
   }),
   useRoute: jest.fn(),
   createNavigationDetails: jest.fn(),
@@ -181,6 +183,15 @@ const renderWithAddressList = () => {
 describe('AddressList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    const { useParams } = jest.requireMock(
+      '../../../../util/navigation/navUtils',
+    );
+    useParams.mockReturnValue({
+      title: TITLE,
+      groupId: ACCOUNT_GROUP_ID,
+      source: 'copy_button',
+    });
   });
 
   it('renders correctly with list of addresses from a specific account group', () => {
@@ -277,6 +288,32 @@ describe('AddressList', () => {
       mockCreateEventBuilder.mockClear();
       mockAddProperties.mockClear();
       mockBuild.mockClear();
+    });
+
+    it('tracks "Address List Viewed" event when screen is shown', () => {
+      renderWithAddressList();
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.ADDRESS_LIST_VIEWED,
+      );
+      expect(mockAddProperties).toHaveBeenCalledWith({
+        source: 'copy_button',
+        account_type: expect.any(String),
+      });
+      expect(mockBuild).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalled();
+    });
+
+    it('tracks "Address List Viewed" only once on re-render', () => {
+      const { rerender } = renderWithAddressList();
+
+      rerender(<AddressList />);
+
+      const addressListViewedCalls = mockCreateEventBuilder.mock.calls.filter(
+        ([eventName]) => eventName === MetaMetricsEvents.ADDRESS_LIST_VIEWED,
+      );
+
+      expect(addressListViewedCalls).toHaveLength(1);
     });
 
     it('tracks "Copied Address" event when copy button is pressed', async () => {

--- a/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
+++ b/app/components/Views/MultichainAccounts/AddressList/AddressList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -6,7 +6,10 @@ import { FlashList } from '@shopify/flash-list';
 
 import { useStyles } from '../../../hooks/useStyles';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { selectInternalAccountListSpreadByScopesByGroupId } from '../../../../selectors/multichainAccounts/accounts';
+import {
+  selectInternalAccountListSpreadByScopesByGroupId,
+  selectInternalAccountsByGroupId,
+} from '../../../../selectors/multichainAccounts/accounts';
 import { IconName, Toaster, toast } from '@metamask/design-system-react-native';
 import MultichainAddressRow, {
   MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID,
@@ -24,6 +27,10 @@ import ClipboardManager from '../../../../core/ClipboardManager';
 import getHeaderCompactStandardNavbarOptions from '../../../../component-library/components-temp/HeaderCompactStandard/getHeaderCompactStandardNavbarOptions';
 import { strings } from '../../../../../locales/i18n';
 import { EVENT_NAME } from '../../../../core/Analytics/MetaMetrics.events';
+import {
+  getAddressListViewedAccountType,
+  trackAddressListViewed,
+} from '../../../../util/analytics/addressListViewedTracking';
 
 export const createAddressListNavigationDetails =
   createNavigationDetails<AddressListProps>(
@@ -40,13 +47,33 @@ export const AddressList = () => {
   const { styles } = useStyles(styleSheet, {});
   const { trackEvent, createEventBuilder } = useAnalytics();
 
-  const { groupId, title, onLoad } = useParams<AddressListProps>();
+  const { groupId, title, source, onLoad } = useParams<AddressListProps>();
 
   const selectInternalAccountsSpreadByScopes = useSelector(
     selectInternalAccountListSpreadByScopesByGroupId,
   );
   const internalAccountsSpreadByScopes =
     selectInternalAccountsSpreadByScopes(groupId);
+
+  const selectInternalAccountsByGroup = useSelector(
+    selectInternalAccountsByGroupId,
+  );
+  const internalAccounts = selectInternalAccountsByGroup(groupId);
+
+  const hasTrackedViewRef = useRef(false);
+
+  useEffect(() => {
+    if (hasTrackedViewRef.current || !source) {
+      return;
+    }
+
+    hasTrackedViewRef.current = true;
+
+    trackAddressListViewed(trackEvent, createEventBuilder, {
+      source,
+      account_type: getAddressListViewedAccountType(internalAccounts),
+    });
+  }, [source, internalAccounts, trackEvent, createEventBuilder]);
 
   const renderAddressItem = useCallback(
     ({ item }: { item: AddressItem }) => {

--- a/app/components/Views/MultichainAccounts/AddressList/types.ts
+++ b/app/components/Views/MultichainAccounts/AddressList/types.ts
@@ -5,6 +5,7 @@ import { type InternalAccount } from '@metamask/keyring-internal-api';
 export interface AddressListProps {
   groupId: AccountGroupId;
   title: string;
+  source: string;
   onLoad?: () => void;
 }
 

--- a/app/components/Views/MultichainAccounts/sheets/MultichainAccountActions/MultichainAccountActions.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/MultichainAccountActions/MultichainAccountActions.test.tsx
@@ -161,6 +161,7 @@ describe('MultichainAccountActions', () => {
       {
         groupId: mockAccountGroup.id,
         title: `Addresses / ${mockAccountGroup.metadata.name}`,
+        source: 'account_actions',
         onLoad: expect.any(Function),
       },
     );

--- a/app/components/Views/MultichainAccounts/sheets/MultichainAccountActions/MultichainAccountActions.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/MultichainAccountActions/MultichainAccountActions.tsx
@@ -29,6 +29,7 @@ import {
   MULTICHAIN_ACCOUNT_ACTIONS_ADDRESSES,
 } from './MultichainAccountActions.testIds';
 import { createAddressListNavigationDetails } from '../../AddressList/AddressList';
+import { AddressListViewedSource } from '../../../../../util/analytics/addressListViewedTracking';
 import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
 import {
   endTrace,
@@ -110,6 +111,7 @@ const MultichainAccountActions = () => {
         title: `${strings('multichain_accounts.address_list.addresses')} / ${
           accountGroup.metadata.name
         }`,
+        source: AddressListViewedSource.ACCOUNT_ACTIONS,
         onLoad: () => {
           endTrace({ name: TraceName.ShowAccountAddressList });
         },

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -836,6 +836,7 @@ describe('Wallet', () => {
         expect.objectContaining({
           groupId: expect.any(String),
           title: expect.any(String),
+          source: 'receive_button',
         }),
       );
     });

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -188,6 +188,7 @@ import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
 import { Carousel } from '../../UI/Carousel';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { createAddressListNavigationDetails } from '../../Views/MultichainAccounts/AddressList';
+import { AddressListViewedSource } from '../../../util/analytics/addressListViewedTracking';
 import { AssetPollingProvider } from '../../hooks/AssetPolling/AssetPollingProvider';
 import { usePna25BottomSheet } from '../../hooks/usePna25BottomSheet';
 import { useSafeChains } from '../../hooks/useSafeChains';
@@ -486,6 +487,7 @@ const Wallet = ({
           title: `${strings(
             'multichain_accounts.address_list.receiving_address',
           )}`,
+          source: AddressListViewedSource.RECEIVE_BUTTON,
         }),
       );
     } else {

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -81,6 +81,7 @@ enum EVENT_NAME {
   // Wallet
   WALLET_OPENED = 'Wallet Opened',
   ADDRESS_COPIED = 'Address Copied',
+  ADDRESS_LIST_VIEWED = 'Address List Viewed',
   QR_CODE_VIEWED = 'QR Code Viewed',
   TOKEN_ADDED = 'Token Added',
   COLLECTIBLE_ADDED = 'Collectible Added',
@@ -900,6 +901,7 @@ const events = {
 
   WALLET_OPENED: generateOpt(EVENT_NAME.WALLET_OPENED),
   ADDRESS_COPIED: generateOpt(EVENT_NAME.ADDRESS_COPIED),
+  ADDRESS_LIST_VIEWED: generateOpt(EVENT_NAME.ADDRESS_LIST_VIEWED),
   QR_CODE_VIEWED: generateOpt(EVENT_NAME.QR_CODE_VIEWED),
   TOKEN_ADDED: generateOpt(EVENT_NAME.TOKEN_ADDED),
   COLLECTIBLE_ADDED: generateOpt(EVENT_NAME.COLLECTIBLE_ADDED),

--- a/app/util/analytics/addressListViewedTracking.test.ts
+++ b/app/util/analytics/addressListViewedTracking.test.ts
@@ -1,0 +1,134 @@
+import { KeyringTypes } from '@metamask/keyring-controller';
+import {
+  AddressListViewedSource,
+  getAddressListViewedAccountType,
+  trackAddressListViewed,
+  AddressListViewedProperties,
+} from './addressListViewedTracking';
+import {
+  createMockSnapInternalAccount,
+  internalAccount1,
+  internalSolanaAccount1,
+} from '../../util/test/accountsControllerTestUtils';
+import { getAddressAccountType } from '../address';
+import { MetaMetricsEvents } from '../../core/Analytics';
+import { ITrackingEvent } from './analytics.types';
+
+jest.mock('../../core/Analytics');
+jest.mock('../address', () => ({
+  ...jest.requireActual('../address'),
+  getAddressAccountType: jest.fn(),
+}));
+
+const mockGetAddressAccountType = jest.mocked(getAddressAccountType);
+
+describe('addressListViewedTracking', () => {
+  const mockTrackEvent = jest.fn();
+  const mockCreateEventBuilder = jest.fn();
+  const mockAddProperties = jest.fn();
+  const mockBuild = jest.fn();
+
+  const mockProperties: AddressListViewedProperties = {
+    source: AddressListViewedSource.COPY_BUTTON,
+    account_type: 'MetaMask',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    mockAddProperties.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
+    mockBuild.mockReturnValue({
+      name: 'Address List Viewed',
+      properties: mockProperties,
+      sensitiveProperties: {},
+      saveDataRecording: false,
+      isAnonymous: false,
+      hasProperties: true,
+    } as ITrackingEvent);
+  });
+
+  describe('getAddressListViewedAccountType', () => {
+    it('returns MetaMask when accounts array is empty', () => {
+      expect(getAddressListViewedAccountType([])).toBe('MetaMask');
+    });
+
+    it('returns keyring metadata for non-EVM addresses', () => {
+      expect(getAddressListViewedAccountType([internalSolanaAccount1])).toBe(
+        KeyringTypes.snap,
+      );
+      expect(mockGetAddressAccountType).not.toHaveBeenCalled();
+    });
+
+    it('returns getAddressAccountType for EVM addresses when available', () => {
+      mockGetAddressAccountType.mockReturnValue('MetaMask');
+
+      expect(getAddressListViewedAccountType([internalAccount1])).toBe(
+        'MetaMask',
+      );
+      expect(mockGetAddressAccountType).toHaveBeenCalledWith(
+        internalAccount1.address,
+      );
+    });
+
+    it('falls back to keyring metadata when getAddressAccountType throws', () => {
+      mockGetAddressAccountType.mockImplementation(() => {
+        throw new Error('The address is not imported');
+      });
+
+      const snapAccount = createMockSnapInternalAccount(
+        internalAccount1.address,
+        'Snap Account',
+      );
+
+      expect(getAddressListViewedAccountType([snapAccount])).toBe(
+        KeyringTypes.snap,
+      );
+    });
+  });
+
+  describe('trackAddressListViewed', () => {
+    it('creates event with ADDRESS_LIST_VIEWED', () => {
+      trackAddressListViewed(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        mockProperties,
+      );
+
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.ADDRESS_LIST_VIEWED,
+      );
+    });
+
+    it('adds properties to the event builder', () => {
+      trackAddressListViewed(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        mockProperties,
+      );
+
+      expect(mockAddProperties).toHaveBeenCalledWith(mockProperties);
+    });
+
+    it('builds and tracks the event', () => {
+      trackAddressListViewed(
+        mockTrackEvent,
+        mockCreateEventBuilder,
+        mockProperties,
+      );
+
+      expect(mockBuild).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Address List Viewed',
+        }),
+      );
+    });
+  });
+});

--- a/app/util/analytics/addressListViewedTracking.ts
+++ b/app/util/analytics/addressListViewedTracking.ts
@@ -1,0 +1,70 @@
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { MetaMetricsEvents } from '../../core/Analytics';
+import { getQrCodeViewedAccountType } from './qrCodeViewedTracking';
+import { IMetaMetricsEvent, JsonMap } from './analytics.types';
+
+export const AddressListViewedSource = {
+  COPY_BUTTON: 'copy_button',
+  RECEIVE_BUTTON: 'receive_button',
+  ACCOUNT_DETAILS: 'account_details',
+  ACCOUNT_ACTIONS: 'account_actions',
+} as const;
+
+export type AddressListViewedSourceValue =
+  (typeof AddressListViewedSource)[keyof typeof AddressListViewedSource];
+
+/**
+ * Properties for Address List Viewed tracking.
+ *
+ * @property source - Entry point that opened the address list
+ * @property account_type - Account type from getAddressListViewedAccountType
+ */
+export interface AddressListViewedProperties extends JsonMap {
+  source: string;
+  account_type: string;
+}
+
+type AddressListViewedEventFactory<TEvent> = (event: IMetaMetricsEvent) => {
+  addProperties: (properties: AddressListViewedProperties) => {
+    build: () => TEvent;
+  };
+};
+
+/**
+ * Resolve account_type for Address List Viewed from the account group's accounts.
+ *
+ * @param accounts - Internal accounts in the address list group
+ * @returns Account type string for analytics
+ */
+export const getAddressListViewedAccountType = (
+  accounts: InternalAccount[],
+): string => {
+  const firstAccount = accounts[0];
+  if (!firstAccount) {
+    return 'MetaMask';
+  }
+
+  return getQrCodeViewedAccountType(firstAccount);
+};
+
+/**
+ * Track Address List Viewed with the mobile analytics schema.
+ * Generic over the event type so callers using either MetricsEventBuilder
+ * (ITrackingEvent) or AnalyticsEventBuilder (AnalyticsTrackingEvent) are
+ * both accepted without a lossy union parameter.
+ *
+ * @param trackEvent - trackEvent function (MetaMetrics or useAnalytics)
+ * @param createEventBuilder - createEventBuilder function (MetricsEventBuilder or AnalyticsEventBuilder)
+ * @param properties - Address list view properties
+ */
+export const trackAddressListViewed = <TEvent>(
+  trackEvent: (event: TEvent) => void,
+  createEventBuilder: AddressListViewedEventFactory<TEvent>,
+  properties: AddressListViewedProperties,
+): void => {
+  trackEvent(
+    createEventBuilder(MetaMetricsEvents.ADDRESS_LIST_VIEWED)
+      .addProperties(properties)
+      .build(),
+  );
+};


### PR DESCRIPTION
## **Description**

Adds Segment analytics for **Address List Viewed** (TMCU-858) so we can measure how often users open the multichain address list and which entry point they used.

When the address list screen opens, the app now fires `Address List Viewed` with:
- `source` — entry point (`copy_button`, `receive_button`, `account_details`, `account_actions`)
- `account_type` — resolved from the account group’s internal accounts

Navigation to the address list now passes a required `source` route param from all four entry points. A reusable `addressListViewedTracking` helper mirrors the existing QR Code Viewed pattern.

Depends on segment-schema PR https://github.com/Consensys/segment-schema/pull/613 merging and deploying first.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-858

## **Manual testing steps**

N/A — analytics-only instrumentation with no user-facing UI changes. Verification is via unit tests and Segment Debugger after the schema deploys:

```gherkin
Feature: Address List Viewed analytics

  Scenario: user opens address list from wallet receive button
    Given MetaMetrics is enabled and segment-schema PR 613 is deployed
    When user taps Receive on the wallet home screen
    Then Address List Viewed is emitted with source receive_button and account_type

  Scenario: user opens address list from wallet copy button
    Given MetaMetrics is enabled and segment-schema PR 613 is deployed
    When user taps the copy icon in the wallet navbar
    Then Address List Viewed is emitted with source copy_button and account_type
```

Unit tests run:
- `yarn run jest app/util/analytics/addressListViewedTracking.test.ts`
- `yarn run jest app/components/Views/MultichainAccounts/AddressList/AddressList.test.tsx`
- `yarn run jest app/components/Views/MultichainAccounts/sheets/MultichainAccountActions/MultichainAccountActions.test.tsx`

## **Screenshots/Recordings**

N/A — analytics-only change with no user-facing UI updates. Segment Debugger output can be attached after schema deploy.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](https://github.com/MetaMask/metamask-mobile/blob/main/app/util/trace.ts) for usage and [`addToken`](https://github.com/MetaMask/metamask-mobile/blob/main/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation with no user-facing behavior changes; `source` is required on navigation params, so any missed call site would fail typing/tests rather than breaking wallet flows.
> 
> **Overview**
> Adds **Address List Viewed** MetaMetrics/Segment instrumentation so opens of the multichain address list are measured with **entry point** and **account type**.
> 
> Navigation to the address list now requires a **`source`** route param (`copy_button`, `receive_button`, `account_details`, `account_actions`), wired from wallet navbar copy, wallet Receive, account details Networks link, and account actions sheet. **`AddressList`** reads `source`, resolves `account_type` from the group’s internal accounts, and fires the event **once per visit** (guarded by a ref; skipped if `source` is missing).
> 
> New **`addressListViewedTracking`** helper and **`ADDRESS_LIST_VIEWED`** event registration follow the existing QR Code Viewed pattern; unit tests cover the helper and screen analytics (including copy-event assertions updated to disambiguate multiple `addProperties` calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe29652ee05a6dcb47c507e6a7ee86d1db3512d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->