### PR TITLE
fix(predict): fix scoreboard score cutoff for wide scores cp-7.82.0

### DIFF
--- a/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
+++ b/app/components/UI/Predict/components/PredictSportScoreboard/PredictSportScoreboard.tsx
@@ -124,12 +124,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
   });
 
   const teamLogoSize = compact ? COMPACT_TEAM_LOGO_SIZE : TEAM_LOGO_SIZE;
-  const showScores = !(compact && isScheduled);
-  const scoreWidthClass = isScheduled
-    ? 'opacity-0 w-16'
-    : compact
-      ? 'w-12'
-      : 'w-16';
+  const showScores = isLive || isEnded;
 
   // Team display order is sport-dependent: soccer (and other draw-capable
   // leagues) show the home team on the left, while US sports (e.g. American
@@ -189,7 +184,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             variant={TextVariant.DisplayMd}
             color={TextColor.TextDefault}
             fontWeight={FontWeight.Bold}
-            twClassName={`${scoreWidthClass} ${compact ? 'pl-2' : 'pl-3'}`}
+            twClassName={`${compact ? 'pl-2' : 'pl-3'}`}
             numberOfLines={1}
           >
             {leftScore}
@@ -267,7 +262,7 @@ const PredictSportScoreboard: React.FC<PredictSportScoreboardProps> = ({
             variant={TextVariant.DisplayMd}
             color={TextColor.TextDefault}
             fontWeight={FontWeight.Bold}
-            twClassName={`${scoreWidthClass} ${compact ? 'pr-2' : 'pr-3'} text-right`}
+            twClassName={`${compact ? 'pr-2' : 'pr-3'} text-right`}
             numberOfLines={1}
           >
             {rightScore}


### PR DESCRIPTION
## **Description**

Fix game clock width on the Predict sport scoreboard to prevent wide scores (e.g., 123) from being cut off. On devices like iPhone 17 Pro, the score container had insufficient width, causing scores with 3+ digits to be clipped. The fix adjusts the score display layout to properly accommodate wider score values.

## **Changelog**

CHANGELOG entry: Fixed a bug causing wide sport scores to be cut off on the predict scoreboard.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-960

## **Manual testing steps**

```gherkin
Feature: Predict sport scoreboard

  Scenario: user views a game with a wide score (3+ digits)
    Given the user is on the Predict scoreboard screen
    And a live or completed sport game has a score of 100 or higher (e.g., Knicks 123 vs Spurs 118)

    When user views the scoreboard card
    Then the full score is displayed without being cut off
```

## **Screenshots/Recordings**

### **Before**

<!-- Scores like 123 were clipped on iPhone 17 Pro -->

### **After**
<img width="320" alt="Simulator Screenshot - mm-blue - 2026-06-11 at 12 23 33" src="https://github.com/user-attachments/assets/f06ef67d-abd0-46c6-a49c-438aeb8ae8c9" />
<img width="320" alt="Simulator Screenshot - mm-blue - 2026-06-11 at 12 23 25" src="https://github.com/user-attachments/assets/648109fd-b2d7-4bdf-8df2-e25b4ac4b534" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in Predict scoreboard; scheduled non-compact cards no longer reserve invisible score slots.
> 
> **Overview**
> Updates **Predict sport scoreboard** score rendering so live and final games can show wide scores (e.g. 100+) without clipping.
> 
> **`showScores`** is now tied to **`isLive || isEnded`** instead of hiding scores only in compact scheduled cards. Scheduled games no longer render score text or the old invisible fixed-width placeholders.
> 
> Fixed Tailwind width classes on score **`Text`** (`w-12` / `w-16` / `opacity-0 w-16`) are removed; scores keep padding only so they can grow with digit count and give the center status area more flexible space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78a1eae545f933699d858aa82b2e6b71e86a4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->