### PR TITLE
chore(perps): bump @metamask/perps-controller to 8.1.0

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -142,6 +142,7 @@ export const PerpsMarketListViewSelectorsIDs = {
   BACK_BUTTON: 'perps-market-list-back-button',
   SEARCH_CLEAR_BUTTON: 'perps-market-list-search-bar-clear',
   SEARCH_BAR: 'perps-market-list-search-bar',
+  NO_RESULTS: 'perps-market-list-no-results',
   SKELETON_ROW: 'perps-market-list-skeleton-row',
   LIST_HEADER: 'perps-market-list-header',
   MARKET_LIST: 'perps-market-list',

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -252,7 +252,10 @@ const PerpsMarketListView = ({
     // Empty search results - show when user has typed and no markets match
     if (searchQuery.trim() && filteredMarkets.length === 0) {
       return (
-        <View style={styles.emptyStateContainer}>
+        <View
+          style={styles.emptyStateContainer}
+          testID={PerpsMarketListViewSelectorsIDs.NO_RESULTS}
+        >
           <Icon
             name={IconName.Search}
             size={IconSize.Xl}

--- a/app/components/UI/Perps/utils/marketDataTransform.test.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.test.ts
@@ -68,7 +68,7 @@ describe('marketDataTransform', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         symbol: 'BTC',
-        name: 'BTC',
+        name: 'Bitcoin', // Human-readable name from HYPERLIQUID_ASSET_NAMES (@metamask/perps-controller 8.1.0)
         maxLeverage: '50x',
         price: '$52,000', // PRICE_RANGES_UNIVERSAL: 5 sig figs, 0 decimals for $10k-$100k
         change24h: '+$2,000', // No trailing zeros

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@metamask/network-enablement-controller": "^5.3.0",
     "@metamask/notification-services-controller": "24.1.1",
     "@metamask/permission-controller": "^13.1.1",
-    "@metamask/perps-controller": "^8.0.0",
+    "@metamask/perps-controller": "^8.1.0",
     "@metamask/phishing-controller": "^17.2.0",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8285,6 +8285,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/controller-utils@npm:^12.2.0":
+  version: 12.2.0
+  resolution: "@metamask/controller-utils@npm:12.2.0"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/ethjs-unit": "npm:^0.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    "@spruceid/siwe-parser": "npm:2.1.0"
+    "@types/bn.js": "npm:^5.1.5"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    cockatiel: "npm:^3.1.2"
+    eth-ens-namehash: "npm:^2.0.8"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+  checksum: 10/24551cec486319b39e0db6792e5d26bafa7fb87dce63d516cc80a5645f7c185b7911e89d21189e7270d338436074bc6e1e6e0983b008cb130292ee1e1902c28d
+  languageName: node
+  linkType: hard
+
 "@metamask/core-backend@npm:^6.3.0, @metamask/core-backend@npm:^6.3.2, @metamask/core-backend@npm:^6.3.3":
   version: 6.3.3
   resolution: "@metamask/core-backend@npm:6.3.3"
@@ -9426,13 +9448,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/perps-controller@npm:8.0.0"
+"@metamask/perps-controller@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@metamask/perps-controller@npm:8.1.0"
   dependencies:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/utils": "npm:^11.9.0"
     "@myx-trade/sdk": "npm:^0.1.265"
@@ -9443,7 +9465,7 @@ __metadata:
   dependenciesMeta:
     "@myx-trade/sdk":
       optional: true
-  checksum: 10/7b06134fbb3a945a44a5349a29a120094069d66f011af9989ae560099e1bd12a4932aa1c5cb66a5a5c40b41f96738d7e633d3332e482b3e01d9b7f52be6363aa
+  checksum: 10/adb4501e0d5fcb8837ea87bdea43bc5c0444838d218d0cdd3d3153fb3dc25307906e5078f7ac38f2799569bb7d82c64c3d352b78d77829da4068275c5dec6849
   languageName: node
   linkType: hard
 
@@ -35280,7 +35302,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:24.1.1"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/perps-controller": "npm:^8.0.0"
+    "@metamask/perps-controller": "npm:^8.1.0"
     "@metamask/phishing-controller": "npm:^17.2.0"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/preferences-controller": "npm:^23.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,28 +8264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^12.0.0, @metamask/controller-utils@npm:^12.1.0, @metamask/controller-utils@npm:^12.1.1":
-  version: 12.1.1
-  resolution: "@metamask/controller-utils@npm:12.1.1"
-  dependencies:
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/ethjs-unit": "npm:^0.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    "@spruceid/siwe-parser": "npm:2.1.0"
-    "@types/bn.js": "npm:^5.1.5"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    cockatiel: "npm:^3.1.2"
-    eth-ens-namehash: "npm:^2.0.8"
-    fast-deep-equal: "npm:^3.1.3"
-    lodash: "npm:^4.17.21"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-  checksum: 10/39e22e0247ee26a83316563c35ec206053bf95310e66441a6d416f33837f62da97abea1d52429b208e22b23fc97ad13b8a6d93d94607638b0567a45efdab1933
-  languageName: node
-  linkType: hard
-
-"@metamask/controller-utils@npm:^12.2.0":
+"@metamask/controller-utils@npm:^12.0.0, @metamask/controller-utils@npm:^12.1.0, @metamask/controller-utils@npm:^12.1.1, @metamask/controller-utils@npm:^12.2.0":
   version: 12.2.0
   resolution: "@metamask/controller-utils@npm:12.2.0"
   dependencies:


### PR DESCRIPTION
## **Description**

Bumps `@metamask/perps-controller` from `^8.0.0` to `^8.1.0` (now published on npm).

`8.1.0` adds human-readable market names and keyword/ranked search (TAT-2413 / TAT-3338). Searching a market by its **full name** now resolves to the matching market. Previously `filterMarketsByQuery` only matched the ticker **symbol**, so searching "bitcoin", "tesla", or "spacex" returned **"No tokens found"** even though BTC, TSLA, and SPCX exist.

This PR also adds a `perps-market-list-no-results` testID to the market-search empty state so the search behaviour can be asserted directly in e2e/recipes (empty-state present for a no-match query, absent once results appear) instead of relying on screenshots.

## **Changelog**

CHANGELOG entry: Perps market search now matches full market names and keywords — e.g. searching "bitcoin" finds BTC (and BCH), "tesla" finds TSLA, "spacex" finds SPCX.

## **Related issues**

Refs: TAT-2413, TAT-3338

## **Manual testing steps**

```gherkin
Feature: Perps market search by name

  Scenario: user searches a market by its full name
    Given the user is unlocked and on the Perps Markets search screen

    When the user types "bitcoin"
    Then the BTC market (and BCH "Bitcoin Cash") are listed

    When the user clears and types "tesla"
    Then the TSLA market is listed

    When the user clears and types "spacex"
    Then the SPCX market is listed
```

## **Screenshots/Recordings**

Validated end-to-end on iOS (sim `mm-4`) with a recipe using testID assertions: the `perps-market-list-no-results` empty state is **present** for a no-match control query and **absent** once a name query matches.

<table>
<tr><th>Before — <code>perps-controller@8.0.0</code></th><th>After — <code>perps-controller@8.1.0</code></th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/059ffb2d33f337b829f7648eef551362ff7f8f9f/fixes/31537/before-bitcoin-8.0.0.png" width="260"><br/>"bitcoin" → <b>No tokens found</b> (only ticker "BTC" matched)</td>
<td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/059ffb2d33f337b829f7648eef551362ff7f8f9f/fixes/31537/after-bitcoin-8.1.0.png" width="260"><br/>"bitcoin" → <b>BTC</b> + <b>BCH</b> (matched by name)</td>
</tr>
</table>

The name search also works for stocks and pre-IPO markets:

<table>
<tr><th>"tesla" → TSLA</th><th>"spacex" → SPCX</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/059ffb2d33f337b829f7648eef551362ff7f8f9f/fixes/31537/after-tesla-8.1.0.png" width="260"></td>
<td><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/059ffb2d33f337b829f7648eef551362ff7f8f9f/fixes/31537/after-spacex-8.1.0.png" width="260"></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump with localized UI/testID changes; search behavior improves without touching auth or payments.
> 
> **Overview**
> **Upgrades `@metamask/perps-controller` to 8.1.0** so Perps market search can match **full names and keywords**, not just tickers (e.g. "bitcoin" → BTC/BCH). Displayed market **names** now come from the controller’s asset name map (tests expect BTC → **Bitcoin**).
> 
> Adds **`perps-market-list-no-results`** on the market list empty-search UI for e2e assertions, and a **`BACK_BUTTON`** testID alias alongside existing list selectors. Lockfile also picks up **`@metamask/controller-utils@12.2.0`** via the perps-controller dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad856729285c6681a55ea0aa7fc317db26d6d98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->