### PR TITLE
feat(rewards): gate VIP features behind feature flag

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -48,6 +48,10 @@ jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));
 
+jest.mock('../../../../selectors/featureFlagController/vipProgram', () => ({
+  selectVipProgramEnabled: jest.fn(),
+}));
+
 jest.mock(
   '../../../../selectors/multichainAccounts/accountTreeController',
   () => ({
@@ -65,6 +69,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { selectSelectedAccountGroup } from '../../../../selectors/multichainAccounts/accountTreeController';
 
 const mockSelectActiveTab = selectActiveTab as jest.MockedFunction<
@@ -82,6 +87,10 @@ const mockSelectRewardsSubscriptionId =
 const mockSelectIsCurrentSubscriptionVipEnabled =
   selectIsCurrentSubscriptionVipEnabled as jest.MockedFunction<
     typeof selectIsCurrentSubscriptionVipEnabled
+  >;
+const mockSelectVipProgramEnabled =
+  selectVipProgramEnabled as jest.MockedFunction<
+    typeof selectVipProgramEnabled
   >;
 const mockSelectHideUnlinkedAccountsBanner =
   selectHideUnlinkedAccountsBanner as jest.MockedFunction<
@@ -265,6 +274,7 @@ describe('RewardsDashboard', () => {
     activeTab: 'campaigns' as const,
     subscriptionId: 'test-subscription-id',
     isVipEnabled: false,
+    isVipProgramEnabled: true,
     hideUnlinkedAccountsBanner: false,
     hideCurrentAccountNotOptedInBannerArray: [],
     selectedAccountGroup: mockSelectedAccountGroup,
@@ -334,6 +344,9 @@ describe('RewardsDashboard', () => {
     mockSelectIsCurrentSubscriptionVipEnabled.mockReturnValue(
       defaultSelectorValues.isVipEnabled,
     );
+    mockSelectVipProgramEnabled.mockReturnValue(
+      defaultSelectorValues.isVipProgramEnabled,
+    );
     mockSelectHideUnlinkedAccountsBanner.mockReturnValue(
       defaultSelectorValues.hideUnlinkedAccountsBanner,
     );
@@ -366,6 +379,8 @@ describe('RewardsDashboard', () => {
         return defaultSelectorValues.subscriptionId;
       if (selector === selectIsCurrentSubscriptionVipEnabled)
         return defaultSelectorValues.isVipEnabled;
+      if (selector === selectVipProgramEnabled)
+        return defaultSelectorValues.isVipProgramEnabled;
       if (selector === selectHideUnlinkedAccountsBanner)
         return defaultSelectorValues.hideUnlinkedAccountsBanner;
       if (selector === selectHideCurrentAccountNotOptedInBannerArray)
@@ -483,6 +498,7 @@ describe('RewardsDashboard', () => {
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
         if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+        if (selector === selectVipProgramEnabled) return true;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
@@ -498,6 +514,30 @@ describe('RewardsDashboard', () => {
       expect(getByTestId(REWARDS_VIEW_SELECTORS.VIP_BUTTON)).toBeOnTheScreen();
     });
 
+    it('does not render the VIP button when the VIP program flag is off, even if the subscription is VIP', () => {
+      mockSelectIsCurrentSubscriptionVipEnabled.mockReturnValue(true);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+        if (selector === selectVipProgramEnabled) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedAccountGroup)
+          return defaultSelectorValues.selectedAccountGroup;
+        if (selector === mockHasAcceptedVipInviteSelector) return false;
+        return undefined;
+      });
+
+      const { queryByTestId } = render(<RewardsDashboard />);
+
+      expect(queryByTestId(REWARDS_VIEW_SELECTORS.VIP_BUTTON)).toBeNull();
+    });
+
     it('navigates to VIP splash when the invite has not been accepted', () => {
       mockSelectIsCurrentSubscriptionVipEnabled.mockReturnValue(true);
       mockUseSelector.mockImplementation((selector) => {
@@ -506,6 +546,7 @@ describe('RewardsDashboard', () => {
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
         if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+        if (selector === selectVipProgramEnabled) return true;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
@@ -531,6 +572,7 @@ describe('RewardsDashboard', () => {
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
         if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+        if (selector === selectVipProgramEnabled) return true;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
@@ -1295,6 +1337,7 @@ describe('RewardsDashboard', () => {
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
         if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+        if (selector === selectVipProgramEnabled) return true;
         if (selector === selectHideUnlinkedAccountsBanner)
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -26,6 +26,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { useRewardOptinSummary } from '../hooks/useRewardOptinSummary';
 import {
   useRewardDashboardModals,
@@ -53,6 +54,7 @@ const RewardsDashboard: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const isVipEnabled = useSelector(selectIsCurrentSubscriptionVipEnabled);
   const hasAcceptedVipInvite = useSelector(
     selectHasAcceptedVipInvite(subscriptionId),
@@ -288,7 +290,7 @@ const RewardsDashboard: React.FC = () => {
         <HeaderRoot
           endAccessory={
             <Box twClassName="flex-row gap-2">
-              {isVipEnabled && (
+              {isVipProgramEnabled && isVipEnabled && (
                 <Pressable
                   accessibilityRole="button"
                   onPress={handleVipPress}

--- a/app/components/UI/Rewards/Views/RewardsVipSplashView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipSplashView.test.tsx
@@ -7,6 +7,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { VIP_SPLASH_SCREEN_TEST_IDS } from '../components/Vip/VipSplashScreen';
 import { useVipDashboard } from '../hooks/useVipDashboard';
 import RewardsVipSplashView from './RewardsVipSplashView';
@@ -16,6 +17,7 @@ const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 const mockSubscriptionId = 'test-subscription-id';
 let mockIsVipEnabled = true;
+let mockIsVipProgramEnabled = true;
 let mockCanGoBack = true;
 let mockVipSplashAccepted: Record<string, boolean> = {};
 
@@ -117,6 +119,10 @@ jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));
 
+jest.mock('../../../../selectors/featureFlagController/vipProgram', () => ({
+  selectVipProgramEnabled: jest.fn(),
+}));
+
 jest.mock('../../../Views/ErrorBoundary', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => children,
@@ -141,6 +147,7 @@ describe('RewardsVipSplashView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsVipEnabled = true;
+    mockIsVipProgramEnabled = true;
     mockCanGoBack = true;
     mockVipSplashAccepted = {};
     mockUseVipDashboard.mockReturnValue({
@@ -154,6 +161,9 @@ describe('RewardsVipSplashView', () => {
       if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
       if (selector === selectIsCurrentSubscriptionVipEnabled) {
         return mockIsVipEnabled;
+      }
+      if (selector === selectVipProgramEnabled) {
+        return mockIsVipProgramEnabled;
       }
 
       return (
@@ -226,6 +236,17 @@ describe('RewardsVipSplashView', () => {
 
   it('replaces with dashboard when the user cannot view VIP', () => {
     mockIsVipEnabled = false;
+
+    const { queryByTestId } = render(<RewardsVipSplashView />);
+
+    expect(queryByTestId(VIP_SPLASH_SCREEN_TEST_IDS.CONTAINER)).toBeNull();
+    expect(mockNavigateDispatch).toHaveBeenCalledWith(
+      StackActions.replace(Routes.REWARDS_DASHBOARD),
+    );
+  });
+
+  it('replaces with dashboard when the VIP program flag is off, even if the subscription is VIP', () => {
+    mockIsVipProgramEnabled = false;
 
     const { queryByTestId } = render(<RewardsVipSplashView />);
 

--- a/app/components/UI/Rewards/Views/RewardsVipSplashView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipSplashView.tsx
@@ -7,6 +7,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import VipSplashScreen from '../components/Vip/VipSplashScreen';
 import { useVipDashboard } from '../hooks/useVipDashboard';
@@ -14,11 +15,14 @@ import { useVipDashboard } from '../hooks/useVipDashboard';
 const RewardsVipSplashViewContent: React.FC = () => {
   const navigation = useNavigation();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const isVipEnabled = useSelector(selectIsCurrentSubscriptionVipEnabled);
   const hasAcceptedVipInvite = useSelector(
     selectHasAcceptedVipInvite(subscriptionId),
   );
-  const canViewVip = Boolean(subscriptionId && isVipEnabled);
+  const canViewVip = Boolean(
+    isVipProgramEnabled && subscriptionId && isVipEnabled,
+  );
 
   useVipDashboard();
 

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
@@ -7,6 +7,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipDashboard } from '../hooks/useVipDashboard';
 import type { VipDashboardState } from '../../../../core/Engine/controllers/rewards-controller/types';
@@ -171,6 +172,10 @@ jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));
 
+jest.mock('../../../../selectors/featureFlagController/vipProgram', () => ({
+  selectVipProgramEnabled: jest.fn(),
+}));
+
 jest.mock('../../../Views/ErrorBoundary', () => ({
   __esModule: true,
   default: function MockErrorBoundary({
@@ -288,6 +293,7 @@ const mockSubscribed = () => {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectRewardsSubscriptionId) return 'test-subscription-id';
     if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+    if (selector === selectVipProgramEnabled) return true;
     return undefined;
   });
 };
@@ -354,6 +360,25 @@ describe('RewardsVipTiersView', () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId) return 'sub';
       if (selector === selectIsCurrentSubscriptionVipEnabled) return false;
+      if (selector === selectVipProgramEnabled) return true;
+      return undefined;
+    });
+
+    const { queryByTestId } = render(<RewardsVipTiersView />);
+    expect(queryByTestId(REWARDS_VIP_TIERS_VIEW_TEST_IDS.ROOT)).toBeNull();
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        StackActions.replace(Routes.REWARDS_DASHBOARD),
+      );
+    });
+  });
+
+  it('redirects to the rewards dashboard when the VIP program flag is off, even for a VIP subscription', async () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectRewardsSubscriptionId)
+        return 'test-subscription-id';
+      if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+      if (selector === selectVipProgramEnabled) return false;
       return undefined;
     });
 

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.tsx
@@ -15,6 +15,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipDashboard } from '../hooks/useVipDashboard';
@@ -33,8 +34,11 @@ const RewardsVipTiersViewContent: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const isVipEnabled = useSelector(selectIsCurrentSubscriptionVipEnabled);
-  const canViewVip = Boolean(subscriptionId && isVipEnabled);
+  const canViewVip = Boolean(
+    isVipProgramEnabled && subscriptionId && isVipEnabled,
+  );
 
   const {
     dashboard,

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -8,6 +8,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { REWARDS_VIEW_SELECTORS } from './RewardsView.constants';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipDashboard } from '../hooks/useVipDashboard';
@@ -186,6 +187,10 @@ jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));
 
+jest.mock('../../../../selectors/featureFlagController/vipProgram', () => ({
+  selectVipProgramEnabled: jest.fn(),
+}));
+
 jest.mock('../../../Views/ErrorBoundary', () => ({
   __esModule: true,
   default: function MockErrorBoundary({
@@ -346,6 +351,7 @@ const mockSubscribed = () => {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectRewardsSubscriptionId) return 'test-subscription-id';
     if (selector === selectIsCurrentSubscriptionVipEnabled) return true;
+    if (selector === selectVipProgramEnabled) return true;
     return (
       selector as (state: ReturnType<typeof getRewardsSelectorState>) => unknown
     )(getRewardsSelectorState());
@@ -665,6 +671,37 @@ describe('RewardsVipView', () => {
         return 'test-subscription-id';
       }
       if (selector === selectIsCurrentSubscriptionVipEnabled) {
+        return false;
+      }
+      if (selector === selectVipProgramEnabled) {
+        return true;
+      }
+      return undefined;
+    });
+
+    const { queryByTestId } = render(<RewardsVipView />);
+
+    expect(queryByTestId(REWARDS_VIEW_SELECTORS.VIP_VIEW)).toBeNull();
+    expect(mockUseTrackRewardsPageView).toHaveBeenCalledWith({
+      page_type: 'vip',
+      enabled: false,
+    });
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(
+        StackActions.replace(Routes.REWARDS_DASHBOARD),
+      );
+    });
+  });
+
+  it('redirects to the rewards dashboard when the VIP program flag is off, even for a VIP subscription', async () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectRewardsSubscriptionId) {
+        return 'test-subscription-id';
+      }
+      if (selector === selectIsCurrentSubscriptionVipEnabled) {
+        return true;
+      }
+      if (selector === selectVipProgramEnabled) {
         return false;
       }
       return undefined;

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -24,6 +24,7 @@ import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipDashboard } from '../hooks/useVipDashboard';
@@ -66,8 +67,11 @@ const RewardsVipViewContent: React.FC = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const isVipEnabled = useSelector(selectIsCurrentSubscriptionVipEnabled);
-  const canViewVip = Boolean(subscriptionId && isVipEnabled);
+  const canViewVip = Boolean(
+    isVipProgramEnabled && subscriptionId && isVipEnabled,
+  );
   const referralCode = useSelector(selectReferralCode);
   const hasAcceptedVipInvite = useSelector(
     selectHasAcceptedVipInvite(subscriptionId),

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -277,9 +277,11 @@ export type RewardsControllerIsRewardsFeatureEnabledAction = {
 };
 
 /**
- * Check if the VIP feature is enabled
+ * Check if the VIP feature is enabled.
+ * VIP is a sub-feature of rewards, so it requires both the rewards feature
+ * and the dedicated VIP feature flag to be enabled.
  *
- * @returns boolean - True if VIP feature is enabled, false otherwise
+ * @returns boolean - True if the VIP feature is enabled, false otherwise
  */
 export type RewardsControllerIsVipFeatureEnabledAction = {
   type: `RewardsController:isVipFeatureEnabled`;

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -277,6 +277,16 @@ export type RewardsControllerIsRewardsFeatureEnabledAction = {
 };
 
 /**
+ * Check if the VIP feature is enabled
+ *
+ * @returns boolean - True if VIP feature is enabled, false otherwise
+ */
+export type RewardsControllerIsVipFeatureEnabledAction = {
+  type: `RewardsController:isVipFeatureEnabled`;
+  handler: RewardsController['isVipFeatureEnabled'];
+};
+
+/**
  * Check if there is an active season.
  * Temporarily hardcoded to false while no season is configured. Callers
  * gate season-scoped flows (points estimates, rewards rows, dashboard
@@ -864,6 +874,7 @@ export type RewardsControllerMethodActions =
   | RewardsControllerEstimatePointsAction
   | RewardsControllerAddPointsEstimateToHistoryAction
   | RewardsControllerIsRewardsFeatureEnabledAction
+  | RewardsControllerIsVipFeatureEnabledAction
   | RewardsControllerHasActiveSeasonAction
   | RewardsControllerGetSeasonMetadataAction
   | RewardsControllerGetSeasonStatusAction

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -3318,6 +3318,23 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
+    it('returns null when VIP is disabled via isVipDisabled callback', async () => {
+      const vipDisabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+        isVipDisabled: () => true,
+      });
+
+      const result = await vipDisabledController.getPerpsDiscountForAccount(
+        CAIP_ACCOUNT_1,
+        10,
+      );
+
+      expect(result).toBeNull();
+      expect(mockMessenger.call).not.toHaveBeenCalled();
+    });
+
     it('returns null for accounts the controller has never seen (unhydrated)', async () => {
       const result = await controller.getPerpsDiscountForAccount(
         CAIP_ACCOUNT_2,
@@ -3871,6 +3888,21 @@ describe('RewardsController', () => {
       expect(result).toBeNull();
     });
 
+    it('returns null when VIP is disabled via isVipDisabled callback', async () => {
+      const vipDisabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+        isVipDisabled: () => true,
+      });
+
+      const result =
+        await vipDisabledController.getVipTierForAccount(CAIP_ACCOUNT_1);
+
+      expect(result).toBeNull();
+      expect(mockMessenger.call).not.toHaveBeenCalled();
+    });
+
     it('returns null for accounts the controller has never seen (unhydrated)', async () => {
       const result = await controller.getVipTierForAccount(CAIP_ACCOUNT_2);
       expect(result).toBeNull();
@@ -3920,6 +3952,51 @@ describe('RewardsController', () => {
       const result = disabledController.isRewardsFeatureEnabled();
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('isVipFeatureEnabled', () => {
+    it('returns true when neither rewards nor VIP is disabled', () => {
+      const enabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+        isVipDisabled: () => false,
+      });
+
+      expect(enabledController.isVipFeatureEnabled()).toBe(true);
+    });
+
+    it('returns false when VIP is disabled via isVipDisabled callback', () => {
+      const vipDisabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+        isVipDisabled: () => true,
+      });
+
+      expect(vipDisabledController.isVipFeatureEnabled()).toBe(false);
+    });
+
+    it('returns false when rewards is disabled even if VIP is enabled', () => {
+      const rewardsDisabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+        isVipDisabled: () => false,
+      });
+
+      expect(rewardsDisabledController.isVipFeatureEnabled()).toBe(false);
+    });
+
+    it('defaults to enabled when isVipDisabled is not provided', () => {
+      const defaultController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+      });
+
+      expect(defaultController.isVipFeatureEnabled()).toBe(true);
     });
   });
 
@@ -7038,6 +7115,24 @@ describe('RewardsController', () => {
         ...apiDashboard,
         lastFetched: 123,
       });
+    });
+
+    it('returns null without fetching when VIP is disabled via isVipDisabled callback', async () => {
+      const vipDisabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+        isVipDisabled: () => true,
+      });
+
+      const result =
+        await vipDisabledController.getVIPDashboard(mockSubscriptionId);
+
+      expect(result).toBeNull();
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:getVIPDashboard',
+        mockSubscriptionId,
+      );
     });
 
     it('persists fetched VIP dashboard to vipDashboard state', async () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -552,6 +552,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'invalidateSubscriptionCache',
   'isOptInSupported',
   'isRewardsFeatureEnabled',
+  'isVipFeatureEnabled',
   'linkAccountsToSubscriptionCandidate',
   'linkAccountToSubscriptionCandidate',
   'logout',
@@ -585,6 +586,7 @@ export class RewardsController extends BaseController<
     { payload: OndoGmCampaignParticipantOutcomeDto; lastFetched: number }
   > = new Map();
   #isDisabled: () => boolean;
+  #isVipDisabled: () => boolean;
   #reauthPromises: Map<string, Promise<void>> = new Map();
 
   // Deduplicates concurrent /vip/fees fetches for the same subscriptionId.
@@ -752,10 +754,12 @@ export class RewardsController extends BaseController<
     messenger,
     state,
     isDisabled,
+    isVipDisabled,
   }: {
     messenger: RewardsControllerMessenger;
     state?: Partial<RewardsControllerState>;
     isDisabled?: () => boolean;
+    isVipDisabled?: () => boolean;
   }) {
     super({
       name: controllerName,
@@ -768,6 +772,7 @@ export class RewardsController extends BaseController<
     });
 
     this.#isDisabled = isDisabled ?? (() => false);
+    this.#isVipDisabled = isVipDisabled ?? (() => false);
 
     this.messenger.registerMethodActionHandlers(
       this,
@@ -1798,8 +1803,7 @@ export class RewardsController extends BaseController<
   }
 
   async getVipTierForAccount(account: CaipAccountId): Promise<number | null> {
-    const rewardsEnabled = this.isRewardsFeatureEnabled();
-    if (!rewardsEnabled) return null;
+    if (!this.isVipFeatureEnabled()) return null;
 
     const subscriptionId = this.getActualSubscriptionId(account);
     if (!subscriptionId) return null;
@@ -1841,8 +1845,7 @@ export class RewardsController extends BaseController<
     account: CaipAccountId,
     baseFeeBips: number,
   ): Promise<number | null> {
-    const rewardsEnabled = this.isRewardsFeatureEnabled();
-    if (!rewardsEnabled) return null;
+    if (!this.isVipFeatureEnabled()) return null;
 
     const vipDiscountBips = await this.#getVipPerpsDiscountBips(
       account,
@@ -2316,6 +2319,18 @@ export class RewardsController extends BaseController<
   isRewardsFeatureEnabled(): boolean {
     const isDisabled = this.#isDisabled();
     if (isDisabled) return false;
+    return true;
+  }
+
+  /**
+   * Check if the VIP feature is enabled.
+   * VIP is a sub-feature of rewards, so it requires both the rewards feature
+   * and the dedicated VIP feature flag to be enabled.
+   * @returns boolean - True if the VIP feature is enabled, false otherwise
+   */
+  isVipFeatureEnabled(): boolean {
+    if (!this.isRewardsFeatureEnabled()) return false;
+    if (this.#isVipDisabled()) return false;
     return true;
   }
 
@@ -4490,6 +4505,8 @@ export class RewardsController extends BaseController<
   async getVIPDashboard(
     subscriptionId: string,
   ): Promise<VipDashboardState | null> {
+    if (!this.isVipFeatureEnabled()) return null;
+
     return await wrapWithCache<VipDashboardState | null>({
       key: subscriptionId,
       ttl: VIP_DASHBOARD_CACHE_THRESHOLD_MS,

--- a/app/core/Engine/controllers/rewards-controller/index.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.test.ts
@@ -9,11 +9,13 @@ import {
 import { rewardsControllerInit } from '.';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { isVersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 
 jest.mock('./RewardsController');
 jest.mock('../../../../selectors/settings');
+jest.mock('../../../../selectors/featureFlagController/vipProgram');
 jest.mock('../../../../util/remoteFeatureFlag');
 
 describe('rewardsControllerInit', () => {
@@ -21,6 +23,7 @@ describe('rewardsControllerInit', () => {
   const selectBasicFunctionalityEnabledMock = jest.mocked(
     selectBasicFunctionalityEnabled,
   );
+  const selectVipProgramEnabledMock = jest.mocked(selectVipProgramEnabled);
   const isVersionGatedFeatureFlagMock = jest.mocked(isVersionGatedFeatureFlag);
 
   let initRequestMock: jest.Mocked<
@@ -72,6 +75,7 @@ describe('rewardsControllerInit', () => {
 
     // Default mock return values
     selectBasicFunctionalityEnabledMock.mockReturnValue(true);
+    selectVipProgramEnabledMock.mockReturnValue(true);
     isVersionGatedFeatureFlagMock.mockReturnValue(false);
   });
 
@@ -133,6 +137,31 @@ describe('rewardsControllerInit', () => {
       const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
       const isDisabledFn = constructorArgs.isDisabled as () => boolean;
       expect(isDisabledFn()).toBe(true);
+    });
+  });
+
+  describe('isVipDisabled function', () => {
+    it('returns false when the VIP program is enabled', () => {
+      selectVipProgramEnabledMock.mockReturnValue(true);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isVipDisabledFn = constructorArgs.isVipDisabled as () => boolean;
+      expect(isVipDisabledFn()).toBe(false);
+      expect(selectVipProgramEnabledMock).toHaveBeenCalledWith(
+        initRequestMock.getState(),
+      );
+    });
+
+    it('returns true when the VIP program is disabled', () => {
+      selectVipProgramEnabledMock.mockReturnValue(false);
+
+      rewardsControllerInit(initRequestMock);
+
+      const constructorArgs = rewardsControllerClassMock.mock.calls[0][0];
+      const isVipDisabledFn = constructorArgs.isVipDisabled as () => boolean;
+      expect(isVipDisabledFn()).toBe(true);
     });
   });
 });

--- a/app/core/Engine/controllers/rewards-controller/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.ts
@@ -1,4 +1,5 @@
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import type { MessengerClientInitFunction } from '../../types';
 import {
   RewardsController,
@@ -26,6 +27,10 @@ export const rewardsControllerInit: MessengerClientInitFunction<
     isDisabled: () => {
       const isEnabled = selectBasicFunctionalityEnabled(getState());
       return !isEnabled;
+    },
+    isVipDisabled: () => {
+      const isVipEnabled = selectVipProgramEnabled(getState());
+      return !isVipEnabled;
     },
   });
 
@@ -80,6 +85,7 @@ export type {
   RewardsControllerInvalidateSubscriptionCacheAction,
   RewardsControllerIsOptInSupportedAction,
   RewardsControllerIsRewardsFeatureEnabledAction,
+  RewardsControllerIsVipFeatureEnabledAction,
   RewardsControllerLinkAccountsToSubscriptionCandidateAction,
   RewardsControllerLinkAccountToSubscriptionCandidateAction,
   RewardsControllerLogoutAction,


### PR DESCRIPTION
## **Description**

Gates all VIP rewards surfaces behind the existing app-wide
`vipProgramEnabled` remote feature flag (`selectVipProgramEnabled`,
`app/selectors/featureFlagController/vipProgram`). This is the broader
app flag already consumed by the Perps fee hooks and `useVipTier` — this
PR extends the same gate to the rewards controller and the rewards VIP
UI surfaces.

When the flag is OFF:

- The homepage VIP icon does not render, which implicitly prevents
  navigation into the VIP screens.
- The VIP splash page is unreachable (redirects to the dashboard).
- `RewardsController` VIP methods short-circuit: `getVIPDashboard` and
  `getVipTierForAccount` return `null`, and `getPerpsDiscountForAccount`
  returns `null` (no discount applied).

### Implementation

- Threaded an `isVipDisabled` callback into the `RewardsController`
  constructor, mirroring the existing `isDisabled` rewards-feature gate.
  Added `isVipFeatureEnabled()` which ANDs the rewards gate with the VIP
  gate (VIP is a sub-feature of rewards). Exposed it via the messenger
  (`RewardsController:isVipFeatureEnabled`).
- Wired `selectVipProgramEnabled` into the controller init
  (`rewards-controller/index.ts`) following the exact pattern used for
  `selectBasicFunctionalityEnabled`.
- Gated `RewardsDashboard` VIP icon render and `RewardsVipSplashView`
  reachability with `selectVipProgramEnabled`.

## **Changelog**

CHANGELOG entry: VIP rewards surfaces (home VIP icon, VIP splash page) and VIP controller endpoints (`getVIPDashboard`, `getVipTierForAccount`, `getPerpsDiscountForAccount`) are now gated behind the `vipProgramEnabled` feature flag.

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. With `vipProgramEnabled` OFF: open Rewards home as a VIP-eligible
   subscription — the crown/VIP icon should not appear; deep-linking to
   the VIP splash route should bounce back to the dashboard; perps fee
   estimates should show no VIP discount.
2. With `vipProgramEnabled` ON: VIP icon renders for VIP subscriptions,
   splash is reachable, and the perps VIP discount applies as before.

## **Screenshots/Recordings**

N/A — gating only; no new UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when perps VIP discounts and VIP dashboards apply (fee/pricing UX) and add a second gate on rewards VIP navigation; behavior is flag-driven with broad test coverage but touches money-adjacent controller paths.
> 
> **Overview**
> VIP rewards behavior is now tied to the remote **`vipProgramEnabled`** flag via **`selectVipProgramEnabled`**, in addition to existing subscription VIP checks.
> 
> **Rewards UI:** The dashboard VIP icon only shows when both the program flag and subscription VIP are on. Splash, main VIP, and tiers views treat **`canViewVip`** as requiring the flag and redirect to the dashboard when it is off (including deep links).
> 
> **RewardsController:** An **`isVipDisabled`** constructor callback (wired from **`selectVipProgramEnabled`** at init, like basic functionality for rewards) drives new **`isVipFeatureEnabled()`** (rewards enabled AND VIP not disabled). VIP APIs **`getVIPDashboard`**, **`getVipTierForAccount`**, and **`getPerpsDiscountForAccount`** short-circuit when VIP is disabled instead of using only **`isRewardsFeatureEnabled`**.
> 
> Tests were updated across dashboard/VIP views, controller init, and controller unit tests for flag-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ac167f510db20257ceaec7f84b9da160af1123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
