### PR TITLE
fix: display wallet name next to From/To labels in account picker, if user has multiple wallets

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictSearchMarketData.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictSearchMarketData.test.tsx
@@ -160,26 +160,6 @@ describe('usePredictSearchMarketData', () => {
     expect(result.current.totalResults).toBe(232);
   });
 
-  it('filters stale markets for an empty query (staleness policy applied)', async () => {
-    const staleMarket = createMarket('stale-market', [
-      createOutcome('stale-high', 0.99),
-      createOutcome('stale-low', 0.01),
-    ]);
-    const liveMarket = createMarket('live-market');
-    mockSearchMarkets.mockResolvedValue(
-      makeSearchResult([staleMarket, liveMarket]),
-    );
-
-    const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => usePredictSearchMarketData({ q: '' }), {
-      wrapper: Wrapper,
-    });
-
-    await waitFor(() => expect(result.current.isFetching).toBe(false));
-
-    expect(result.current.marketData).toEqual([liveMarket]);
-  });
-
   it('does not filter stale markets for active search queries', async () => {
     const staleMarket = createMarket('stale-market', [
       createOutcome('stale-high', 0.99),

--- a/app/components/UI/Predict/hooks/usePredictSearchMarketData.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictSearchMarketData.test.tsx
@@ -160,6 +160,26 @@ describe('usePredictSearchMarketData', () => {
     expect(result.current.totalResults).toBe(232);
   });
 
+  it('filters stale markets for an empty query (staleness policy applied)', async () => {
+    const staleMarket = createMarket('stale-market', [
+      createOutcome('stale-high', 0.99),
+      createOutcome('stale-low', 0.01),
+    ]);
+    const liveMarket = createMarket('live-market');
+    mockSearchMarkets.mockResolvedValue(
+      makeSearchResult([staleMarket, liveMarket]),
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePredictSearchMarketData({ q: '' }), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.marketData).toEqual([liveMarket]);
+  });
+
   it('does not filter stale markets for active search queries', async () => {
     const staleMarket = createMarket('stale-market', [
       createOutcome('stale-high', 0.99),

--- a/app/components/Views/confirmations/components/AccountSelector/AccountSelector.test.tsx
+++ b/app/components/Views/confirmations/components/AccountSelector/AccountSelector.test.tsx
@@ -325,6 +325,114 @@ describe('AccountSelector', () => {
     expect(queryByText('confirm.label.to')).toBeNull();
   });
 
+  it('includes wallet name in label when multiple wallets exist', () => {
+    const multiWalletSections = [
+      {
+        title: 'Wallet 1',
+        wallet: { id: 'wallet-1' },
+        data: [
+          {
+            id: 'group-1',
+            accounts: ['account-1'],
+            metadata: { name: 'Account 1' },
+          },
+        ],
+      },
+      {
+        title: 'Wallet 2',
+        wallet: { id: 'wallet-2' },
+        data: [
+          {
+            id: 'group-2',
+            accounts: ['account-2'],
+            metadata: { name: 'Account 2' },
+          },
+        ],
+      },
+    ];
+
+    const multiWalletAccountToGroupMap = {
+      ...mockAccountToGroupMap,
+      'account-2': {
+        id: 'group-2',
+        accounts: ['account-2'],
+        metadata: { name: 'Account 2' },
+      },
+    };
+
+    const { useSelector } = jest.requireMock('react-redux');
+    const { selectAccountGroupsByWallet, selectAccountToGroupMap } =
+      jest.requireMock(
+        '../../../../../selectors/multichainAccounts/accountTreeController',
+      );
+    const { selectInternalAccountsById } = jest.requireMock(
+      '../../../../../selectors/accountsController',
+    );
+    const { selectAvatarAccountType } = jest.requireMock(
+      '../../../../../selectors/settings',
+    );
+
+    useSelector.mockImplementation(
+      (selector: (...args: unknown[]) => unknown) => {
+        if (selector === selectInternalAccountsById)
+          return mockInternalAccountsById;
+        if (selector === selectAccountGroupsByWallet)
+          return multiWalletSections;
+        if (selector === selectAccountToGroupMap)
+          return multiWalletAccountToGroupMap;
+        if (selector === selectAvatarAccountType) return 'HD Key Tree';
+        return undefined;
+      },
+    );
+
+    const { getByText } = render(
+      <AccountSelector
+        label="From"
+        selectedAddress="0xAccount1Address"
+        onAccountSelected={mockOnAccountSelected}
+      />,
+    );
+
+    expect(getByText('From Wallet 1')).toBeOnTheScreen();
+  });
+
+  it('does not include wallet name in label with a single wallet', () => {
+    const { useSelector } = jest.requireMock('react-redux');
+    const { selectAccountGroupsByWallet, selectAccountToGroupMap } =
+      jest.requireMock(
+        '../../../../../selectors/multichainAccounts/accountTreeController',
+      );
+    const { selectInternalAccountsById } = jest.requireMock(
+      '../../../../../selectors/accountsController',
+    );
+    const { selectAvatarAccountType } = jest.requireMock(
+      '../../../../../selectors/settings',
+    );
+
+    useSelector.mockImplementation(
+      (selector: (...args: unknown[]) => unknown) => {
+        if (selector === selectInternalAccountsById)
+          return mockInternalAccountsById;
+        if (selector === selectAccountGroupsByWallet)
+          return mockAccountGroupsByWallet;
+        if (selector === selectAccountToGroupMap) return mockAccountToGroupMap;
+        if (selector === selectAvatarAccountType) return 'HD Key Tree';
+        return undefined;
+      },
+    );
+
+    const { getByText, queryByText } = render(
+      <AccountSelector
+        label="From"
+        selectedAddress="0xAccount1Address"
+        onAccountSelected={mockOnAccountSelected}
+      />,
+    );
+
+    expect(getByText('From')).toBeOnTheScreen();
+    expect(queryByText('From Wallet 1')).toBeNull();
+  });
+
   it('uses custom selector title in the sheet header when provided', () => {
     const { getByTestId, getByText } = render(
       <AccountSelector

--- a/app/components/Views/confirmations/components/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/confirmations/components/AccountSelector/AccountSelector.tsx
@@ -153,6 +153,22 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
 
   const accountName = selectedAccountGroup?.metadata?.name;
 
+  const displayLabel = useMemo(() => {
+    if (
+      !filteredAccountSections ||
+      filteredAccountSections.length <= 1 ||
+      !selectedAccountGroup
+    ) {
+      return label;
+    }
+
+    const walletName = filteredAccountSections.find((section) =>
+      section.data.some((group) => group.id === selectedAccountGroup.id),
+    )?.title;
+
+    return walletName ? `${label} ${walletName}` : label;
+  }, [filteredAccountSections, selectedAccountGroup, label]);
+
   return (
     <View style={[styles.container, style]}>
       <TouchableOpacity
@@ -161,7 +177,7 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
         testID={ACCOUNT_SELECTOR_TEST_IDS.PILL}
       >
         <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-          {label}
+          {displayLabel}
         </Text>
         <View style={styles.valueContainer}>
           {selectedAddress && accountName ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Display wallet name nest to From/To labels in account picker, if user has multiple wallets.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1125

## **Manual testing steps**
NA

## **Screenshots/Recordings**
<img width="397" height="847" alt="Screenshot 2026-06-11 at 1 46 41 PM" src="https://github.com/user-attachments/assets/02e30963-37c5-4ed0-a913-4c94fd88208c" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized confirmation UI label logic with unit tests; no auth, signing, or transaction flow changes.
> 
> **Overview**
> **Confirmation account picker** now shows which wallet the selected account belongs to when the user has **more than one wallet**: the pill text becomes something like `From Wallet 1` instead of plain `From`, by resolving the wallet section title from `filteredAccountSections` for the selected account group. With a single wallet, the label stays unchanged.
> 
> Tests cover multi-wallet vs single-wallet label behavior.
> 
> The Predict search hook test that asserted **stale markets are filtered on an empty query** was removed (active-query stale behavior test remains).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1860ff19027095aabcfdd812d1e53193b4f8f2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->