### PR TITLE
feat(ci): add run-performance label to force PR performance tests (MMQA-1931)

### DIFF
--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -41,7 +41,7 @@ Using any of these labels should be exceptional in case of CI friction and urgen
 
 ### Force Performance Tests
 
-- **run-performance**: Forces the PR performance E2E workflow to run (all performance tests on Android low-profile devices), even when Smart E2E Selection would skip them (e.g. no performance-relevant changes detected, `skip-e2e`, or `pr-not-ready-for-e2e`). Adding or removing this label re-triggers CI. Not honored on fork PRs.
+- **run-performance-tests**: Forces the PR performance E2E workflow to run (all performance tests on Android low-profile devices), even when Smart E2E Selection would skip them (e.g. no performance-relevant changes detected, `skip-e2e`, or `pr-not-ready-for-e2e`). Adding or removing this label re-triggers CI. Not honored on fork PRs.
 
 ### Block merge if any is present
 

--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -39,6 +39,10 @@ Using any of these labels should be exceptional in case of CI friction and urgen
 
 - **skip-smart-e2e-selection**: Bypasses the AI-powered Smart E2E Selection so that the full E2E test suite runs instead of an AI-picked subset. This label does **not** force E2E builds/tests to run on a PR that would otherwise skip them (e.g. docs-only changes). Whether E2E runs at all is determined by path filters, branch, and other skip labels — not this label.
 
+### Force Performance Tests
+
+- **run-performance**: Forces the PR performance E2E workflow to run (all performance tests on Android low-profile devices), even when Smart E2E Selection would skip them (e.g. no performance-relevant changes detected, `skip-e2e`, or `pr-not-ready-for-e2e`). Adding or removing this label re-triggers CI. Not honored on fork PRs.
+
 ### Block merge if any is present
 
 - **needs-qa**: The PR requires a full manual QA prior to being merged and added to a release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1001,22 +1001,29 @@ jobs:
 
   run-performance-tests-pr:
     name: 'Run Performance Tests (PR)'
-    # Only run on pull_request events unless AI explicitly found no relevant changes.
+    # Run when:
+    # - run-performance label is on the PR (forced run, all tests), OR
+    # - smart-e2e-selection ran and AI selected performance tags.
     # ai_performance_test_tags == '[]'  → AI ran and found no perf-relevant changes: skip.
-    # ai_performance_test_tags == ''    → conservative fallback (AI failed): run all tests.
+    # ai_performance_test_tags == ''    → conservative fallback (AI failed) or run-performance label: run all tests.
     # ai_performance_test_tags == '[…]' → specific tags selected: run those tests.
     if: >-
       ${{
         github.event_name == 'pull_request' &&
         !cancelled() &&
-        needs.smart-e2e-selection.result != 'skipped' &&
-        needs.smart-e2e-selection.outputs.ai_performance_test_tags != '[]'
+        (
+          needs.get_requirements.outputs.run_performance == 'true' ||
+          (
+            needs.smart-e2e-selection.result == 'success' &&
+            needs.smart-e2e-selection.outputs.ai_performance_test_tags != '[]'
+          )
+        )
       }}
-    needs: [smart-e2e-selection]
+    needs: [get_requirements, smart-e2e-selection]
     uses: ./.github/workflows/run-performance-e2e.yml
     with:
-      performance_tags: ${{ needs.smart-e2e-selection.outputs.ai_performance_test_tags }}
-      performance_tags_reasoning: ${{ needs.smart-e2e-selection.outputs.ai_performance_test_reasoning }}
+      performance_tags: ${{ needs.get_requirements.outputs.run_performance != 'true' && needs.smart-e2e-selection.outputs.ai_performance_test_tags || '' }}
+      performance_tags_reasoning: ${{ needs.get_requirements.outputs.run_performance == 'true' && 'Forced run via run-performance label on PR' || needs.smart-e2e-selection.outputs.ai_performance_test_reasoning }}
       build_variant: 'e2e'
       branch_name: ${{ github.head_ref }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1002,10 +1002,10 @@ jobs:
   run-performance-tests-pr:
     name: 'Run Performance Tests (PR)'
     # Run when:
-    # - run-performance label is on the PR (forced run, all tests), OR
+    # - run-performance-tests label is on the PR (forced run, all tests), OR
     # - smart-e2e-selection ran and AI selected performance tags.
     # ai_performance_test_tags == '[]'  → AI ran and found no perf-relevant changes: skip.
-    # ai_performance_test_tags == ''    → conservative fallback (AI failed) or run-performance label: run all tests.
+    # ai_performance_test_tags == ''    → conservative fallback (AI failed) or run-performance-tests label: run all tests.
     # ai_performance_test_tags == '[…]' → specific tags selected: run those tests.
     if: >-
       ${{
@@ -1023,7 +1023,7 @@ jobs:
     uses: ./.github/workflows/run-performance-e2e.yml
     with:
       performance_tags: ${{ needs.get_requirements.outputs.run_performance != 'true' && needs.smart-e2e-selection.outputs.ai_performance_test_tags || '' }}
-      performance_tags_reasoning: ${{ needs.get_requirements.outputs.run_performance == 'true' && 'Forced run via run-performance label on PR' || needs.smart-e2e-selection.outputs.ai_performance_test_reasoning }}
+      performance_tags_reasoning: ${{ needs.get_requirements.outputs.run_performance == 'true' && 'Forced run via run-performance-tests label on PR' || needs.smart-e2e-selection.outputs.ai_performance_test_reasoning }}
       build_variant: 'e2e'
       branch_name: ${{ github.head_ref }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -27,7 +27,7 @@ on:
         description: 'Whether the smart-e2e-selection job should run. False for non-PR events, forks, or hard E2E skips.'
         value: ${{ jobs.detect-changes.outputs.run_smart_e2e_selection }}
       run_performance:
-        description: 'Whether performance E2E tests should be forced to run via the run-performance PR label'
+        description: 'Whether performance E2E tests should be forced to run via the run-performance-tests PR label'
         value: ${{ jobs.detect-changes.outputs.run_performance }}
 
 jobs:
@@ -112,9 +112,9 @@ jobs:
             echo "-> SKIP_SMART_SELECTION=true due to 'skip-smart-e2e-selection' label on PR"
           fi
 
-          if echo "$LABELS" | grep -qx "run-performance"; then
+          if echo "$LABELS" | grep -qx "run-performance-tests"; then
             echo "RUN_PERFORMANCE=true" >> "$GITHUB_OUTPUT"
-            echo "-> RUN_PERFORMANCE=true due to 'run-performance' label on PR"
+            echo "-> RUN_PERFORMANCE=true due to 'run-performance-tests' label on PR"
           fi
 
       - name: Filter changed files

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -26,6 +26,9 @@ on:
       run_smart_e2e_selection:
         description: 'Whether the smart-e2e-selection job should run. False for non-PR events, forks, or hard E2E skips.'
         value: ${{ jobs.detect-changes.outputs.run_smart_e2e_selection }}
+      run_performance:
+        description: 'Whether performance E2E tests should be forced to run via the run-performance PR label'
+        value: ${{ jobs.detect-changes.outputs.run_performance }}
 
 jobs:
   detect-changes:
@@ -40,6 +43,7 @@ jobs:
       changed_files: ${{ steps.set-outputs.outputs.changed_files }}
       block_merge_for_e2e_readiness: ${{ steps.set-outputs.outputs.block_merge }}
       run_smart_e2e_selection: ${{ steps.set-outputs.outputs.run_smart_e2e_selection }}
+      run_performance: ${{ steps.set-outputs.outputs.run_performance }}
     env:
       # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
       # For a `push` event, the head commit hash is `github.sha`.
@@ -85,6 +89,7 @@ jobs:
             echo "SKIP_E2E=false"
             echo "LABEL_BLOCKS_MERGE=false"
             echo "SKIP_SMART_SELECTION=false"
+            echo "RUN_PERFORMANCE=false"
           } >> "$GITHUB_OUTPUT"
 
           LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
@@ -107,6 +112,11 @@ jobs:
             echo "-> SKIP_SMART_SELECTION=true due to 'skip-smart-e2e-selection' label on PR"
           fi
 
+          if echo "$LABELS" | grep -qx "run-performance"; then
+            echo "RUN_PERFORMANCE=true" >> "$GITHUB_OUTPUT"
+            echo "-> RUN_PERFORMANCE=true due to 'run-performance' label on PR"
+          fi
+
       - name: Filter changed files
         id: filter
         if: steps.skip-merge-queue.outputs.up-to-date != 'true'
@@ -124,6 +134,7 @@ jobs:
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           SHOULD_SKIP_E2E: ${{ steps.skip-e2e-tag.outputs.SKIP == 'true' || steps.check-labels.outputs.SKIP_E2E == 'true' }}
           LABEL_BLOCKS_MERGE: ${{ steps.check-labels.outputs.LABEL_BLOCKS_MERGE }}
+          RUN_PERFORMANCE_LABEL: ${{ steps.check-labels.outputs.RUN_PERFORMANCE }}
           ALL_CHANGES_COUNT: ${{ steps.filter.outputs.all_changes_count }}
           ALL_CHANGES_FILES: ${{ github.event_name == 'pull_request' && steps.filter.outputs.all_changes_files || '' }}
           IGNORABLE_COUNT: ${{ steps.filter.outputs.e2e_ignorable_count }}
@@ -220,6 +231,13 @@ jobs:
             echo "-> BLOCK_MERGE bypassed — ignorable-only changes, E2E_WORKFLOWS_COUNT=0"
           fi
 
+          RUN_PERF=false
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && \
+                "$IS_FORK" != "true" && \
+                "$RUN_PERFORMANCE_LABEL" == "true" ]]; then
+            RUN_PERF=true
+          fi
+
           echo "$MSG"
           {
             echo "android_final=$ANDROID"
@@ -227,6 +245,7 @@ jobs:
             echo "e2e_needed=$E2E_NEEDED"
             echo "run_smart_e2e_selection=$RUN_SMART"
             echo "block_merge=$BLOCK_MERGE"
+            echo "run_performance=$RUN_PERF"
           } >> "$GITHUB_OUTPUT"
 
           {

--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -18,7 +18,7 @@ jobs:
        github.event.label.name == 'skip-e2e-flakiness-detection' ||
        github.event.label.name == 'pr-not-ready-for-e2e' ||
        github.event.label.name == 'force-builds' ||
-       github.event.label.name == 'run-performance')
+       github.event.label.name == 'run-performance-tests')
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -17,7 +17,8 @@ jobs:
        github.event.label.name == 'skip-e2e' ||
        github.event.label.name == 'skip-e2e-flakiness-detection' ||
        github.event.label.name == 'pr-not-ready-for-e2e' ||
-       github.event.label.name == 'force-builds')
+       github.event.label.name == 'force-builds' ||
+       github.event.label.name == 'run-performance')
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
## **Description**

Adds a `run-performance` PR label so QA can force the performance E2E workflow on demand, following the same pattern as `skip-e2e` and `force-builds`.

When the label is present on an internal PR, `get-requirements.yml` sets `run_performance=true`, CI re-runs via `rerun-ci-on-skipped-e2e-labels.yml`, and the `Run Performance Tests (PR)` job executes all performance tests on Android low-profile devices — even when Smart E2E Selection would skip them (e.g. no performance-relevant changes, `skip-e2e`, or `pr-not-ready-for-e2e`). Without the label, the existing Smart E2E Selection behavior is unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

Refs: MMQA-1931

## **Manual testing steps**

```gherkin
Feature: run-performance PR label

  Scenario: force performance tests on a PR without AI-selected tags
    Given an open internal PR where Smart E2E Selection returns no performance tags
    When the run-performance label is added to the PR
    Then CI is re-triggered and the Run Performance Tests (PR) job executes

  Scenario: default behavior without the label
    Given an open internal PR without the run-performance label
    When CI runs after a push
    Then performance tests only run when Smart E2E Selection selects performance tags
```

## **Screenshots/Recordings**

N/A — CI workflow change only; validation is via GitHub Actions job execution.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow gating and documentation; no app runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Adds a **`run-performance-tests`** PR label so QA can **force the PR performance E2E workflow** to run the **full Android low-profile performance suite**, even when Smart E2E Selection would skip perf tests (e.g. `ai_performance_test_tags == '[]'`, `skip-e2e`, or `pr-not-ready-for-e2e`).
> 
> **`get-requirements.yml`** detects the label on internal (non-fork) PRs and exposes **`run_performance`**. **`ci.yml`** updates **`Run Performance Tests (PR)`** to run when `run_performance` is true **or** when Smart E2E Selection returns non-empty perf tags; a forced run passes **blank `performance_tags`** (run all) and a fixed reasoning string. **`rerun-ci-on-skipped-e2e-labels.yml`** re-triggers CI when the label is added or removed. **`LABELING_GUIDELINES.md`** documents the label and fork limitation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c47b4e80cbbff0b467aca05675c857fdb3a08ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->