### PR TITLE
fix: avoid sentry capture for recoverable ramps order fetches

### DIFF
--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -36,6 +36,16 @@ jest.mock('../../hooks/useRampsOrders', () => ({
   }),
 }));
 
+const mockLoggerLog = jest.fn();
+const mockLoggerError = jest.fn();
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    log: (...args: unknown[]) => mockLoggerLog(...args),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
+}));
+
 jest.mock('../../../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../../../util/theme');
   return {
@@ -143,17 +153,25 @@ describe('OrderDetails', () => {
     expect(queryByTestId('order-content')).not.toBeOnTheScreen();
   });
 
-  it('shows loading state when order is pending and refreshing', () => {
+  it('shows loading state when order is pending and refreshing', async () => {
     mockUseParams.mockReturnValue({ orderId: 'ord-123' });
     mockGetOrderById.mockReturnValue({
       ...mockOrder,
       status: RampsOrderStatus.Pending,
     });
-    // eslint-disable-next-line no-empty-function -- Never-resolving promise for loading state test
-    mockRefreshOrder.mockImplementation(() => new Promise<never>(() => {}));
+    let resolveRefresh: () => void = () => undefined;
+    mockRefreshOrder.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
     const { UNSAFE_getAllByType } = render();
     const indicators = UNSAFE_getAllByType(ActivityIndicator);
     expect(indicators.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      resolveRefresh();
+    });
   });
 
   it('shows error state with retry when refresh fails', async () => {
@@ -174,6 +192,16 @@ describe('OrderDetails', () => {
       fireEvent.press(getByText('ramps_order_details.try_again'));
     });
     expect(mockRefreshOrder).toHaveBeenCalled();
+    expect(mockLoggerLog).toHaveBeenCalledWith(
+      'FiatOrders::RampsOrderDetails recoverable error while refreshing order',
+      expect.objectContaining({
+        orderId: 'ord-123',
+        provider: 'paypal',
+        status: RampsOrderStatus.Pending,
+        errorMessage: 'Refresh failed',
+      }),
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
   it('tracks RAMPS_SCREEN_VIEWED when order is displayed', async () => {
@@ -234,5 +262,14 @@ describe('OrderDetails', () => {
       'metamask://on-ramp/providers/paypal?orderId=abc',
       '0x123',
     );
+    expect(mockLoggerLog).toHaveBeenCalledWith(
+      'RampsOrderDetails: recoverable error fetching order from callback URL',
+      expect.objectContaining({
+        providerCode: 'paypal',
+        logContext: '',
+        errorMessage: 'Network request failed',
+      }),
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -118,10 +118,17 @@ const OrderDetails = () => {
           walletAddress: undefined,
         });
       } catch (fetchError) {
-        Logger.error(fetchError as Error, {
-          message: `RampsOrderDetails: error fetching order from callback URL${logContext}`,
-          callbackUrl,
-        });
+        Logger.log(
+          'RampsOrderDetails: recoverable error fetching order from callback URL',
+          {
+            providerCode,
+            logContext,
+            errorMessage:
+              fetchError instanceof Error
+                ? fetchError.message
+                : strings('ramps_order_details.error_message'),
+          },
+        );
         setError(
           fetchError instanceof Error && fetchError.message
             ? fetchError.message
@@ -191,12 +198,18 @@ const OrderDetails = () => {
         order.walletAddress,
       );
     } catch (fetchError) {
-      Logger.error(fetchError as Error, {
-        message: 'FiatOrders::RampsOrderDetails error while refreshing order',
-        orderId: order.providerOrderId,
-        provider: order.provider?.id,
-        status: order.status,
-      });
+      Logger.log(
+        'FiatOrders::RampsOrderDetails recoverable error while refreshing order',
+        {
+          orderId: order.providerOrderId,
+          provider: order.provider?.id,
+          status: order.status,
+          errorMessage:
+            fetchError instanceof Error
+              ? fetchError.message
+              : strings('ramps_order_details.error_message'),
+        },
+      );
       setError(
         fetchError instanceof Error && fetchError.message
           ? fetchError.message


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Handled V2 Ramps order-detail retrieval failures are recoverable UI states with retry. This change keeps the existing error/retry UI but records provider/API failures as breadcrumbs with sanitized context instead of capturing them as Sentry exceptions. This reduces noise for upstream 500 responses such as Sentry issue METAMASK-MOBILE-4B39.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TRAM-358539
Refs: METAMASK-MOBILE-4B39, TRAM-3460

## **Manual testing steps**

```gherkin
Feature: Ramps order details recoverable fetch errors

  Scenario: pending Ramps order refresh fails
    Given a pending V2 Ramps order is opened from the order details screen

    When the order refresh request returns an upstream error
    Then the order details screen shows the existing retry error state
    And the recoverable failure is logged as a breadcrumb instead of a Sentry exception
```

## **Screenshots/Recordings**

### **Before**

N/A - observability-only change; UI behavior is unchanged.

### **After**

N/A - observability-only change; UI behavior is unchanged.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A - observability-only change; no runtime performance path altered.
- [x] I've tested with a power user scenario
  - N/A - observability-only change; no account/token rendering path altered.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A - this change intentionally avoids capturing recoverable upstream order-fetch failures as Sentry exceptions.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-293feb33-5803-4969-aab8-fdcd4d5dc522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-293feb33-5803-4969-aab8-fdcd4d5dc522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

