### PR TITLE
perf: migrate TabsBar underline animation to Reanimated UI thread

### DIFF
--- a/app/component-library/components-temp/Tabs/TabsBar/TabsBar.tsx
+++ b/app/component-library/components-temp/Tabs/TabsBar/TabsBar.tsx
@@ -284,6 +284,36 @@ const TabsBar: React.FC<TabsBarProps> = ({
     }
   };
 
+  const tabRow = (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      twClassName="relative gap-6"
+    >
+      {tabs.map((tab, index) => (
+        <Tab
+          key={`${tab.key}-${layoutGeneration}`}
+          label={tab.label}
+          isActive={index === activeIndex}
+          isDisabled={tab.isDisabled}
+          onPress={() => handleTabPress(index)}
+          onLayout={(layoutEvent) => handleTabLayout(index, layoutEvent)}
+          testID={tab.testID ?? `${testID}-tab-${index}`}
+        />
+      ))}
+
+      {/* Animated underline */}
+      {activeIndex >= 0 && isInitialized && (
+        <Reanimated.View
+          style={[
+            tw.style('absolute bottom-0 h-0.5 bg-icon-default'),
+            underlineStyle,
+          ]}
+        />
+      )}
+    </Box>
+  );
+
   return (
     <Box
       twClassName={`relative overflow-hidden ${twClassName || ''}`}
@@ -300,64 +330,10 @@ const TabsBar: React.FC<TabsBarProps> = ({
           contentContainerStyle={tw.style('flex-row px-4')}
           scrollsToTop={false}
         >
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="relative gap-6"
-          >
-            {tabs.map((tab, index) => (
-              <Tab
-                key={`${tab.key}-${layoutGeneration}`}
-                label={tab.label}
-                isActive={index === activeIndex}
-                isDisabled={tab.isDisabled}
-                onPress={() => handleTabPress(index)}
-                onLayout={(layoutEvent) => handleTabLayout(index, layoutEvent)}
-                testID={tab.testID ?? `${testID}-tab-${index}`}
-              />
-            ))}
-
-            {/* Animated underline for scrollable tabs */}
-            {activeIndex >= 0 && isInitialized && (
-              <Reanimated.View
-                style={[
-                  tw.style('absolute bottom-0 h-0.5 bg-icon-default'),
-                  underlineStyle,
-                ]}
-              />
-            )}
-          </Box>
+          {tabRow}
         </ScrollView>
       ) : (
-        <Box twClassName="px-4">
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="relative gap-6"
-          >
-            {tabs.map((tab, index) => (
-              <Tab
-                key={`${tab.key}-${layoutGeneration}`}
-                label={tab.label}
-                isActive={index === activeIndex}
-                isDisabled={tab.isDisabled}
-                onPress={() => handleTabPress(index)}
-                onLayout={(layoutEvent) => handleTabLayout(index, layoutEvent)}
-                testID={tab.testID ?? `${testID}-tab-${index}`}
-              />
-            ))}
-
-            {/* Animated underline for non-scrollable tabs */}
-            {activeIndex >= 0 && isInitialized && (
-              <Reanimated.View
-                style={[
-                  tw.style('absolute bottom-0 h-0.5 bg-icon-default'),
-                  underlineStyle,
-                ]}
-              />
-            )}
-          </Box>
-        </Box>
+        <Box twClassName="px-4">{tabRow}</Box>
       )}
     </Box>
   );

--- a/app/component-library/components-temp/Tabs/TabsBar/TabsBar.tsx
+++ b/app/component-library/components-temp/Tabs/TabsBar/TabsBar.tsx
@@ -6,7 +6,12 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
-import { Animated, ScrollView, LayoutChangeEvent } from 'react-native';
+import { ScrollView, LayoutChangeEvent } from 'react-native';
+import Reanimated, {
+  useSharedValue,
+  withTiming,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
 // External dependencies.
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -50,10 +55,9 @@ const TabsBar: React.FC<TabsBarProps> = ({
 
   const scrollViewRef = useRef<ScrollView>(null);
 
-  const underlineAnimated = useRef(new Animated.Value(0)).current;
-  const underlineWidthAnimated = useRef(new Animated.Value(0)).current;
+  const underlineX = useSharedValue(0);
+  const underlineW = useSharedValue(0);
   const tabLayouts = useRef<(TabLayout | undefined)[]>([]);
-  const currentAnimation = useRef<Animated.CompositeAnimation | null>(null);
   const rafCallbackId = useRef<number | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
   const [layoutsReady, setLayoutsReady] = useState(false);
@@ -96,12 +100,6 @@ const TabsBar: React.FC<TabsBarProps> = ({
       setLayoutsReady(false);
       setScrollEnabled(false);
 
-      // Stop any ongoing animation
-      if (currentAnimation.current) {
-        currentAnimation.current.stop();
-        currentAnimation.current = null;
-      }
-
       // Force Tab remount so onLayout fires for every tab after structural changes
       setLayoutGeneration((generation) => generation + 1);
     }
@@ -110,12 +108,6 @@ const TabsBar: React.FC<TabsBarProps> = ({
   // Animation function for smooth underline transitions
   const animateToTab = useCallback(
     (targetIndex: number) => {
-      // Stop any ongoing animation
-      if (currentAnimation.current) {
-        currentAnimation.current.stop();
-        currentAnimation.current = null;
-      }
-
       // Validate target index
       if (targetIndex < 0 || targetIndex >= tabs.length) {
         return;
@@ -131,31 +123,14 @@ const TabsBar: React.FC<TabsBarProps> = ({
       const isFirstTime = !isInitialized;
 
       if (isFirstTime) {
-        // First time - set position immediately
-        underlineAnimated.setValue(activeTabLayout.x);
-        underlineWidthAnimated.setValue(activeTabLayout.width);
+        // First time - set position immediately without animation
+        underlineX.value = activeTabLayout.x;
+        underlineW.value = activeTabLayout.width;
         setIsInitialized(true);
       } else {
-        // Animate to new position
-        const animation = Animated.parallel([
-          Animated.timing(underlineAnimated, {
-            toValue: activeTabLayout.x,
-            duration: 200,
-            useNativeDriver: false,
-          }),
-          Animated.timing(underlineWidthAnimated, {
-            toValue: activeTabLayout.width,
-            duration: 200,
-            useNativeDriver: false,
-          }),
-        ]);
-
-        currentAnimation.current = animation;
-        animation.start((finished) => {
-          if (finished && currentAnimation.current === animation) {
-            currentAnimation.current = null;
-          }
-        });
+        // Animate to new position on the UI thread
+        underlineX.value = withTiming(activeTabLayout.x, { duration: 200 });
+        underlineW.value = withTiming(activeTabLayout.width, { duration: 200 });
       }
 
       // Handle scrolling
@@ -166,13 +141,7 @@ const TabsBar: React.FC<TabsBarProps> = ({
         });
       }
     },
-    [
-      scrollEnabled,
-      underlineAnimated,
-      underlineWidthAnimated,
-      tabs.length,
-      isInitialized,
-    ],
+    [scrollEnabled, underlineX, underlineW, tabs.length, isInitialized],
   );
 
   // Animate when activeIndex changes and layouts are ready
@@ -292,13 +261,14 @@ const TabsBar: React.FC<TabsBarProps> = ({
     [tabs.length, layoutsReady, containerWidth, animateToTab, isInitialized],
   );
 
+  const underlineStyle = useAnimatedStyle(() => ({
+    width: underlineW.value,
+    transform: [{ translateX: underlineX.value }],
+  }));
+
   // Cleanup effect
   useEffect(
     () => () => {
-      if (currentAnimation.current) {
-        currentAnimation.current.stop();
-        currentAnimation.current = null;
-      }
       if (rafCallbackId.current !== null) {
         cancelAnimationFrame(rafCallbackId.current);
         rafCallbackId.current = null;
@@ -349,11 +319,11 @@ const TabsBar: React.FC<TabsBarProps> = ({
 
             {/* Animated underline for scrollable tabs */}
             {activeIndex >= 0 && isInitialized && (
-              <Animated.View
-                style={tw.style('absolute bottom-0 h-0.5 bg-icon-default', {
-                  width: underlineWidthAnimated,
-                  transform: [{ translateX: underlineAnimated }],
-                })}
+              <Reanimated.View
+                style={[
+                  tw.style('absolute bottom-0 h-0.5 bg-icon-default'),
+                  underlineStyle,
+                ]}
               />
             )}
           </Box>
@@ -379,11 +349,11 @@ const TabsBar: React.FC<TabsBarProps> = ({
 
             {/* Animated underline for non-scrollable tabs */}
             {activeIndex >= 0 && isInitialized && (
-              <Animated.View
-                style={tw.style('absolute bottom-0 h-0.5 bg-icon-default', {
-                  width: underlineWidthAnimated,
-                  transform: [{ translateX: underlineAnimated }],
-                })}
+              <Reanimated.View
+                style={[
+                  tw.style('absolute bottom-0 h-0.5 bg-icon-default'),
+                  underlineStyle,
+                ]}
               />
             )}
           </Box>


### PR DESCRIPTION
## **Description**

`TabsBar` animates the active-tab underline with two `Animated.timing` calls both using `useNativeDriver: false`. Because `width` cannot use the native driver, the entire `Animated.parallel` runs on the JS thread — doing ~12 frames of layout work per tab switch. When the JS thread is busy (tab content mounting, data fetching), the underline stutters precisely when the user expects responsiveness.

This PR migrates the two `Animated.Value`s to Reanimated v3 `useSharedValue` + `withTiming` + `useAnimatedStyle`, running the underline animation entirely on the UI thread. Reanimated can animate `width` in a worklet, eliminating all per-frame JS involvement. The `Animated.parallel` and its `currentAnimation` tracking ref are also removed — Reanimated automatically cancels in-flight animations when a new value is assigned.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31276

## **Manual testing steps**

```gherkin
Feature: TabsBar underline animation performance

  Scenario: user switches tabs while JS thread is busy
    Given the app is open on the Wallet screen with the default tab bar visible

    When user taps between tabs repeatedly
    Then the underline slides smoothly to the active tab with no stutter

  Scenario: underline initialises to the correct position on mount
    Given the app is opened fresh

    When the TabsBar renders
    Then the underline is positioned under the active tab without animation

  Scenario: underline tracks active tab in a scrollable tab bar
    Given a screen with many tabs (overflow/scrollable)

    When user taps a tab that is off-screen
    Then the tab bar scrolls and the underline moves to the correct position
```

## **Screenshots/Recordings**

N/A — internal performance change; underline appearance and position are unchanged, only the thread it runs on differs.

### **Before**

Animation driven on JS thread via `Animated.parallel` with `useNativeDriver: false`.

https://github.com/user-attachments/assets/25011515-404c-4154-a30c-3053d8765fdb

### **After**

Animation driven on UI thread via Reanimated `useSharedValue` / `withTiming` / `useAnimatedStyle`.

https://github.com/user-attachments/assets/54696ded-4ad6-43ff-82ae-639100a69c32

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI animation refactor in a shared component library file; visual behavior and tab logic are intended to stay the same with no auth or data changes.
> 
> **Overview**
> **Migrates the `TabsBar` active-tab underline from React Native `Animated` to Reanimated v3** so position and width animate on the UI thread instead of the JS thread.
> 
> `Animated.Value` + `Animated.parallel` / `Animated.timing` with `useNativeDriver: false` are replaced by `useSharedValue`, `withTiming`, and `useAnimatedStyle`. The underline renders as `Reanimated.View` with a shared animated style. **Manual animation cancellation** (`currentAnimation` ref and stop calls on tab reset/unmount) is removed; Reanimated replaces in-flight animations when new values are set. **Behavior is unchanged**: first paint snaps the underline without animation; later tab switches use a 200ms timing; scrollable bars still scroll the active tab into view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31913d2f2a01251320519c7ba62508dfa4b3ae09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->