### PR TITLE
fix: approval transaction shows undefined until confirmed WPN-1251

### DIFF
--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
@@ -211,6 +211,25 @@ describe('MultichainTransactionListItem', () => {
     expect(getByText('-0.00001 SOL')).toBeTruthy();
   });
 
+  it('renders correctly for an Interaction transaction without a base fee', () => {
+    const interactionTransaction = {
+      ...mockTransaction,
+      type: TransactionType.Unknown,
+      fees: [],
+    };
+
+    const { getByText, queryByText } = renderWithProvider(
+      <MultichainTransactionListItem
+        transaction={interactionTransaction}
+        chainId={SolScope.Mainnet}
+        navigation={mockNavigation as unknown as NavigationProp<ParamListBase>}
+      />,
+    );
+
+    expect(getByText('transactions.interaction')).toBeTruthy();
+    expect(queryByText('undefined undefined')).toBeNull();
+  });
+
   it('navigates to transaction details sheet when pressed', () => {
     const { getByTestId } = renderWithProvider(
       <MultichainTransactionListItem

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -113,7 +113,7 @@ const MultichainTransactionListItem = ({
     }
 
     if (transaction.type === TransactionType.Unknown) {
-      return `${baseFee?.amount} ${baseFee?.unit}`;
+      return baseFee ? `${baseFee.amount} ${baseFee.unit}` : ``;
     }
 
     return `${to?.amount} ${to?.unit}`;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fixes an Activity list rendering issue where approval/interaction transactions could show undefined undefined as the transaction amount while fee data is unavailable.

For TransactionType.Unknown transactions, the list item now only renders the base fee amount when baseFee exists. If no base fee is available yet, the amount area is left blank instead of displaying undefined values.

A unit test was added to cover interaction transactions without base fee data.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed approval or interaction transactions could show undefined undefined in the Activity list.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [WPN-1251](https://consensyssoftware.atlassian.net/browse/WPN-1251)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Tron network swap approval display

  Scenario: user swaps a TRC20 token to TRX
    Given the user is swapping a TRC20 token to TRX on the Tron network

    When the swap creates an approval transaction
    Then the approval transaction does not display "undefined undefined" in Activity

    When the approval transaction is confirmed
    Then the base fee amount is displayed in Activity
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="443" height="434" alt="Screenshot 2026-06-11 at 13 40 53" src="https://github.com/user-attachments/assets/30a99aaa-a880-498d-81e4-aa1fc973bd84" />


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/da7c835b-bdf6-4a0d-b13f-8763983ceecd

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[WPN-1251]: https://consensyssoftware.atlassian.net/browse/WPN-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-only change in the multichain Activity list item with a focused unit test; no auth, data, or payment logic touched.
> 
> **Overview**
> Fixes Activity list rows for **interaction/approval** transactions (`TransactionType.Unknown`) that could show **`undefined undefined`** while base fee data is not yet available.
> 
> `displayAmount` in `MultichainTransactionListItem` now renders the base fee only when `baseFee` exists; otherwise the amount field stays **blank** until fees arrive. A unit test covers interaction transactions with **no fees**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1850ae7e499a8add55702a00a7310e1d1c62f208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->