### PR TITLE
chore: replace BottomSheet with BottomSheetDialog in QuickBuy to remove backdrop overlay

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -23,7 +23,7 @@ jest.mock('./hooks/useQuickBuySetup', () => ({
 }));
 
 let storedOnOpenCallback: (() => void) | undefined;
-const mockOnCloseBottomSheet = jest.fn((cb?: () => void) => cb?.());
+const mockOnCloseDialog = jest.fn((cb?: () => void) => cb?.());
 
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
@@ -32,7 +32,7 @@ jest.mock('@metamask/design-system-react-native', () => {
 
   return {
     ...actual,
-    BottomSheet: ReactMock.forwardRef(
+    BottomSheetDialog: ReactMock.forwardRef(
       (
         {
           children,
@@ -44,14 +44,14 @@ jest.mock('@metamask/design-system-react-native', () => {
         ref: unknown,
       ) => {
         ReactMock.useImperativeHandle(ref, () => ({
-          onOpenBottomSheet: (cb: () => void) => {
+          onOpenDialog: (cb: () => void) => {
             storedOnOpenCallback = cb;
           },
-          onCloseBottomSheet: mockOnCloseBottomSheet,
+          onCloseDialog: mockOnCloseDialog,
         }));
         return ReactMock.createElement(
           View,
-          { testID: 'mock-bottom-sheet', onTouchEnd: onClose },
+          { testID: 'mock-bottom-sheet-dialog', onTouchEnd: onClose },
           children,
         );
       },
@@ -254,6 +254,7 @@ describe('QuickBuyRoot', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     storedOnOpenCallback = undefined;
+    mockOnCloseDialog.mockImplementation((cb?: () => void) => cb?.());
     (useQuickBuyController as jest.Mock).mockReturnValue(buildHookResult());
     (useQuickBuySetup as jest.Mock).mockReturnValue({
       chainId: '0x1',
@@ -421,7 +422,7 @@ describe('QuickBuyRoot', () => {
       return <Pressable testID="probe-close" onPress={onClose} />;
     };
 
-    it('animates the sheet down via onCloseBottomSheet and runs the parent onClose', () => {
+    it('animates the sheet down via onCloseDialog and runs the parent onClose', () => {
       const onClose = jest.fn();
       renderWithProvider(
         <QuickBuyRoot
@@ -441,7 +442,7 @@ describe('QuickBuyRoot', () => {
         fireEvent.press(screen.getByTestId('probe-close'));
       });
 
-      expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+      expect(mockOnCloseDialog).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -1,6 +1,6 @@
 import {
-  BottomSheet,
-  type BottomSheetRef,
+  BottomSheetDialog,
+  type BottomSheetDialogRef,
   Box,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -83,7 +83,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   children,
 }) => {
   const tw = useTailwind();
-  const bottomSheetRef = useRef<BottomSheetRef>(null);
+  const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
   const [isContentReady, setIsContentReady] = useState(false);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
   const [lockedHeight, setLockedHeight] = useState<number | null>(null);
@@ -115,7 +115,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   );
 
   useEffect(() => {
-    bottomSheetRef.current?.onOpenBottomSheet(() => {
+    bottomSheetRef.current?.onOpenDialog(() => {
       setIsContentReady(true);
     });
   }, []);
@@ -126,8 +126,8 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const requestClose = useCallback(() => {
     setIsClosing(true);
     const sheet = bottomSheetRef.current;
-    if (sheet?.onCloseBottomSheet) {
-      sheet.onCloseBottomSheet(onClose);
+    if (sheet?.onCloseDialog) {
+      sheet.onCloseDialog(onClose);
     } else {
       onClose();
     }
@@ -147,7 +147,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   );
 
   return (
-    <BottomSheet
+    <BottomSheetDialog
       ref={bottomSheetRef}
       isInteractable={!isSubmittingTx}
       onClose={onClose}
@@ -186,7 +186,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           <QuickBuyBottomSheetSkeleton />
         </AnimatedScrollView>
       )}
-    </BottomSheet>
+    </BottomSheetDialog>
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
@@ -28,7 +28,7 @@ jest.mock('./hooks/useQuickBuySetup', () => ({
   useQuickBuySetup: jest.fn(),
 }));
 
-// Captures the onOpenBottomSheet callback registered by QuickBuyBottomSheetInner.
+// Captures the onOpenDialog callback registered by QuickBuyRootInner.
 // Call storedOnOpenCallback() inside act() after render to simulate the sheet
 // finishing its open animation and make isContentReady become true.
 let storedOnOpenCallback: (() => void) | undefined;
@@ -41,7 +41,7 @@ jest.mock('@metamask/design-system-react-native', () => {
 
   return {
     ...actual,
-    BottomSheet: ReactMock.forwardRef(
+    BottomSheetDialog: ReactMock.forwardRef(
       (
         {
           children,
@@ -53,13 +53,14 @@ jest.mock('@metamask/design-system-react-native', () => {
         ref: unknown,
       ) => {
         ReactMock.useImperativeHandle(ref, () => ({
-          onOpenBottomSheet: (cb: () => void) => {
+          onOpenDialog: (cb: () => void) => {
             storedOnOpenCallback = cb;
           },
+          onCloseDialog: (cb?: () => void) => cb?.(),
         }));
         return ReactMock.createElement(
           View,
-          { testID: 'mock-bottom-sheet', onTouchEnd: onClose },
+          { testID: 'mock-bottom-sheet-dialog', onTouchEnd: onClose },
           children,
         );
       },
@@ -305,7 +306,9 @@ describe('QuickBuy.Root', () => {
         />,
       );
 
-      expect(screen.queryByTestId('mock-bottom-sheet')).not.toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('mock-bottom-sheet-dialog'),
+      ).not.toBeOnTheScreen();
     });
 
     it('mounts the inner sheet when visible with a valid position', () => {
@@ -318,7 +321,7 @@ describe('QuickBuy.Root', () => {
         />,
       );
 
-      expect(screen.getByTestId('mock-bottom-sheet')).toBeOnTheScreen();
+      expect(screen.getByTestId('mock-bottom-sheet-dialog')).toBeOnTheScreen();
     });
   });
 


### PR DESCRIPTION
## **Description**

QuickBuy's bottom sheet previously used the full `BottomSheet` wrapper from `@metamask/design-system-react-native`, which includes a `BottomSheetOverlay` (dark backdrop) that was obscuring the asset details chart underneath. This change swaps the wrapper for `BottomSheetDialog` directly — the lower-level component that the Design System team recommends for this use case.

`BottomSheetDialog` provides all the core sheet behaviour (slide-in/out animation, swipe-to-dismiss gesture, drag handle, keyboard avoidance) without rendering any backdrop overlay. The imperative ref API is updated from `onOpenBottomSheet`/`onCloseBottomSheet` to `onOpenDialog`/`onCloseDialog` accordingly.

The asset details chart now remains fully visible underneath the open sheet.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: QuickBuy sheet without backdrop

  Scenario: User opens QuickBuy from the asset detail view
    Given the user is on the Asset detail view
      And the asset details chart is visible

    When the user taps the QuickBuy CTA
    Then the QuickBuy bottom sheet slides up without a dark overlay
      And the asset chart underneath remains visible

    When the user swipes the sheet down
    Then the sheet dismisses normally
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-11 at 10 55 20" src="https://github.com/user-attachments/assets/ebd99ff5-b845-493a-99a0-424ea6a3511d" />

<!-- [screenshot showing dark backdrop over the chart] -->

### **After**

<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-11 at 10 51 43" src="https://github.com/user-attachments/assets/898e87e6-3fdf-41b3-b03f-27f68093febc" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI wrapper swap in a single feature with equivalent sheet behavior; tests updated and no auth, payment, or data-path changes.
> 
> **Overview**
> **QuickBuy** now uses **`BottomSheetDialog`** from the design system instead of **`BottomSheet`**, so the sheet no longer renders the dark **`BottomSheetOverlay`** backdrop and the asset chart stays visible under the open sheet.
> 
> The imperative ref API is aligned with the dialog component: **`onOpenDialog`** / **`onCloseDialog`** replace **`onOpenBottomSheet`** / **`onCloseBottomSheet`** for deferred content readiness and animated dismiss. **`QuickBuyRoot.test.tsx`** and **`QuickBuySheet.test.tsx`** mocks and assertions were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d1759a04e0321eb68b7daa36d8c3ab73abf0f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->