### PR TITLE
feat(analytics): emit wallet-side deeplink-protocol events on MetaMetrics

### DIFF
--- a/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.test.ts
+++ b/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.test.ts
@@ -12,6 +12,8 @@ import AppConstants from '../../AppConstants';
 import { DappClient } from '../dapp-sdk-types';
 import { createMockInternalAccount } from '../../../util/test/accountsControllerTestUtils';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { analytics } from '../../../util/analytics/analytics';
+import { MetaMetricsEvents } from '../../Analytics';
 
 jest.mock('../SDKConnect');
 jest.mock('react-native');
@@ -20,6 +22,11 @@ jest.mock('../utils/DevLogger');
 jest.mock('../../../util/Logger');
 jest.mock('../handlers/handleCustomRpcCalls');
 jest.mock('../handlers/handleBatchRpcResponse');
+jest.mock('../../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: jest.fn(),
+  },
+}));
 jest.mock('../../Permissions', () => ({
   ...jest.requireActual('../../Permissions'),
   getPermittedAccounts: jest.fn().mockReturnValue([]),
@@ -592,6 +599,124 @@ describe('DeeplinkProtocolService', () => {
       service.connections.channel1 = {} as any;
       service.removeConnection('channel1');
       expect(service.connections.channel1).toBeUndefined();
+    });
+  });
+
+  describe('WAPI-1347 Part B — deeplink_protocol wallet analytics', () => {
+    const originatorWithAnon = {
+      url: 'https://dapp.example',
+      title: 'Example',
+      platform: 'ios',
+      dappId: 'dapp-id',
+      apiVersion: '2.1.0',
+      anonId: 'anon-123',
+    };
+
+    const originatorWithoutAnon = {
+      url: 'https://dapp.example',
+      title: 'Example',
+      platform: 'ios',
+      dappId: 'dapp-id',
+    };
+
+    describe('Remote Connection Request Received (handleConnection)', () => {
+      beforeEach(() => {
+        // Prevent the fire-and-forget async tail from running side effects;
+        // the connection event is emitted synchronously before it.
+        service.handleConnectionEventAsync = jest
+          .fn()
+          .mockResolvedValue(null);
+        service.sendMessage = jest.fn().mockResolvedValue(null);
+      });
+
+      const buildParams = (originatorInfo: object) => ({
+        dappPublicKey: 'key',
+        url: 'https://dapp.example',
+        scheme: 'scheme',
+        channelId: 'channelA',
+        originatorInfo: Buffer.from(
+          JSON.stringify({ originatorInfo }),
+        ).toString('base64'),
+      });
+
+      it('tracks the event over deeplink_protocol when anonId is present', async () => {
+        await service.handleConnection(buildParams(originatorWithAnon));
+
+        expect(analytics.trackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: MetaMetricsEvents.REMOTE_CONNECTION_REQUEST_RECEIVED
+              .category,
+            properties: expect.objectContaining({
+              transport_type: 'deeplink_protocol',
+              sdk_version: '2.1.0',
+              remote_session_id: 'anon-123',
+            }),
+          }),
+        );
+      });
+
+      it('does not track when anonId is missing', async () => {
+        await service.handleConnection(buildParams(originatorWithoutAnon));
+
+        expect(analytics.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('SDK Legacy RPC Request Received (processDappRpcRequest)', () => {
+      beforeEach(() => {
+        service.connections.channelA = {
+          clientId: 'channelA',
+          originatorInfo: originatorWithAnon,
+          connected: true,
+          validUntil: Date.now(),
+          scheme: 'scheme',
+        };
+        // TODO: Replace "any" with type
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        service.bridgeByClientId.channelA = { onMessage: jest.fn() } as any;
+      });
+
+      const buildRpcParams = (method: string) => ({
+        dappPublicKey: 'key',
+        url: 'https://dapp.example',
+        scheme: 'scheme',
+        channelId: 'channelA',
+        request: JSON.stringify({ id: '1', method, params: [] }),
+      });
+
+      it('tracks the event over deeplink_protocol for a tracked method', async () => {
+        await service.processDappRpcRequest(
+          buildRpcParams('eth_sendTransaction'),
+        );
+
+        expect(analytics.trackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: MetaMetricsEvents.SDK_LEGACY_RPC_REQUEST_RECEIVED.category,
+            properties: expect.objectContaining({
+              transport_type: 'deeplink_protocol',
+              sdk_version: '2.1.0',
+              rpc_method: 'eth_sendTransaction',
+              remote_session_id: 'anon-123',
+            }),
+          }),
+        );
+      });
+
+      it('does not track for an untracked method', async () => {
+        await service.processDappRpcRequest(buildRpcParams('eth_chainId'));
+
+        expect(analytics.trackEvent).not.toHaveBeenCalled();
+      });
+
+      it('does not track when the channel has no stored anonId', async () => {
+        service.connections.channelA.originatorInfo = originatorWithoutAnon;
+
+        await service.processDappRpcRequest(
+          buildRpcParams('eth_sendTransaction'),
+        );
+
+        expect(analytics.trackEvent).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.ts
+++ b/app/core/SDKConnect/SDKDeeplinkProtocol/DeeplinkProtocolService.ts
@@ -18,6 +18,7 @@ import BatchRPCManager from '../BatchRPCManager';
 import RPCQueueManager from '../RPCQueueManager';
 import SDKConnect from '../SDKConnect';
 import {
+  ANALYTICS_TRACKED_RPC_METHODS,
   DEFAULT_SESSION_TIMEOUT_MS,
   METHODS_TO_DELAY,
   RPC_METHODS,
@@ -25,6 +26,9 @@ import {
 import handleBatchRpcResponse from '../handlers/handleBatchRpcResponse';
 import handleCustomRpcCalls from '../handlers/handleCustomRpcCalls';
 import DevLogger from '../utils/DevLogger';
+import { MetaMetricsEvents } from '../../Analytics';
+import { analytics } from '../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import { wait, waitForKeychainUnlocked } from '../utils/wait.util';
 import { AccountsController } from '@metamask/accounts-controller';
 import {
@@ -438,6 +442,77 @@ export default class DeeplinkProtocolService {
     }
   }
 
+  /**
+   * Fires the wallet-side `Remote Connection Request Received` event for the
+   * deeplink-protocol transport, completing the wallet half of the v1 paired
+   * dapp↔wallet schema (the socket-relay path already emits this from
+   * `connectToChannel`). Only non-PII properties are sent and the call is a
+   * no-op when the dapp didn't supply an `anonId`.
+   *
+   * @param originatorInfo - Self-reported, unverified dapp metadata decoded
+   * from the deeplink. Only `anonId` and `apiVersion` are read here.
+   */
+  private trackConnectionRequestReceived(originatorInfo?: OriginatorInfo) {
+    const anonId = originatorInfo?.anonId;
+
+    if (!anonId) {
+      return;
+    }
+
+    DevLogger.log(
+      `[MM SDK Analytics] event=${MetaMetricsEvents.REMOTE_CONNECTION_REQUEST_RECEIVED.category} anonId=${anonId}`,
+    );
+
+    analytics.trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.REMOTE_CONNECTION_REQUEST_RECEIVED,
+      )
+        .addProperties({
+          transport_type: 'deeplink_protocol',
+          sdk_version: originatorInfo?.apiVersion,
+          remote_session_id: anonId,
+        })
+        .build(),
+    );
+  }
+
+  /**
+   * Fires the wallet-side `SDK Legacy RPC Request Received` event for the
+   * deeplink-protocol transport, mirroring the socket-relay path in
+   * `handleConnectionMessage`. No-op unless the channel has a stored `anonId`
+   * and the method is in `ANALYTICS_TRACKED_RPC_METHODS`. Only non-PII
+   * properties are sent (no params, addresses, or `originatorInfo` content).
+   *
+   * @param channelId - The deeplink channel id used to look up the stored
+   * connection's `originatorInfo`.
+   * @param method - The RPC method name received from the dapp.
+   */
+  private trackRpcRequestReceived(channelId: string, method?: string) {
+    const originatorInfo = this.connections[channelId]?.originatorInfo;
+    const anonId = originatorInfo?.anonId;
+
+    if (!anonId || !method || !ANALYTICS_TRACKED_RPC_METHODS.includes(method)) {
+      return;
+    }
+
+    DevLogger.log(
+      `[MM SDK Analytics] event=${MetaMetricsEvents.SDK_LEGACY_RPC_REQUEST_RECEIVED.category} anonId=${anonId}`,
+    );
+
+    analytics.trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.SDK_LEGACY_RPC_REQUEST_RECEIVED,
+      )
+        .addProperties({
+          transport_type: 'deeplink_protocol',
+          sdk_version: originatorInfo?.apiVersion,
+          rpc_method: method,
+          remote_session_id: anonId,
+        })
+        .build(),
+    );
+  }
+
   public async handleConnection(params: {
     dappPublicKey: string;
     url: string;
@@ -465,6 +540,11 @@ export default class DeeplinkProtocolService {
     const originatorInfoJson = JSON.parse(decodedOriginatorInfo);
 
     const originatorInfo = originatorInfoJson.originatorInfo;
+
+    // Wallet-side analytics: fires for every connect deeplink received over the
+    // deeplink-protocol transport (new session or reconnect), mirroring the
+    // socket-relay path. See WAPI-1347 Part B.
+    this.trackConnectionRequestReceived(originatorInfo);
 
     const clientInfo: DappClient = {
       clientId: params.channelId,
@@ -554,6 +634,9 @@ export default class DeeplinkProtocolService {
         message: 'Invalid origin',
       });
     }
+
+    // Wallet-side analytics: RPC bundled with a connect deeplink. See WAPI-1347 Part B.
+    this.trackRpcRequestReceived(params.channelId, requestObject.method);
 
     // Handle custom rpc method
     const processedRpc = await handleCustomRpcCalls({
@@ -883,6 +966,11 @@ export default class DeeplinkProtocolService {
       }
 
       this.currentClientId = sessionId;
+
+      // Wallet-side analytics: standalone RPC request over the deeplink
+      // protocol (mmsdk deeplink). See WAPI-1347 Part B.
+      this.trackRpcRequestReceived(sessionId, data.method);
+
       // Handle custom rpc method
       const processedRpc = await handleCustomRpcCalls({
         batchRPCManager: this.batchRPCManager,


### PR DESCRIPTION
## **Description**

Completes **Part B of [WAPI-1347](https://consensyssoftware.atlassian.net/browse/WAPI-1347)**, the follow-up to Part A ([#29186](https://github.com/MetaMask/metamask-mobile/pull/29186), merged). It adds the **wallet half** of the paired v1 dapp↔wallet analytics schema for the SDKv1 **deeplink-protocol** transport, which previously emitted nothing on the wallet side.

`DeeplinkProtocolService` now fires the same MetaMetrics events the socket-relay path already emits, with `transport_type: 'deeplink_protocol'`:

| Location | Event | Key properties |
|----------|-------|----------------|
| `handleConnection()` | `Remote Connection Request Received` | `transport_type: 'deeplink_protocol'`, `sdk_version`, `remote_session_id` |
| `processDappRpcRequest()` (RPC bundled with a connect) | `SDK Legacy RPC Request Received` | `transport_type: 'deeplink_protocol'`, `sdk_version`, `rpc_method`, `remote_session_id` |
| `handleMessage()` → `handleEventAsync()` (standalone `mmsdk` RPC) | `SDK Legacy RPC Request Received` | same as above |

This mirrors the existing socket-relay emitters (`connectToChannel.ts`, `handleConnectionMessage.ts`) so deeplink-protocol volume is directly comparable to socket-relay volume.

**Why a re-implementation, not a revival of #28084:** the closed [#28084](https://github.com/MetaMask/metamask-mobile/pull/28084) wrote these against `@metamask/sdk-analytics` / `/v1/events`, which was removed by [#28322](https://github.com/MetaMask/metamask-mobile/pull/28322) + [#27864](https://github.com/MetaMask/metamask-mobile/pull/27864). This routes them through MetaMetrics instead.

**Primary analytical use case (per the ticket):** compare dapp `sdk_connection_initiated (deeplink)` volume against wallet `connect received (deeplink_protocol)` volume. If they track closely → real active usage. If the wallet count is near zero → deeplinks aren't reaching MetaMask → the transport is safe to remove.

**Privacy:** all emits are guarded by `anonId` presence (and `ANALYTICS_TRACKED_RPC_METHODS` for RPC events) and send only non-PII properties (`transport_type`, `sdk_version`, `rpc_method`, `remote_session_id`). No addresses, RPC params, or `originatorInfo` content.

**Schema note:** `transport_type: 'deeplink_protocol'` already exists in the SDK Legacy RPC Request schemas ([segment-schema#526](https://github.com/Consensys/segment-schema/pull/526)). Reviewer should confirm no additional schema PR is needed for the connection-received event before merge.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [WAPI-1347](https://consensyssoftware.atlassian.net/browse/WAPI-1347)

## **Manual testing steps**

Feature: Wallet-side deeplink-protocol analytics

  Scenario: connection request received fires over deeplink protocol
  Given MetaMask is installed with MetaMetrics enabled
  And the dapp's originatorInfo carries an anonId
  When a dapp opens metamask://connect?comm=deeplinking&... (iOS deeplink protocol)
  Then a "Remote Connection Request Received" event is emitted with transport_type='deeplink_protocol', sdk_version, and remote_session_id

  Scenario: RPC request received fires over deeplink protocol
  Given a dapp is connected via the deeplink protocol
  When the dapp sends a tracked RPC (e.g. eth_sendTransaction) via metamask://mmsdk?...
  Then an "SDK Legacy RPC Request Received" event is emitted with transport_type='deeplink_protocol' and rpc_method=<method>

  Scenario: no event without anonId
  Given a dapp connects via the deeplink protocol without an anonId
  When the connect deeplink is received
  Then no analytics event is emitted

## **Screenshots/Recordings**

### **Before**

N/A — the deeplink-protocol path emitted no wallet-side events.

### **After**

<!-- Console / Segment debugger evidence to be attached -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[WAPI-1347]: https://consensyssoftware.atlassian.net/browse/WAPI-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WAPI-1347]: https://consensyssoftware.atlassian.net/browse/WAPI-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only additions on the SDK deeplink path with anonId and method allowlists; no change to connection or RPC handling logic.
> 
> **Overview**
> Adds **wallet-side MetaMetrics** for the SDK v1 **deeplink-protocol** path in `DeeplinkProtocolService`, matching what `connectToChannel` / `handleConnectionMessage` already do for **socket_relay** (WAPI-1347 Part B).
> 
> Two private helpers emit events only when the dapp supplies **`anonId`**, and RPC events only for methods in **`ANALYTICS_TRACKED_RPC_METHODS`**, with non-PII props: `transport_type: 'deeplink_protocol'`, `sdk_version`, `remote_session_id`, and `rpc_method` where applicable.
> 
> **Remote Connection Request Received** runs from **`handleConnection`** on every connect deeplink. **SDK Legacy RPC Request Received** runs from **`processDappRpcRequest`** (RPC bundled with connect) and from **`handleMessage`** (standalone `mmsdk` RPC).
> 
> Unit tests mock `analytics.trackEvent` and cover positive and negative cases (missing `anonId`, untracked RPC methods).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163b93421b199ab78e901f3b75559afc7f74c11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->