### PR TITLE
fix(ramp): recover headless deposit order and dismiss webview on Back to app

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -59,6 +59,7 @@ jest.mock('../../headless/sessionRegistry', () => ({
   getSession: jest.fn(),
   closeSession: jest.fn(),
   failSession: jest.fn(),
+  registerSessionDismiss: jest.fn(),
 }));
 
 jest.mock('../../../../../util/Logger', () => ({
@@ -664,6 +665,9 @@ describe('Checkout', () => {
       .closeSession as jest.Mock;
     const mockFailSession = jest.requireMock('../../headless/sessionRegistry')
       .failSession as jest.Mock;
+    const mockRegisterSessionDismiss = jest.requireMock(
+      '../../headless/sessionRegistry',
+    ).registerSessionDismiss as jest.Mock;
     const showV2OrderToastMock = jest.requireMock('../../utils/v2OrderToast')
       .showV2OrderToast as jest.Mock;
 
@@ -688,6 +692,7 @@ describe('Checkout', () => {
       mockGetSession.mockReset();
       mockCloseSession.mockReset();
       mockFailSession.mockReset();
+      mockRegisterSessionDismiss.mockReset();
       mockParentPop = jest.fn();
       mockNavigation.getParent.mockImplementation(() => ({
         pop: mockParentPop,
@@ -697,6 +702,48 @@ describe('Checkout', () => {
       }));
       mockGetOrderFromCallback.mockResolvedValue(mockOrder);
       mockUseRampsUnifiedV2Enabled.mockReturnValue(true);
+    });
+
+    it('registers a valid-scope dismiss on mount and clears it on unmount', () => {
+      mockUseParams.mockReturnValue(callbackFlowParams);
+
+      const { unmount } = renderWithProvider(<Checkout />, {}, true, false);
+
+      // Mount registers a function for this session id.
+      expect(mockRegisterSessionDismiss).toHaveBeenCalledWith(
+        'hs-1',
+        expect.any(Function),
+      );
+
+      // The registered dismiss is Checkout's own teardown: invoking it walks
+      // Checkout's mounted navigation (getParent().pop()).
+      const registeredDismiss = mockRegisterSessionDismiss.mock.calls.find(
+        (call) => typeof call[1] === 'function',
+      )?.[1] as () => void;
+      registeredDismiss();
+      expect(mockParentPop).toHaveBeenCalled();
+
+      unmount();
+
+      // Unmount clears the registration so the registry never holds a dismiss
+      // tied to an unmounted navigation.
+      expect(mockRegisterSessionDismiss).toHaveBeenCalledWith(
+        'hs-1',
+        undefined,
+      );
+    });
+
+    it('does not register a dismiss when there is no headless session', () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test Provider',
+        providerCode: 'moonpay',
+        walletAddress: '0xdeadbeef',
+      });
+
+      renderWithProvider(<Checkout />, {}, true, false);
+
+      expect(mockRegisterSessionDismiss).not.toHaveBeenCalled();
     });
 
     it('fires onOrderCreated, closes the session, and pops the ramp stack when a live session is present', async () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -38,6 +38,7 @@ import {
   closeSession,
   failSession,
   getSession,
+  registerSessionDismiss,
 } from '../../headless/sessionRegistry';
 import {
   dismissHeadlessFlow,
@@ -201,6 +202,21 @@ const Checkout = () => {
   const dismissActiveHeadlessFlow = useCallback(() => {
     dismissHeadlessFlow(navigation);
   }, [navigation]);
+
+  // Hand the session Checkout's OWN valid-scope teardown. `useTransakRouting`'s
+  // hook-scoped `dismissHeadlessFlow` no-ops once Checkout is the focused
+  // route, so the session-registered dismiss (used by the recovery / completion
+  // paths in useTransakRouting) must come from here (TRAM-3637). This effect is
+  // pure registration: it never touches terminal state.
+  useEffect(() => {
+    if (!headlessSessionId) {
+      return;
+    }
+    registerSessionDismiss(headlessSessionId, dismissActiveHeadlessFlow);
+    return () => {
+      registerSessionDismiss(headlessSessionId, undefined);
+    };
+  }, [headlessSessionId, dismissActiveHeadlessFlow]);
 
   const failHeadlessCheckout = useCallback(
     (checkoutError: unknown) => {

--- a/app/components/UI/Ramp/headless/sessionRegistry.test.ts
+++ b/app/components/UI/Ramp/headless/sessionRegistry.test.ts
@@ -6,6 +6,7 @@ import {
   failSession,
   getActiveSessionId,
   getSession,
+  registerSessionDismiss,
   setStatus,
   toHeadlessBuyError,
 } from './sessionRegistry';
@@ -141,6 +142,43 @@ describe('sessionRegistry', () => {
     });
   });
 
+  describe('registerSessionDismiss', () => {
+    it('sets the dismiss fn on a live session', () => {
+      const session = createSession(baseParams, buildCallbacks());
+      const dismiss = jest.fn();
+
+      registerSessionDismiss(session.id, dismiss);
+
+      expect(getSession(session.id)?.dismiss).toBe(dismiss);
+    });
+
+    it('clears the dismiss fn when called with undefined', () => {
+      const session = createSession(baseParams, buildCallbacks());
+      registerSessionDismiss(session.id, jest.fn());
+
+      registerSessionDismiss(session.id, undefined);
+
+      expect(getSession(session.id)?.dismiss).toBeUndefined();
+    });
+
+    it('is a no-op when the session is absent', () => {
+      expect(() =>
+        registerSessionDismiss('does-not-exist', jest.fn()),
+      ).not.toThrow();
+      expect(getSession('does-not-exist')).toBeUndefined();
+    });
+
+    it('does not resurrect an already-closed session', () => {
+      const callbacks = buildCallbacks();
+      const session = createSession(baseParams, callbacks);
+      closeSession(session.id, { reason: 'user_dismissed' });
+
+      registerSessionDismiss(session.id, jest.fn());
+
+      expect(getSession(session.id)).toBeUndefined();
+    });
+  });
+
   describe('callbacks', () => {
     it('stores the callbacks on the session by reference', () => {
       const callbacks = buildCallbacks();
@@ -185,6 +223,27 @@ describe('sessionRegistry', () => {
       const s = createSession(baseParams, buildCallbacks());
       setStatus(s.id, 'failed');
       expect(getActiveSessionId()).toBeUndefined();
+    });
+
+    it('clears the registered dismiss and fires onClose exactly once', () => {
+      const callbacks = buildCallbacks();
+      const session = createSession(baseParams, callbacks);
+      const dismiss = jest.fn();
+      registerSessionDismiss(session.id, dismiss);
+
+      closeSession(session.id, { reason: 'user_dismissed' });
+
+      expect(session.dismiss).toBeUndefined();
+      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+      expect(callbacks.onClose).toHaveBeenCalledWith({
+        reason: 'user_dismissed',
+      });
+      // closeSession itself never invokes the dismiss - that is the caller's
+      // job; it only drops the reference so it cannot be reused.
+      expect(dismiss).not.toHaveBeenCalled();
+
+      closeSession(session.id, { reason: 'user_dismissed' });
+      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -258,6 +317,25 @@ describe('sessionRegistry', () => {
       );
       expect(callbacks.onClose).toHaveBeenCalledWith({ reason: 'unknown' });
       expect(getSession(session.id)).toBeUndefined();
+    });
+
+    it('clears the registered dismiss and fires onError exactly once', () => {
+      const callbacks = buildCallbacks();
+      const session = createSession(baseParams, callbacks);
+      const dismiss = jest.fn();
+      registerSessionDismiss(session.id, dismiss);
+
+      failSession(session.id, new Error('provider failed'));
+
+      expect(session.dismiss).toBeUndefined();
+      expect(callbacks.onError).toHaveBeenCalledTimes(1);
+      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
+      expect(getSession(session.id)).toBeUndefined();
+
+      // A second failSession on the now-removed session is inert.
+      failSession(session.id, new Error('again'));
+      expect(callbacks.onError).toHaveBeenCalledTimes(1);
+      expect(callbacks.onClose).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/Ramp/headless/sessionRegistry.ts
+++ b/app/components/UI/Ramp/headless/sessionRegistry.ts
@@ -169,6 +169,28 @@ export function endSession(id: string): void {
 }
 
 /**
+ * Registers (or clears) the screen-scoped teardown for a live session. Called
+ * by Checkout on mount with its own valid-scope `dismissHeadlessFlow`, and
+ * again with `undefined` on unmount so the registry never holds a dismiss tied
+ * to an unmounted navigation. No-op when the session is absent, so callers do
+ * not have to null-check the session first.
+ *
+ * See TRAM-3637: tearing the headless flow down from `useTransakRouting`'s
+ * (HeadlessHost-scoped) navigation no-ops once Checkout is the focused route,
+ * whereas Checkout's own mounted navigation tears down reliably.
+ */
+export function registerSessionDismiss(
+  sessionId: string,
+  dismiss: (() => void) | undefined,
+): void {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+  session.dismiss = dismiss;
+}
+
+/**
  * Returns the id of the first non-terminal session, if any. Used by
  * `startHeadlessBuy` to enforce a "single live session at a time" policy:
  * starting a new session auto-cancels the previous one (Phase 5).
@@ -216,6 +238,10 @@ export function closeSession(
     session.status =
       options?.terminalStatus === 'failed' ? 'failed' : 'cancelled';
   }
+  // Drop the screen-scoped dismiss as the session is torn down so a stale
+  // teardown (tied to a navigation that may since have unmounted) can never
+  // be reused (TRAM-3637).
+  session.dismiss = undefined;
   sessions.delete(id);
   try {
     session.callbacks.onClose(info);

--- a/app/components/UI/Ramp/headless/types.ts
+++ b/app/components/UI/Ramp/headless/types.ts
@@ -198,6 +198,14 @@ export interface HeadlessSession {
   params: HeadlessBuyParams;
   callbacks: HeadlessBuyCallbacks;
   createdAt: number;
+  /**
+   * Optional teardown for the in-app ramp flow, registered by the screen that
+   * actually owns the mounted navigation (Checkout). The screen-scoped
+   * dismiss is reliable where a hook-scoped `dismissHeadlessFlow` no-ops
+   * once Checkout is the focused route (TRAM-3637). Cleared whenever the
+   * session terminates so a stale dismiss can never be reused.
+   */
+  dismiss?: () => void;
 }
 
 /**

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -100,6 +100,7 @@ const mockRequestOtt = jest.fn();
 const mockGeneratePaymentWidgetUrl = jest.fn();
 const mockSubmitPurposeOfUsageForm = jest.fn();
 const mockLogoutFromProvider = jest.fn();
+const mockGetActiveOrders = jest.fn();
 
 let mockUserRegion: unknown = {
   country: { currency: 'USD', isoCode: 'US' },
@@ -122,6 +123,7 @@ jest.mock('./useTransakController', () => ({
     requestOtt: mockRequestOtt,
     generatePaymentWidgetUrl: mockGeneratePaymentWidgetUrl,
     submitPurposeOfUsageForm: mockSubmitPurposeOfUsageForm,
+    getActiveOrders: mockGetActiveOrders,
   }),
 }));
 
@@ -216,6 +218,7 @@ jest.mock('../Views/NativeFlow/KycWebview', () => ({
 
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 jest.mock('@metamask/ramps-controller', () => ({
@@ -242,6 +245,7 @@ describe('useTransakRouting', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedHandleNavigationStateChange = null;
+    mockGetActiveOrders.mockResolvedValue([]);
     mockUserRegion = {
       country: { currency: 'USD', isoCode: 'US' },
       regionCode: 'us-ca',
@@ -1768,7 +1772,19 @@ describe('useTransakRouting', () => {
       expect(mockParentPop).toHaveBeenCalled();
     });
 
-    it('treats a Transak redirect without orderId as user dismissal when headless', async () => {
+    it('treats a Transak redirect without orderId as user dismissal when headless and no active order matches', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      // No active order on Transak's side matches the captured quote.
+      mockGetActiveOrders.mockResolvedValue([]);
+
       const handler = await runApprovedFlowHeadless();
       expect(handler).not.toBeNull();
       if (!handler) return;
@@ -1779,6 +1795,7 @@ describe('useTransakRouting', () => {
         });
       });
 
+      expect(mockGetActiveOrders).toHaveBeenCalled();
       expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
         reason: 'user_dismissed',
       });
@@ -1864,6 +1881,353 @@ describe('useTransakRouting', () => {
       );
       expect(mockCloseSession).not.toHaveBeenCalled();
       expect(mockParentPop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('headless Back to app recovery (redirect without orderId)', () => {
+    const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+      .getSession as jest.Mock;
+    const mockCloseSession = jest.requireMock('../headless/sessionRegistry')
+      .closeSession as jest.Mock;
+    const mockFailSession = jest.requireMock('../headless/sessionRegistry')
+      .failSession as jest.Mock;
+    const mockShowV2OrderToast = jest.requireMock('../utils/v2OrderToast')
+      .showV2OrderToast as jest.Mock;
+
+    const HEADLESS_CONFIG = {
+      baseRoute: 'RampHeadlessHost',
+      baseRouteParams: { headlessSessionId: 'hs-1' },
+    };
+
+    const NO_ORDER_ID_URL = 'https://redirect.example.com/callback';
+
+    const depositOrder = {
+      id: 'order-hs',
+      providerOrderId: 'order-hs',
+      provider: 'transak-native',
+      walletAddress: MOCK_WALLET_ADDRESS,
+      paymentDetails: {},
+    };
+
+    const refreshedOrder = {
+      providerOrderId: 'order-hs',
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.05',
+      status: 'Pending',
+      fiatAmount: 100,
+      exchangeRate: 2000,
+      networkFees: 0,
+      partnerFees: 0,
+      totalFeesFiat: 0,
+      paymentMethod: { id: 'card' },
+      network: { chainId: '1', name: 'Ethereum' },
+      fiatCurrency: { symbol: 'USD' },
+    };
+
+    const liveSession = (overrides?: { dismiss?: () => void }) => ({
+      id: 'hs-1',
+      status: 'continued',
+      callbacks: {
+        onOrderCreated: jest.fn(),
+        onError: jest.fn(),
+        onClose: jest.fn(),
+      },
+      ...overrides,
+    });
+
+    // Runs the APPROVED webview flow so the hook captures the quoteId
+    // (`test-quote-id`) in its ref, then returns the redirect handler. Pass the
+    // session the registry should report while routing.
+    const runApprovedFlowAndGetHandler = async (
+      session: ReturnType<typeof liveSession> | undefined,
+    ) => {
+      mockGetSession.mockReturnValue(session);
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        mobileNumber: '+1',
+        dob: '1990-01-01',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'APPROVED',
+        kycType: 'SIMPLE',
+      });
+      mockGetUserLimits.mockResolvedValue({
+        remaining: { '1': 10000, '30': 50000, '365': 200000 },
+      });
+      mockRequestOtt.mockResolvedValue({ ott: 'test-ott' });
+      mockGeneratePaymentWidgetUrl.mockReturnValue(
+        'https://payment.example.com',
+      );
+
+      const { result } = renderHook(() => useTransakRouting(HEADLESS_CONFIG));
+      await act(async () => {
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
+      });
+      return capturedHandleNavigationStateChange;
+    };
+
+    beforeEach(() => {
+      mockGetSession.mockReset();
+      mockCloseSession.mockReset();
+      mockFailSession.mockReset();
+      mockParentPop.mockReset();
+      mockGetOrder.mockResolvedValue(depositOrder);
+      mockRefreshOrder.mockResolvedValue(refreshedOrder);
+      mockGetActiveOrders.mockResolvedValue([]);
+    });
+
+    it('captures the active order whose quoteId matches and completes the session', async () => {
+      const session = liveSession();
+      mockGetActiveOrders.mockResolvedValue([
+        { orderId: 'recovered-order', quoteId: 'test-quote-id' },
+        { orderId: 'unrelated', quoteId: 'some-other-quote' },
+      ]);
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      expect(mockGetActiveOrders).toHaveBeenCalledTimes(1);
+      // processCapturedOrder runs against the matched (raw) orderId.
+      expect(mockGetOrder).toHaveBeenCalledWith(
+        'recovered-order',
+        MOCK_WALLET_ADDRESS,
+      );
+      expect(mockAddOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ providerOrderId: 'order-hs' }),
+      );
+      expect(session.callbacks.onOrderCreated).toHaveBeenCalledWith('order-hs');
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+      expect(mockCloseSession).not.toHaveBeenCalledWith('hs-1', {
+        reason: 'user_dismissed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+      expect(mockShowV2OrderToast).not.toHaveBeenCalled();
+    });
+
+    it('treats it as user dismissal when active orders exist but none match the quote', async () => {
+      const session = liveSession();
+      mockGetActiveOrders.mockResolvedValue([
+        { orderId: 'unrelated-1', quoteId: 'other-quote-a' },
+        { orderId: 'unrelated-2', quoteId: 'other-quote-b' },
+      ]);
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      // No wrong-order pickup.
+      expect(mockGetOrder).not.toHaveBeenCalled();
+      expect(session.callbacks.onOrderCreated).not.toHaveBeenCalled();
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'user_dismissed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+    });
+
+    it('swallows a second redirect that arrives while getActiveOrders is still pending', async () => {
+      const session = liveSession();
+      let resolveActiveOrders: (orders: unknown[]) => void = () => undefined;
+      mockGetActiveOrders.mockReturnValue(
+        new Promise((resolve) => {
+          resolveActiveOrders = resolve as (orders: unknown[]) => void;
+        }),
+      );
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        // First redirect kicks off recovery; getActiveOrders stays pending.
+        const firstCall = handler({ url: NO_ORDER_ID_URL });
+        // Second redirect must be swallowed by the termination guard.
+        await handler({ url: NO_ORDER_ID_URL });
+        // Now let the first recovery resolve with a match.
+        resolveActiveOrders([
+          { orderId: 'recovered-order', quoteId: 'test-quote-id' },
+        ]);
+        await firstCall;
+      });
+
+      // Only one sweep, one terminal callback.
+      expect(mockGetActiveOrders).toHaveBeenCalledTimes(1);
+      expect(session.callbacks.onOrderCreated).toHaveBeenCalledTimes(1);
+      expect(mockCloseSession).toHaveBeenCalledTimes(1);
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+    });
+
+    it('keeps addOrder but skips onOrderCreated/closeSession when the session is removed mid-capture', async () => {
+      const session = liveSession();
+      mockGetActiveOrders.mockResolvedValue([
+        { orderId: 'recovered-order', quoteId: 'test-quote-id' },
+      ]);
+      // Simulate another path tearing the session down during the capture's
+      // awaits: the session is live up to refreshOrder, then gone.
+      mockRefreshOrder.mockImplementation(async () => {
+        mockGetSession.mockReturnValue(undefined);
+        return refreshedOrder;
+      });
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      // Activity stays correct.
+      expect(mockAddOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ providerOrderId: 'order-hs' }),
+      );
+      // But the consumer is not notified twice and no extra closeSession fires.
+      expect(session.callbacks.onOrderCreated).not.toHaveBeenCalled();
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      // Dismiss still runs once.
+      expect(mockParentPop).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries getActiveOrders and recovers when the order appears on a later attempt', async () => {
+      const session = liveSession();
+      mockGetActiveOrders
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { orderId: 'recovered-order', quoteId: 'test-quote-id' },
+        ]);
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      expect(mockGetActiveOrders).toHaveBeenCalledTimes(2);
+      expect(session.callbacks.onOrderCreated).toHaveBeenCalledWith('order-hs');
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'completed',
+      });
+    });
+
+    it('treats a 401 from getActiveOrders as dismissal without failing the session', async () => {
+      const Logger = jest.requireMock('../../../../util/Logger');
+      const mockLoggerError = Logger.error as jest.Mock;
+      const session = liveSession();
+      const unauthorized = new Error('Unauthorized') as Error & {
+        httpStatus: number;
+      };
+      unauthorized.httpStatus = 401;
+      mockGetActiveOrders.mockRejectedValue(unauthorized);
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      expect(mockFailSession).not.toHaveBeenCalled();
+      expect(session.callbacks.onError).not.toHaveBeenCalled();
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'user_dismissed',
+      });
+      expect(mockParentPop).toHaveBeenCalled();
+      // A 401 is expected here, so it is not logged as an error.
+      expect(mockLoggerError).not.toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          message:
+            'useTransakRouting: Failed to recover order after Back to app',
+        }),
+      );
+    });
+
+    it('does nothing for a non-headless redirect without orderId and never calls getActiveOrders', async () => {
+      mockGetSession.mockReturnValue(undefined);
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        mobileNumber: '+1',
+        dob: '1990-01-01',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'APPROVED',
+        kycType: 'SIMPLE',
+      });
+      mockGetUserLimits.mockResolvedValue({
+        remaining: { '1': 10000, '30': 50000, '365': 200000 },
+      });
+      mockRequestOtt.mockResolvedValue({ ott: 'test-ott' });
+      mockGeneratePaymentWidgetUrl.mockReturnValue(
+        'https://payment.example.com',
+      );
+
+      // No headless config: plain Unified Buy v2.
+      const { result } = renderHook(() => useTransakRouting());
+      await act(async () => {
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
+      });
+      const handler = capturedHandleNavigationStateChange;
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      expect(mockGetActiveOrders).not.toHaveBeenCalled();
+      expect(mockCloseSession).not.toHaveBeenCalled();
+      expect(mockGetOrder).not.toHaveBeenCalled();
+    });
+
+    it('dismisses via the session-registered dismiss AFTER the terminal closeSession', async () => {
+      const sessionDismiss = jest.fn();
+      const session = liveSession({ dismiss: sessionDismiss });
+      mockGetActiveOrders.mockResolvedValue([]);
+
+      const handler = await runApprovedFlowAndGetHandler(session);
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({ url: NO_ORDER_ID_URL });
+      });
+
+      // The registry-scoped dismiss is used, not the hook-scoped pop.
+      expect(sessionDismiss).toHaveBeenCalledTimes(1);
+      expect(mockParentPop).not.toHaveBeenCalled();
+      expect(mockCloseSession).toHaveBeenCalledWith('hs-1', {
+        reason: 'user_dismissed',
+      });
+      // closeSession runs before the dismiss.
+      const closeOrder =
+        mockCloseSession.mock.invocationCallOrder[0] ?? Infinity;
+      const dismissOrder = sessionDismiss.mock.invocationCallOrder[0] ?? 0;
+      expect(closeOrder).toBeLessThan(dismissOrder);
     });
   });
 });

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -27,6 +27,7 @@ import { selectTokens } from '../../../../selectors/rampsController';
 import useRampAccountAddress from './useRampAccountAddress';
 import { isHttpUnauthorized } from '../utils/isHttpUnauthorized';
 import { parseUserFacingError } from '../utils/parseUserFacingError';
+import { redactUrlForAnalytics } from '../utils/redactUrlForAnalytics';
 import { useRampsOrders } from './useRampsOrders';
 import {
   closeSession,
@@ -145,6 +146,16 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const { themeAppearance, colors } = useTheme();
   const trackEvent = useAnalytics();
   const processingOrderIdRef = useRef<string | null>(null);
+  // The quoteId of the Transak quote handed to the payment webview. Captured
+  // in `routeAfterAuthentication` (the same hook instance that later receives
+  // the redirect) so the "Back to app" recovery path can match the active
+  // order strictly by quoteId without re-deriving it from the current render
+  // (TRAM-3637).
+  const quoteIdRef = useRef<string | undefined>(undefined);
+  // Guards the no-orderId recovery branch: set true before the first await so
+  // repeated "Back to app" taps / a second redirect during recovery are
+  // swallowed (only one getActiveOrders call, one terminal callback).
+  const dismissRecoveryStartedRef = useRef<boolean>(false);
   const { addOrder, refreshOrder } = useRampsOrders();
 
   const dismissActiveHeadlessFlow = useCallback(() => {
@@ -158,6 +169,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
     getAdditionalRequirements,
     createOrder: transakCreateOrder,
     getOrder,
+    getActiveOrders,
     getUserLimits,
     requestOtt,
     generatePaymentWidgetUrl,
@@ -334,9 +346,14 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
     ({ orderId }: { orderId: string }) => {
       // Headless mode: fire `onOrderCreated`, close the session, and pop
       // out of the ramp stack so the caller regains foreground. The
-      // consumer drives post-order UI themselves — no RAMPS_ORDER_DETAILS.
+      // consumer drives post-order UI themselves - no RAMPS_ORDER_DETAILS.
       const session = getSession(headlessSessionId);
       if (headlessSessionId && session) {
+        // Capture the session-registered dismiss BEFORE closeSession clears
+        // it. Checkout registers its own valid-scope teardown, which works
+        // where the hook-scoped `dismissActiveHeadlessFlow` no-ops once
+        // Checkout is the focused route (TRAM-3637).
+        const dismiss = session.dismiss ?? dismissActiveHeadlessFlow;
         try {
           session.callbacks.onOrderCreated(orderId);
         } catch (callbackError) {
@@ -346,7 +363,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
           );
         }
         closeSession(headlessSessionId, { reason: 'completed' });
-        dismissActiveHeadlessFlow();
+        dismiss();
         return;
       }
       navigation.reset({
@@ -388,6 +405,194 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
     [navigation, buildBaseRouteEntry],
   );
 
+  const trackOrderConfirmed = useCallback(
+    (rampsOrder: Awaited<ReturnType<typeof refreshOrder>>) => {
+      trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
+        ramp_type: 'DEPOSIT',
+        amount_source: Number(rampsOrder.fiatAmount),
+        amount_destination: Number(rampsOrder.cryptoAmount),
+        exchange_rate: Number(rampsOrder.exchangeRate),
+        gas_fee: rampsOrder.networkFees ? Number(rampsOrder.networkFees) : 0,
+        processing_fee: rampsOrder.partnerFees
+          ? Number(rampsOrder.partnerFees)
+          : 0,
+        total_fee: Number(rampsOrder.totalFeesFiat),
+        payment_method_id: rampsOrder.paymentMethod?.id || '',
+        country: regionIsoCode,
+        chain_id: rampsOrder.network?.chainId || '',
+        currency_destination: rampsOrder.cryptoCurrency?.assetId || '',
+        currency_destination_symbol: rampsOrder.cryptoCurrency?.symbol || '',
+        currency_destination_network: rampsOrder.network?.name || '',
+        currency_source: rampsOrder.fiatCurrency?.symbol || '',
+      });
+    },
+    [trackEvent, regionIsoCode],
+  );
+
+  // Shared capture path for a freshly produced Transak order, used by BOTH the
+  // redirect-with-orderId path and the "Back to app" recovery path. `addOrder`
+  // always runs so Activity/Redux stays correct even if the session was torn
+  // down mid-flight (TRAM-3637 Bug 1). For a live headless session it fires
+  // `onOrderCreated`, closes the session as `completed`, and tears the flow
+  // down via the session-registered dismiss LAST. Non-headless callers keep
+  // the toast + RAMPS_ORDER_DETAILS reset unchanged.
+  const processCapturedOrder = useCallback(
+    async (rawOrderId: string) => {
+      // Capture the session and its dismiss BEFORE any await/closeSession so a
+      // dismiss tied to Checkout's scope is not lost when closeSession clears
+      // it.
+      const sessionBefore = getSession(headlessSessionId);
+      const dismiss = sessionBefore?.dismiss ?? dismissActiveHeadlessFlow;
+
+      const depositOrder = await getOrder(rawOrderId, walletAddress || '');
+
+      if (!depositOrder) {
+        throw new Error('Missing order');
+      }
+
+      const providerCode = normalizeProviderCode(
+        String(depositOrder.provider ?? 'transak-native'),
+      );
+      const rampsOrder = await refreshOrder(
+        providerCode,
+        depositOrder.providerOrderId,
+        walletAddress || depositOrder.walletAddress,
+      );
+
+      addOrder({
+        ...rampsOrder,
+        paymentDetails: depositOrder.paymentDetails,
+      });
+
+      const sessionAfter = getSession(headlessSessionId);
+      if (sessionAfter) {
+        // Live headless session: hand the orderId to the consumer, close the
+        // session, track, then dismiss LAST.
+        try {
+          sessionAfter.callbacks.onOrderCreated(rampsOrder.providerOrderId);
+        } catch (callbackError) {
+          Logger.error(
+            callbackError as Error,
+            'useTransakRouting: onOrderCreated callback threw',
+          );
+        }
+        closeSession(headlessSessionId, { reason: 'completed' });
+        trackOrderConfirmed(rampsOrder);
+        dismiss();
+        return;
+      }
+
+      if (sessionBefore) {
+        // The session was live when we started but was closed during the
+        // awaits (e.g. a concurrent dismissal). `addOrder` already ran so
+        // Activity is correct; skip onOrderCreated/closeSession to avoid a
+        // double-fire, and dismiss LAST.
+        dismiss();
+        return;
+      }
+
+      // Non-headless (or a headlessSessionId whose session is already gone):
+      // preserve the existing toast + RAMPS_ORDER_DETAILS reset behavior.
+      showV2OrderToast({
+        orderId: rampsOrder.providerOrderId,
+        cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
+        cryptoAmount: rampsOrder.cryptoAmount,
+        status: rampsOrder.status,
+      });
+
+      navigateToOrderProcessingCallback({
+        orderId: rampsOrder.providerOrderId,
+      });
+
+      trackOrderConfirmed(rampsOrder);
+    },
+    [
+      getOrder,
+      walletAddress,
+      addOrder,
+      refreshOrder,
+      navigateToOrderProcessingCallback,
+      trackOrderConfirmed,
+      headlessSessionId,
+      dismissActiveHeadlessFlow,
+    ],
+  );
+
+  // Recovers the order when Transak's "Back to app" redirects with no orderId
+  // while the order is still processing (TRAM-3637 Bug 1). Pulls the active
+  // orders from Transak, matches STRICTLY on the quoteId handed to the webview,
+  // and routes a match through `processCapturedOrder`. Bounded retry covers the
+  // window where Transak has not yet listed the just-created order.
+  const recoverHeadlessOrderWithoutId = useCallback(async () => {
+    if (!headlessSessionId) {
+      // Non-headless redirect without an orderId is a no-op, same as before.
+      return;
+    }
+    const session = getSession(headlessSessionId);
+    if (!session) {
+      return;
+    }
+    // Set BEFORE any await so repeated "Back to app" taps / a second redirect
+    // during recovery are swallowed: only one getActiveOrders sweep and one
+    // terminal callback.
+    if (dismissRecoveryStartedRef.current) {
+      return;
+    }
+    dismissRecoveryStartedRef.current = true;
+
+    const dismiss = session.dismiss ?? dismissActiveHeadlessFlow;
+
+    try {
+      // 3 attempts. The first runs immediately (a just-created order is
+      // usually listed already); failed attempts back off ~200ms then ~400ms
+      // before retrying to cover Transak's eventual-consistency window.
+      const backoffsMs = [200, 400, 800];
+      for (let attempt = 0; attempt < backoffsMs.length; attempt += 1) {
+        // Bail if the session was torn down between attempts.
+        if (!getSession(headlessSessionId)) {
+          return;
+        }
+        const activeOrders = await getActiveOrders();
+        const matchedOrder = activeOrders.find(
+          (o) => o.quoteId === quoteIdRef.current,
+        );
+        if (matchedOrder) {
+          // Re-check liveness before committing the terminal capture.
+          if (!getSession(headlessSessionId)) {
+            return;
+          }
+          await processCapturedOrder(matchedOrder.orderId);
+          return;
+        }
+        if (attempt < backoffsMs.length - 1) {
+          await new Promise<void>((resolve) =>
+            setTimeout(resolve, backoffsMs[attempt]),
+          );
+        }
+      }
+      // No active order matched the quote across retries: treat as a genuine
+      // user dismissal and tear the flow down.
+      closeSession(headlessSessionId, { reason: 'user_dismissed' });
+      dismiss();
+    } catch (e) {
+      // A 401 here just means the session is no longer authenticated; treat it
+      // as a dismissal rather than surfacing an error to the consumer.
+      if (!isHttpUnauthorized(e)) {
+        Logger.error(e as Error, {
+          message:
+            'useTransakRouting: Failed to recover order after Back to app',
+        });
+      }
+      closeSession(headlessSessionId, { reason: 'user_dismissed' });
+      dismiss();
+    }
+  }, [
+    headlessSessionId,
+    dismissActiveHeadlessFlow,
+    getActiveOrders,
+    processCapturedOrder,
+  ]);
+
   const handleNavigationStateChange = useCallback(
     async ({ url }: { url: string }) => {
       if (!url.startsWith(REDIRECTION_URL)) return;
@@ -404,11 +609,15 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         return;
       }
 
+      // Diagnostic only: never log the raw url (it carries provider tokens).
+      Logger.log(
+        `useTransakRouting: Transak redirect received (hasOrderId=${Boolean(
+          orderId,
+        )}, url=${redactUrlForAnalytics(url)})`,
+      );
+
       if (!orderId) {
-        if (headlessSessionId) {
-          closeSession(headlessSessionId, { reason: 'user_dismissed' });
-          dismissActiveHeadlessFlow();
-        }
+        await recoverHeadlessOrderWithoutId();
         return;
       }
       if (processingOrderIdRef.current === orderId) {
@@ -417,61 +626,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       processingOrderIdRef.current = orderId;
 
       try {
-        const depositOrder = await getOrder(orderId, walletAddress || '');
-
-        if (!depositOrder) {
-          throw new Error('Missing order');
-        }
-
-        const providerCode = normalizeProviderCode(
-          String(depositOrder.provider ?? 'transak-native'),
-        );
-        const rampsOrder = await refreshOrder(
-          providerCode,
-          depositOrder.providerOrderId,
-          walletAddress || depositOrder.walletAddress,
-        );
-
-        addOrder({
-          ...rampsOrder,
-          paymentDetails: depositOrder.paymentDetails,
-        });
-
-        // Suppress the toast when a headless session is driving this
-        // flow — the consumer handles its own notification UI. Keep
-        // `addOrder` and the analytics event in both modes so Redux
-        // state + telemetry parity is preserved.
-        if (!getSession(headlessSessionId)) {
-          showV2OrderToast({
-            orderId: rampsOrder.providerOrderId,
-            cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
-            cryptoAmount: rampsOrder.cryptoAmount,
-            status: rampsOrder.status,
-          });
-        }
-
-        navigateToOrderProcessingCallback({
-          orderId: rampsOrder.providerOrderId,
-        });
-
-        trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-          ramp_type: 'DEPOSIT',
-          amount_source: Number(rampsOrder.fiatAmount),
-          amount_destination: Number(rampsOrder.cryptoAmount),
-          exchange_rate: Number(rampsOrder.exchangeRate),
-          gas_fee: rampsOrder.networkFees ? Number(rampsOrder.networkFees) : 0,
-          processing_fee: rampsOrder.partnerFees
-            ? Number(rampsOrder.partnerFees)
-            : 0,
-          total_fee: Number(rampsOrder.totalFeesFiat),
-          payment_method_id: rampsOrder.paymentMethod?.id || '',
-          country: regionIsoCode,
-          chain_id: rampsOrder.network?.chainId || '',
-          currency_destination: rampsOrder.cryptoCurrency?.assetId || '',
-          currency_destination_symbol: rampsOrder.cryptoCurrency?.symbol || '',
-          currency_destination_network: rampsOrder.network?.name || '',
-          currency_source: rampsOrder.fiatCurrency?.symbol || '',
-        });
+        await processCapturedOrder(orderId);
       } catch (error) {
         processingOrderIdRef.current = null;
         Logger.error(error as Error, {
@@ -483,13 +638,8 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       }
     },
     [
-      getOrder,
-      walletAddress,
-      addOrder,
-      refreshOrder,
-      navigateToOrderProcessingCallback,
-      regionIsoCode,
-      trackEvent,
+      processCapturedOrder,
+      recoverHeadlessOrderWithoutId,
       headlessSessionId,
       dismissActiveHeadlessFlow,
     ],
@@ -651,6 +801,13 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
                 if (!paymentUrl) {
                   throw new Error('Failed to generate payment URL');
                 }
+
+                // Remember which quote this webview is for so a "Back to app"
+                // redirect with no orderId can recover the matching active
+                // order strictly by quoteId (TRAM-3637). Same hook instance
+                // owns the redirect handler, so this ref is the source of
+                // truth - do not re-derive from the current render.
+                quoteIdRef.current = quote.quoteId;
 
                 navigateToWebviewModalCallback({
                   paymentUrl,


### PR DESCRIPTION
## **Description**

The Money account / MM Pay fiat deposit runs the **headless buy** (`useFiatConfirm` -> `startHeadlessBuy` -> `Routes.RAMP.*` + `HeadlessHost` + `useTransakRouting` + the `Views/Checkout` webview). When a user finished a Transak card purchase and tapped Transak's **"Back to app"** while the order was still processing, Transak redirected to our callback **without an `orderId`**, and two things broke:

1. **Order lost (no polling / not in Activity).** The `!orderId` branch in `useTransakRouting.handleNavigationStateChange` treated the redirect as `closeSession({ reason: 'user_dismissed' })` and never ran the capture path, so `addOrder`/`onOrderCreated` never fired. The order was never added to `fiatOrders` state, so it was never polled and never appeared in Activity, and the MM Pay consumer saw a dismissal instead of an order.
2. **Webview would not close.** The teardown called `dismissHeadlessFlow(navigation)` from `useTransakRouting`'s (HeadlessHost-scoped) navigation. After the `navigation.reset` that mounts Checkout, that `getParent().getParent().goBack()` walk no longer resolves to the headless-entry modal, so it no-ops. The native `X` worked because it tears down from Checkout's own mounted navigation.

**Fix (capture stays in the hook, dismiss is delegated to the screen that owns the mounted navigation):**

- **Recover the order.** On a redirect with no `orderId`, pull `getActiveOrders()` and match **strictly by `quoteId`** (captured into a ref in `routeAfterAuthentication`, the only key that maps to `TransakOrder.quoteId`), with a small bounded retry to cover Transak's listing lag. A match is funneled through the existing capture path (`getOrder` -> `refreshOrder` -> `addOrder` -> `onOrderCreated` -> `closeSession('completed')`), so polling and Activity work again. No match (or a 401) falls back to `user_dismissed`.
- **Reliable dismissal.** `Checkout` registers its own valid-scope `dismissActiveHeadlessFlow` on the session; the hook tears down through that registered dismiss, invoked **last**, after the session is already terminal. This fixes "Back to app" closing the webview, and Checkout's unmount-close then no-ops (so it cannot overwrite a `completed` with `user_dismissed`).
- **Idempotency + sequencing.** A guard set before the first `await` makes repeated "Back to app" taps trigger a single recovery sweep and one terminal callback; `addOrder` always runs (Activity stays correct) even if the session is torn down mid-capture.
- Added a redacted diagnostic log of the redirect URL to confirm the provider callback shape in UAT.

## **Changelog**

CHANGELOG entry: Fixed the deposit "Back to app" button so finishing a card purchase reliably returns to the app, records the order, and shows it in Activity.

## **Related issues**

Fixes: [TRAM-3637](https://consensyssoftware.atlassian.net/browse/TRAM-3637)

## **Manual testing steps**

```gherkin
Feature: Transak "Back to app" during a processing deposit (headless / MM Pay)

  Scenario: order is still processing when the user taps "Back to app"
    Given the user adds funds to their Money account and pays by debit/credit card
    And the Transak status screen shows "Your Crypto is on the way" with "Back to app"

    When the user taps "Back to app"
    Then the Transak webview and headless flow close immediately
    And the deposit order appears in Activity and polls to completion
    And the MM Pay consumer lands on its post-order screen (not a dismissal)

  Scenario: repeated taps and the native X behave identically
    When the user taps "Back to app" multiple times (or taps the X)
    Then the flow tears down exactly once with no duplicate order or stuck webview

  Scenario: user genuinely backs out before an order exists
    Given no order has been created yet
    When the user leaves via the callback with no recoverable order
    Then the session closes as a user dismissal and the webview closes
```

## **Screenshots/Recordings**

### **Before**

See TRAM-3637: tapping "Back to app" did nothing (webview stayed open, user had to tap the X) and the order never reached Activity.

### **After**

N/A in this draft - device recording on the Money account UAT build is pending (see author checklist below). This change is JS logic in the Transak redirect handler; unit tests cover capture, recovery, race, and idempotency.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Device QA is pending (this draft) and tracked as the remaining verification step: the change is logic-only in the redirect handler with no perf-sensitive path, so no new Sentry traces were added.

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TRAM-3637]: https://consensyssoftware.atlassian.net/browse/TRAM-3637
