### PR TITLE
feat(card): gate Money Account card linkage on allowlisted spending token

### DIFF
--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -14,6 +14,7 @@ import {
   selectIsCardholder,
   selectIsMoneyAccountCardLinkInProgress,
   selectIsMoneyAccountDelegatedForCard,
+  selectMoneyAccountVedaTokenConfig,
 } from '../../../../selectors/cardController';
 import {
   selectPendingMoneyAccountCardLink,
@@ -165,6 +166,7 @@ const buildSelectors = (
     isMonadSponsorshipEnabled?: boolean;
     moneyAccountCardLinkInProgress?: boolean;
     cardFeatureFlag?: unknown;
+    vedaConfig?: unknown;
   } = {},
 ) => ({
   primaryMoneyAccount: { address: MONEY_ACCOUNT_ADDRESS },
@@ -194,6 +196,12 @@ const buildSelectors = (
       },
     },
   },
+  vedaConfig: {
+    caipChainId: 'eip155:143',
+    address: '0xveda',
+    decimals: 6,
+    delegationContract: '0xdelegation',
+  },
   ...overrides,
 });
 
@@ -219,6 +227,7 @@ const applySelectorMocks = (state: ReturnType<typeof buildSelectors>) => {
     if (selector === getGasFeesSponsoredNetworkEnabled)
       return (_chainId: string) => state.isMonadSponsorshipEnabled;
     if (selector === selectCardFeatureFlag) return state.cardFeatureFlag;
+    if (selector === selectMoneyAccountVedaTokenConfig) return state.vedaConfig;
     return undefined;
   });
 };
@@ -324,6 +333,33 @@ describe('useMoneyAccountCardLinkage', () => {
       expect(result.current.canLink).toBe(false);
       expect(result.current.hasMoneyAccountRequirements).toBe(false);
       expect(result.current.moneyAccountCardToken).toBeNull();
+    });
+
+    it('reports canLink=true when VEDA is allowlisted by address under the mUSD display symbol', () => {
+      applySelectorMocks(
+        buildSelectors({
+          cardFeatureFlag: {
+            chains: {
+              'eip155:143': {
+                enabled: true,
+                tokens: [
+                  {
+                    address: '0xveda',
+                    symbol: 'mUSD',
+                    decimals: 6,
+                    enabled: true,
+                    name: 'MetaMask USD',
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      );
+      const { result } = renderLinkageHook();
+      expect(result.current.canLink).toBe(true);
+      expect(result.current.hasMoneyAccountRequirements).toBe(true);
+      expect(result.current.moneyAccountCardToken).toBe(MOCK_TOKEN);
     });
 
     it('reports canLink=false when VEDA is present but disabled in the cardFeature flag', () => {

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -6,6 +6,7 @@ import Logger from '../../../../util/Logger';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../selectors/featureFlagController/gasFeesSponsored';
+import { selectCardFeatureFlag } from '../../../../selectors/featureFlagController/card';
 import {
   selectCardDelegationSettings,
   selectCardHomeDataStatus,
@@ -163,6 +164,7 @@ const buildSelectors = (
     cardHomeDataStatus?: CardHomeDataStatusMock;
     isMonadSponsorshipEnabled?: boolean;
     moneyAccountCardLinkInProgress?: boolean;
+    cardFeatureFlag?: unknown;
   } = {},
 ) => ({
   primaryMoneyAccount: { address: MONEY_ACCOUNT_ADDRESS },
@@ -176,6 +178,22 @@ const buildSelectors = (
   cardHomeDataStatus: 'success' as CardHomeDataStatusMock,
   isMonadSponsorshipEnabled: true,
   moneyAccountCardLinkInProgress: false,
+  cardFeatureFlag: {
+    chains: {
+      'eip155:143': {
+        enabled: true,
+        tokens: [
+          {
+            address: '0xveda',
+            symbol: 'veda',
+            decimals: 6,
+            enabled: true,
+            name: 'Veda',
+          },
+        ],
+      },
+    },
+  },
   ...overrides,
 });
 
@@ -200,6 +218,7 @@ const applySelectorMocks = (state: ReturnType<typeof buildSelectors>) => {
       return state.pendingMoneyAccountCardLink;
     if (selector === getGasFeesSponsoredNetworkEnabled)
       return (_chainId: string) => state.isMonadSponsorshipEnabled;
+    if (selector === selectCardFeatureFlag) return state.cardFeatureFlag;
     return undefined;
   });
 };
@@ -278,6 +297,60 @@ describe('useMoneyAccountCardLinkage', () => {
       applySelectorMocks(buildSelectors({ vaultConfig: undefined }));
       const { result } = renderLinkageHook();
       expect(result.current.canLink).toBe(false);
+    });
+
+    it('reports canLink=false when VEDA is not allowlisted in the cardFeature flag', () => {
+      applySelectorMocks(
+        buildSelectors({
+          cardFeatureFlag: {
+            chains: {
+              'eip155:143': {
+                enabled: true,
+                tokens: [
+                  {
+                    address: '0xusdc',
+                    symbol: 'USDC',
+                    decimals: 6,
+                    enabled: true,
+                    name: 'USD Coin',
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      );
+      const { result } = renderLinkageHook();
+      expect(result.current.canLink).toBe(false);
+      expect(result.current.hasMoneyAccountRequirements).toBe(false);
+      expect(result.current.moneyAccountCardToken).toBeNull();
+    });
+
+    it('reports canLink=false when VEDA is present but disabled in the cardFeature flag', () => {
+      applySelectorMocks(
+        buildSelectors({
+          cardFeatureFlag: {
+            chains: {
+              'eip155:143': {
+                enabled: true,
+                tokens: [
+                  {
+                    address: '0xveda',
+                    symbol: 'veda',
+                    decimals: 6,
+                    enabled: false,
+                    name: 'Veda',
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      );
+      const { result } = renderLinkageHook();
+      expect(result.current.canLink).toBe(false);
+      expect(result.current.hasMoneyAccountRequirements).toBe(false);
+      expect(result.current.moneyAccountCardToken).toBeNull();
     });
 
     it('reports canLink=false when the Monad USDC token cannot be resolved', () => {

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -28,6 +28,7 @@ import { useTheme } from '../../../../util/theme';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../selectors/featureFlagController/gasFeesSponsored';
+import { selectCardFeatureFlag } from '../../../../selectors/featureFlagController/card';
 import {
   selectCardDelegationSettings,
   selectCardHomeDataStatus,
@@ -47,6 +48,7 @@ import {
 } from '../../../../core/Engine/controllers/card-controller/utils/moneyAccountCardToken';
 import { CardLinkageInProgressError } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import { BAANX_MAX_LIMIT } from '../constants';
+import { isMoneyAccountCardTokenAllowlisted } from '../util/vedaToken';
 import { CardFundingToken } from '../types';
 import { UserCancelledError } from './useCardDelegation';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
@@ -118,6 +120,7 @@ export const useMoneyAccountCardLinkage =
     const isCardAuthenticated = useSelector(selectIsCardAuthenticated);
     const isCardholder = useSelector(selectIsCardholder);
     const delegationSettings = useSelector(selectCardDelegationSettings);
+    const cardFeatureFlag = useSelector(selectCardFeatureFlag);
     const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
     const isAlreadyDelegated = useSelector(
       selectIsMoneyAccountDelegatedForCard,
@@ -133,16 +136,26 @@ export const useMoneyAccountCardLinkage =
     const [status, setStatus] = useState<LinkageStatus>('idle');
     const [error, setError] = useState<Error | null>(null);
 
-    const moneyAccountCardToken = useMemo(
+    const rawMoneyAccountCardToken = useMemo(
       () => resolveMoneyAccountCardToken(delegationSettings),
       [delegationSettings],
     );
 
-    const hasRequirements = hasMoneyAccountCardRequirements({
-      isMoneyAccountEnabled,
-      vaultConfig,
-      moneyAccountAddress: primaryMoneyAccount?.address,
-    });
+    const isMoneyAccountCardSupported = useMemo(
+      () => isMoneyAccountCardTokenAllowlisted(cardFeatureFlag?.chains),
+      [cardFeatureFlag],
+    );
+
+    const moneyAccountCardToken = isMoneyAccountCardSupported
+      ? rawMoneyAccountCardToken
+      : null;
+
+    const hasRequirements =
+      hasMoneyAccountCardRequirements({
+        isMoneyAccountEnabled,
+        vaultConfig,
+        moneyAccountAddress: primaryMoneyAccount?.address,
+      }) && isMoneyAccountCardSupported;
 
     const canSubmitDelegation = Boolean(
       hasRequirements &&

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -36,6 +36,7 @@ import {
   selectIsCardholder,
   selectIsMoneyAccountCardLinkInProgress,
   selectIsMoneyAccountDelegatedForCard,
+  selectMoneyAccountVedaTokenConfig,
 } from '../../../../selectors/cardController';
 import {
   selectPendingMoneyAccountCardLink,
@@ -120,6 +121,7 @@ export const useMoneyAccountCardLinkage =
     const isCardAuthenticated = useSelector(selectIsCardAuthenticated);
     const isCardholder = useSelector(selectIsCardholder);
     const delegationSettings = useSelector(selectCardDelegationSettings);
+    const vedaConfig = useSelector(selectMoneyAccountVedaTokenConfig);
     const cardFeatureFlag = useSelector(selectCardFeatureFlag);
     const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
     const isAlreadyDelegated = useSelector(
@@ -142,8 +144,9 @@ export const useMoneyAccountCardLinkage =
     );
 
     const isMoneyAccountCardSupported = useMemo(
-      () => isMoneyAccountCardTokenAllowlisted(cardFeatureFlag?.chains),
-      [cardFeatureFlag],
+      () =>
+        isMoneyAccountCardTokenAllowlisted(cardFeatureFlag?.chains, vedaConfig),
+      [cardFeatureFlag, vedaConfig],
     );
 
     const moneyAccountCardToken = isMoneyAccountCardSupported

--- a/app/components/UI/Card/util/buildTokenList.test.ts
+++ b/app/components/UI/Card/util/buildTokenList.test.ts
@@ -301,4 +301,110 @@ describe('buildTokenList', () => {
       expect(result[0].displaySymbol).toBeUndefined();
     });
   });
+
+  describe('enforceSupportList', () => {
+    const createDelegationSettings = (
+      networks: DelegationSettingsResponse['networks'],
+    ): DelegationSettingsResponse => ({
+      networks,
+      count: networks.length,
+      _links: { self: 'https://api.example.com' },
+    });
+
+    const lineaUsdcAndFoo = createDelegationSettings([
+      {
+        network: 'linea',
+        chainId: '59144',
+        environment: 'production',
+        delegationContract: '0xDelegation',
+        tokens: {
+          usdc: { symbol: 'usdc', decimals: 6, address: '0xUSDC' },
+          foo: { symbol: 'foo', decimals: 18, address: '0xFOO' },
+        },
+      },
+    ]);
+
+    const vedaOnMonad = createDelegationSettings([
+      {
+        network: 'monad',
+        chainId: '143',
+        environment: 'production',
+        delegationContract: '0xDelegation',
+        tokens: {
+          veda: { symbol: 'veda', decimals: 6, address: '0xVEDA' },
+        },
+      },
+    ]);
+
+    it('drops tokens absent from the support list when enforceSupportList is true', () => {
+      const result = buildDelegationTokenList({
+        delegationSettings: lineaUsdcAndFoo,
+        enforceSupportList: true,
+        getSupportedTokensByChainId: () => [
+          { symbol: 'USDC', address: '0xUSDC', name: 'USD Coin' },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].symbol).toBe('USDC');
+    });
+
+    it('keeps unsupported tokens when enforceSupportList is false (default)', () => {
+      const result = buildDelegationTokenList({
+        delegationSettings: lineaUsdcAndFoo,
+        getSupportedTokensByChainId: () => [],
+      });
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('matches the support list by address even when the symbol differs', () => {
+      const result = buildDelegationTokenList({
+        delegationSettings: lineaUsdcAndFoo,
+        enforceSupportList: true,
+        getSupportedTokensByChainId: () => [
+          { symbol: 'USD Coin', address: '0xusdc', name: 'USD Coin' },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe('0xUSDC');
+    });
+
+    it('drops the veda entry when it is not in the support list', () => {
+      const result = buildDelegationTokenList({
+        delegationSettings: vedaOnMonad,
+        enforceSupportList: true,
+        getSupportedTokensByChainId: () => [],
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('keeps the veda entry (as mUSD) when present in the support list by symbol', () => {
+      const result = buildDelegationTokenList({
+        delegationSettings: vedaOnMonad,
+        enforceSupportList: true,
+        getSupportedTokensByChainId: () => [
+          { symbol: 'veda', address: '0xVEDA', name: 'Veda' },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].displaySymbol).toBe('mUSD');
+    });
+
+    it('keeps the veda entry when matched by address even if the support-list symbol differs', () => {
+      const result = buildDelegationTokenList({
+        delegationSettings: vedaOnMonad,
+        enforceSupportList: true,
+        getSupportedTokensByChainId: () => [
+          { symbol: 'mUSD', address: '0xveda', name: 'MetaMask USD' },
+        ],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].displaySymbol).toBe('mUSD');
+    });
+  });
 });

--- a/app/components/UI/Card/util/buildTokenList.ts
+++ b/app/components/UI/Card/util/buildTokenList.ts
@@ -24,6 +24,7 @@ interface SupportedToken {
 interface BuildTokenListParams {
   delegationSettings: DelegationSettingsResponse | null;
   getSupportedTokensByChainId: (chainId: CaipChainId) => SupportedToken[];
+  enforceSupportList?: boolean;
 }
 
 function getCaipChainId(
@@ -61,6 +62,7 @@ function shouldProcessNetwork(
 export function buildDelegationTokenList({
   delegationSettings,
   getSupportedTokensByChainId,
+  enforceSupportList = false,
 }: BuildTokenListParams): CardFundingToken[] {
   if (!delegationSettings?.networks) {
     return [];
@@ -89,6 +91,20 @@ export function buildDelegationTokenList({
       );
       if (isDuplicate) continue;
 
+      const sdkTokens = getSupportedTokensByChainId?.(caipChainId) ?? [];
+      const sdkToken = sdkTokens.find(
+        (t) =>
+          (!!t.address &&
+            t.address.toLowerCase() === tokenConfig.address.toLowerCase()) ||
+          (!!t.symbol &&
+            !!tokenConfig.symbol &&
+            t.symbol.toLowerCase() === tokenConfig.symbol.toLowerCase()),
+      );
+
+      if (enforceSupportList && !sdkToken) {
+        continue;
+      }
+
       const isVedaEntry = tokenKey === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY;
 
       if (isVedaEntry) {
@@ -108,12 +124,6 @@ export function buildDelegationTokenList({
         });
         continue;
       }
-
-      // Get metadata from SDK if available
-      const sdkTokens = getSupportedTokensByChainId?.(caipChainId) ?? [];
-      const sdkToken = sdkTokens.find(
-        (t) => t.symbol?.toLowerCase() === tokenConfig.symbol.toLowerCase(),
-      );
 
       const symbol = sdkToken?.symbol ?? tokenConfig.symbol;
 

--- a/app/components/UI/Card/util/vedaToken.test.ts
+++ b/app/components/UI/Card/util/vedaToken.test.ts
@@ -199,52 +199,122 @@ describe('isVedaToken', () => {
 });
 
 describe('isMoneyAccountCardTokenAllowlisted', () => {
+  const vedaConfig = getVedaTokenConfig(makeSettings());
+
   it('returns false when chains is null/undefined', () => {
-    expect(isMoneyAccountCardTokenAllowlisted(null)).toBe(false);
-    expect(isMoneyAccountCardTokenAllowlisted(undefined)).toBe(false);
+    expect(isMoneyAccountCardTokenAllowlisted(null, vedaConfig)).toBe(false);
+    expect(isMoneyAccountCardTokenAllowlisted(undefined, vedaConfig)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when vedaConfig is null/undefined', () => {
+    const chains = { 'eip155:143': { tokens: [{ symbol: 'veda' }] } };
+    expect(isMoneyAccountCardTokenAllowlisted(chains, null)).toBe(false);
+    expect(isMoneyAccountCardTokenAllowlisted(chains, undefined)).toBe(false);
   });
 
   it('returns true when an enabled veda token is present', () => {
     expect(
-      isMoneyAccountCardTokenAllowlisted({
-        'eip155:143': {
-          tokens: [{ symbol: 'veda', enabled: true }],
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': {
+            tokens: [{ symbol: 'veda', enabled: true }],
+          },
         },
-      }),
+        vedaConfig,
+      ),
     ).toBe(true);
   });
 
   it('matches the veda symbol case-insensitively', () => {
     expect(
-      isMoneyAccountCardTokenAllowlisted({
-        'eip155:143': { tokens: [{ symbol: 'VEDA', enabled: true }] },
-      }),
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': { tokens: [{ symbol: 'VEDA', enabled: true }] },
+        },
+        vedaConfig,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches by VEDA address when allowlisted under the mUSD display symbol', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': {
+            tokens: [
+              {
+                address: VEDA_ADDRESS,
+                symbol: MONEY_ACCOUNT_DISPLAY_SYMBOL,
+                enabled: true,
+              },
+            ],
+          },
+        },
+        vedaConfig,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the VEDA address case-insensitively', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': {
+            tokens: [{ address: VEDA_ADDRESS.toUpperCase(), symbol: 'mUSD' }],
+          },
+        },
+        vedaConfig,
+      ),
     ).toBe(true);
   });
 
   it('treats a token with enabled omitted as enabled', () => {
     expect(
-      isMoneyAccountCardTokenAllowlisted({
-        'eip155:143': { tokens: [{ symbol: 'veda' }] },
-      }),
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': { tokens: [{ symbol: 'veda' }] },
+        },
+        vedaConfig,
+      ),
     ).toBe(true);
   });
 
   it('returns false when the veda token is disabled', () => {
     expect(
-      isMoneyAccountCardTokenAllowlisted({
-        'eip155:143': { tokens: [{ symbol: 'veda', enabled: false }] },
-      }),
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': { tokens: [{ symbol: 'veda', enabled: false }] },
+        },
+        vedaConfig,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the matching token is on a different chain', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:59144': {
+            tokens: [{ address: VEDA_ADDRESS, symbol: 'mUSD' }],
+          },
+        },
+        vedaConfig,
+      ),
     ).toBe(false);
   });
 
   it('returns false when no veda token is allowlisted', () => {
     expect(
-      isMoneyAccountCardTokenAllowlisted({
-        'eip155:143': {
-          tokens: [{ symbol: 'USDC', enabled: true }],
+      isMoneyAccountCardTokenAllowlisted(
+        {
+          'eip155:143': {
+            tokens: [{ symbol: 'USDC', enabled: true }],
+          },
         },
-      }),
+        vedaConfig,
+      ),
     ).toBe(false);
   });
 });

--- a/app/components/UI/Card/util/vedaToken.test.ts
+++ b/app/components/UI/Card/util/vedaToken.test.ts
@@ -3,6 +3,7 @@ import type { DelegationSettingsResponse } from '../types';
 import {
   getVedaTokenConfig,
   isVedaToken,
+  isMoneyAccountCardTokenAllowlisted,
   MONEY_ACCOUNT_DELEGATION_NETWORK,
   MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
   MONEY_ACCOUNT_DISPLAY_SYMBOL,
@@ -193,6 +194,57 @@ describe('isVedaToken', () => {
         },
         vedaConfig,
       ),
+    ).toBe(false);
+  });
+});
+
+describe('isMoneyAccountCardTokenAllowlisted', () => {
+  it('returns false when chains is null/undefined', () => {
+    expect(isMoneyAccountCardTokenAllowlisted(null)).toBe(false);
+    expect(isMoneyAccountCardTokenAllowlisted(undefined)).toBe(false);
+  });
+
+  it('returns true when an enabled veda token is present', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted({
+        'eip155:143': {
+          tokens: [{ symbol: 'veda', enabled: true }],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('matches the veda symbol case-insensitively', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted({
+        'eip155:143': { tokens: [{ symbol: 'VEDA', enabled: true }] },
+      }),
+    ).toBe(true);
+  });
+
+  it('treats a token with enabled omitted as enabled', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted({
+        'eip155:143': { tokens: [{ symbol: 'veda' }] },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the veda token is disabled', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted({
+        'eip155:143': { tokens: [{ symbol: 'veda', enabled: false }] },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when no veda token is allowlisted', () => {
+    expect(
+      isMoneyAccountCardTokenAllowlisted({
+        'eip155:143': {
+          tokens: [{ symbol: 'USDC', enabled: true }],
+        },
+      }),
     ).toBe(false);
   });
 });

--- a/app/components/UI/Card/util/vedaToken.ts
+++ b/app/components/UI/Card/util/vedaToken.ts
@@ -76,8 +76,7 @@ export const isVedaToken = (
 
 /**
  * True when the Money Account spending token (VEDA) is present and enabled in
- * the cardFeature allowlist, matched by the canonical `veda` symbol — the same
- * key the provider's delegation settings use — across all configured chains.
+ * the cardFeature allowlist for VEDA's chain.
  */
 export const isMoneyAccountCardTokenAllowlisted = (
   chains:
@@ -85,22 +84,28 @@ export const isMoneyAccountCardTokenAllowlisted = (
         string,
         | {
             tokens?:
-              | { symbol?: string | null; enabled?: boolean | null }[]
+              | {
+                  address?: string | null;
+                  symbol?: string | null;
+                  enabled?: boolean | null;
+                }[]
               | null;
           }
         | undefined
       >
     | null
     | undefined,
+  vedaConfig: VedaTokenConfig | null | undefined,
 ): boolean => {
-  if (!chains) {
+  if (!chains || !vedaConfig) {
     return false;
   }
-  return Object.values(chains).some((chain) =>
-    (chain?.tokens ?? []).some(
-      (token) =>
-        token?.enabled !== false &&
-        token?.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
-    ),
+  const target = vedaConfig.address.toLowerCase();
+  const chain = chains[vedaConfig.caipChainId];
+  return (chain?.tokens ?? []).some(
+    (token) =>
+      token?.enabled !== false &&
+      (token?.address?.toLowerCase() === target ||
+        token?.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY),
   );
 };

--- a/app/components/UI/Card/util/vedaToken.ts
+++ b/app/components/UI/Card/util/vedaToken.ts
@@ -73,3 +73,34 @@ export const isVedaToken = (
     token.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY
   );
 };
+
+/**
+ * True when the Money Account spending token (VEDA) is present and enabled in
+ * the cardFeature allowlist, matched by the canonical `veda` symbol — the same
+ * key the provider's delegation settings use — across all configured chains.
+ */
+export const isMoneyAccountCardTokenAllowlisted = (
+  chains:
+    | Record<
+        string,
+        | {
+            tokens?:
+              | { symbol?: string | null; enabled?: boolean | null }[]
+              | null;
+          }
+        | undefined
+      >
+    | null
+    | undefined,
+): boolean => {
+  if (!chains) {
+    return false;
+  }
+  return Object.values(chains).some((chain) =>
+    (chain?.tokens ?? []).some(
+      (token) =>
+        token?.enabled !== false &&
+        token?.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+    ),
+  );
+};

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -1272,6 +1272,22 @@ describe('MoneyHomeView', () => {
         mockDataEnabled: false,
       });
       mockSelectIsCardholder.mockReturnValue(true);
+      // Money Account ↔ card requirements met (incl. VEDA allowlisted) so the
+      // link CTA is offered.
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: true,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'veda' },
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
     });
 
     it('renders MetaMask Card section in link mode', () => {
@@ -1732,6 +1748,20 @@ describe('MoneyHomeView', () => {
 
     it('selects mode="link" when cardholder but not linked', () => {
       mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: true,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'veda' },
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
@@ -1740,8 +1770,49 @@ describe('MoneyHomeView', () => {
       ).toBeOnTheScreen();
     });
 
+    it('hides the card section when cardholder but VEDA is not allowlisted (cannot link)', () => {
+      mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: false,
+        isCardAuthenticated: true,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: null,
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
+
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.LINK_CONTAINER),
+      ).not.toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+
     it('selects mode="link" for cardholder even with zero transactions', () => {
       mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: true,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'veda' },
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
       mockUseMoneyAccountTransactions.mockReturnValue({
         allTransactions: [],
         deposits: [],
@@ -1795,11 +1866,11 @@ describe('MoneyHomeView', () => {
     it('disables the link button when linkage is in progress', () => {
       mockSelectIsCardholder.mockReturnValue(true);
       mockUseMoneyAccountCardLinkage.mockReturnValue({
-        hasMoneyAccountRequirements: false,
+        hasMoneyAccountRequirements: true,
         isCardAuthenticated: false,
         isCardLinkedToMoneyAccount: false,
-        primaryMoneyAccount: undefined,
-        moneyAccountCardToken: null,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'veda' },
         canLink: false,
         status: 'idle',
         isLinking: true,
@@ -1931,6 +2002,20 @@ describe('MoneyHomeView', () => {
     it('uses 3% cashback copy in link mode when user holds a Metal card', () => {
       mockSelectIsCardholder.mockReturnValue(true);
       mockSelectHasMetalCard.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: true,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'veda' },
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
 
       const { getByText } = renderWithProvider(<MoneyHomeView />);
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -562,11 +562,6 @@ const MoneyHomeView = () => {
     [navigation, trackActivitySurfaceClicked],
   );
 
-  // `link` mode is only offered when the Money Account ↔ card requirements are
-  // met — which now includes the card spending token (VEDA) being allowlisted
-  // in the cardFeature flag (see useMoneyAccountCardLinkage). When a cardholder
-  // / authenticated user can't link (e.g. VEDA not enabled), the card section
-  // is hidden rather than showing a dead "Link card" CTA.
   let metamaskCardMode: 'upsell' | 'link' | 'manage' | null;
   if (isCardLinkedToMoneyAccount) {
     metamaskCardMode = 'manage';

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -165,6 +165,7 @@ const MoneyHomeView = () => {
     isCardAuthenticated,
     isCardLinkedToMoneyAccount,
     isLinking,
+    hasMoneyAccountRequirements,
   } = useMoneyAccountCardLinkage();
 
   let displayState: MoneyBalanceDisplayState;
@@ -561,11 +562,16 @@ const MoneyHomeView = () => {
     [navigation, trackActivitySurfaceClicked],
   );
 
-  let metamaskCardMode: 'upsell' | 'link' | 'manage';
+  // `link` mode is only offered when the Money Account ↔ card requirements are
+  // met — which now includes the card spending token (VEDA) being allowlisted
+  // in the cardFeature flag (see useMoneyAccountCardLinkage). When a cardholder
+  // / authenticated user can't link (e.g. VEDA not enabled), the card section
+  // is hidden rather than showing a dead "Link card" CTA.
+  let metamaskCardMode: 'upsell' | 'link' | 'manage' | null;
   if (isCardLinkedToMoneyAccount) {
     metamaskCardMode = 'manage';
   } else if (isCardAuthenticated || isCardholder) {
-    metamaskCardMode = 'link';
+    metamaskCardMode = hasMoneyAccountRequirements ? 'link' : null;
   } else {
     metamaskCardMode = 'upsell';
   }
@@ -690,23 +696,27 @@ const MoneyHomeView = () => {
             <Divider />
           </>
         )}
-        <MoneyMetaMaskCard
-          mode={metamaskCardMode}
-          onGetNowPress={navigateToCardHome}
-          onHeaderPress={handleCardHeaderPress}
-          onLinkPress={handleLinkCardPress}
-          onManagePress={navigateToCardHome}
-          showMetalCard={hasMetalCard}
-          isLinkDisabled={isLinking}
-          cardBalance={cardBalance}
-          apy={apyPercent}
-          analyticsScreen={CardScreens.MONEY_HOME}
-          analyticsEntryPoint={CardEntryPoint.MONEY_HOME_METAMASK_CARD}
-          analyticsFlow={CardFlow.MONEY_ACCOUNT_LINKAGE}
-          analyticsCardState={cardState}
-          analyticsReady={isCardAnalyticsReady}
-        />
-        <Divider />
+        {metamaskCardMode && (
+          <>
+            <MoneyMetaMaskCard
+              mode={metamaskCardMode}
+              onGetNowPress={navigateToCardHome}
+              onHeaderPress={handleCardHeaderPress}
+              onLinkPress={handleLinkCardPress}
+              onManagePress={navigateToCardHome}
+              showMetalCard={hasMetalCard}
+              isLinkDisabled={isLinking}
+              cardBalance={cardBalance}
+              apy={apyPercent}
+              analyticsScreen={CardScreens.MONEY_HOME}
+              analyticsEntryPoint={CardEntryPoint.MONEY_HOME_METAMASK_CARD}
+              analyticsFlow={CardFlow.MONEY_ACCOUNT_LINKAGE}
+              analyticsCardState={cardState}
+              analyticsReady={isCardAnalyticsReady}
+            />
+            <Divider />
+          </>
+        )}
         {isFunded && (
           <>
             <MoneyCondensedInfoCards

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -69,8 +69,26 @@ const makeVedaDelegationSettings = () => ({
   _links: { self: '/v1/delegation/chain/config' },
 });
 
+const MONAD_VEDA_FEATURE_FLAG = {
+  chains: {
+    'eip155:143': {
+      enabled: true,
+      tokens: [
+        {
+          address: VEDA_ADDRESS,
+          symbol: 'veda',
+          decimals: 6,
+          enabled: true,
+          name: 'Veda',
+        },
+      ],
+    },
+  },
+};
+
 const createMockRootState = (
   overrides: Partial<CardControllerState> = {},
+  cardFeatureFlag?: unknown,
 ): RootState =>
   ({
     engine: {
@@ -86,6 +104,13 @@ const createMockRootState = (
           moneyAccountCardLinkInProgress: false,
           ...overrides,
         },
+        ...(cardFeatureFlag !== undefined
+          ? {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: { cardFeature: cardFeatureFlag },
+              },
+            }
+          : {}),
       },
     },
   }) as unknown as RootState;
@@ -727,6 +752,78 @@ describe('selectCardAvailableTokens', () => {
       expect(tokensB[0]?.walletAddress).toBe(WALLET_B);
     });
 
+    it('drops a placeholder whose token is not in the cardFeature allowlist', () => {
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        jest.fn().mockReturnValue({ address: WALLET_A }),
+      );
+      const homeData = {
+        ...mockCardHomeData,
+        fundingAssets: [],
+        delegationSettings: {
+          networks: [
+            {
+              network: 'linea',
+              environment: 'production',
+              chainId: '59144',
+              delegationContract: '0xdeleg000000000000000000000000000000000004',
+              tokens: {
+                FOO: {
+                  address: '0xfoo0000000000000000000000000000000000099',
+                  symbol: 'FOO',
+                  decimals: 18,
+                },
+              },
+            },
+          ],
+          count: 1,
+          _links: { self: '/v1/delegation/chain/config' },
+        },
+      } as unknown as CardHomeData;
+      const state = createMockRootState({
+        cardHomeData:
+          homeData as unknown as CardControllerState['cardHomeData'],
+      });
+      expect(selectCardAvailableTokens(state)).toStrictEqual([]);
+    });
+
+    it('drops the veda placeholder when veda is not allowlisted on monad', () => {
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        jest.fn().mockReturnValue({ address: WALLET_A }),
+      );
+      const homeData = {
+        ...mockCardHomeData,
+        fundingAssets: [],
+        delegationSettings: makeVedaDelegationSettings(),
+      } as unknown as CardHomeData;
+      const state = createMockRootState({
+        cardHomeData:
+          homeData as unknown as CardControllerState['cardHomeData'],
+      });
+      expect(selectCardAvailableTokens(state)).toStrictEqual([]);
+    });
+
+    it('keeps the veda placeholder as mUSD when monad+veda is allowlisted in cardFeature', () => {
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        jest.fn().mockReturnValue({ address: WALLET_A }),
+      );
+      const homeData = {
+        ...mockCardHomeData,
+        fundingAssets: [],
+        delegationSettings: makeVedaDelegationSettings(),
+      } as unknown as CardHomeData;
+      const state = createMockRootState(
+        {
+          cardHomeData:
+            homeData as unknown as CardControllerState['cardHomeData'],
+        },
+        MONAD_VEDA_FEATURE_FLAG,
+      );
+      const tokens = selectCardAvailableTokens(state);
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].displaySymbol).toBe('mUSD');
+      expect(tokens[0].isMoneyAccountEntry).toBe(true);
+    });
+
     it('suppresses the placeholder when the current wallet already has a real entry for the same token+chain', () => {
       mockSelectSelectedInternalAccountByScope.mockReturnValue(
         jest.fn().mockReturnValue({ address: WALLET_A }),
@@ -878,10 +975,13 @@ describe('selectCardAvailableTokens', () => {
       mockSelectSelectedInternalAccountByScope.mockReturnValue(
         jest.fn().mockReturnValue({ address: WALLET_A } as InternalAccount),
       );
-      const state = createMockRootState({
-        cardHomeData:
-          cardHomeDataWithVeda as unknown as CardControllerState['cardHomeData'],
-      });
+      const state = createMockRootState(
+        {
+          cardHomeData:
+            cardHomeDataWithVeda as unknown as CardControllerState['cardHomeData'],
+        },
+        MONAD_VEDA_FEATURE_FLAG,
+      );
       const tokens = selectCardAvailableTokens(state);
       const placeholder = tokens.find(
         (t) => t.fundingStatus === FundingStatus.NotEnabled,

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -225,12 +225,15 @@ export const selectCardAvailableTokens = createSelector(
 
     const placeholders = buildDelegationTokenList({
       delegationSettings,
+      enforceSupportList: true,
       getSupportedTokensByChainId: (chainId) =>
-        (cardFeatureFlag?.chains?.[chainId]?.tokens ?? []).map((t) => ({
-          address: t.address ?? undefined,
-          symbol: t.symbol ?? undefined,
-          name: t.name ?? undefined,
-        })),
+        (cardFeatureFlag?.chains?.[chainId]?.tokens ?? [])
+          .filter((t) => t?.enabled !== false)
+          .map((t) => ({
+            address: t.address ?? undefined,
+            symbol: t.symbol ?? undefined,
+            name: t.name ?? undefined,
+          })),
     })
       .filter(
         (placeholder) =>

--- a/app/selectors/featureFlagController/card/index.ts
+++ b/app/selectors/featureFlagController/card/index.ts
@@ -4,6 +4,22 @@ import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFla
 
 export const defaultCardFeatureFlag: CardFeatureFlag = {
   chains: {
+    'eip155:143': {
+      enabled: true,
+      foxConnectAddresses: {
+        global: '0x40A695A16C213afEf1c87Fd471Fb73157b948f3f',
+        us: '0x144c1cE815Bd1Eb71678978fE8641cC4e3fd59e6',
+      },
+      tokens: [
+        {
+          address: '0x754704bc059f8c67012fed69bc8a327a5aafb603',
+          decimals: 6,
+          enabled: true,
+          name: 'USD Coin',
+          symbol: 'USDC',
+        },
+      ],
+    },
     'eip155:59144': {
       balanceScannerAddress: '0xed9f04f2da1b42ae558d5e688fe2ef7080931c9a',
       enabled: true,
@@ -61,6 +77,13 @@ export const defaultCardFeatureFlag: CardFeatureFlag = {
           name: 'MetaMask USD',
           symbol: 'mUSD',
         },
+        {
+          address: '0x61B19879F4033c2b5682a969cccC9141e022823c',
+          decimals: 6,
+          enabled: true,
+          name: 'Aave Linea mUSD',
+          symbol: 'amUSD',
+        },
       ],
     },
     'eip155:8453': {
@@ -90,6 +113,13 @@ export const defaultCardFeatureFlag: CardFeatureFlag = {
           enabled: true,
           name: 'Aave Base USDC',
           symbol: 'aUSDC',
+        },
+        {
+          address: '0x4200000000000000000000000000000000000006',
+          decimals: 18,
+          enabled: true,
+          name: 'Wrapped Ether',
+          symbol: 'WETH',
         },
       ],
     },


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Reason for the change:** The Money Account ↔ MetaMask Card linkage and the card funding token placeholders were derived purely from the provider's delegation settings, without checking whether the spending token (VEDA, on Monad) was actually enabled in the `cardFeature` remote feature flag. As a result, cardholders/authenticated users could be shown a "Link card" CTA — and a VEDA/mUSD placeholder token — even when the token was not allowlisted (or was explicitly disabled) in the feature flag, leading to a dead CTA and tokens that should not be offered.

**Improvement/solution:** This PR makes the feature flag the source of truth for whether the Money Account card spending token is offered, and hides the card section / drops the placeholder when it is not:

- **`vedaToken.ts`** — adds `isMoneyAccountCardTokenAllowlisted(chains)`, which returns `true` only when the VEDA spending token (matched by the canonical `veda` symbol, the same key the provider's delegation settings use) is present **and** not disabled (`enabled !== false`) in any configured chain of the `cardFeature` flag.
- **`useMoneyAccountCardLinkage.tsx`** — reads the `cardFeature` flag via `selectCardFeatureFlag`, computes `isMoneyAccountCardSupported`, and gates both the resolved `moneyAccountCardToken` (now `null` when unsupported) and `hasRequirements` on it. When VEDA is missing or disabled, `canLink`/`hasMoneyAccountRequirements` become `false` and `moneyAccountCardToken` is `null`.
- **`MoneyHomeView.tsx`** — `metamaskCardMode` can now be `null`. For authenticated/cardholder users, `link` mode is only offered when `hasMoneyAccountRequirements` is met; otherwise the entire `MoneyMetaMaskCard` section (and its divider) is hidden rather than rendering a dead "Link card" CTA.
- **`buildTokenList.ts`** — `buildDelegationTokenList` gains an opt-in `enforceSupportList` flag. When enabled, a delegation token is dropped unless it matches the SDK/feature-flag support list by address (case-insensitive) **or** symbol. The SDK-token lookup was hoisted earlier so it applies to all entries (including the VEDA entry).
- **`cardController.ts`** — `selectCardAvailableTokens` now passes `enforceSupportList: true` and filters the feature-flag tokens to those with `enabled !== false` before building placeholders, so disabled/unlisted tokens never appear as funding placeholders.
- **`featureFlagController/card/index.ts`** — updates `defaultCardFeatureFlag`: adds the Monad (`eip155:143`) chain entry with USDC and FoxConnect addresses, and adds `amUSD` (Aave Linea mUSD) on Linea and `WETH` on Base.

Unit tests were added/updated across the hook, selectors, and utils to cover the allowlisted, missing, and disabled token cases.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: Fixed the MetaMask Card section on the Money screen so the "Link card" option and funding token placeholders are only shown when the card spending token is enabled in the card feature configuration.

## **Related issues**

Fixes: null

## **Manual testing steps**

```gherkin
Feature: Money Account card linkage gated on allowlisted spending token

  Scenario: Card section is hidden when the spending token is not allowlisted
    Given I am an authenticated cardholder on the Money home screen
    And the card spending token (VEDA) is not present in the cardFeature flag
    When the Money home screen renders
    Then the MetaMask Card section is not shown
    And no "Link card" CTA is offered

  Scenario: Card section is hidden when the spending token is disabled
    Given I am an authenticated cardholder on the Money home screen
    And the card spending token (VEDA) is present but disabled in the cardFeature flag
    When the Money home screen renders
    Then the MetaMask Card section is not shown

  Scenario: Link CTA is offered when the spending token is allowlisted
    Given I am an authenticated cardholder on the Money home screen
    And the card spending token (VEDA) is enabled on Monad in the cardFeature flag
    When the Money home screen renders
    Then the MetaMask Card section is shown in "link" mode
    And the Money Account funding token placeholder is displayed as mUSD

  Scenario: Unsupported funding placeholders are dropped
    Given a delegation token is not present in the cardFeature support list
    When the available card tokens are computed
    Then that token does not appear as a funding placeholder
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible card linkage and funding token lists based on remote feature flags; misconfiguration could hide valid link CTAs or show fewer placeholders than before.
> 
> **Overview**
> **Money Account ↔ MetaMask Card flows now respect the `cardFeature` remote flag** for the VEDA (mUSD) spending token, instead of trusting delegation settings alone.
> 
> `isMoneyAccountCardTokenAllowlisted` decides whether VEDA is enabled on Monad in the flag (by `veda` symbol or matching address, including mUSD-labeled entries). **`useMoneyAccountCardLinkage`** nulls the card token and clears requirements when not allowlisted, so **`canLink`** stays false. **Money home** only shows link mode when requirements pass; otherwise the MetaMask Card block is hidden for cardholders/authenticated users (no dead “Link card” CTA).
> 
> **Card funding placeholders** use **`buildDelegationTokenList`** with optional **`enforceSupportList`**: tokens must match the flag/SDK list by address or symbol; **`selectCardAvailableTokens`** turns this on and skips `enabled: false` entries. Default **`cardFeature`** adds Monad (`eip155:143`) and extra Linea/Base tokens in config defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d67d030ed9ad4b2d226207692ce3f21e4fc1af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->