### PR TITLE
refactor(wallet): extract WalletHeader into standalone component

### DIFF
--- a/app/components/Views/Wallet/WalletHeader.tsx
+++ b/app/components/Views/Wallet/WalletHeader.tsx
@@ -1,0 +1,163 @@
+import React, { memo, useCallback } from 'react';
+import type { LayoutChangeEvent } from 'react-native';
+import {
+  BadgeStatus,
+  BadgeStatusStatus,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  BadgeWrapperPositionAnchorShape,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  ButtonIcon,
+  ButtonIconSize,
+  IconColor,
+  IconName,
+  SelectButton,
+  SelectButtonVariant,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import {
+  type NavigationProp,
+  type ParamListBase,
+  useNavigation,
+} from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+
+import AddressCopy from '../../UI/AddressCopy';
+import CardButton from '../../UI/Card/components/CardButton';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { createAccountSelectorNavDetails } from '../AccountSelector';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { useAccountGroupName } from '../../hooks/multichainAccounts/useAccountGroupName';
+import { useAccountName } from '../../hooks/useAccountName';
+import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import Routes from '../../../constants/navigation/Routes';
+import { isNotificationsFeatureEnabled } from '../../../util/notifications';
+import {
+  getMetamaskNotificationsUnreadCount,
+  selectIsMetamaskNotificationsEnabled,
+} from '../../../selectors/notifications';
+import { selectMoneyEnableMoneyAccountFlag } from '../../UI/Money/selectors/featureFlags';
+import { WalletViewSelectorsIDs } from './WalletView.testIds';
+
+const TOUCH_SLOP = { top: 12, bottom: 12, left: 12, right: 12 };
+
+interface WalletHeaderProps {
+  onLayout?: (e: LayoutChangeEvent) => void;
+}
+
+const WalletHeader = ({ onLayout }: WalletHeaderProps) => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const { trackEvent } = useAnalytics();
+
+  const accountName = useAccountName();
+  const accountGroupName = useAccountGroupName();
+  const displayName = accountGroupName || accountName;
+
+  const isNotificationEnabled = useSelector(
+    selectIsMetamaskNotificationsEnabled,
+  );
+  const unreadNotificationCount = useSelector(
+    getMetamaskNotificationsUnreadCount,
+  );
+  const isMoneyAccountEnabled = useSelector(selectMoneyEnableMoneyAccountFlag);
+
+  const hasBadge =
+    isNotificationsFeatureEnabled() &&
+    isNotificationEnabled &&
+    unreadNotificationCount > 0;
+
+  const handleHamburgerPress = useCallback(() => {
+    trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.NAVIGATION_TAPS_SETTINGS,
+      )
+        .addProperties({ action: 'Navigation Drawer', name: 'Settings' })
+        .build(),
+    );
+    navigation.navigate(Routes.SETTINGS_VIEW);
+  }, [navigation, trackEvent]);
+
+  const handleCardPress = useCallback(() => {
+    trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.CARD_HOME_CLICKED,
+      ).build(),
+    );
+    navigation.navigate(Routes.CARD.ROOT);
+  }, [navigation, trackEvent]);
+
+  const handleActivityPress = useCallback(() => {
+    trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.ACTIVITY_CLICKED,
+      ).build(),
+    );
+    navigation.navigate(Routes.TRANSACTIONS_VIEW);
+  }, [navigation, trackEvent]);
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={2}
+      twClassName="pl-2 pr-3 py-2"
+      testID={WalletViewSelectorsIDs.WALLET_HEADER_ROOT}
+      onLayout={onLayout}
+    >
+      <SelectButton
+        placeholder=""
+        value={displayName}
+        variant={SelectButtonVariant.Secondary}
+        onPress={() =>
+          navigation.navigate(...createAccountSelectorNavDetails({}))
+        }
+        testID={WalletViewSelectorsIDs.ACCOUNT_ICON}
+        hitSlop={TOUCH_SLOP}
+        textProps={{
+          variant: TextVariant.BodyMd,
+          fontWeight: FontWeight.Medium,
+          ellipsizeMode: 'tail',
+        }}
+      />
+
+      {isMoneyAccountEnabled && (
+        <ButtonIcon
+          iconProps={{ color: IconColor.IconDefault }}
+          onPress={handleActivityPress}
+          iconName={IconName.Clock}
+          size={ButtonIconSize.Md}
+          testID={WalletViewSelectorsIDs.WALLET_ACTIVITY_BUTTON}
+          hitSlop={TOUCH_SLOP}
+          twClassName="ml-auto"
+        />
+      )}
+      <AddressCopy
+        testID={WalletViewSelectorsIDs.NAVBAR_ADDRESS_COPY_BUTTON}
+        hitSlop={TOUCH_SLOP}
+      />
+      <CardButton onPress={handleCardPress} touchAreaSlop={TOUCH_SLOP} />
+      <BadgeWrapper
+        position={BadgeWrapperPosition.TopRight}
+        positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+        badge={
+          hasBadge ? <BadgeStatus status={BadgeStatusStatus.Attention} /> : null
+        }
+      >
+        <ButtonIcon
+          iconProps={{ color: IconColor.IconDefault }}
+          onPress={handleHamburgerPress}
+          iconName={IconName.Menu}
+          size={ButtonIconSize.Md}
+          testID={WalletViewSelectorsIDs.WALLET_HAMBURGER_MENU_BUTTON}
+          hitSlop={TOUCH_SLOP}
+        />
+      </BadgeWrapper>
+    </Box>
+  );
+};
+
+export default memo(WalletHeader);

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -52,29 +52,13 @@ import {
   PERPS_GTM_MODAL_SHOWN,
   PREDICT_GTM_MODAL_SHOWN,
 } from '../../../constants/storage';
-import HeaderRoot from '../../../component-library/components-temp/HeaderRoot';
-import PickerAccount from '../../../component-library/components/Pickers/PickerAccount';
-import AddressCopy from '../../UI/AddressCopy';
-import CardButton from '../../UI/Card/components/CardButton';
 import { selectMoneyEnableMoneyAccountFlag } from '../../UI/Money/selectors/featureFlags';
 import MoneyBalanceCard from '../../UI/Money/components/MoneyBalanceCard';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { createAccountSelectorNavDetails } from '../AccountSelector';
-import { isNotificationsFeatureEnabled } from '../../../util/notifications';
-import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import {
-  BadgeStatus,
-  BadgeStatusStatus,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-  BadgeWrapperPositionAnchorShape,
-  ButtonIcon,
-  ButtonIconSize,
-  IconColor as MMDSIconColor,
-  IconName as MMDSIconName,
   Text as CustomText,
   TextColor,
 } from '@metamask/design-system-react-native';
+import WalletHeader from './WalletHeader';
 
 import {
   NavigationProp,
@@ -96,7 +80,6 @@ import {
 } from '../../../component-library/components/Toast';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import Routes from '../../../constants/navigation/Routes';
-import { MetaMetricsEvents } from '../../../core/Analytics';
 import {
   trackActionButtonClick,
   ActionButtonType,
@@ -110,17 +93,11 @@ import {
   selectChainId,
   selectProviderConfig,
 } from '../../../selectors/networkController';
-import {
-  getMetamaskNotificationsUnreadCount,
-  selectIsMetamaskNotificationsEnabled,
-} from '../../../selectors/notifications';
 import { selectSelectedAccountGroupId } from '../../../selectors/multichainAccounts/accountTreeController';
 import { selectShouldShowWalletHomeOnboardingSteps } from '../../../selectors/onboarding';
 import { getIsNetworkOnboarded } from '../../../util/networks';
 import NotificationsService from '../../../util/notifications/services/NotificationService';
 import { useTheme } from '../../../util/theme';
-import { useAccountGroupName } from '../../hooks/multichainAccounts/useAccountGroupName';
-import { useAccountName } from '../../hooks/useAccountName';
 import usePrevious from '../../hooks/usePrevious';
 import { PERFORMANCE_CONFIG } from '@metamask/perps-controller';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -227,14 +204,6 @@ const createStyles = ({ colors }: Theme) =>
     carousel: {
       overflow: 'hidden', // Allow for smooth height animations
     },
-    headerActionButtonsContainer: {
-      flexDirection: 'row',
-      gap: 8,
-    },
-    headerAccountPickerStyle: {
-      marginRight: 16,
-      backgroundColor: 'transparent',
-    },
     accountGroupBalanceContainer: {
       marginBottom: 16,
     },
@@ -333,7 +302,6 @@ const Wallet = ({
   storePrivacyPolicyClickedOrClosed,
 }: WalletProps) => {
   const { navigate } = useNavigation();
-  const walletRef = useRef(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const isMountedRef = useRef(true);
   const refreshInProgressRef = useRef(false);
@@ -546,12 +514,8 @@ const Wallet = ({
 
   const currentToast = toastRef?.current;
 
-  const accountName = useAccountName();
-  const accountGroupName = useAccountGroupName();
-
   useSafeChains();
 
-  const displayName = accountGroupName || accountName;
   useAccountsWithNetworkActivitySync();
 
   const isSocialLogin = useSelector(selectSeedlessOnboardingLoginFlow);
@@ -707,14 +671,6 @@ const Wallet = ({
     (state: RootState) => state.networkOnboarded.networkOnboardedState,
   );
 
-  const isNotificationEnabled = useSelector(
-    selectIsMetamaskNotificationsEnabled,
-  );
-
-  const unreadNotificationCount = useSelector(
-    getMetamaskNotificationsUnreadCount,
-  );
-
   const homeGrowthBanner = useHomeGrowthBanner();
 
   /**
@@ -831,40 +787,6 @@ const Wallet = ({
       scrollSubscribersRef.current.forEach((cb) => cb());
     }
   }, []);
-
-  const touchAreaSlop = useMemo(
-    () => ({ top: 12, bottom: 12, left: 12, right: 12 }),
-    [],
-  );
-
-  const handleHamburgerPress = useCallback(() => {
-    trackEvent(
-      AnalyticsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.NAVIGATION_TAPS_SETTINGS,
-      )
-        .addProperties({ action: 'Navigation Drawer', name: 'Settings' })
-        .build(),
-    );
-    navigation.navigate(Routes.SETTINGS_VIEW);
-  }, [navigation, trackEvent]);
-
-  const handleCardPress = useCallback(() => {
-    trackEvent(
-      AnalyticsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.CARD_HOME_CLICKED,
-      ).build(),
-    );
-    navigation.navigate(Routes.CARD.ROOT);
-  }, [navigation, trackEvent]);
-
-  const handleActivityPress = useCallback(() => {
-    trackEvent(
-      AnalyticsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.ACTIVITY_CLICKED,
-      ).build(),
-    );
-    navigation.navigate(Routes.TRANSACTIONS_VIEW);
-  }, [navigation, trackEvent]);
 
   const turnOnBasicFunctionality = useCallback(() => {
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
@@ -1084,7 +1006,7 @@ const Wallet = ({
                     : undefined
                 }
               >
-                <HeaderRoot
+                <WalletHeader
                   onLayout={
                     isDiscoveryTabsTreatment
                       ? (e) => {
@@ -1096,94 +1018,7 @@ const Wallet = ({
                         }
                       : undefined
                   }
-                  testID={WalletViewSelectorsIDs.WALLET_HEADER_ROOT}
-                  style={undefined}
-                  endAccessory={
-                    <View
-                      style={styles.headerActionButtonsContainer}
-                      accessible={false}
-                    >
-                      {isMoneyAccountEnabled && (
-                        <ButtonIcon
-                          iconProps={{
-                            color: MMDSIconColor.IconDefault,
-                          }}
-                          onPress={handleActivityPress}
-                          iconName={MMDSIconName.Clock}
-                          size={ButtonIconSize.Md}
-                          testID={WalletViewSelectorsIDs.WALLET_ACTIVITY_BUTTON}
-                          hitSlop={touchAreaSlop}
-                        />
-                      )}
-                      <AddressCopy
-                        testID={
-                          WalletViewSelectorsIDs.NAVBAR_ADDRESS_COPY_BUTTON
-                        }
-                        hitSlop={touchAreaSlop}
-                      />
-                      <CardButton
-                        onPress={handleCardPress}
-                        touchAreaSlop={touchAreaSlop}
-                      />
-                      {isNotificationsFeatureEnabled() ? (
-                        <BadgeWrapper
-                          position={BadgeWrapperPosition.TopRight}
-                          positionAnchorShape={
-                            BadgeWrapperPositionAnchorShape.Circular
-                          }
-                          badge={
-                            isNotificationEnabled &&
-                            unreadNotificationCount > 0 ? (
-                              <BadgeStatus
-                                status={BadgeStatusStatus.Attention}
-                              />
-                            ) : null
-                          }
-                        >
-                          <ButtonIcon
-                            iconProps={{
-                              color: MMDSIconColor.IconDefault,
-                            }}
-                            onPress={handleHamburgerPress}
-                            iconName={MMDSIconName.Menu}
-                            size={ButtonIconSize.Md}
-                            testID={
-                              WalletViewSelectorsIDs.WALLET_HAMBURGER_MENU_BUTTON
-                            }
-                            hitSlop={touchAreaSlop}
-                          />
-                        </BadgeWrapper>
-                      ) : (
-                        <ButtonIcon
-                          iconProps={{
-                            color: MMDSIconColor.IconDefault,
-                          }}
-                          onPress={handleHamburgerPress}
-                          iconName={MMDSIconName.Menu}
-                          size={ButtonIconSize.Md}
-                          testID={
-                            WalletViewSelectorsIDs.WALLET_HAMBURGER_MENU_BUTTON
-                          }
-                          hitSlop={touchAreaSlop}
-                        />
-                      )}
-                    </View>
-                  }
-                  twClassName="pl-1 pr-3"
-                >
-                  <PickerAccount
-                    ref={walletRef}
-                    accountName={displayName}
-                    onPress={() =>
-                      navigation.navigate(
-                        ...createAccountSelectorNavDetails({}),
-                      )
-                    }
-                    testID={WalletViewSelectorsIDs.ACCOUNT_ICON}
-                    hitSlop={touchAreaSlop}
-                    style={styles.headerAccountPickerStyle}
-                  />
-                </HeaderRoot>
+                />
               </Reanimated.View>
               <View
                 ref={containerViewRef}


### PR DESCRIPTION
## **Description**

Extracts the wallet header JSX block from `Wallet/index.tsx` into a self-contained `WalletHeader` component. The original `HeaderRoot` was deprecated and contained unused button-mapping logic. The new component uses MMDS `Box` and `SelectButton` (Secondary variant) instead, with `React.memo` to prevent unnecessary re-renders from parent state changes.

**What changed:**
- New `app/components/Views/Wallet/WalletHeader.tsx` — self-contained header with all header-specific selectors, hooks, and handlers
- `Wallet/index.tsx` — replaced ~100-line `HeaderRoot` JSX block with `<WalletHeader onLayout={...} />`
- `SelectButton` (Secondary) replaces `PickerAccount` with proper text ellipsis truncation via `textProps`
- `Box` with `twClassName` replaces `View` + inline `StyleSheet` styles
- Module-level `TOUCH_SLOP` constant avoids per-render object allocation
- `BadgeWrapper` with `badge={null}` eliminates the duplicated `ButtonIcon` conditional

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Wallet header

  Scenario: user views the wallet screen
    Given the app is open on the main wallet screen

    When the wallet screen loads
    Then the header shows the account name in a SelectButton (Secondary)
    And tapping the SelectButton opens the account selector
    And the hamburger menu, address copy, and card buttons are present and functional
    And long account names are truncated with an ellipsis
    And notification badge appears on the hamburger when unread notifications exist
```

## **Screenshots/Recordings**

### **Before**

<!-- Original HeaderRoot with PickerAccount -->

### **After**

<!-- WalletHeader with MMDS SelectButton Secondary -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor on the wallet home header with navigation and analytics preserved; no auth, payments, or data-layer changes.
> 
> **Overview**
> Pulls the wallet top bar out of **`Wallet/index.tsx`** into a dedicated **`WalletHeader`** component so header selectors, navigation handlers, and analytics stay in one place. **`Wallet`** now renders **`<WalletHeader onLayout={...} />`** and drops the large inline **`HeaderRoot`** block.
> 
> The header UI moves to MMDS **`Box`** + **`SelectButton` (Secondary)** instead of **`HeaderRoot`** / **`PickerAccount`**, with **`textProps`** for tail ellipsis on long account names. Action buttons (activity when money account is on, address copy, card, menu) and unread notification badge behavior are unchanged in intent; the menu badge uses a single **`BadgeWrapper`** with **`badge={null}`** when there is nothing to show instead of duplicating the hamburger **`ButtonIcon`**. **`React.memo`** and a module-level **`TOUCH_SLOP`** reduce re-renders and per-render allocations from parent wallet state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c077c68a7136e20808f5c758d1d2a9fb98159b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->