### PR TITLE
feat: improve wallet-connect types

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -662,7 +662,7 @@ class WalletConnect2Session {
       }
 
       return this.handleAdapterRequest({
-        origin: unverifiedOrigin,
+        origin: this.channelId,
         requestEvent,
         scope: normalizedRequestChainId,
       });

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -662,7 +662,7 @@ class WalletConnect2Session {
       }
 
       return this.handleAdapterRequest({
-        channelId: this.channelId,
+        origin: unverifiedOrigin,
         requestEvent,
         scope: normalizedRequestChainId,
       });
@@ -791,11 +791,11 @@ class WalletConnect2Session {
    * the request namespace.
    */
   private handleAdapterRequest = async ({
-    channelId,
+    origin,
     requestEvent,
     scope,
   }: {
-    channelId: string;
+    origin: string;
     requestEvent: WalletKitTypes.SessionRequest;
     scope: CaipChainId;
   }) => {
@@ -806,7 +806,7 @@ class WalletConnect2Session {
 
     try {
       const result = await handleMultichainRequestByAdapter({
-        channelId,
+        origin,
         connectedAddresses,
         scope,
         requestId: requestEvent.id,

--- a/app/core/WalletConnect/multichain/helpers.test.ts
+++ b/app/core/WalletConnect/multichain/helpers.test.ts
@@ -332,7 +332,7 @@ describe('handleRequestByAdapter', () => {
     mockedGetAdapter.mockReturnValue(fakeAdapter);
 
     const args = {
-      channelId: 'channel',
+      origin: 'https://dapp.example.com',
       connectedAddresses: ['tron:0x2b6653dc:TAddr' as CaipAccountId],
       scope: 'tron:0x2b6653dc' as CaipChainId,
       requestId: 1,
@@ -352,7 +352,7 @@ describe('handleRequestByAdapter', () => {
 
     await expect(
       handleRequestByAdapter({
-        channelId: 'channel',
+        origin: 'https://dapp.example.com',
         connectedAddresses: [],
         scope: 'tron:0x2b6653dc',
         requestId: 1,

--- a/app/core/WalletConnect/multichain/helpers.test.ts
+++ b/app/core/WalletConnect/multichain/helpers.test.ts
@@ -332,7 +332,7 @@ describe('handleRequestByAdapter', () => {
     mockedGetAdapter.mockReturnValue(fakeAdapter);
 
     const args = {
-      origin: 'https://dapp.example.com',
+      origin: 'channelId',
       connectedAddresses: ['tron:0x2b6653dc:TAddr' as CaipAccountId],
       scope: 'tron:0x2b6653dc' as CaipChainId,
       requestId: 1,
@@ -352,7 +352,7 @@ describe('handleRequestByAdapter', () => {
 
     await expect(
       handleRequestByAdapter({
-        origin: 'https://dapp.example.com',
+        origin: 'channelId',
         connectedAddresses: [],
         scope: 'tron:0x2b6653dc',
         requestId: 1,

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -8,7 +8,7 @@
 
 import type { KnownCaipNamespace } from '@metamask/utils';
 
-import type { ChainAdapter } from './types';
+import type { AnyChainAdapter } from './types';
 
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { tronAdapter } from './tron';
@@ -16,26 +16,26 @@ import { tronAdapter } from './tron';
 
 // Keyed by raw namespace string so lookups accept whatever a dapp proposal
 // sent, which we don't trust upfront.
-const adapters = new Map<string, ChainAdapter>();
+const adapters = new Map<string, AnyChainAdapter>();
 
 /**
  * Register a `ChainAdapter` under its CAIP-2 namespace.
  */
-export function registerAdapter(adapter: ChainAdapter): void {
+export function registerAdapter(adapter: AnyChainAdapter): void {
   adapters.set(adapter.namespace, adapter);
 }
 
 /**
  * Returns the adapter for a CAIP-2 namespace, if any.
  */
-export function getAdapter(namespace: string): ChainAdapter | undefined {
+export function getAdapter(namespace: string): AnyChainAdapter | undefined {
   return adapters.get(namespace);
 }
 
 /**
  * Returns every registered adapter, in insertion order.
  */
-export function getAllAdapters(): ChainAdapter[] {
+export function getAllAdapters(): AnyChainAdapter[] {
   return Array.from(adapters.values());
 }
 

--- a/app/core/WalletConnect/multichain/router.ts
+++ b/app/core/WalletConnect/multichain/router.ts
@@ -1,37 +1,36 @@
 import type { CaipAccountId, CaipChainId, Json } from '@metamask/utils';
 import Engine from '../../Engine';
-import type { SnapMappedRequest } from './types';
+import type { RpcMethod, RpcResponse, RpcSpec } from './types';
 
 /**
- * Route a non-EVM request through the MultichainRoutingService.
+ * Build a Snap caller bound to one Snap RPC spec, routing each request
+ * through the MultichainRoutingService.
  */
-export async function callMultichainRoutingService({
-  origin,
-  connectedAddresses,
-  scope,
-  requestId,
-  mappedRequest,
-}: {
-  origin: string;
-  connectedAddresses: CaipAccountId[];
-  scope: CaipChainId;
-  requestId: number;
-  mappedRequest: SnapMappedRequest;
-}): Promise<unknown> {
-  return Engine.controllerMessenger.call(
-    'MultichainRoutingService:handleRequest',
-    {
+export function createSnapCaller<Spec extends RpcSpec<Spec>>() {
+  return async <Method extends RpcMethod<Spec>>({
+    origin,
+    connectedAddresses,
+    scope,
+    requestId,
+    request,
+  }: {
+    origin: string;
+    connectedAddresses: CaipAccountId[];
+    scope: CaipChainId;
+    requestId: number;
+    request: { method: Method; params: Spec[Method]['params'] };
+  }): Promise<RpcResponse<Spec, Method>> =>
+    Engine.controllerMessenger.call('MultichainRoutingService:handleRequest', {
       connectedAddresses,
       origin,
       scope,
       request: {
         jsonrpc: '2.0' as const,
         id: requestId,
-        method: mappedRequest.method,
-        ...(mappedRequest.params
-          ? { params: mappedRequest.params as Record<string, Json> | Json[] }
+        method: request.method,
+        ...(request.params
+          ? { params: request.params as Record<string, Json> | Json[] }
           : {}),
       },
-    },
-  );
+    }) as Promise<RpcResponse<Spec, Method>>;
 }

--- a/app/core/WalletConnect/multichain/router.ts
+++ b/app/core/WalletConnect/multichain/router.ts
@@ -6,13 +6,13 @@ import type { SnapMappedRequest } from './types';
  * Route a non-EVM request through the MultichainRoutingService.
  */
 export async function callMultichainRoutingService({
-  channelId,
+  origin,
   connectedAddresses,
   scope,
   requestId,
   mappedRequest,
 }: {
-  channelId: string;
+  origin: string;
   connectedAddresses: CaipAccountId[];
   scope: CaipChainId;
   requestId: number;
@@ -22,7 +22,7 @@ export async function callMultichainRoutingService({
     'MultichainRoutingService:handleRequest',
     {
       connectedAddresses,
-      origin: channelId,
+      origin,
       scope,
       request: {
         jsonrpc: '2.0' as const,

--- a/app/core/WalletConnect/multichain/tron/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.test.ts
@@ -287,5 +287,32 @@ describe('multichain/tron', () => {
         signature: ['0xsig'],
       });
     });
+
+    it('passes the dapp origin to the Snap routing service when provided', async () => {
+      mockedCallMultichainRoutingService.mockResolvedValue({
+        signature: '0xsig',
+      });
+
+      await tronAdapter.handleRequest({
+        origin: 'https://tron.example.com',
+        connectedAddresses: ['tron:0x2b6653dc:TTestAddress' as CaipAccountId],
+        scope: 'tron:728126428' as CaipChainId,
+        requestId: 1,
+        method: 'tron_signMessage',
+        params: {
+          address: 'TTestAddress',
+          message: 'hello',
+        },
+      });
+
+      expect(mockedCallMultichainRoutingService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          origin: 'https://tron.example.com',
+          connectedAddresses: ['tron:728126428:TTestAddress'],
+          scope: 'tron:728126428',
+          requestId: 1,
+        }),
+      );
+    });
   });
 });

--- a/app/core/WalletConnect/multichain/tron/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.test.ts
@@ -252,7 +252,7 @@ describe('multichain/tron', () => {
       });
 
       const result = await tronAdapter.handleRequest({
-        origin: 'https://tron.example.com',
+        origin: 'channelId',
         connectedAddresses: ['tron:0x2b6653dc:TTestAddress' as CaipAccountId],
         scope: 'tron:728126428' as CaipChainId,
         requestId: 1,
@@ -269,7 +269,7 @@ describe('multichain/tron', () => {
       });
 
       expect(mockedCallTronSnap).toHaveBeenCalledWith({
-        origin: 'https://tron.example.com',
+        origin: 'channelId',
         connectedAddresses: ['tron:728126428:TTestAddress'],
         scope: 'tron:728126428',
         requestId: 1,
@@ -296,7 +296,7 @@ describe('multichain/tron', () => {
       });
 
       await tronAdapter.handleRequest({
-        origin: 'https://tron.example.com',
+        origin: 'channelId',
         connectedAddresses: ['tron:0x2b6653dc:TTestAddress' as CaipAccountId],
         scope: 'tron:728126428' as CaipChainId,
         requestId: 1,
@@ -309,7 +309,7 @@ describe('multichain/tron', () => {
 
       expect(mockedCallTronSnap).toHaveBeenCalledWith(
         expect.objectContaining({
-          origin: 'https://tron.example.com',
+          origin: 'channelId',
           connectedAddresses: ['tron:728126428:TTestAddress'],
           scope: 'tron:728126428',
           requestId: 1,
@@ -319,7 +319,7 @@ describe('multichain/tron', () => {
 
     it('rejects unsupported WalletConnect methods', async () => {
       const args = {
-        origin: 'https://tron.example.com',
+        origin: 'channelId',
         connectedAddresses: [] as CaipAccountId[],
         scope: 'tron:728126428' as CaipChainId,
         requestId: 1,

--- a/app/core/WalletConnect/multichain/tron/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.test.ts
@@ -7,7 +7,7 @@ import type { CaipAccountId, CaipChainId } from '@metamask/utils';
 
 import Engine from '../../../Engine';
 import { getPermittedCaipChainIds } from '../../../Permissions';
-import { callMultichainRoutingService } from '../router';
+import { createSnapCaller } from '../router';
 import {
   enrichCaveatValue,
   getScopedPermissions,
@@ -42,9 +42,12 @@ jest.mock('../../../Permissions', () => ({
   getPermittedCaipChainIds: jest.fn(),
 }));
 
-jest.mock('../router', () => ({
-  callMultichainRoutingService: jest.fn(),
-}));
+jest.mock('../router', () => {
+  const snapCallerMock = jest.fn();
+  return {
+    createSnapCaller: () => snapCallerMock,
+  };
+});
 
 jest.mock('../../../SDKConnect/utils/DevLogger', () => ({
   log: jest.fn(),
@@ -55,8 +58,7 @@ const mockedGetAccountsFromSelectedAccountGroup = Engine.context
 const mockedGetCaveat = Engine.context.PermissionController
   .getCaveat as jest.Mock;
 const mockedGetPermittedCaipChainIds = getPermittedCaipChainIds as jest.Mock;
-const mockedCallMultichainRoutingService =
-  callMultichainRoutingService as jest.Mock;
+const mockedCallTronSnap = (createSnapCaller as unknown as () => jest.Mock)();
 const mockedGetCaipAccountIdsFromCaip25CaveatValue =
   getCaipAccountIdsFromCaip25CaveatValue as jest.Mock;
 
@@ -66,7 +68,7 @@ describe('multichain/tron', () => {
     mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([]);
     mockedGetCaveat.mockReturnValue(undefined);
     mockedGetPermittedCaipChainIds.mockResolvedValue([]);
-    mockedCallMultichainRoutingService.mockResolvedValue(undefined);
+    mockedCallTronSnap.mockResolvedValue(undefined);
     mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
   });
 
@@ -245,7 +247,7 @@ describe('multichain/tron', () => {
     });
 
     it('handles requests by mapping, routing, and normalizing the result', async () => {
-      mockedCallMultichainRoutingService.mockResolvedValue({
+      mockedCallTronSnap.mockResolvedValue({
         signature: '0xsig',
       });
 
@@ -266,12 +268,12 @@ describe('multichain/tron', () => {
         },
       });
 
-      expect(mockedCallMultichainRoutingService).toHaveBeenCalledWith({
+      expect(mockedCallTronSnap).toHaveBeenCalledWith({
         origin: 'https://tron.example.com',
         connectedAddresses: ['tron:728126428:TTestAddress'],
         scope: 'tron:728126428',
         requestId: 1,
-        mappedRequest: {
+        request: {
           method: 'signTransaction',
           params: {
             address: 'TTestAddress',
@@ -289,7 +291,7 @@ describe('multichain/tron', () => {
     });
 
     it('passes the dapp origin to the Snap routing service when provided', async () => {
-      mockedCallMultichainRoutingService.mockResolvedValue({
+      mockedCallTronSnap.mockResolvedValue({
         signature: '0xsig',
       });
 
@@ -305,7 +307,7 @@ describe('multichain/tron', () => {
         },
       });
 
-      expect(mockedCallMultichainRoutingService).toHaveBeenCalledWith(
+      expect(mockedCallTronSnap).toHaveBeenCalledWith(
         expect.objectContaining({
           origin: 'https://tron.example.com',
           connectedAddresses: ['tron:728126428:TTestAddress'],
@@ -313,6 +315,26 @@ describe('multichain/tron', () => {
           requestId: 1,
         }),
       );
+    });
+
+    it('rejects unsupported WalletConnect methods', async () => {
+      const args = {
+        origin: 'https://tron.example.com',
+        connectedAddresses: [] as CaipAccountId[],
+        scope: 'tron:728126428' as CaipChainId,
+        requestId: 1,
+        method: 'tron_unknownMethod',
+        params: {},
+      };
+
+      await expect(
+        // @ts-expect-error - misbehaving client sending an unapproved method
+        tronAdapter.handleRequest(args),
+      ).rejects.toThrow(
+        'WalletConnect Tron method tron_unknownMethod is not supported',
+      );
+
+      expect(mockedCallTronSnap).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/core/WalletConnect/multichain/tron/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.test.ts
@@ -250,7 +250,7 @@ describe('multichain/tron', () => {
       });
 
       const result = await tronAdapter.handleRequest({
-        channelId: 'metamask',
+        origin: 'https://tron.example.com',
         connectedAddresses: ['tron:0x2b6653dc:TTestAddress' as CaipAccountId],
         scope: 'tron:728126428' as CaipChainId,
         requestId: 1,
@@ -267,7 +267,7 @@ describe('multichain/tron', () => {
       });
 
       expect(mockedCallMultichainRoutingService).toHaveBeenCalledWith({
-        channelId: 'metamask',
+        origin: 'https://tron.example.com',
         connectedAddresses: ['tron:728126428:TTestAddress'],
         scope: 'tron:728126428',
         requestId: 1,

--- a/app/core/WalletConnect/multichain/tron/adapter.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.ts
@@ -4,25 +4,16 @@ import {
   type CaipChainId,
   KnownCaipNamespace,
 } from '@metamask/utils';
-import {
-  Caip25CaveatType,
-  type Caip25CaveatValue,
-  Caip25EndowmentPermissionName,
-  getCaipAccountIdsFromCaip25CaveatValue,
-} from '@metamask/chain-agnostic-permission';
-import { PermissionDoesNotExistError } from '@metamask/permission-controller';
+import { type Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
 
-import Engine from '../../../Engine';
-import { getPermittedCaipChainIds } from '../../../Permissions';
-import DevLogger from '../../../SDKConnect/utils/DevLogger';
 import {
+  buildAdapterScopedPermissions,
   caipAccountIdDecimalToHex,
   caipAccountIdHexToDecimal,
   caipChainIdDecimalToHex,
   caipChainIdHexToDecimal,
-  collectRequestedChainsForNamespace,
   doesProposalOrSessionIncludeNamespace,
-  prioritizeSelectedCaipAccountIds,
+  enrichCaveatValueForNamespace,
 } from '../utils';
 import type {
   AdapterHandleRequestArgs,
@@ -114,54 +105,14 @@ export async function getScopedPermissions({
 }: {
   channelId: string;
 }): Promise<NamespaceConfig | undefined> {
-  const permittedChains = await getPermittedCaipChainIds(channelId);
-  const tronChains = permittedChains.filter((chain) =>
-    chain.startsWith(`${KnownCaipNamespace.Tron}:`),
-  );
-
-  if (tronChains.length === 0) {
-    return undefined;
-  }
-
-  let permittedTronAccounts: CaipAccountId[] = [];
-  try {
-    const permissionCaveat = Engine.context.PermissionController?.getCaveat(
-      channelId,
-      Caip25EndowmentPermissionName,
-      Caip25CaveatType,
-    );
-    if (permissionCaveat) {
-      permittedTronAccounts = getCaipAccountIdsFromCaip25CaveatValue(
-        permissionCaveat.value as Parameters<
-          typeof getCaipAccountIdsFromCaip25CaveatValue
-        >[0],
-      ).filter((account) => account.startsWith(`${KnownCaipNamespace.Tron}:`));
-    }
-  } catch (error) {
-    if (!(error instanceof PermissionDoesNotExistError)) {
-      DevLogger.log(
-        '[wc][multichain/tron] failed to read permission caveat',
-        error,
-      );
-    }
-  }
-
-  if (permittedTronAccounts.length === 0) {
-    return undefined;
-  }
-
-  const sortedPermittedTronAccounts = prioritizeSelectedCaipAccountIds(
-    permittedTronAccounts,
-  );
-
-  return {
-    chains: tronChains.map((chain) => normalizeCaipChainIdOutbound(chain)),
-    methods: [...TRON_METHODS],
-    events: [...TRON_EVENTS],
-    accounts: sortedPermittedTronAccounts.map((account) =>
-      normalizeTronAccountIdOutbound(account),
-    ),
-  };
+  return buildAdapterScopedPermissions({
+    channelId,
+    namespace: KnownCaipNamespace.Tron,
+    methods: TRON_METHODS,
+    events: TRON_EVENTS,
+    normalizeChainIdOutbound: normalizeCaipChainIdOutbound,
+    normalizeAccountIdOutbound: normalizeTronAccountIdOutbound,
+  });
 }
 
 /**
@@ -202,33 +153,14 @@ export function enrichCaveatValue({
   proposal: ProposalParamsLight;
   caveatValue: Caip25CaveatValue;
 }): Caip25CaveatValue {
-  const requestedTronChains = collectRequestedChainsForNamespace({
+  return enrichCaveatValueForNamespace({
     proposal,
+    caveatValue,
     namespace: KnownCaipNamespace.Tron,
+    supportedScopes: SUPPORTED_TRON_SCOPES,
+    fallbackScope: TrxScope.Mainnet as CaipChainId,
+    normalizeChainIdInbound: normalizeCaipChainIdInbound,
   });
-
-  if (requestedTronChains.length === 0) {
-    return caveatValue;
-  }
-
-  const normalizedScopes = requestedTronChains
-    .map((chain) => normalizeCaipChainIdInbound(chain))
-    .filter((chain) => SUPPORTED_TRON_SCOPES.has(chain));
-
-  const scopesToAdd =
-    normalizedScopes.length > 0 ? normalizedScopes : [TrxScope.Mainnet];
-
-  const extraOptionalScopes = Object.fromEntries(
-    scopesToAdd.map((scope) => [scope, { accounts: [] }]),
-  );
-
-  return {
-    ...caveatValue,
-    optionalScopes: {
-      ...caveatValue.optionalScopes,
-      ...extraOptionalScopes,
-    },
-  };
 }
 
 /**

--- a/app/core/WalletConnect/multichain/tron/adapter.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.ts
@@ -20,20 +20,27 @@ import type {
   ChainAdapter,
   NamespaceConfig,
   ProposalParamsLight,
+  RpcMethod,
+  RpcResponse,
 } from '../types';
-import { callMultichainRoutingService } from '../router';
-import { mapRequestInbound, mapRequestOutbound } from './mapper';
-import type {
-  TronSnapSignatureResult,
-  TronWalletConnectMethod,
-  TronWalletConnectSignMessageParams,
-  TronWalletConnectSignTransactionParams,
-} from './types';
+import { createSnapCaller } from '../router';
+import {
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+} from './mapper';
+import type { TronSnapSpec, TronWalletConnectSpec } from './types';
+
+/**
+ * Snap caller bound to the Tron Snap spec.
+ */
+const callTronSnap = createSnapCaller<TronSnapSpec>();
 
 /**
  * WalletConnect methods the wallet exposes for the Tron namespace.
  */
-const TRON_METHODS: readonly TronWalletConnectMethod[] = [
+const TRON_METHODS: readonly RpcMethod<TronWalletConnectSpec>[] = [
   'tron_signTransaction',
   'tron_signMessage',
 ];
@@ -175,35 +182,48 @@ export async function handleRequest({
   requestId,
   method,
   params,
-}: AdapterHandleRequestArgs): Promise<unknown> {
+}: AdapterHandleRequestArgs<TronWalletConnectSpec>): Promise<
+  RpcResponse<TronWalletConnectSpec>
+> {
   const normalizedConnectedAddresses = connectedAddresses.map((account) =>
     normalizeTronAccountIdInbound(account),
   );
-  // Throws for unsupported methods, guaranteeing `method` is a
-  // `TronWalletConnectMethod` from here on.
-  const mappedRequest = mapRequestInbound({ method, params });
-  const result = await callMultichainRoutingService({
-    origin,
-    connectedAddresses: normalizedConnectedAddresses,
-    scope,
-    requestId,
-    mappedRequest,
-  });
 
-  return mapRequestOutbound({
-    method: method as TronWalletConnectMethod,
-    params: params as
-      | TronWalletConnectSignMessageParams
-      | TronWalletConnectSignTransactionParams,
-    result: result as TronSnapSignatureResult,
-  });
+  if (method === 'tron_signMessage') {
+    const result = await callTronSnap({
+      origin,
+      connectedAddresses: normalizedConnectedAddresses,
+      scope,
+      requestId,
+      request: mapSignMessageRequest({ params }),
+    });
+
+    return mapSignMessageResponse(result);
+  }
+
+  if (method === 'tron_signTransaction') {
+    const result = await callTronSnap({
+      origin,
+      connectedAddresses: normalizedConnectedAddresses,
+      scope,
+      requestId,
+      request: mapSignTransactionRequest({ params }),
+    });
+
+    return mapSignTransactionResponse({ params, result });
+  }
+
+  throw new Error(`WalletConnect Tron method ${method} is not supported`);
 }
 
 /**
  * `ChainAdapter` for Tron, registered in `multichain/registry.ts` behind
  * the `tron` feature flag.
  */
-export const tronAdapter: ChainAdapter = {
+export const tronAdapter: ChainAdapter<
+  KnownCaipNamespace.Tron,
+  TronWalletConnectSpec
+> = {
   namespace: KnownCaipNamespace.Tron,
   redirectMethods: TRON_METHODS,
   approvedMethods: TRON_METHODS,

--- a/app/core/WalletConnect/multichain/tron/adapter.ts
+++ b/app/core/WalletConnect/multichain/tron/adapter.ts
@@ -237,7 +237,7 @@ export function enrichCaveatValue({
  * WalletConnect format for the dapp.
  */
 export async function handleRequest({
-  channelId,
+  origin,
   connectedAddresses,
   scope,
   requestId,
@@ -251,7 +251,7 @@ export async function handleRequest({
   // `TronWalletConnectMethod` from here on.
   const mappedRequest = mapRequestInbound({ method, params });
   const result = await callMultichainRoutingService({
-    channelId,
+    origin,
     connectedAddresses: normalizedConnectedAddresses,
     scope,
     requestId,

--- a/app/core/WalletConnect/multichain/tron/mapper.test.ts
+++ b/app/core/WalletConnect/multichain/tron/mapper.test.ts
@@ -1,8 +1,10 @@
 import {
   extractTronRawDataHex,
   extractTronType,
-  mapRequestInbound,
-  mapRequestOutbound,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
 } from './mapper';
 
 describe('multichain/tron - mapper', () => {
@@ -53,10 +55,9 @@ describe('multichain/tron - mapper', () => {
     });
   });
 
-  describe('mapRequestInbound', () => {
+  describe('inbound request mappers', () => {
     it('maps tron_signMessage to canonical signMessage with a base64 message', () => {
-      const result = mapRequestInbound({
-        method: 'tron_signMessage',
+      const result = mapSignMessageRequest({
         params: { address: 'TAddress', message: 'hello' },
       });
 
@@ -66,21 +67,8 @@ describe('multichain/tron - mapper', () => {
       });
     });
 
-    it('omits non-string fields when mapping tron_signMessage', () => {
-      const result = mapRequestInbound({
-        method: 'tron_signMessage',
-        params: { address: 42, message: 'hello' },
-      });
-
-      expect(result).toStrictEqual({
-        method: 'signMessage',
-        params: { message: 'aGVsbG8=' },
-      });
-    });
-
     it('maps tron_signTransaction in the legacy double-wrap format', () => {
-      const result = mapRequestInbound({
-        method: 'tron_signTransaction',
+      const result = mapSignTransactionRequest({
         params: {
           address: 'TAddress',
           transaction: {
@@ -102,8 +90,7 @@ describe('multichain/tron - mapper', () => {
     });
 
     it('maps tron_signTransaction in the v1 flat format', () => {
-      const result = mapRequestInbound({
-        method: 'tron_signTransaction',
+      const result = mapSignTransactionRequest({
         params: {
           address: 'TAddress',
           transaction: {
@@ -122,46 +109,21 @@ describe('multichain/tron - mapper', () => {
       });
     });
 
-    it('omits address and type when missing in input', () => {
-      const result = mapRequestInbound({
-        method: 'tron_signTransaction',
-        params: { transaction: { raw_data_hex: '0xabc' } },
+    it('omits the contract type when missing in input', () => {
+      const result = mapSignTransactionRequest({
+        params: { address: 'TAddress', transaction: { raw_data_hex: '0xabc' } },
       });
 
       expect(result).toStrictEqual({
         method: 'signTransaction',
-        params: { transaction: { rawDataHex: '0xabc' } },
+        params: { address: 'TAddress', transaction: { rawDataHex: '0xabc' } },
       });
-    });
-
-    it('throws for any non-supported Tron method', () => {
-      expect(() =>
-        mapRequestInbound({
-          method: 'tron_sendTransaction',
-          params: { transaction: { raw_data_hex: '0xabc' } },
-        }),
-      ).toThrow(
-        'WalletConnect Tron method tron_sendTransaction is not supported',
-      );
-
-      expect(() =>
-        mapRequestInbound({
-          method: 'tron_someFutureMethod',
-          params: { foo: 'bar' },
-        }),
-      ).toThrow(
-        'WalletConnect Tron method tron_someFutureMethod is not supported',
-      );
     });
   });
 
-  describe('mapRequestOutbound', () => {
-    it('returns the result unchanged for non tron_signTransaction methods', () => {
-      const result = mapRequestOutbound({
-        method: 'tron_signMessage',
-        params: { address: 'T', message: 'hello' },
-        result: { signature: '0xsig' },
-      });
+  describe('outbound response mappers', () => {
+    it('forwards the snap message signature unchanged', () => {
+      const result = mapSignMessageResponse({ signature: '0xsig' });
 
       expect(result).toStrictEqual({ signature: '0xsig' });
     });
@@ -173,8 +135,7 @@ describe('multichain/tron - mapper', () => {
         transaction: { transaction: original },
       };
 
-      const result = mapRequestOutbound({
-        method: 'tron_signTransaction',
+      const result = mapSignTransactionResponse({
         params,
         result: { signature: '0xsig' },
       });
@@ -190,8 +151,7 @@ describe('multichain/tron - mapper', () => {
       const original = { raw_data_hex: '0xabc', visible: false };
       const params = { address: 'TAddr', transaction: original };
 
-      const result = mapRequestOutbound({
-        method: 'tron_signTransaction',
+      const result = mapSignTransactionResponse({
         params,
         result: { signature: '0xsig' },
       });
@@ -201,30 +161,6 @@ describe('multichain/tron - mapper', () => {
         visible: false,
         signature: ['0xsig'],
       });
-    });
-
-    it('returns the snap result unchanged when no original transaction is present', () => {
-      const snapResult = { signature: '0xsig' };
-
-      expect(
-        mapRequestOutbound({
-          method: 'tron_signTransaction',
-          params: { address: 'TAddr' },
-          result: snapResult,
-        }),
-      ).toBe(snapResult);
-    });
-
-    it('returns the snap result unchanged when the signature is missing', () => {
-      const snapResult = {};
-
-      expect(
-        mapRequestOutbound({
-          method: 'tron_signTransaction',
-          params: { transaction: { raw_data_hex: '0xabc' } },
-          result: snapResult,
-        }),
-      ).toBe(snapResult);
     });
   });
 });

--- a/app/core/WalletConnect/multichain/tron/mapper.ts
+++ b/app/core/WalletConnect/multichain/tron/mapper.ts
@@ -1,33 +1,26 @@
 import { isObject } from '@metamask/utils';
+import type { RpcRequest } from '../types';
 import type {
-  TronSnapMappedRequest,
-  TronSnapSignatureResult,
-  TronSnapSignMessageParams,
-  TronSnapSignTransactionParams,
-  TronWalletConnectMethod,
-  TronWalletConnectRequest,
-  TronWalletConnectSignMessageParams,
-  TronWalletConnectSignTransactionParams,
+  TronAddress,
+  TronSnapSpec,
+  TronWalletConnectSpec,
   TronWalletConnectTransaction,
 } from './types';
 
 /**
- * Extract `raw_data_hex` from a WalletConnect transaction container, walking
- * the legacy double-wrap (`transaction.transaction`) if present.
+ * Extract `raw_data_hex` from a WalletConnect transaction, walking the legacy
+ * double-wrap (`transaction.transaction`) if present.
  */
 export function extractTronRawDataHex(
-  value: Record<string, unknown> | undefined,
+  transaction: TronWalletConnectTransaction | undefined,
 ): string | undefined {
-  if (!value) {
+  if (!transaction) {
     return undefined;
   }
-
-  const candidate = value as TronWalletConnectTransaction;
-
-  if (typeof candidate.raw_data_hex === 'string') {
-    return candidate.raw_data_hex;
+  if (typeof transaction.raw_data_hex === 'string') {
+    return transaction.raw_data_hex;
   }
-  return extractTronRawDataHex(candidate.transaction);
+  return extractTronRawDataHex(transaction.transaction);
 }
 
 /**
@@ -35,152 +28,103 @@ export function extractTronRawDataHex(
  * legacy double-wrap if present.
  */
 export function extractTronType(
-  value: Record<string, unknown> | undefined,
+  transaction: TronWalletConnectTransaction | undefined,
 ): string | undefined {
-  if (!value) {
+  if (!transaction) {
     return undefined;
   }
-
-  const candidate = value as TronWalletConnectTransaction;
-
-  const contractType = candidate.raw_data?.contract?.[0]?.type;
+  const contractType = transaction.raw_data?.contract?.[0]?.type;
   if (typeof contractType === 'string' && contractType.length > 0) {
     return contractType;
   }
-  return extractTronType(candidate.transaction);
+  return extractTronType(transaction.transaction);
 }
 
 /**
- * Unwrap a Tron transaction container, walking the legacy double-wrap
- * (`transaction.transaction`) if present. Returns the innermost transaction
- * object, or `undefined` if the input is not an object.
+ * Unwrap the legacy double-wrap (`transaction.transaction`) if present.
  */
 function unwrapTronTransaction(
-  value: unknown,
-): Record<string, unknown> | undefined {
-  if (!isObject(value)) {
-    return undefined;
-  }
-  return isObject(value.transaction) ? value.transaction : value;
+  transaction: TronWalletConnectTransaction,
+): TronWalletConnectTransaction {
+  return isObject(transaction.transaction)
+    ? transaction.transaction
+    : transaction;
 }
 
 /**
- * Map a WC-shaped Tron request into the Tron Snap's params shape.
- *
- * `tron_signMessage` → `signMessage` (message base64-encoded);
- * `tron_signTransaction` → `signTransaction` (`raw_data_hex` →
- * `rawDataHex`).
- *
- * Throws on any other method. The WC namespace approval restricts dapps to
- * these two, so unsupported methods indicate a misbehaving client.
+ * Convert WalletConnect message signing params into the canonical Tron Snap
+ * request. The Tron snap expects `message` to be base64-encoded.
  */
-export function mapRequestInbound({
-  method,
+export function mapSignMessageRequest({
   params,
-}: TronWalletConnectRequest): TronSnapMappedRequest {
-  const param = isObject(params) ? params : undefined;
-
-  if (method === 'tron_signMessage') {
-    const mappedParams: Partial<TronSnapSignMessageParams> = {};
-    const address = param?.address;
-    const message = param?.message;
-
-    if (typeof address === 'string') {
-      mappedParams.address = address as TronSnapSignMessageParams['address'];
-    }
-    if (typeof message === 'string') {
-      // The Tron snap requires `message` to be base64-encoded
-      // (validated against /^(?:[A-Za-z0-9+/]{4})*...$/ then decoded via
-      // Buffer.from(message, 'base64').toString('utf8')).
-      mappedParams.message = Buffer.from(message, 'utf8').toString('base64');
-    }
-
-    return {
-      method: 'signMessage',
-      params: mappedParams,
-    };
-  }
-
-  if (method === 'tron_signTransaction') {
-    const rawDataHex = extractTronRawDataHex(param);
-    const type = extractTronType(param);
-
-    const mappedTransaction: Partial<
-      TronSnapSignTransactionParams['transaction']
-    > = {};
-    if (typeof rawDataHex === 'string') {
-      mappedTransaction.rawDataHex = rawDataHex;
-    }
-    if (typeof type === 'string') {
-      mappedTransaction.type = type;
-    }
-
-    const mappedParams: {
-      address?: TronSnapSignTransactionParams['address'];
-      transaction: Partial<TronSnapSignTransactionParams['transaction']>;
-    } = {
-      transaction: mappedTransaction,
-    };
-    const address = param?.address;
-    if (typeof address === 'string') {
-      mappedParams.address =
-        address as TronSnapSignTransactionParams['address'];
-    }
-
-    return {
-      method: 'signTransaction',
-      params: mappedParams,
-    };
-  }
-
-  throw new Error(`WalletConnect Tron method ${method} is not supported`);
+}: {
+  params: TronWalletConnectSpec['tron_signMessage']['params'];
+}): RpcRequest<TronSnapSpec, 'signMessage'> {
+  return {
+    method: 'signMessage',
+    params: {
+      address: params.address as TronAddress,
+      message: Buffer.from(params.message, 'utf8').toString('base64'),
+    },
+  };
 }
 
 /**
- * Normalize the Tron Snap's response for a WC request before forwarding it
- * to the dapp.
- *
- * `tron_signTransaction` dapps expect the original transaction with a
- * `signature` array appended; the Snap returns just `{ signature }`, so we
- * re-attach it. `tron_signMessage` passes through unchanged. Throws on any
- * other method.
+ * Forward the Tron Snap message signature in the WalletConnect
+ * `tron_signMessage` response shape.
  */
-export function mapRequestOutbound({
-  method,
+export function mapSignMessageResponse(
+  result: TronSnapSpec['signMessage']['response'],
+): TronWalletConnectSpec['tron_signMessage']['response'] {
+  return result;
+}
+
+/**
+ * Convert WalletConnect transaction signing params into the canonical Tron
+ * Snap transaction request. WalletConnect can send either the v1 flat
+ * transaction or the legacy double-wrapped shape.
+ */
+export function mapSignTransactionRequest({
+  params,
+}: {
+  params: TronWalletConnectSpec['tron_signTransaction']['params'];
+}): RpcRequest<TronSnapSpec, 'signTransaction'> {
+  const transaction: TronSnapSpec['signTransaction']['params']['transaction'] =
+    {};
+
+  const rawDataHex = extractTronRawDataHex(params.transaction);
+  if (typeof rawDataHex === 'string') {
+    transaction.rawDataHex = rawDataHex;
+  }
+
+  const type = extractTronType(params.transaction);
+  if (typeof type === 'string') {
+    transaction.type = type;
+  }
+
+  return {
+    method: 'signTransaction',
+    params: {
+      address: params.address as TronAddress,
+      transaction,
+    },
+  };
+}
+
+/**
+ * Convert the Tron Snap transaction signature into the response expected by
+ * WalletConnect Tron dapps: the original transaction with the signature
+ * appended as `signature: [hexSignature]`.
+ */
+export function mapSignTransactionResponse({
   params,
   result,
 }: {
-  method: TronWalletConnectMethod;
-  params:
-    | TronWalletConnectSignMessageParams
-    | TronWalletConnectSignTransactionParams;
-  result: TronSnapSignatureResult;
-}):
-  | TronSnapSignatureResult
-  | (TronWalletConnectTransaction & {
-      signature: string[];
-    }) {
-  if (method === 'tron_signMessage') {
-    return result;
-  }
-
-  if (method === 'tron_signTransaction') {
-    const { transaction: transactionContainer } =
-      params as TronWalletConnectSignTransactionParams;
-
-    const originalTransaction = unwrapTronTransaction(transactionContainer);
-
-    const signature = result.signature;
-
-    if (originalTransaction && typeof signature === 'string') {
-      return {
-        ...originalTransaction,
-        signature: [signature],
-      };
-    }
-
-    return result;
-  }
-
-  throw new Error(`WalletConnect Tron method ${method} is not supported`);
+  params: TronWalletConnectSpec['tron_signTransaction']['params'];
+  result: TronSnapSpec['signTransaction']['response'];
+}): TronWalletConnectSpec['tron_signTransaction']['response'] {
+  return {
+    ...unwrapTronTransaction(params.transaction),
+    signature: [result.signature],
+  };
 }

--- a/app/core/WalletConnect/multichain/tron/types.ts
+++ b/app/core/WalletConnect/multichain/tron/types.ts
@@ -1,54 +1,9 @@
-import type { SnapMappedRequest } from '../types';
+import type { RpcMethod } from '../types';
 
 /**
  * A Tron address in Base58Check format, starting with 'T'.
  */
 export type TronAddress = `T${string}`;
-
-/**
- * Canonical Snap params for `signMessage`.
- */
-export interface TronSnapSignMessageParams {
-  address: TronAddress;
-  /**
-   * Base64-encoded message. The Snap base64-decodes it before signing.
-   */
-  message: string;
-}
-
-/**
- * Canonical Snap params for `signTransaction`.
- */
-export interface TronSnapSignTransactionParams {
-  address: TronAddress;
-  transaction: {
-    rawDataHex: string;
-    type: string;
-  };
-}
-
-/**
- * WalletConnect JSON-RPC method names supported by the Tron bridge.
- */
-export type TronWalletConnectMethod =
-  | 'tron_signMessage'
-  | 'tron_signTransaction';
-
-/**
- * Raw WalletConnect request handled by the Tron mapper.
- */
-export interface TronWalletConnectRequest<Params = unknown> {
-  method: TronWalletConnectMethod | string;
-  params: Params;
-}
-
-/**
- * WalletConnect params for `tron_signMessage`.
- */
-export interface TronWalletConnectSignMessageParams {
-  address?: string;
-  message?: string;
-}
 
 /**
  * Minimal TronWeb `raw_data` shape needed to recover the contract type.
@@ -68,32 +23,58 @@ export interface TronWalletConnectTransaction {
 }
 
 /**
- * WalletConnect params for `tron_signTransaction`.
+ * WalletConnect Tron RPC contract.
+ *
+ * `tron_method_version: 'v1'` asks dapps for the flat v1 transaction shape,
+ * but the mapper still accepts the legacy double-wrapped shape for backwards
+ * compatibility.
+ *
+ * @see https://docs.reown.com/advanced/multichain/rpc-reference/tron-rpc
  */
-export interface TronWalletConnectSignTransactionParams {
-  address?: string;
-  transaction?: TronWalletConnectTransaction;
-  [key: string]: unknown;
+export interface TronWalletConnectSpec {
+  tron_signMessage: {
+    params: {
+      address: string;
+      message: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  tron_signTransaction: {
+    params: {
+      address: string;
+      transaction: TronWalletConnectTransaction;
+    };
+    response: TronWalletConnectTransaction & {
+      signature: string[];
+    };
+  };
 }
 
 /**
- * Signature result from the Tron Snap. Always a single hex-encoded
- * signature for both `signMessage` and `signTransaction`.
+ * Tron Snap RPC contract used by the mobile WalletConnect bridge.
  */
-export interface TronSnapSignatureResult {
-  signature?: string;
+export interface TronSnapSpec {
+  signMessage: {
+    params: {
+      address: TronAddress;
+      message: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  signTransaction: {
+    params: {
+      address: TronAddress;
+      transaction: {
+        rawDataHex?: string;
+        type?: string;
+      };
+    };
+    response: {
+      signature: string;
+    };
+  };
 }
-
-/**
- * Union of request shapes returned by the inbound Tron mapper.
- */
-export type TronSnapMappedRequest =
-  | (SnapMappedRequest<Partial<TronSnapSignMessageParams>> & {
-      method: 'signMessage';
-    })
-  | (SnapMappedRequest<{
-      address?: TronSnapSignTransactionParams['address'];
-      transaction: Partial<TronSnapSignTransactionParams['transaction']>;
-    }> & {
-      method: 'signTransaction';
-    });

--- a/app/core/WalletConnect/multichain/types.ts
+++ b/app/core/WalletConnect/multichain/types.ts
@@ -33,7 +33,10 @@ export interface SnapMappedRequest<Param = unknown> {
  * Arguments passed to a chain adapter's `handleRequest` method.
  */
 export interface AdapterHandleRequestArgs {
-  channelId: string;
+  /**
+   * URL-like dapp origin used by Snaps for confirmation UI.
+   */
+  origin: string;
   connectedAddresses: CaipAccountId[];
   scope: CaipChainId;
   requestId: number;

--- a/app/core/WalletConnect/multichain/types.ts
+++ b/app/core/WalletConnect/multichain/types.ts
@@ -22,17 +22,55 @@ export interface NamespaceConfig {
 }
 
 /**
- * Snap-shaped request after WC method translation.
+ * Pairing of `params` and `response` for one JSON-RPC method in a spec.
  */
-export interface SnapMappedRequest<Param = unknown> {
-  method: string;
-  params: Param;
+interface RpcMethodSpec {
+  params: unknown;
+  response: unknown;
 }
 
 /**
- * Arguments passed to a chain adapter's `handleRequest` method.
+ * Static JSON-RPC method specification: a map of method name to its
+ * `params`/`response` pairing.
+ *
+ * Self-referential (`Record<keyof Spec, ...>`) so concrete specs can be plain
+ * interfaces, which have no string index signature. Used bare, `RpcSpec` is
+ * the type-erased spec accepting any method name.
  */
-export interface AdapterHandleRequestArgs {
+export type RpcSpec<Spec = Record<string, RpcMethodSpec>> = Record<
+  keyof Spec,
+  RpcMethodSpec
+>;
+
+/**
+ * Runtime JSON-RPC method names derived from a method spec.
+ */
+export type RpcMethod<Spec extends RpcSpec<Spec>> = keyof Spec & string;
+
+/**
+ * Runtime JSON-RPC request derived from a method spec.
+ */
+export type RpcRequest<
+  Spec extends RpcSpec<Spec>,
+  Method extends RpcMethod<Spec> = RpcMethod<Spec>,
+> =
+  Method extends RpcMethod<Spec>
+    ? { method: Method; params: Spec[Method]['params'] }
+    : never;
+
+/**
+ * WalletConnect-shaped response paired with a method in the spec. Defaults to
+ * the union of every response in the spec.
+ */
+export type RpcResponse<
+  Spec extends RpcSpec<Spec>,
+  Method extends RpcMethod<Spec> = RpcMethod<Spec>,
+> = Spec[Method]['response'];
+
+/**
+ * Fixed context fields every adapter receives alongside the request.
+ */
+interface AdapterRequestContext {
   /**
    * URL-like dapp origin used by Snaps for confirmation UI.
    */
@@ -40,9 +78,17 @@ export interface AdapterHandleRequestArgs {
   connectedAddresses: CaipAccountId[];
   scope: CaipChainId;
   requestId: number;
-  method: string;
-  params: unknown;
 }
+
+/**
+ * Arguments passed to a chain adapter's `handleRequest` method.
+ */
+export type AdapterHandleRequestArgs<Spec extends RpcSpec<Spec> = RpcSpec> =
+  RpcRequest<Spec> extends infer Request
+    ? Request extends unknown
+      ? AdapterRequestContext & Request
+      : never
+    : never;
 
 /**
  * Minimal shape of a WalletConnect session proposal.
@@ -56,11 +102,14 @@ export type ProposalParamsLight = Pick<
  * Adapter contract every non-EVM chain implements. Registered in
  * `./registry.ts` behind a per-chain feature flag.
  */
-export interface ChainAdapter {
+export interface ChainAdapter<
+  CaipNamespace extends KnownCaipNamespace = KnownCaipNamespace,
+  Spec extends RpcSpec<Spec> = RpcSpec,
+> {
   /**
    * CAIP-2 namespace this adapter handles (`'tron'`, `'solana'`, ...).
    */
-  namespace: KnownCaipNamespace;
+  namespace: CaipNamespace;
 
   /**
    * Methods that should redirect the user back to the dapp after handling.
@@ -109,5 +158,14 @@ export interface ChainAdapter {
   /**
    * Handle a WC request and return its WalletConnect-shaped result.
    */
+  handleRequest(
+    args: AdapterHandleRequestArgs<Spec>,
+  ): Promise<RpcResponse<Spec>>;
+}
+
+/**
+ * Type-erased `ChainAdapter` view used by the registry.
+ */
+export interface AnyChainAdapter extends Omit<ChainAdapter, 'handleRequest'> {
   handleRequest(args: AdapterHandleRequestArgs): Promise<unknown>;
 }

--- a/app/core/WalletConnect/multichain/utils.ts
+++ b/app/core/WalletConnect/multichain/utils.ts
@@ -14,6 +14,13 @@
  * https://specs.walletconnect.com/2.0/specs/clients/sign/namespaces#16-all-chains-in-the-namespace-must-contain-the-namespace-prefix
  */
 import {
+  Caip25CaveatType,
+  type Caip25CaveatValue,
+  Caip25EndowmentPermissionName,
+  getCaipAccountIdsFromCaip25CaveatValue,
+} from '@metamask/chain-agnostic-permission';
+import { PermissionDoesNotExistError } from '@metamask/permission-controller';
+import {
   type CaipAccountId,
   type CaipChainId,
   type KnownCaipNamespace,
@@ -22,6 +29,8 @@ import {
 } from '@metamask/utils';
 import type { SessionTypes } from '@walletconnect/types';
 import Engine from '../../Engine';
+import DevLogger from '../../SDKConnect/utils/DevLogger';
+import { getPermittedCaipChainIds } from '../../Permissions';
 import { NamespaceConfig, ProposalParamsLight } from './types';
 
 type NamespaceReferenceSource = Partial<ProposalParamsLight> & {
@@ -122,6 +131,124 @@ export function doesProposalOrSessionIncludeNamespace({
   namespace: KnownCaipNamespace;
 }): boolean {
   return getReferencedNamespaces(proposalOrSession).has(namespace);
+}
+
+/**
+ * Build a non-EVM namespace slice from the wallet's permitted CAIP chains and
+ * accounts. Chain-specific adapters pass only their namespace, supported WC
+ * methods/events, and optional outbound normalizers.
+ */
+export async function buildAdapterScopedPermissions({
+  channelId,
+  namespace,
+  methods,
+  events,
+  normalizeChainIdOutbound = (chainId) => chainId,
+  normalizeAccountIdOutbound = (accountId) => accountId,
+}: {
+  channelId: string;
+  namespace: KnownCaipNamespace;
+  methods: readonly string[];
+  events: readonly string[];
+  normalizeChainIdOutbound?: (chainId: CaipChainId) => CaipChainId;
+  normalizeAccountIdOutbound?: (accountId: CaipAccountId) => CaipAccountId;
+}): Promise<NamespaceConfig | undefined> {
+  const permittedChains = await getPermittedCaipChainIds(channelId);
+  const namespaceChains = permittedChains.filter((chain) =>
+    chain.startsWith(`${namespace}:`),
+  );
+
+  if (namespaceChains.length === 0) {
+    return undefined;
+  }
+
+  let permittedNamespaceAccounts: CaipAccountId[] = [];
+  try {
+    const permissionCaveat = Engine.context.PermissionController?.getCaveat(
+      channelId,
+      Caip25EndowmentPermissionName,
+      Caip25CaveatType,
+    );
+    if (permissionCaveat) {
+      permittedNamespaceAccounts = getCaipAccountIdsFromCaip25CaveatValue(
+        permissionCaveat.value as Parameters<
+          typeof getCaipAccountIdsFromCaip25CaveatValue
+        >[0],
+      ).filter((account) => account.startsWith(`${namespace}:`));
+    }
+  } catch (error) {
+    if (!(error instanceof PermissionDoesNotExistError)) {
+      DevLogger.log(
+        `[wc][multichain/${namespace}] failed to read permission caveat`,
+        error,
+      );
+    }
+  }
+
+  if (permittedNamespaceAccounts.length === 0) {
+    return undefined;
+  }
+
+  const sortedPermittedNamespaceAccounts = prioritizeSelectedCaipAccountIds(
+    permittedNamespaceAccounts,
+  );
+
+  return {
+    chains: namespaceChains.map((chain) => normalizeChainIdOutbound(chain)),
+    methods: [...methods],
+    events: [...events],
+    accounts: sortedPermittedNamespaceAccounts.map((account) =>
+      normalizeAccountIdOutbound(account),
+    ),
+  };
+}
+
+/**
+ * Seed adapter-supported CAIP-2 scopes into the CAIP-25 caveat. Unsupported
+ * requested scopes fall back to the adapter's main supported scope.
+ */
+export function enrichCaveatValueForNamespace({
+  proposal,
+  caveatValue,
+  namespace,
+  supportedScopes,
+  fallbackScope,
+  normalizeChainIdInbound = (chainId) => chainId,
+}: {
+  proposal: ProposalParamsLight;
+  caveatValue: Caip25CaveatValue;
+  namespace: KnownCaipNamespace;
+  supportedScopes: ReadonlySet<CaipChainId>;
+  fallbackScope: CaipChainId;
+  normalizeChainIdInbound?: (chainId: CaipChainId) => CaipChainId;
+}): Caip25CaveatValue {
+  const requestedChains = collectRequestedChainsForNamespace({
+    proposal,
+    namespace,
+  });
+
+  if (requestedChains.length === 0) {
+    return caveatValue;
+  }
+
+  const scopesToAdd = requestedChains
+    .map((chain) => normalizeChainIdInbound(chain))
+    .filter((chain) => supportedScopes.has(chain));
+
+  const extraOptionalScopes = Object.fromEntries(
+    (scopesToAdd.length > 0 ? scopesToAdd : [fallbackScope]).map((scope) => [
+      scope,
+      { accounts: [] },
+    ]),
+  );
+
+  return {
+    ...caveatValue,
+    optionalScopes: {
+      ...caveatValue.optionalScopes,
+      ...extraOptionalScopes,
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR introduces a generic, type-safe adapter framework for the WalletConnect non-EVM layer and migrates the Tron adapter onto it. It is a pure refactor with no user-facing behavior change

Why: the per-chain adapters duplicated request/response plumbing and relied on loosely-typed unknown params, so a method, its params, and its response were never linked at the type level 

What changed:

- Spec-first types (multichain/types.ts): a chain now declares a single RpcSpec interface (method → { params; response }), and everything else is derived — RpcMethod, RpcRequest (a discriminated union on method), RpcResponse. AdapterHandleRequestArgs distributes the context over that union so narrowing on method narrows params.
- ChainAdapter<Namespace, Spec> binds an adapter to its namespace and spec; the registry stores the type-erased AnyChainAdapter view since lookups dispatch on an untrusted runtime string.
- createSnapCaller<Spec>() (router.ts): a spec-bound Snap caller where the response type is derived from the request's method — request/response can no longer mismatch. The single unknown→typed cast lives here, at the messenger boundary.
- Factored shared helpers into multichain/utils.ts (scoped-permission building, caveat enrichment, CAIP hex↔decimal conversion, account prioritization) so adapters stay thin.
- origin instead of channelId is threaded into handleAdapterRequest (WalletConnect2Session.ts), giving Snaps the real dapp origin for confirmation UI.
- Tron adapter migrated to strict spec types (params/response no longer optional, aligned on the Reown docs), mappers split into pure mapXRequest/mapXResponse functions, and unsupported methods now throw instead of falling through.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: improve wallet-connect types

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Tron WalletConnect signing over the refactored adapter
  Scenario: user signs a message from a Tron dapp
    Given a WalletConnect session is approved for the Tron namespace
    When the dapp requests tron_signMessage
    Then the wallet shows the confirmation with the correct dapp origin
    And the dapp receives a valid signature

  Scenario: user signs a transaction from a Tron dapp
    Given a WalletConnect session is approved for the Tron namespace
    When the dapp requests tron_signTransaction (v1 flat or legacy double-wrapped)
    Then the wallet routes it to the Tron Snap
    And the dapp receives the original transaction with the signature appended

  Scenario: an unsupported method is rejected
    Given a WalletConnect session is approved for the Tron namespace
    When a misbehaving dapp sends an unapproved method
    Then the request is rejected with a "method not supported" error
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no UI change.

### **After**

<!-- [screenshots/recordings] -->

N/A — no UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WalletConnect Tron signing and MultichainRoutingService routing with stricter typing and mapper changes; risk is moderated because the PR is a refactor with expanded tests, but signing paths remain security-sensitive.
> 
> **Overview**
> Introduces a **spec-first, type-safe** WalletConnect non-EVM adapter layer and migrates Tron onto it, with **no intended user-facing behavior change**.
> 
> **Core typing:** Chains declare an `RpcSpec` (method → params/response); `RpcRequest`, `RpcResponse`, and `AdapterHandleRequestArgs` tie method names to params at compile time. `ChainAdapter<Namespace, Spec>` is registered as `AnyChainAdapter` for runtime namespace lookup. **`createSnapCaller<Spec>()`** replaces the loose `callMultichainRoutingService` / `SnapMappedRequest` path so Snap calls are spec-bound at the messenger boundary.
> 
> **Plumbing:** Non-EVM session dispatch renames **`channelId` → `origin`** on `handleAdapterRequest` and adapter `handleRequest` (documented for Snap confirmation UI). Shared **`buildAdapterScopedPermissions`** and **`enrichCaveatValueForNamespace`** move duplicated permission/caveat logic out of chain adapters.
> 
> **Tron:** `TronWalletConnectSpec` / `TronSnapSpec` replace ad-hoc mapper types; inbound/outbound mapping splits into **`mapSignMessage*`** / **`mapSignTransaction*`**; unsupported WC methods **throw** instead of routing. Tests updated for the new router and stricter transaction response mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7a1affd4a9d3c54e88df099a728fb0b9c5543c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->