### PR TITLE
fix: enable QuickBuy sell tab for Tron balances

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.test.ts
@@ -1,0 +1,148 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { SolScope, TrxScope } from '@metamask/keyring-api';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import type { RootState } from '../../../../../../../reducers';
+import { selectSelectedInternalAccountByScope } from '../../../../../../../selectors/multichainAccounts/accounts';
+import { usePositionTokenBalance } from './usePositionTokenBalance';
+import type { QuickBuyTarget } from '../types';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/accountTrackerController', () => ({
+  selectAccountsByChainId: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/tokenBalancesController', () => ({
+  selectTokensBalances: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../../../selectors/currencyRateController', () => ({
+  selectCurrencyRates: jest.fn(() => ({})),
+  selectCurrentCurrency: jest.fn(() => 'usd'),
+}));
+
+jest.mock('../../../../../../../selectors/multichain/multichain', () => ({
+  selectMultichainBalances: jest.fn(() => ({
+    'tron-account-id': {
+      'tron:728126428/trc20:HTXTokenAddress': { amount: '42' },
+    },
+    'solana-account-id': {
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+        amount: '12.5',
+      },
+    },
+  })),
+  selectMultichainAssetsRates: jest.fn(() => ({
+    'tron:728126428/trc20:HTXTokenAddress': { rate: '0.000001' },
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501': {
+      rate: '200',
+    },
+  })),
+}));
+
+const mockUseSelector = useSelector as unknown as jest.Mock;
+const mockSelectSelectedInternalAccountByScope =
+  selectSelectedInternalAccountByScope as unknown as jest.Mock;
+
+const MOCK_STATE = {
+  engine: {
+    backgroundState: {
+      NetworkController: { networkConfigurationsByChainId: {} },
+    },
+  },
+} as unknown as RootState;
+
+const htxTarget: QuickBuyTarget = {
+  chain: TrxScope.Mainnet,
+  tokenAddress: 'tron:728126428/trc20:HTXTokenAddress',
+  tokenSymbol: 'HTX',
+  tokenName: 'HTX',
+};
+
+const htxDestToken = {
+  address: 'tron:728126428/trc20:HTXTokenAddress',
+  chainId: TrxScope.Mainnet,
+  symbol: 'HTX',
+  name: 'HTX',
+  decimals: 6,
+} as BridgeToken;
+
+const solTarget: QuickBuyTarget = {
+  chain: SolScope.Mainnet,
+  tokenAddress: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  tokenSymbol: 'SOL',
+  tokenName: 'Solana',
+};
+
+const solDestToken = {
+  address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  chainId: SolScope.Mainnet,
+  symbol: 'SOL',
+  name: 'Solana',
+  decimals: 9,
+} as BridgeToken;
+
+const mockSelectorsWithNonEvmBalances = (): void => {
+  jest.clearAllMocks();
+  mockUseSelector.mockImplementation(
+    (selector: (state: RootState) => unknown) => selector(MOCK_STATE),
+  );
+  mockSelectSelectedInternalAccountByScope.mockReturnValue((scope: string) => {
+    if (scope === TrxScope.Mainnet) return { id: 'tron-account-id' };
+    if (scope === SolScope.Mainnet) return { id: 'solana-account-id' };
+    return undefined;
+  });
+};
+
+describe('usePositionTokenBalance', () => {
+  it('returns a held Tron token balance from multichain balance data', () => {
+    mockSelectorsWithNonEvmBalances();
+
+    const { result } = renderHook(() =>
+      usePositionTokenBalance(htxTarget, htxDestToken),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        address: 'tron:728126428/trc20:HTXTokenAddress',
+        chainId: TrxScope.Mainnet,
+        symbol: 'HTX',
+        balance: '42',
+        balanceFiat: '$0.00',
+        tokenFiatAmount: 0.000042,
+        currencyExchangeRate: 0.000001,
+      }),
+    );
+  });
+
+  it('returns a held Solana token balance from multichain balance data', () => {
+    mockSelectorsWithNonEvmBalances();
+
+    const { result } = renderHook(() =>
+      usePositionTokenBalance(solTarget, solDestToken),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        chainId: SolScope.Mainnet,
+        symbol: 'SOL',
+        balance: '12.5',
+        balanceFiat: '$2500.00',
+        tokenFiatAmount: 2500,
+        currencyExchangeRate: 200,
+      }),
+    );
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.ts
@@ -2,12 +2,10 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { formatUnits } from 'ethers/lib/utils';
 import {
-  isSolanaChainId,
   isNonEvmChainId,
   isNativeAddress,
   formatChainIdToHex,
 } from '@metamask/bridge-controller';
-import { SolScope } from '@metamask/keyring-api';
 import type { Hex, CaipChainId } from '@metamask/utils';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 import type { RootState } from '../../../../../../../reducers';
@@ -51,19 +49,16 @@ export const usePositionTokenBalance = (
   target: QuickBuyTarget | null,
   destToken: BridgeToken | undefined,
 ): BridgeToken | undefined => {
-  const accountAddress = useSelector(
-    (state: RootState) =>
-      selectSelectedInternalAccountByScope(state)(EVM_SCOPE)?.address,
+  const selectAccountByScope = useSelector(
+    selectSelectedInternalAccountByScope,
   );
+  const accountAddress = selectAccountByScope(EVM_SCOPE)?.address;
   const accountsByChainId = useSelector(selectAccountsByChainId);
   const tokenBalances = useSelector(selectTokensBalances);
   const tokenMarketData = useSelector(selectTokenMarketData);
   const currencyRates = useSelector(selectCurrencyRates);
   const currentCurrency = useSelector(selectCurrentCurrency);
 
-  const solanaAccount = useSelector((state: RootState) =>
-    selectSelectedInternalAccountByScope(state)(SolScope.Mainnet),
-  );
   const multichainBalances = useSelector(selectMultichainBalances);
   const multichainRates = useSelector(selectMultichainAssetsRates);
 
@@ -87,20 +82,12 @@ export const usePositionTokenBalance = (
     >[1];
     const zeroFiat = addCurrencySymbol('0.00', fiatCurrency);
 
-    // ─── Non-EVM, non-Solana (BTC, Tron) ──────────────────────────
-    // The multichain selectors above (`selectMultichainBalances`,
-    // `selectMultichainAssetsRates`) are chain-agnostic. We early-return here
-    // so the EVM branch's `formatChainIdToHex` doesn't throw "Invalid
-    // cross-chain swaps chainId" and crash the QuickBuy sheet.
-    if (isNonEvmChainId(caipChainId) && !isSolanaChainId(caipChainId)) {
-      return undefined;
-    }
-
-    // ─── Solana branch ─────────────────────────────────────────────────
-    if (isNonEvmChainId(caipChainId) && isSolanaChainId(caipChainId)) {
-      if (!solanaAccount) return undefined;
+    // ─── Non-EVM branch ─────────────────────────────────────────────────
+    if (isNonEvmChainId(caipChainId)) {
+      const nonEvmAccount = selectAccountByScope(caipChainId);
+      if (!nonEvmAccount) return undefined;
       const balanceEntry =
-        multichainBalances?.[solanaAccount.id]?.[destToken.address];
+        multichainBalances?.[nonEvmAccount.id]?.[destToken.address];
       const amountStr = balanceEntry?.amount;
       if (!amountStr) return undefined;
       const balanceNum = parseFloat(amountStr);
@@ -201,7 +188,7 @@ export const usePositionTokenBalance = (
     target,
     destToken,
     accountAddress,
-    solanaAccount,
+    selectAccountByScope,
     multichainBalances,
     multichainRates,
     accountsByChainId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix QuickBuy sell eligibility for non-EVM assets by resolving the selected account for the target CAIP chain instead of only supporting Solana.
- Preserve EVM balance handling and reuse the existing multichain balance/rate path for Tron and other non-EVM CAIP chains.
- Add hook-level regression coverage for a held Tron token balance and preservation coverage for Solana.

## Work Item
TRAM-379856: [Bug]: Quick Buy bottom sheet on HTX (Tron) - Sell tab is not clickable

## Verification
- `NODE_OPTIONS="--max-old-space-size=8192" yarn jest app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.test.ts --runInBand --forceExit`
  - Result: PASS output for both Tron and Solana test cases, but the Jest process did not exit in this cloud environment and had to be stopped.
- `yarn prettier --check "app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.ts" "app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.test.ts"` — passed.
- `NODE_OPTIONS="--max-old-space-size=8192" yarn eslint "app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.ts" "app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePositionTokenBalance.test.ts"` — passed.
- `yarn lint:tsc` — failed on existing unrelated missing module errors in `app/util/termsOfUse/index.test.tsx` and `app/util/termsOfUse/termsOfUse.ts` for `./termsOfUseContent`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f22b78-53a2-47e2-836a-71f0856240c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f22b78-53a2-47e2-836a-71f0856240c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

