### PR TITLE
feat: Cherry-pick: update World Cup event count in PredictionsSection and related components (7.81.0)

### DIFF
--- a/app/components/Views/Homepage/Homepage.test.tsx
+++ b/app/components/Views/Homepage/Homepage.test.tsx
@@ -245,6 +245,11 @@ jest.mock('@tanstack/react-query', () => {
   const actual = jest.requireActual('@tanstack/react-query');
   return {
     ...actual,
+    useQuery: jest.fn(() => ({
+      data: 510,
+      isLoading: false,
+      refetch: jest.fn().mockResolvedValue(undefined),
+    })),
     useQueryClient: jest.fn(() => ({
       invalidateQueries: jest.fn(() => Promise.resolve()),
     })),

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -52,6 +52,15 @@ const worldCupHomepageMarketsMock = (
   fetchMore: jest.fn(),
 });
 
+const worldCupEventCountMock = (
+  eventCount: number | undefined = 510,
+  opts: { isFetching?: boolean } = {},
+) => ({
+  eventCount,
+  isFetching: opts.isFetching ?? false,
+  refetch: jest.fn(),
+});
+
 const HOMEPAGE_DISCOVERY_WINNER_MARKET = {
   id: 'market-1',
   title: '2026 FIFA World Cup Winner',
@@ -204,6 +213,7 @@ jest.mock('./hooks', () => {
   const worldCupMock = jest.fn(() =>
     worldCupMarketsWithDiscoveryChampionship(),
   );
+  const worldCupEventCount = jest.fn(() => worldCupEventCountMock());
   const nbaMock = jest.fn(() =>
     worldCupHomepageMarketsMock([HOMEPAGE_DISCOVERY_NBA_CHAMPION_PARENT]),
   );
@@ -222,6 +232,7 @@ jest.mock('./hooks', () => {
       refetch: jest.fn(),
     })),
     useHomepagePredictWorldCupMarkets: worldCupMock,
+    useHomepagePredictWorldCupEventCount: worldCupEventCount,
     useHomepagePredictTaggedMarkets: jest.fn(
       ({ customQueryParams }: { customQueryParams: string }) =>
         customQueryParams === tagQueries.nbaChampion
@@ -229,6 +240,7 @@ jest.mock('./hooks', () => {
           : worldCupHomepageMarketsMock([]),
     ),
     __mockUsePredictWorldCupHomepageMarkets: worldCupMock,
+    __mockUsePredictWorldCupEventCount: worldCupEventCount,
     __mockUsePredictNbaChampionHomepageMarkets: nbaMock,
   };
 });
@@ -254,6 +266,8 @@ const mockUsePredictPositionsForHomepage =
   jest.requireMock('./hooks').usePredictPositionsForHomepage;
 const mockUsePredictWorldCupHomepageMarkets = jest.requireMock('./hooks')
   .__mockUsePredictWorldCupHomepageMarkets as jest.Mock;
+const mockUsePredictWorldCupEventCount = jest.requireMock('./hooks')
+  .__mockUsePredictWorldCupEventCount as jest.Mock;
 const mockUsePredictNbaChampionHomepageMarkets = jest.requireMock('./hooks')
   .__mockUsePredictNbaChampionHomepageMarkets as jest.Mock;
 const mockSelectPrivacyMode = jest.requireMock(
@@ -386,6 +400,7 @@ describe('PredictionsSection', () => {
     mockUsePredictWorldCupHomepageMarkets.mockReturnValue(
       worldCupMarketsWithDiscoveryChampionship(),
     );
+    mockUsePredictWorldCupEventCount.mockReturnValue(worldCupEventCountMock());
     mockUsePredictNbaChampionHomepageMarkets.mockReturnValue(
       worldCupHomepageMarketsMock([HOMEPAGE_DISCOVERY_NBA_CHAMPION_PARENT]),
     );
@@ -858,6 +873,27 @@ describe('PredictionsSection', () => {
 
       expect(toJSON()).not.toBeNull();
       expect(screen.getByText('Predictions')).toBeOnTheScreen();
+    });
+
+    it('shows the World Cup API total with a plus sign in the discovery row', () => {
+      mockUsePredictMarketsForHomepage.mockReturnValue({
+        markets: [],
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+      mockUsePredictWorldCupHomepageMarkets.mockReturnValue(
+        worldCupHomepageMarketsMock([HOMEPAGE_DISCOVERY_WINNER_MARKET]),
+      );
+      mockUsePredictWorldCupEventCount.mockReturnValue(
+        worldCupEventCountMock(48),
+      );
+
+      renderWithProvider(
+        <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+      );
+
+      expect(screen.getByText('48+ events in total')).toBeOnTheScreen();
     });
 
     it('still renders treatment discovery when trending markets fail', async () => {

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -26,6 +26,7 @@ import {
   usePredictPositionsForHomepage,
   useHomepagePredictTaggedMarkets,
   useHomepagePredictWorldCupMarkets,
+  useHomepagePredictWorldCupEventCount,
   HOMEPAGE_PREDICT_TAG_QUERIES,
   usePredictHomepageDiscoveryExperiment,
 } from './hooks';
@@ -54,6 +55,7 @@ import type { TransactionActiveAbTestEntry } from '../../../../../util/transacti
 /** Loads both feeds the World Cup discovery rail needs (World Cup tag + NBA Champion event). */
 const useWorldCupDiscoveryFeeds = (enabled: boolean) => ({
   worldCup: useHomepagePredictWorldCupMarkets({ enabled }),
+  worldCupEventCount: useHomepagePredictWorldCupEventCount({ enabled }),
   nbaChampion: useHomepagePredictTaggedMarkets({
     enabled,
     customQueryParams: HOMEPAGE_PREDICT_TAG_QUERIES.nbaChampion,
@@ -336,14 +338,17 @@ const PredictionsSectionDefault = forwardRef<
 
     const {
       worldCup: worldCupHomepageMarkets,
+      worldCupEventCount,
       nbaChampion: nbaChampionHomepageMarkets,
     } = useWorldCupDiscoveryFeeds(isPredictEnabled && isTreatmentDiscovery);
     const { refetch: refetchWorldCupHomepageMarkets } = worldCupHomepageMarkets;
+    const { refetch: refetchWorldCupEventCount } = worldCupEventCount;
     const { refetch: refetchNbaChampionHomepageMarkets } =
       nbaChampionHomepageMarkets;
     const isLoadingWorldCupHomepage = useTreatmentDiscoveryFeedsLoading({
       isTreatmentDiscovery,
-      isWorldCupFetching: worldCupHomepageMarkets.isFetching,
+      isWorldCupFetching:
+        worldCupHomepageMarkets.isFetching || worldCupEventCount.isFetching,
       isNbaChampionFetching: nbaChampionHomepageMarkets.isFetching,
     });
 
@@ -410,6 +415,7 @@ const PredictionsSectionDefault = forwardRef<
       const tasks: Promise<unknown>[] = [refreshPositions(), refetchMarkets()];
       if (isTreatmentDiscovery) {
         tasks.push(refetchWorldCupHomepageMarkets());
+        tasks.push(refetchWorldCupEventCount());
         tasks.push(refetchNbaChampionHomepageMarkets());
       }
       await Promise.all(tasks);
@@ -418,6 +424,7 @@ const PredictionsSectionDefault = forwardRef<
       refetchMarkets,
       isTreatmentDiscovery,
       refetchWorldCupHomepageMarkets,
+      refetchWorldCupEventCount,
       refetchNbaChampionHomepageMarkets,
     ]);
 
@@ -458,6 +465,7 @@ const PredictionsSectionDefault = forwardRef<
                   markets={markets}
                   transactionActiveAbTests={discoveryTransactionActiveAbTests}
                   worldCupHomepage={worldCupHomepageMarkets}
+                  worldCupEventCount={worldCupEventCount.eventCount}
                   nbaChampionHomepage={nbaChampionHomepageMarkets}
                   emptyStateTransactionActiveAbTests={
                     discoveryTransactionActiveAbTests
@@ -485,25 +493,28 @@ const PredictionsSectionDefault = forwardRef<
             />
           </>
         ) : (
-          <HomepagePredictTrendingMarkets
-            title={title}
-            onViewAll={handleViewAllPredictions}
-            headerTestIdKey="predictions"
-            discoveryLayout={discoveryLayout}
-            isLoadingMarkets={isLoadingMarkets}
-            markets={markets}
-            transactionActiveAbTests={discoveryTransactionActiveAbTests}
-            worldCupHomepage={worldCupHomepageMarkets}
-            nbaChampionHomepage={nbaChampionHomepageMarkets}
-            emptyStateTransactionActiveAbTests={
-              discoveryTransactionActiveAbTests
-            }
-            onEmptyStateTreatmentCtaClick={
-              shouldTrackEmptyState
-                ? trackEmptyStateTreatmentCtaClick
-                : undefined
-            }
-          />
+          <Box paddingBottom={3}>
+            <HomepagePredictTrendingMarkets
+              title={title}
+              onViewAll={handleViewAllPredictions}
+              headerTestIdKey="predictions"
+              discoveryLayout={discoveryLayout}
+              isLoadingMarkets={isLoadingMarkets}
+              markets={markets}
+              transactionActiveAbTests={discoveryTransactionActiveAbTests}
+              worldCupHomepage={worldCupHomepageMarkets}
+              worldCupEventCount={worldCupEventCount.eventCount}
+              nbaChampionHomepage={nbaChampionHomepageMarkets}
+              emptyStateTransactionActiveAbTests={
+                discoveryTransactionActiveAbTests
+              }
+              onEmptyStateTreatmentCtaClick={
+                shouldTrackEmptyState
+                  ? trackEmptyStateTreatmentCtaClick
+                  : undefined
+              }
+            />
+          </Box>
         )}
       </PredictionsSectionShell>
     );
@@ -624,9 +635,11 @@ const PredictionsSectionTrendingOnly = forwardRef<
     const isListLayout = discoveryLayout === 'list';
     const {
       worldCup: worldCupHomepageMarkets,
+      worldCupEventCount,
       nbaChampion: nbaChampionHomepageMarkets,
     } = useWorldCupDiscoveryFeeds(isPredictEnabled && isListLayout);
     const { refetch: refetchWorldCupHomepageMarkets } = worldCupHomepageMarkets;
+    const { refetch: refetchWorldCupEventCount } = worldCupEventCount;
     const { refetch: refetchNbaChampionHomepageMarkets } =
       nbaChampionHomepageMarkets;
 
@@ -639,6 +652,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
       const tasks: Promise<unknown>[] = [refetchMarkets()];
       if (isListLayout) {
         tasks.push(refetchWorldCupHomepageMarkets());
+        tasks.push(refetchWorldCupEventCount());
         tasks.push(refetchNbaChampionHomepageMarkets());
       }
       await Promise.all(tasks);
@@ -646,6 +660,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
       refetchMarkets,
       isListLayout,
       refetchWorldCupHomepageMarkets,
+      refetchWorldCupEventCount,
       refetchNbaChampionHomepageMarkets,
     ]);
 
@@ -661,6 +676,7 @@ const PredictionsSectionTrendingOnly = forwardRef<
         isLoading={
           isListLayout
             ? worldCupHomepageMarkets.isFetching ||
+              worldCupEventCount.isFetching ||
               nbaChampionHomepageMarkets.isFetching
             : isLoadingMarkets
         }
@@ -670,18 +686,23 @@ const PredictionsSectionTrendingOnly = forwardRef<
         sectionIndex={sectionIndex}
         totalSectionsLoaded={totalSectionsLoaded}
       >
-        <HomepagePredictTrendingMarkets
-          title={title}
-          onViewAll={handleViewAllPredictions}
-          headerTestIdKey="trending-predictions"
-          discoveryLayout={discoveryLayout}
-          isLoadingMarkets={isLoadingMarkets}
-          markets={markets}
-          transactionActiveAbTests={trendingTransactionActiveAbTests}
-          emptyStateTransactionActiveAbTests={trendingTransactionActiveAbTests}
-          worldCupHomepage={worldCupHomepageMarkets}
-          nbaChampionHomepage={nbaChampionHomepageMarkets}
-        />
+        <Box paddingBottom={3}>
+          <HomepagePredictTrendingMarkets
+            title={title}
+            onViewAll={handleViewAllPredictions}
+            headerTestIdKey="trending-predictions"
+            discoveryLayout={discoveryLayout}
+            isLoadingMarkets={isLoadingMarkets}
+            markets={markets}
+            transactionActiveAbTests={trendingTransactionActiveAbTests}
+            emptyStateTransactionActiveAbTests={
+              trendingTransactionActiveAbTests
+            }
+            worldCupHomepage={worldCupHomepageMarkets}
+            worldCupEventCount={worldCupEventCount.eventCount}
+            nbaChampionHomepage={nbaChampionHomepageMarkets}
+          />
+        </Box>
       </PredictionsSectionShell>
     );
   },
@@ -711,18 +732,25 @@ const PredictionsSectionSportsOnly = forwardRef<
 
     const {
       worldCup: worldCupHomepageMarkets,
+      worldCupEventCount,
       nbaChampion: nbaChampionHomepageMarkets,
     } = useWorldCupDiscoveryFeeds(isPredictEnabled);
     const { refetch: refetchWorldCupHomepageMarkets } = worldCupHomepageMarkets;
+    const { refetch: refetchWorldCupEventCount } = worldCupEventCount;
     const { refetch: refetchNbaChampionHomepageMarkets } =
       nbaChampionHomepageMarkets;
 
     const refresh = useCallback(async () => {
       await Promise.all([
         refetchWorldCupHomepageMarkets(),
+        refetchWorldCupEventCount(),
         refetchNbaChampionHomepageMarkets(),
       ]);
-    }, [refetchWorldCupHomepageMarkets, refetchNbaChampionHomepageMarkets]);
+    }, [
+      refetchWorldCupHomepageMarkets,
+      refetchWorldCupEventCount,
+      refetchNbaChampionHomepageMarkets,
+    ]);
 
     return (
       <PredictionsSectionShell
@@ -732,6 +760,7 @@ const PredictionsSectionSportsOnly = forwardRef<
         refresh={refresh}
         isLoading={
           worldCupHomepageMarkets.isFetching ||
+          worldCupEventCount.isFetching ||
           nbaChampionHomepageMarkets.isFetching
         }
         isEmpty={false}
@@ -740,13 +769,16 @@ const PredictionsSectionSportsOnly = forwardRef<
         sectionIndex={sectionIndex}
         totalSectionsLoaded={totalSectionsLoaded}
       >
-        <HomepagePredictWorldCupDiscovery
-          title={title}
-          onViewAll={handleViewAllPredictions}
-          headerTestIdKey="trending-predictions"
-          worldCup={worldCupHomepageMarkets}
-          nbaChampion={nbaChampionHomepageMarkets}
-        />
+        <Box paddingBottom={3}>
+          <HomepagePredictWorldCupDiscovery
+            title={title}
+            onViewAll={handleViewAllPredictions}
+            headerTestIdKey="trending-predictions"
+            worldCup={worldCupHomepageMarkets}
+            worldCupEventCount={worldCupEventCount.eventCount}
+            nbaChampion={nbaChampionHomepageMarkets}
+          />
+        </Box>
       </PredictionsSectionShell>
     );
   },

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingMarkets.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictTrendingMarkets.tsx
@@ -20,6 +20,7 @@ export interface HomepagePredictTrendingMarketsProps {
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   /** Required when `discoveryLayout` is `list` (World Cup discovery rail). */
   worldCupHomepage?: UseHomepagePredictWorldCupMarketsResult;
+  worldCupEventCount?: number;
   /** Required when `discoveryLayout` is `list` (NBA champion event, separate from World Cup tag). */
   nbaChampionHomepage?: UseHomepagePredictTaggedMarketsResult;
   emptyStateTransactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -38,6 +39,7 @@ const HomepagePredictTrendingMarkets = ({
   markets,
   transactionActiveAbTests,
   worldCupHomepage,
+  worldCupEventCount,
   nbaChampionHomepage,
   emptyStateTransactionActiveAbTests,
   onEmptyStateTreatmentCtaClick,
@@ -65,6 +67,7 @@ const HomepagePredictTrendingMarkets = ({
       onViewAll={onViewAll}
       headerTestIdKey={headerTestIdKey}
       worldCup={worldCupHomepage}
+      worldCupEventCount={worldCupEventCount}
       nbaChampion={nbaChampionHomepage}
       transactionActiveAbTests={emptyStateTransactionActiveAbTests}
       onTreatmentCtaClick={onEmptyStateTreatmentCtaClick}

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/MensWorldCupRow.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/MensWorldCupRow.tsx
@@ -17,7 +17,7 @@ import HomepagePredictDiscoveryMaterialGlyph from './HomepagePredictDiscoveryMat
 
 interface MensWorldCupRowProps {
   onPress: () => void;
-  eventCountLabel: string;
+  eventCountLabel?: string;
 }
 
 const MensWorldCupRow = ({
@@ -48,13 +48,15 @@ const MensWorldCupRow = ({
         >
           {strings('predict.homepage_discovery.fifa_world_cup_2026_title')}
         </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          color={TextColor.TextAlternative}
-          numberOfLines={1}
-        >
-          {eventCountLabel}
-        </Text>
+        {eventCountLabel ? (
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            numberOfLines={1}
+          >
+            {eventCountLabel}
+          </Text>
+        ) : null}
       </Box>
       <Icon
         name={IconName.ArrowRight}

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictWorldCupDiscovery/index.tsx
@@ -44,6 +44,7 @@ export interface HomepagePredictWorldCupDiscoveryProps {
   ) => void;
   headerTestIdKey: PredictionsTrendingHeaderTestId;
   worldCup: UseHomepagePredictWorldCupMarketsResult;
+  worldCupEventCount?: number;
   nbaChampion: UseHomepagePredictTaggedMarketsResult;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   onTreatmentCtaClick?: (
@@ -59,6 +60,7 @@ const HomepagePredictWorldCupDiscovery: React.FC<
   onViewAll,
   headerTestIdKey,
   worldCup,
+  worldCupEventCount,
   nbaChampion,
   transactionActiveAbTests,
   onTreatmentCtaClick,
@@ -90,7 +92,7 @@ const HomepagePredictWorldCupDiscovery: React.FC<
       ? WORLD_CUP_CTA_CATEGORY_NAME
       : 'nba';
 
-  const { marketData, isFetching, hasMore } = worldCup;
+  const { marketData, isFetching } = worldCup;
   const { marketData: nbaMarketData, isFetching: isNbaFetching } = nbaChampion;
 
   const isInitialLoad = isFetching && marketData.length === 0;
@@ -99,14 +101,15 @@ const HomepagePredictWorldCupDiscovery: React.FC<
     isNbaFetching &&
     nbaMarketData.length === 0;
 
-  const eventCountLabel = useMemo(() => {
-    const n = marketData.length;
-    const i18nKey =
-      n > 0 && hasMore
-        ? 'predict.homepage_discovery.events_in_total_overflow'
-        : 'predict.homepage_discovery.events_in_total';
-    return strings(i18nKey, { count: n });
-  }, [marketData.length, hasMore]);
+  const eventCountLabel = useMemo(
+    () =>
+      worldCupEventCount === undefined
+        ? undefined
+        : strings('predict.homepage_discovery.events_in_total_overflow', {
+            count: worldCupEventCount,
+          }),
+    [worldCupEventCount],
+  );
 
   const championshipRow: ChampionshipRowState = useMemo(() => {
     if (championshipRowKind === 'nba') {

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.test.ts
@@ -1,0 +1,149 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { DEFAULT_PREDICT_WORLD_CUP_FLAG } from '../../../../../UI/Predict/constants/flags';
+import { usePredictWorldCupMarkets } from '../../../../../UI/Predict/hooks/usePredictWorldCup';
+import {
+  useHomepagePredictWorldCupEventCount,
+  useHomepagePredictWorldCupMarkets,
+} from './useHomepagePredictWorldCupMarkets';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../UI/Predict/hooks/usePredictWorldCup', () => ({
+  usePredictWorldCupMarkets: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.Mock;
+const mockUsePredictWorldCupMarkets = jest.mocked(usePredictWorldCupMarkets);
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { cacheTime: Infinity, retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+};
+
+describe('useHomepagePredictWorldCupMarkets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(DEFAULT_PREDICT_WORLD_CUP_FLAG);
+    mockUsePredictWorldCupMarkets.mockReturnValue({
+      marketData: [{ id: 'market-1' }] as never,
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+  });
+
+  it('fetches the homepage World Cup event count using the configured World Cup tag', async () => {
+    mockUseSelector.mockReturnValue({
+      ...DEFAULT_PREDICT_WORLD_CUP_FLAG,
+      tagSlug: 'remote-configured-world-cup-tag',
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        pagination: { totalResults: 48 },
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.eventCount).toBe(48));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://gamma-api.polymarket.com/events/pagination?tag_slug=remote-configured-world-cup-tag&limit=1&active=true&closed=false&archived=false',
+    );
+  });
+
+  it('omits the event count when pagination metadata is missing', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        pagination: {},
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.eventCount).toBeUndefined();
+  });
+
+  it('omits the event count when pagination totalResults is not a number', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        pagination: { totalResults: '48' },
+      }),
+    });
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.eventCount).toBeUndefined();
+  });
+
+  it('does not fall back to the loaded market count while the event count is loading', () => {
+    mockUsePredictWorldCupMarkets.mockReturnValue({
+      marketData: Array.from({ length: 19 }, (_, index) => ({
+        id: `market-${index}`,
+      })) as never,
+      isFetching: false,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: jest.fn(),
+      fetchMore: jest.fn(),
+    });
+    mockFetch.mockReturnValue(new Promise(() => undefined));
+
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupEventCount({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.eventCount).toBeUndefined();
+    expect(result.current.isFetching).toBe(true);
+  });
+
+  it('does not request the event count when the homepage query is disabled', () => {
+    renderHook(() => useHomepagePredictWorldCupEventCount({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps the market hook scoped to market data only', () => {
+    const { result } = renderHook(
+      () => useHomepagePredictWorldCupMarkets({ enabled: true }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current).not.toHaveProperty('eventCount');
+    expect(result.current).not.toHaveProperty('totalResults');
+  });
+});

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictWorldCupMarkets.ts
@@ -1,20 +1,108 @@
 import { useSelector } from 'react-redux';
+import { useQuery } from '@tanstack/react-query';
 import { usePredictWorldCupMarkets } from '../../../../../UI/Predict/hooks/usePredictWorldCup';
 import type { UsePredictMarketDataResult } from '../../../../../UI/Predict/hooks/usePredictMarketData';
 import { PREDICT_WORLD_CUP_TAB_KEYS } from '../../../../../UI/Predict/constants/worldCupTabs';
 import { selectPredictWorldCupConfig } from '../../../../../UI/Predict/selectors/featureFlags';
+import { getPolymarketEndpoints } from '../../../../../UI/Predict/providers/polymarket/utils';
 
 interface UseHomepagePredictWorldCupMarketsArgs {
   enabled: boolean;
 }
 
+interface UseHomepagePredictWorldCupEventCountResult {
+  eventCount?: number;
+  isFetching: boolean;
+  refetch: () => Promise<void>;
+}
+
+const HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_LIMIT = 1;
+const HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_STALE_TIME = 10_000;
+
+const homepagePredictWorldCupEventCountKeys = {
+  all: (queryParams: string) =>
+    [
+      'homepage',
+      'predict',
+      'worldCup',
+      'eventCount',
+      'paginationTotalResults',
+      queryParams,
+    ] as const,
+};
+
+const buildHomepagePredictWorldCupEventCountQuery = (
+  tagSlug: string,
+): string => {
+  const queryParams = new URLSearchParams();
+  queryParams.set('tag_slug', tagSlug);
+  queryParams.set(
+    'limit',
+    String(HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_LIMIT),
+  );
+  queryParams.set('active', 'true');
+  queryParams.set('closed', 'false');
+  queryParams.set('archived', 'false');
+
+  return queryParams.toString();
+};
+
+const fetchHomepagePredictWorldCupEventCount = async (
+  queryParams: string,
+): Promise<number | null> => {
+  const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
+
+  const response = await fetch(
+    `${GAMMA_API_ENDPOINT}/events/pagination?${queryParams}`,
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to get homepage World Cup event count');
+  }
+
+  const data = await response.json();
+  const totalResults = data?.pagination?.totalResults;
+
+  return typeof totalResults === 'number' ? totalResults : null;
+};
+
 /**
  * Homepage discovery: loads World Cup markets using the same ALL-tab query path
- * as the dedicated World Cup screen (`buildPredictWorldCupAllQuery` → keyset API).
+ * as the dedicated World Cup screen, but keeps its event-count query private to
+ * this hook so `/events/pagination` is only requested by the homepage row.
+ */
+export function useHomepagePredictWorldCupEventCount({
+  enabled,
+}: UseHomepagePredictWorldCupMarketsArgs): UseHomepagePredictWorldCupEventCountResult {
+  const config = useSelector(selectPredictWorldCupConfig);
+  const eventCountQueryParams = buildHomepagePredictWorldCupEventCountQuery(
+    config.tagSlug,
+  );
+  const eventCountQuery = useQuery({
+    queryKey: homepagePredictWorldCupEventCountKeys.all(eventCountQueryParams),
+    queryFn: () =>
+      fetchHomepagePredictWorldCupEventCount(eventCountQueryParams),
+    staleTime: HOMEPAGE_PREDICT_WORLD_CUP_EVENT_COUNT_STALE_TIME,
+    enabled,
+  });
+  const refetch = async () => {
+    await eventCountQuery.refetch();
+  };
+
+  return {
+    eventCount: eventCountQuery.data ?? undefined,
+    isFetching: eventCountQuery.isLoading,
+    refetch,
+  };
+}
+
+/**
+ * Homepage discovery: loads World Cup markets using the same ALL-tab query path
+ * as the dedicated World Cup screen.
  */
 export function useHomepagePredictWorldCupMarkets({
   enabled,
-}: UseHomepagePredictWorldCupMarketsArgs): UsePredictMarketDataResult {
+}: UseHomepagePredictWorldCupMarketsArgs): UseHomepagePredictWorldCupMarketsResult {
   const config = useSelector(selectPredictWorldCupConfig);
 
   return usePredictWorldCupMarkets({


### PR DESCRIPTION
## Summary
Cherry-pick of one merged PR from `main` into `release/7.81.0`: 

- https://github.com/MetaMask/metamask-mobile/pull/31465 - feat: update World Cup event count in PredictionsSection and related components

## Related
- Cherry-pick of b54fda6 from main

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only homepage UI and a lightweight Polymarket fetch; no auth or payment paths. Main risk is wrong/missing subtitle if the pagination API fails.
> 
> **Overview**
> The homepage Predict World Cup discovery row now shows **total event count from Polymarket’s `/events/pagination` API** (via new `useHomepagePredictWorldCupEventCount`) instead of inferring it from how many markets were loaded and `hasMore`.
> 
> `PredictionsSection` loads and refetches that count with the World Cup/NBA discovery feeds, includes it in loading state, and passes `worldCupEventCount` into the discovery UI. **`HomepagePredictWorldCupDiscovery`** always uses the overflow copy (e.g. `48+ events in total`) when a numeric total exists, and **`MensWorldCupRow`** hides the subtitle until the count is available. Tests and React Query mocks were updated for the new hook and label behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54fda604535f32ca854b323e4ab944bf5c08ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->