### PR TITLE
fix: make saving state logs to a file on Android more performant

### DIFF
--- a/app/util/logs/index.test.ts
+++ b/app/util/logs/index.test.ts
@@ -781,14 +781,18 @@ describe('logs :: downloadStateLogs', () => {
       subject: 'TestApp State logs -  v1.0.0 (100)',
       title: 'TestApp State logs -  v1.0.0 (100)',
       url: '/mock/path/state-logs-v1.0.0-(100).json',
+      filename: 'state-logs-v1.0.0-(100).json',
+      type: 'application/json',
+      failOnCancel: false,
     });
   });
 
-  it('generates and shares logs on Android', async () => {
+  it('generates and shares logs as a file on Android', async () => {
     (getApplicationName as jest.Mock).mockResolvedValue('TestApp');
     (getVersion as jest.Mock).mockResolvedValue('1.0.0');
     (getBuildNumber as jest.Mock).mockResolvedValue('100');
     (Device.isIos as jest.Mock).mockReturnValue(false);
+    (Device.isAndroid as jest.Mock).mockReturnValue(true);
 
     const mockStateInput = merge({}, initialRootState, {
       engine: {
@@ -803,11 +807,20 @@ describe('logs :: downloadStateLogs', () => {
 
     await downloadStateLogs(mockStateInput);
 
-    expect(RNFS.writeFile).not.toHaveBeenCalled();
+    // The logs are written to disk and the real file is shared, so that the
+    // Android share sheet offers a save/download option (issue #24359).
+    expect(RNFS.writeFile).toHaveBeenCalledWith(
+      '/mock/path/state-logs-v1.0.0-(100).json',
+      expect.any(String),
+      'utf8',
+    );
     expect(Share.open).toHaveBeenCalledWith({
       subject: 'TestApp State logs -  v1.0.0 (100)',
       title: 'TestApp State logs -  v1.0.0 (100)',
-      url: expect.stringContaining('data:text/plain;base64,'),
+      url: '/mock/path/state-logs-v1.0.0-(100).json',
+      filename: 'state-logs-v1.0.0-(100).json',
+      type: 'application/json',
+      failOnCancel: false,
     });
   });
 
@@ -901,11 +914,9 @@ describe('logs :: downloadStateLogs', () => {
 
     await downloadStateLogs(mockStateInput, false);
 
-    expect(Share.open).toHaveBeenCalledWith({
-      subject: 'TestApp State logs -  v1.0.0 (100)',
-      title: 'TestApp State logs -  v1.0.0 (100)',
-      url: expect.stringContaining('data:text/plain;base64,'),
-    });
+    const [, writtenContent] = (RNFS.writeFile as jest.Mock).mock.calls[0];
+    const jsonData = JSON.parse(writtenContent);
+    expect(jsonData.loggedIn).toBe(false);
   });
 
   it('includes analytics id in logs when analytics is enabled', async () => {
@@ -930,12 +941,8 @@ describe('logs :: downloadStateLogs', () => {
 
     expect(analytics.getAnalyticsId).toHaveBeenCalled();
 
-    const shareOpenCalls = (Share.open as jest.Mock).mock.calls;
-    const [shareOpenArgs] = shareOpenCalls[0];
-    const { url } = shareOpenArgs;
-    const base64Data = url.replace('data:text/plain;base64,', '');
-    const decodedData = Buffer.from(base64Data, 'base64').toString('utf-8');
-    const jsonData = JSON.parse(decodedData);
+    const [, writtenContent] = (RNFS.writeFile as jest.Mock).mock.calls[0];
+    const jsonData = JSON.parse(writtenContent);
     expect(jsonData.metaMetricsId).toBe('test-analytics-id');
   });
 
@@ -959,20 +966,10 @@ describe('logs :: downloadStateLogs', () => {
 
     await downloadStateLogs(mockStateInput);
 
-    expect(Share.open).toHaveBeenCalledWith({
-      subject: 'TestApp State logs -  v1.0.0 (100)',
-      title: 'TestApp State logs -  v1.0.0 (100)',
-      url: expect.stringContaining('data:text/plain;base64,'),
-    });
-
-    // Access the arguments passed to Share.open
-    const shareOpenCalls = (Share.open as jest.Mock).mock.calls;
-    expect(shareOpenCalls.length).toBeGreaterThan(0);
-    const [shareOpenArgs] = shareOpenCalls[0];
-    const { url } = shareOpenArgs;
-    const base64Data = url.replace('data:text/plain;base64,', '');
-    const decodedData = Buffer.from(base64Data, 'base64').toString('utf-8');
-    const jsonData = JSON.parse(decodedData);
+    const writeFileCalls = (RNFS.writeFile as jest.Mock).mock.calls;
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    const [, writtenContent] = writeFileCalls[0];
+    const jsonData = JSON.parse(writtenContent);
     expect(jsonData).not.toHaveProperty('metaMetricsId');
   });
 
@@ -998,13 +995,10 @@ describe('logs :: downloadStateLogs', () => {
     await downloadStateLogs(mockStateInput);
 
     // Then the logs should include the remote feature flag environment
-    const shareOpenCalls = (Share.open as jest.Mock).mock.calls;
-    expect(shareOpenCalls.length).toBeGreaterThan(0);
-    const [shareOpenArgs] = shareOpenCalls[0];
-    const { url } = shareOpenArgs;
-    const base64Data = url.replace('data:text/plain;base64,', '');
-    const decodedData = Buffer.from(base64Data, 'base64').toString('utf-8');
-    const jsonData = JSON.parse(decodedData);
+    const writeFileCalls = (RNFS.writeFile as jest.Mock).mock.calls;
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    const [, writtenContent] = writeFileCalls[0];
+    const jsonData = JSON.parse(writtenContent);
     expect(jsonData.remoteFeatureFlagEnvironment).toBe('Development');
   });
 
@@ -1030,13 +1024,10 @@ describe('logs :: downloadStateLogs', () => {
     await downloadStateLogs(mockStateInput);
 
     // Then the logs should include the remote feature flag distribution
-    const shareOpenCalls = (Share.open as jest.Mock).mock.calls;
-    expect(shareOpenCalls.length).toBeGreaterThan(0);
-    const [shareOpenArgs] = shareOpenCalls[0];
-    const { url } = shareOpenArgs;
-    const base64Data = url.replace('data:text/plain;base64,', '');
-    const decodedData = Buffer.from(base64Data, 'base64').toString('utf-8');
-    const jsonData = JSON.parse(decodedData);
+    const writeFileCalls = (RNFS.writeFile as jest.Mock).mock.calls;
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    const [, writtenContent] = writeFileCalls[0];
+    const jsonData = JSON.parse(writtenContent);
     expect(jsonData.remoteFeatureFlagDistribution).toBe('Main');
   });
 
@@ -1059,13 +1050,10 @@ describe('logs :: downloadStateLogs', () => {
 
     await downloadStateLogs(mockStateInput);
 
-    const shareOpenCalls = (Share.open as jest.Mock).mock.calls;
-    expect(shareOpenCalls.length).toBeGreaterThan(0);
-    const [shareOpenArgs] = shareOpenCalls[0];
-    const { url } = shareOpenArgs;
-    const base64Data = url.replace('data:text/plain;base64,', '');
-    const decodedData = Buffer.from(base64Data, 'base64').toString('utf-8');
-    const jsonData = JSON.parse(decodedData);
+    const writeFileCalls = (RNFS.writeFile as jest.Mock).mock.calls;
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    const [, writtenContent] = writeFileCalls[0];
+    const jsonData = JSON.parse(writtenContent);
     expect(jsonData.otaVersion).toBeDefined();
     expect(jsonData.runtimeVersion).toBeDefined();
   });

--- a/app/util/logs/index.ts
+++ b/app/util/logs/index.ts
@@ -6,11 +6,8 @@ import {
 } from 'react-native-device-info';
 import Share from 'react-native-share'; // eslint-disable-line  import-x/default
 import RNFS from 'react-native-fs';
-// eslint-disable-next-line import-x/no-nodejs-modules
-import { Buffer } from 'buffer';
 import Logger from '../../util/Logger';
 import { RootState } from '../../reducers';
-import Device from '../../util/device';
 import { analytics } from '../analytics/analytics';
 import {
   getFeatureFlagAppDistribution,
@@ -140,9 +137,8 @@ export const downloadStateLogs = async (
   const metaMetricsId = analytics.isEnabled()
     ? await analytics.getAnalyticsId()
     : undefined;
-  const path =
-    RNFS.DocumentDirectoryPath +
-    `/state-logs-v${appVersion}-(${buildNumber}).json`;
+  const filename = `state-logs-v${appVersion}-(${buildNumber}).json`;
+  const path = `${RNFS.DocumentDirectoryPath}/${filename}`;
   // A not so great way to copy objects by value
 
   try {
@@ -161,19 +157,23 @@ export const downloadStateLogs = async (
       loggedIn,
     );
 
-    let url = `data:text/plain;base64,${new Buffer(
-      stateLogsWithReleaseDetails,
-    ).toString('base64')}`;
-    // // Android accepts attachements as BASE64
-    if (Device.isIos()) {
-      await RNFS.writeFile(path, stateLogsWithReleaseDetails, 'utf8');
-      url = path;
-    }
+    // Write the logs to a real file on both platforms and share that file.
+    // Previously Android shared a `data:text/plain;base64,...` URL, which was
+    // slow for large states and only surfaced "send to" targets in the share
+    // sheet (no option to save/download the file). Sharing an actual file with
+    // a filename and JSON mime type lets Android offer "Save to Files"/Drive.
+    await RNFS.writeFile(path, stateLogsWithReleaseDetails, 'utf8');
 
+    // Pass the plain file path (no `file://` scheme). react-native-share
+    // copies it into its own FileProvider and shares a `content://` URI;
+    // passing a raw `file://` URI crashes Android with FileUriExposedException.
     await Share.open({
       subject: `${appName} State logs -  v${appVersion} (${buildNumber})`,
       title: `${appName} State logs -  v${appVersion} (${buildNumber})`,
-      url,
+      url: path,
+      filename,
+      type: 'application/json',
+      failOnCancel: false,
     });
   } catch (err) {
     const e = err as Error;


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On Android, **Settings → Advanced → Download State Logs** was slow to respond, and when the share window finally appeared it only offered "send to" targets (email/messaging/apps) with no way to actually save or download the logs file.

The cause was that Android shared the logs as a base64 `data:text/plain` URL via `Share.open`. Encoding the entire state to base64 was slow for large states, and the result was a text-only share intent with no file to save.

This PR makes state logs a real file download on both platforms:

- The logs are written to a file (as iOS already did) and shared by their **plain path** with a `filename` and `application/json` MIME type. `react-native-share` copies the file into its own FileProvider and shares a `content://` URI, so Android's share sheet now offers "Save to Files"/Drive. (A raw `file://` URI is intentionally avoided — it would crash Android with `FileUriExposedException`.)
- Dropping the base64 encoding step also removes the delay that prompted the report.

iOS behavior is unchanged in practice (it already wrote and shared the file); the share path is now unified across platforms.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Download State Logs on Android so the logs can be saved/downloaded as a file, and removed the delay before the share sheet appears

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/24359

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Download state logs on Android

  Scenario: User downloads and saves state logs
    Given I am on an Android device with the wallet unlocked
    And I navigate to Settings > Advanced

    When I tap "Download state logs"
    Then the share sheet appears promptly
    And it offers an option to save/download the file (e.g. "Save to Files"/Drive)

  Scenario: User saves the file
    Given the share sheet is open
    When I choose "Save to Files" (or Drive) and confirm
    Then a "state-logs-v<version>-(<build>).json" file is saved and can be reopened
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<!-- Recording: share sheet appears delayed with only "send to" targets, no save/download option (per issue #24359). -->

Not applicable

### **After**

<!-- Recording: share sheet appears promptly and offers "Save to Files"; file is saved. -->

Not applicable
## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.