### PR TITLE
refactor: make auth hooks React Compiler compatible [TO-844]

### DIFF
--- a/app/components/hooks/useSyncSRPs.ts
+++ b/app/components/hooks/useSyncSRPs.ts
@@ -13,7 +13,7 @@ export const useSyncSRPs = () => {
       return;
     }
 
-    (async () => {
+    const syncSRPs = async () => {
       try {
         setLoading(true);
         await Authentication.syncSeedPhrases();
@@ -22,7 +22,9 @@ export const useSyncSRPs = () => {
       } finally {
         setLoading(false);
       }
-    })();
+    };
+
+    syncSRPs();
   }, [isSocialLoginEnabled]);
 
   return { loading };

--- a/app/core/Authentication/hooks/useAuthCapabilities.ts
+++ b/app/core/Authentication/hooks/useAuthCapabilities.ts
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { UseAuthCapabilitiesResult } from './useAuthCapabilities.types';
 import { RootState } from '../../../reducers';
-import useAuthentication from './useAuthentication';
+import { Authentication } from '../Authentication';
 
 /**
  * Hook that detects device authentication capabilities using expo-local-authentication.
@@ -10,7 +10,6 @@ import useAuthentication from './useAuthentication';
  * Priority: REMEMBER_ME > BIOMETRIC > PASSCODE > PASSWORD
  */
 const useAuthCapabilities = (): UseAuthCapabilitiesResult => {
-  const { getAuthCapabilities } = useAuthentication();
   const [isLoading, setIsLoading] = useState(true);
   const [capabilities, setCapabilities] = useState<
     UseAuthCapabilitiesResult['capabilities'] | null
@@ -22,23 +21,23 @@ const useAuthCapabilities = (): UseAuthCapabilitiesResult => {
     (state: RootState) => state.security.allowLoginWithRememberMe,
   );
 
-  const fetchAuthCapabilities = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      // No need to catch error as it will return default capabilities
-      const result = await getAuthCapabilities({
-        osAuthEnabled,
-        allowLoginWithRememberMe,
-      });
-      setCapabilities(result);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [osAuthEnabled, allowLoginWithRememberMe, getAuthCapabilities]);
-
   useEffect(() => {
+    const fetchAuthCapabilities = async () => {
+      setIsLoading(true);
+      try {
+        // No need to catch error as it will return default capabilities
+        const result = await Authentication.getAuthCapabilities({
+          osAuthEnabled,
+          allowLoginWithRememberMe,
+        });
+        setCapabilities(result);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
     fetchAuthCapabilities();
-  }, [fetchAuthCapabilities, osAuthEnabled, allowLoginWithRememberMe]);
+  }, [osAuthEnabled, allowLoginWithRememberMe]);
 
   return {
     isLoading,


### PR DESCRIPTION
Inline async effects and call `Authentication` directly so `useAuthCapabilities` and `useSyncSRPs` follow React Compiler–friendly patterns without behavior changes.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Refactors two hooks to follow React Compiler–friendly patterns (see `docs/performance/react-compiler.md`) without changing runtime behavior:

**`useAuthCapabilities`**
- Removes the `useCallback` → `useEffect` indirection and calls `Authentication.getAuthCapabilities` directly instead of via `useAuthentication()` (which returns a new object every render).
- Inlines the async fetch inside `useEffect` with deps `[osAuthEnabled, allowLoginWithRememberMe]` only.

**`useSyncSRPs`**
- Replaces the async IIFE inside `useEffect` with a named async function (`syncSRPs`), matching the pattern used in `useAuthCapabilities`.

No API or consumer changes. Existing unit tests cover loading lifecycle, re-fetch on selector changes, and error handling.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — internal React Compiler compatibility refactor

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — behavior-preserving refactor; covered by existing unit tests:

```bash
yarn jest app/core/Authentication/hooks/useAuthCapabilities.test.ts
yarn jest app/components/hooks/useSyncSRPs.test.ts
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI changes

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c6e4415655f66dde0872feed694b2999f011c56f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->