### PR TITLE
fix: token selection in withdraw money account page

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -190,7 +190,7 @@ describe('usePayWithCryptoSection', () => {
 
     const expectedPreferred = {
       address: MUSD_TOKEN_ADDRESS,
-      chainId: CHAIN_IDS.MAINNET,
+      chainId: CHAIN_IDS.MONAD,
     };
     expect(usePayWithPreferredTokenMock).toHaveBeenCalledWith({
       preferredToken: expectedPreferred,

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -868,7 +868,7 @@ describe('Transaction Pay Utils', () => {
       expect(result).toBe(OVERRIDE);
     });
 
-    it('returns the mUSD mainnet fallback for moneyAccountWithdraw transactions when no override is provided', () => {
+    it('returns the mUSD Monad fallback for moneyAccountWithdraw transactions when no override is provided', () => {
       const result = resolvePreferredPayToken({
         override: undefined,
         transactionMeta: withdrawTransactionMeta,
@@ -876,7 +876,7 @@ describe('Transaction Pay Utils', () => {
 
       expect(result).toStrictEqual({
         address: MUSD_TOKEN_ADDRESS,
-        chainId: CHAIN_IDS.MAINNET,
+        chainId: CHAIN_IDS.MONAD,
       });
     });
 

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -318,8 +318,8 @@ export function isMatchingPayToken(
  * Resolves the preferred pay token for a transaction.
  *
  * Returns the explicit override when provided. Otherwise, falls back to
- * mUSD on mainnet for moneyAccountWithdraw transactions so the preferred-token
- * row in the pay-with bottom sheet reflects the deposit-default asset.
+ * mUSD on Monad for moneyAccountWithdraw transactions so the preferred-token
+ * row in the pay-with bottom sheet reflects the withdraw-default asset.
  *
  */
 export function resolvePreferredPayToken({
@@ -338,7 +338,7 @@ export function resolvePreferredPayToken({
   ) {
     return {
       address: MUSD_TOKEN_ADDRESS,
-      chainId: CHAIN_IDS.MAINNET,
+      chainId: CHAIN_IDS.MONAD,
     };
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fix token selection in withdraw money account page.

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1510

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to default chain ID for one transaction type in the confirmation pay-with flow, with tests updated.
> 
> **Overview**
> Fixes **money account withdraw** confirmation so the pay-with flow defaults to **mUSD on Monad** instead of mUSD on **Ethereum mainnet**.
> 
> `resolvePreferredPayToken` now returns `CHAIN_IDS.MONAD` for `moneyAccountWithdraw` when no override is set, aligning the preferred-token row in the pay-with sheet with the withdraw-default asset. Unit tests for `transaction-pay` and `usePayWithCryptoSection` were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8d041ea9ef18c5e65679b1999ae5d33ee1799f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->