### PR TITLE
fix(ci): upload Appium failure screen recordings when tests fail

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -326,7 +326,7 @@ jobs:
           retention-days: 7
 
       - name: Upload failure screen recordings (Namespace)
-        if: ${{ (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider == 'namespace' }}
+        if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider == 'namespace' }}
         uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
         with:
           name: appium-smoke-videos-${{ inputs.test-suite-name }}
@@ -334,7 +334,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
       - name: Upload failure screen recordings (current)
-        if: ${{ (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider != 'namespace' }}
+        if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
           name: appium-smoke-videos-${{ inputs.test-suite-name }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Appium smoke CI jobs were skipping the **Upload failure screen recordings** step when tests failed, so no `appium-smoke-videos-*` artifact was produced for debugging (e.g. [Appium Smoke Tests (iOS) run #6, job appium-accounts-ios-smoke](https://github.com/MetaMask/metamask-mobile/actions/runs/27402029386/job/80983538947)).

**Why:** GitHub Actions skips subsequent steps after a failed step unless their `if` condition includes a job status function (`always()`, `failure()`, etc.). The recording upload only checked `steps.run-tests-*.outcome == 'failure'`, which is not sufficient on its own.

**Fix:** Add `always() &&` to both Namespace and current runner upload conditions in `run-appium-e2e-workflow.yml`, matching the pattern already used for the Playwright HTML report upload in the same workflow.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (CI workflow bug observed in Actions run 27402029386)

## **Manual testing steps**

```gherkin
Feature: Appium failure screen recording artifact upload

  Scenario: CI uploads recordings when Appium smoke tests fail
    Given an Appium smoke workflow job where Run Appium smoke tests fails
    When the job reaches the Upload failure screen recordings step
    Then the step is not skipped
    And the appium-smoke-videos-<suite-name> artifact is available when MP4 files were saved during the run
```

Post-merge verification: re-run a failing Appium smoke job (or trigger a known-failing test) and confirm the upload step executes and the video artifact appears.

## **Screenshots/Recordings**

N/A — CI workflow-only change; no user-facing UI impact.

### **Before**

Upload step skipped after test failure; no failure recording artifact on the run.

### **After**

Upload step runs on test failure; failure recordings available when saved to `tests/test-reports/appium-smoke-videos/<suite>/`.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-929e305b-924d-4955-bfeb-626434c644fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-929e305b-924d-4955-bfeb-626434c644fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

