### PR TITLE
fix: guard Ramp toast navigation before ready

### DIFF
--- a/app/components/UI/Ramp/utils/v2OrderToast.test.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.test.ts
@@ -12,6 +12,7 @@ import { strings } from '../../../../../locales/i18n';
 
 jest.mock('../../../../core/ToastService');
 jest.mock('../../../../core/NavigationService', () => ({
+  isReady: jest.fn(() => true),
   navigation: {
     navigate: jest.fn(),
   },
@@ -78,6 +79,26 @@ describe('v2OrderToast', () => {
         Routes.RAMP.RAMPS_ORDER_DETAILS,
         { orderId: 'test-order-id', showCloseButton: true },
       );
+    });
+
+    it('does not close toast or navigate when Track button is pressed before navigation is ready', () => {
+      (NavigationService.isReady as jest.Mock).mockReturnValueOnce(false);
+      (strings as jest.Mock)
+        .mockReturnValueOnce('Processing your purchase of ETH')
+        .mockReturnValueOnce('This should only take a few minutes...')
+        .mockReturnValueOnce('Track');
+
+      const params: V2OrderToastParams = {
+        orderId: 'test-order-id',
+        cryptocurrency: 'ETH',
+        status: RampsOrderStatus.Pending,
+      };
+
+      const result = buildV2OrderToastOptions(params);
+
+      expect(() => result?.linkButtonOptions?.onPress()).not.toThrow();
+      expect(mockToastService.closeToast).not.toHaveBeenCalled();
+      expect(NavigationService.navigation.navigate).not.toHaveBeenCalled();
     });
 
     it('returns toast options for COMPLETED state with success icon', () => {

--- a/app/components/UI/Ramp/utils/v2OrderToast.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.ts
@@ -85,6 +85,10 @@ export function buildV2OrderToastOptions(
         linkButtonOptions: {
           label: strings('ramps_v2.notifications.track'),
           onPress: () => {
+            if (!NavigationService.isReady()) {
+              return;
+            }
+
             ToastService.closeToast();
             NavigationService.navigation.navigate(
               Routes.RAMP.RAMPS_ORDER_DETAILS,

--- a/app/core/NavigationService/NavigationService.test.ts
+++ b/app/core/NavigationService/NavigationService.test.ts
@@ -47,6 +47,7 @@ describe('NavigationService', () => {
         type: 'stack',
         routeNames: ['Home'],
       })),
+      isReady: jest.fn(() => true),
     } as unknown as NavigationContainerRef<ParamListBase>;
 
     mockLoggerError = jest.spyOn(Logger, 'error');
@@ -85,6 +86,30 @@ describe('NavigationService', () => {
 
       expect(navigation1).toBeDefined();
       expect(navigation2).toBeDefined();
+    });
+  });
+
+  describe('isReady', () => {
+    it('returns false when navigation does not exist', () => {
+      expect(NavigationService.isReady()).toBe(false);
+      expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    it('returns true when navigation exists and is ready', () => {
+      NavigationService.navigation = mockNavigation;
+
+      expect(NavigationService.isReady()).toBe(true);
+    });
+
+    it('returns false when navigation exists but is not ready', () => {
+      const unreadyNavigation = {
+        ...mockNavigation,
+        isReady: jest.fn(() => false),
+      } as unknown as NavigationContainerRef<ParamListBase>;
+
+      NavigationService.navigation = unreadyNavigation;
+
+      expect(NavigationService.isReady()).toBe(false);
     });
   });
 

--- a/app/core/NavigationService/NavigationService.ts
+++ b/app/core/NavigationService/NavigationService.ts
@@ -107,6 +107,13 @@ class NavigationService {
   }
 
   /**
+   * Checks whether the navigation container is mounted and ready to receive actions.
+   */
+  static isReady(): boolean {
+    return Boolean(this.#navigation?.isReady?.());
+  }
+
+  /**
    * Resets the navigation reference. Only for testing purposes.
    * @internal
    */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a NavigationService readiness helper that checks the mounted navigation container without throwing
- guard the Ramp V2 order toast Track action when navigation is not ready
- add focused regression coverage for the unready navigation path

## Verification
- `yarn install --immutable` (completed with existing peer/deprecation warnings)
- `yarn skills` (completed)
- `yarn eslint app/components/UI/Ramp/utils/v2OrderToast.ts app/components/UI/Ramp/utils/v2OrderToast.test.ts app/core/NavigationService/NavigationService.ts app/core/NavigationService/NavigationService.test.ts` (0 errors; existing deprecation warnings in `v2OrderToast.ts` for `renderNumber` and `Avatar`)
- `yarn jest app/components/UI/Ramp/utils/v2OrderToast.test.ts app/core/NavigationService/NavigationService.test.ts` (both files reported PASS, then Node exited with heap OOM)
- `NODE_OPTIONS='--max-old-space-size=8192' yarn jest app/components/UI/Ramp/utils/v2OrderToast.test.ts app/core/NavigationService/NavigationService.test.ts --runInBand --forceExit` (both files reported PASS; process hung during shutdown and was stopped)
- `NODE_OPTIONS='--max-old-space-size=8192' yarn node ./node_modules/jest/bin/jest.js app/components/UI/Ramp/utils/v2OrderToast.test.ts app/core/NavigationService/NavigationService.test.ts --runInBand --forceExit` (both files reported PASS; process hung during shutdown and was stopped)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b60d61df-c4b6-4cdb-b5df-ae6566355149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b60d61df-c4b6-4cdb-b5df-ae6566355149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

