### PR TITLE
feat: migrate zkSync Era default RPC to Infura

### DIFF
--- a/app/components/hooks/useAddNetwork.test.ts
+++ b/app/components/hooks/useAddNetwork.test.ts
@@ -17,6 +17,7 @@ describe('useAddNetwork', () => {
         chainId: '0x1',
         nickname: 'Ethereum',
         rpcUrl: 'https://mainnet.infura.io/v3/YOUR_INFURA_API_KEY',
+        failoverRpcUrls: [],
         ticker: 'ETH',
         warning: false,
         rpcPrefs: {

--- a/app/store/migrations/141.test.ts
+++ b/app/store/migrations/141.test.ts
@@ -1,0 +1,361 @@
+import migrate from './141';
+import { merge } from 'lodash';
+import { captureException } from '@sentry/react-native';
+import initialRootState from '../../util/test/initial-root-state';
+import { RootState } from '../../reducers';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+const mockedCaptureException = jest.mocked(captureException);
+
+describe('Migration #141 - Replace zkSync Era Network RPC URL', () => {
+  const ZKSYNC_CHAIN_ID = CHAIN_IDS.ZKSYNC_ERA;
+  const LINEA_CHAIN_ID = CHAIN_IDS.LINEA_MAINNET;
+  const MAINNET_CHAIN_ID = '0x1';
+  const SEPOLIA_CHAIN_ID = '0xaa36a7';
+  const OLD_RPC_URL = 'https://mainnet.era.zksync.io';
+  const NEW_RPC_URL = `https://zksync-mainnet.infura.io/v3/${
+    process.env.MM_INFURA_PROJECT_ID === 'null'
+      ? ''
+      : process.env.MM_INFURA_PROJECT_ID
+  }`;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  const invalidStates = [
+    {
+      state: null,
+      errorMessage: "FATAL ERROR: Migration 141: Invalid state error: 'object'",
+      scenario: 'state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: null,
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 141: Invalid engine state error: 'object'",
+      scenario: 'engine state is invalid',
+    },
+    {
+      state: merge({}, initialRootState, {
+        engine: {
+          backgroundState: null,
+        },
+      }),
+      errorMessage:
+        "FATAL ERROR: Migration 141: Invalid engine backgroundState error: 'object'",
+      scenario: 'backgroundState is invalid',
+    },
+  ];
+
+  for (const { errorMessage, scenario, state } of invalidStates) {
+    it(`should capture exception if ${scenario}`, async () => {
+      const newState = await migrate(state);
+
+      expect(newState).toStrictEqual(state);
+      expect(mockedCaptureException).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockedCaptureException.mock.calls[0][0].message).toBe(
+        errorMessage,
+      );
+    });
+  }
+
+  it('should replace the zkSync Era RPC URL when the user relies on Infura on another chain', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [MAINNET_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://mainnet.infura.io/v3/some-key' },
+                  { url: 'https://non-infura.rpc' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: OLD_RPC_URL },
+                  { url: 'https://another.rpc' },
+                ],
+                defaultRpcEndpointIndex: 0,
+                nativeCurrency: 'ETH',
+                name: 'zkSync Era',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const expectedState = merge({}, oldState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: NEW_RPC_URL },
+                  { url: 'https://another.rpc' },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(expectedState);
+  });
+
+  it('should do nothing if the zkSync Era network configuration is missing', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [MAINNET_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://mainnet.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should do nothing if the zkSync Era RPC URL is not the legacy URL', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [MAINNET_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://mainnet.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://custom.zksync.rpc' },
+                  { url: 'https://another.rpc' },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should handle cases where rpcEndpoints is not an array', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [MAINNET_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://mainnet.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: null,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should do nothing if no networks use Infura RPC endpoints', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [MAINNET_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://non-infura.rpc' },
+                  { url: 'https://another-non-infura.rpc' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [{ url: OLD_RPC_URL }],
+                defaultRpcEndpointIndex: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should exclude LINEA_MAINNET from Infura RPC endpoint checks', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [LINEA_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://linea-mainnet.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [{ url: OLD_RPC_URL }],
+                defaultRpcEndpointIndex: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should exclude ZKSYNC_ERA itself from Infura RPC endpoint checks', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://zksync-mainnet.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should exclude testnets (e.g. Sepolia) from Infura RPC endpoint checks', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [SEPOLIA_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://sepolia.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [{ url: OLD_RPC_URL }],
+                defaultRpcEndpointIndex: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(oldState);
+  });
+
+  it('should preserve other endpoint and network fields when rewriting the URL', async () => {
+    const oldState = merge({}, initialRootState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [MAINNET_CHAIN_ID]: {
+                rpcEndpoints: [
+                  { url: 'https://mainnet.infura.io/v3/some-key' },
+                ],
+                defaultRpcEndpointIndex: 0,
+              },
+              [ZKSYNC_CHAIN_ID]: {
+                chainId: ZKSYNC_CHAIN_ID,
+                name: 'zkSync Era',
+                nativeCurrency: 'ETH',
+                blockExplorerUrls: ['https://explorer.zksync.io/'],
+                defaultBlockExplorerUrlIndex: 0,
+                rpcEndpoints: [
+                  {
+                    url: 'https://custom.zksync.rpc',
+                    networkClientId: 'custom-id',
+                    type: 'custom',
+                  },
+                  {
+                    url: OLD_RPC_URL,
+                    networkClientId: 'zksync-id',
+                    type: 'custom',
+                    failoverUrls: ['https://failover.zksync.rpc'],
+                  },
+                ],
+                defaultRpcEndpointIndex: 1,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const expectedState = merge({}, oldState, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [ZKSYNC_CHAIN_ID]: {
+                rpcEndpoints: [
+                  {
+                    url: 'https://custom.zksync.rpc',
+                    networkClientId: 'custom-id',
+                    type: 'custom',
+                  },
+                  {
+                    url: NEW_RPC_URL,
+                    networkClientId: 'zksync-id',
+                    type: 'custom',
+                    failoverUrls: ['https://failover.zksync.rpc'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const newState = await migrate(oldState);
+    expect(newState).toStrictEqual(expectedState);
+  });
+});

--- a/app/store/migrations/141.ts
+++ b/app/store/migrations/141.ts
@@ -1,0 +1,127 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+import Logger from '../../util/Logger';
+import { RpcEndpointType } from '@metamask/network-controller';
+import {
+  allowedInfuraHosts,
+  infuraChainIdsTestNets,
+} from '../../util/networks/customNetworks';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+
+const ZKSYNC_ERA_CHAIN_ID = CHAIN_IDS.ZKSYNC_ERA;
+const INFURA_KEY = process.env.MM_INFURA_PROJECT_ID;
+const infuraProjectId = INFURA_KEY === 'null' ? '' : INFURA_KEY;
+const ZKSYNC_LEGACY_URL = 'https://mainnet.era.zksync.io';
+const ZKSYNC_INFURA_URL = `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`;
+
+/**
+ * Migration to update the zkSync Era network configuration by replacing
+ * "https://mainnet.era.zksync.io" with "https://zksync-mainnet.infura.io/v3/{infuraProjectId}".
+ *
+ * Only applied when the user already relies on Infura on at least one other
+ * supported chain (excluding testnets, Linea Mainnet, and zkSync Era itself).
+ *
+ * @param state - The current MetaMask mobile state.
+ * @returns The updated state with the revised Infura endpoint for the zkSync Era network.
+ */
+export default function migrate(state: unknown) {
+  if (!ensureValidState(state, 141)) {
+    return state;
+  }
+
+  const { engine } = state;
+  if (
+    hasProperty(engine.backgroundState, 'NetworkController') &&
+    isObject(engine.backgroundState.NetworkController) &&
+    hasProperty(
+      engine.backgroundState.NetworkController,
+      'networkConfigurationsByChainId',
+    ) &&
+    isObject(
+      engine.backgroundState.NetworkController.networkConfigurationsByChainId,
+    )
+  ) {
+    const networkConfigurationsByChainId =
+      engine.backgroundState.NetworkController.networkConfigurationsByChainId;
+
+    const usesInfura = Object.entries(networkConfigurationsByChainId)
+      .filter(
+        ([chainId]) =>
+          ![
+            ...infuraChainIdsTestNets,
+            CHAIN_IDS.LINEA_MAINNET,
+            CHAIN_IDS.ZKSYNC_ERA,
+          ].includes(chainId),
+      )
+      .some(([, networkConfig]) => {
+        if (
+          !isObject(networkConfig) ||
+          !Array.isArray(networkConfig.rpcEndpoints) ||
+          typeof networkConfig.defaultRpcEndpointIndex !== 'number'
+        ) {
+          return false;
+        }
+
+        const defaultRpcEndpoint =
+          networkConfig.rpcEndpoints?.[networkConfig.defaultRpcEndpointIndex];
+
+        if (
+          !isObject(defaultRpcEndpoint) ||
+          typeof defaultRpcEndpoint.url !== 'string'
+        ) {
+          return false;
+        }
+
+        try {
+          const urlHost = new URL(defaultRpcEndpoint.url).host;
+          return (
+            defaultRpcEndpoint.type === RpcEndpointType.Infura ||
+            allowedInfuraHosts.includes(urlHost)
+          );
+        } catch {
+          return false;
+        }
+      });
+
+    if (!usesInfura) {
+      return state;
+    }
+
+    const zkSyncNetworkConfig =
+      networkConfigurationsByChainId[ZKSYNC_ERA_CHAIN_ID];
+    if (
+      isObject(zkSyncNetworkConfig) &&
+      hasProperty(zkSyncNetworkConfig, 'rpcEndpoints')
+    ) {
+      const { rpcEndpoints } = zkSyncNetworkConfig;
+
+      if (Array.isArray(rpcEndpoints)) {
+        const endpointIndex = rpcEndpoints.findIndex(
+          (endpoint) =>
+            isObject(endpoint) && endpoint.url === ZKSYNC_LEGACY_URL,
+        );
+
+        if (endpointIndex !== -1) {
+          Logger.log(
+            `Migration 141: Updating '${ZKSYNC_LEGACY_URL}' to '${ZKSYNC_INFURA_URL}' in zkSync Era network RPC endpoints.`,
+          );
+
+          rpcEndpoints[endpointIndex] = {
+            ...rpcEndpoints[endpointIndex],
+            url: ZKSYNC_INFURA_URL,
+          };
+
+          networkConfigurationsByChainId[ZKSYNC_ERA_CHAIN_ID] = {
+            ...zkSyncNetworkConfig,
+            rpcEndpoints,
+          };
+
+          engine.backgroundState.NetworkController.networkConfigurationsByChainId =
+            networkConfigurationsByChainId;
+        }
+      }
+    }
+  }
+
+  return state;
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -141,6 +141,7 @@ import migration137 from './137';
 import migration138 from './138';
 import migration139 from './139';
 import migration140 from './140';
+import migration141 from './141';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -301,6 +302,7 @@ export const migrationList: MigrationsList = {
   138: migration138,
   139: migration139,
   140: migration140,
+  141: migration141,
 };
 
 // Enable both synchronous and asynchronous migrations

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -132,7 +132,8 @@ export const PopularList = [
   {
     chainId: toHex('324'),
     nickname: 'zkSync Era',
-    rpcUrl: `https://mainnet.era.zksync.io`,
+    rpcUrl: `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`,
+    failoverRpcUrls: [],
     ticker: 'ETH',
     warning: true,
     rpcPrefs: {

--- a/tests/api-mocking/mock-responses/defaults/rpc-endpoints.ts
+++ b/tests/api-mocking/mock-responses/defaults/rpc-endpoints.ts
@@ -34,15 +34,6 @@ export const DEFAULT_RPC_ENDPOINT_MOCKS: MockEventsObject = {
       },
     },
     {
-      urlEndpoint: 'https://mainnet.era.zksync.io/',
-      responseCode: 200,
-      response: {
-        jsonrpc: '2.0',
-        id: 1,
-        result: '0x0',
-      },
-    },
-    {
       urlEndpoint: /^https:\/\/virtual\.mainnet\.rpc\.tenderly\.co\/.+$/,
       responseCode: 200,
       response: {

--- a/tests/resources/networks.e2e.js
+++ b/tests/resources/networks.e2e.js
@@ -27,7 +27,7 @@ const PopularNetworksList = {
     providerConfig: {
       type: 'rpc',
       chainId: toHex('324'),
-      rpcUrl: `https://mainnet.era.zksync.io`,
+      rpcUrl: `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`,
       nickname: 'zkSync Era Mainnet',
       ticker: 'FTM',
     },


### PR DESCRIPTION
## **Description**

Replace the deprecated public zkSync Era endpoint `https://mainnet.era.zksync.io` with the Infura URL `https://zksync-mainnet.infura.io/v3/${infuraProjectId}` in the PopularList default, plus a state migration (141) that flips already-installed users — but only when the user already relies on Infura on at least one other chain (excluding testnets, Linea Mainnet, and zkSync itself). Users who explicitly set a non Infura zkSync RPC keep their choice.

## **Changelog**

CHANGELOG entry: feat: migrate zkSync Era default RPC to Infura

## **Related issues**

Fixes:  migrate zkSync Era default RPC to Infura

## **Manual testing steps**

1. `yarn start:ios` (or `yarn start:android`).
2. Add a network → Popular → zkSync Era → confirm the RPC URL is the Infura URL and balance loads.
3. Migration smoke: load a debug build with persisted state pointing zkSync at the legacy URL and Optimism at Infura. Cold start the app; confirm zkSync endpoint flips to Infura. Without the Optimism Infura entry, the zkSync URL stays as the legacy one.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
