### PR TITLE
fix: rename "Monthly Top Traders" to "Weekly Top Traders"

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -139,7 +139,7 @@ describe('TopTradersSection', () => {
   it('navigates to the Top Traders view when the section header is pressed', () => {
     renderWithProvider(<TopTradersSection {...defaultProps} />);
 
-    fireEvent.press(screen.getByText('Top Traders'));
+    fireEvent.press(screen.getByText('Weekly Top Traders'));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.SOCIAL_LEADERBOARD.VIEW, {
       source: 'home_carousel',

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -174,7 +174,7 @@ describe('TopTradersView', () => {
 
   it('renders the Top Traders title', () => {
     renderWithProvider(<TopTradersView />);
-    expect(screen.getByText('Top Traders')).toBeOnTheScreen();
+    expect(screen.getByText('Weekly Top Traders')).toBeOnTheScreen();
   });
 
   it('calls goBack when the back button is pressed', () => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1037,7 +1037,7 @@
   },
   "social_leaderboard": {
     "top_traders_view": {
-      "title": "Top Traders",
+      "title": "Weekly Top Traders",
       "chain_filter": {
         "all": "All"
       }
@@ -9669,7 +9669,7 @@
       "related_assets": "Related Assets",
       "perpetuals": "Perpetuals",
       "predictions": "Predictions",
-      "top_traders": "Top Traders",
+      "top_traders": "Weekly Top Traders",
       "defi": "DeFi",
       "nfts": "NFTs",
       "trending_tokens": "Trending",


### PR DESCRIPTION
## **Description**

Updates `locales/languages/en.json` to replace "Monthly Top Traders" with "Weekly Top Traders" in two places:
- `social_leaderboard.top_traders_view.title` — full-screen leaderboard title
- `top_traders` — home widget label

The UI labels said "Monthly" but the leaderboard reflects a weekly timeframe, causing a mismatch between the copy and the actual data shown.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A — copy-only fix identified via visual inspection of the app

## **Manual testing steps**

```gherkin
Feature: Weekly Top Traders label

  Scenario: user views the Top Traders section
    Given the app is open on the home screen

    When user scrolls to the Top Traders widget
    Then the widget title reads "Weekly Top Traders"

    When user taps the widget to open the full leaderboard
    Then the screen title reads "Weekly Top Traders"
```

## **Screenshots/Recordings**

### **Before**

Monthly Top Traders (as seen in UI)

### **After**

Weekly Top Traders

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in English locale plus test expectation updates; no logic, API, or navigation changes.
> 
> **Overview**
> Renames the Top Traders copy to **Weekly Top Traders** so the home widget and full leaderboard title match the weekly timeframe of the data.
> 
> `locales/languages/en.json` updates `social_leaderboard.top_traders_view.title` and `homepage.sections.top_traders`. Component code is unchanged; tests in `TopTradersSection.test.tsx` and `TopTradersView.test.tsx` now assert the new label when tapping the section header and on the leaderboard screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b953ca2a7b71748b7da1776a299c250231b096cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->