### PR TITLE
fix: make Select Quote bottom sheet scrollable when 4+ quotes are shown

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySelectQuoteScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySelectQuoteScreen.tsx
@@ -8,6 +8,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { ScrollView } from 'react-native-gesture-handler';
 import { fromTokenMinimalUnit } from '../../../../../../util/number/bigint';
 import formatFiat from '../../../../../../util/formatFiat';
 import { isGaslessQuote } from '../../../../../UI/Bridge/utils/isGaslessQuote';
@@ -92,7 +93,10 @@ const QuickBuySelectQuoteScreen: React.FC = () => {
           </Text>
         </Box>
       ) : (
-        <>
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
           <Box twClassName="px-4 pb-2 mb-2">
             <Text
               variant={TextVariant.BodySm}
@@ -106,7 +110,7 @@ const QuickBuySelectQuoteScreen: React.FC = () => {
               <QuoteRow key={rowProps.quoteRequestId} {...rowProps} />
             ))}
           </Box>
-        </>
+        </ScrollView>
       )}
     </>
   );

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySelectQuoteScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySelectQuoteScreen.tsx
@@ -8,6 +8,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { fromTokenMinimalUnit } from '../../../../../../util/number/bigint';
 import formatFiat from '../../../../../../util/formatFiat';
@@ -16,6 +17,10 @@ import { QuoteRow } from '../../../../../UI/Bridge/components/QuoteSelectorView/
 import { strings } from '../../../../../../../locales/i18n';
 import { useQuickBuyContext } from './useQuickBuyContext';
 import QuickBuySubScreenHeader from './components/QuickBuySubScreenHeader';
+
+const styles = StyleSheet.create({
+  scrollView: { flex: 1 },
+});
 
 const QuickBuySelectQuoteScreen: React.FC = () => {
   const {
@@ -96,6 +101,7 @@ const QuickBuySelectQuoteScreen: React.FC = () => {
         <ScrollView
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
+          style={styles.scrollView}
         >
           <Box twClassName="px-4 pb-2 mb-2">
             <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When the Select Quote bottom sheet displayed 4 or more quotes, the list overflowed the visible area and overlapped the device's rounded corners and home indicator with no way to scroll to the last quote. This fix wraps the quote list in a `ScrollView` (from `react-native-gesture-handler`) in `QuickBuySelectQuoteScreen`, keeping the header sticky above the scrollable content so all quotes are fully accessible regardless of how many are returned.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31464

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Select Quote bottom sheet scrollability

  Scenario: User can scroll when 4 or more quotes are available
    Given the user is on a token detail screen (e.g. SOL) with the Quick Buy sheet open
    And the token has 4 or more bridge/swap quotes available

    When the user taps the rate row to open the Select Quote screen
    Then all quotes are visible and the list is scrollable

    When the user scrolls down
    Then the last quote is fully visible and does not overlap the device corners or home indicator

    When the user taps a quote
    Then the sheet navigates back to the Quote Details screen with the selected quote applied
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/1b3f0716-c70a-4eca-a194-226a7c161ec6


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout change to one Quick Buy screen; no swap, quote selection, or transaction logic is modified.
> 
> **Overview**
> Fixes overflow on the Quick Buy **Select Quote** bottom sheet when many bridge quotes are returned by making the quote list scrollable while keeping `QuickBuySubScreenHeader` fixed above it.
> 
> The info text and `QuoteRow` list are wrapped in a `react-native-gesture-handler` `ScrollView` with `flex: 1`, `keyboardShouldPersistTaps="handled"`, and hidden vertical scroll indicators—matching the scroll pattern used on other Quick Buy sub-screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55af21225a96aab07fb9d50ca693639a3925038e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->