### PR TITLE
fix(swaps): preserve destination token

### DIFF
--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -267,11 +267,13 @@ export const useSwapBridgeNavigation = ({
         : undefined;
 
       let destTokenToSet: BridgeToken | undefined;
+      let isExplicitDestTokenSelection = false;
       if (
         validDestTokenBase &&
         !areAddressesEqual(sourceToken.address, validDestTokenBase.address)
       ) {
         destTokenToSet = validDestTokenBase;
+        isExplicitDestTokenSelection = true;
       } else {
         const defaultDestToken = getDefaultDestToken(sourceToken.chainId);
         if (
@@ -330,7 +332,7 @@ export const useSwapBridgeNavigation = ({
         params,
       });
 
-      dispatch(setIsDestTokenManuallySet(false));
+      dispatch(setIsDestTokenManuallySet(isExplicitDestTokenSelection));
       dispatch(setAbTestContext(abTestContext));
       dispatch(setSourceToken(sourceToken));
       if (destTokenToSet) {

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/useSwapBridgeNavigation.test.ts
@@ -423,7 +423,7 @@ describe('useSwapBridgeNavigation', () => {
     expect(mockFetchPopularTokens).toHaveBeenCalledTimes(0);
   });
 
-  it('resets isDestTokenManuallySet flag when navigating to swaps', () => {
+  it('resets isDestTokenManuallySet flag when navigating to swaps without an explicit dest token', () => {
     const { result } = renderHookWithProvider(
       () =>
         useSwapBridgeNavigation({
@@ -437,6 +437,31 @@ describe('useSwapBridgeNavigation', () => {
 
     expect(mockSetIsDestTokenManuallySet).toHaveBeenCalledWith(false);
     expect(mockFetchPopularTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets isDestTokenManuallySet when an explicit dest token is provided', () => {
+    const destOverride: BridgeToken = {
+      address: '0x0000000000000000000000000000000000000005',
+      symbol: 'DEST_OVERRIDE',
+      name: 'Dest Override Token',
+      decimals: 18,
+      chainId: mockChainId,
+    };
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useSwapBridgeNavigation({
+          location: mockLocation,
+          sourcePage: mockSourcePage,
+          sourceToken: mockSourceToken,
+        }),
+      { state: initialState },
+    );
+
+    result.current.goToSwaps(undefined, destOverride);
+
+    expect(mockSetIsDestTokenManuallySet).toHaveBeenCalledWith(true);
+    expect(mockSetDestToken).toHaveBeenCalledWith(destOverride);
   });
 
   it('uses home page filter network when no token is provided', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Ensure that a user's selection of a token on the Explore page is treated as a manual destination token selection so that it persists. Currently, if only the source token is changed, the destination token resets to the default pair instead of sticking to the user's selection.

Any time the swaps screen is navigated to with a source and destination set, those need to be persisted.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that destination token to be reset upon source token change.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4559

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Persist destination token from external navigation

  Scenario: user keeps Explore-selected destination token after changing source on swaps 
    Given the user opened swaps from Explore with an explicit destination token And the swaps form shows that token as the destination And the destination token is not the default pair for the current source
    When the user changes only the source token on the swaps form
    Then the destination token remains the Explore-selected token
    And the destination token is not reset to the default pair for the new source
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/72105252-cae7-4f01-a34b-1fbfe86ab016

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/05e66af8-e15e-4a7c-bf74-63c7bce12994

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Redux flag change in swap navigation with unit test coverage; no auth or transaction submission logic touched.
> 
> **Overview**
> When opening swaps/bridge, navigation no longer always clears **`isDestTokenManuallySet`**. **`useSwapBridgeNavigation`** now sets that Redux flag to **`true`** only when the destination comes from an explicit caller-provided token (hook `destToken` / `goToSwaps` override) that differs from the source; default-pair and native fallbacks still leave it **`false`**.
> 
> Tests were updated to match: one case still expects **`false`** when there is no explicit dest, and a new case expects **`true`** when `goToSwaps(undefined, destOverride)` is used. That lets **`useAutoUpdateDestToken`** keep an Explore-selected destination after the user changes only the source token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96eb640930ab4a742c0d62eb4a009563cf528f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->