### PR TITLE
fix(predict): scroll World Cup bracket pill into view on navigation

### DIFF
--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.test.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ScrollView } from 'react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import PredictWorldCup, {
   PREDICT_WORLD_CUP_SCREEN_TEST_IDS,
@@ -328,6 +329,60 @@ describe('PredictWorldCup', () => {
     );
 
     expect(mockTrackFeedViewed).toHaveBeenCalledTimes(1);
+  });
+
+  it('scrolls the initial pill into view once its layout is measured', () => {
+    const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo');
+    mockRouteParams = { initialTab: 'group_l' };
+
+    render(<PredictWorldCup />);
+
+    fireEvent(
+      screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-group_l`),
+      'layout',
+      { nativeEvent: { layout: { x: 800, width: 51 } } },
+    );
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ x: 784, animated: false });
+
+    scrollToSpy.mockRestore();
+  });
+
+  it('scrolls the selected pill into view when a tab is pressed', () => {
+    const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo');
+
+    render(<PredictWorldCup />);
+
+    fireEvent(
+      screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-props`),
+      'layout',
+      { nativeEvent: { layout: { x: 200, width: 51 } } },
+    );
+
+    fireEvent.press(
+      screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-props`),
+    );
+
+    expect(scrollToSpy).toHaveBeenLastCalledWith({ x: 184, animated: true });
+
+    scrollToSpy.mockRestore();
+  });
+
+  it('clamps the scroll offset to zero for an early pill', () => {
+    const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo');
+    mockRouteParams = { initialTab: 'live' };
+
+    render(<PredictWorldCup />);
+
+    fireEvent(
+      screen.getByTestId(`${PREDICT_WORLD_CUP_SCREEN_TEST_IDS.TAB}-live`),
+      'layout',
+      { nativeEvent: { layout: { x: 10, width: 51 } } },
+    );
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ x: 0, animated: false });
+
+    scrollToSpy.mockRestore();
   });
 
   it('uses a configured available stage initial tab', () => {

--- a/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
+++ b/app/components/UI/Predict/views/PredictWorldCup/PredictWorldCup.tsx
@@ -7,7 +7,12 @@ import React, {
 } from 'react';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
-import { Pressable, RefreshControl, ScrollView } from 'react-native';
+import {
+  type LayoutChangeEvent,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+} from 'react-native';
 import { FlashList } from '@shopify/flash-list';
 import {
   Theme,
@@ -81,6 +86,7 @@ interface WorldCupTabButtonProps {
   tab: PredictWorldCupAvailableTab;
   isActive: boolean;
   onPress: () => void;
+  onLayout: (event: LayoutChangeEvent) => void;
 }
 
 const WorldCupLiveTabLabelContent = ({ label }: { label: string }) => {
@@ -125,12 +131,14 @@ const WorldCupTabButton = ({
   tab,
   isActive,
   onPress,
+  onLayout,
 }: WorldCupTabButtonProps) => {
   const tw = useTailwind();
 
   return (
     <Pressable
       onPress={onPress}
+      onLayout={onLayout}
       style={tw.style(
         'min-w-[51px] flex-row items-center justify-center gap-2 rounded-xl bg-muted p-2',
         isActive && 'bg-icon-default',
@@ -283,6 +291,11 @@ const WorldCupTabContent = ({
 const PredictWorldCup: React.FC = () => {
   const tw = useTailwind();
   const navigation = useNavigation();
+  const tabsScrollViewRef = useRef<ScrollView>(null);
+  const tabLayoutsRef = useRef<Record<string, { x: number; width: number }>>(
+    {},
+  );
+  const hasScrolledToInitialTabRef = useRef(false);
   const hasTrackedInitialFeedViewed = useRef(false);
   const feedSessionId = useMemo(() => uuidv4(), []);
   const feedSessionStartTime = useMemo(() => Date.now(), []);
@@ -378,6 +391,35 @@ const PredictWorldCup: React.FC = () => {
     });
   }, [navigation, route.params?.entryPoint, transactionActiveAbTests]);
 
+  const scrollActiveTabIntoView = useCallback(
+    (tabKey: PredictWorldCupTabKey, animated: boolean) => {
+      const layout = tabLayoutsRef.current[tabKey];
+      if (!layout || !tabsScrollViewRef.current) {
+        return;
+      }
+
+      // Offset so the pill isn't flush against the screen edge (matches px-4).
+      const targetX = Math.max(layout.x - 16, 0);
+      tabsScrollViewRef.current.scrollTo({ x: targetX, animated });
+    },
+    [],
+  );
+
+  const handleTabLayout = useCallback(
+    (tabKey: PredictWorldCupTabKey, event: LayoutChangeEvent) => {
+      const { x, width } = event.nativeEvent.layout;
+      tabLayoutsRef.current[tabKey] = { x, width };
+
+      // The initial tab can be off-screen (e.g. a late-stage bracket); bring it
+      // into view once its layout is measured.
+      if (!hasScrolledToInitialTabRef.current && tabKey === activeTab) {
+        hasScrolledToInitialTabRef.current = true;
+        scrollActiveTabIntoView(tabKey, false);
+      }
+    },
+    [activeTab, scrollActiveTabIntoView],
+  );
+
   const handleTabPress = useCallback(
     (tabKey: PredictWorldCupTabKey) => {
       if (tabKey === activeTab) {
@@ -400,6 +442,13 @@ const PredictWorldCup: React.FC = () => {
     [activeTab, entryPoint, feedSessionId, feedSessionStartTime],
   );
 
+  useEffect(() => {
+    // Keep the active pill visible when the tab changes (tap or resolved
+    // initial tab). On first mount the layout may not be measured yet, in which
+    // case `handleTabLayout` performs the initial scroll instead.
+    scrollActiveTabIntoView(activeTab, true);
+  }, [activeTab, scrollActiveTabIntoView]);
+
   if (!isScreenEnabled) {
     return null;
   }
@@ -418,6 +467,7 @@ const PredictWorldCup: React.FC = () => {
 
       <Box twClassName="flex-1">
         <ScrollView
+          ref={tabsScrollViewRef}
           horizontal
           showsHorizontalScrollIndicator={false}
           style={tw.style('grow-0')}
@@ -430,6 +480,7 @@ const PredictWorldCup: React.FC = () => {
               tab={tab}
               isActive={activeTab === tab.key}
               onPress={() => handleTabPress(tab.key)}
+              onLayout={(event) => handleTabLayout(tab.key, event)}
             />
           ))}
         </ScrollView>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a user navigates directly to a specific World Cup bracket (e.g. tapping "Bracket L" from the homepage), the destination screen correctly filters to that bracket, but the horizontal filter pill row stays scrolled all the way to the left. As a result the selected bracket's pill can be rendered off-screen, so the user has no visual confirmation that the list was actually filtered unless they manually scroll the pills to the right.

This PR makes the active pill always visible:

- Each pill now reports its layout (`x` / `width`) via `onLayout`, stored in a ref keyed by tab.
- A new `scrollActiveTabIntoView` helper scrolls the pills `ScrollView` so the active pill sits just inside the left edge (offset to match the `px-4` content padding, clamped to `0`).
- The active pill is scrolled into view on initial mount once its layout is measured (handles the deep-link case where the pill is off-screen) and again whenever the active tab changes (tap, or initial tab resolving after availability loads).

No data-fetching or feature-flag logic was changed — the change is confined to the pill row's scroll position.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the World Cup filter pills not scrolling to reveal the selected bracket when navigating directly to it.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: PRED-932

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: World Cup bracket filter pills

  Scenario: user navigates directly to a specific bracket
    Given the World Cup screen is enabled
    When the user taps a specific bracket (e.g. "Bracket L") from the homepage
    Then the World Cup screen opens filtered to that bracket
    And the filter pill row is scrolled so the selected bracket pill is in view

  Scenario: user taps a filter pill that is partially off-screen
    Given the user is on the World Cup screen
    When the user taps a pill near the right edge of the visible row
    Then the pill row scrolls to bring the selected pill into view
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f9f4405a-5277-4b60-99ee-7f0ff1a4801a

<!-- [screenshots/recordings] -->

Navigating to a late-stage bracket left the pill row scrolled to the left, so the selected bracket pill was off-screen.

### **After**

https://github.com/user-attachments/assets/6822eafd-f96b-4203-9af7-947a2f3d4cb6
<!-- [screenshots/recordings] -->

Navigating to a bracket scrolls the pill row so the selected bracket pill is visible. _Recording to be attached._

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only scroll positioning on the Predict World Cup screen; no changes to data, flags, or navigation contracts beyond pill visibility.
> 
> **Overview**
> Fixes the World Cup horizontal filter pill row so the **active** pill stays visible when users land on a deep-linked bracket or switch tabs.
> 
> **`PredictWorldCup`** now records each pill’s layout via `onLayout`, scrolls the tab `ScrollView` with a 16px left offset (matching `px-4`, clamped at 0), and runs that scroll on initial layout for the active tab (non-animated) and whenever `activeTab` changes (animated). Tab selection and feed logic are unchanged.
> 
> Tests spy on `ScrollView.scrollTo` for deep-link initial tab, tab press, and early-pill clamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682585812506197b938125028ef6f581f461fa09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->