### PR TITLE
fix(swaps): suppress bridge post-trade notifications

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -120,6 +120,10 @@ import {
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button/Button.types.ts';
 import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable/index.ts';
+import {
+  hidePostTradeNotificationSurface,
+  showPostTradeNotificationSurface,
+} from '../../utils/postTradeNotifications';
 
 const SCROLL_NEAR_BOTTOM_PX = 160;
 
@@ -221,6 +225,16 @@ const BridgeViewContent = ({ latestSourceBalance }: BridgeViewContentProps) => {
   useRecipientInitialization(hasInitializedRecipient);
 
   useBridgeViewOnFocus({ inputRef, keypadRef });
+
+  useFocusEffect(
+    useCallback(() => {
+      showPostTradeNotificationSurface();
+
+      return () => {
+        hidePostTradeNotificationSurface();
+      };
+    }, []),
+  );
 
   // Scroll to top when navigating to the bridge view if requested
   useFocusEffect(

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
@@ -44,6 +44,10 @@ import {
 import styleSheet from './PostTradeBottomSheet.styles';
 import { usePostTradeTxStatus } from './usePostTradeTxStatus';
 import { useBridgeQuoteRequest } from '../../hooks/useBridgeQuoteRequest';
+import {
+  hidePostTradeNotificationSurface,
+  showPostTradeNotificationSurface,
+} from '../../utils/postTradeNotifications';
 
 export const getTradeSubtitle = ({
   sourceAmount,
@@ -127,6 +131,14 @@ export const PostTradeBottomSheet = () => {
     transactionMetaId: params.transactionMetaId,
     transactionHash: params.transactionHash,
   });
+
+  useEffect(() => {
+    showPostTradeNotificationSurface();
+
+    return () => {
+      hidePostTradeNotificationSurface();
+    };
+  }, []);
 
   useEffect(() => {
     const isTerminalStatus =

--- a/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts
@@ -24,6 +24,7 @@ import {
   POST_TRADE_MODAL_VARIANTS,
 } from '../../components/PostTradeBottomSheet/abTestConfig';
 import Engine from '../../../../../core/Engine';
+import { withPostTradeNotificationSuppression } from '../../utils/postTradeNotifications';
 
 interface Params {
   activeQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] | null;
@@ -68,11 +69,15 @@ export const useBridgeConfirm = ({
     try {
       dispatch(setIsSubmittingTx(true));
 
-      const submittedTransaction = await submitBridgeTx({
-        quoteResponse: activeQuote,
-        location,
-        transactionActiveAbTests,
-      });
+      const submitTransaction = () =>
+        submitBridgeTx({
+          quoteResponse: activeQuote,
+          location,
+          transactionActiveAbTests,
+        });
+      const submittedTransaction = isPostTradeModalEnabled
+        ? await withPostTradeNotificationSuppression(submitTransaction)
+        : await submitTransaction();
       const transactionHash =
         submittedTransaction &&
         'hash' in submittedTransaction &&

--- a/app/components/UI/Bridge/utils/postTradeNotifications.test.ts
+++ b/app/components/UI/Bridge/utils/postTradeNotifications.test.ts
@@ -1,0 +1,147 @@
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { NotificationSkipPredicate } from '../../../../core/notificationSkipPredicates';
+
+const mockRegisterNotificationSkipPredicate = jest.fn();
+const mockGetIsBridgeTransaction = jest.fn();
+
+jest.mock('../../../../core/notificationSkipPredicates', () => ({
+  __esModule: true,
+  registerNotificationSkipPredicate: mockRegisterNotificationSkipPredicate,
+}));
+
+jest.mock('./transaction', () => ({
+  __esModule: true,
+  getIsBridgeTransaction: mockGetIsBridgeTransaction,
+}));
+
+const loadPostTradeNotifications = () => {
+  jest.resetModules();
+  mockRegisterNotificationSkipPredicate.mockReset();
+  mockGetIsBridgeTransaction.mockReset();
+
+  return jest.requireActual(
+    './postTradeNotifications',
+  ) as typeof import('./postTradeNotifications');
+};
+
+const getRegisteredPredicate = (): NotificationSkipPredicate => {
+  expect(mockRegisterNotificationSkipPredicate).toHaveBeenCalledTimes(1);
+  return mockRegisterNotificationSkipPredicate.mock
+    .calls[0][0] as NotificationSkipPredicate;
+};
+
+const transactionMeta = (
+  txMeta: Partial<TransactionMeta> = {},
+): TransactionMeta =>
+  ({
+    id: 'tx-1',
+    type: TransactionType.contractInteraction,
+    ...txMeta,
+  }) as TransactionMeta;
+
+describe('postTradeNotifications', () => {
+  it('registers once and suppresses tracked submissions only while a surface is visible', async () => {
+    const {
+      showPostTradeNotificationSurface,
+      hidePostTradeNotificationSurface,
+      withPostTradeNotificationSuppression,
+    } = loadPostTradeNotifications();
+
+    showPostTradeNotificationSurface();
+    showPostTradeNotificationSurface();
+
+    expect(mockRegisterNotificationSkipPredicate).toHaveBeenCalledTimes(1);
+
+    await expect(
+      withPostTradeNotificationSuppression(() =>
+        Promise.resolve({ id: 'submitted-tx' }),
+      ),
+    ).resolves.toEqual({ id: 'submitted-tx' });
+
+    const predicate = getRegisteredPredicate();
+
+    expect(predicate(transactionMeta({ id: 'submitted-tx' }))).toBe(true);
+    expect(predicate(transactionMeta({ id: 'untracked-tx' }))).toBe(false);
+
+    hidePostTradeNotificationSurface();
+    hidePostTradeNotificationSurface();
+    hidePostTradeNotificationSurface();
+
+    expect(predicate(transactionMeta({ id: 'submitted-tx' }))).toBe(false);
+  });
+
+  it('suppresses in-flight Bridge and batch transactions while a surface is visible', async () => {
+    const {
+      showPostTradeNotificationSurface,
+      withPostTradeNotificationSuppression,
+    } = loadPostTradeNotifications();
+    const bridgeTxMeta = transactionMeta({ id: 'bridge-tx' });
+    const batchTxMeta = transactionMeta({
+      id: 'batch-tx',
+      type: TransactionType.batch,
+    });
+
+    showPostTradeNotificationSurface();
+
+    await withPostTradeNotificationSuppression(async () => {
+      const predicate = getRegisteredPredicate();
+
+      mockGetIsBridgeTransaction.mockReturnValueOnce(true);
+      expect(predicate(bridgeTxMeta)).toBe(true);
+      expect(mockGetIsBridgeTransaction).toHaveBeenCalledWith(bridgeTxMeta);
+
+      mockGetIsBridgeTransaction.mockReturnValueOnce(false);
+      expect(predicate(batchTxMeta)).toBe(true);
+
+      return { id: 'submitted-batch-tx' };
+    });
+  });
+
+  it('does not suppress missing or unrelated transaction metadata', async () => {
+    const {
+      showPostTradeNotificationSurface,
+      withPostTradeNotificationSuppression,
+    } = loadPostTradeNotifications();
+
+    showPostTradeNotificationSurface();
+    mockGetIsBridgeTransaction.mockReturnValue(false);
+
+    await withPostTradeNotificationSuppression(async () => {
+      const predicate = getRegisteredPredicate();
+
+      expect(predicate(undefined)).toBe(false);
+      expect(predicate(transactionMeta({ id: 'unrelated-tx' }))).toBe(false);
+
+      return undefined;
+    });
+  });
+
+  it('clears pending submission state when submit fails', async () => {
+    const {
+      showPostTradeNotificationSurface,
+      withPostTradeNotificationSuppression,
+    } = loadPostTradeNotifications();
+    const bridgeTxMeta = transactionMeta({ id: 'bridge-tx' });
+    const error = new Error('submit failed');
+
+    showPostTradeNotificationSurface();
+    mockGetIsBridgeTransaction.mockReturnValue(true);
+
+    await expect(
+      withPostTradeNotificationSuppression(async () => {
+        const predicate = getRegisteredPredicate();
+
+        expect(predicate(bridgeTxMeta)).toBe(true);
+
+        throw error;
+      }),
+    ).rejects.toThrow(error);
+
+    const predicate = getRegisteredPredicate();
+
+    expect(predicate(bridgeTxMeta)).toBe(false);
+  });
+});

--- a/app/components/UI/Bridge/utils/postTradeNotifications.ts
+++ b/app/components/UI/Bridge/utils/postTradeNotifications.ts
@@ -1,0 +1,84 @@
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { registerNotificationSkipPredicate } from '../../../../core/notificationSkipPredicates';
+import { getIsBridgeTransaction } from './transaction';
+
+const MAX_TRACKED_TRANSACTION_IDS = 50;
+const trackedTransactionIds = new Set<string>();
+
+let visibleSurfaceCount = 0;
+let pendingSubmissions = 0;
+let isNotificationSkipPredicateRegistered = false;
+
+function isPostTradeNotificationTransaction(
+  transactionMeta: TransactionMeta | undefined,
+): boolean {
+  if (visibleSurfaceCount === 0) {
+    return false;
+  }
+
+  if (transactionMeta?.id && trackedTransactionIds.has(transactionMeta.id)) {
+    return true;
+  }
+
+  if (!transactionMeta || pendingSubmissions === 0) {
+    return false;
+  }
+
+  return (
+    getIsBridgeTransaction(transactionMeta) ||
+    transactionMeta.type === TransactionType.batch
+  );
+}
+
+function ensureNotificationSkipPredicateRegistered(): void {
+  if (isNotificationSkipPredicateRegistered) {
+    return;
+  }
+
+  registerNotificationSkipPredicate(isPostTradeNotificationTransaction);
+  isNotificationSkipPredicateRegistered = true;
+}
+
+function trackPostTradeTransaction(txMetaId: string): void {
+  trackedTransactionIds.delete(txMetaId);
+  trackedTransactionIds.add(txMetaId);
+
+  if (trackedTransactionIds.size > MAX_TRACKED_TRANSACTION_IDS) {
+    const oldest = trackedTransactionIds.values().next().value;
+    if (oldest !== undefined) {
+      trackedTransactionIds.delete(oldest);
+    }
+  }
+}
+
+export function showPostTradeNotificationSurface(): void {
+  ensureNotificationSkipPredicateRegistered();
+  visibleSurfaceCount += 1;
+}
+
+export function hidePostTradeNotificationSurface(): void {
+  visibleSurfaceCount = Math.max(0, visibleSurfaceCount - 1);
+}
+
+export async function withPostTradeNotificationSuppression<
+  SubmittedTransaction extends { id?: unknown } | undefined,
+>(
+  submitTransaction: () => Promise<SubmittedTransaction>,
+): Promise<SubmittedTransaction> {
+  ensureNotificationSkipPredicateRegistered();
+  pendingSubmissions += 1;
+
+  try {
+    const submittedTransaction = await submitTransaction();
+    if (typeof submittedTransaction?.id === 'string') {
+      trackPostTradeTransaction(submittedTransaction.id);
+    }
+
+    return submittedTransaction;
+  } finally {
+    pendingSubmissions = Math.max(0, pendingSubmissions - 1);
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Users can see generic transaction notifications while the swap screen or post-trade bottom sheet is already presenting the transaction state. Those notifications compete with the post-trade modal experience and can make the flow feel noisy.

This change adds a post-trade notification suppression helper that registers a notification skip predicate, tracks visible post-trade surfaces, and suppresses tracked in-flight transaction notifications while the relevant UI is visible. `BridgeView` and `PostTradeBottomSheet` now increment/decrement the visible surface count, and the confirm flow wraps `submitBridgeTx` with suppression when the post-trade modal A/B treatment is enabled.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed duplicate Bridge transaction notifications while post-trade screens are visible.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge post-trade notification suppression

  Scenario: user submits a Bridge transaction with the post-trade modal treatment enabled
    Given the Bridge post-trade modal treatment is enabled
    And the user is on the Bridge screen with a valid quote

    When user submits the Bridge transaction
    Then the post-trade bottom sheet opens
    And the app does not show a competing generic transaction notification for the submitted Bridge transaction

  Scenario: user leaves Bridge post-trade UI
    Given the user submitted a Bridge transaction
    And the Bridge post-trade bottom sheet is visible

    When user dismisses the post-trade bottom sheet or navigates away from Bridge
    Then post-trade notification suppression is released for future non-Bridge surfaces
```

Additional validation:

- `yarn jest app/components/UI/Bridge/hooks/useBridgeConfirm/useBridgeConfirm.test.ts app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.test.ts --collectCoverage=false`
- `yarn prettier --check app/components/UI/Bridge/utils/postTradeNotifications.ts app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx app/components/UI/Bridge/hooks/useBridgeConfirm/index.ts app/components/UI/Bridge/Views/BridgeView/index.tsx`
- `git diff --check`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A - notification timing/state-management change; no screenshots or recordings captured in this thread.

### **After**

N/A - notification timing/state-management change; no screenshots or recordings captured in this thread.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hooks into global notification skip predicates for submitted transactions; mis-scoping could hide legitimate toasts, though suppression is gated on visible post-trade surfaces and tracked bridge/batch txs.
> 
> **Overview**
> Adds **`postTradeNotifications`** helpers that register a global notification skip predicate and only suppress generic transaction toasts while Bridge post-trade UI is visible.
> 
> **BridgeView** and **PostTradeBottomSheet** increment/decrement a ref-counted “visible surface” on focus/mount cleanup. When the post-trade modal A/B variant is on, **`useBridgeConfirm`** wraps **`submitBridgeTx`** in **`withPostTradeNotificationSuppression`**, which tracks submitted tx ids and temporarily skips notifications for in-flight bridge/batch txs until surfaces are dismissed. Unit tests cover registration, ref-counting, and failure cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a16760b1960edbd7ebbab7bd739dcf7b5177fd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->