### PR TITLE
test: add deeplink E2E tests

### DIFF
--- a/tests/smoke/deeplinks/deeplink-navigation.spec.ts
+++ b/tests/smoke/deeplinks/deeplink-navigation.spec.ts
@@ -1,0 +1,63 @@
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import { loginToApp } from '../../flows/wallet.flow';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { SmokeWalletPlatform } from '../../tags';
+import Assertions from '../../framework/Assertions';
+import QuoteView from '../../page-objects/swaps/QuoteView';
+import DeeplinkModal from '../../page-objects/swaps/Deeplink';
+import WalletView from '../../page-objects/wallet/WalletView';
+
+const SWAP_DEEPLINK = 'metamask://swap';
+const SEND_DEEPLINK =
+  'metamask://send/0x0000000000000000000000000000000000000000@1?value=0';
+const HOME_DEEPLINK = 'metamask://home';
+const NFT_DEEPLINK = 'metamask://nft';
+
+describe(SmokeWalletPlatform('Deeplink Navigation'), () => {
+  beforeEach(async () => {
+    jest.setTimeout(150000);
+  });
+
+  it('opens various screens via deeplinks', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+      },
+      async () => {
+        await loginToApp();
+
+        // Verify swap deeplink
+        await device.openURL({ url: SWAP_DEEPLINK });
+        await Assertions.expectElementToBeVisible(QuoteView.sourceTokenArea, {
+          timeout: 20000,
+          description: 'Swap quote view opens after swap deeplink',
+        });
+
+        // Verify send deeplink
+        await device.openURL({ url: SEND_DEEPLINK });
+        await DeeplinkModal.tapContinue();
+        await Assertions.expectTextDisplayed('Sending', {
+          timeout: 20000,
+          description: 'Send confirmation view opens after send deeplink',
+        });
+
+        // Verify home deeplink
+        await device.openURL({ url: HOME_DEEPLINK });
+        await DeeplinkModal.tapContinue();
+        await Assertions.expectElementToBeVisible(WalletView.container, {
+          timeout: 20000,
+          description: 'Wallet home opens after home deeplink',
+        });
+
+        // Verify NFT deeplink
+        await device.openURL({ url: NFT_DEEPLINK });
+        await DeeplinkModal.tapContinue();
+        await Assertions.expectTextDisplayed('NFTs', {
+          timeout: 20000,
+          description: 'NFT full view opens after nft deeplink',
+        });
+      },
+    );
+  });
+});

--- a/tests/smoke/deeplinks/deeplink-navigation.spec.ts
+++ b/tests/smoke/deeplinks/deeplink-navigation.spec.ts
@@ -5,12 +5,18 @@ import { SmokeWalletPlatform } from '../../tags';
 import Assertions from '../../framework/Assertions';
 import QuoteView from '../../page-objects/swaps/QuoteView';
 import DeeplinkModal from '../../page-objects/swaps/Deeplink';
-import WalletView from '../../page-objects/wallet/WalletView';
+import NetworkListModal from '../../page-objects/Network/NetworkListModal';
+import { testSpecificMock } from '../../helpers/swap/swap-mocks';
 
-const SWAP_DEEPLINK = 'metamask://swap';
+// Swap 1 USDC → ETH on Ethereum mainnet (1000000 = 1 USDC in atomic units)
+// Address must be checksummed to match the mock server URL pattern
+const SWAP_DEEPLINK =
+  'metamask://swap?from=eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&to=eip155:1/slip44:60&amount=1000000';
+// Send 3 ETH to zero address on mainnet (chainId=1, value in wei)
 const SEND_DEEPLINK =
-  'metamask://send/0x0000000000000000000000000000000000000000@1?value=0';
-const HOME_DEEPLINK = 'metamask://home';
+  'metamask://send/0x0000000000000000000000000000000000000000@1?value=3e18';
+// Navigate home and auto-open the network selector
+const HOME_DEEPLINK = 'metamask://home?openNetworkSelector=true';
 const NFT_DEEPLINK = 'metamask://nft';
 
 describe(SmokeWalletPlatform('Deeplink Navigation'), () => {
@@ -18,37 +24,50 @@ describe(SmokeWalletPlatform('Deeplink Navigation'), () => {
     jest.setTimeout(150000);
   });
 
-  it('opens various screens via deeplinks', async () => {
+  it('opens various screens via deeplinks with correct parameters', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder().build(),
         restartDevice: true,
+        testSpecificMock,
       },
       async () => {
         await loginToApp();
 
-        // Verify swap deeplink
+        // Verify swap deeplink pre-fills USDC as source token
         await device.openURL({ url: SWAP_DEEPLINK });
         await Assertions.expectElementToBeVisible(QuoteView.sourceTokenArea, {
           timeout: 20000,
           description: 'Swap quote view opens after swap deeplink',
         });
+        await Assertions.expectTextDisplayed('USDC', {
+          timeout: 10000,
+          description: 'Source token USDC is pre-filled from deeplink params',
+        });
 
-        // Verify send deeplink
+        // Verify send deeplink shows correct amount
         await device.openURL({ url: SEND_DEEPLINK });
         await DeeplinkModal.tapContinue();
         await Assertions.expectTextDisplayed('Sending', {
           timeout: 20000,
           description: 'Send confirmation view opens after send deeplink',
         });
+        await Assertions.expectTextDisplayed('3 ETH', {
+          timeout: 10000,
+          description: 'Send amount 3 ETH matches deeplink value param',
+        });
 
-        // Verify home deeplink
+        // Verify home deeplink opens wallet with network selector
         await device.openURL({ url: HOME_DEEPLINK });
         await DeeplinkModal.tapContinue();
-        await Assertions.expectElementToBeVisible(WalletView.container, {
-          timeout: 20000,
-          description: 'Wallet home opens after home deeplink',
-        });
+        await Assertions.expectElementToBeVisible(
+          NetworkListModal.selectNetwork,
+          {
+            timeout: 20000,
+            description:
+              'Network selector opens from home deeplink openNetworkSelector param',
+          },
+        );
 
         // Verify NFT deeplink
         await device.openURL({ url: NFT_DEEPLINK });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds a E2E smoke test under tests/smoke/deeplinks/ that validates 4 deeplink routes (swap, send, home, nft) in a single test

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modifications.
> 
> **Overview**
> Adds a new smoke E2E spec at `tests/smoke/deeplinks/deeplink-navigation.spec.ts` that exercises four `metamask://` routes in one flow after login.
> 
> The test opens swap, send, home (with `openNetworkSelector=true`), and NFT deeplinks via `device.openURL`, dismisses the deeplink confirmation where needed, and asserts the right UI (swap quote with **USDC**, send flow showing **3 ETH**, network selector, NFTs screen). Swap coverage uses `testSpecificMock` and a 150s Jest timeout with `restartDevice: true`, matching other smoke tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d65159650948f40bbc19da7a0d4b9f84951bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->