### PR TITLE
test(e2e): make Gestures and Assertions cross-framework by default

### DIFF
--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -38,20 +38,207 @@
 
 ## Framework Architecture
 
-### Core Classes:
+### Core Classes
 
 - **`Assertions`** - Enhanced assertions with auto-retry and detailed error messages
 - **`Gestures`** - Robust user interactions with configurable element state checking
 - **`Matchers`** - Type-safe element selectors with flexible options
 - **`Utilities`** - Core utilities with specialized element state checking
 
-### Key Features:
+### Key Features
 
 - ✅ **Auto-retry** - Handles flaky network/UI conditions
+- ✅ **Cross-framework** - `Gestures`, `Assertions`, and `Matchers` work in both Detox and Appium
 - ✅ **Configurable element state checking** - Control visibility, enabled, and stability checks per interaction
 - ✅ **Performance optimization** - Stability checking disabled by default for better performance
 - ✅ **Better error messages** - Descriptive errors with retry context and timing
 - ✅ **Type safety** - Full TypeScript support with IntelliSense
+
+### Cross-Framework Support
+
+`Gestures`, `Assertions`, and the three common `Matchers` methods (`getElementByID`, `getElementByText`, `getElementByLabel`) automatically route to the correct framework at runtime. Page objects that use them work in both Detox and Appium with no changes.
+
+```
+Page object calls Gestures.waitAndTap(elem)
+        │
+        ├── Detox run  → existing Detox implementation (retry, stability checks)
+        └── Appium run → AppiumGestureStrategy → PlaywrightGestures
+```
+
+This means a Detox smoke test and its Appium counterpart share the same page object calls — only the test runner wrapper and login flow differ between them.
+
+## Writing Page Objects
+
+### Default Pattern — works in both frameworks
+
+Use `Matchers.getElementByID/Text/Label` for getters and `Gestures`/`Assertions` for actions. No framework-specific imports needed.
+
+```typescript
+import Matchers from '../framework/Matchers';
+import Gestures from '../framework/Gestures';
+import Assertions from '../framework/Assertions';
+import { LoginPageSelectors } from './LoginPage.testIds';
+
+class LoginPage {
+  get passwordInput() {
+    return Matchers.getElementByID(LoginPageSelectors.PASSWORD_INPUT);
+  }
+
+  get errorMessage() {
+    return Matchers.getElementByText('Invalid password');
+  }
+
+  async enterPassword(password: string): Promise<void> {
+    await Gestures.typeText(this.passwordInput, password, {
+      elemDescription: 'password input',
+    });
+  }
+
+  async verifyErrorVisible(): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.errorMessage);
+  }
+}
+
+export default new LoginPage();
+```
+
+### Edge Case: different selector per framework
+
+When the same element has a different testID or selector strategy between Detox and Appium, use `resolve()` from the framework:
+
+```typescript
+import { resolve } from '../framework';
+
+// Different testID per framework
+get actionButton() {
+  return resolve({
+    detoxTestID: TabBarSelectorIDs.TRADE,
+    appiumTestID: TabBarSelectorIDs.ACTIONS,
+  });
+}
+
+// Different testID on iOS Appium vs everything else
+get container() {
+  return resolve({
+    testID: WalletViewSelectorsIDs.WALLET_CONTAINER,
+    iosAppiumTestID: WalletViewSelectorsIDs.EYE_SLASH_ICON,
+  });
+}
+```
+
+Available `resolve()` shapes:
+
+| Shape                                                   | When to use                                             |
+| ------------------------------------------------------- | ------------------------------------------------------- |
+| `{ testID }`                                            | Same testID works in all frameworks/platforms           |
+| `{ detoxTestID, appiumTestID }`                         | Different testID between Detox and Appium               |
+| `{ detoxTestID, androidAppiumTestID, iosAppiumTestID }` | All three differ                                        |
+| `{ testID, iosAppiumTestID }`                           | Detox + Android Appium share testID; iOS Appium differs |
+| `{ label }`                                             | Match by accessibility label                            |
+| `{ text }`                                              | Match by visible text                                   |
+
+### Edge Case: different selector type per framework
+
+When the selector strategy itself differs (e.g. Detox matches by ID+label, Appium matches by text), use `encapsulated()`:
+
+```typescript
+import { encapsulated } from '../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../framework/PlaywrightMatchers';
+
+getAccountElementByName(accountName: string) {
+  return encapsulated({
+    detox: () => Matchers.getElementByIDAndLabel(AccountCellIds.ADDRESS, accountName),
+    appium: () => PlaywrightMatchers.getElementByText(accountName),
+  });
+}
+```
+
+### Edge Case: different action flow per framework
+
+When the action itself must differ structurally between frameworks (e.g. Appium must scroll before tapping, or must hide the keyboard after typing), use `encapsulatedAction()`:
+
+```typescript
+import { encapsulatedAction } from '../framework/encapsulatedAction';
+
+async enterPassword(password: string): Promise<void> {
+  await encapsulatedAction({
+    detox: async () => {
+      await Gestures.typeText(this.passwordInput, password);
+    },
+    appium: async () => {
+      await Gestures.typeText(this.passwordInput, password);
+      await PlaywrightGestures.hideKeyboard(); // iOS Appium requires explicit dismiss
+    },
+  });
+}
+```
+
+**Only use `encapsulatedAction` when the flow genuinely differs.** If the same `Gestures.*` or `Assertions.*` call works for both, there is no need to branch.
+
+### Selector decision tree
+
+```
+Does the same Matchers.getElementByID/Text/Label call work for both?
+  YES → use it directly, no branching needed
+
+  NO → Does only the testID value differ per framework?
+    YES → resolve({ detoxTestID, appiumTestID, ... })
+
+    NO → Does only the selector type differ (ID vs text vs label)?
+      YES → encapsulated({ detox: ..., appium: ... })
+
+      NO → Does the action flow itself differ?
+        YES → encapsulatedAction({ detox: ..., appium: ... })
+```
+
+## Test Organization — Detox vs Appium Specs
+
+Detox smoke tests live in `tests/smoke/`. Appium equivalents live in `tests/smoke-appium/` with the same folder structure. Because page objects are cross-framework, the test body is nearly identical — only the runner wrapper and login helper differ:
+
+```typescript
+// Detox: tests/smoke/accounts/my-feature.spec.ts
+describe(SmokeAccounts('My feature'), () => {
+  it('does the thing', async () => {
+    await withFixtures(
+      { fixture: new FixtureBuilder().build(), restartDevice: true },
+      async () => {
+        await loginToApp();
+        await SomePage.tapSomething();
+        await Assertions.expectElementToBeVisible(SomePage.result);
+      },
+    );
+  });
+});
+
+// Appium: tests/smoke-appium/accounts/my-feature.spec.ts
+appiumTest.describe(SmokeAccounts('My feature'), () => {
+  appiumTest(
+    'does the thing',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder().build(),
+          restartDevice: true,
+          currentDeviceDetails,
+        },
+        async () => {
+          await loginToAppPlaywright({ scenarioType: 'e2e' });
+          await SomePage.tapSomething(); // identical
+          await Assertions.expectElementToBeVisible(SomePage.result); // identical
+        },
+      );
+    },
+  );
+});
+```
+
+The only required differences are:
+
+- `import { test as appiumTest }` from the Playwright fixture index
+- `{ driver: _driver, currentDeviceDetails }` fixture args
+- `currentDeviceDetails` passed to `withFixtures`
+- `loginToAppPlaywright(...)` instead of `loginToApp()`
+- Drop any `device.*` (Detox-only) calls
 
 ## Test Atomicity and Coupling
 
@@ -110,52 +297,6 @@ new FixtureBuilder().build();
 ```
 
 ## Framework Best Practices
-
-### Page Object Model (POM) Pattern
-
-- ALWAYS use the Page Object Model pattern for organizing test code
-- Move all element selectors to Page Objects or dedicated selector files
-- When adding one or more testID to a component or view, place it in a dedicated file next to where it is being used with the file extension `.testIds.ts`
-- Access UI elements through Page Object methods, not directly in test specs
-
-#### Page Object Structure Example:
-
-```typescript
-import { LoginPageSelectors } from './LoginPage.selectors';
-
-class LoginPage {
-  // Getter pattern for elements
-  get emailInput() {
-    return Matchers.getElementByID(LoginPageSelectors.EMAIL_INPUT);
-  }
-  get passwordInput() {
-    return Matchers.getElementByID(LoginPageSelectors.PASSWORD_INPUT);
-  }
-  get loginButton() {
-    return Matchers.getElementByID(LoginPageSelectors.LOGIN_BUTTON);
-  }
-
-  // Public methods for actions
-  async login(email: string, password: string): Promise<void> {
-    await Gestures.typeText(this.emailInput, email, {
-      description: 'enter email',
-    });
-    await Gestures.typeText(this.passwordInput, password, {
-      description: 'enter password',
-    });
-    await Gestures.tap(this.loginButton, { description: 'tap login button' });
-  }
-
-  // Public methods for verifications
-  async verifyLoginError(expectedError: string): Promise<void> {
-    await Assertions.expectTextDisplayed(expectedError, {
-      description: 'login error should be displayed',
-    });
-  }
-}
-
-export default new LoginPage();
-```
 
 ### TestIDs location example:
 
@@ -255,6 +396,23 @@ The following patterns are prohibited in test specs:
    await Assertions.expectElementToBeVisible(element);
    ```
 
+4. **Framework-specific imports in page objects when not needed**
+
+   ```typescript
+   // DON'T — unnecessary when the same call works cross-framework:
+   import PlaywrightAssertions from '../framework/PlaywrightAssertions';
+   import { asPlaywrightElement } from '../framework/EncapsulatedElement';
+
+   await PlaywrightAssertions.expectElementToBeVisible(
+     await asPlaywrightElement(this.heading),
+   );
+
+   // DO:
+   import Assertions from '../framework/Assertions';
+
+   await Assertions.expectElementToBeVisible(this.heading);
+   ```
+
 ## Handling Flaky Tests
 
 ### Common Issues and Solutions
@@ -321,7 +479,8 @@ Before submitting E2E tests, ensure:
 - [ ] Element selectors defined once and reused
 - [ ] Framework configuration used appropriately
 - [ ] Error handling for expected failure scenarios
-- [ ] Tests work on both iOS and Android platforms
+- [ ] `Gestures`/`Assertions`/`Matchers` used directly — `PlaywrightAssertions`, `PlaywrightGestures`, `asPlaywrightElement` only imported when the flow genuinely requires framework-specific branching
+- [ ] `encapsulatedAction` only used when Detox and Appium flows structurally differ — not just to call the same method twice
 
 ## Debugging Failed Tests
 

--- a/tests/framework/Assertions.ts
+++ b/tests/framework/Assertions.ts
@@ -4,9 +4,12 @@ import { AssertionOptions } from './types.ts';
 import Matchers from './Matchers.ts';
 import {
   asDetoxElement,
+  asPlaywrightElement,
   type EncapsulatedElementType,
 } from './EncapsulatedElement.ts';
 import { Json } from '@metamask/utils';
+import { FrameworkDetector } from './FrameworkDetector.ts';
+import PlaywrightAssertions from './PlaywrightAssertions.ts';
 
 /**
  * Assertions with auto-retry and better error messages
@@ -24,6 +27,13 @@ export default class Assertions {
       | EncapsulatedElementType,
     options: AssertionOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return PlaywrightAssertions.expectElementToBeVisible(
+        asPlaywrightElement(elem as EncapsulatedElementType),
+        options,
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       description = 'element should be visible',
@@ -63,6 +73,13 @@ export default class Assertions {
       | EncapsulatedElementType,
     options: AssertionOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return PlaywrightAssertions.expectElementToNotBeVisible(
+        asPlaywrightElement(elem as EncapsulatedElementType),
+        options,
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       description = 'element should not visible',
@@ -96,6 +113,14 @@ export default class Assertions {
     text: string,
     options: AssertionOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return PlaywrightAssertions.expectElementText(
+        asPlaywrightElement(elem),
+        text,
+        options,
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       description = `element has text "${text}"`,
@@ -205,6 +230,10 @@ export default class Assertions {
     text: string,
     options: AssertionOptions & { allowDuplicates?: boolean } = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return PlaywrightAssertions.expectTextDisplayed(text, options);
+    }
+
     const { timeout = BASE_DEFAULTS.timeout, allowDuplicates = false } =
       options;
 
@@ -240,6 +269,10 @@ export default class Assertions {
     text: string,
     options: AssertionOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return PlaywrightAssertions.expectTextNotDisplayed(text, options);
+    }
+
     const { timeout = BASE_DEFAULTS.timeout } = options;
     return Utilities.executeWithRetry(
       async () => {

--- a/tests/framework/EncapsulatedElement.test.ts
+++ b/tests/framework/EncapsulatedElement.test.ts
@@ -632,13 +632,6 @@ describe('EncapsulatedElement', () => {
       ).toBe(true);
     });
 
-    it('returns true for { custom }', () => {
-      const config: LocatorConfig = {
-        detox: () => createMockDetoxElement(),
-      };
-      expect(isSelector({ custom: config })).toBe(true);
-    });
-
     it('returns false for null', () => {
       expect(isSelector(null)).toBe(false);
     });
@@ -802,24 +795,6 @@ describe('EncapsulatedElement', () => {
         expect(spy).toHaveBeenCalledTimes(1);
         const config = spy.mock.calls[0][0] as LocatorConfig;
         expect(typeof config.detox).toBe('function');
-        spy.mockRestore();
-      });
-    });
-
-    describe('{ custom }', () => {
-      it('delegates directly to encapsulated() with the provided LocatorConfig', () => {
-        FrameworkDetector.setFramework(TestFramework.DETOX);
-        const mockDetoxElement = createMockDetoxElement();
-        const spy = createSpyOnEncapsulatedCreate();
-        spy.mockReturnValue(mockDetoxElement);
-        const customConfig: LocatorConfig = {
-          detox: () => mockDetoxElement,
-        };
-
-        resolve({ custom: customConfig });
-
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy.mock.calls[0][0]).toBe(customConfig);
         spy.mockRestore();
       });
     });

--- a/tests/framework/GestureStrategy.ts
+++ b/tests/framework/GestureStrategy.ts
@@ -346,9 +346,17 @@ export class AppiumGestureStrategy implements GestureStrategy {
    * @param elem - The element to tap
    * @returns A promise that resolves when the tap is complete
    */
-  async tap(elem: EncapsulatedElementType): Promise<void> {
+  async tap(
+    elem: EncapsulatedElementType,
+    opts?: UnifiedGestureOptions,
+  ): Promise<void> {
     const el = await asPlaywrightElement(elem);
-    await PlaywrightGestures.waitAndTap(el);
+    await PlaywrightGestures.waitAndTap(el, {
+      timeout: opts?.timeout,
+      delay: opts?.delay,
+      checkForDisplayed: opts?.checkForDisplayed ?? true,
+      checkForEnabled: opts?.checkForEnabled,
+    });
   }
 
   /**
@@ -365,7 +373,7 @@ export class AppiumGestureStrategy implements GestureStrategy {
     await PlaywrightGestures.waitAndTap(el, {
       timeout: opts?.timeout,
       delay: opts?.delay,
-      checkForDisplayed: opts?.checkForDisplayed,
+      checkForDisplayed: opts?.checkForDisplayed ?? true,
       checkForEnabled: opts?.checkForEnabled,
       waitForInteractive: opts?.waitForInteractive,
       enabledStableReads: opts?.enabledStableReads,

--- a/tests/framework/GestureStrategy.ts
+++ b/tests/framework/GestureStrategy.ts
@@ -38,6 +38,8 @@ export interface UnifiedGestureOptions {
   enabledStableReads?: number;
   /** Extra wait (ms) after enabled/interactive, before click — Appium only */
   postEnabledSettleMs?: number;
+  /** Long press duration in ms — passed through to PlaywrightGestures.longPress */
+  duration?: number;
 }
 
 /**
@@ -279,6 +281,7 @@ export class DetoxGestureStrategy implements GestureStrategy {
     await Gestures.longPress(asDetoxElement(elem), {
       timeout: opts?.timeout,
       elemDescription: opts?.description,
+      duration: opts?.duration,
     });
   }
 
@@ -445,9 +448,12 @@ export class AppiumGestureStrategy implements GestureStrategy {
    * @param elem - The element to long press
    * @returns A promise that resolves when the long press is complete
    */
-  async longPress(elem: EncapsulatedElementType): Promise<void> {
+  async longPress(
+    elem: EncapsulatedElementType,
+    opts?: UnifiedGestureOptions,
+  ): Promise<void> {
     const el = await asPlaywrightElement(elem);
-    await PlaywrightGestures.longPress(el);
+    await PlaywrightGestures.longPress(el, opts?.duration);
   }
 
   /**

--- a/tests/framework/Gestures.ts
+++ b/tests/framework/Gestures.ts
@@ -334,6 +334,7 @@ export default class Gestures {
       return UnifiedGestures.longPress(elem as EncapsulatedElementType, {
         timeout: options.timeout,
         description: options.elemDescription,
+        duration: options.duration,
       });
     }
 

--- a/tests/framework/Gestures.ts
+++ b/tests/framework/Gestures.ts
@@ -12,6 +12,8 @@ import {
 import { createLogger } from './logger.ts';
 import { sleep } from '../../app/util/testUtils';
 import { type EncapsulatedElementType } from './EncapsulatedElement.ts';
+import { FrameworkDetector } from './FrameworkDetector.ts';
+import UnifiedGestures from './UnifiedGestures.ts';
 
 const logger = createLogger({ name: 'Gestures' });
 
@@ -87,6 +89,14 @@ export default class Gestures {
     elem: DetoxElement | WebElement | EncapsulatedElementType,
     options: TapOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.tap(elem as EncapsulatedElementType, {
+        timeout: options.timeout,
+        description: options.elemDescription,
+        delay: options.delay,
+      });
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       checkStability = false,
@@ -124,6 +134,14 @@ export default class Gestures {
     elem: DetoxElement | WebElement | EncapsulatedElementType,
     options: TapOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.waitAndTap(elem as EncapsulatedElementType, {
+        timeout: options.timeout,
+        description: options.elemDescription,
+        delay: options.delay,
+      });
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       checkStability = false,
@@ -161,6 +179,17 @@ export default class Gestures {
     index: number,
     options: TapOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.tapAtIndex(
+        elem as EncapsulatedElementType,
+        index,
+        {
+          timeout: options.timeout,
+          description: options.elemDescription,
+        },
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       elemDescription,
@@ -208,6 +237,17 @@ export default class Gestures {
     point: { x: number; y: number },
     options: TapOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.tapAtPoint(
+        elem as EncapsulatedElementType,
+        point,
+        {
+          timeout: options.timeout,
+          description: options.elemDescription,
+        },
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       checkStability = false,
@@ -244,6 +284,13 @@ export default class Gestures {
     elem: DetoxElement | EncapsulatedElementType,
     options: TapOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.dblTap(elem as EncapsulatedElementType, {
+        timeout: options.timeout,
+        description: options.elemDescription,
+      });
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       checkStability = false,
@@ -283,6 +330,13 @@ export default class Gestures {
     elem: DetoxElement | EncapsulatedElementType,
     options: LongPressOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.longPress(elem as EncapsulatedElementType, {
+        timeout: options.timeout,
+        description: options.elemDescription,
+      });
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       checkStability = false,
@@ -324,6 +378,13 @@ export default class Gestures {
     text: string,
     options: TypeTextOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.typeText(elem as EncapsulatedElementType, text, {
+        timeout: options.timeout,
+        description: options.elemDescription,
+      });
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       clearFirst = true,
@@ -417,6 +478,17 @@ export default class Gestures {
     text: string,
     options: GestureOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.replaceText(
+        elem as EncapsulatedElementType,
+        text,
+        {
+          timeout: options.timeout,
+          description: options.elemDescription,
+        },
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       checkStability = false,
@@ -458,6 +530,15 @@ export default class Gestures {
     direction: 'up' | 'down' | 'left' | 'right',
     options: SwipeOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.swipe(elem as EncapsulatedElementType, direction, {
+        timeout: options.timeout,
+        description: options.elemDescription,
+        speed: options.speed,
+        percentage: options.percentage,
+      });
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       speed = 'fast',
@@ -506,6 +587,19 @@ export default class Gestures {
     scrollableContainer: Promise<Detox.NativeMatcher>,
     options: ScrollOptions = {},
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      return UnifiedGestures.scrollToElement(
+        targetElement as EncapsulatedElementType,
+        scrollableContainer,
+        {
+          timeout: options.timeout,
+          description: options.elemDescription,
+          direction: options.direction,
+          scrollAmount: options.scrollAmount,
+        },
+      );
+    }
+
     const {
       timeout = BASE_DEFAULTS.timeout,
       direction = 'down',

--- a/tests/framework/Selector.ts
+++ b/tests/framework/Selector.ts
@@ -1,7 +1,6 @@
 import {
   encapsulated,
   type EncapsulatedElementType,
-  type LocatorConfig,
 } from './EncapsulatedElement.ts';
 import PlaywrightMatchers from './PlaywrightMatchers.ts';
 
@@ -15,18 +14,13 @@ export type Selector =
       androidAppiumTestID: string;
       iosAppiumTestID: string;
     }
-  | { testID: string; iosAppiumTestID: string; index?: number }
-  | { custom: LocatorConfig };
+  | { testID: string; iosAppiumTestID: string; index?: number };
 
 /**
  * Moves `encapsulated()` to a single location so page-objects can use declarative Selectors without importing encapsulated() or LocatorConfig.
  * This can also be used in the original Matchers, Assertions, and Gestures methods that currently return DetoxElements to make them cross-framework compatible without page-object changes.
  */
 export function resolve(selector: Selector): EncapsulatedElementType {
-  if ('custom' in selector) {
-    return encapsulated(selector.custom);
-  }
-
   if ('androidAppiumTestID' in selector) {
     return encapsulated({
       detox: () =>
@@ -155,7 +149,6 @@ export function isSelector(value: unknown): value is Selector {
     'text' in v ||
     'detoxTestID' in v ||
     'androidAppiumTestID' in v ||
-    'iosAppiumTestID' in v ||
-    'custom' in v
+    'iosAppiumTestID' in v
   );
 }

--- a/tests/page-objects/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.ts
+++ b/tests/page-objects/Settings/SecurityAndPrivacy/SecurityAndPrivacyView.ts
@@ -5,7 +5,6 @@ import {
 import Matchers from '../../../framework/Matchers';
 import Gestures from '../../../framework/Gestures';
 import { EncapsulatedElementType } from '../../../framework';
-import UnifiedGestures from '../../../framework/UnifiedGestures';
 
 class SecurityAndPrivacy {
   get changePasswordButton(): EncapsulatedElementType {
@@ -112,8 +111,8 @@ class SecurityAndPrivacy {
   }
 
   async tapRevealSecretRecoveryPhraseButton(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.revealSecretRecoveryPhraseButton, {
-      description: 'Reveal secret recovery phrase button',
+    await Gestures.waitAndTap(this.revealSecretRecoveryPhraseButton, {
+      elemDescription: 'Reveal secret recovery phrase button',
     });
   }
 

--- a/tests/page-objects/Settings/SettingsView.ts
+++ b/tests/page-objects/Settings/SettingsView.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../app/components/Views/Settings/SettingsView.testIds';
 import { CommonSelectorsText } from '../../../app/util/Common.testIds';
 import { EncapsulatedElementType } from '../../framework';
-import UnifiedGestures from '../../framework/UnifiedGestures';
 
 class SettingsView {
   get title(): EncapsulatedElementType {
@@ -119,8 +118,8 @@ class SettingsView {
   }
 
   async tapSecurityAndPrivacy(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.securityAndPrivacyButton, {
-      description: 'Settings - Security and Privacy Button',
+    await Gestures.waitAndTap(this.securityAndPrivacyButton, {
+      elemDescription: 'Settings - Security and Privacy Button',
     });
   }
 

--- a/tests/page-objects/wallet/AccountListBottomSheet.ts
+++ b/tests/page-objects/wallet/AccountListBottomSheet.ts
@@ -125,7 +125,11 @@ class AccountListBottomSheet {
   getAccountElementByAccountNameV2(
     accountName: string,
   ): EncapsulatedElementType {
-    return Matchers.getElementByIDAndLabel(AccountCellIds.ADDRESS, accountName);
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByIDAndLabel(AccountCellIds.ADDRESS, accountName),
+      appium: () => PlaywrightMatchers.getElementByText(accountName),
+    });
   }
 
   getSelectElement(index: number): EncapsulatedElementType {

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -1,17 +1,14 @@
 import Matchers from '../../framework/Matchers';
-import UnifiedGestures from '../../framework/UnifiedGestures';
+import Gestures from '../../framework/Gestures';
 import { TabBarSelectorIDs } from '../../../app/components/Nav/Main/TabBar.testIds';
 import {
   Assertions,
-  PlaywrightAssertions,
   Utilities,
   resolve,
   EncapsulatedElementType,
-  asPlaywrightElement,
 } from '../../framework';
-import { encapsulatedAction } from '../../framework/encapsulatedAction';
+import { encapsulated } from '../../framework/EncapsulatedElement';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
-import PlaywrightGestures from '../../framework/PlaywrightGestures';
 import ActivitiesView from '../Transactions/ActivitiesView';
 import SettingsView from '../Settings/SettingsView';
 import AccountMenu from '../AccountMenu/AccountMenu';
@@ -56,40 +53,21 @@ class TabBarComponent {
   }
 
   get homeButton(): EncapsulatedElementType {
-    return resolve({
-      custom: {
-        detox: () => Matchers.getElementByText('Home'),
-        appium: () =>
-          PlaywrightMatchers.getElementById(TabBarSelectorIDs.WALLET, {
-            exact: true,
-          }),
-      },
+    return encapsulated({
+      detox: () => Matchers.getElementByText('Home'),
+      appium: () =>
+        PlaywrightMatchers.getElementById(TabBarSelectorIDs.WALLET, {
+          exact: true,
+        }),
     });
   }
 
   async tapHome(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await encapsulatedAction({
-          detox: async () => {
-            await UnifiedGestures.waitAndTap(this.homeButton, {
-              timeout: 2000,
-            });
-            await Assertions.expectElementToBeVisible(WalletView.container, {
-              timeout: 500,
-            });
-          },
-          appium: async () => {
-            await PlaywrightGestures.waitAndTap(
-              await asPlaywrightElement(this.homeButton),
-            );
-            await PlaywrightAssertions.expectElementToBeVisible(
-              await asPlaywrightElement(WalletView.container),
-              {
-                timeout: 500,
-              },
-            );
-          },
+        await Gestures.waitAndTap(this.homeButton, { timeout: 2000 });
+        await Assertions.expectElementToBeVisible(WalletView.container, {
+          timeout: 500,
         });
       },
       {
@@ -103,9 +81,7 @@ class TabBarComponent {
   async tapWallet(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await UnifiedGestures.waitAndTap(this.tabBarWalletButton, {
-          timeout: 2000,
-        });
+        await Gestures.waitAndTap(this.tabBarWalletButton, { timeout: 2000 });
         await Assertions.expectElementToBeVisible(WalletView.container, {
           timeout: 500,
         });
@@ -120,46 +96,33 @@ class TabBarComponent {
   }
 
   async tapBrowser(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.tabBarBrowserButton, {
-      description: 'Tab Bar - Browser Button',
+    await Gestures.waitAndTap(this.tabBarBrowserButton, {
+      elemDescription: 'Tab Bar - Browser Button',
     });
   }
 
   async tapActions(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.tabBarActionButton, {
-      description: 'Tab Bar - Trade Button',
+    await Gestures.waitAndTap(this.tabBarActionButton, {
+      elemDescription: 'Tab Bar - Actions Button',
     });
   }
 
   async tapTrade(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.tabBarTradeButton, {
-      description: 'Tab Bar - Trade Button',
+    await Gestures.waitAndTap(this.tabBarTradeButton, {
+      elemDescription: 'Tab Bar - Trade Button',
     });
   }
 
   async tapAccountsMenu(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await UnifiedGestures.waitAndTap(this.tabBarWalletButton, {
-          timeout: 2000,
+        await Gestures.waitAndTap(this.tabBarWalletButton, { timeout: 2000 });
+        await Assertions.expectElementToBeVisible(WalletView.container, {
+          timeout: 500,
         });
-        await encapsulatedAction({
-          detox: async () => {
-            await Assertions.expectElementToBeVisible(WalletView.container);
-            await UnifiedGestures.waitAndTap(WalletView.hamburgerMenuButton);
-            await Assertions.expectElementToBeVisible(AccountMenu.container);
-          },
-          appium: async () => {
-            await PlaywrightAssertions.expectElementToBeVisible(
-              await asPlaywrightElement(WalletView.container),
-              { timeout: 500 },
-            );
-            await UnifiedGestures.waitAndTap(WalletView.hamburgerMenuButton);
-            await PlaywrightAssertions.expectElementToBeVisible(
-              await asPlaywrightElement(AccountMenu.container),
-              { timeout: 500 },
-            );
-          },
+        await Gestures.waitAndTap(WalletView.hamburgerMenuButton);
+        await Assertions.expectElementToBeVisible(AccountMenu.container, {
+          timeout: 500,
         });
       },
       {
@@ -172,24 +135,12 @@ class TabBarComponent {
   async tapSettings(): Promise<void> {
     await this.tapAccountsMenu();
     await AccountMenu.tapSettings();
-    await encapsulatedAction({
-      detox: async () => {
-        await Assertions.expectElementToBeVisible(SettingsView.title);
-      },
-      appium: async () => {
-        await PlaywrightAssertions.expectElementToBeVisible(
-          await asPlaywrightElement(SettingsView.title),
-          { description: 'Settings view title' },
-        );
-      },
-    });
+    await Assertions.expectElementToBeVisible(SettingsView.title);
   }
   async tapExploreButton(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await UnifiedGestures.waitAndTap(this.tabBarExploreButton, {
-          timeout: 2000,
-        });
+        await Gestures.waitAndTap(this.tabBarExploreButton, { timeout: 2000 });
         await Assertions.expectElementToBeVisible(TrendingView.searchButton, {
           description: 'Trending view search button should be visible',
           timeout: 500,
@@ -205,40 +156,27 @@ class TabBarComponent {
   }
 
   async tapActivity(): Promise<void> {
-    await encapsulatedAction({
-      detox: async () => {
-        await Utilities.executeWithRetry(
-          async () => {
-            await UnifiedGestures.waitAndTap(this.tabBarActivityButton, {
-              timeout: 2000,
-            });
-            await Assertions.expectElementToBeVisible(ActivitiesView.title, {
-              description: 'Activity View Title',
-              timeout: 500,
-            });
-          },
-          {
-            // Each attempt: ~2.5s (2s tap + 0.5s assertion). 15 retries ≈ ~37s total budget.
-            maxRetries: 15,
-            timeout: 45000,
-            description: 'Tap Activity Button',
-          },
-        );
+    await Utilities.executeWithRetry(
+      async () => {
+        await Gestures.waitAndTap(this.tabBarActivityButton, { timeout: 2000 });
+        await Assertions.expectElementToBeVisible(ActivitiesView.title, {
+          description: 'Activity View Title',
+          timeout: 500,
+        });
       },
-      appium: async () => {
-        await PlaywrightGestures.waitAndTap(
-          await asPlaywrightElement(this.tabBarActivityButton),
-        );
+      {
+        // Each attempt: ~2.5s (2s tap + 0.5s assertion). 15 retries ≈ ~37s total budget.
+        maxRetries: 15,
+        timeout: 45000,
+        description: 'Tap Activity Button',
       },
-    });
+    );
   }
 
   async tapRewards(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await UnifiedGestures.waitAndTap(this.tabBarRewardsButton, {
-          timeout: 2000,
-        });
+        await Gestures.waitAndTap(this.tabBarRewardsButton, { timeout: 2000 });
       },
       {
         // Each attempt: ~2.5s (2s tap + 0.5s default delay) + 500ms retry interval ≈ 3s/cycle → ~15 retries within 45s.

--- a/tests/smoke-appium/accounts/reveal-secret-recovery-phrase.spec.ts
+++ b/tests/smoke-appium/accounts/reveal-secret-recovery-phrase.spec.ts
@@ -8,18 +8,14 @@ import SecurityAndPrivacy from '../../page-objects/Settings/SecurityAndPrivacy/S
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { defaultGanacheOptions } from '../../framework/Constants.js';
-import { asPlaywrightElement } from '../../framework/EncapsulatedElement.js';
-import PlaywrightAssertions from '../../framework/PlaywrightAssertions.js';
+import Assertions from '../../framework/Assertions.js';
 
 appiumTest.describe(
   SmokeAccounts('Secret Recovery Phrase Reveal from Settings'),
   () => {
     appiumTest(
       'navigate to reveal SRP screen and make the quiz',
-      async ({
-        driver: _driver, // required: sets globalThis.driver for Appium page objects
-        currentDeviceDetails,
-      }) => {
+      async ({ driver: _driver, currentDeviceDetails }) => {
         await withFixtures(
           {
             fixture: new FixtureBuilder().build(),
@@ -35,11 +31,8 @@ appiumTest.describe(
             await SecurityAndPrivacy.tapRevealSecretRecoveryPhraseButton();
             await completeSrpQuiz(defaultGanacheOptions.mnemonic);
 
-            await PlaywrightAssertions.expectElementToBeVisible(
-              await asPlaywrightElement(
-                SecurityAndPrivacy.securityAndPrivacyHeading,
-              ),
-              { description: 'Security and privacy heading' },
+            await Assertions.expectElementToBeVisible(
+              SecurityAndPrivacy.securityAndPrivacyHeading,
             );
           },
         );

--- a/tests/smoke-appium/accounts/wallet-details.spec.ts
+++ b/tests/smoke-appium/accounts/wallet-details.spec.ts
@@ -1,0 +1,69 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokeAccounts } from '../../tags.js';
+import { loginToAppPlaywright } from '../../flows/wallet.flow.js';
+import { completeSrpQuiz } from '../../flows/accounts.flow.js';
+import AccountListBottomSheet from '../../page-objects/wallet/AccountListBottomSheet.js';
+import Assertions from '../../framework/Assertions.js';
+import WalletView from '../../page-objects/wallet/WalletView.js';
+import AccountDetails from '../../page-objects/MultichainAccounts/AccountDetails.js';
+import WalletDetails from '../../page-objects/MultichainAccounts/WalletDetails.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import { defaultGanacheOptions } from '../../framework/Constants.js';
+
+appiumTest.describe(SmokeAccounts('Wallet details'), () => {
+  const FIRST = 0;
+
+  appiumTest(
+    'goes to the wallet details, creates an account and exports srp',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder()
+            .withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountOneQrAccountOneSimpleKeyPairAccount()
+            .build(),
+          restartDevice: true,
+          currentDeviceDetails,
+        },
+        async () => {
+          await loginToAppPlaywright({ scenarioType: 'e2e' });
+          await WalletView.tapIdenticon();
+
+          await Assertions.expectElementToBeVisible(
+            AccountListBottomSheet.accountList,
+            { description: 'Account list should be visible' },
+          );
+          await AccountListBottomSheet.tapAccountEllipsisButtonV2(FIRST);
+          await AccountDetails.tapEditWalletName();
+          await Assertions.expectTextDisplayed('Wallet 1', {
+            description: 'Wallet 1 should be visible',
+          });
+
+          await WalletDetails.tapCreateAccount();
+          const visibleAccounts = ['Account 1', 'Account 2', 'Account 3'];
+          for (const accountName of visibleAccounts) {
+            await Assertions.expectElementToBeVisible(
+              AccountListBottomSheet.getAccountElementByAccountNameV2(
+                accountName,
+              ),
+              { description: `Account ${accountName} should be visible` },
+            );
+          }
+
+          await WalletDetails.tapSRP();
+          await completeSrpQuiz(defaultGanacheOptions.mnemonic);
+
+          await WalletView.tapIdenticon();
+          for (const accountName of visibleAccounts) {
+            await Assertions.expectElementToBeVisible(
+              AccountListBottomSheet.getAccountElementByAccountNameV2(
+                accountName,
+              ),
+              { description: `Account ${accountName} should be visible` },
+            );
+          }
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

This PR makes `Gestures` and `Assertions` — the two most widely-used E2E framework utilities — work in both Detox and Appium without requiring page object changes.

**Problem:** 174+ existing page objects call `Gestures.*` and `Assertions.*` which route directly to Detox APIs. Running them in Appium required migrating every page object to `UnifiedGestures`/`PlaywrightAssertions`, which meant touching hundreds of files.

**Solution:** Add a `FrameworkDetector.isAppium()` guard at the top of each method. The Appium branch delegates to `UnifiedGestures`/`PlaywrightAssertions`; the Detox branch runs the existing implementation unchanged. This avoids a circular reference (`DetoxGestureStrategy` internally calls `Gestures.*`) because the guard only redirects on the Appium path.

```
Appium call:  Gestures.tap(elem) → isAppium=true  → UnifiedGestures → AppiumGestureStrategy → PlaywrightGestures
Detox call:   Gestures.tap(elem) → isAppium=false → existing Detox implementation (no change)
```

**Changes:**
- `Gestures.ts`: 10 methods shimmed (`tap`, `waitAndTap`, `tapAtIndex`, `tapAtPoint`, `dblTap`, `longPress`, `typeText`, `replaceText`, `swipe`, `scrollToElement`)
- `Assertions.ts`: 5 canonical methods shimmed (`expectElementToBeVisible`, `expectElementToNotBeVisible`, `expectElementToHaveText`, `expectTextDisplayed`, `expectTextNotDisplayed`)
- `GestureStrategy.ts`: `checkForDisplayed` defaults to `true` in Appium strategy (matches Detox behaviour)
- `Selector.ts`: Removed `custom` variant — use `encapsulated()` directly (was just an alias)
- Page objects reverted: `TabBarComponent`, `SettingsView`, `SecurityAndPrivacyView` — unnecessary `UnifiedGestures`/`encapsulatedAction` usage replaced with plain `Gestures`/`Assertions`
- New Appium smoke test: `tests/smoke-appium/accounts/wallet-details.spec.ts` — lift-and-shift from Detox, 11 page object calls identical
- Updated `docs/testing/e2e-testing.md` with the new cross-framework paradigm, selector decision tree, and Detox vs Appium spec comparison

## **Changelog**

<!-- mms-check: type=changelog required=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — this is a framework-layer change. Existing Detox smoke tests exercise the Detox path; the new `wallet-details.spec.ts` exercises the Appium path.

To verify Detox path is unchanged:
```
yarn test:e2e:ios:debug:run --testNamePattern "Wallet Details"
```

To verify Appium path works:
```
yarn appium-smoke:ios --grep "goes to the wallet details"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — documentation and framework-layer change only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — framework/test-only change, no production app code modified
- [x] I've tested with a power user scenario
  - N/A — framework/test-only change
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — framework/test-only change

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core E2E gesture/assertion path used by hundreds of page objects; Detox behavior is intended unchanged but mis-routing or circular delegation could break both runners.
> 
> **Overview**
> **`Gestures` and `Assertions` now route to Appium at runtime** via `FrameworkDetector.isAppium()`, delegating to `UnifiedGestures` / `PlaywrightAssertions` while leaving the Detox implementations unchanged. That lets existing page objects run in both runners without swapping to `UnifiedGestures` or `PlaywrightAssertions` everywhere.
> 
> **Supporting tweaks:** Appium taps default `checkForDisplayed` to true; long-press `duration` is forwarded; **`resolve()` drops the `{ custom }` selector** in favor of direct `encapsulated()`. **Page objects** (`TabBarComponent`, settings flows, account list) are simplified to plain `Gestures`/`Assertions`, with **`encapsulated()`** only where selectors differ (e.g. Home tab, account-by-name).
> 
> **Docs** in `e2e-testing.md` document cross-framework usage, selector branching (`resolve`, `encapsulated`, `encapsulatedAction`), and Detox vs `smoke-appium` spec layout. **New Appium smoke** `wallet-details.spec.ts` mirrors the Detox flow; **reveal SRP** spec uses shared `Assertions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53609ccb4d1a9f17be337d14ae5433c4254ab3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->