### PR TITLE
feat(perf): send BrowserStack profiling metrics (FPS, CPU, memory) to Sentry

### DIFF
--- a/tests/reporters/PerformanceReporter.ts
+++ b/tests/reporters/PerformanceReporter.ts
@@ -559,10 +559,25 @@ class PerformanceReporter {
     metrics: MetricsEntry[],
   ): Promise<void> {
     for (const metric of metrics) {
-      if (!metric.profilingSummary) continue;
+      // Skip if no profiling data or if enrichment produced an error object
+      // (BrowserStackEnricher sets profilingSummary to { error: '...' } on failure)
+      if (!metric.profilingSummary || metric.profilingSummary.error) continue;
+
+      // Derive status that matches what the fixture sends: timedOut is a
+      // distinct Sentry status and must not be collapsed to 'failed'.
+      const testStatus = !metric.testFailed
+        ? 'passed'
+        : metric.failureReason === 'timedOut'
+          ? 'timedOut'
+          : 'failed';
+
+      // Anchor Sentry transaction to the actual test end time, not report time.
+      const testEndTimestamp = metric.timestamp
+        ? new Date(metric.timestamp).getTime() / 1000
+        : undefined;
 
       try {
-        await publishPerformanceScenarioToSentry({
+        const sent = await publishPerformanceScenarioToSentry({
           metrics: {
             steps: metric.steps || [],
             timestamp: metric.timestamp || new Date().toISOString(),
@@ -581,11 +596,15 @@ class PerformanceReporter {
           projectName: metric.projectName || 'unknown',
           testFilePath: metric.testFilePath,
           tags: metric.tags || [],
-          status: metric.testFailed ? 'failed' : 'passed',
+          status: testStatus,
           videoRecordingUrl: metric.videoURL ?? null,
           profilingSummary: metric.profilingSummary,
+          testEndTimestamp,
         });
-        logger.info(`Profiling data for "${metric.testName}" sent to Sentry`);
+
+        if (sent) {
+          logger.info(`Profiling data for "${metric.testName}" sent to Sentry`);
+        }
       } catch (error) {
         logger.error(
           `Failed to publish profiling data to Sentry for "${metric.testName}": ${error}`,

--- a/tests/reporters/PerformanceReporter.ts
+++ b/tests/reporters/PerformanceReporter.ts
@@ -13,6 +13,7 @@ import { BrowserStackEnricher } from './providers/browserstack/BrowserStackEnric
 import { HtmlReportGenerator } from './generators/HtmlReportGenerator';
 import { CsvReportGenerator } from './generators/CsvReportGenerator';
 import { JsonReportGenerator } from './generators/JsonReportGenerator';
+import { publishPerformanceScenarioToSentry } from './providers/sentry/PerformanceSentryPublisher';
 import type {
   MetricsEntry,
   SessionData,
@@ -502,6 +503,9 @@ class PerformanceReporter {
       // Merge session data into metrics (video URLs, profiling, network logs)
       const metricsWithSession = this.mergeSessionDataIntoMetrics();
 
+      // Publish profiling data (FPS, CPU, memory) to Sentry for enriched metrics
+      await this.publishProfilingDataToSentry(metricsWithSession);
+
       const reportData: ReportData = {
         metrics: metricsWithSession,
         sessions: this.sessions,
@@ -546,6 +550,45 @@ class PerformanceReporter {
       if (files.length > 0) {
         logger.info(
           `   Files: ${files.slice(0, 15).join(', ')}${files.length > 15 ? ` (+${files.length - 15} more)` : ''}`,
+        );
+      }
+    }
+  }
+
+  private async publishProfilingDataToSentry(
+    metrics: MetricsEntry[],
+  ): Promise<void> {
+    for (const metric of metrics) {
+      if (!metric.profilingSummary) continue;
+
+      try {
+        await publishPerformanceScenarioToSentry({
+          metrics: {
+            steps: metric.steps || [],
+            timestamp: metric.timestamp || new Date().toISOString(),
+            thresholdMarginPercent: metric.thresholdMarginPercent ?? 10,
+            team: metric.team ?? null,
+            total: metric.total || 0,
+            totalThreshold: metric.totalThreshold ?? null,
+            hasThresholds: metric.hasThresholds ?? false,
+            totalValidation: metric.totalValidation ?? null,
+            device: metric.device,
+            ...(metric.sessionCreationDurationMs !== undefined && {
+              sessionCreationDurationMs: metric.sessionCreationDurationMs,
+            }),
+          },
+          testTitle: metric.testName,
+          projectName: metric.projectName || 'unknown',
+          testFilePath: metric.testFilePath,
+          tags: metric.tags || [],
+          status: metric.testFailed ? 'failed' : 'passed',
+          videoRecordingUrl: metric.videoURL ?? null,
+          profilingSummary: metric.profilingSummary,
+        });
+        logger.info(`Profiling data for "${metric.testName}" sent to Sentry`);
+      } catch (error) {
+        logger.error(
+          `Failed to publish profiling data to Sentry for "${metric.testName}": ${error}`,
         );
       }
     }

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
@@ -370,6 +370,87 @@ describe('PerformanceSentryPublisher', () => {
     expect(longTimerKeys.every((key: string) => key.length <= 64)).toBe(true);
   });
 
+  it('includes profiling measurements when profilingSummary is provided', async () => {
+    process.env.E2E_PERFORMANCE_SENTRY_DSN =
+      'https://publicKey@o123.ingest.sentry.io/4567';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+
+    const sent = await publishPerformanceScenarioToSentry({
+      metrics: createMetrics(),
+      testTitle: 'Import wallet flow',
+      projectName: 'browserstack-android',
+      testFilePath: 'tests/performance/onboarding/import-wallet.spec.js',
+      tags: ['@PerformanceOnboarding'],
+      status: 'passed',
+      retry: 0,
+      workerIndex: 0,
+      profilingSummary: {
+        status: 'completed',
+        issues: 1,
+        criticalIssues: 0,
+        uiRendering: { slowFrames: 12.5, frozenFrames: 2.1, anrs: 0 },
+        cpu: { avg: 34.2, max: 78.5, unit: '%' },
+        memory: { avg: 210.4, max: 310.8, unit: 'MB' },
+      },
+    });
+
+    expect(sent).toBe(true);
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    const body = requestInit?.body as string;
+    const [, , payloadLine] = body.split('\n');
+    const payload = JSON.parse(payloadLine);
+
+    expect(payload.measurements.profiling_slow_frames_pct.value).toBe(12.5);
+    expect(payload.measurements.profiling_slow_frames_pct.unit).toBe('percent');
+    expect(payload.measurements.profiling_frozen_frames_pct.value).toBe(2.1);
+    expect(payload.measurements.profiling_frozen_frames_pct.unit).toBe(
+      'percent',
+    );
+    expect(payload.measurements.profiling_anrs.value).toBe(0);
+    expect(payload.measurements.profiling_anrs.unit).toBe('none');
+    expect(payload.measurements.profiling_cpu_avg_pct.value).toBe(34.2);
+    expect(payload.measurements.profiling_cpu_avg_pct.unit).toBe('percent');
+    expect(payload.measurements.profiling_cpu_max_pct.value).toBe(78.5);
+    expect(payload.measurements.profiling_memory_avg_mb.value).toBe(210.4);
+    expect(payload.measurements.profiling_memory_avg_mb.unit).toBe('megabyte');
+    expect(payload.measurements.profiling_memory_max_mb.value).toBe(310.8);
+    expect(payload.extra.profiling_summary.uiRendering.slowFrames).toBe(12.5);
+  });
+
+  it('does not include profiling measurements when profilingSummary is absent', async () => {
+    process.env.E2E_PERFORMANCE_SENTRY_DSN =
+      'https://publicKey@o123.ingest.sentry.io/4567';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+
+    const sent = await publishPerformanceScenarioToSentry({
+      metrics: createMetrics(),
+      testTitle: 'Import wallet flow',
+      projectName: 'browserstack-android',
+      testFilePath: 'tests/performance/onboarding/import-wallet.spec.js',
+      tags: ['@PerformanceOnboarding'],
+      status: 'passed',
+      retry: 0,
+      workerIndex: 0,
+    });
+
+    expect(sent).toBe(true);
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    const body = requestInit?.body as string;
+    const [, , payloadLine] = body.split('\n');
+    const payload = JSON.parse(payloadLine);
+
+    expect(payload.measurements.profiling_slow_frames_pct).toBeUndefined();
+    expect(payload.measurements.profiling_frozen_frames_pct).toBeUndefined();
+    expect(payload.measurements.profiling_anrs).toBeUndefined();
+    expect(payload.extra.profiling_summary).toBeNull();
+  });
+
   it('does not send when sample rate is invalid', async () => {
     process.env.E2E_PERFORMANCE_SENTRY_DSN =
       'https://publicKey@o123.ingest.sentry.io/4567';

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
@@ -451,6 +451,34 @@ describe('PerformanceSentryPublisher', () => {
     expect(payload.extra.profiling_summary).toBeNull();
   });
 
+  it('anchors transaction timestamps to testEndTimestamp when provided', async () => {
+    process.env.E2E_PERFORMANCE_SENTRY_DSN =
+      'https://publicKey@o123.ingest.sentry.io/4567';
+    fetchMock.mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const testEndTimestamp = 1700000000; // fixed Unix seconds
+    await publishPerformanceScenarioToSentry({
+      metrics: createMetrics({ total: 1.3 }),
+      testTitle: 'Import wallet flow',
+      projectName: 'browserstack-android',
+      testFilePath: 'tests/performance/onboarding/import-wallet.spec.js',
+      tags: [],
+      status: 'passed',
+      retry: 0,
+      workerIndex: 0,
+      testEndTimestamp,
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    const body = requestInit?.body as string;
+    const [, , payloadLine] = body.split('\n');
+    const payload = JSON.parse(payloadLine);
+
+    expect(payload.timestamp).toBe(testEndTimestamp);
+    // startTimestamp = endTimestamp - totalDurationMs/1000 = 1700000000 - 1.3
+    expect(payload.start_timestamp).toBeCloseTo(testEndTimestamp - 1.3, 3);
+  });
+
   it('does not send when sample rate is invalid', async () => {
     process.env.E2E_PERFORMANCE_SENTRY_DSN =
       'https://publicKey@o123.ingest.sentry.io/4567';

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '../../../framework/logger';
 import type { MetricsOutput } from '../../PerformanceTracker';
+import type { ProfilingSummary } from '../../types';
 
 const logger = createLogger({ name: 'PerformanceSentryPublisher' });
 
@@ -22,6 +23,13 @@ const RESERVED_MEASUREMENT_KEYS = [
   'scenario_total_time_ms',
   'scenario_total_threshold_ms',
   'bs_session_creation_ms',
+  'profiling_slow_frames_pct',
+  'profiling_frozen_frames_pct',
+  'profiling_anrs',
+  'profiling_cpu_avg_pct',
+  'profiling_cpu_max_pct',
+  'profiling_memory_avg_mb',
+  'profiling_memory_max_mb',
 ] as const;
 
 interface PublishPerformanceScenarioOptions {
@@ -34,6 +42,7 @@ interface PublishPerformanceScenarioOptions {
   retry?: number;
   workerIndex?: number;
   videoRecordingUrl?: string | null;
+  profilingSummary?: ProfilingSummary | null;
 }
 
 interface ParsedSentryDsn {
@@ -56,7 +65,7 @@ interface TimerMeasurement {
 
 interface SentryMeasurement {
   value: number;
-  unit: 'millisecond';
+  unit: 'millisecond' | 'none' | 'percent' | 'megabyte';
 }
 
 interface MirroredScenarioAttributes {
@@ -297,6 +306,42 @@ export async function publishPerformanceScenarioToSentry(
     };
   }
 
+  if (options.profilingSummary?.uiRendering) {
+    const { slowFrames, frozenFrames, anrs } =
+      options.profilingSummary.uiRendering;
+    measurements.profiling_slow_frames_pct = {
+      value: slowFrames,
+      unit: 'percent',
+    };
+    measurements.profiling_frozen_frames_pct = {
+      value: frozenFrames,
+      unit: 'percent',
+    };
+    measurements.profiling_anrs = { value: anrs, unit: 'none' };
+  }
+
+  if (options.profilingSummary?.cpu) {
+    measurements.profiling_cpu_avg_pct = {
+      value: options.profilingSummary.cpu.avg,
+      unit: 'percent',
+    };
+    measurements.profiling_cpu_max_pct = {
+      value: options.profilingSummary.cpu.max,
+      unit: 'percent',
+    };
+  }
+
+  if (options.profilingSummary?.memory) {
+    measurements.profiling_memory_avg_mb = {
+      value: options.profilingSummary.memory.avg,
+      unit: 'megabyte',
+    };
+    measurements.profiling_memory_max_mb = {
+      value: options.profilingSummary.memory.max,
+      unit: 'megabyte',
+    };
+  }
+
   const provider = options.metrics.device.provider || 'unknown';
   const teamId = options.metrics.team?.teamId || 'unknown';
   const teamName = options.metrics.team?.teamName || 'unknown';
@@ -407,6 +452,7 @@ export async function publishPerformanceScenarioToSentry(
       total_validation: options.metrics.totalValidation,
       timer_steps: timerMeasurements,
       bs_session_creation_ms: options.metrics.sessionCreationDurationMs ?? null,
+      profiling_summary: options.profilingSummary ?? null,
       sentry_project_id: parsedDsn.projectId,
     },
   };

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
@@ -43,6 +43,8 @@ interface PublishPerformanceScenarioOptions {
   workerIndex?: number;
   videoRecordingUrl?: string | null;
   profilingSummary?: ProfilingSummary | null;
+  /** Unix epoch seconds. When provided, anchors the transaction to the actual test end time instead of the moment the publish call is made. */
+  testEndTimestamp?: number;
 }
 
 interface ParsedSentryDsn {
@@ -261,7 +263,7 @@ export async function publishPerformanceScenarioToSentry(
   const transactionSpanId = createHexId(16);
 
   const totalDurationMs = Math.round(options.metrics.total * 1000);
-  const endTimestamp = Date.now() / 1000;
+  const endTimestamp = options.testEndTimestamp ?? Date.now() / 1000;
   const startTimestamp = endTimestamp - totalDurationMs / 1000;
 
   const usedMeasurementKeys = new Set<string>(RESERVED_MEASUREMENT_KEYS);


### PR DESCRIPTION
## **Description**

Currently the performance E2E pipeline sends timer step durations (e.g. login time, swap time) to Sentry after each test via `publishPerformanceScenarioToSentry`. However, the BrowserStack App Profiling v2 data — which includes UI rendering (slow/frozen frames, ANRs), CPU, and memory — is fetched after all tests complete in `PerformanceReporter.onEnd()` but never forwarded to Sentry.

This PR closes that gap by:

1. Extending `publishPerformanceScenarioToSentry` to accept an optional `profilingSummary` and emit the following typed Sentry measurements when present:
   - `profiling_slow_frames_pct` (percent) — % of slow frames (<60 fps equivalent)
   - `profiling_frozen_frames_pct` (percent) — % of frozen frames (>700 ms)
   - `profiling_anrs` (none) — ANR count
   - `profiling_cpu_avg_pct` / `profiling_cpu_max_pct` (percent)
   - `profiling_memory_avg_mb` / `profiling_memory_max_mb` (megabyte)
2. Adding `publishProfilingDataToSentry` in `PerformanceReporter` that is called after session enrichment (`mergeSessionDataIntoMetrics`) and sends a Sentry transaction per test that has profiling data.

For non-BrowserStack runs (local/simulator), behaviour is unchanged — only the existing timer-step transaction is sent. For BrowserStack runs, each test also gets a profiling transaction with the above measurements.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMQA-1929

## **Manual testing steps**

```gherkin
Feature: BrowserStack profiling metrics in Sentry

  Scenario: Run performance E2E tests on BrowserStack and verify Sentry data
    Given a BrowserStack performance test run completes with profiling data available
    When the PerformanceReporter finishes and calls publishProfilingDataToSentry
    Then each test that has a profilingSummary emits a Sentry transaction
    And that transaction contains measurements for profiling_slow_frames_pct, profiling_frozen_frames_pct, profiling_anrs, profiling_cpu_avg_pct, profiling_cpu_max_pct, profiling_memory_avg_mb, profiling_memory_max_mb
    And tests without profilingSummary (local runs) are not affected
```

## **Screenshots/Recordings**

N/A — infrastructure/tooling change with no UI impact.

### **Before**

BrowserStack profiling data (FPS, CPU, memory) only in HTML/CSV/JSON local reports, absent from Sentry.

### **After**

BrowserStack profiling data available as typed Sentry measurements on a dedicated profiling transaction per test, queryable in Sentry Performance.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds post-run Sentry uploads for BrowserStack tests (possible duplicate timer transactions alongside the existing fixture publish) and expands the performance telemetry pipeline, but changes are gated on profiling data and env-controlled Sentry settings.
> 
> **Overview**
> After BrowserStack session enrichment, **PerformanceReporter** now publishes Sentry transactions for tests that have a valid `profilingSummary`, so UI/CPU/memory profiling that previously only appeared in local reports is also sent to Sentry.
> 
> **`publishPerformanceScenarioToSentry`** accepts optional `profilingSummary` and `testEndTimestamp`, maps BrowserStack profiling into typed Sentry measurements (`profiling_slow_frames_pct`, `profiling_frozen_frames_pct`, `profiling_anrs`, CPU/memory metrics), mirrors the summary in `extra.profiling_summary`, and anchors transaction start/end to the test end time when provided. Runs without profiling or with enrichment errors are skipped unchanged.
> 
> Unit tests cover profiling payload shape, absence of profiling fields, and timestamp anchoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0060635e4ae8554a2bbf0a2273323fe7a7743fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->