### PR TITLE
fix: change 'Money balance' label to 'Money account' on perps and predict pages

### DIFF
--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -329,7 +329,7 @@ describe('PayWithRow', () => {
     it('renders money balance label without inline balance', () => {
       const { getByTestId, queryByTestId } = renderMoneyAccount();
 
-      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money balance');
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money account');
       expect(queryByTestId('pay-with-balance')).toBeNull();
     });
 
@@ -357,7 +357,7 @@ describe('PayWithRow', () => {
     it('renders money account row regardless of isResultReady when paymentOverride is MoneyAccount', () => {
       const { getByTestId } = renderMoneyAccount({ isResultReady: true });
 
-      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money balance');
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money account');
     });
 
     it('renders money account row for perps deposit', () => {
@@ -369,7 +369,7 @@ describe('PayWithRow', () => {
       const { getByTestId } = renderMoneyAccount();
 
       expect(getByTestId('pay-with')).toBeDefined();
-      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money balance');
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money account');
     });
   });
 

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -327,7 +327,7 @@ function PayWithRowMoneyAccount() {
             color={TextColor.TextDefault}
             testID={TransactionPayComponentIDs.PAY_WITH_SYMBOL}
           >
-            {strings('confirm.pay_with_bottom_sheet.money_balance')}
+            {strings('confirm.pay_with_bottom_sheet.money_account')}
           </Text>
           <Icon
             name={IconName.ArrowDown}

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -28,7 +28,7 @@ jest.mock('../../../../../../../locales/i18n', () => ({
       'confirm.pay_with_bottom_sheet.available_balance': `${
         params?.balance ?? ''
       } available`,
-      'confirm.pay_with_bottom_sheet.money_balance': 'Money account',
+      'confirm.pay_with_bottom_sheet.money_account': 'Money account',
     };
     return translations[key] ?? key;
   },

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -28,7 +28,7 @@ jest.mock('../../../../../../../locales/i18n', () => ({
       'confirm.pay_with_bottom_sheet.available_balance': `${
         params?.balance ?? ''
       } available`,
-      'confirm.pay_with_bottom_sheet.money_balance': 'Money balance',
+      'confirm.pay_with_bottom_sheet.money_balance': 'Money account',
     };
     return translations[key] ?? key;
   },
@@ -222,7 +222,7 @@ describe('usePayWithMoneyAccountSection', () => {
       expect(result.current?.rows[0]).toEqual(
         expect.objectContaining({
           id: 'money-account-musd',
-          title: 'Money balance',
+          title: 'Money account',
           subtitle: '$100.00 available',
           isSelected: false,
           isLastUsed: false,

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -101,7 +101,7 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
         source: MoneyIcon,
         style: styles.moneyIcon,
       }),
-      title: strings('confirm.pay_with_bottom_sheet.money_balance'),
+      title: strings('confirm.pay_with_bottom_sheet.money_account'),
       subtitle,
       isSelected: isMoneyAccountSelected,
       isLastUsed: false,

--- a/app/components/Views/confirmations/hooks/pay/usePayWithSections.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithSections.test.ts
@@ -55,8 +55,8 @@ const MONEY_ACCOUNT_SECTION_MOCK: PayWithSectionConfig = {
   rows: [
     {
       id: 'money-account-musd',
-      icon: 'Money balance',
-      title: 'Money balance',
+      icon: 'Money account',
+      title: 'Money account',
     },
   ],
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7397,7 +7397,7 @@
       "other_assets": "Other assets",
       "other_assets_description": "Select from your tokens",
       "other_assets_receive_description": "Select the token you want to receive",
-      "money_balance": "Money balance"
+      "money_balance": "Money account"
     },
     "staking_footer": {
       "part1": "By continuing, you agree to our ",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7397,7 +7397,7 @@
       "other_assets": "Other assets",
       "other_assets_description": "Select from your tokens",
       "other_assets_receive_description": "Select the token you want to receive",
-      "money_balance": "Money account"
+      "money_account": "Money account"
     },
     "staking_footer": {
       "part1": "By continuing, you agree to our ",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Change "Money balance" label to "Money account" on perps / predict pages.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1528

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and i18n key rename only; no payment or transaction logic changes.
> 
> **Overview**
> Renames the pay-with **Money** option from **"Money balance"** to **"Money account"** for confirmation flows (including perps/predict money-account payment).
> 
> The English string key `confirm.pay_with_bottom_sheet.money_balance` is replaced with `money_account` in `en.json`, and UI/hooks (`pay-with-row`, `usePayWithMoneyAccountSection`) plus related tests now use the new copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bcd3a502279477f6a76e662c282249d24bd1afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->