### PR TITLE
feat: MUSD-943 refactored useMoneyAccountBalance to support latest iteration of money-account-balance-service

### DIFF
--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -197,12 +197,9 @@ const buildBalanceReturn = (
   overrides: Partial<ReturnType<typeof useMoneyAccountBalance>> = {},
 ) =>
   ({
-    musdBalanceQuery: {} as never,
+    moneyBalanceQuery: {} as never,
     vaultApyQuery: {} as never,
-    musdEquivalentBalanceQuery: {} as never,
-    isAggregatedBalanceLoading: false,
-    musdFiatFormatted: undefined,
-    musdSHFvdFiatFormatted: undefined,
+    isBalanceLoading: false,
     tokenTotal: new BigNumber(0),
     totalFiatFormatted: '$0.00',
     totalFiatRaw: '0',

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -366,12 +366,10 @@ describe('MoneyHomeView', () => {
 
     defaultMoneyAccountBalance = {
       totalFiatFormatted: '$3.00',
-      musdFiatFormatted: '$1.00',
-      musdSHFvdFiatFormatted: '$2.00',
       totalFiatRaw: '3',
       tokenTotal: new BigNumber('3'),
       withdrawableMusd: undefined,
-      isAggregatedBalanceLoading: false,
+      isBalanceLoading: false,
       isBalanceFetchError: false,
       isBalanceFetching: false,
       isBalanceUnavailable: false,
@@ -384,13 +382,11 @@ describe('MoneyHomeView', () => {
         data: { apy: 0.05, timestamp: '2026-01-01T00:00:00Z' },
         isLoading: false,
       },
-      musdBalanceQuery: {
-        data: { balance: '1000000' },
-        isLoading: false,
-      },
-      musdEquivalentBalanceQuery: {
+      moneyBalanceQuery: {
         data: {
-          balanceOfInAssets: '2000000',
+          musdBalance: '1000000',
+          vmusdValueInMusd: '2000000',
+          totalBalance: '3000000',
         },
         isLoading: false,
       },
@@ -504,12 +500,10 @@ describe('MoneyHomeView', () => {
     beforeEach(() => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: undefined,
-        musdFiatFormatted: undefined,
-        musdSHFvdFiatFormatted: undefined,
         totalFiatRaw: undefined,
         tokenTotal: undefined,
         withdrawableMusd: undefined,
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: true,
         isBalanceFetching: false,
         isBalanceUnavailable: true,
@@ -519,8 +513,7 @@ describe('MoneyHomeView', () => {
         apyPercent: 5,
         apyPercentFormatted: '5%',
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
     });
 
@@ -565,15 +558,14 @@ describe('MoneyHomeView', () => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: undefined,
         totalFiatRaw: undefined,
-        isAggregatedBalanceLoading: true,
+        isBalanceLoading: true,
         isBalanceFetchError: true,
         isBalanceFetching: false,
         lastKnownTotalFiatFormatted: undefined,
         refetchBalance: jest.fn(),
         apyPercent: 5,
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
 
       const { getByTestId, queryByTestId } = renderWithProvider(
@@ -602,14 +594,13 @@ describe('MoneyHomeView', () => {
         mockUseMoneyAccountBalance.mockReturnValue({
           totalFiatFormatted: undefined,
           totalFiatRaw: undefined,
-          isAggregatedBalanceLoading: false,
+          isBalanceLoading: false,
           isBalanceFetchError: false,
           isBalanceFetching: false,
           refetchBalance: jest.fn(),
           apyPercent: 5,
           vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-          musdBalanceQuery: { data: undefined, isLoading: false },
-          musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+          moneyBalanceQuery: { data: undefined, isLoading: false },
         } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       });
 
@@ -641,12 +632,10 @@ describe('MoneyHomeView', () => {
     describe('dust threshold gating', () => {
       const dustMock = {
         totalFiatFormatted: '$0.00',
-        musdFiatFormatted: '$0.00',
-        musdSHFvdFiatFormatted: '$0.00',
         // 0.0001 < DUST_THRESHOLD (0.01) — displays as $0.00 but is above zero
         totalFiatRaw: '0.0001',
         withdrawableMusd: undefined,
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
         refetchBalance: jest.fn(),
@@ -654,8 +643,7 @@ describe('MoneyHomeView', () => {
         apyPercent: 5,
         apyPercentFormatted: '5%',
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>;
 
       beforeEach(() => {
@@ -697,7 +685,7 @@ describe('MoneyHomeView', () => {
         mockUseMoneyAccountBalance.mockReturnValue({
           totalFiatFormatted: undefined,
           totalFiatRaw: undefined,
-          isAggregatedBalanceLoading: false,
+          isBalanceLoading: false,
           isBalanceFetchError: false,
           isBalanceFetching: false,
           isBalanceUnavailable: true,
@@ -705,8 +693,7 @@ describe('MoneyHomeView', () => {
           refetchBalance: jest.fn(),
           apyPercent: 5,
           vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-          musdBalanceQuery: { data: undefined, isLoading: false },
-          musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+          moneyBalanceQuery: { data: undefined, isLoading: false },
         } as unknown as ReturnType<typeof useMoneyAccountBalance>);
         mockUseMoneyAccountTransactions.mockReturnValue({
           allTransactions: [],
@@ -768,14 +755,13 @@ describe('MoneyHomeView', () => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: '$0.00',
         totalFiatRaw: '0',
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
         refetchBalance: mockRefetchBalance,
         apyPercent: 5,
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: [],
@@ -940,7 +926,7 @@ describe('MoneyHomeView', () => {
         totalFiatFormatted: undefined,
         totalFiatRaw: undefined,
         tokenTotal: undefined,
-        isAggregatedBalanceLoading: true,
+        isBalanceLoading: true,
         isBalanceFetchError: false,
         isBalanceFetching: true,
         isBalanceUnavailable: false,
@@ -959,7 +945,7 @@ describe('MoneyHomeView', () => {
         ...defaultMoneyAccountBalance,
         totalFiatFormatted: '$0.00',
         totalFiatRaw: '0',
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
@@ -977,7 +963,7 @@ describe('MoneyHomeView', () => {
         ...defaultMoneyAccountBalance,
         totalFiatFormatted: '$0.00',
         totalFiatRaw: '0',
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
@@ -1121,14 +1107,13 @@ describe('MoneyHomeView', () => {
       totalFiatFormatted: '$0.00',
       totalFiatRaw: '0',
       tokenTotal: new BigNumber(0),
-      isAggregatedBalanceLoading: false,
+      isBalanceLoading: false,
       isBalanceFetchError: false,
       isBalanceFetching: false,
       refetchBalance: mockRefetchBalance,
       apyPercent: 5,
       vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-      musdBalanceQuery: { data: undefined, isLoading: false },
-      musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      moneyBalanceQuery: { data: undefined, isLoading: false },
     } as unknown as ReturnType<typeof useMoneyAccountBalance>);
     mockUseMoneyAccountTransactions.mockReturnValue({
       allTransactions: [],
@@ -1180,16 +1165,13 @@ describe('MoneyHomeView', () => {
       // for all values, exercising the no-plus-prefix path.
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: '$3.00',
-        musdFiatFormatted: '$1.00',
-        musdSHFvdFiatFormatted: '$2.00',
         totalFiatRaw: '3',
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         apyDecimal: 0.05,
         apyPercent: 5,
         apyPercentFormatted: '5%',
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as ReturnType<typeof useMoneyAccountBalance>);
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
@@ -1208,11 +1190,9 @@ describe('MoneyHomeView', () => {
       mockMoneyFormatFiat.mockReturnValue('$0.00');
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: undefined,
-        musdFiatFormatted: undefined,
-        musdSHFvdFiatFormatted: undefined,
         totalFiatRaw: undefined,
         tokenTotal: undefined,
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
         refetchBalance: jest.fn(),
@@ -1220,8 +1200,7 @@ describe('MoneyHomeView', () => {
         apyPercent: 5,
         apyPercentFormatted: '5%',
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
 
       const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
@@ -1536,12 +1515,10 @@ describe('MoneyHomeView', () => {
     beforeEach(() => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: '$0.00',
-        musdFiatFormatted: '$0.00',
-        musdSHFvdFiatFormatted: '$0.00',
         totalFiatRaw: '0',
         tokenTotal: new BigNumber(0),
         withdrawableMusd: undefined,
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
         refetchBalance: mockRefetchBalance,
@@ -1549,8 +1526,7 @@ describe('MoneyHomeView', () => {
         apyPercent: 5,
         apyPercentFormatted: '5%',
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: [],
@@ -1711,14 +1687,13 @@ describe('MoneyHomeView', () => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: undefined,
         totalFiatRaw: undefined,
-        isAggregatedBalanceLoading: true,
+        isBalanceLoading: true,
         isBalanceFetchError: false,
         isBalanceFetching: false,
         refetchBalance: mockRefetchBalance,
         apyPercent: 5,
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: [],
@@ -1749,12 +1724,10 @@ describe('MoneyHomeView', () => {
     beforeEach(() => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: '$0.00',
-        musdFiatFormatted: '$0.00',
-        musdSHFvdFiatFormatted: '$0.00',
         totalFiatRaw: '0',
         tokenTotal: new BigNumber(0),
         withdrawableMusd: undefined,
-        isAggregatedBalanceLoading: false,
+        isBalanceLoading: false,
         isBalanceFetchError: false,
         isBalanceFetching: false,
         refetchBalance: mockRefetchBalance,
@@ -1762,8 +1735,7 @@ describe('MoneyHomeView', () => {
         apyPercent: 5,
         apyPercentFormatted: '5%',
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
-        musdBalanceQuery: { data: undefined, isLoading: false },
-        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+        moneyBalanceQuery: { data: undefined, isLoading: false },
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: Array.from({ length: 3 }, (_, index) => ({

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -112,7 +112,7 @@ const MoneyHomeView = () => {
     totalFiatFormatted,
     totalFiatRaw,
     vaultApyQuery,
-    isAggregatedBalanceLoading,
+    isBalanceLoading,
     lastKnownTotalFiatFormatted,
     refetchBalance,
     apyPercent,
@@ -660,7 +660,7 @@ const MoneyHomeView = () => {
             <MoneyEarnings
               monthlyEarnings={monthlyEarnings}
               yearlyEarnings={yearlyEarnings}
-              isLoading={vaultApyQuery.isLoading || isAggregatedBalanceLoading}
+              isLoading={vaultApyQuery.isLoading || isBalanceLoading}
               onInfoPress={handleEarningsInfoPress}
             />
             <Divider />

--- a/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.test.tsx
@@ -149,23 +149,19 @@ describe('MoneyPotentialEarningsView', () => {
       totalFiatFormatted: '$10,000.00',
       totalFiatRaw: '10000',
       tokenTotal: undefined,
-      isAggregatedBalanceLoading: false,
+      isBalanceLoading: false,
       vaultApyQuery: {
         data: { apy: 0.04, timestamp: '2026-01-01T00:00:00Z' },
         isLoading: false,
       },
-      musdBalanceQuery: {
-        data: { balance: '10000000000' },
-        isLoading: false,
-      },
-      musdEquivalentBalanceQuery: {
+      moneyBalanceQuery: {
         data: {
-          balanceOfInAssets: '0',
+          musdBalance: '10000000000',
+          vmusdValueInMusd: '0',
+          totalBalance: '10000000000',
         },
         isLoading: false,
       },
-      musdFiatFormatted: '$10,000.00',
-      musdSHFvdFiatFormatted: '$0.00',
     } as ReturnType<typeof useMoneyAccountBalance>);
   });
 

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -96,7 +96,7 @@ const createBalanceMock = (
     totalFiatFormatted: '$1,000.00',
     totalFiatRaw: '1000',
     tokenTotal: undefined,
-    isAggregatedBalanceLoading: false,
+    isBalanceLoading: false,
     isBalanceFetchError: false,
     isBalanceFetching: false,
     refetchBalance: jest.fn(),
@@ -107,20 +107,14 @@ const createBalanceMock = (
       data: { apy: 0.04, timestamp: '2026-01-01T00:00:00Z' },
       isLoading: false,
     },
-    musdBalanceQuery: {
-      data: { balance: '1000000000' },
-      isLoading: false,
-    },
-    musdEquivalentBalanceQuery: {
+    moneyBalanceQuery: {
       data: {
-        musdEquivalentValue: '0',
-        musdSHFvdBalance: '0',
-        exchangeRate: '1000000',
+        musdBalance: '1000000000',
+        vmusdValueInMusd: '0',
+        totalBalance: '1000000000',
       },
       isLoading: false,
     },
-    musdFiatFormatted: '$1,000.00',
-    musdSHFvdFiatFormatted: '$0.00',
     ...overrides,
   }) as ReturnType<typeof useMoneyAccountBalance>;
 
@@ -536,7 +530,7 @@ describe('MoneyBalanceCard', () => {
   describe('loading states', () => {
     it('renders balance skeleton when balance is loading', () => {
       mockUseMoneyAccountBalance.mockReturnValue(
-        createBalanceMock({ isAggregatedBalanceLoading: true }),
+        createBalanceMock({ isBalanceLoading: true }),
       );
 
       const { getByTestId, queryByTestId } = renderWithProvider(

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -53,7 +53,7 @@ const MoneyBalanceCard = () => {
     totalFiatRaw,
     totalFiatFormatted,
     apyPercent,
-    isAggregatedBalanceLoading,
+    isBalanceLoading,
     isBalanceFetchError,
     isBalanceFetching,
     refetchBalance,
@@ -86,7 +86,7 @@ const MoneyBalanceCard = () => {
   const isUnavailable =
     hasMoneyAccount &&
     !isBalanceFetchError &&
-    !isAggregatedBalanceLoading &&
+    !isBalanceLoading &&
     totalFiatFormatted === undefined;
 
   // Genuinely zero balance — distinct from unavailable.
@@ -188,7 +188,7 @@ const MoneyBalanceCard = () => {
         </Text>
       );
     }
-    if (isAggregatedBalanceLoading || isRetrying) {
+    if (isBalanceLoading || isRetrying) {
       return (
         <Skeleton
           height={24}

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -103,7 +103,7 @@ interface SetupOptions {
   isCardAuthenticated?: boolean;
   isCardVerified?: boolean;
   isCardLinkedToMoneyAccount?: boolean;
-  isAggregatedBalanceLoading?: boolean;
+  isBalanceLoading?: boolean;
   tokenTotal?: BigNumber;
 }
 
@@ -113,7 +113,7 @@ const setupDefaultMocks = ({
   isCardAuthenticated = false,
   isCardVerified = false,
   isCardLinkedToMoneyAccount = false,
-  isAggregatedBalanceLoading = false,
+  isBalanceLoading = false,
   tokenTotal = new BigNumber(0),
 }: SetupOptions = {}) => {
   mockUseOnboardingStep.mockReturnValue({
@@ -126,7 +126,7 @@ const setupDefaultMocks = ({
   });
   mockUseMoneyAccountBalance.mockReturnValue({
     tokenTotal,
-    isAggregatedBalanceLoading,
+    isBalanceLoading,
   } as ReturnType<typeof useMoneyAccountBalance>);
   (mockUseMoneyAccountCardLinkage as jest.Mock).mockReturnValue({
     startLinkFlow: mockStartLinkFlow,
@@ -156,7 +156,7 @@ describe('MoneyOnboardingCard', () => {
     });
 
     it('returns null when balance is loading', () => {
-      setupDefaultMocks({ isAggregatedBalanceLoading: true });
+      setupDefaultMocks({ isBalanceLoading: true });
 
       const { toJSON } = render(<MoneyOnboardingCard />);
 
@@ -187,7 +187,7 @@ describe('MoneyOnboardingCard', () => {
     it('does not call incrementStep while balance is loading', () => {
       setupDefaultMocks({
         currentStep: 0,
-        isAggregatedBalanceLoading: true,
+        isBalanceLoading: true,
         tokenTotal: new BigNumber(1),
       });
 

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -48,7 +48,7 @@ const MoneyOnboardingCard = () => {
   });
 
   const { initiateDeposit } = useMoneyAccountDeposit();
-  const { tokenTotal, isAggregatedBalanceLoading } = useMoneyAccountBalance();
+  const { tokenTotal, isBalanceLoading } = useMoneyAccountBalance();
   const { trackOnboardingEvent } = useMoneyAnalytics({
     screen_name: SCREEN_NAMES.MONEY_HOME,
     component_name: COMPONENT_NAMES.MONEY_ONBOARDING_CARD,
@@ -65,7 +65,7 @@ const MoneyOnboardingCard = () => {
   const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
 
   const isMoneyAccountFunded = Boolean(
-    !isAggregatedBalanceLoading && tokenTotal?.isGreaterThan(0),
+    !isBalanceLoading && tokenTotal?.isGreaterThan(0),
   );
   const isCardAnalyticsReady =
     cardHomeDataStatus === 'success' || cardHomeDataStatus === 'error';
@@ -200,7 +200,7 @@ const MoneyOnboardingCard = () => {
   useEffect(() => {
     if (
       hasTrackedCardStepViewRef.current ||
-      isAggregatedBalanceLoading ||
+      isBalanceLoading ||
       !isCardAnalyticsReady ||
       !isOnboardingCardVisible ||
       !isVisibleAfterAutoSkip ||
@@ -223,7 +223,7 @@ const MoneyOnboardingCard = () => {
     trackEvent,
     createEventBuilder,
     effectiveCurrentStep,
-    isAggregatedBalanceLoading,
+    isBalanceLoading,
     isCardAnalyticsReady,
     isOnboardingCardVisible,
     isVisibleAfterAutoSkip,
@@ -330,11 +330,7 @@ const MoneyOnboardingCard = () => {
     handleSkipPress,
   ]);
 
-  if (
-    isAggregatedBalanceLoading ||
-    !isOnboardingCardVisible ||
-    !isVisibleAfterAutoSkip
-  ) {
+  if (isBalanceLoading || !isOnboardingCardVisible || !isVisibleAfterAutoSkip) {
     return null;
   }
 

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -308,15 +308,12 @@ describe('useMoneyAccountBalance', () => {
       }
       return undefined;
     });
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        musdBalance: { data: { balance: '0' }, isLoading: false },
-        musdEquivalentBalance: {
-          data: { balanceOfInAssets: '0' },
-          isLoading: false,
-        },
-      }),
-    );
+    setupDefaultQueries({
+      data: { musdBalance: '0', vmusdValueInMusd: '0', totalBalance: '0' },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
 
     const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -522,11 +519,12 @@ describe('useMoneyAccountBalance', () => {
     });
 
     it('isBalanceUnavailable is true on a balance fetch error', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: { data: undefined, isLoading: false, isError: true },
-        }),
-      );
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+      });
 
       const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -548,11 +546,12 @@ describe('useMoneyAccountBalance', () => {
     });
 
     it('does not persist the balance on a fetch error', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: { data: undefined, isLoading: false, isError: true },
-        }),
-      );
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+      });
 
       renderHook(() => useMoneyAccountBalance());
 

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import { useQueries } from '@tanstack/react-query';
+import { useQuery } from '@metamask/react-data-query';
 import useMoneyAccountBalance, {
   getLiveVedaVaultExchangeRate,
 } from './useMoneyAccountBalance';
@@ -24,9 +24,8 @@ jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
 }));
 
-jest.mock('@tanstack/react-query', () => ({
-  ...jest.requireActual('@tanstack/react-query'),
-  useQueries: jest.fn(),
+jest.mock('@metamask/react-data-query', () => ({
+  useQuery: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -38,8 +37,16 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
-// Selector modules are only used as identity references in the useSelector mock;
-// they don't need to be individually mocked.
+const mockInvalidateQueries = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../core/ReactQueryService', () => ({
+  __esModule: true,
+  default: {
+    queryClient: {
+      invalidateQueries: (...args: unknown[]) => mockInvalidateQueries(...args),
+    },
+  },
+}));
+
 jest.mock('../../../../selectors/moneyAccountController', () => ({
   selectPrimaryMoneyAccount: jest.fn(),
   selectMoneyAccounts: jest.fn(),
@@ -56,7 +63,7 @@ jest.mock('../../../../selectors/networkController', () => ({
 }));
 
 const mockUseSelector = jest.mocked(useSelector);
-const mockUseQueries = jest.mocked(useQueries);
+const mockUseQuery = jest.mocked(useQuery);
 const mockControllerMessengerCall = jest.mocked(
   Engine.controllerMessenger.call,
 );
@@ -124,13 +131,22 @@ interface QueryState<T> {
   refetch?: jest.Mock;
 }
 
-const DEFAULT_MUSD_BALANCE_QUERY: QueryState<{ balance: string }> = {
-  data: { balance: '1000000' },
+const DEFAULT_MONEY_BALANCE_QUERY: QueryState<{
+  musdBalance: string;
+  vmusdValueInMusd: string;
+  totalBalance: string;
+}> = {
+  data: {
+    musdBalance: '1000000',
+    vmusdValueInMusd: '2000000',
+    totalBalance: '3000000',
+  },
   isLoading: false,
   isError: false,
   isFetching: false,
   refetch: jest.fn(),
 };
+
 const DEFAULT_VAULT_APY_QUERY: QueryState<{ apy: number }> = {
   data: { apy: 0.05 },
   isLoading: false,
@@ -138,34 +154,24 @@ const DEFAULT_VAULT_APY_QUERY: QueryState<{ apy: number }> = {
   isFetching: false,
   refetch: jest.fn(),
 };
-const DEFAULT_MUSD_EQUIVALENT_BALANCE_QUERY: QueryState<{
-  balanceOfInAssets: string;
-}> = {
-  data: { balanceOfInAssets: '2000000' },
-  isLoading: false,
-  isError: false,
-  isFetching: false,
-  refetch: jest.fn(),
-};
 
-function makeQueryResults({
-  musdBalance = DEFAULT_MUSD_BALANCE_QUERY,
-  vaultApy = DEFAULT_VAULT_APY_QUERY,
-  musdEquivalentBalance = DEFAULT_MUSD_EQUIVALENT_BALANCE_QUERY,
-}: {
-  musdBalance?: QueryState<{ balance: string }>;
-  vaultApy?: QueryState<{ apy: number }>;
-  musdEquivalentBalance?: QueryState<{ balanceOfInAssets: string }>;
-} = {}) {
-  return [
-    musdBalance,
-    vaultApy,
-    musdEquivalentBalance,
-  ] as unknown as ReturnType<typeof useQueries>;
-}
-
-function setupDefaultQueries() {
-  mockUseQueries.mockReturnValue(makeQueryResults());
+function setupDefaultQueries(
+  moneyBalance: QueryState<{
+    musdBalance: string;
+    vmusdValueInMusd: string;
+    totalBalance: string;
+  }> = DEFAULT_MONEY_BALANCE_QUERY,
+  vaultApy: QueryState<{ apy: number }> = DEFAULT_VAULT_APY_QUERY,
+) {
+  mockUseQuery.mockImplementation(((options: { queryKey?: unknown[] }) => {
+    if (
+      options.queryKey?.[0] ===
+      'MoneyAccountBalanceService:getMoneyAccountBalance'
+    ) {
+      return moneyBalance;
+    }
+    return vaultApy;
+  }) as unknown as typeof useQuery);
 }
 
 describe('getLiveVedaVaultExchangeRate', () => {
@@ -200,45 +206,32 @@ describe('useMoneyAccountBalance', () => {
     setupDefaultQueries();
   });
 
-  it('isAggregatedBalanceLoading is true when musdBalanceQuery is loading', () => {
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        musdBalance: { data: undefined, isLoading: true },
-      }),
-    );
+  it('isBalanceLoading is true when moneyBalanceQuery is loading', () => {
+    setupDefaultQueries({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetching: false,
+    });
 
     const { result } = renderHook(() => useMoneyAccountBalance());
 
-    expect(result.current.isAggregatedBalanceLoading).toBe(true);
+    expect(result.current.isBalanceLoading).toBe(true);
   });
 
-  it('isAggregatedBalanceLoading is true when musdEquivalentBalanceQuery is loading', () => {
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        musdBalance: { data: { balance: '0' }, isLoading: false },
-        musdEquivalentBalance: { data: undefined, isLoading: true },
-      }),
-    );
-
+  it('isBalanceLoading is false when query has completed', () => {
     const { result } = renderHook(() => useMoneyAccountBalance());
 
-    expect(result.current.isAggregatedBalanceLoading).toBe(true);
-  });
-
-  it('isAggregatedBalanceLoading is false when both queries have completed', () => {
-    const { result } = renderHook(() => useMoneyAccountBalance());
-
-    expect(result.current.isAggregatedBalanceLoading).toBe(false);
+    expect(result.current.isBalanceLoading).toBe(false);
   });
 
   it('returns undefined tokenTotal when still loading', () => {
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        musdBalance: { data: undefined, isLoading: true },
-        vaultApy: { data: undefined, isLoading: false },
-        musdEquivalentBalance: { data: undefined, isLoading: true },
-      }),
-    );
+    setupDefaultQueries({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetching: false,
+    });
 
     const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -246,25 +239,26 @@ describe('useMoneyAccountBalance', () => {
   });
 
   it('returns sum of musd and vault token balances as tokenTotal when loaded', () => {
-    // balance '1000000' = 1 mUSD (6 decimals), musdEquivalentValue '2000000' = 2 mUSD
+    // musdBalance '1000000' = 1 mUSD (6 decimals), vmusdValueInMusd '2000000' = 2 mUSD
     const { result } = renderHook(() => useMoneyAccountBalance());
 
     expect(result.current.tokenTotal?.toFixed(0)).toBe('3');
   });
 
   it('returns withdrawableMusd as the vmUSD-shares-only mUSD equivalent when loaded', () => {
-    // musdEquivalentValue '2000000' = 2 mUSD (6 decimals) — vmUSD shares only, not including bare mUSD
+    // vmusdValueInMusd '2000000' = 2 mUSD (6 decimals) — vmUSD shares only, not including bare mUSD
     const { result } = renderHook(() => useMoneyAccountBalance());
 
     expect(result.current.withdrawableMusd?.toFixed(0)).toBe('2');
   });
 
   it('returns undefined withdrawableMusd while loading', () => {
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        musdEquivalentBalance: { data: undefined, isLoading: true },
-      }),
-    );
+    setupDefaultQueries({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetching: false,
+    });
 
     const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -277,7 +271,6 @@ describe('useMoneyAccountBalance', () => {
         return { address: MOCK_ADDRESS };
       }
       if (selector === selectTokenMarketData) {
-        // No price data available
         return {};
       }
       if (selector === selectCurrencyRates) {
@@ -292,8 +285,6 @@ describe('useMoneyAccountBalance', () => {
     const { result } = renderHook(() => useMoneyAccountBalance());
 
     expect(result.current.totalFiatFormatted).toBeUndefined();
-    expect(result.current.musdFiatFormatted).toBeUndefined();
-    expect(result.current.musdSHFvdFiatFormatted).toBeUndefined();
     expect(result.current.totalFiatRaw).toBeUndefined();
   });
 
@@ -336,15 +327,13 @@ describe('useMoneyAccountBalance', () => {
 
   it('returns formatted total fiat when all data is available', () => {
     // musdFiatRate = price(0.0005) * conversionRate(2000) = 1.0
-    // musd balance 1 * 1.0 = $1.00, musdSHFvd balance 2 * 1.0 = $2.00, total = $3.00
+    // musd balance 1 * 1.0 = $1.00, vmUSD balance 2 * 1.0 = $2.00, total = $3.00
     const { result } = renderHook(() => useMoneyAccountBalance());
 
     expect(result.current.totalFiatFormatted).toBe('$3.00');
-    expect(result.current.musdFiatFormatted).toBe('$1.00');
-    expect(result.current.musdSHFvdFiatFormatted).toBe('$2.00');
   });
 
-  it('disables musdBalanceQuery and GET_MUSD_EQUIVALENT_VALUE query when no account address', () => {
+  it('disables moneyBalanceQuery when no account address', () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectPrimaryMoneyAccount) {
         return undefined;
@@ -366,11 +355,12 @@ describe('useMoneyAccountBalance', () => {
 
     renderHook(() => useMoneyAccountBalance());
 
-    const queriesArg = mockUseQueries.mock.calls[0][0] as {
-      queries: { enabled?: boolean }[];
-    };
-    expect(queriesArg.queries[0].enabled).toBe(false);
-    expect(queriesArg.queries[2].enabled).toBe(false);
+    const balanceCallArgs = mockUseQuery.mock.calls.find(
+      ([opts]) =>
+        (opts as { queryKey: string[] }).queryKey[0] ===
+        'MoneyAccountBalanceService:getMoneyAccountBalance',
+    );
+    expect((balanceCallArgs?.[0] as { enabled?: boolean }).enabled).toBe(false);
   });
 
   it('totalFiatRaw is the string representation of totalFiat', () => {
@@ -398,11 +388,12 @@ describe('useMoneyAccountBalance', () => {
   });
 
   it('returns undefined for all APY fields when vault APY data is not available', () => {
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        vaultApy: { data: undefined, isLoading: true },
-      }),
-    );
+    setupDefaultQueries(DEFAULT_MONEY_BALANCE_QUERY, {
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetching: false,
+    });
 
     const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -412,15 +403,16 @@ describe('useMoneyAccountBalance', () => {
   });
 
   it('collapses sub-cent total fiat to $0.00 when both balances are 1 minimal unit', () => {
-    mockUseQueries.mockReturnValue(
-      makeQueryResults({
-        musdBalance: { data: { balance: '1' }, isLoading: false },
-        musdEquivalentBalance: {
-          data: { balanceOfInAssets: '1' },
-          isLoading: false,
-        },
-      }),
-    );
+    setupDefaultQueries({
+      data: {
+        musdBalance: '1',
+        vmusdValueInMusd: '1',
+        totalBalance: '2',
+      },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
 
     const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -428,28 +420,13 @@ describe('useMoneyAccountBalance', () => {
   });
 
   describe('error surface', () => {
-    it('exposes isBalanceFetchError true when musdBalanceQuery has errored', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: { data: undefined, isLoading: false, isError: true },
-        }),
-      );
-
-      const { result } = renderHook(() => useMoneyAccountBalance());
-
-      expect(result.current.isBalanceFetchError).toBe(true);
-    });
-
-    it('exposes isBalanceFetchError true when musdEquivalentBalanceQuery has errored', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdEquivalentBalance: {
-            data: undefined,
-            isLoading: false,
-            isError: true,
-          },
-        }),
-      );
+    it('exposes isBalanceFetchError true when moneyBalanceQuery has errored', () => {
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+      });
 
       const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -463,11 +440,12 @@ describe('useMoneyAccountBalance', () => {
     });
 
     it('returns undefined totalFiatFormatted on balance fetch error', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: { data: undefined, isLoading: false, isError: true },
-        }),
-      );
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+      });
 
       const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -475,11 +453,12 @@ describe('useMoneyAccountBalance', () => {
     });
 
     it('returns undefined totalFiatRaw on balance fetch error', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: { data: undefined, isLoading: false, isError: true },
-        }),
-      );
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+      });
 
       const { result } = renderHook(() => useMoneyAccountBalance());
 
@@ -487,59 +466,44 @@ describe('useMoneyAccountBalance', () => {
     });
 
     it('returns undefined tokenTotal on balance fetch error', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: { data: undefined, isLoading: false, isError: true },
-        }),
-      );
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: false,
+      });
 
       const { result } = renderHook(() => useMoneyAccountBalance());
 
       expect(result.current.tokenTotal).toBeUndefined();
     });
 
-    it('exposes isBalanceFetching true when either balance query is fetching', () => {
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: {
-            data: undefined,
-            isLoading: false,
-            isError: true,
-            isFetching: true,
-          },
-        }),
-      );
+    it('exposes isBalanceFetching true when balance query is fetching', () => {
+      setupDefaultQueries({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        isFetching: true,
+      });
 
       const { result } = renderHook(() => useMoneyAccountBalance());
 
       expect(result.current.isBalanceFetching).toBe(true);
     });
 
-    it('refetchBalance calls refetch on both balance queries', async () => {
-      const mockMusdRefetch = jest.fn().mockResolvedValue({});
-      const mockEquivalentRefetch = jest.fn().mockResolvedValue({});
-
-      mockUseQueries.mockReturnValue(
-        makeQueryResults({
-          musdBalance: {
-            data: { balance: '1000000' },
-            isLoading: false,
-            refetch: mockMusdRefetch,
-          },
-          musdEquivalentBalance: {
-            data: { balanceOfInAssets: '2000000' },
-            isLoading: false,
-            refetch: mockEquivalentRefetch,
-          },
-        }),
-      );
-
+    it('refetchBalance invalidates the balance query via ReactQueryService', async () => {
       const { result } = renderHook(() => useMoneyAccountBalance());
 
       await result.current.refetchBalance();
 
-      expect(mockMusdRefetch).toHaveBeenCalledTimes(1);
-      expect(mockEquivalentRefetch).toHaveBeenCalledTimes(1);
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: [
+          'MoneyAccountBalanceService:getMoneyAccountBalance',
+          MOCK_ADDRESS,
+        ],
+        refetchType: 'all',
+      });
     });
   });
 

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -1,10 +1,11 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useMemo, useCallback } from 'react';
 import {
-  type MusdEquivalentValueResponse,
-  NormalizedVaultApyResponse,
+  type MoneyAccountBalanceResponse,
+  type NormalizedVaultApyResponse,
 } from '@metamask/money-account-balance-service';
-import { useQueries, type UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@metamask/react-data-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { fromTokenMinimalUnitString } from '../../../../util/number';
@@ -22,6 +23,7 @@ import {
 import { toChecksumAddress } from '../../../../util/address';
 import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
 import Engine from '../../../../core/Engine';
+import ReactQueryService from '../../../../core/ReactQueryService';
 import useMoneyAccountInfo from './useMoneyAccountInfo';
 import {
   isPersistedMoneyBalanceUsable,
@@ -61,34 +63,19 @@ const useMoneyAccountBalance = (
   const currentCurrency = useSelector(selectCurrentCurrency);
   const lastKnownBalance = useSelector(selectLastKnownMoneyBalance);
 
-  const [musdBalanceQuery, vaultApyQuery, musdEquivalentBalanceQuery] =
-    useQueries({
-      queries: [
-        {
-          queryKey: [
-            MoneyAccountBalanceServiceQueryKeys.GET_MUSD_BALANCE,
-            moneyAccountAddress,
-          ],
-          enabled: Boolean(moneyAccountAddress),
-          refetchInterval,
-        },
-        {
-          queryKey: [MoneyAccountBalanceServiceQueryKeys.GET_VAULT_APY],
-        },
-        {
-          queryKey: [
-            MoneyAccountBalanceServiceQueryKeys.GET_MUSD_EQUIVALENT_VALUE,
-            moneyAccountAddress,
-          ],
-          enabled: Boolean(moneyAccountAddress),
-          refetchInterval,
-        },
-      ],
-    }) as [
-      UseQueryResult<{ balance: string }>,
-      UseQueryResult<NormalizedVaultApyResponse>,
-      UseQueryResult<MusdEquivalentValueResponse>,
-    ];
+  const moneyBalanceQuery = useQuery({
+    queryKey: [
+      MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
+      moneyAccountAddress as string,
+    ],
+    enabled: Boolean(moneyAccountAddress),
+    refetchInterval,
+  }) as UseQueryResult<MoneyAccountBalanceResponse>;
+
+  const vaultApyQuery = useQuery({
+    queryKey: [MoneyAccountBalanceServiceQueryKeys.GET_VAULT_APY],
+    refetchInterval: 10 * 60 * 1000, // 5 minutes
+  }) as UseQueryResult<NormalizedVaultApyResponse>;
 
   const musdFiatRate = useMemo(() => {
     const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
@@ -112,124 +99,95 @@ const useMoneyAccountBalance = (
   }, [tokenMarketData, currencyRates, networkConfigurations]);
 
   /**
-   * True while any query that feeds into the aggregated balance is still fetching.
-   * isLoading is only true when there is no cached data even if it's stale.
+   * True while the balance query is loading with no cached data (even if stale).
    */
-  const isAggregatedBalanceLoading = useMemo(
-    () => musdBalanceQuery.isLoading || musdEquivalentBalanceQuery.isLoading,
-    [musdBalanceQuery.isLoading, musdEquivalentBalanceQuery.isLoading],
-  );
+  const isBalanceLoading = moneyBalanceQuery.isLoading;
 
-  /** True when either balance query has errored. Any failure → full error state. */
-  const isBalanceFetchError = useMemo(
-    () => musdBalanceQuery.isError || musdEquivalentBalanceQuery.isError,
-    [musdBalanceQuery.isError, musdEquivalentBalanceQuery.isError],
-  );
+  /** Any balance fetch failure → full error state. */
+  const isBalanceFetchError = moneyBalanceQuery.isError;
 
   /**
-   * True while a user-initiated refetch is in flight (has isError + isFetching).
-   * Distinguishes retry-in-flight (show skeleton) from auto-refetch (has cache,
-   * update silently).
+   * True while a refetch is in flight. Combined with isError, lets callers
+   * distinguish retry-in-flight (show skeleton) from silent auto-refetch.
    */
-  const isBalanceFetching = useMemo(
-    () => musdBalanceQuery.isFetching || musdEquivalentBalanceQuery.isFetching,
-    [musdBalanceQuery.isFetching, musdEquivalentBalanceQuery.isFetching],
-  );
-
-  const refetchMusdBalance = musdBalanceQuery.refetch;
-  const refetchMusdEquivalentBalance = musdEquivalentBalanceQuery.refetch;
+  const isBalanceFetching = moneyBalanceQuery.isFetching;
 
   const refetchBalance = useCallback(
-    () => Promise.all([refetchMusdBalance(), refetchMusdEquivalentBalance()]),
-    [refetchMusdBalance, refetchMusdEquivalentBalance],
+    () =>
+      ReactQueryService.queryClient.invalidateQueries({
+        queryKey: [
+          MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
+          moneyAccountAddress,
+        ],
+        refetchType: 'all',
+      }),
+    [moneyAccountAddress],
   );
 
-  const { musdFiat, musdSHFvdFiat, tokenTotal, totalFiat, withdrawableMusd } =
-    useMemo(() => {
-      // mUSD balance: raw uint256 (6 decimals) → decimal BigNumber
-      const musdDecimal = musdBalanceQuery.data?.balance
-        ? new BigNumber(
-            fromTokenMinimalUnitString(
-              musdBalanceQuery.data.balance,
-              MUSD_DECIMALS,
-            ),
-          )
-        : new BigNumber(0);
+  const { tokenTotal, totalFiat, withdrawableMusd } = useMemo(() => {
+    // Total balance (mUSD + vmUSD in mUSD terms) from the service's Multicall3 response.
+    const totalDecimal = moneyBalanceQuery.data?.totalBalance
+      ? new BigNumber(
+          fromTokenMinimalUnitString(
+            moneyBalanceQuery.data.totalBalance,
+            MUSD_DECIMALS,
+          ),
+        )
+      : new BigNumber(0);
 
-      // musdSHFvd balance expressed in mUSD.
-      const musdSHFvdDecimal = musdEquivalentBalanceQuery.data
-        ?.balanceOfInAssets
-        ? new BigNumber(
-            fromTokenMinimalUnitString(
-              musdEquivalentBalanceQuery.data.balanceOfInAssets,
-              MUSD_DECIMALS,
-            ),
-          )
-        : new BigNumber(0);
+    // vmUSD balance expressed in mUSD — the withdrawable amount.
+    const vmusdDecimal = moneyBalanceQuery.data?.vmusdValueInMusd
+      ? new BigNumber(
+          fromTokenMinimalUnitString(
+            moneyBalanceQuery.data.vmusdValueInMusd,
+            MUSD_DECIMALS,
+          ),
+        )
+      : new BigNumber(0);
 
-      // vmUSD shares expressed in mUSD via the vault rate — this is the withdrawable amount.
-      // Undefined while loading or on error so callers can distinguish from a genuine zero.
-      const computedWithdrawableMusd =
-        isAggregatedBalanceLoading || isBalanceFetchError
-          ? undefined
-          : musdSHFvdDecimal;
+    // Undefined while loading or on error so callers can distinguish from a genuine zero.
+    const computedWithdrawableMusd =
+      isBalanceLoading || isBalanceFetchError ? undefined : vmusdDecimal;
 
-      if (!musdFiatRate) {
-        // Undefined during loading or error so callers can distinguish from a genuine zero.
-        const settledTokenTotal =
-          isAggregatedBalanceLoading || isBalanceFetchError
-            ? undefined
-            : musdDecimal.plus(musdSHFvdDecimal);
-        return {
-          musdFiat: undefined,
-          musdSHFvdFiat: undefined,
-          tokenTotal: settledTokenTotal,
-          // A zero balance is $0.00 regardless of the missing rate — 0 tokens
-          // convert to 0 fiat without one. Only a non-zero balance is genuinely
-          // unavailable when there's no rate to convert it.
-          totalFiat: settledTokenTotal?.isZero() ? new BigNumber(0) : undefined,
-          withdrawableMusd: computedWithdrawableMusd,
-        };
-      }
+    const computedTokenTotal =
+      isBalanceLoading || isBalanceFetchError ? undefined : totalDecimal;
 
-      const computedMusdFiat = musdDecimal.times(musdFiatRate);
-      const computedMusdSHFvdFiat = musdSHFvdDecimal.times(musdFiatRate);
+    if (!musdFiatRate) {
+      // Undefined during loading or error so callers can distinguish from a genuine zero.
+      const settledTokenTotal =
+        isBalanceLoading || isBalanceFetchError ? undefined : totalDecimal;
 
       return {
-        musdFiat: computedMusdFiat,
-        musdSHFvdFiat: computedMusdSHFvdFiat,
-        // Undefined during loading or error so callers can distinguish from a genuine zero.
-        tokenTotal:
-          isAggregatedBalanceLoading || isBalanceFetchError
-            ? undefined
-            : musdDecimal.plus(musdSHFvdDecimal),
-        // Both fiat values share musdFiatRate as their sole dependency — computing
-        // them inside this guard means no null assertions are needed.
-        totalFiat: isBalanceFetchError
-          ? undefined
-          : computedMusdFiat.plus(computedMusdSHFvdFiat),
+        musdFiat: undefined,
+        musdSHFvdFiat: undefined,
+        tokenTotal: settledTokenTotal,
+        // A zero balance is $0.00 regardless of the missing rate — 0 tokens
+        // convert to 0 fiat without one. Only a non-zero balance is genuinely
+        // unavailable when there's no rate to convert it.
+        totalFiat: settledTokenTotal?.isZero() ? new BigNumber(0) : undefined,
         withdrawableMusd: computedWithdrawableMusd,
       };
-    }, [
-      isAggregatedBalanceLoading,
-      isBalanceFetchError,
-      musdBalanceQuery.data,
-      musdEquivalentBalanceQuery.data,
-      musdFiatRate,
-    ]);
+    }
 
-  const musdFiatFormatted =
-    !isBalanceFetchError && musdFiat
-      ? moneyFormatFiat(musdFiat, currentCurrency)
-      : undefined;
-  const musdSHFvdFiatFormatted =
-    !isBalanceFetchError && musdSHFvdFiat
-      ? moneyFormatFiat(musdSHFvdFiat, currentCurrency)
-      : undefined;
+    return {
+      tokenTotal: computedTokenTotal,
+      totalFiat: isBalanceFetchError
+        ? undefined
+        : totalDecimal.times(musdFiatRate),
+      withdrawableMusd: computedWithdrawableMusd,
+    };
+  }, [
+    isBalanceLoading,
+    isBalanceFetchError,
+    moneyBalanceQuery.data,
+    musdFiatRate,
+  ]);
+
   const totalFiatFormatted =
     !isBalanceFetchError && totalFiat
       ? moneyFormatFiat(totalFiat, currentCurrency)
       : undefined;
+
   const totalFiatRaw =
     !isBalanceFetchError && totalFiat ? totalFiat.toString() : undefined;
 
@@ -240,7 +198,7 @@ const useMoneyAccountBalance = (
     if (
       moneyAccountAddress &&
       !isBalanceFetchError &&
-      !isAggregatedBalanceLoading &&
+      !isBalanceLoading &&
       totalFiatFormatted !== undefined
     ) {
       dispatch(
@@ -256,9 +214,9 @@ const useMoneyAccountBalance = (
     dispatch,
     moneyAccountAddress,
     isBalanceFetchError,
-    isAggregatedBalanceLoading,
     totalFiatFormatted,
     currentCurrency,
+    isBalanceLoading,
   ]);
 
   // True whenever there is no fresh balance to show — still loading, a fetch
@@ -282,17 +240,14 @@ const useMoneyAccountBalance = (
     apyPercent !== undefined ? `${apyPercent}%` : undefined;
 
   return {
-    musdBalanceQuery,
+    moneyBalanceQuery,
     vaultApyQuery,
-    musdEquivalentBalanceQuery,
-    isAggregatedBalanceLoading,
+    isBalanceLoading,
     isBalanceFetchError,
     isBalanceFetching,
     isBalanceUnavailable,
     lastKnownTotalFiatFormatted,
     refetchBalance,
-    musdFiatFormatted,
-    musdSHFvdFiatFormatted,
     tokenTotal,
     totalFiatFormatted,
     totalFiatRaw,

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -31,6 +31,7 @@ import {
 } from '../../../../core/redux/slices/moneyBalance';
 
 const DEFAULT_REFETCH_INTERVAL = 30 * 1000; // 30 seconds
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
 // TODO: Remove __DEV__ values before launch. This is temporary to circumvent the Vault's current 0% APY.
 const DEV_APY = {
@@ -73,7 +74,7 @@ const useMoneyAccountBalance = (
 
   const vaultApyQuery = useQuery({
     queryKey: [MoneyAccountBalanceServiceQueryKeys.GET_VAULT_APY],
-    refetchInterval: 10 * 60 * 1000, // 5 minutes
+    refetchInterval: FIVE_MINUTES_MS,
   }) as UseQueryResult<NormalizedVaultApyResponse>;
 
   const musdFiatRate = useMemo(() => {

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -8,7 +8,6 @@ import { useQuery } from '@metamask/react-data-query';
 import type { UseQueryResult } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { fromTokenMinimalUnitString } from '../../../../util/number';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
 import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
 import {
@@ -125,23 +124,17 @@ const useMoneyAccountBalance = (
   );
 
   const { tokenTotal, totalFiat, withdrawableMusd } = useMemo(() => {
-    // Total balance (mUSD + vmUSD in mUSD terms) from the service's Multicall3 response.
+    // Total balance (mUSD + vmUSD) from the service's Multicall3 response.
     const totalDecimal = moneyBalanceQuery.data?.totalBalance
-      ? new BigNumber(
-          fromTokenMinimalUnitString(
-            moneyBalanceQuery.data.totalBalance,
-            MUSD_DECIMALS,
-          ),
+      ? new BigNumber(moneyBalanceQuery.data.totalBalance).shiftedBy(
+          -MUSD_DECIMALS,
         )
       : new BigNumber(0);
 
-    // vmUSD balance expressed in mUSD — the withdrawable amount.
+    // the withdrawable amount.
     const vmusdDecimal = moneyBalanceQuery.data?.vmusdValueInMusd
-      ? new BigNumber(
-          fromTokenMinimalUnitString(
-            moneyBalanceQuery.data.vmusdValueInMusd,
-            MUSD_DECIMALS,
-          ),
+      ? new BigNumber(moneyBalanceQuery.data.vmusdValueInMusd).shiftedBy(
+          -MUSD_DECIMALS,
         )
       : new BigNumber(0);
 

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -83,14 +83,15 @@ const getConfirmedHandler = (): TransactionConfirmedHandler => {
 beforeEach(() => {
   jest.clearAllMocks();
   let readCount = 0;
-  mockGetQueryData.mockImplementation((queryKey: [string]) => {
-    const phase = readCount < 2 ? 'baseline' : 'next';
+  mockGetQueryData.mockImplementation(() => {
+    const phase = readCount < 1 ? 'baseline' : 'next';
     readCount += 1;
 
-    if (queryKey[0] === MoneyAccountBalanceServiceQueryKeys.GET_MUSD_BALANCE) {
-      return { balance: phase === 'baseline' ? '1000000' : '1100000' };
-    }
-    return { balanceOfInAssets: phase === 'baseline' ? '2000000' : '2100000' };
+    return {
+      musdBalance: phase === 'baseline' ? '1000000' : '1100000',
+      vmusdValueInMusd: phase === 'baseline' ? '2000000' : '2100000',
+      totalBalance: phase === 'baseline' ? '3000000' : '3200000',
+    };
   });
 
   mockSelectPrimaryMoneyAccount.mockReturnValue({
@@ -116,41 +117,34 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
     );
   });
 
-  it('invalidates both balance queries on confirmed deposit tx', async () => {
+  it('invalidates the balance query on confirmed deposit tx', async () => {
     renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
     const handler = getConfirmedHandler();
 
     handler(makeTx(TransactionType.moneyAccountDeposit));
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
     });
 
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
       queryKey: [
-        MoneyAccountBalanceServiceQueryKeys.GET_MUSD_BALANCE,
-        MOCK_ADDRESS,
-      ],
-      refetchType: 'all',
-    });
-    expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: [
-        MoneyAccountBalanceServiceQueryKeys.GET_MUSD_EQUIVALENT_VALUE,
+        MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
         MOCK_ADDRESS,
       ],
       refetchType: 'all',
     });
   });
 
-  it('invalidates both balance queries on confirmed withdraw tx', async () => {
+  it('invalidates the balance query on confirmed withdraw tx', async () => {
     renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
     const handler = getConfirmedHandler();
 
     handler(makeTx(TransactionType.moneyAccountWithdraw));
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
   });
 
   it('invalidates on confirmed tx with nested deposit', async () => {
@@ -163,10 +157,10 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
       ]),
     );
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
   });
 
   it('invalidates on confirmed tx with nested withdraw', async () => {
@@ -179,10 +173,10 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
       ]),
     );
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
   });
 
   it('does not invalidate for non-confirmed status', () => {
@@ -227,9 +221,9 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
 
     handler(makeTx(TransactionType.moneyAccountDeposit));
     await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -3,6 +3,7 @@ import {
   TransactionStatus,
 } from '@metamask/transaction-controller';
 import { useEffect } from 'react';
+import type { MoneyAccountBalanceResponse } from '@metamask/money-account-balance-service';
 import Engine from '../../../../core/Engine';
 import ReactQueryService from '../../../../core/ReactQueryService';
 import { store } from '../../../../store';
@@ -18,45 +19,30 @@ const MAX_RETRIES = 4;
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 4000;
 
-type MusdBalanceSnapshot = { balance: string } | undefined;
-type MusdEquivalentSnapshot = { balanceOfInAssets: string } | undefined;
+type MoneyBalanceSnapshot = MoneyAccountBalanceResponse | undefined;
 
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-const readBalanceSnapshot = (address: string) => ({
-  musd: ReactQueryService.queryClient.getQueryData<MusdBalanceSnapshot>([
-    MoneyAccountBalanceServiceQueryKeys.GET_MUSD_BALANCE,
+const readBalanceSnapshot = (address: string) =>
+  ReactQueryService.queryClient.getQueryData<MoneyBalanceSnapshot>([
+    MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
     address,
-  ]),
-  equivalent:
-    ReactQueryService.queryClient.getQueryData<MusdEquivalentSnapshot>([
-      MoneyAccountBalanceServiceQueryKeys.GET_MUSD_EQUIVALENT_VALUE,
-      address,
-    ]),
-});
+  ]);
 
 const didBalanceChange = (
-  before: ReturnType<typeof readBalanceSnapshot>,
-  after: ReturnType<typeof readBalanceSnapshot>,
-) =>
-  before.musd?.balance !== after.musd?.balance ||
-  before.equivalent?.balanceOfInAssets !== after.equivalent?.balanceOfInAssets;
+  before: MoneyBalanceSnapshot,
+  after: MoneyBalanceSnapshot,
+) => before?.totalBalance !== after?.totalBalance;
 
 const invalidateBalanceQueries = async (address: string) =>
-  Promise.all([
-    ReactQueryService.queryClient.invalidateQueries({
-      queryKey: [MoneyAccountBalanceServiceQueryKeys.GET_MUSD_BALANCE, address],
-      refetchType: 'all',
-    }),
-    ReactQueryService.queryClient.invalidateQueries({
-      queryKey: [
-        MoneyAccountBalanceServiceQueryKeys.GET_MUSD_EQUIVALENT_VALUE,
-        address,
-      ],
-      refetchType: 'all',
-    }),
-  ]);
+  ReactQueryService.queryClient.invalidateQueries({
+    queryKey: [
+      MoneyAccountBalanceServiceQueryKeys.GET_MONEY_ACCOUNT_BALANCE,
+      address,
+    ],
+    refetchType: 'all',
+  });
 
 /**
  * Capture the pre-invalidation cached snapshot as a baseline, then invalidate +

--- a/app/components/UI/Money/queryKeys.ts
+++ b/app/components/UI/Money/queryKeys.ts
@@ -2,9 +2,10 @@ import { MoneyAccountBalanceService } from '@metamask/money-account-balance-serv
 
 export const MoneyAccountBalanceServiceQueryKeys = {
   GET_MUSD_BALANCE: `${MoneyAccountBalanceService.name}:getMusdBalance`,
-  GET_MUSDSHFVD_BALANCE: `${MoneyAccountBalanceService.name}:getMusdSHFvdBalance`,
+  GET_VMUSD_BALANCE: `${MoneyAccountBalanceService.name}:getVmusdBalance`,
   GET_VAULT_APY: `${MoneyAccountBalanceService.name}:getVaultApy`,
-  /** Internally, this helper fetches the musdSHFvd balance and exchange rate */
+  /** Internally, this helper fetches the vmUSD balance and exchange rate */
   GET_MUSD_EQUIVALENT_VALUE: `${MoneyAccountBalanceService.name}:getMusdEquivalentValue`,
   GET_EXCHANGE_RATE: `${MoneyAccountBalanceService.name}:getExchangeRate`,
+  GET_MONEY_ACCOUNT_BALANCE: `${MoneyAccountBalanceService.name}:getMoneyAccountBalance`,
 } as const;

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -732,7 +732,7 @@ describe('useTransactionCustomAmount', () => {
     it('does NOT set isMaxAmount=true for money account withdraw when Max is pressed', async () => {
       // Same class of bug as perps: isMaxAmount=true makes TPC use on-chain
       // token.balanceRaw (mUSD only) instead of the typed aggregate (mUSD +
-      // musdSHFvd).
+      // vmUSD).
       useTokenFiatRateMock.mockReturnValue(1);
       useMoneyAccountBalanceMock.mockReturnValue({
         withdrawableMusd: new BigNumber(500),

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -204,7 +204,7 @@ export function useTransactionCustomAmount({
       // calculatePostQuoteSourceAmounts substitutes `token.balanceRaw` when
       // isMaxAmount is true: wrong for HyperLiquid (wallet USDC vs typed HL
       // balance) and wrong for money account (on-chain mUSD only vs mUSD +
-      // musdSHFvd fiat total). Keeping isMaxAmount false routes the typed
+      // vmUSD fiat total). Keeping isMaxAmount false routes the typed
       // amount through as token.amountRaw.
       const shouldSetMax =
         percentage === 100 && !isPerpsWithdraw && !isMoneyAccountWithdraw;

--- a/app/core/Engine/messengers/perps-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/perps-controller-messenger/index.ts
@@ -31,6 +31,8 @@ export function getPerpsControllerMessenger(
     namespace: 'PerpsController',
     parent: rootExtendedMessenger,
   });
+  // PerpsController's 98-member action union intersected with GlobalActions exceeds TS's type complexity limit
+  // @ts-expect-error TS2590
   rootExtendedMessenger.delegate({
     actions: [
       'GeolocationController:getGeolocation',

--- a/app/core/Engine/messengers/perps-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/perps-controller-messenger/index.ts
@@ -31,8 +31,6 @@ export function getPerpsControllerMessenger(
     namespace: 'PerpsController',
     parent: rootExtendedMessenger,
   });
-  // PerpsController's 98-member action union intersected with GlobalActions exceeds TS's type complexity limit
-  // @ts-expect-error TS2590
   rootExtendedMessenger.delegate({
     actions: [
       'GeolocationController:getGeolocation',

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-balance-service": "^1.0.0",
+    "@metamask/money-account-balance-service": "^2.0.0",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.0.5",
     "@metamask/multichain-account-service": "^10.0.2",
@@ -553,12 +553,6 @@
     "valid-url": "1.0.9",
     "viem": "^2.28.0",
     "vm-browserify": "1.1.2"
-  },
-  "previewBuilds": {
-    "@metamask/money-account-balance-service": {
-      "type": "breaking",
-      "previewVersion": "1.0.2-preview-1b0db3500"
-    }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-balance-service": "^1.0.0",
+    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.0.5",
     "@metamask/multichain-account-service": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "@metamask/metamask-eth-abis": "3.1.1",
     "@metamask/mobile-wallet-protocol-core": "^0.4.0",
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
-    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service",
+    "@metamask/money-account-balance-service": "^1.0.0",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^2.0.5",
     "@metamask/multichain-account-service": "^10.0.2",
@@ -553,6 +553,12 @@
     "valid-url": "1.0.9",
     "viem": "^2.28.0",
     "vm-browserify": "1.1.2"
+  },
+  "previewBuilds": {
+    "@metamask/money-account-balance-service": {
+      "type": "breaking",
+      "previewVersion": "1.0.2-preview-1b0db3500"
+    }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9216,9 +9216,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-balance-service@npm:@metamask-previews/money-account-balance-service@1.0.2-preview-1b0db3500":
-  version: 1.0.2-preview-1b0db3500
-  resolution: "@metamask-previews/money-account-balance-service@npm:1.0.2-preview-1b0db3500"
+"@metamask/money-account-balance-service@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/money-account-balance-service@npm:2.0.0"
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
@@ -9230,7 +9230,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/a9d478855792ffe79e0982bcb03033e9c725f3dcf21dc0087428336aa2f9fc88296f636e28895ea1288a6a43573d1bb880d5c84278001ff3b460fa0def0d2ed2
+  checksum: 10/47c66554d975250d8de73287d7eb35fb3c3d57de53514902ec5801482f20c12e69c8ebc2910996a3c97c73d5acdc403660e53b755aff88a7877a3979f6cc9544
   languageName: node
   linkType: hard
 
@@ -35350,7 +35350,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-balance-service": "npm:^1.0.0"
+    "@metamask/money-account-balance-service": "npm:^2.0.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.0.5"
     "@metamask/multichain-account-service": "npm:^10.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9216,21 +9216,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-balance-service@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/money-account-balance-service@npm:1.0.0"
+"@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service::locator=metamask%40workspace%3A.":
+  version: 1.0.2
+  resolution: "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service#.yalc/@metamask/money-account-balance-service::hash=acbc75&locator=metamask%40workspace%3A."
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/base-data-service": "npm:^0.1.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/base-data-service": "npm:^0.1.3"
+    "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^30.1.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-  checksum: 10/d6b9c863bfe21ad6ccce01434d97be3d6667b2ff686fe6ecfe7a592024b270b78ee3358419d570438f9f5a5bc6df56b776bcfdef2c85e1ecc35a668ed2bf484e
+    "@metamask/utils": "npm:^11.11.0"
+  checksum: 10/7f8304e21bf4109226f9dc4a354e3fc4fe9bcfb88e65f4b9964a0dd97144caa05a567ae305715b1d4c41a613a870776fe93b57a9544ff43b618de2a61dc7fcb7
   languageName: node
   linkType: hard
 
@@ -9815,7 +9815,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/remote-feature-flag-controller@npm:^4.2.0, @metamask/remote-feature-flag-controller@npm:^4.2.1, @metamask/remote-feature-flag-controller@npm:^4.2.2":
+"@metamask/remote-feature-flag-controller@npm:^4.2.1, @metamask/remote-feature-flag-controller@npm:^4.2.2":
   version: 4.2.2
   resolution: "@metamask/remote-feature-flag-controller@npm:4.2.2"
   dependencies:
@@ -35350,7 +35350,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-balance-service": "npm:^1.0.0"
+    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.0.5"
     "@metamask/multichain-account-service": "npm:^10.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9216,9 +9216,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service::locator=metamask%40workspace%3A.":
-  version: 1.0.2
-  resolution: "@metamask/money-account-balance-service@file:.yalc/@metamask/money-account-balance-service#.yalc/@metamask/money-account-balance-service::hash=acbc75&locator=metamask%40workspace%3A."
+"@metamask/money-account-balance-service@npm:@metamask-previews/money-account-balance-service@1.0.2-preview-1b0db3500":
+  version: 1.0.2-preview-1b0db3500
+  resolution: "@metamask-previews/money-account-balance-service@npm:1.0.2-preview-1b0db3500"
   dependencies:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
@@ -9230,7 +9230,7 @@ __metadata:
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/7f8304e21bf4109226f9dc4a354e3fc4fe9bcfb88e65f4b9964a0dd97144caa05a567ae305715b1d4c41a613a870776fe93b57a9544ff43b618de2a61dc7fcb7
+  checksum: 10/a9d478855792ffe79e0982bcb03033e9c725f3dcf21dc0087428336aa2f9fc88296f636e28895ea1288a6a43573d1bb880d5c84278001ff3b460fa0def0d2ed2
   languageName: node
   linkType: hard
 
@@ -35350,7 +35350,7 @@ __metadata:
     "@metamask/mobile-provider": "npm:^3.0.0"
     "@metamask/mobile-wallet-protocol-core": "npm:^0.4.0"
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
-    "@metamask/money-account-balance-service": "file:.yalc/@metamask/money-account-balance-service"
+    "@metamask/money-account-balance-service": "npm:^1.0.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^2.0.5"
     "@metamask/multichain-account-service": "npm:^10.0.2"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Replaces the three separate `useQueries` calls (mUSD balance, vmUSD equivalent, vault APY) with a single `useQuery` backed by the new `MoneyAccountBalanceService:getMoneyAccountBalance` multicall method. This batches the on-chain reads into one RPC round-trip, cutting latency and simplifying the data flow.

Key changes:
- `useMoneyAccountBalance` now consumes `@metamask/react-data-query`'s `useQuery` instead of `@tanstack/react-query`'s `useQueries`
- Removed unused `musdFiatFormatted` / `musdSHFvdFiatFormatted` variables from `useMoneyAccountBalance`
- Renamed`isAggregatedBalanceLoading` to `isBalanceLoading` in `useMoneyAccountBalance`
- Fix broken refresh on pull-down in Money Home.
- `useRefreshMoneyBalanceOnTxConfirm` updated to use the consolidated query key and compare `totalBalance` snapshots
- Bumped `@metamask/money-account-balance-service` dependency

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor useMoneyAccountBalance to support latest version of money-account-balance-service

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-943](https://consensyssoftware.atlassian.net/browse/MUSD-943)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account balance display

  Scenario: User sees their total balance on the Money home screen
    Given the user has a Money account with mUSD and/or vmUSD holdings
    When the user navigates to the Money home screen
    Then the total fiat balance displays correctly

  Scenario: Balance refreshes after a confirmed transaction
    Given the user is on the Money home screen
    When a Money-related transaction confirms on-chain
    Then the balance updates to reflect the new total

  Scenario: Money APY refreshes when cache becomes stale
    Given the app has been open for ~5 mins
    When the user visits Money Home
    Then the APY is still visible
    And loading skeletons are not visible in the APY row of balance and on "Earn on your crypto" section
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A
### **After**

<!-- [screenshots/recordings] -->
N/A - Optimizations have same user-facing appearance
## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-943]: https://consensyssoftware.atlassian.net/browse/MUSD-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Money balance, loading/error UI, withdraw max-amount behavior, and post-tx refresh; behavior should match prior totals but depends on the new balance-service preview API.
> 
> **Overview**
> **Consolidates Money account on-chain balance reads** into one `MoneyAccountBalanceService:getMoneyAccountBalance` query (via `@metamask/react-data-query` `useQuery`) instead of separate mUSD and vmUSD equivalent queries, with vault APY still on its own query and a **5-minute** refetch interval.
> 
> `useMoneyAccountBalance` now derives totals from `moneyBalanceQuery` (`totalBalance`, `vmusdValueInMusd`), drops per-component **`musdFiatFormatted` / `musdSHFvdFiatFormatted`**, renames **`isAggregatedBalanceLoading` → `isBalanceLoading`**, and **pull-to-refresh / manual refetch** invalidates the single balance query key. Post-tx refresh (`useRefreshMoneyBalanceOnTxConfirm`) invalidates once and compares **`totalBalance`** snapshots.
> 
> Money Home, balance card, onboarding, and related tests are updated for the new hook shape; **`@metamask/money-account-balance-service`** is pinned to a **preview** build until release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0bcec64464991b1589a8f5b200bfd96b45cbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->