### PR TITLE
fix(card): clear Card authentication data when the user resets the app

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -3876,6 +3876,11 @@ describe('Authentication', () => {
         setLocked: jest.fn().mockResolvedValue(undefined),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
 
+      Engine.context.CardController = {
+        resetAll: jest.fn().mockResolvedValue(undefined),
+        setResetInProgress: jest.fn(),
+      } as unknown as (typeof Engine.context)['CardController'];
+
       Engine.context.KeyringController = {
         setLocked: jest.fn().mockResolvedValue(undefined),
         isUnlocked: jest.fn(() => true),
@@ -3959,6 +3964,11 @@ describe('Authentication', () => {
         setLocked: jest.fn().mockResolvedValue(undefined),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
 
+      Engine.context.CardController = {
+        resetAll: jest.fn().mockResolvedValue(undefined),
+        setResetInProgress: jest.fn(),
+      } as unknown as (typeof Engine.context)['CardController'];
+
       Engine.context.KeyringController = {
         setLocked: jest.fn().mockResolvedValue(undefined),
         isUnlocked: jest.fn(() => true),
@@ -4019,6 +4029,23 @@ describe('Authentication', () => {
       expect(EngineClass.disableAutomaticVaultBackup).toBe(false);
     });
 
+    it('re-enables Card reactive fetching even when an error occurs', async () => {
+      // Arrange
+      jest
+        .spyOn(Authentication, 'newWalletAndKeychain')
+        .mockRejectedValueOnce(new Error('Authentication failed'));
+
+      // Act
+      await (
+        Authentication as unknown as { resetWalletState: () => Promise<void> }
+      ).resetWalletState();
+
+      // Assert - suppression is lifted despite the error
+      expect(
+        Engine.context.CardController.setResetInProgress,
+      ).toHaveBeenLastCalledWith(false);
+    });
+
     it('calls all required methods to reset wallet state', async () => {
       // Arrange
       const newWalletAndKeychain = jest.spyOn(
@@ -4046,6 +4073,15 @@ describe('Authentication', () => {
       expect(resetRewardsSpy).toHaveBeenCalledTimes(1);
       expect(resetRewardsSpy).toHaveBeenCalledWith(
         'RewardsController:resetAll',
+      );
+      expect(Engine.context.CardController.resetAll).toHaveBeenCalledTimes(1);
+      const setResetSpy = Engine.context.CardController
+        .setResetInProgress as jest.Mock;
+      expect(setResetSpy).toHaveBeenNthCalledWith(1, true);
+      expect(setResetSpy).toHaveBeenLastCalledWith(false);
+      // Suppression is enabled before the temporary wallet is created
+      expect(setResetSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        newWalletAndKeychain.mock.invocationCallOrder[0],
       );
       expect(loggerSpy).not.toHaveBeenCalled();
       expect(resetProviderTokenSpy).toHaveBeenCalledTimes(1);

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -1565,6 +1565,12 @@ class AuthenticationService {
       // This prevents the temporary wallet (created during reset) from being backed up
       EngineClass.disableAutomaticVaultBackup = true;
 
+      // Suppress Card's reactive data fetching during reset. The temporary
+      // wallet created below emits KeyringController:unlock and rebuilds the
+      // account tree, which would otherwise make CardController fetch CardHome
+      // data (with the still-present old tokens) only to discard it in resetAll.
+      Engine.context.CardController.setResetInProgress(true);
+
       try {
         await this.newWalletAndKeychain(`${Date.now()}`, {
           currentAuthType: AUTHENTICATION_TYPE.UNKNOWN,
@@ -1579,11 +1585,16 @@ class AuthenticationService {
 
         await Engine.controllerMessenger.call('RewardsController:resetAll');
 
+        // Clear all Card auth/session/onboarding data (CARD-431)
+        await Engine.context.CardController.resetAll();
+
         // Lock the app and navigate to onboarding
         await this.lockApp({ navigateToLogin: false });
       } finally {
         // ALWAYS re-enable automatic vault backups, even if error occurs
         EngineClass.disableAutomaticVaultBackup = false;
+        // ALWAYS re-enable Card reactive fetching, even if an error occurs
+        Engine.context.CardController.setResetInProgress(false);
       }
     } catch (error) {
       const errorMsg = `Failed to createNewVaultAndKeychain: ${error}`;

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -20,15 +20,23 @@ import {
   type CardFundingAsset,
 } from './provider-types';
 import { CardTokenStore } from './CardTokenStore';
+import { CardOnboardingStore } from './CardOnboardingStore';
+import ReduxService from '../../../redux';
+import { resetCardState } from '../../../redux/slices/card';
 
 jest.mock('./CardTokenStore');
+jest.mock('./CardOnboardingStore');
 jest.mock('../../../../util/Logger');
+jest.mock('../../../redux/slices/card', () => ({
+  resetCardState: jest.fn(() => ({ type: 'card/resetCardState' })),
+}));
 
 const mockGasFeesSponsoredMap: Record<string, boolean> = { '0x8f': true };
 jest.mock('../../../redux', () => ({
   __esModule: true,
   default: {
     store: {
+      dispatch: jest.fn(),
       getState: () => ({
         engine: {
           backgroundState: {
@@ -53,6 +61,10 @@ jest.mock(
 );
 
 const mockTokenStore = CardTokenStore as jest.Mocked<typeof CardTokenStore>;
+const mockOnboardingStore = CardOnboardingStore as jest.Mocked<
+  typeof CardOnboardingStore
+>;
+const mockDispatch = ReduxService.store.dispatch as jest.Mock;
 
 async function flushPromises(times = 5): Promise<void> {
   for (let i = 0; i < times; i++) {
@@ -576,6 +588,130 @@ describe('CardController — auth methods', () => {
     });
   });
 
+  describe('resetAll', () => {
+    function buildMultiProviderController(
+      stateOverrides: Partial<typeof defaultCardControllerState> = {},
+    ) {
+      const baanx = buildMockProvider();
+      const other = buildMockProvider({ id: 'other' });
+      const controller = new CardController({
+        messenger: buildMessenger(),
+        providers: { baanx, other },
+        state: { activeProviderId: 'baanx', ...stateOverrides },
+      });
+      return { controller, baanx, other };
+    }
+
+    it('removes tokens and onboarding data for every registered provider', async () => {
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller, baanx, other } = buildMultiProviderController({
+        isAuthenticated: true,
+      });
+
+      await controller.resetAll();
+
+      expect(baanx.logout).toHaveBeenCalledWith(mockTokenSet);
+      expect(other.logout).toHaveBeenCalledWith(mockTokenSet);
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('other');
+      expect(mockOnboardingStore.remove).toHaveBeenCalledWith('baanx');
+      expect(mockOnboardingStore.remove).toHaveBeenCalledWith('other');
+    });
+
+    it('continues cleanup when provider.logout throws', async () => {
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller, baanx } = buildMultiProviderController({
+        isAuthenticated: true,
+      });
+      baanx.logout.mockRejectedValue(new Error('Server error'));
+
+      await controller.resetAll();
+
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(mockOnboardingStore.remove).toHaveBeenCalledWith('baanx');
+      expect(controller.state.isAuthenticated).toBe(false);
+    });
+
+    it('skips provider.logout when no tokens exist but still clears stores', async () => {
+      mockTokenStore.get.mockResolvedValue(null);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller, baanx } = buildMultiProviderController();
+
+      await controller.resetAll();
+
+      expect(baanx.logout).not.toHaveBeenCalled();
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('baanx');
+      expect(mockOnboardingStore.remove).toHaveBeenCalledWith('baanx');
+    });
+
+    it('resets controller state to defaults', async () => {
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller } = buildMultiProviderController({
+        isAuthenticated: true,
+        selectedCountry: 'US',
+        cardholderAccounts: ['eip155:1:0xabc'],
+        providerData: { baanx: { location: 'us' } },
+      });
+
+      await controller.resetAll();
+
+      expect(controller.state).toStrictEqual(defaultCardControllerState);
+    });
+
+    it('dispatches resetCardState to wipe the redux card slice', async () => {
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller } = buildMultiProviderController();
+
+      await controller.resetAll();
+
+      expect(resetCardState).toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'card/resetCardState',
+      });
+    });
+
+    it('clears all data without reading the card feature flag', async () => {
+      // buildMessenger() registers no action handlers, so any messenger.call
+      // (e.g. a feature-flag lookup) would throw. resetAll completing proves
+      // it is not gated on the flag.
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller } = buildMultiProviderController({
+        isAuthenticated: true,
+      });
+
+      await expect(controller.resetAll()).resolves.toBeUndefined();
+      expect(controller.state.isAuthenticated).toBe(false);
+    });
+
+    it('continues with remaining providers when one provider cleanup rejects', async () => {
+      mockTokenStore.get
+        .mockRejectedValueOnce(new Error('keychain read failed'))
+        .mockResolvedValue(mockTokenSet);
+      mockTokenStore.remove.mockResolvedValue(true);
+      mockOnboardingStore.remove.mockResolvedValue(true);
+      const { controller, other } = buildMultiProviderController({
+        isAuthenticated: true,
+      });
+
+      await controller.resetAll();
+
+      expect(other.logout).toHaveBeenCalledWith(mockTokenSet);
+      expect(mockTokenStore.remove).toHaveBeenCalledWith('other');
+      expect(controller.state).toStrictEqual(defaultCardControllerState);
+    });
+  });
+
   describe('validateAndRefreshSession', () => {
     it('returns isAuthenticated:false when no tokens exist', async () => {
       const provider = buildMockProvider();
@@ -818,6 +954,99 @@ describe('CardController — event subscriptions', () => {
       mockMessenger.subscribe as jest.Mock
     ).mock.calls.find(([event]) => event === 'KeyringController:unlock')?.[1];
     await unlockHandler?.();
+
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  function buildMessengerForUnlock() {
+    const mockMessenger = buildMockMessenger();
+    (mockMessenger.call as jest.Mock).mockImplementation((action: string) => {
+      if (action === 'AccountsController:getState') {
+        return { internalAccounts: { accounts: {} } };
+      }
+      if (action === 'RemoteFeatureFlagController:getState') {
+        return { remoteFeatureFlags: {} };
+      }
+      return undefined;
+    });
+    return mockMessenger;
+  }
+
+  function getHandler(messenger: CardControllerMessenger, event: string) {
+    return (messenger.subscribe as jest.Mock).mock.calls.find(
+      ([subscribedEvent]) => subscribedEvent === event,
+    )?.[1];
+  }
+
+  it('ignores KeyringController:unlock while a reset is in progress', async () => {
+    const provider = buildMockProvider();
+    mockTokenStore.get.mockResolvedValue(null);
+    const mockMessenger = buildMessengerForUnlock();
+    const controller = new CardController({
+      messenger: mockMessenger,
+      providers: { baanx: provider },
+      state: { activeProviderId: 'baanx' },
+    });
+    const validateSpy = jest
+      .spyOn(controller, 'validateAndRefreshSession')
+      .mockResolvedValue({ isAuthenticated: false });
+
+    controller.setResetInProgress(true);
+    await getHandler(mockMessenger, 'KeyringController:unlock')?.();
+
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores AccountTreeController:stateChange while a reset is in progress', () => {
+    const provider = buildMockProvider();
+    const { controller, messenger } =
+      buildControllerWithMockMessenger(provider);
+    const fetchSpy = jest
+      .spyOn(controller, 'fetchCardHomeData')
+      .mockResolvedValue();
+
+    controller.setResetInProgress(true);
+    getHandler(messenger, 'AccountTreeController:stateChange')?.('acc-key');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores RemoteFeatureFlagController:stateChange while a reset is in progress', () => {
+    const provider = buildMockProvider();
+    const { controller, messenger } = buildControllerWithMockMessenger(
+      provider,
+      {
+        cardHomeData: mockCardHomeData as unknown as Record<string, null>,
+        cardHomeDataStatus: 'success',
+      },
+    );
+    const fetchSpy = jest
+      .spyOn(controller, 'fetchCardHomeData')
+      .mockResolvedValue();
+
+    controller.setResetInProgress(true);
+    getHandler(messenger, 'RemoteFeatureFlagController:stateChange')?.('{}');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(controller.state.cardHomeData).not.toBeNull();
+  });
+
+  it('resumes reactive fetching after setResetInProgress(false)', async () => {
+    const provider = buildMockProvider();
+    mockTokenStore.get.mockResolvedValue(null);
+    const mockMessenger = buildMessengerForUnlock();
+    const controller = new CardController({
+      messenger: mockMessenger,
+      providers: { baanx: provider },
+      state: { activeProviderId: 'baanx' },
+    });
+    const validateSpy = jest
+      .spyOn(controller, 'validateAndRefreshSession')
+      .mockResolvedValue({ isAuthenticated: false });
+
+    controller.setResetInProgress(true);
+    controller.setResetInProgress(false);
+    await getHandler(mockMessenger, 'KeyringController:unlock')?.();
 
     expect(validateSpy).toHaveBeenCalledTimes(1);
   });

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -42,6 +42,8 @@ import {
   type ICardProvider,
 } from './provider-types';
 import { CardTokenStore } from './CardTokenStore';
+import { CardOnboardingStore } from './CardOnboardingStore';
+import { resetCardState } from '../../../redux/slices/card';
 import { isEthAccount } from '../../../Multichain/utils';
 import { pickPrimaryFromReordered, reorderAssets } from './utils/assetPriority';
 import { encodeErc20ApproveCalldata } from './utils/encodeErc20ApproveCalldata';
@@ -147,6 +149,7 @@ export class CardController extends BaseController<
   private fetchCardHomeDataPromise: Promise<void> | null = null;
   private fetchGeneration = 0;
   private previousEvmAddress: string | null = null;
+  private resetInProgress = false;
 
   constructor({
     messenger,
@@ -171,8 +174,8 @@ export class CardController extends BaseController<
   }
 
   #subscribeToEvents(): void {
-    // On app unlock: run both cardholder check AND session verification
     this.messenger.subscribe('KeyringController:unlock', () => {
+      if (this.resetInProgress) return;
       this.#triggerCardholderCheck();
       this.validateAndRefreshSession().catch((error) =>
         Logger.error(error as Error, {
@@ -188,6 +191,7 @@ export class CardController extends BaseController<
     this.messenger.subscribe(
       'AccountTreeController:stateChange',
       (_key: string) => {
+        if (this.resetInProgress) return;
         this.#triggerCardholderCheck();
         this.#handleAccountSwitch();
       },
@@ -205,6 +209,7 @@ export class CardController extends BaseController<
     this.messenger.subscribe(
       'RemoteFeatureFlagController:stateChange',
       (_cardFeatureKey: string) => {
+        if (this.resetInProgress) return;
         this.#handleCardFeatureFlagChange();
       },
       (state) => JSON.stringify(state.remoteFeatureFlags?.cardFeature ?? {}),
@@ -583,6 +588,69 @@ export class CardController extends BaseController<
         pid
       ] = {};
     });
+  }
+
+  /**
+   * Toggles reset mode. While enabled, the controller ignores its reactive
+   * triggers.
+   * @param value - Whether to set reset in progress
+   */
+  setResetInProgress(value: boolean): void {
+    this.resetInProgress = value;
+  }
+
+  /**
+   * Wipes all Card data, returning it to a fresh-install state. Used by the
+   * app reset / delete-wallet flow (see Authentication.resetWalletState).
+   * @returns {Promise<void>}
+   */
+  async resetAll(): Promise<void> {
+    try {
+      for (const pid of Object.keys(this.providers)) {
+        try {
+          const tokens = await CardTokenStore.get(pid);
+          if (tokens) {
+            try {
+              await this.providers[pid].logout(tokens);
+            } catch (error) {
+              Logger.error(error as Error, {
+                tags: { feature: 'card', provider: pid },
+                context: {
+                  name: 'CardController',
+                  data: { method: 'resetAll/providerLogout' },
+                },
+              });
+            }
+          }
+          await CardTokenStore.remove(pid);
+          await CardOnboardingStore.remove(pid);
+        } catch (error) {
+          Logger.error(error as Error, {
+            tags: { feature: 'card', provider: pid },
+            context: {
+              name: 'CardController',
+              data: { method: 'resetAll/providerCleanup' },
+            },
+          });
+        }
+      }
+
+      this.currentSession = null;
+      this.refreshPromise = null;
+      this.invalidateFetch();
+      if (this.#cardholderCheckTimer !== undefined) {
+        clearTimeout(this.#cardholderCheckTimer);
+        this.#cardholderCheckTimer = undefined;
+      }
+      this.update(() => ({ ...defaultCardControllerState }));
+
+      ReduxService.store.dispatch(resetCardState());
+    } catch (error) {
+      Logger.error(error as Error, {
+        tags: { feature: 'card' },
+        context: { name: 'CardController', data: { method: 'resetAll' } },
+      });
+    }
   }
 
   async validateAndRefreshSession(): Promise<{


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The app reset / "delete wallet" flow (`Authentication.deleteWallet` → `resetWalletState`) restores the app to a fresh-install state and already clears Rewards and Seedless Onboarding, but it never touched the Card. As a result, a user who was logged in to the Card stayed logged in after resetting the app (CARD-431). Card auth lives in four places, none of which the reset cleared: `CardController` state, `CardTokenStore` (SecureKeychain tokens, per provider), `CardOnboardingStore` (SecureKeychain onboarding ids, per provider), and the redux `card` slice.

This PR follows the existing Rewards pattern:

- Adds `CardController.resetAll()` — a local-first, best-effort wipe that, for **every registered provider**, attempts a non-blocking server-side `provider.logout()` then removes its `CardTokenStore` and `CardOnboardingStore` entries, resets the controller state to defaults (clearing in-memory session, refresh/fetch promises, and the cardholder-check timer), and dispatches `resetCardState()` to wipe the redux slice. Each step is independently guarded so one failure never blocks the rest. It is intentionally **not** gated on the card feature flag, so stale credentials are cleared even if the flag was disabled remotely after login.
- Wires `Engine.context.CardController.resetAll()` into `Authentication.resetWalletState()`, alongside the existing Rewards/Seedless Onboarding resets.

While testing, the reset was observed firing CardHome network requests (`/config`, card status, cardholder check). These come from the temporary throwaway wallet created during reset: it emits `KeyringController:unlock` and rebuilds the account tree, and because the old Card tokens were still present, `CardController` eagerly fetched CardHome data on the **authenticated** path only to discard it moments later. To stop this, a `setResetInProgress(true/false)` guard was added; `resetWalletState` enables it around `newWalletAndKeychain()` (cleared in a `finally`), and the `unlock` / `AccountTreeController:stateChange` / `RemoteFeatureFlagController:stateChange` handlers early-return while it is set.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where Card login and session data was retained after resetting the app, leaving the user still logged in to the Card.

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/CARD-431

## **Manual testing steps**

```gherkin
Feature: Card data cleared on app reset

  Scenario: A logged-in Card user resets the app
    Given the user is logged in to the Card
    And Card session and onboarding data are stored on the device
    When the user resets the app via the delete-wallet flow
    And the user creates or imports a wallet again
    Then the Card is in a logged-out, fresh-install state
    And no Card authentication, session, or onboarding data remains in the keychain

  Scenario: No CardHome requests fire during the reset
    Given the user is logged in to the Card
    And a network inspector is attached
    When the user resets the app
    Then no CardHome network requests (e.g. /config, card status, cardholder check) are sent during the reset flow
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no UI changes (auth/session/keychain and network behavior only).

### **After**

N/A — no UI changes (auth/session/keychain and network behavior only).

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches delete-wallet reset ordering and secure keychain/Redux card state; failures are isolated per provider but auth/session wipe is security-sensitive.
> 
> **Overview**
> Fixes **CARD-431**: app reset no longer leaves Card logged in.
> 
> **`Authentication.resetWalletState`** now calls **`CardController.setResetInProgress(true)`** before the temporary wallet is created and **`resetAll()`** after Rewards reset, with **`setResetInProgress(false)`** in the same `finally` as vault-backup re-enable (including on failure).
> 
> **`CardController.resetAll()`** (new) best-effort clears every provider: optional **`logout`**, **`CardTokenStore`** / **`CardOnboardingStore`** removal, default controller state, and **`resetCardState`** in Redux—not gated on the card feature flag.
> 
> **`setResetInProgress`** suppresses reactive work during reset: **`KeyringController:unlock`**, **`AccountTreeController:stateChange`**, and **`RemoteFeatureFlagController:stateChange`** no longer trigger session validation or CardHome fetches while old tokens still exist.
> 
> Tests cover **`resetAll`** edge cases and reset-in-progress guard behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b22781b7fc368aae0686e5d0464660aa02c95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->