### PR TITLE
feat: `Button` migration (no codeowners)

### DIFF
--- a/app/components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.tsx
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityModal/BasicFunctionalityModal.tsx
@@ -9,10 +9,6 @@ import BottomSheet, {
 } from '../../../../component-library/components/BottomSheets/BottomSheet';
 import { strings } from '../../../../../locales/i18n';
 import { useTheme } from '../../../../util/theme';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../../component-library/components/Buttons/Button';
 import Checkbox from '../../../../component-library/components/Checkbox/Checkbox';
 import { useSelector } from 'react-redux';
 import { toggleBasicFunctionality } from '../../../../actions/settings';
@@ -32,6 +28,9 @@ import { selectIsMetamaskNotificationsEnabled } from '../../../../selectors/noti
 import { selectIsBackupAndSyncEnabled } from '../../../../selectors/identity';
 import useThunkDispatch from '../../../hooks/useThunkDispatch';
 import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
   Text,
   TextVariant,
   FontWeight,
@@ -155,26 +154,28 @@ const BasicFunctionalityModal = () => {
         />
         <View style={styles.buttonsContainer}>
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariant.Secondary}
             size={ButtonSize.Lg}
             style={styles.button}
             accessibilityRole={'button'}
             accessible
-            label={strings('default_settings.sheet.buttons.cancel')}
             onPress={handleCancel}
-          />
+          >
+            {strings('default_settings.sheet.buttons.cancel')}
+          </Button>
           <View style={styles.spacer} />
           <Button
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             isDisabled={!isChecked}
             isDanger
             size={ButtonSize.Lg}
             style={styles.button}
             accessibilityRole={'button'}
             accessible
-            label={strings('default_settings.sheet.buttons.turn_off')}
             onPress={handleSwitchToggle}
-          />
+          >
+            {strings('default_settings.sheet.buttons.turn_off')}
+          </Button>
         </View>
       </View>
     </View>
@@ -190,24 +191,26 @@ const BasicFunctionalityModal = () => {
       </Text>
       <View style={styles.buttonsContainer}>
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariant.Secondary}
           size={ButtonSize.Lg}
           style={styles.button}
           accessibilityRole={'button'}
           accessible
-          label={strings('default_settings.sheet.buttons.cancel')}
           onPress={handleCancel}
-        />
+        >
+          {strings('default_settings.sheet.buttons.cancel')}
+        </Button>
         <View style={styles.spacer} />
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           style={styles.button}
           accessibilityRole={'button'}
           accessible
-          label={strings('default_settings.sheet.buttons.turn_on')}
           onPress={handleSwitchToggle}
-        />
+        >
+          {strings('default_settings.sheet.buttons.turn_on')}
+        </Button>
       </View>
     </View>
   );

--- a/app/components/UI/DeepLinkModal/DeepLinkModal.tsx
+++ b/app/components/UI/DeepLinkModal/DeepLinkModal.tsx
@@ -14,11 +14,6 @@ import styleSheet from './DeepLinkModal.styles';
 import { strings } from '../../../../locales/i18n';
 import { useParams } from '../../../util/navigation/navUtils';
 import { useStyles } from '../../../component-library/hooks';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../component-library/components/Buttons/Button';
 import Checkbox from '../../../component-library/components/Checkbox';
 import { ScrollView } from 'react-native-gesture-handler';
 import { Box } from '../../../components/UI/Box/Box';
@@ -40,6 +35,9 @@ import {
   Text,
   TextVariant,
   TextColor,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 
 const ModalImage = memo<ModalImageProps>(({ linkType, styles }) => {
@@ -238,16 +236,15 @@ const DeepLinkModal = () => {
         </Box>
       )}
       <Button
-        variant={ButtonVariants.Primary}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
-        width={ButtonWidthTypes.Full}
-        label={
-          LINK_TYPE_MAP[linkType].buttonLabel ||
-          strings('deep_link_modal.continue_button')
-        }
+        isFullWidth
         onPress={onPrimaryButtonPressed}
         style={styles.actionButtonMargin}
-      />
+      >
+        {LINK_TYPE_MAP[linkType].buttonLabel ||
+          strings('deep_link_modal.continue_button')}
+      </Button>
     </BottomSheet>
   );
 };

--- a/app/components/UI/DeleteWalletModal/index.tsx
+++ b/app/components/UI/DeleteWalletModal/index.tsx
@@ -21,11 +21,6 @@ import { RootState } from '../../../reducers';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../component-library/components/BottomSheets/BottomSheet';
-import Button, {
-  ButtonVariants,
-  ButtonSize,
-  ButtonWidthTypes,
-} from '../../../component-library/components/Buttons/Button';
 import { useSignOut } from '../../../util/identity/hooks/useAuthentication';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import trackOnboarding from '../../../util/metrics/TrackOnboarding/trackOnboarding';
@@ -38,6 +33,9 @@ import {
   TextVariant,
   TextColor,
   FontWeight,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 
 if (Device.isAndroid() && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -201,10 +199,9 @@ const DeleteWalletModal: React.FC = () => {
           </View>
 
           <Button
-            variant={ButtonVariants.Primary}
+            variant={ButtonVariant.Primary}
             size={ButtonSize.Lg}
-            label={strings('login.reset_wallet')}
-            width={ButtonWidthTypes.Full}
+            isFullWidth
             isDanger
             onPress={() => {
               setIsResetWallet(true);
@@ -213,7 +210,9 @@ const DeleteWalletModal: React.FC = () => {
               });
             }}
             testID={ForgotPasswordModalSelectorsIDs.RESET_WALLET_BUTTON}
-          />
+          >
+            {strings('login.reset_wallet')}
+          </Button>
         </View>
       ) : (
         <View style={styles.container}>
@@ -270,25 +269,27 @@ const DeleteWalletModal: React.FC = () => {
             </View>
             <View style={styles.buttonContainer}>
               <Button
-                variant={ButtonVariants.Primary}
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Lg}
                 onPress={deleteWallet}
-                label={strings('login.erase_my')}
-                width={ButtonWidthTypes.Full}
+                isFullWidth
                 isDanger
                 testID={ForgotPasswordModalSelectorsIDs.YES_RESET_WALLET_BUTTON}
-                loading={isDeletingWallet}
+                isLoading={isDeletingWallet}
                 isDisabled={isDeletingWallet}
-              />
+              >
+                {strings('login.erase_my')}
+              </Button>
               <Button
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 size={ButtonSize.Lg}
                 onPress={triggerClose}
-                label={strings('login.cancel')}
-                width={ButtonWidthTypes.Full}
+                isFullWidth
                 testID={ForgotPasswordModalSelectorsIDs.CANCEL_BUTTON}
                 isDisabled={isDeletingWallet}
-              />
+              >
+                {strings('login.cancel')}
+              </Button>
             </View>
           </View>
         </View>

--- a/app/components/UI/DeprecatedNetworkModal/DeprecatedNetworkModal.tsx
+++ b/app/components/UI/DeprecatedNetworkModal/DeprecatedNetworkModal.tsx
@@ -4,18 +4,17 @@ import { Linking, View } from 'react-native';
 import { useStyles } from '../../../component-library/hooks';
 import { strings } from '../../../../locales/i18n';
 import styleSheet from './DeprecatedNetworkModal.styles';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../component-library/components/Buttons/Button';
-import { CONNECTING_TO_DEPRECATED_NETWORK } from '../../../constants/urls';
-import BottomSheet from '../../../component-library/components/BottomSheets/BottomSheet';
-import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
   Text,
   TextVariant,
   TextColor,
 } from '@metamask/design-system-react-native';
+import { CONNECTING_TO_DEPRECATED_NETWORK } from '../../../constants/urls';
+import BottomSheet from '../../../component-library/components/BottomSheets/BottomSheet';
+import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import { trackExternalLinkClicked } from '../../../util/analytics/externalLinkTracking';
 
 const DeprecatedNetworkModal = () => {
@@ -51,20 +50,19 @@ const DeprecatedNetworkModal = () => {
       </Text>
       <View style={{ ...styles.footer }}>
         <Button
-          variant={ButtonVariants.Primary}
+          variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           onPress={dismissModal}
           style={styles.button}
-          label={
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextDefault}
-              style={styles.buttonLabel}
-            >
-              {strings('network_information.got_it')}
-            </Text>
-          }
-        />
+        >
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+            style={styles.buttonLabel}
+          >
+            {strings('network_information.got_it')}
+          </Text>
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
@@ -2,11 +2,11 @@ import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import Button, {
+import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../../component-library/components/Buttons/Button';
+} from '@metamask/design-system-react-native';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { TokenI } from '../../../../Tokens/types';
 import { WalletViewSelectorsIDs } from '../../../../../Views/Wallet/WalletView.testIds';
@@ -36,16 +36,15 @@ const EarningsHistoryButton = ({ asset }: EarningsHistoryButtonProps) => {
     <View>
       <Button
         testID={WalletViewSelectorsIDs.EARN_EARNINGS_HISTORY_BUTTON}
-        width={ButtonWidthTypes.Full}
-        variant={ButtonVariants.Secondary}
+        isFullWidth
+        variant={ButtonVariant.Secondary}
         size={ButtonSize.Md}
-        label={
-          outputToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
-            ? strings('earn.view_earnings_history.lending')
-            : strings('earn.view_earnings_history.staking')
-        }
         onPress={onViewEarningsHistoryPress}
-      />
+      >
+        {outputToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
+          ? strings('earn.view_earnings_history.lending')
+          : strings('earn.view_earnings_history.staking')}
+      </Button>
     </View>
   );
 };

--- a/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistoryButton/EarningsHistoryButton.tsx
@@ -2,11 +2,11 @@ import { useNavigation } from '@react-navigation/native';
 import React from 'react';
 import { View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import {
-  Button,
-  ButtonVariant,
+import Button, {
   ButtonSize,
-} from '@metamask/design-system-react-native';
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { TokenI } from '../../../../Tokens/types';
 import { WalletViewSelectorsIDs } from '../../../../../Views/Wallet/WalletView.testIds';
@@ -36,15 +36,16 @@ const EarningsHistoryButton = ({ asset }: EarningsHistoryButtonProps) => {
     <View>
       <Button
         testID={WalletViewSelectorsIDs.EARN_EARNINGS_HISTORY_BUTTON}
-        isFullWidth
-        variant={ButtonVariant.Secondary}
+        width={ButtonWidthTypes.Full}
+        variant={ButtonVariants.Secondary}
         size={ButtonSize.Md}
+        label={
+          outputToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
+            ? strings('earn.view_earnings_history.lending')
+            : strings('earn.view_earnings_history.staking')
+        }
         onPress={onViewEarningsHistoryPress}
-      >
-        {outputToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
-          ? strings('earn.view_earnings_history.lending')
-          : strings('earn.view_earnings_history.staking')}
-      </Button>
+      />
     </View>
   );
 };

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -18,10 +18,6 @@ import Icon, {
   IconSize,
 } from '../../../component-library/components/Icons/Icon';
 import AvatarGroup from '../../../component-library/components/Avatars/AvatarGroup';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-} from '../../../component-library/components/Buttons/Button';
 import { getHost } from '../../../util/browser';
 import WebsiteIcon from '../WebsiteIcon';
 import styleSheet from './PermissionsSummary.styles';
@@ -73,6 +69,9 @@ import {
   TextVariant,
   TextColor,
   FontWeight,
+  Button,
+  ButtonVariant,
+  ButtonSize,
 } from '@metamask/design-system-react-native';
 
 const PermissionsSummary = ({
@@ -671,11 +670,10 @@ const PermissionsSummary = ({
           {isAlreadyConnected && isDisconnectAllShown && (
             <View style={styles.disconnectAllContainer}>
               <Button
-                variant={ButtonVariants.Secondary}
+                variant={ButtonVariant.Secondary}
                 testID={
                   ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS
                 }
-                label={strings('accounts.disconnect_all')}
                 onPress={toggleRevokeAllPermissionsModal}
                 startIconName={IconName.Logout}
                 isDanger
@@ -683,7 +681,9 @@ const PermissionsSummary = ({
                 style={{
                   ...styles.disconnectButton,
                 }}
-              />
+              >
+                {strings('accounts.disconnect_all')}
+              </Button>
             </View>
           )}
           {showActionButtons && !isNonDappNetworkSwitch && (
@@ -717,8 +717,7 @@ const PermissionsSummary = ({
             <View style={styles.nonDappNetworkSwitchButtons}>
               <View style={styles.actionButtonsContainer}>
                 <Button
-                  variant={ButtonVariants.Primary}
-                  label={strings('permissions.add_this_network')}
+                  variant={ButtonVariant.Primary}
                   testID={
                     NetworkNonPemittedBottomSheetSelectorsIDs.ADD_THIS_NETWORK_BUTTON
                   }
@@ -727,12 +726,13 @@ const PermissionsSummary = ({
                   style={{
                     ...styles.disconnectButton,
                   }}
-                />
+                >
+                  {strings('permissions.add_this_network')}
+                </Button>
               </View>
               <View style={styles.actionButtonsContainer}>
                 <Button
-                  variant={ButtonVariants.Secondary}
-                  label={strings('permissions.choose_from_permitted_networks')}
+                  variant={ButtonVariant.Secondary}
                   testID={
                     NetworkNonPemittedBottomSheetSelectorsIDs.CHOOSE_FROM_PERMITTED_NETWORKS_BUTTON
                   }
@@ -741,7 +741,9 @@ const PermissionsSummary = ({
                   style={{
                     ...styles.disconnectButton,
                   }}
-                />
+                >
+                  {strings('permissions.choose_from_permitted_networks')}
+                </Button>
               </View>
             </View>
           )}

--- a/app/components/UI/SheetActionView/SheetActionVIew.tsx
+++ b/app/components/UI/SheetActionView/SheetActionVIew.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { View } from 'react-native';
 import {
+  Button,
+  ButtonVariant,
   ButtonSize,
-  ButtonVariants,
-} from '../../../component-library/components/Buttons/Button';
-import Button from '../../../component-library/components/Buttons/Button/Button';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import createStyles from './SheetActionView.styles';
 import { SheetActionViewI } from './SheetActionView.types';
@@ -14,19 +14,21 @@ const SheetActionView = ({ onConfirm, onCancel }: SheetActionViewI) => {
   return (
     <View style={styles.actionsContainer}>
       <Button
-        label={strings('action_view.cancel')}
         onPress={onCancel}
-        variant={ButtonVariants.Secondary}
+        variant={ButtonVariant.Secondary}
         size={ButtonSize.Lg}
         style={styles.cancelButton}
-      />
+      >
+        {strings('action_view.cancel')}
+      </Button>
       <Button
-        label={strings('action_view.confirm')}
         onPress={onConfirm}
-        variant={ButtonVariants.Primary}
+        variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}
         style={styles.confirmButton}
-      />
+      >
+        {strings('action_view.confirm')}
+      </Button>
     </View>
   );
 };

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.test.tsx
@@ -76,26 +76,6 @@ jest.mock(
   },
 );
 
-jest.mock(
-  '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase',
-  () => {
-    const { TouchableOpacity, View } = jest.requireActual('react-native');
-    return ({
-      children,
-      onPress,
-      label,
-    }: {
-      children?: React.ReactNode;
-      onPress?: () => void;
-      label?: React.ReactNode;
-    }) => (
-      <TouchableOpacity testID="apply-button" onPress={onPress}>
-        <View>{label || children}</View>
-      </TouchableOpacity>
-    );
-  },
-);
-
 describe('TrendingTokenPriceChangeBottomSheet', () => {
   const mockOnClose = jest.fn();
 

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.tsx
@@ -1,6 +1,11 @@
 import React, { useRef, useState, useCallback, useEffect } from 'react';
 import { TrendingTokensBottomSheetTestIds } from './TrendingTokensBottomSheet.testIds';
-import { HeaderStandard } from '@metamask/design-system-react-native';
+import {
+  HeaderStandard,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import { View, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import { useTheme } from '../../../../../util/theme';
 import BottomSheet, {
@@ -16,11 +21,6 @@ import Icon, {
   IconColor,
 } from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-  ButtonSize,
-} from '../../../../../component-library/components/Buttons/Button';
 
 export enum PriceChangeOption {
   PriceChange = 'price_change',
@@ -262,12 +262,13 @@ const TrendingTokenPriceChangeBottomSheet: React.FC<
       </View>
       <View style={optionStyles.buttonContainer}>
         <Button
-          variant={ButtonVariants.Primary}
-          label={strings('trending.apply')}
+          variant={ButtonVariant.Primary}
           onPress={handleApply}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-        />
+          isFullWidth
+        >
+          {strings('trending.apply')}
+        </Button>
       </View>
     </BottomSheet>
   );

--- a/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.tsx
+++ b/app/components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.tsx
@@ -266,6 +266,7 @@ const TrendingTokenPriceChangeBottomSheet: React.FC<
           onPress={handleApply}
           size={ButtonSize.Lg}
           isFullWidth
+          testID="apply-button"
         >
           {strings('trending.apply')}
         </Button>

--- a/app/components/UI/UpdateNeeded/UpdateNeeded.tsx
+++ b/app/components/UI/UpdateNeeded/UpdateNeeded.tsx
@@ -7,10 +7,6 @@ import Routes from '../../../constants/navigation/Routes';
 import { useTheme } from '../../../util/theme';
 import ReusableModal, { ReusableModalRef } from '../ReusableModal';
 import Logger from '../../../util/Logger';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../component-library/components/Buttons/Button';
 import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon';
 import {
   IconColor,
@@ -23,6 +19,8 @@ import { ScrollView } from 'react-native-gesture-handler';
 import generateDeviceAnalyticsMetaData from '../../../util/metrics';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import {
+  Button,
+  ButtonVariant,
   HeaderBase,
   Text,
   TextVariant,
@@ -135,12 +133,13 @@ const UpdateNeeded = () => {
       </ScrollView>
       <View style={styles.actionButtonWrapper}>
         <Button
-          variant={ButtonVariants.Primary}
-          width={ButtonWidthTypes.Full}
-          label={strings('update_needed.primary_action')}
+          variant={ButtonVariant.Primary}
+          isFullWidth
           onPress={onUpdatePressed}
           style={styles.actionButton}
-        />
+        >
+          {strings('update_needed.primary_action')}
+        </Button>
       </View>
     </ReusableModal>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Button` component from DSRN (no codeowners scope).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-445

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: button migrations

  Scenario: user sees modified files
    Given user interacts with Button components changes in this PR

    When user sees the new Button implementation
    Then he doesn't see a difference (visual) from previous implementation
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/46556e03-2b71-4aaf-927a-1ab914d42480

### **After**

https://github.com/user-attachments/assets/828f4220-5576-405e-a54e-5cf34a1c72ca

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only component swap with equivalent props; wallet delete still uses the same handlers with loading/disabled state on the new Button API.
> 
> **Overview**
> This PR continues the **DSRN `Button` migration** in UI surfaces that are outside codeowner-heavy areas, swapping the local component-library `Button` for `@metamask/design-system-react-native`.
> 
> Affected flows include basic functionality settings, deep link, delete wallet, deprecated network, permissions summary (disconnect / network actions), sheet action confirm/cancel, trending sort **Apply**, and force-update. The API updates are consistent: `ButtonVariants` → `ButtonVariant`, `label` → **children**, `ButtonWidthTypes.Full` → **`isFullWidth`**, and delete-wallet uses **`isLoading`** instead of `loading`.
> 
> **Trending** tests drop the old `ButtonBase` mock and rely on the design-system button’s `testID="apply-button"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e7878cefc31be9fb949cad91af90758b5c32b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->