### PR TITLE
feat: add solana wallet-connect support

### DIFF
--- a/app/core/WalletConnect/multichain/registry.test.ts
+++ b/app/core/WalletConnect/multichain/registry.test.ts
@@ -22,6 +22,7 @@ import {
   getAllAdapters,
   getAllRegisteredNamespaces,
 } from './registry';
+import { solanaAdapter } from './solana';
 import { tronAdapter } from './tron';
 
 describe('multichain/registry', () => {
@@ -29,18 +30,24 @@ describe('multichain/registry', () => {
     expect(getAdapter('tron')).toBe(tronAdapter);
   });
 
+  it('registers the solana adapter under the solana CAIP-2 namespace', () => {
+    expect(getAdapter('solana')).toBe(solanaAdapter);
+  });
+
   it('returns undefined for namespaces that have no registered adapter', () => {
     expect(getAdapter('eip155')).toBeUndefined();
     expect(getAdapter('cosmos')).toBeUndefined();
   });
 
-  it('exposes the tron namespace via getAllRegisteredNamespaces', () => {
+  it('exposes the registered namespaces via getAllRegisteredNamespaces', () => {
     expect(getAllRegisteredNamespaces()).toContain('tron');
+    expect(getAllRegisteredNamespaces()).toContain('solana');
   });
 
-  it('exposes the tron adapter via getAllAdapters', () => {
+  it('exposes the registered adapters via getAllAdapters', () => {
     const adapters = getAllAdapters();
 
     expect(adapters).toContain(tronAdapter);
+    expect(adapters).toContain(solanaAdapter);
   });
 });

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -13,6 +13,7 @@ import type { AnyChainAdapter } from './types';
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { tronAdapter } from './tron';
 ///: END:ONLY_INCLUDE_IF
+import { solanaAdapter } from './solana';
 
 // Keyed by raw namespace string so lookups accept whatever a dapp proposal
 // sent, which we don't trust upfront.
@@ -49,3 +50,4 @@ export function getAllRegisteredNamespaces(): KnownCaipNamespace[] {
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 registerAdapter(tronAdapter);
 ///: END:ONLY_INCLUDE_IF
+registerAdapter(solanaAdapter);

--- a/app/core/WalletConnect/multichain/solana/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/solana/adapter.test.ts
@@ -1,0 +1,380 @@
+import { SolScope } from '@metamask/keyring-api';
+import {
+  getCaipAccountIdsFromCaip25CaveatValue,
+  type Caip25CaveatValue,
+} from '@metamask/chain-agnostic-permission';
+import { PermissionDoesNotExistError } from '@metamask/permission-controller';
+import type { CaipAccountId, CaipChainId } from '@metamask/utils';
+
+import Engine from '../../../Engine';
+import { getPermittedCaipChainIds } from '../../../Permissions';
+import { createSnapCaller } from '../router';
+import {
+  enrichCaveatValue,
+  getScopedPermissions,
+  solanaAdapter,
+} from './adapter';
+
+jest.mock('@metamask/chain-agnostic-permission', () => ({
+  ...jest.requireActual('@metamask/chain-agnostic-permission'),
+  getCaipAccountIdsFromCaip25CaveatValue: jest.fn(),
+}));
+
+jest.mock('../../../Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: {
+        getAccountsFromSelectedAccountGroup: jest.fn().mockReturnValue([]),
+      },
+      PermissionController: {
+        getCaveat: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../../Permissions', () => ({
+  getPermittedCaipChainIds: jest.fn(),
+}));
+
+jest.mock('../router', () => {
+  const snapCallerMock = jest.fn();
+  return {
+    createSnapCaller: () => snapCallerMock,
+  };
+});
+
+jest.mock('../../../SDKConnect/utils/DevLogger', () => ({
+  log: jest.fn(),
+}));
+
+jest.mock('@solana/transactions', () => ({
+  getTransactionDecoder: () => ({
+    decode: (bytes: Uint8Array) => ({ __bytes: bytes }),
+  }),
+  getSignatureFromTransaction: jest.fn(() => 'extracted-base58-signature'),
+}));
+
+const mockedGetAccountsFromSelectedAccountGroup = Engine.context
+  .AccountTreeController.getAccountsFromSelectedAccountGroup as jest.Mock;
+const mockedGetCaveat = Engine.context.PermissionController
+  .getCaveat as jest.Mock;
+const mockedGetPermittedCaipChainIds = getPermittedCaipChainIds as jest.Mock;
+const mockedCallSolanaSnap = (createSnapCaller as unknown as () => jest.Mock)();
+const mockedGetCaipAccountIdsFromCaip25CaveatValue =
+  getCaipAccountIdsFromCaip25CaveatValue as jest.Mock;
+
+describe('multichain/solana', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([]);
+    mockedGetCaveat.mockReturnValue(undefined);
+    mockedGetPermittedCaipChainIds.mockResolvedValue([]);
+    mockedCallSolanaSnap.mockResolvedValue(undefined);
+    mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+  });
+
+  describe('enrichCaveatValue', () => {
+    it('adds the Solana optional scope when a proposal references Solana', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              solana: { chains: [SolScope.Mainnet], methods: [], events: [] },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [SolScope.Mainnet]: { accounts: [] },
+        },
+      });
+    });
+
+    it('falls back to Solana Mainnet when only unsupported Solana scopes are requested', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              solana: {
+                chains: [SolScope.Devnet],
+                methods: [],
+                events: [],
+              },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [SolScope.Mainnet]: { accounts: [] },
+        },
+      });
+    });
+  });
+
+  describe('getScopedPermissions', () => {
+    it('returns scoped permissions for permitted Solana chains and accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([
+        'eip155:1',
+        SolScope.Mainnet,
+      ]);
+      mockedGetCaveat.mockReturnValue({ value: {} });
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([
+        'eip155:1:0xabc',
+        `${SolScope.Mainnet}:SolAddrA`,
+      ]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toStrictEqual({
+        chains: [SolScope.Mainnet],
+        methods: [
+          'solana_getAccounts',
+          'solana_requestAccounts',
+          'solana_signMessage',
+          'solana_signTransaction',
+          'solana_signAllTransactions',
+          'solana_signAndSendTransaction',
+        ],
+        events: [],
+        accounts: [`${SolScope.Mainnet}:SolAddrA`],
+      });
+    });
+
+    it('prioritizes selected Solana account ids when building scoped permissions', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([SolScope.Mainnet]);
+      mockedGetCaveat.mockReturnValue({ value: {} });
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([
+        `${SolScope.Mainnet}:SolAddrA`,
+        `${SolScope.Mainnet}:SolAddrB`,
+      ]);
+      mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([
+        { address: 'SolAddrB', scopes: [SolScope.Mainnet] },
+      ]);
+
+      const result = await getScopedPermissions({ channelId: 'wc-topic' });
+
+      expect(result?.accounts).toStrictEqual([
+        `${SolScope.Mainnet}:SolAddrB`,
+        `${SolScope.Mainnet}:SolAddrA`,
+      ]);
+    });
+
+    it('returns undefined when there are no Solana chains or accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue(['eip155:1']);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+
+      mockedGetPermittedCaipChainIds.mockResolvedValue([SolScope.Mainnet]);
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('continues when getCaveat throws PermissionDoesNotExistError', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([SolScope.Mainnet]);
+      mockedGetCaveat.mockImplementation(() => {
+        throw new PermissionDoesNotExistError('wc-topic', 'endowment:caip25');
+      });
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('solanaAdapter', () => {
+    it('declares the Solana CAIP namespace and approved methods', () => {
+      expect(solanaAdapter.namespace).toBe('solana');
+      expect(solanaAdapter.redirectMethods).toStrictEqual([
+        'solana_signMessage',
+        'solana_signTransaction',
+        'solana_signAllTransactions',
+        'solana_signAndSendTransaction',
+      ]);
+      expect(solanaAdapter.approvedMethods).toStrictEqual([
+        'solana_getAccounts',
+        'solana_requestAccounts',
+        'solana_signMessage',
+        'solana_signTransaction',
+        'solana_signAllTransactions',
+        'solana_signAndSendTransaction',
+      ]);
+      expect(solanaAdapter.getSessionProperties).toBeUndefined();
+    });
+
+    it('returns connected accounts for account methods', async () => {
+      await expect(
+        solanaAdapter.handleRequest({
+          origin: 'https://solana.example.com',
+          connectedAddresses: [
+            `${SolScope.Mainnet}:SolAddrA` as CaipAccountId,
+            `${SolScope.Mainnet}:SolAddrB` as CaipAccountId,
+          ],
+          scope: SolScope.Mainnet as CaipChainId,
+          requestId: 1,
+          method: 'solana_getAccounts',
+          params: undefined,
+        }),
+      ).resolves.toStrictEqual([
+        { pubkey: 'SolAddrA' },
+        { pubkey: 'SolAddrB' },
+      ]);
+    });
+
+    it('handles requests by mapping, routing, and normalizing the result', async () => {
+      const snapResult = { signedTransaction: 'signed-tx' };
+      mockedCallSolanaSnap.mockResolvedValue(snapResult);
+
+      const result = await solanaAdapter.handleRequest({
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA` as CaipAccountId],
+        scope: SolScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'solana_signTransaction',
+        params: { transaction: 'serialized-tx' },
+      });
+
+      expect(mockedCallSolanaSnap).toHaveBeenCalledWith({
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA`],
+        scope: SolScope.Mainnet,
+        requestId: 1,
+        request: {
+          method: 'signTransaction',
+          params: {
+            account: { address: 'SolAddrA' },
+            transaction: 'serialized-tx',
+            scope: SolScope.Mainnet,
+          },
+        },
+      });
+      expect(result).toStrictEqual({
+        signature: 'extracted-base58-signature',
+        transaction: 'signed-tx',
+      });
+    });
+
+    it('passes the dapp origin to the Snap routing service when provided', async () => {
+      const snapResult = { signedTransaction: 'signed-tx' };
+      mockedCallSolanaSnap.mockResolvedValue(snapResult);
+
+      await solanaAdapter.handleRequest({
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA` as CaipAccountId],
+        scope: SolScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'solana_signTransaction',
+        params: { transaction: 'serialized-tx' },
+      });
+
+      expect(mockedCallSolanaSnap).toHaveBeenCalledWith({
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA`],
+        scope: SolScope.Mainnet,
+        requestId: 1,
+        request: {
+          method: 'signTransaction',
+          params: {
+            account: { address: 'SolAddrA' },
+            transaction: 'serialized-tx',
+            scope: SolScope.Mainnet,
+          },
+        },
+      });
+    });
+
+    it('iterates solana_signAllTransactions requests when transactions are provided', async () => {
+      mockedCallSolanaSnap
+        .mockResolvedValueOnce({ signedTransaction: 'signed-a' })
+        .mockResolvedValueOnce({ signedTransaction: 'signed-b' });
+
+      const result = await solanaAdapter.handleRequest({
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA` as CaipAccountId],
+        scope: SolScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'solana_signAllTransactions',
+        params: { transactions: ['tx-a', 'tx-b'] },
+      });
+
+      expect(mockedCallSolanaSnap).toHaveBeenCalledTimes(2);
+      expect(mockedCallSolanaSnap).toHaveBeenNthCalledWith(1, {
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA`],
+        scope: SolScope.Mainnet,
+        requestId: 1,
+        request: {
+          method: 'signTransaction',
+          params: {
+            account: { address: 'SolAddrA' },
+            scope: SolScope.Mainnet,
+            transaction: 'tx-a',
+          },
+        },
+      });
+      expect(mockedCallSolanaSnap).toHaveBeenNthCalledWith(2, {
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA`],
+        scope: SolScope.Mainnet,
+        requestId: 1,
+        request: {
+          method: 'signTransaction',
+          params: {
+            account: { address: 'SolAddrA' },
+            scope: SolScope.Mainnet,
+            transaction: 'tx-b',
+          },
+        },
+      });
+      expect(result).toStrictEqual({
+        transactions: ['signed-a', 'signed-b'],
+      });
+    });
+
+    it('rejects unsupported WalletConnect methods', async () => {
+      const args = {
+        origin: 'https://solana.example.com',
+        connectedAddresses: [`${SolScope.Mainnet}:SolAddrA` as CaipAccountId],
+        scope: SolScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'solana_unknownMethod',
+        params: {},
+      };
+
+      await expect(
+        // @ts-expect-error - misbehaving client sending an unapproved method
+        solanaAdapter.handleRequest(args),
+      ).rejects.toThrow(
+        'WalletConnect Solana method solana_unknownMethod is not supported',
+      );
+
+      expect(mockedCallSolanaSnap).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/solana/adapter.ts
+++ b/app/core/WalletConnect/multichain/solana/adapter.ts
@@ -1,0 +1,235 @@
+import { SolScope } from '@metamask/keyring-api';
+import { type CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+import { type Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
+
+import {
+  buildAdapterScopedPermissions,
+  enrichCaveatValueForNamespace,
+} from '../utils';
+import type {
+  AdapterHandleRequestArgs,
+  ChainAdapter,
+  NamespaceConfig,
+  ProposalParamsLight,
+  RpcMethod,
+  RpcResponse,
+} from '../types';
+import { createSnapCaller } from '../router';
+import {
+  mapAccountRequest,
+  mapSignAndSendTransactionRequest,
+  mapSignAndSendTransactionResponse,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+} from './mapper';
+import type { SolanaSnapSpec, SolanaWalletConnectSpec } from './types';
+
+/**
+ * Snap caller bound to the Solana Snap spec.
+ */
+const callSolanaSnap = createSnapCaller<SolanaSnapSpec>();
+
+/**
+ * WalletConnect methods the wallet exposes for the Solana namespace.
+ */
+const SOLANA_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
+  'solana_getAccounts',
+  'solana_requestAccounts',
+  'solana_signMessage',
+  'solana_signTransaction',
+  'solana_signAllTransactions',
+  'solana_signAndSendTransaction',
+];
+
+/**
+ * WalletConnect Solana methods that should redirect users back to the dapp
+ * after handling. Read-only account methods intentionally stay out.
+ */
+const SOLANA_REDIRECT_METHODS: readonly RpcMethod<SolanaWalletConnectSpec>[] = [
+  'solana_signMessage',
+  'solana_signTransaction',
+  'solana_signAllTransactions',
+  'solana_signAndSendTransaction',
+];
+
+/**
+ * WalletConnect events the wallet may emit for the Solana namespace.
+ */
+const SOLANA_EVENTS: readonly string[] = [];
+
+/**
+ * CAIP-2 chain IDs we will seed into the CAIP-25 caveat.
+ *
+ * The Solana Snap supports Mainnet, Testnet, and Devnet, but the mobile
+ * permission UI exposes only Mainnet today (Testnet/Devnet are gated out of
+ * `NON_EVM_CAIP_CHAIN_IDS` in `selectors/multichainNetworkController`,
+ * pending a feature flag). Any testnet scope we inject would be stripped by
+ * the approval UI when it rebuilds `optionalScopes` from `selectedChainIds`,
+ * leaving the Solana namespace empty and breaking `approveSession`.
+ *
+ * Restricting to Mainnet keeps mainnet-only dapps working; testnet requests
+ * fall back to Mainnet via `enrichCaveatValue`. When the feature flag lands,
+ * widen this to `Object.values(SolScope)`.
+ */
+const SUPPORTED_SOLANA_SCOPES = new Set<CaipChainId>([
+  SolScope.Mainnet as CaipChainId,
+]);
+
+/**
+ * Build the Solana namespace slice from the wallet's current state.
+ *
+ * Account changes are handled here by rebuilding the namespace accounts with
+ * the currently selected MetaMask Mobile account first. The current
+ * `@walletconnect/solana-adapter` dapp package receives that `session_update`,
+ * but does not update its cached `publicKey` from the reordered account list.
+ */
+export async function getScopedPermissions({
+  channelId,
+}: {
+  channelId: string;
+}): Promise<NamespaceConfig | undefined> {
+  return buildAdapterScopedPermissions({
+    channelId,
+    namespace: KnownCaipNamespace.Solana,
+    methods: SOLANA_METHODS,
+    events: SOLANA_EVENTS,
+  });
+}
+
+/**
+ * Seed Solana scopes into the CAIP-25 caveat. One `optionalScope` per
+ * supported Solana chain the proposal references.
+ *
+ * Only `SUPPORTED_SOLANA_SCOPES` are carried through; unsupported testnets
+ * fall back to Mainnet. Widening `SUPPORTED_SOLANA_SCOPES` later lets this
+ * function carry multi-chain requests (e.g. Mainnet + Devnet) end-to-end with
+ * no further change.
+ */
+export function enrichCaveatValue({
+  proposal,
+  caveatValue,
+}: {
+  proposal: ProposalParamsLight;
+  caveatValue: Caip25CaveatValue;
+}): Caip25CaveatValue {
+  return enrichCaveatValueForNamespace({
+    proposal,
+    caveatValue,
+    namespace: KnownCaipNamespace.Solana,
+    supportedScopes: SUPPORTED_SOLANA_SCOPES,
+    fallbackScope: SolScope.Mainnet as CaipChainId,
+  });
+}
+
+/**
+ * Handle a WalletConnect request for the Solana namespace by mapping it to the
+ * multichain routing service, then mapping the result back to the expected
+ * WalletConnect format for the dapp
+ */
+export async function handleRequest({
+  origin,
+  connectedAddresses,
+  scope,
+  requestId,
+  method,
+  params,
+}: AdapterHandleRequestArgs<SolanaWalletConnectSpec>): Promise<
+  RpcResponse<SolanaWalletConnectSpec>
+> {
+  if (method === 'solana_getAccounts' || method === 'solana_requestAccounts') {
+    return mapAccountRequest({ connectedAddresses });
+  }
+
+  if (method === 'solana_signAllTransactions') {
+    const transactions = params.transactions ?? [];
+
+    const results: SolanaWalletConnectSpec['solana_signAllTransactions']['response']['transactions'] =
+      [];
+
+    for (const transaction of transactions) {
+      const result = await callSolanaSnap({
+        origin,
+        connectedAddresses,
+        scope,
+        requestId,
+        request: mapSignTransactionRequest({
+          params: { transaction },
+          scope,
+          connectedAddresses,
+        }),
+      });
+
+      results.push(result.signedTransaction);
+    }
+
+    return { transactions: results };
+  }
+
+  if (method === 'solana_signMessage') {
+    const result = await callSolanaSnap({
+      origin,
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignMessageRequest({
+        params,
+      }),
+    });
+
+    return mapSignMessageResponse(result);
+  }
+
+  if (method === 'solana_signTransaction') {
+    const result = await callSolanaSnap({
+      origin,
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignTransactionRequest({
+        params,
+        scope,
+        connectedAddresses,
+      }),
+    });
+
+    return mapSignTransactionResponse(result);
+  }
+
+  if (method === 'solana_signAndSendTransaction') {
+    const result = await callSolanaSnap({
+      origin,
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignAndSendTransactionRequest({
+        params,
+        scope,
+        connectedAddresses,
+      }),
+    });
+
+    return mapSignAndSendTransactionResponse(result);
+  }
+
+  throw new Error(
+    `WalletConnect Solana method ${String(method)} is not supported`,
+  );
+}
+
+/**
+ * `ChainAdapter` for Solana, registered in `multichain/registry.ts` behind
+ * the `solana` feature flag.
+ */
+export const solanaAdapter: ChainAdapter<
+  KnownCaipNamespace.Solana,
+  SolanaWalletConnectSpec
+> = {
+  namespace: KnownCaipNamespace.Solana,
+  redirectMethods: SOLANA_REDIRECT_METHODS,
+  approvedMethods: SOLANA_METHODS,
+  enrichCaveatValue,
+  getScopedPermissions,
+  handleRequest,
+};

--- a/app/core/WalletConnect/multichain/solana/index.ts
+++ b/app/core/WalletConnect/multichain/solana/index.ts
@@ -1,0 +1,1 @@
+export { solanaAdapter } from './adapter';

--- a/app/core/WalletConnect/multichain/solana/mapper.test.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.test.ts
@@ -1,0 +1,117 @@
+import { SolScope } from '@metamask/keyring-api';
+import { base58 } from 'ethers/lib/utils';
+import {
+  mapAccountRequest,
+  mapSignAndSendTransactionRequest,
+  mapSignAndSendTransactionResponse,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+} from './mapper';
+
+jest.mock('@solana/transactions', () => ({
+  getTransactionDecoder: () => ({
+    decode: (bytes: Uint8Array) => ({ __bytes: bytes }),
+  }),
+  getSignatureFromTransaction: jest.fn(() => 'extracted-base58-signature'),
+}));
+
+const MAINNET_CAIP_ACCOUNT_A = `${SolScope.Mainnet}:SolAddrA` as const;
+const MAINNET_CAIP_ACCOUNT_B = `${SolScope.Mainnet}:SolAddrB` as const;
+
+describe('multichain/solana - mapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('mapAccountRequest', () => {
+    it('maps CAIP-10 account ids to WalletConnect Solana account objects', () => {
+      expect(
+        mapAccountRequest({
+          connectedAddresses: [MAINNET_CAIP_ACCOUNT_A, MAINNET_CAIP_ACCOUNT_B],
+        }),
+      ).toStrictEqual([{ pubkey: 'SolAddrA' }, { pubkey: 'SolAddrB' }]);
+    });
+  });
+
+  describe('inbound request mappers', () => {
+    it('maps solana_signMessage with base58 message to canonical signMessage payload', () => {
+      const messageBytes = Buffer.from('hello world', 'utf8');
+      const base58Message = base58.encode(messageBytes);
+
+      expect(
+        mapSignMessageRequest({
+          params: { pubkey: 'SolAddrA', message: base58Message },
+        }),
+      ).toStrictEqual({
+        method: 'signMessage',
+        params: {
+          account: { address: 'SolAddrA' },
+          message: messageBytes.toString('base64'),
+        },
+      });
+    });
+
+    it('maps solana_signTransaction to canonical signTransaction payload using the first connected CAIP account', () => {
+      expect(
+        mapSignTransactionRequest({
+          params: { transaction: 'base64-tx' },
+          scope: SolScope.Mainnet,
+          connectedAddresses: [MAINNET_CAIP_ACCOUNT_A, MAINNET_CAIP_ACCOUNT_B],
+        }),
+      ).toStrictEqual({
+        method: 'signTransaction',
+        params: {
+          account: { address: 'SolAddrA' },
+          transaction: 'base64-tx',
+          scope: SolScope.Mainnet,
+        },
+      });
+    });
+
+    it('maps solana_signAndSendTransaction to canonical signAndSendTransaction payload', () => {
+      expect(
+        mapSignAndSendTransactionRequest({
+          params: {
+            transaction: 'base64-tx',
+            sendOptions: { skipPreflight: true, minContextSlot: 123 },
+          },
+          scope: SolScope.Mainnet,
+          connectedAddresses: [MAINNET_CAIP_ACCOUNT_A],
+        }),
+      ).toStrictEqual({
+        method: 'signAndSendTransaction',
+        params: {
+          account: { address: 'SolAddrA' },
+          transaction: 'base64-tx',
+          scope: SolScope.Mainnet,
+          options: { skipPreflight: true, minContextSlot: 123 },
+        },
+      });
+    });
+  });
+
+  describe('outbound response mappers', () => {
+    it('maps solana_signMessage Snap signature to the WalletConnect signMessage response', () => {
+      expect(mapSignMessageResponse({ signature: 'base58-sig' })).toStrictEqual(
+        { signature: 'base58-sig' },
+      );
+    });
+
+    it('maps solana_signTransaction Snap signedTransaction to spec-compliant { signature, transaction }', () => {
+      expect(
+        mapSignTransactionResponse({ signedTransaction: 'c2lnbmVkLXR4' }),
+      ).toStrictEqual({
+        signature: 'extracted-base58-signature',
+        transaction: 'c2lnbmVkLXR4',
+      });
+    });
+
+    it('maps solana_signAndSendTransaction Snap signature to the WalletConnect signature response', () => {
+      expect(
+        mapSignAndSendTransactionResponse({ signature: 'base58-txid' }),
+      ).toStrictEqual({ signature: 'base58-txid' });
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/solana/mapper.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.ts
@@ -62,8 +62,14 @@ export function mapSignMessageResponse(
 
 /**
  * Convert WalletConnect transaction params into the canonical Solana Snap
- * transaction request. The signer is resolved from the first connected CAIP
- * account, matching the WalletConnect session account selected by Mobile.
+ * transaction request.
+ *
+ * WalletConnect treats the first account in the session account list as the
+ * currently selected account. Mobile preserves that invariant when building
+ * scoped permissions by prioritizing the selected CAIP account ID first, and
+ * refreshes the WalletConnect session whenever the selected MetaMask account
+ * changes. Because of that ordering contract, `connectedAddresses[0]` is the
+ * active signer for this request.
  */
 export function mapSignTransactionRequest({
   params,
@@ -106,6 +112,13 @@ export function mapSignTransactionResponse(
  * Convert WalletConnect sign-and-send params into the canonical Solana Snap
  * transaction request. WalletConnect names send options `sendOptions`; the
  * Solana Snap keyring API expects them under `options`.
+ *
+ * WalletConnect treats the first account in the session account list as the
+ * currently selected account. Mobile preserves that invariant when building
+ * scoped permissions by prioritizing the selected CAIP account ID first, and
+ * refreshes the WalletConnect session whenever the selected MetaMask account
+ * changes. Because of that ordering contract, `connectedAddresses[0]` is the
+ * active signer for this request.
  */
 export function mapSignAndSendTransactionRequest({
   params,

--- a/app/core/WalletConnect/multichain/solana/mapper.ts
+++ b/app/core/WalletConnect/multichain/solana/mapper.ts
@@ -1,0 +1,156 @@
+import {
+  type CaipAccountId,
+  type CaipChainId,
+  parseCaipAccountId,
+} from '@metamask/utils';
+import {
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+} from '@solana/transactions';
+import { base58 } from 'ethers/lib/utils';
+import type { RpcRequest } from '../types';
+import type { SolanaSnapSpec, SolanaWalletConnectSpec } from './types';
+
+/**
+ * Map connected CAIP-10 account ids to the WalletConnect Solana account
+ * response shape. Account methods are handled locally by the adapter because
+ * they do not need Snap routing.
+ */
+export function mapAccountRequest({
+  connectedAddresses,
+}: {
+  connectedAddresses: CaipAccountId[];
+}): SolanaWalletConnectSpec['solana_getAccounts']['response'] {
+  return connectedAddresses
+    .map((accountId) => {
+      const { address } = parseCaipAccountId(accountId);
+      return address;
+    })
+    .map((pubkey) => ({ pubkey }));
+}
+
+/**
+ * Convert WalletConnect sign message params into the canonical Solana Snap
+ * request. WalletConnect sends the message as base58 bytes; the snap expects
+ * base64.
+ */
+export function mapSignMessageRequest({
+  params,
+}: {
+  params: SolanaWalletConnectSpec['solana_signMessage']['params'];
+}): RpcRequest<SolanaSnapSpec, 'signMessage'> {
+  return {
+    method: 'signMessage',
+    params: {
+      account: { address: params.pubkey },
+      message: Buffer.from(base58.decode(params.message)).toString('base64'),
+    },
+  };
+}
+
+/**
+ * Forward the Solana Snap message signature in the WalletConnect response
+ * shape.
+ */
+export function mapSignMessageResponse(
+  result: SolanaSnapSpec['signMessage']['response'],
+): SolanaWalletConnectSpec['solana_signMessage']['response'] {
+  return {
+    signature: result.signature,
+  };
+}
+
+/**
+ * Convert WalletConnect transaction params into the canonical Solana Snap
+ * transaction request. The signer is resolved from the first connected CAIP
+ * account, matching the WalletConnect session account selected by Mobile.
+ */
+export function mapSignTransactionRequest({
+  params,
+  scope,
+  connectedAddresses,
+}: {
+  params: SolanaWalletConnectSpec['solana_signTransaction']['params'];
+  scope: CaipChainId;
+  connectedAddresses: CaipAccountId[];
+}): RpcRequest<SolanaSnapSpec, 'signTransaction'> {
+  const { address } = parseCaipAccountId(connectedAddresses[0]);
+
+  return {
+    method: 'signTransaction',
+    params: {
+      account: { address },
+      transaction: params.transaction,
+      scope,
+    },
+  };
+}
+
+/**
+ * Convert the Solana Snap signed transaction response into WalletConnect's
+ * `solana_signTransaction` response, which includes both the full signed
+ * transaction and the extracted fee-payer signature.
+ */
+export function mapSignTransactionResponse(
+  result: SolanaSnapSpec['signTransaction']['response'],
+): SolanaWalletConnectSpec['solana_signTransaction']['response'] {
+  const { signedTransaction } = result;
+
+  return {
+    signature: extractSignatureFromSignedTransaction(signedTransaction),
+    transaction: signedTransaction,
+  };
+}
+
+/**
+ * Convert WalletConnect sign-and-send params into the canonical Solana Snap
+ * transaction request. WalletConnect names send options `sendOptions`; the
+ * Solana Snap keyring API expects them under `options`.
+ */
+export function mapSignAndSendTransactionRequest({
+  params,
+  scope,
+  connectedAddresses,
+}: {
+  params: SolanaWalletConnectSpec['solana_signAndSendTransaction']['params'];
+  scope: CaipChainId;
+  connectedAddresses: CaipAccountId[];
+}): RpcRequest<SolanaSnapSpec, 'signAndSendTransaction'> {
+  const { address } = parseCaipAccountId(connectedAddresses[0]);
+
+  return {
+    method: 'signAndSendTransaction',
+    params: {
+      account: { address },
+      transaction: params.transaction,
+      scope,
+      ...(params.sendOptions ? { options: params.sendOptions } : {}),
+    },
+  };
+}
+
+/**
+ * Forward the Solana Snap transaction signature in the WalletConnect
+ * `solana_signAndSendTransaction` response shape.
+ */
+export function mapSignAndSendTransactionResponse(
+  result: SolanaSnapSpec['signAndSendTransaction']['response'],
+): SolanaWalletConnectSpec['solana_signAndSendTransaction']['response'] {
+  return {
+    signature: result.signature,
+  };
+}
+
+/**
+ * Extract the fee-payer signature (base58) from a base64-encoded signed
+ * Solana transaction. The WalletConnect Solana spec requires the `signature`
+ * field for `solana_signTransaction`, while the snap returns the full signed
+ * transaction.
+ */
+function extractSignatureFromSignedTransaction(
+  signedTransactionBase64: string,
+): string {
+  const bytes = new Uint8Array(Buffer.from(signedTransactionBase64, 'base64'));
+  const transaction = getTransactionDecoder().decode(bytes);
+  return getSignatureFromTransaction(transaction);
+}

--- a/app/core/WalletConnect/multichain/solana/types.ts
+++ b/app/core/WalletConnect/multichain/solana/types.ts
@@ -1,0 +1,111 @@
+import type { CaipChainId } from '@metamask/utils';
+import type { RpcMethod } from '../types';
+
+/**
+ * WalletConnect Solana RPC contract.
+ *
+ * @see https://docs.reown.com/advanced/multichain/rpc-reference/solana-rpc
+ */
+export interface SolanaWalletConnectSpec {
+  solana_getAccounts: {
+    params: undefined;
+    response: {
+      pubkey: string;
+    }[];
+  };
+  solana_requestAccounts: {
+    params: undefined;
+    response: {
+      pubkey: string;
+    }[];
+  };
+  solana_signMessage: {
+    params: {
+      pubkey: string;
+      /**
+       * Base58-encoded message bytes.
+       */
+      message: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  solana_signTransaction: {
+    params: {
+      transaction: string;
+    };
+    response: {
+      /**
+       * Base58 fee-payer signature extracted from the signed transaction.
+       */
+      signature: string;
+      transaction?: string;
+    };
+  };
+  solana_signAllTransactions: {
+    params: {
+      transactions: string[];
+    };
+    response: {
+      transactions: string[];
+    };
+  };
+  solana_signAndSendTransaction: {
+    params: {
+      transaction: string;
+      sendOptions?: Record<string, unknown>;
+    };
+    response: {
+      signature: string;
+    };
+  };
+}
+
+/**
+ * Canonical Snap account reference used to resolve the selected keyring
+ * account before routing the signing request.
+ */
+export interface SolanaSnapAccountParam {
+  address: string;
+}
+
+/**
+ * Solana Snap keyring RPC contract used by the snap.
+ */
+export interface SolanaSnapSpec {
+  signMessage: {
+    params: {
+      account: SolanaSnapAccountParam;
+      /**
+       * Base64-encoded message.
+       */
+      message: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  signTransaction: {
+    params: {
+      account: SolanaSnapAccountParam;
+      transaction: string;
+      scope: CaipChainId;
+      options?: Record<string, unknown>;
+    };
+    response: {
+      signedTransaction: string;
+    };
+  };
+  signAndSendTransaction: {
+    params: {
+      account: SolanaSnapAccountParam;
+      transaction: string;
+      scope: CaipChainId;
+      options?: Record<string, unknown>;
+    };
+    response: {
+      signature: string;
+    };
+  };
+}

--- a/package.json
+++ b/package.json
@@ -388,6 +388,7 @@
     "@sentry/react-native": "~7.2.0",
     "@shopify/flash-list": "2.0.3",
     "@solana/addresses": "2.0.0",
+    "@solana/transactions": "2.1.1",
     "@tanstack/react-query": "^4.43.0",
     "@tommasini/react-native-scrollable-tab-view": "patch:@tommasini/react-native-scrollable-tab-view@npm%3A1.1.1#~/.yarn/patches/@tommasini-react-native-scrollable-tab-view-npm-1.1.1-153a9df479.patch",
     "@tradle/react-native-http": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -387,7 +387,7 @@
     "@sentry/react": "~8.54.0",
     "@sentry/react-native": "~7.2.0",
     "@shopify/flash-list": "2.0.3",
-    "@solana/addresses": "2.0.0",
+    "@solana/addresses": "2.1.1",
     "@solana/transactions": "2.1.1",
     "@tanstack/react-query": "^4.43.0",
     "@tommasini/react-native-scrollable-tab-view": "patch:@tommasini/react-native-scrollable-tab-view@npm%3A1.1.1#~/.yarn/patches/@tommasini-react-native-scrollable-tab-view-npm-1.1.1-153a9df479.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14135,20 +14135,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/addresses@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@solana/addresses@npm:2.0.0"
-  dependencies:
-    "@solana/assertions": "npm:2.0.0"
-    "@solana/codecs-core": "npm:2.0.0"
-    "@solana/codecs-strings": "npm:2.0.0"
-    "@solana/errors": "npm:2.0.0"
-  peerDependencies:
-    typescript: ">=5"
-  checksum: 10/f99d09c72046c73858aa8b7bc323e634a60b1023a4d280036bc94489e431075c7f29d2889e8787e33a04cfdecbe77cd8ca26c31ded73f735dc98e49c3151cc17
-  languageName: node
-  linkType: hard
-
 "@solana/addresses@npm:2.1.1, @solana/addresses@npm:^2.0.0":
   version: 2.1.1
   resolution: "@solana/addresses@npm:2.1.1"
@@ -14161,17 +14147,6 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10/0350aa5c96c9862701e5414ca14007fafe7b9c4dfd2623bc041ff7efe6a63afac37d9bf01f860c26ae0f252e5bca7af9059a20f944fe3dc273d0558f2da69d34
-  languageName: node
-  linkType: hard
-
-"@solana/assertions@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@solana/assertions@npm:2.0.0"
-  dependencies:
-    "@solana/errors": "npm:2.0.0"
-  peerDependencies:
-    typescript: ">=5"
-  checksum: 10/c1af37ae1bd79b1657395d9315ac261dabc9908a64af6ed80e3b7e5140909cd8c8c757f0c41fff084e26fbb4d32f091c89c092a8c1ed5e6f4565dfe7426c0979
   languageName: node
   linkType: hard
 
@@ -14204,17 +14179,6 @@ __metadata:
   dependencies:
     buffer: "npm:~6.0.3"
   checksum: 10/c64b996b832b2b7966a09e97f501fdd1409fece8975f7fb47698d7b8addb97504360cfb2f3d1368949c643d23ed9a4c9f79e19bbd721ebe5bf229353252f649e
-  languageName: node
-  linkType: hard
-
-"@solana/codecs-core@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@solana/codecs-core@npm:2.0.0"
-  dependencies:
-    "@solana/errors": "npm:2.0.0"
-  peerDependencies:
-    typescript: ">=5"
-  checksum: 10/e58a72e67bee3e5da60201eecda345c604b49138d5298e39b8e7d4d57a4dee47be3b0ecc8fc3429a2a60a42c952eaf860d43d3df1eb2b1d857e35368eca9c820
   languageName: node
   linkType: hard
 
@@ -14280,18 +14244,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/codecs-numbers@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@solana/codecs-numbers@npm:2.0.0"
-  dependencies:
-    "@solana/codecs-core": "npm:2.0.0"
-    "@solana/errors": "npm:2.0.0"
-  peerDependencies:
-    typescript: ">=5"
-  checksum: 10/500144d549ea0292c2f672300610df9054339a31cb6a4e61b29623308ef3b14f15eb587ee6139cf3334d2e0f29db1da053522da244b12184bb8fbdb097b7102b
-  languageName: node
-  linkType: hard
-
 "@solana/codecs-numbers@npm:2.0.0-rc.1":
   version: 2.0.0-rc.1
   resolution: "@solana/codecs-numbers@npm:2.0.0-rc.1"
@@ -14328,20 +14280,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/98375fba3b10a2dee1031332079d1e3bad0f1d99c8f59c1429049dcbbd0c6133d6c3fe8f2373e2498bb0a77778e766fb83da0aca40a1321ace0db241ee2148ec
-  languageName: node
-  linkType: hard
-
-"@solana/codecs-strings@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@solana/codecs-strings@npm:2.0.0"
-  dependencies:
-    "@solana/codecs-core": "npm:2.0.0"
-    "@solana/codecs-numbers": "npm:2.0.0"
-    "@solana/errors": "npm:2.0.0"
-  peerDependencies:
-    fastestsmallesttextencoderdecoder: ^1.0.22
-    typescript: ">=5"
-  checksum: 10/4380136e2603c2cee12a28438817beb34b0fe45da222b8c38342c5b3680f02086ec7868cde0bb7b4e5dd459af5988613af1d97230c6a193db3be1c45122aba39
   languageName: node
   linkType: hard
 
@@ -14419,20 +14357,6 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10/2bc0af5deee37722967cf400dcb2c67a6786663e332c761f0092c3b9dd246c757586bf8504db24b64b4a57f6e90d5e2f8c0dbbc10894811cdf947f8b5445aa28
-  languageName: node
-  linkType: hard
-
-"@solana/errors@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@solana/errors@npm:2.0.0"
-  dependencies:
-    chalk: "npm:^5.3.0"
-    commander: "npm:^12.1.0"
-  peerDependencies:
-    typescript: ">=5"
-  bin:
-    errors: bin/cli.mjs
-  checksum: 10/4191f96cad47c64266ec501ae1911a6245fd02b2f68a2c53c3dabbc63eb7c5462f170a765b584348b195da2387e7ca02096d792c67352c2c30a4f3a3cc7e4270
   languageName: node
   linkType: hard
 
@@ -35600,7 +35524,7 @@ __metadata:
     "@sentry/react": "npm:~8.54.0"
     "@sentry/react-native": "npm:~7.2.0"
     "@shopify/flash-list": "npm:2.0.3"
-    "@solana/addresses": "npm:2.0.0"
+    "@solana/addresses": "npm:2.1.1"
     "@solana/transactions": "npm:2.1.1"
     "@storybook/addon-controls": "npm:^7.5.1"
     "@storybook/addon-ondevice-controls": "npm:^6.5.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35601,6 +35601,7 @@ __metadata:
     "@sentry/react-native": "npm:~7.2.0"
     "@shopify/flash-list": "npm:2.0.3"
     "@solana/addresses": "npm:2.0.0"
+    "@solana/transactions": "npm:2.1.1"
     "@storybook/addon-controls": "npm:^7.5.1"
     "@storybook/addon-ondevice-controls": "npm:^6.5.6"
     "@storybook/builder-webpack5": "npm:^7.5.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This PR adds the Solana adapter to the WalletConnect non-EVM layer.

Why: WalletConnect dapps could not reach a user's Solana account through MetaMask Mobile .

What changed: a new solanaAdapter (multichain/solana/) implementing the ChainAdapter contract.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: add solana wallet-connect support

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Solana WalletConnect signing

  Scenario: user connects a Solana dapp over WalletConnect
    Given a dapp initiates a WalletConnect connection requesting the Solana namespace
    When the user approves the session with a Solana account
    Then the dapp receives the account via solana_getAccounts/solana_requestAccounts

  Scenario: user signs a message
    Given an approved Solana WalletConnect session
    When the dapp requests solana_signMessage
    Then the wallet shows the confirmation with the correct dapp origin
    And the dapp receives a valid base58 signature

  Scenario: user signs and sends a transaction
    Given an approved Solana WalletConnect session on Mainnet
    When the dapp requests solana_signTransaction / solana_signAllTransactions / solana_signAndSendTransaction
    Then the wallet routes the request to the Solana Snap
    And the dapp receives the expected signature(s)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no UI change.

### **After**

<!-- [screenshots/recordings] -->

N/A — no UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New WalletConnect signing and transaction routing touches permissions and the Solana Snap, but it mirrors the existing Tron adapter pattern and is heavily unit-tested.
> 
> **Overview**
> Adds **Solana** to the WalletConnect multichain layer by registering a new `solanaAdapter` in `multichain/registry.ts` and implementing the full `ChainAdapter` contract under `multichain/solana/`.
> 
> Session setup seeds **CAIP-25** optional scopes for Solana (Mainnet only today, with unsupported testnet proposals falling back to Mainnet) and builds scoped permissions from permitted chains/accounts, putting the selected mobile account first in the session account list. Incoming RPCs cover account reads plus **sign message**, **sign transaction**, **sign all transactions**, and **sign and send**; signing paths map WalletConnect payloads to the Solana Snap via the existing snap router and map responses back (including fee-payer signature extraction for `solana_signTransaction` using `@solana/transactions`). Dependencies bump `@solana/addresses` to **2.1.1** and add `@solana/transactions` **2.1.1**; registry and adapter behavior are covered by new unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2cc1b0f5654dc7651710857a4d99a7ca44aa56b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->