### PR TITLE
Fix Buy availability with additional enabled networks

### DIFF
--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
@@ -42,9 +42,16 @@ jest.mock('../../../../core/redux/slices/bridge', () => ({
   selectIsSwapsEnabled: jest.fn(),
 }));
 
+const mockUseDepositEnabled = jest.fn(() => ({ isDepositEnabled: true }));
 jest.mock('../../../UI/Ramp/Deposit/hooks/useDepositEnabled', () => ({
   __esModule: true,
-  default: () => ({ isDepositEnabled: true }),
+  default: () => mockUseDepositEnabled(),
+}));
+
+const mockUseRampsUnifiedV1Enabled = jest.fn(() => false);
+jest.mock('../../../UI/Ramp/hooks/useRampsUnifiedV1Enabled', () => ({
+  __esModule: true,
+  default: () => mockUseRampsUnifiedV1Enabled(),
 }));
 
 // Mock useAnalytics hook
@@ -88,6 +95,36 @@ describe('AssetDetailsActions', () => {
     },
   });
 
+  const createStateWithFundAvailability = ({
+    enabledEvmNetworkMap,
+    rampNetworks,
+  }: {
+    enabledEvmNetworkMap: Record<string, boolean>;
+    rampNetworks: { chainId: string; active: boolean }[];
+  }) => ({
+    ...initialRootState,
+    fiatOrders: {
+      ...initialRootState.fiatOrders,
+      networks:
+        rampNetworks as typeof initialRootState.fiatOrders.networks,
+    },
+    engine: {
+      ...initialRootState.engine,
+      backgroundState: {
+        ...initialRootState.engine.backgroundState,
+        NetworkEnablementController: {
+          ...initialRootState.engine.backgroundState
+            .NetworkEnablementController,
+          enabledNetworkMap: {
+            ...initialRootState.engine.backgroundState
+              .NetworkEnablementController.enabledNetworkMap,
+            eip155: enabledEvmNetworkMap,
+          },
+        },
+      },
+    },
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     mockNavigate.mockClear();
@@ -95,6 +132,8 @@ describe('AssetDetailsActions', () => {
     mockTrackEvent.mockClear();
     mockCreateEventBuilder.mockClear();
     jest.mocked(selectIsSwapsEnabled).mockReset();
+    mockUseDepositEnabled.mockReturnValue({ isDepositEnabled: true });
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
   });
 
   it('renders without crashing', () => {
@@ -301,6 +340,43 @@ describe('AssetDetailsActions', () => {
     // The receive button should always be enabled
     const receiveButton = getByTestId(TokenOverviewSelectorsIDs.RECEIVE_BUTTON);
     expect(receiveButton).not.toBeDisabled();
+  });
+
+  it('keeps buy enabled when a ramp-supported network remains enabled with HyperEVM', () => {
+    mockUseDepositEnabled.mockReturnValue({ isDepositEnabled: false });
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
+    const state = createStateWithFundAvailability({
+      enabledEvmNetworkMap: {
+        '0x1': true,
+        '0x3e7': true,
+      },
+      rampNetworks: [{ chainId: '1', active: true }],
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state },
+    );
+
+    expect(getByTestId(TokenOverviewSelectorsIDs.BUY_BUTTON)).not.toBeDisabled();
+  });
+
+  it('disables buy when no funding option supports the enabled networks', () => {
+    mockUseDepositEnabled.mockReturnValue({ isDepositEnabled: false });
+    mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
+    const state = createStateWithFundAvailability({
+      enabledEvmNetworkMap: {
+        '0x3e7': true,
+      },
+      rampNetworks: [{ chainId: '1', active: true }],
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <AssetDetailsActions {...defaultProps} />,
+      { state },
+    );
+
+    expect(getByTestId(TokenOverviewSelectorsIDs.BUY_BUTTON)).toBeDisabled();
   });
 
   // Note: Test for fund button visibility when both deposit and ramp are unavailable

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, useMemo } from 'react';
 import { View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import styleSheet from './AssetDetailsActions.styles';
@@ -20,6 +20,10 @@ import {
   ActionLocation,
   ActionPosition,
 } from '../../../../util/analytics/actionButtonTracking';
+import { getRampNetworks } from '../../../../reducers/fiatOrders';
+import { selectEVMEnabledNetworks } from '../../../../selectors/networkEnablementController';
+import { isNetworkRampSupported } from '../../../UI/Ramp/Aggregator/utils';
+import useRampsUnifiedV1Enabled from '../../../UI/Ramp/hooks/useRampsUnifiedV1Enabled';
 
 export interface AssetDetailsActionsProps {
   displayBuyButton: boolean | undefined;
@@ -84,9 +88,21 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
     return unsubscribe;
   }, [navigation]);
 
-  // Check if FundActionMenu would be empty
   const { isDepositEnabled } = useDepositEnabled();
-  const isBuyMenuAvailable = isDepositEnabled || true;
+  const rampNetworks = useSelector(getRampNetworks);
+  const enabledEvmChainIds = useSelector(selectEVMEnabledNetworks);
+  const isRampsUnifiedV1Enabled = useRampsUnifiedV1Enabled();
+  const hasRampSupportedEnabledNetwork = useMemo(
+    () =>
+      enabledEvmChainIds.some((chainId) =>
+        isNetworkRampSupported(chainId, rampNetworks),
+      ),
+    [enabledEvmChainIds, rampNetworks],
+  );
+  const isBuyMenuAvailable =
+    isDepositEnabled ||
+    isRampsUnifiedV1Enabled ||
+    hasRampSupportedEnabledNetwork;
 
   // Button should be enabled if we have standard funding options OR a custom onBuy function
   const isBuyingAvailable = isBuyMenuAvailable || !!onBuy;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Derive wallet Buy button availability from deposit, unified buy, or any enabled EVM network supported by ramps.
- Add regression coverage for HyperEVM enabled alongside Ethereum so Buy stays enabled when a supported popular network remains available.
- Add a control case where Buy is disabled when no enabled network has a supported funding path.

## Verification
- `yarn skills` - completed after `yarn install` restored the Yarn install state.
- `yarn jest app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx` - assertions passed, then Jest process hit a heap OOM during shutdown.
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx --runInBand` - assertions passed, but the process hung after printing PASS and was stopped.
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx --runInBand --forceExit` - assertions passed, but the process still hung after printing PASS and was stopped.
- `yarn eslint "app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx" "app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx"` - passed with existing `MainActionButton` deprecation warnings.
- `yarn lint:tsc` - failed on unrelated missing `app/util/termsOfUse/termsOfUseContent` imports.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-814ccb4e-c41f-44f3-83cd-0ef768946ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-814ccb4e-c41f-44f3-83cd-0ef768946ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

