### PR TITLE
feat: trader avatar maskicon fallback

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -66,7 +66,7 @@ describe('TopTraderCard', () => {
     expect(screen.getByTestId('top-trader-avatar-trader-1')).toBeOnTheScreen();
   });
 
-  it('renders fallback AvatarBase when avatarUri is absent', () => {
+  it('renders Maskicon fallback when avatarUri is absent', () => {
     const traderNoAvatar = { ...baseTrader, avatarUri: undefined };
     renderWithProvider(
       <TopTraderCard
@@ -74,7 +74,10 @@ describe('TopTraderCard', () => {
         onFollowPress={mockOnFollowPress}
       />,
     );
-    expect(screen.getByText('S')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(`top-trader-card-${traderNoAvatar.id}`),
+    ).toBeOnTheScreen();
+    expect(screen.queryByText('S')).toBeNull();
   });
 
   it('shows Follow when not following', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -89,7 +89,7 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
               variant={AvatarAccountVariant.Maskicon}
               address={trader.address}
               size={AvatarAccountSize.Xl}
-              twClassName={`w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px]`}
+              twClassName={`w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full`}
               maskiconProps={{ size: AVATAR_SIZE }}
             />
           )}

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -1,6 +1,7 @@
 import {
-  AvatarBase,
-  AvatarBaseSize,
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
   Box,
   BoxAlignItems,
   Button,
@@ -17,6 +18,7 @@ import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
 import { formatPnl } from '../utils/formatPnl';
+import { hasRealAvatar } from '../utils/avatarFallback';
 
 export interface TopTraderCardProps {
   trader: TopTrader;
@@ -73,7 +75,7 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
         testID={`top-trader-card-pressable-${trader.id}`}
       >
         <Box alignItems={BoxAlignItems.Center} twClassName="gap-1">
-          {trader.avatarUri ? (
+          {hasRealAvatar(trader.avatarUri) ? (
             <Image
               source={{ uri: trader.avatarUri }}
               style={tw.style(
@@ -83,10 +85,12 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
               testID={`top-trader-avatar-${trader.id}`}
             />
           ) : (
-            <AvatarBase
-              size={AvatarBaseSize.Xl}
-              fallbackText={trader.username.charAt(0).toUpperCase()}
+            <AvatarAccount
+              variant={AvatarAccountVariant.Maskicon}
+              address={trader.address}
+              size={AvatarAccountSize.Xl}
               twClassName={`w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px]`}
+              maskiconProps={{ size: AVATAR_SIZE }}
             />
           )}
 

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -44,7 +44,7 @@ describe('TraderRow', () => {
     expect(screen.getByTestId('trader-row-trader-1')).toBeOnTheScreen();
   });
 
-  it('renders fallback AvatarBase when avatarUri is absent', () => {
+  it('renders Maskicon fallback when avatarUri is absent', () => {
     const traderNoAvatar = { ...baseTrader, avatarUri: undefined };
     renderWithProvider(
       <TraderRow trader={traderNoAvatar} onFollowPress={mockOnFollowPress} />,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -1,6 +1,7 @@
 import {
-  AvatarBase,
-  AvatarBaseSize,
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -20,6 +21,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { TopRankAvatar, TopRankIndicator } from '../topRank';
 import type { TopTrader } from '../types';
 import { formatPnl } from '../utils/formatPnl';
+import { hasRealAvatar } from '../utils/avatarFallback';
 
 const AVATAR_SIZE = 40;
 // Fixed row height so the skeleton placeholder can match it exactly without
@@ -89,7 +91,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
           />
 
           <TopRankAvatar rank={trader.overallRank}>
-            {trader.avatarUri ? (
+            {hasRealAvatar(trader.avatarUri) ? (
               <Image
                 source={{ uri: trader.avatarUri }}
                 style={tw.style(
@@ -98,9 +100,10 @@ const TraderRow: React.FC<TraderRowProps> = ({
                 resizeMode="cover"
               />
             ) : (
-              <AvatarBase
-                size={AvatarBaseSize.Lg}
-                fallbackText={trader.username.charAt(0).toUpperCase()}
+              <AvatarAccount
+                variant={AvatarAccountVariant.Maskicon}
+                address={trader.address}
+                size={AvatarAccountSize.Lg}
               />
             )}
           </TopRankAvatar>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -104,6 +104,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
                 variant={AvatarAccountVariant.Maskicon}
                 address={trader.address}
                 size={AvatarAccountSize.Lg}
+                twClassName="rounded-full"
               />
             )}
           </TopRankAvatar>

--- a/app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.test.ts
@@ -1,0 +1,29 @@
+import { hasRealAvatar } from './avatarFallback';
+
+describe('hasRealAvatar', () => {
+  it('returns false for null, undefined, and empty string', () => {
+    expect(hasRealAvatar(null)).toBe(false);
+    expect(hasRealAvatar(undefined)).toBe(false);
+    expect(hasRealAvatar('')).toBe(false);
+  });
+
+  it('returns false for the known ENS fallback placeholder', () => {
+    expect(
+      hasRealAvatar(
+        'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for real Clicker-hosted avatar URLs', () => {
+    expect(
+      hasRealAvatar(
+        'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxMjY0NDk3fQ',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for any non-default URL', () => {
+    expect(hasRealAvatar('https://example.com/avatar.png')).toBe(true);
+  });
+});

--- a/app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.ts
@@ -1,0 +1,18 @@
+// Clicker returns a generic placeholder image for every `.eth` trader who
+// has no real profile picture. We want those to fall through to the Maskicon
+// fallback rather than render the shared placeholder. Add URLs here if we
+// learn of additional defaults (Farcaster, Twitter, etc.).
+const KNOWN_DEFAULT_AVATAR_URLS: readonly string[] = [
+  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png',
+];
+
+/**
+ * True when `avatarUri` is a real per-user image, false when it's missing,
+ * empty, or matches a known shared placeholder.
+ */
+export function hasRealAvatar(
+  avatarUri: string | null | undefined,
+): avatarUri is string {
+  if (!avatarUri) return false;
+  return !KNOWN_DEFAULT_AVATAR_URLS.includes(avatarUri);
+}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
@@ -48,7 +48,7 @@ describe('ProfileHeader', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders fallback AvatarBase when imageUrl is falsy', () => {
+  it('renders Maskicon fallback when imageUrl is falsy', () => {
     const profileNoImage = { ...baseProfile, imageUrl: '' };
     renderWithProvider(
       <ProfileHeader profile={profileNoImage} followerCount={45} />,
@@ -77,7 +77,7 @@ describe('ProfileHeader', () => {
     expect(screen.getByText('0 followers')).toBeOnTheScreen();
   });
 
-  it('renders the fallback letter when imageUrl is undefined', () => {
+  it('renders without a fallback letter when imageUrl is undefined', () => {
     const profileWithoutImage: TraderProfile = {
       ...baseProfile,
       imageUrl: undefined,
@@ -87,10 +87,11 @@ describe('ProfileHeader', () => {
       <ProfileHeader profile={profileWithoutImage} followerCount={45} />,
     );
 
-    expect(screen.getByText('D')).toBeOnTheScreen();
+    expect(screen.queryByText('D')).toBeNull();
+    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
   });
 
-  it('renders the fallback letter when imageUrl is empty', () => {
+  it('renders without a fallback letter when imageUrl is empty string', () => {
     const profileWithoutImage: TraderProfile = {
       ...baseProfile,
       imageUrl: '',
@@ -100,7 +101,8 @@ describe('ProfileHeader', () => {
       <ProfileHeader profile={profileWithoutImage} followerCount={45} />,
     );
 
-    expect(screen.getByText('D')).toBeOnTheScreen();
+    expect(screen.queryByText('D')).toBeNull();
+    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
   });
 
   describe('X (Twitter) icon', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -8,8 +8,9 @@ import {
   TextColor,
   BoxFlexDirection,
   BoxAlignItems,
-  AvatarBase,
-  AvatarBaseSize,
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
   Icon,
   IconName,
   IconSize,
@@ -21,6 +22,8 @@ import type { TraderProfile } from '@metamask/social-controllers';
 import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { TopRankAvatar } from '../../../Homepage/Sections/TopTraders/topRank';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
 
 const AVATAR_SIZE = 40;
 
@@ -58,7 +61,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
       testID={TraderProfileViewSelectorsIDs.HEADER}
     >
       <TopRankAvatar rank={rank ?? 0}>
-        {profile.imageUrl ? (
+        {hasRealAvatar(profile.imageUrl) ? (
           <Image
             source={{ uri: profile.imageUrl }}
             style={tw.style(
@@ -67,9 +70,10 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
             resizeMode="cover"
           />
         ) : (
-          <AvatarBase
-            size={AvatarBaseSize.Lg}
-            fallbackText={profile.name.charAt(0).toUpperCase()}
+          <AvatarAccount
+            variant={AvatarAccountVariant.Maskicon}
+            address={profile.address}
+            size={AvatarAccountSize.Lg}
           />
         )}
       </TopRankAvatar>

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -74,6 +74,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
             variant={AvatarAccountVariant.Maskicon}
             address={profile.address}
             size={AvatarAccountSize.Lg}
+            twClassName="rounded-full"
           />
         )}
       </TopRankAvatar>


### PR DESCRIPTION
  ## **Description**

Replace the letter-initial avatar fallback with a Maskicon (MetaMask's deterministic mask-shaped account art) across the three trader-avatar surfaces — Top Traders carousel, leaderboard list rows, and the trader profile header. Falls back consistently with how wallet accounts render elsewhere in the app.

Three components previously rendered a single-letter `AvatarBase` (`S` for swisscheese, `D` for dutchiono, etc.) when no profile image URL was present. They now render a Maskicon seeded by the trader's wallet address:

  - `TopTraderCard` — 60px Xl avatar in the homepage carousel
  - `TraderRow` — 40px Lg avatar in the leaderboard list
  - `ProfileHeader` — 40px Lg avatar on the trader detail screen

  **Detecting Clicker's "default" image URL**

Verified empirically: Clicker returns a generic placeholder (`daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png`) for every `.eth` trader without a real profile picture. Before this PR, a naive `trader.avatarUri ? <Image> :
 <Maskicon>` check would render that shared placeholder as an `Image` since the field is non-null, defeating the fallback for many traders (aparjey.eth, jakey.eth, stakedao.eth, etc.).

Added a small `hasRealAvatar()` helper that returns false for null/empty *and* for known shared placeholder URLs. The list lives in `app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.ts` and is easy to extend if we discover more defaults (Farcaster, Twitter, etc.).

  ## **Changelog**

  CHANGELOG entry: Updated traders without a profile picture to render a Maskicon (matching the wallet identity art elsewhere in the app) instead of a single-letter avatar.

  ## **Related issues**

  Fixes: https://consensyssoftware.atlassian.net/browse/TSA-636

  ## **Manual testing steps**

  ```gherkin
  Feature: Trader avatar Maskicon fallback

    Scenario: Trader with a real Clicker-hosted profile image
      Given the user opens any leaderboard surface (Top Traders carousel, list, or profile)
      When a trader has a real Clicker-hosted avatar URL
      Then the avatar renders as before (no visible change)

    Scenario: Trader with no profile image at all
      Given a trader has no avatar URL
      When the trader's row, card, or profile is rendered
      Then a Maskicon seeded by their wallet address is shown
      And the Maskicon is clipped to a circle, matching the real avatar styling

    Scenario: Trader using Clicker's ENS placeholder
      Given a .eth trader has Clicker's generic ENS placeholder URL
      When the trader's row, card, or profile is rendered
      Then the Maskicon fallback is shown (the placeholder image is not used)

    Scenario: Top-3 ranked trader retains the podium decoration
      Given a top-3 ranked trader has no profile image
      Then their Maskicon renders inside the existing TopRankAvatar gradient ring and crown
  ```

  ## **Screenshots/Recordings**

  ### **Before**
<img width="447" height="974" alt="Screenshot 2026-06-11 at 10 17 51 PM" src="https://github.com/user-attachments/assets/17597728-b219-4a2a-b0f2-001b0eb53ec7" />

  ### **After**
<img width="447" height="974" alt="Screenshot 2026-06-11 at 10 13 05 PM" src="https://github.com/user-attachments/assets/1664ab7d-c35a-472c-8c23-1f802c8b18c3" />


  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence per the docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes on social leaderboard surfaces with unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Replaces **letter-initial** `AvatarBase` fallbacks with **Maskicon** `AvatarAccount` art (seeded by wallet address) on Top Traders carousel cards, leaderboard rows, and trader profile headers—aligned with wallet identity elsewhere in the app.
> 
> Adds **`hasRealAvatar()`** so avatars render as `Image` only for real per-user URLs, not for missing/empty values or Clicker’s shared ENS placeholder (`ens-fallback.png`). That placeholder previously slipped through a truthy `avatarUri` check and blocked the fallback for many `.eth` traders.
> 
> Tests are updated to expect Maskicon instead of the first-letter fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448c0c268de6f762f0279c414f0c891f76d907c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->