### PR TITLE
fix(ci): narrow validator return type to exclude blocking field

### DIFF
--- a/.github/scripts/shared/pr-template-checks.ts
+++ b/.github/scripts/shared/pr-template-checks.ts
@@ -10,8 +10,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { tokenize, sectionTokens, Token } from './markdown-tokenizer';
 
-// ─── Public result type ──────────────────────────────────────────────────────
+// ─── Result types ─────────────────────────────────────────────────────────────
 
+// Returned by individual validators — no knowledge of the blocking flag, which
+// is a plan-level concern stamped by runAllChecks.
+type ValidatorResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+// Returned by runAllChecks — adds the blocking flag from the plan entry.
 export type PrTemplateCheckResult =
   | { ok: true }
   | { ok: false; reason: string; blocking: boolean };
@@ -29,7 +36,7 @@ interface ValidationPlanEntry {
 }
 
 type ValidatorContext = { hasNoChangelogLabel: boolean };
-type Validator = (section: string, ctx: ValidatorContext) => PrTemplateCheckResult;
+type Validator = (section: string, ctx: ValidatorContext) => ValidatorResult;
 
 // ─── Template loading (single read at module load) ───────────────────────────
 
@@ -284,7 +291,7 @@ export function extractSection(body: string, title: string): string | null {
 
 export function hasNonEmptyDescription(
   descriptionSection: string,
-): PrTemplateCheckResult {
+): ValidatorResult {
   if (stripHtmlComments(descriptionSection).trim().length === 0) {
     return {
       ok: false,
@@ -296,7 +303,7 @@ export function hasNonEmptyDescription(
 
 export function hasValidIssueLink(
   relatedIssuesSection: string,
-): PrTemplateCheckResult {
+): ValidatorResult {
   // Search only in plain text tokens — a Fixes/Closes/Refs line inside a
   // fenced code block (e.g. a doc example) must not count as the real link.
   const textOutsideFences = tokenize(relatedIssuesSection)
@@ -321,7 +328,7 @@ export function hasValidIssueLink(
 
 export function hasRealManualTesting(
   manualTestingSection: string,
-): PrTemplateCheckResult {
+): ValidatorResult {
   const sanitized = stripHtmlComments(manualTestingSection).trim();
   if (sanitized.length === 0) {
     return {
@@ -342,7 +349,7 @@ export function hasRealManualTesting(
 
 export function hasScreenshotsOrNa(
   screenshotsSection: string,
-): PrTemplateCheckResult {
+): ValidatorResult {
   // Subheadings exist in every PR (they ship with the template); they don't
   // count as content. We trust the author for whether the content is
   // meaningful — CI only enforces "section was filled".
@@ -361,7 +368,7 @@ export function hasScreenshotsOrNa(
 
 export function hasAllAuthorChecklistChecked(
   checklistSection: string,
-): PrTemplateCheckResult {
+): ValidatorResult {
   // Use only checkbox tokens — checkboxes that appear inside fenced code
   // blocks are examples or docs, not real checklist items.
   const checkboxes = tokenize(checklistSection).filter(
@@ -404,7 +411,7 @@ export function hasAllAuthorChecklistChecked(
 export function hasChangelogEntry(
   changelogSection: string,
   hasNoChangelogLabel: boolean,
-): PrTemplateCheckResult {
+): ValidatorResult {
   if (hasNoChangelogLabel) {
     return { ok: true };
   }


### PR DESCRIPTION


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

A recent change added a `blocking: boolean` field to the `PrTemplateCheckResult` failure variant so `runAllChecks` could signal whether a check is CI-blocking. However, individual validators (e.g. `hasNonEmptyDescription`, `hasChangelogEntry`) were still typed as returning `PrTemplateCheckResult`, which forced them to carry the `blocking` field — a concern they have no business knowing about.

This broke TypeScript compilation on every unrelated PR whose CI ran `yarn lint:tsc`, producing:

```
Type '{ ok: false; reason: string; }' is not assignable to type 'PrTemplateCheckResult'.
```

The fix introduces a narrower internal `ValidatorResult` type (without `blocking`) for the 6 individual validators and the `Validator` function alias. `runAllChecks` already stamps `blocking` from the plan entry via `{ ...result, blocking: entry.blocking }`, so `PrTemplateCheckResult` (with `blocking`) remains the correct output type for that public function only.

> [!NOTE]
> Why neither yarn lint:tsc nor Jest caught the type error
>
> yarn lint:tsc runs tsc --project tsconfig.json, whose include only covers app/**/*, tests/**/*, and scripts/**/*. The .github/scripts/ directory is entirely outside that project boundary, so tsc never sees those files. The commit hook runs the same command, so it has the same blind spot.
>
>Jest uses Babel (babel-jest) to transpile TypeScript before running tests. Babel is a transpiler, not a type-checker — it strips all type annotations and runs the plain JavaScript. A type mismatch like returning { ok: false, reason: string } where { ok: false, reason: string, blocking: boolean } is expected is invisible to Babel and therefore invisible to Jest.
>
>The result: both gates passed, yet the production tsc invoked by the GitHub Actions CI workflow (which does point at .github/scripts/) caught the error when another PR ran against main.
>
>Fix applied: introduced a narrower ValidatorResult type for the return of individual validator functions (without blocking), keeping blocking only on the PrTemplateCheckResult produced by the orchestrator — eliminating the mismatch.
>
>Longer-term guard: add a dedicated tsconfig.json inside .github/scripts/ and a CI step that runs tsc --noEmit against it, so these scripts are type-checked on every PR.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #31486

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: PR template CI check compilation

  Scenario: TypeScript compilation succeeds
    Given a developer opens a PR
    When the CI job runs yarn lint:tsc
    Then TypeScript compilation completes without errors
    And the PR is not incorrectly blocked by a type mismatch
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor in GitHub Actions PR template scripts; validator logic and `runAllChecks` blocking behavior are unchanged.
> 
> **Overview**
> Fixes a **TypeScript compile failure** in `.github/scripts/shared/pr-template-checks.ts` after `PrTemplateCheckResult` failures gained a required `blocking` field.
> 
> Introduces an internal **`ValidatorResult`** type (`ok` + optional `reason` only) for the six section validators and the `Validator` alias. **`PrTemplateCheckResult`** (with `blocking`) stays the public shape for **`runAllChecks`**, which already merges `blocking` from each validation-plan entry onto validator failures.
> 
> No runtime behavior change—only separates “validator outcome” from “orchestrator + CI-blocking metadata.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2610dfcafa548fa9da5c280d405ff511f5f66045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->