### PR TITLE
chore: upgrade @metamask/design-system-react-native to v0.29.0

### DIFF
--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -54,7 +54,7 @@ export const getIcon = (status: BaseNotificationStatus | undefined) => {
     case 'error':
     case 'simple_notification_rejected':
       return (
-        <IconAlert severity={IconAlertSeverity.Error} size={IconSize.Lg} />
+        <IconAlert severity={IconAlertSeverity.Danger} size={IconSize.Lg} />
       );
     default:
       return null;

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
@@ -15,9 +15,9 @@ import {
   BoxJustifyContent,
   ButtonSize,
   ButtonsAlignment,
-  IconColor as DSIconColor,
-  IconName as DSIconName,
-  IconSize as DSIconSize,
+  IconColor,
+  IconName,
+  IconSize,
   Spinner,
   Text,
   TextColor,
@@ -82,7 +82,7 @@ const StatusIcon = ({ status }: { status: PostTradeStatus }) => {
 
     return (
       <AvatarIcon
-        iconName={isSuccess ? DSIconName.CheckBold : DSIconName.Error}
+        iconName={isSuccess ? IconName.CheckBold : IconName.Error}
         severity={
           isSuccess ? AvatarIconSeverity.Success : AvatarIconSeverity.Danger
         }
@@ -99,9 +99,9 @@ const StatusIcon = ({ status }: { status: PostTradeStatus }) => {
       twClassName="h-12 w-12 rounded-full"
     >
       <Spinner
-        color={DSIconColor.PrimaryDefault}
+        color={IconColor.PrimaryDefault}
         spinnerIconProps={{
-          size: DSIconSize.Xl,
+          size: IconSize.Xl,
         }}
       />
     </Box>

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
@@ -84,7 +84,7 @@ const StatusIcon = ({ status }: { status: PostTradeStatus }) => {
       <AvatarIcon
         iconName={isSuccess ? DSIconName.CheckBold : DSIconName.Error}
         severity={
-          isSuccess ? AvatarIconSeverity.Success : AvatarIconSeverity.Error
+          isSuccess ? AvatarIconSeverity.Success : AvatarIconSeverity.Danger
         }
         size={AvatarIconSize.Xl}
       />

--- a/app/components/UI/SecurityTrust/utils/securityUtils.ts
+++ b/app/components/UI/SecurityTrust/utils/securityUtils.ts
@@ -99,11 +99,11 @@ export const getResultTypeConfig = (
         subtitle: strings('security_trust.subtitle_malicious'),
         icon: IconName.Error,
         iconColor: IconColor.ErrorDefault,
-        iconAlertSeverity: IconAlertSeverity.Error,
+        iconAlertSeverity: IconAlertSeverity.Danger,
         badge: {
           icon: IconName.Danger,
           iconColor: IconColor.ErrorDefault,
-          iconAlertSeverity: IconAlertSeverity.Error,
+          iconAlertSeverity: IconAlertSeverity.Danger,
           label: strings('security_trust.malicious'),
           bg: 'bg-error-muted',
           textColor: TextColor.ErrorDefault,

--- a/app/components/UI/TokenDetails/components/SecurityBanner.test.tsx
+++ b/app/components/UI/TokenDetails/components/SecurityBanner.test.tsx
@@ -21,7 +21,7 @@ describe('SecurityBanner', () => {
     label: 'Malicious',
     textColor: 'text-error-default' as const,
     subtitle: 'This token is malicious',
-    iconAlertSeverity: IconAlertSeverity.Error,
+    iconAlertSeverity: IconAlertSeverity.Danger,
     icon: undefined,
     iconColor: undefined,
   });

--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@metamask/core-backend": "^6.3.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.28.0",
+    "@metamask/design-system-react-native": "^0.29.0",
     "@metamask/design-system-twrnc-preset": "^0.5.0",
     "@metamask/design-tokens": "^8.5.0",
     "@metamask/earn-controller": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8396,11 +8396,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "@metamask/design-system-react-native@npm:0.28.0"
+"@metamask/design-system-react-native@npm:^0.29.0":
+  version: 0.29.0
+  resolution: "@metamask/design-system-react-native@npm:0.29.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.21.0"
+    "@metamask/design-system-shared": "npm:^0.22.0"
     fast-text-encoding: "npm:^1.0.6"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
@@ -8413,18 +8413,18 @@ __metadata:
     react-native-gesture-handler: ">=2.25.0"
     react-native-reanimated: ">=3.17.0"
     react-native-safe-area-context: ">=5.0.0"
-  checksum: 10/0e2a27244d016a16600ba7f7ab8123b85f0c34ec8cca1afbe44225f617155746bd3a40a0dbaf5bcebe4f30da44c60d3238377b130dadc2c8586e8cccfaacf93f
+  checksum: 10/dd6d4847ccc5fd677a49bd3881439a6776a85cfbd6ea9c4e03eccb0df7427ac56df666f57453ab7ae2c1ce2d3384d1b02d46d49bd0bcf25c848628a638d240a3
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.21.0":
-  version: 0.21.0
-  resolution: "@metamask/design-system-shared@npm:0.21.0"
+"@metamask/design-system-shared@npm:^0.22.0":
+  version: 0.22.0
+  resolution: "@metamask/design-system-shared@npm:0.22.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/77839755eba0c6e8efeb503a98cf0cd1b4891c551bbbf3bc43482867ab89cc24d2653fd4618f2e513f9d8652f3ce33c55dfd6d8d24151720c57ed762488668ee
+  checksum: 10/8d0e6ad002ad6dd248d59b04ce58c4c4fc89cebc7f6d8611ac0cd4dece6630cacd7876e3c31fd3f5f73ee11b08d124de3108c21c2871e4a30bcab06b198aa0db
   languageName: node
   linkType: hard
 
@@ -35257,7 +35257,7 @@ __metadata:
     "@metamask/core-backend": "npm:^6.3.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.28.0"
+    "@metamask/design-system-react-native": "npm:^0.29.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.5.0"
     "@metamask/design-tokens": "npm:^8.5.0"
     "@metamask/earn-controller": "npm:^12.1.0"


### PR DESCRIPTION
## **Description**

Upgrades `@metamask/design-system-react-native` to align with the [v44.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v44.0.0).

**Packages upgraded:**
- `@metamask/design-system-react-native`: `^0.28.0` → `^0.29.0`

**Breaking changes addressed:**

### Severity enum renaming: `.Error` → `.Danger`

`AvatarIconSeverity.Error`, `IconAlertSeverity.Error`, and `TagSeverity.Error` have been renamed to `.Danger` to standardize severity vocabulary. The underlying color tokens are unchanged — `Danger` maps to the same error color.

**Migration:** Rename all `.Error` references to `.Danger` on the three affected enums.

- `app/component-library/components-temp/BaseNotification/index.tsx`: `IconAlertSeverity.Error` → `.Danger`
- `app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx`: `AvatarIconSeverity.Error` → `.Danger`
- `app/components/UI/SecurityTrust/utils/securityUtils.ts`: `IconAlertSeverity.Error` → `.Danger` (2 usages)
- `app/components/UI/TokenDetails/components/SecurityBanner.test.tsx`: `IconAlertSeverity.Error` → `.Danger`

**New additions available for future use:**
- `ListItem`: new list row layout component (local `app/component-library/components/List/ListItem/ListItem.tsx` already carries a `@deprecated` notice)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Design system upgrade to v0.29.0

  Scenario: Core app functionality is unaffected
    Given I am on the main app screen
    When I navigate through the primary user flows
    Then the UI renders correctly with no visual regressions

  Scenario: Error severity indicators still render correctly
    Given I trigger a failed Bridge trade
    When the PostTradeBottomSheet appears with a failed status
    Then the AvatarIcon renders with the expected error (red) color

  Scenario: Security banners render correctly
    Given I view a token flagged as malicious
    When the SecurityBanner and BaseNotification components render
    Then the IconAlert severity indicator shows the correct error color
```

## **Screenshots/Recordings**

### **Before**

N/A — dependency-only update, no visual changes (color tokens unchanged)

### **After**

N/A — dependency-only update, no visual changes (color tokens unchanged)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.