### PR TITLE
feat: [MUSD-956] implement new money activity designs

### DIFF
--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
@@ -165,7 +165,7 @@ describe('MoneyActivityView', () => {
     expect(
       getByTestId(MoneyActivityLoadingTestIds.CONTAINER),
     ).toBeOnTheScreen();
-    expect(queryByTestId('activity-mock-tx-money-tx-1')).toBeNull();
+    expect(queryByTestId('activity-mock-tx-money-tx-converted')).toBeNull();
   });
 
   it('renders the main container', () => {
@@ -203,7 +203,9 @@ describe('MoneyActivityView', () => {
   it('renders transaction rows from activity data', () => {
     const { getByTestId } = renderWithProvider(<MoneyActivityView />);
 
-    expect(getByTestId('activity-mock-tx-money-tx-1')).toBeOnTheScreen();
+    expect(
+      getByTestId('activity-mock-tx-money-tx-converted'),
+    ).toBeOnTheScreen();
   });
 
   it('shows only deposit rows when the Deposits filter is selected', () => {
@@ -213,8 +215,10 @@ describe('MoneyActivityView', () => {
 
     fireEvent.press(getByTestId(MoneyActivityViewTestIds.FILTER_DEPOSITS));
 
-    expect(getByTestId('activity-mock-tx-money-tx-1')).toBeOnTheScreen();
-    expect(queryByTestId('activity-mock-tx-money-tx-4')).toBeNull();
+    expect(
+      getByTestId('activity-mock-tx-money-tx-converted'),
+    ).toBeOnTheScreen();
+    expect(queryByTestId('activity-mock-tx-money-tx-sent')).toBeNull();
   });
 
   it('shows only transfer rows when the Transfers filter is selected', () => {
@@ -224,8 +228,8 @@ describe('MoneyActivityView', () => {
 
     fireEvent.press(getByTestId(MoneyActivityViewTestIds.FILTER_TRANSFERS));
 
-    expect(getByTestId('activity-mock-tx-money-tx-4')).toBeOnTheScreen();
-    expect(queryByTestId('activity-mock-tx-money-tx-1')).toBeNull();
+    expect(getByTestId('activity-mock-tx-money-tx-sent')).toBeOnTheScreen();
+    expect(queryByTestId('activity-mock-tx-money-tx-converted')).toBeNull();
   });
 
   it('renders empty state when there are no transactions', () => {
@@ -249,7 +253,7 @@ describe('MoneyActivityView', () => {
   it('pressing a row navigates to the transaction details sheet when mockDataEnabled is false', () => {
     const { getByTestId } = renderWithProvider(<MoneyActivityView />);
 
-    fireEvent.press(getByTestId('activity-mock-tx-money-tx-1'));
+    fireEvent.press(getByTestId('activity-mock-tx-money-tx-converted'));
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
@@ -356,13 +360,13 @@ describe('MoneyActivityView', () => {
     it('calls trackActivitySurfaceClicked with transaction and MONEY_ACTIVITY_DETAILS redirect when a row is pressed', () => {
       const { getByTestId } = renderWithProvider(<MoneyActivityView />);
 
-      fireEvent.press(getByTestId('activity-mock-tx-money-tx-1'));
+      fireEvent.press(getByTestId('activity-mock-tx-money-tx-converted'));
 
       expect(mockTrackActivitySurfaceClicked).toHaveBeenCalledWith(
         expect.objectContaining({
           redirect_target: SCREEN_NAMES.MONEY_ACTIVITY_DETAILS,
           component_name: COMPONENT_NAMES.MONEY_ACTIVITY_LIST_ITEM,
-          transaction: expect.objectContaining({ id: 'money-tx-1' }),
+          transaction: expect.objectContaining({ id: 'money-tx-converted' }),
         }),
       );
     });

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
@@ -96,7 +96,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'money.activity.empty': 'No activity yet',
       'money.activity.filter_all': 'All',
       'money.activity.filter_deposits': 'Deposits',
-      'money.activity.filter_transfers': 'Transfers',
+      'money.activity.filter_sends': 'Sends',
+      'money.activity.pending': 'Pending',
     };
     return map[key] ?? key;
   },
@@ -206,6 +207,35 @@ describe('MoneyActivityView', () => {
     expect(
       getByTestId('activity-mock-tx-money-tx-converted'),
     ).toBeOnTheScreen();
+  });
+
+  it('renders a Pending section for in-flight rows', () => {
+    const { getByTestId } = renderWithProvider(<MoneyActivityView />);
+
+    // The fixture includes submitted (pending) rows, so the bucket appears.
+    expect(
+      getByTestId(MoneyActivityViewTestIds.PENDING_HEADER),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId('activity-mock-tx-money-tx-depositing'),
+    ).toBeOnTheScreen();
+  });
+
+  it('omits the Pending section when nothing is in flight', () => {
+    mockUseMoneyAccountTransactions.mockReturnValue({
+      allTransactions: MOCK_DEPOSITS.filter(
+        (tx) => tx.id === 'money-tx-converted',
+      ),
+      deposits: MOCK_DEPOSITS.filter((tx) => tx.id === 'money-tx-converted'),
+      transfers: [],
+      submittedTransactions: [],
+      moneyAddress: '0x0000000000000000000000000000000000000001',
+      mockDataEnabled: false,
+    });
+
+    const { queryByTestId } = renderWithProvider(<MoneyActivityView />);
+
+    expect(queryByTestId(MoneyActivityViewTestIds.PENDING_HEADER)).toBeNull();
   });
 
   it('shows only deposit rows when the Deposits filter is selected', () => {

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.testIds.ts
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.testIds.ts
@@ -6,6 +6,7 @@ export const MoneyActivityViewTestIds = {
   FILTER_DEPOSITS: 'money-activity-view-filter-deposits',
   FILTER_TRANSFERS: 'money-activity-view-filter-transfers',
   DATE_HEADER: 'money-activity-view-date-header',
+  PENDING_HEADER: 'money-activity-view-pending-header',
   EMPTY_LIST: 'money-activity-view-empty-list',
   EMPTY_LIST_MESSAGE: 'money-activity-view-empty-list-message',
 };

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -27,7 +27,10 @@ import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransact
 import { useMoneyAccountCardTransactions } from '../../hooks/useMoneyAccountCardTransactions';
 import { mergeMoneyActivity } from '../../hooks/useMoneyActivityItems';
 import { onchainItem, type MoneyActivityItem } from '../../types/moneyActivity';
-import { MoneyActivityFilter } from '../../constants/mockActivityData';
+import {
+  MoneyActivityFilter,
+  MOCK_CARD_TRANSACTIONS,
+} from '../../constants/mockActivityData';
 import { getMoneyActivityStatus } from '../../utils/classifyMoneyActivity';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MoneyActivityViewTestIds } from './MoneyActivityView.testIds';
@@ -143,23 +146,21 @@ const MoneyActivityView = () => {
   // their loading state) into it.
   const showCardActivityLoading = isCardActivityLoading && !mockDataEnabled;
 
+  // In mock mode, use the curated mock card spend; otherwise the real ones.
+  const cardItems = mockDataEnabled ? MOCK_CARD_TRANSACTIONS : cardTransactions;
+
   // Card spends are outgoing, so they belong with transfers (and in "All").
   const allItems = useMemo(
-    () =>
-      mergeMoneyActivity(
-        allTransactions,
-        mockDataEnabled ? [] : cardTransactions,
-      ),
-    [allTransactions, cardTransactions, mockDataEnabled],
+    () => mergeMoneyActivity(allTransactions, cardItems),
+    [allTransactions, cardItems],
   );
   const depositItems = useMemo(
     () => deposits.map(onchainItem).sort((a, b) => b.time - a.time),
     [deposits],
   );
   const transferItems = useMemo(
-    () =>
-      mergeMoneyActivity(transfers, mockDataEnabled ? [] : cardTransactions),
-    [transfers, cardTransactions, mockDataEnabled],
+    () => mergeMoneyActivity(transfers, cardItems),
+    [transfers, cardItems],
   );
 
   const handleFilterPress = useCallback(

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -42,6 +42,7 @@ import {
   SCREEN_NAMES,
 } from '../../constants/moneyEvents';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+import { partition } from 'lodash';
 
 const styles = StyleSheet.create({
   safeArea: { flex: 1 },
@@ -103,8 +104,8 @@ function buildSections(
   items: MoneyActivityItem[],
   locale: string,
 ): ActivitySection[] {
-  const pending = items.filter(isPendingItem);
-  const settled = items.filter((item) => !isPendingItem(item));
+  const [pending, settled] = partition(items, isPendingItem);
+
   const dateSections = groupByDate(settled, locale);
   if (pending.length === 0) {
     return dateSections;

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -28,6 +28,7 @@ import { useMoneyAccountCardTransactions } from '../../hooks/useMoneyAccountCard
 import { mergeMoneyActivity } from '../../hooks/useMoneyActivityItems';
 import { onchainItem, type MoneyActivityItem } from '../../types/moneyActivity';
 import { MoneyActivityFilter } from '../../constants/mockActivityData';
+import { getMoneyActivityStatus } from '../../utils/classifyMoneyActivity';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MoneyActivityViewTestIds } from './MoneyActivityView.testIds';
 import useMountEffect from '../../hooks/useMountEffect';
@@ -46,12 +47,21 @@ const styles = StyleSheet.create({
 const FILTER_LABEL_KEYS = {
   all: 'money.activity.filter_all',
   deposits: 'money.activity.filter_deposits',
-  transfers: 'money.activity.filter_transfers',
+  transfers: 'money.activity.filter_sends',
 } as const;
 
-interface DateSection {
+interface ActivitySection {
   title: string;
   data: MoneyActivityItem[];
+  /** Marks the in-flight bucket so its header renders distinctly from dates. */
+  isPending?: boolean;
+}
+
+/** True for an in-flight on-chain row. Card spends are never pending. */
+function isPendingItem(item: MoneyActivityItem): boolean {
+  return (
+    item.kind === 'onchain' && getMoneyActivityStatus(item.tx) === 'pending'
+  );
 }
 
 function dateKeyUtc(time: number): string {
@@ -61,7 +71,7 @@ function dateKeyUtc(time: number): string {
 function groupByDate(
   items: MoneyActivityItem[],
   locale: string,
-): DateSection[] {
+): ActivitySection[] {
   const groups = new Map<string, MoneyActivityItem[]>();
   for (const item of items) {
     const key = dateKeyUtc(item.time);
@@ -80,6 +90,30 @@ function groupByDate(
     }),
     data,
   }));
+}
+
+/**
+ * Builds the list sections: a single "Pending" bucket (in-flight rows) on top,
+ * followed by the confirmed/failed rows grouped by date.
+ */
+function buildSections(
+  items: MoneyActivityItem[],
+  locale: string,
+): ActivitySection[] {
+  const pending = items.filter(isPendingItem);
+  const settled = items.filter((item) => !isPendingItem(item));
+  const dateSections = groupByDate(settled, locale);
+  if (pending.length === 0) {
+    return dateSections;
+  }
+  return [
+    {
+      title: strings('money.activity.pending'),
+      data: pending,
+      isPending: true,
+    },
+    ...dateSections,
+  ];
 }
 
 const MoneyActivityView = () => {
@@ -177,17 +211,21 @@ const MoneyActivityView = () => {
   }, [filter, allItems, depositItems, transferItems]);
 
   const sections = useMemo(
-    () => groupByDate(filtered, I18n.locale),
+    () => buildSections(filtered, I18n.locale),
     [filtered],
   );
 
-  const renderSectionHeader = ({ section }: { section: DateSection }) => (
+  const renderSectionHeader = ({ section }: { section: ActivitySection }) => (
     <Box twClassName="px-4 pt-2 pb-1 bg-default">
       <Text
         variant={TextVariant.BodyMd}
         fontWeight={FontWeight.Medium}
         color={TextColor.TextAlternative}
-        testID={MoneyActivityViewTestIds.DATE_HEADER}
+        testID={
+          section.isPending
+            ? MoneyActivityViewTestIds.PENDING_HEADER
+            : MoneyActivityViewTestIds.DATE_HEADER
+        }
       >
         {section.title}
       </Text>

--- a/app/components/UI/Money/components/CardActivityItem/CardActivityItem.test.tsx
+++ b/app/components/UI/Money/components/CardActivityItem/CardActivityItem.test.tsx
@@ -44,10 +44,14 @@ const card: CardTransaction = {
 
 interface CapturedRowProps {
   id: string;
-  isFailed: boolean;
   chainId: string;
   onPress?: (id: string) => void;
-  display: { icon: IconName; primaryAmount: string; fiatAmount: string };
+  display: {
+    icon: IconName;
+    primaryAmount: string;
+    fiatAmount: string;
+    status: string;
+  };
 }
 
 describe('CardActivityItem', () => {
@@ -61,8 +65,8 @@ describe('CardActivityItem', () => {
     expect(mockRowView).toHaveBeenCalledTimes(1);
     const props = mockRowView.mock.calls[0][0] as unknown as CapturedRowProps;
     expect(props.id).toBe(card.hash);
-    expect(props.isFailed).toBe(false);
     expect(props.chainId).toBe('0x8f');
+    expect(props.display.status).toBe('confirmed');
     expect(props.display.icon).toBe(IconName.Card);
     expect(props.display.primaryAmount).toBe('-5.38 mUSD');
     expect(props.display.fiatAmount).toContain('5.38');

--- a/app/components/UI/Money/components/CardActivityItem/CardActivityItem.tsx
+++ b/app/components/UI/Money/components/CardActivityItem/CardActivityItem.tsx
@@ -44,7 +44,6 @@ const CardActivityItem = ({
     <ActivityRowView
       id={card.hash}
       display={display}
-      isFailed={false}
       chainId={card.chainId}
       onPress={handlePress}
       showNetworkBadge={showNetworkBadge}

--- a/app/components/UI/Money/components/MoneyActivityItem/ActivityRowView.tsx
+++ b/app/components/UI/Money/components/MoneyActivityItem/ActivityRowView.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
-import { Pressable } from 'react-native';
+import { ActivityIndicator, Pressable } from 'react-native';
 import {
   AvatarIcon,
   AvatarIconSeverity,
   AvatarIconSize,
   Box,
   BoxAlignItems,
+  BoxFlexDirection,
   FontWeight,
   Text,
   TextColor,
@@ -13,7 +14,6 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import type { Hex } from '@metamask/utils';
-import { strings } from '../../../../../../locales/i18n';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import BadgeWrapper from '../../../../../component-library/components/Badges/BadgeWrapper';
@@ -30,7 +30,6 @@ import { MoneyActivityItemTestIds } from './MoneyActivityItem.testIds';
 export interface ActivityRowViewProps {
   id: string;
   display: MoneyTransactionDisplayInfo;
-  isFailed: boolean;
   chainId?: Hex;
   onPress?: (id: string) => void;
   showNetworkBadge?: boolean;
@@ -39,12 +38,14 @@ export interface ActivityRowViewProps {
 const ActivityRowView = ({
   id,
   display,
-  isFailed,
   chainId,
   onPress,
   showNetworkBadge = false,
 }: ActivityRowViewProps) => {
   const tw = useTailwind();
+
+  const isFailed = display.status === 'failed';
+  const isPending = display.status === 'pending';
 
   const networkImageSource = useMemo(
     () =>
@@ -103,24 +104,29 @@ const ActivityRowView = ({
         </Box>
       )}
       <Box twClassName="min-w-0 flex-1 gap-0.5">
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextDefault}
-          numberOfLines={1}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="gap-2"
         >
-          {display.label}
-        </Text>
-        {isFailed ? (
           <Text
-            variant={TextVariant.BodySm}
+            variant={TextVariant.BodyMd}
             fontWeight={FontWeight.Medium}
-            color={TextColor.ErrorDefault}
+            color={isFailed ? TextColor.ErrorDefault : TextColor.TextDefault}
             numberOfLines={1}
+            twClassName="shrink"
           >
-            {strings('money.transaction.failed')}
+            {display.label}
           </Text>
-        ) : display.description ? (
+          {isPending ? (
+            <ActivityIndicator
+              size="small"
+              color={tw.color('text-alternative')}
+              testID={MoneyActivityItemTestIds.PENDING_SPINNER}
+            />
+          ) : null}
+        </Box>
+        {display.description ? (
           <Text
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}

--- a/app/components/UI/Money/components/MoneyActivityItem/ActivityRowView.tsx
+++ b/app/components/UI/Money/components/MoneyActivityItem/ActivityRowView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ActivityIndicator, Pressable } from 'react-native';
+import { Pressable } from 'react-native';
 import {
   AvatarIcon,
   AvatarIconSeverity,
@@ -25,6 +25,7 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
 import type { MoneyTransactionDisplayInfo } from '../../hooks/useMoneyTransactionDisplayInfo';
+import PendingSpinner from '../PendingSpinner/PendingSpinner';
 import { MoneyActivityItemTestIds } from './MoneyActivityItem.testIds';
 
 export interface ActivityRowViewProps {
@@ -119,11 +120,7 @@ const ActivityRowView = ({
             {display.label}
           </Text>
           {isPending ? (
-            <ActivityIndicator
-              size="small"
-              color={tw.color('text-alternative')}
-              testID={MoneyActivityItemTestIds.PENDING_SPINNER}
-            />
+            <PendingSpinner testID={MoneyActivityItemTestIds.PENDING_SPINNER} />
           ) : null}
         </Box>
         {display.description ? (

--- a/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.test.tsx
+++ b/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.test.tsx
@@ -86,6 +86,7 @@ describe('MoneyActivityItem', () => {
       fiatAmount: '$0.00',
       isIncoming: true,
       icon: IconName.Arrow2Down,
+      status: 'confirmed',
     });
   });
 
@@ -119,6 +120,7 @@ describe('MoneyActivityItem', () => {
       fiatAmount: '$0.00',
       isIncoming: false,
       icon: IconName.Arrow2Down,
+      status: 'confirmed',
     });
 
     const { queryByText } = renderWithProvider(
@@ -140,7 +142,17 @@ describe('MoneyActivityItem', () => {
     expect(onPress).toHaveBeenCalledWith(baseTx);
   });
 
-  it('shows "Failed" in the description slot for a failed transaction', () => {
+  it('keeps the real subtitle on a failed row (failure is shown via the label, not the subtitle)', () => {
+    mockUseMoneyTransactionDisplayInfo.mockReturnValue({
+      label: 'Conversion failed',
+      description: 'USDC → mUSD',
+      primaryAmount: '+0.00 mUSD',
+      fiatAmount: '+$0.00',
+      isIncoming: true,
+      icon: IconName.Refresh,
+      status: 'failed',
+    });
+
     const failedTx = {
       ...baseTx,
       status: TransactionStatus.failed,
@@ -150,9 +162,10 @@ describe('MoneyActivityItem', () => {
       <MoneyActivityItem tx={failedTx} moneyAddress="0x1" />,
     );
 
-    expect(getByText('Failed')).toBeOnTheScreen();
-    // Normal description should not appear for failed rows
-    expect(queryByText('Description')).toBeNull();
+    expect(getByText('Conversion failed')).toBeOnTheScreen();
+    // Subtitle is preserved (no generic "Failed" replacement).
+    expect(getByText('USDC → mUSD')).toBeOnTheScreen();
+    expect(queryByText('Failed')).toBeNull();
   });
 
   it('renders network badge subtree when showNetworkBadge is true', () => {
@@ -182,6 +195,7 @@ describe('MoneyActivityItem', () => {
       fiatAmount: '$0.00',
       isIncoming: true,
       icon: IconName.SwapHorizontal,
+      status: 'confirmed',
     });
 
     const { getByTestId } = renderWithProvider(
@@ -192,5 +206,26 @@ describe('MoneyActivityItem', () => {
       'accessibilityLabel',
       IconName.SwapHorizontal,
     );
+  });
+
+  it('shows a spinner and no spinner when status is pending vs confirmed', () => {
+    mockUseMoneyTransactionDisplayInfo.mockReturnValue({
+      label: 'Depositing',
+      description: 'Transak',
+      primaryAmount: '+1,000.00 mUSD',
+      fiatAmount: '+$1000.00',
+      isIncoming: true,
+      icon: IconName.Add,
+      status: 'pending',
+    });
+
+    const { getByTestId, getByText } = renderWithProvider(
+      <MoneyActivityItem tx={baseTx} moneyAddress="0x1" />,
+    );
+
+    expect(getByText('Depositing')).toBeOnTheScreen();
+    expect(
+      getByTestId(MoneyActivityItemTestIds.PENDING_SPINNER),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.test.tsx
+++ b/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.test.tsx
@@ -225,7 +225,9 @@ describe('MoneyActivityItem', () => {
 
     expect(getByText('Depositing')).toBeOnTheScreen();
     expect(
-      getByTestId(MoneyActivityItemTestIds.PENDING_SPINNER),
+      getByTestId(MoneyActivityItemTestIds.PENDING_SPINNER, {
+        includeHiddenElements: true,
+      }),
     ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.testIds.ts
+++ b/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.testIds.ts
@@ -1,4 +1,5 @@
 export const MoneyActivityItemTestIds = {
   ROW: 'money-activity-item-row',
   ICON: 'money-activity-item-icon',
+  PENDING_SPINNER: 'money-activity-item-pending-spinner',
 };

--- a/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.tsx
+++ b/app/components/UI/Money/components/MoneyActivityItem/MoneyActivityItem.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  type TransactionMeta,
-  TransactionStatus,
-} from '@metamask/transaction-controller';
+import { type TransactionMeta } from '@metamask/transaction-controller';
 import { useMoneyTransactionDisplayInfo } from '../../hooks/useMoneyTransactionDisplayInfo';
 import ActivityRowView from './ActivityRowView';
 
@@ -26,7 +23,6 @@ const MoneyActivityItem = ({
     <ActivityRowView
       id={tx.id}
       display={display}
-      isFailed={tx.status === TransactionStatus.failed}
       chainId={tx.chainId}
       onPress={() => onPress?.(tx)}
       showNetworkBadge={showNetworkBadge}

--- a/app/components/UI/Money/components/MoneyActivityList/MoneyActivityList.test.tsx
+++ b/app/components/UI/Money/components/MoneyActivityList/MoneyActivityList.test.tsx
@@ -59,10 +59,10 @@ describe('MoneyActivityList', () => {
 
     expect(getByTestId(MoneyActivityListTestIds.CONTAINER)).toBeOnTheScreen();
     expect(
-      getByTestId(`${MoneyActivityItemTestIds.ROW}-money-tx-1`),
+      getByTestId(`${MoneyActivityItemTestIds.ROW}-${MOCK_ITEMS[0].id}`),
     ).toBeOnTheScreen();
     expect(
-      getByTestId(`${MoneyActivityItemTestIds.ROW}-money-tx-5`),
+      getByTestId(`${MoneyActivityItemTestIds.ROW}-${MOCK_ITEMS[4].id}`),
     ).toBeOnTheScreen();
   });
 
@@ -72,7 +72,7 @@ describe('MoneyActivityList', () => {
     );
 
     expect(
-      queryByTestId(`${MoneyActivityItemTestIds.ROW}-money-tx-6`),
+      queryByTestId(`${MoneyActivityItemTestIds.ROW}-${MOCK_ITEMS[5].id}`),
     ).toBeNull();
   });
 

--- a/app/components/UI/Money/components/PendingSpinner/PendingSpinner.test.tsx
+++ b/app/components/UI/Money/components/PendingSpinner/PendingSpinner.test.tsx
@@ -7,7 +7,19 @@ describe('PendingSpinner', () => {
   it('renders with the provided testID', () => {
     const { getByTestId } = render(<PendingSpinner testID="pending-spinner" />);
 
-    expect(getByTestId('pending-spinner')).toBeOnTheScreen();
+    expect(
+      getByTestId('pending-spinner', { includeHiddenElements: true }),
+    ).toBeOnTheScreen();
+  });
+
+  it('is hidden from assistive technology', () => {
+    const { getByTestId } = render(<PendingSpinner testID="pending-spinner" />);
+
+    const spinner = getByTestId('pending-spinner', {
+      includeHiddenElements: true,
+    });
+    expect(spinner.props.accessibilityElementsHidden).toBe(true);
+    expect(spinner.props.importantForAccessibility).toBe('no-hide-descendants');
   });
 
   it('renders at a custom size without a testID', () => {

--- a/app/components/UI/Money/components/PendingSpinner/PendingSpinner.test.tsx
+++ b/app/components/UI/Money/components/PendingSpinner/PendingSpinner.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { IconSize } from '../../../../../component-library/components/Icons/Icon';
+import PendingSpinner from './PendingSpinner';
+
+describe('PendingSpinner', () => {
+  it('renders with the provided testID', () => {
+    const { getByTestId } = render(<PendingSpinner testID="pending-spinner" />);
+
+    expect(getByTestId('pending-spinner')).toBeOnTheScreen();
+  });
+
+  it('renders at a custom size without a testID', () => {
+    const { toJSON } = render(<PendingSpinner size={IconSize.Lg} />);
+
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/app/components/UI/Money/components/PendingSpinner/PendingSpinner.tsx
+++ b/app/components/UI/Money/components/PendingSpinner/PendingSpinner.tsx
@@ -58,7 +58,15 @@ const PendingSpinner = ({
   );
 
   return (
-    <Animated.View style={[containerStyle, animatedStyle]} testID={testID}>
+    // Decorative: the pending state is conveyed by the row's status label,
+    // so hide the spinner from assistive technology on both platforms.
+    <Animated.View
+      style={[containerStyle, animatedStyle]}
+      testID={testID}
+      accessible={false}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
       <Icon name={IconName.Loading} size={size} color={color} />
     </Animated.View>
   );

--- a/app/components/UI/Money/components/PendingSpinner/PendingSpinner.tsx
+++ b/app/components/UI/Money/components/PendingSpinner/PendingSpinner.tsx
@@ -24,11 +24,7 @@ export interface PendingSpinnerProps {
 }
 
 /**
- * The in-flight indicator from the Money activity design: the `Loading` icon
- * (an open ring) rotating continuously. Uses the shared icon library so the
- * glyph stays in sync with the design system, and a reanimated worklet for the
- * rotation — which runs on the UI thread, so it keeps spinning even while the
- * JS thread is busy (e.g. during initial data/balance load).
+ * The in-flight indicator from the Money activity design
  */
 const PendingSpinner = ({
   size = IconSize.Sm,
@@ -49,8 +45,7 @@ const PendingSpinner = ({
     transform: [{ rotate: `${rotation.value}deg` }],
   }));
 
-  // Explicit dimensions so the rotation pivots around the icon's centre rather
-  // than a zero-size view's origin (the bug in the first reanimated attempt).
+  // Explicit dimensions so the rotation pivots around the icon's centre
   const dimension = Number(size);
   const containerStyle = useMemo(
     () => ({

--- a/app/components/UI/Money/components/PendingSpinner/PendingSpinner.tsx
+++ b/app/components/UI/Money/components/PendingSpinner/PendingSpinner.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useMemo } from 'react';
+import Animated, {
+  Easing,
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+
+const DURATION_MS = 1000;
+
+export interface PendingSpinnerProps {
+  /** Icon size. Defaults to Sm (16px). */
+  size?: IconSize;
+  /** Icon colour. Defaults to the standard icon colour. */
+  color?: string | IconColor;
+  testID?: string;
+}
+
+/**
+ * The in-flight indicator from the Money activity design: the `Loading` icon
+ * (an open ring) rotating continuously. Uses the shared icon library so the
+ * glyph stays in sync with the design system, and a reanimated worklet for the
+ * rotation — which runs on the UI thread, so it keeps spinning even while the
+ * JS thread is busy (e.g. during initial data/balance load).
+ */
+const PendingSpinner = ({
+  size = IconSize.Sm,
+  color = IconColor.Default,
+  testID,
+}: PendingSpinnerProps) => {
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withRepeat(
+      withTiming(360, { duration: DURATION_MS, easing: Easing.linear }),
+      -1,
+    );
+    return () => cancelAnimation(rotation);
+  }, [rotation]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
+
+  // Explicit dimensions so the rotation pivots around the icon's centre rather
+  // than a zero-size view's origin (the bug in the first reanimated attempt).
+  const dimension = Number(size);
+  const containerStyle = useMemo(
+    () => ({
+      width: dimension,
+      height: dimension,
+      alignItems: 'center' as const,
+      justifyContent: 'center' as const,
+    }),
+    [dimension],
+  );
+
+  return (
+    <Animated.View style={[containerStyle, animatedStyle]} testID={testID}>
+      <Icon name={IconName.Loading} size={size} color={color} />
+    </Animated.View>
+  );
+};
+
+export default PendingSpinner;

--- a/app/components/UI/Money/constants/mockActivityData.ts
+++ b/app/components/UI/Money/constants/mockActivityData.ts
@@ -20,13 +20,11 @@ export enum MoneyActivityFilter {
  * When set on mock or enriched {@link TransactionMeta}, overrides the default title from {@link TransactionType}.
  */
 export type MoneyActivityTitleKey =
-  | 'added'
   | 'deposited'
   | 'received'
   | 'card_transaction'
   | 'converted'
-  | 'sent'
-  | 'transferred';
+  | 'sent';
 
 /**
  * {@link TransactionMeta} plus optional Money activity presentation fields.

--- a/app/components/UI/Money/constants/mockActivityData.ts
+++ b/app/components/UI/Money/constants/mockActivityData.ts
@@ -89,11 +89,6 @@ function makeMoneyTx(config: {
   };
 }
 
-// A QA fixture covering the full kind × status matrix from the MUSD-956 design.
-// `type` drives the +/- sign and incoming colour; `moneyActivityTitleKey` pins
-// the kind; `status` drives the label form (Depositing / Deposit failed / …)
-// and the spinner; `moneySubtitle` supplies the subtitle text (the token
-// registry isn't populated in mock mode, so we set it explicitly).
 const MOCK_MONEY_TRANSACTIONS: MoneyActivityTransactionMeta[] = [
   // --- Pending (in-flight): present-tense label + spinner ---
   makeMoneyTx({
@@ -201,8 +196,7 @@ export default MOCK_MONEY_TRANSACTIONS;
 /**
  * Mock card spend for QA. Card rows come from the Accounts API (a separate
  * source from on-chain txns), so they aren't part of MOCK_MONEY_TRANSACTIONS —
- * MoneyActivityView merges these in when mock data is enabled. Time sits within
- * the confirmed rows so it groups under the same date section.
+ * MoneyActivityView merges these in when mock data is enabled.
  */
 export const MOCK_CARD_TRANSACTIONS: CardTransaction[] = [
   {

--- a/app/components/UI/Money/constants/mockActivityData.ts
+++ b/app/components/UI/Money/constants/mockActivityData.ts
@@ -7,6 +7,7 @@ import {
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { MUSD_TOKEN, MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
+import type { CardTransaction } from '../types/moneyActivity';
 
 export type MoneyActivityFilterType = 'deposit' | 'transfer';
 
@@ -196,6 +197,27 @@ const MOCK_MONEY_TRANSACTIONS: MoneyActivityTransactionMeta[] = [
 ];
 
 export default MOCK_MONEY_TRANSACTIONS;
+
+/**
+ * Mock card spend for QA. Card rows come from the Accounts API (a separate
+ * source from on-chain txns), so they aren't part of MOCK_MONEY_TRANSACTIONS —
+ * MoneyActivityView merges these in when mock data is enabled. Time sits within
+ * the confirmed rows so it groups under the same date section.
+ */
+export const MOCK_CARD_TRANSACTIONS: CardTransaction[] = [
+  {
+    hash: '0xca5d000000000000000000000000000000000000000000000000000000000001',
+    time: 1747005600 * 1000,
+    chainId: MOCK_CHAIN_ID,
+    token: {
+      address: MUSD_TOKEN_ADDRESS,
+      symbol: MUSD_TOKEN.symbol,
+      decimals: MUSD_TOKEN.decimals,
+    },
+    amount: '10000000', // 10.00 mUSD → "-10.00 mUSD"
+    to: '0x8dFE562Cbb4E93D5029f39DA26BB6B501a8d1D3e',
+  },
+];
 
 export {
   getMoneyActivityDateKeyUtc,

--- a/app/components/UI/Money/constants/mockActivityData.ts
+++ b/app/components/UI/Money/constants/mockActivityData.ts
@@ -1,6 +1,7 @@
 import {
   type TransactionMeta,
   type TransactionParams,
+  CHAIN_IDS,
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -35,9 +36,12 @@ export type MoneyActivityTransactionMeta = TransactionMeta & {
   moneyActivityTitleKey?: MoneyActivityTitleKey;
 };
 
-export const MOCK_CHAIN_ID = '0x1' as Hex;
+// mUSD activity is gated to the Money Account chain (Monad). Using Monad here
+// lets the mUSD amount resolve through the normal `transferInformation` path so
+// mock rows render real "+/-X.XX mUSD" amounts.
+export const MOCK_CHAIN_ID = CHAIN_IDS.MONAD as Hex;
 
-export const MOCK_NETWORK_CLIENT_ID = 'mainnet';
+export const MOCK_NETWORK_CLIENT_ID = 'monad';
 
 const defaultTxParams = {
   from: '0x0000000000000000000000000000000000000001',
@@ -51,6 +55,7 @@ function makeMoneyTx(config: {
   timestampSec: number;
   type: TransactionType;
   amount: string;
+  status?: TransactionStatus;
   symbol?: string;
   moneySubtitle?: string;
   moneyActivityTitleKey?: MoneyActivityTitleKey;
@@ -60,6 +65,7 @@ function makeMoneyTx(config: {
     timestampSec,
     type,
     amount,
+    status = TransactionStatus.confirmed,
     symbol = MUSD_TOKEN.symbol,
     moneySubtitle,
     moneyActivityTitleKey,
@@ -69,7 +75,7 @@ function makeMoneyTx(config: {
     id,
     chainId: MOCK_CHAIN_ID,
     networkClientId: MOCK_NETWORK_CLIENT_ID,
-    status: TransactionStatus.confirmed,
+    status,
     time: timestampSec * 1000,
     txParams: defaultTxParams,
     type,
@@ -84,52 +90,110 @@ function makeMoneyTx(config: {
   };
 }
 
+// A QA fixture covering the full kind × status matrix from the MUSD-956 design.
+// `type` drives the +/- sign and incoming colour; `moneyActivityTitleKey` pins
+// the kind; `status` drives the label form (Depositing / Deposit failed / …)
+// and the spinner; `moneySubtitle` supplies the subtitle text (the token
+// registry isn't populated in mock mode, so we set it explicitly).
 const MOCK_MONEY_TRANSACTIONS: MoneyActivityTransactionMeta[] = [
+  // --- Pending (in-flight): present-tense label + spinner ---
   makeMoneyTx({
-    id: 'money-tx-1',
+    id: 'money-tx-depositing',
     timestampSec: 1747094400,
     type: TransactionType.moneyAccountDeposit,
-    amount: '100000000',
-    moneyActivityTitleKey: 'added',
+    amount: '1000000000',
+    status: TransactionStatus.submitted,
+    moneySubtitle: 'Transak',
+    moneyActivityTitleKey: 'deposited',
   }),
   makeMoneyTx({
-    id: 'money-tx-2',
+    id: 'money-tx-converting',
+    timestampSec: 1747094100,
+    type: TransactionType.moneyAccountDeposit,
+    amount: '1000000000',
+    status: TransactionStatus.submitted,
+    moneySubtitle: 'ETH → mUSD',
+    moneyActivityTitleKey: 'converted',
+  }),
+  makeMoneyTx({
+    id: 'money-tx-sending',
+    timestampSec: 1747093800,
+    type: TransactionType.moneyAccountWithdraw,
+    amount: '250000000',
+    status: TransactionStatus.submitted,
+    moneySubtitle: 'mUSD → USDC',
+    moneyActivityTitleKey: 'sent',
+  }),
+
+  // --- Failed: red "<action> failed" label, subtitle preserved, zero amount ---
+  makeMoneyTx({
+    id: 'money-tx-deposit-failed',
     timestampSec: 1747090800,
+    type: TransactionType.moneyAccountDeposit,
+    amount: '1000000000',
+    status: TransactionStatus.failed,
+    moneySubtitle: 'Transak',
+    moneyActivityTitleKey: 'deposited',
+  }),
+  makeMoneyTx({
+    id: 'money-tx-conversion-failed',
+    timestampSec: 1747090500,
+    type: TransactionType.moneyAccountDeposit,
+    amount: '1000000000',
+    status: TransactionStatus.failed,
+    moneySubtitle: 'USDC → mUSD',
+    moneyActivityTitleKey: 'converted',
+  }),
+  makeMoneyTx({
+    id: 'money-tx-send-failed',
+    timestampSec: 1747090200,
+    type: TransactionType.moneyAccountWithdraw,
+    amount: '250000000',
+    status: TransactionStatus.failed,
+    moneySubtitle: 'mUSD → USDC',
+    moneyActivityTitleKey: 'sent',
+  }),
+
+  // --- Confirmed ---
+  makeMoneyTx({
+    id: 'money-tx-converted',
+    timestampSec: 1747008000,
+    type: TransactionType.moneyAccountDeposit,
+    amount: '1000000000',
+    moneySubtitle: 'USDC → mUSD',
+    moneyActivityTitleKey: 'converted',
+  }),
+  makeMoneyTx({
+    id: 'money-tx-deposited-fiat',
+    timestampSec: 1747004400,
     type: TransactionType.moneyAccountDeposit,
     amount: '1000000000',
     moneySubtitle: 'Transak',
     moneyActivityTitleKey: 'deposited',
   }),
   makeMoneyTx({
-    id: 'money-tx-3',
-    timestampSec: 1747087200,
-    type: TransactionType.incoming,
+    id: 'money-tx-deposited-musd',
+    timestampSec: 1747000800,
+    type: TransactionType.moneyAccountDeposit,
     amount: '500000000',
+    moneySubtitle: 'mUSD',
+    moneyActivityTitleKey: 'deposited',
+  }),
+  makeMoneyTx({
+    id: 'money-tx-received',
+    timestampSec: 1746997200,
+    type: TransactionType.incoming,
+    amount: '1000000000',
     moneySubtitle: 'From: 0x23231...12345',
     moneyActivityTitleKey: 'received',
   }),
   makeMoneyTx({
-    id: 'money-tx-4',
-    timestampSec: 1747083600,
-    type: TransactionType.moneyAccountWithdraw,
-    amount: '10000000',
-    moneyActivityTitleKey: 'card_transaction',
-  }),
-  makeMoneyTx({
-    id: 'money-tx-5',
-    timestampSec: 1746921600,
-    type: TransactionType.musdConversion,
-    amount: '300000000',
-    moneySubtitle: 'USDC → mUSD',
-    moneyActivityTitleKey: 'converted',
-  }),
-  makeMoneyTx({
-    id: 'money-tx-6',
-    timestampSec: 1746918000,
+    id: 'money-tx-sent',
+    timestampSec: 1746993600,
     type: TransactionType.moneyAccountWithdraw,
     amount: '250000000',
-    moneySubtitle: 'mUSD → ETH',
-    moneyActivityTitleKey: 'transferred',
+    moneySubtitle: 'mUSD → USDC',
+    moneyActivityTitleKey: 'sent',
   }),
 ];
 

--- a/app/components/UI/Money/constants/moneyTokens.ts
+++ b/app/components/UI/Money/constants/moneyTokens.ts
@@ -3,3 +3,12 @@
  * rates from {@link CurrencyRateController} state.
  */
 export const ETH_TICKER = 'ETH';
+
+/**
+ * Token a Money-account withdrawal pays out in. Withdrawals are currently
+ * hardcoded to USDC (see `buildMoneyAccountWithdrawBatch`), so a "Sent" row is
+ * always "mUSD → USDC". Used as the destination-symbol fallback when the token
+ * can't be resolved from the registry (it usually isn't held). Revisit if the
+ * receive token becomes user-selectable.
+ */
+export const MONEY_WITHDRAW_TOKEN_SYMBOL = 'USDC';

--- a/app/components/UI/Money/constants/moneyTokens.ts
+++ b/app/components/UI/Money/constants/moneyTokens.ts
@@ -5,10 +5,6 @@
 export const ETH_TICKER = 'ETH';
 
 /**
- * Token a Money-account withdrawal pays out in. Withdrawals are currently
- * hardcoded to USDC (see `buildMoneyAccountWithdrawBatch`), so a "Sent" row is
- * always "mUSD → USDC". Used as the destination-symbol fallback when the token
- * can't be resolved from the registry (it usually isn't held). Revisit if the
- * receive token becomes user-selectable.
+ * Token used for sends to perps and predict
  */
 export const MONEY_WITHDRAW_TOKEN_SYMBOL = 'USDC';

--- a/app/components/UI/Money/hooks/useMoneyAccountTransactions.test.tsx
+++ b/app/components/UI/Money/hooks/useMoneyAccountTransactions.test.tsx
@@ -257,8 +257,6 @@ describe('useMoneyAccountTransactions', () => {
 
     describe.each([
       TransactionStatus.unapproved,
-      TransactionStatus.approved,
-      TransactionStatus.signed,
       TransactionStatus.rejected,
       TransactionStatus.dropped,
       TransactionStatus.cancelled,
@@ -296,10 +294,15 @@ describe('useMoneyAccountTransactions', () => {
       });
     });
 
+    // `approved`/`signed` are user-confirmed Money txs held by the MetaMask
+    // Pay publish hook while a cross-chain payment completes — they must
+    // surface as pending rows for the whole bridge duration.
     it.each([
       TransactionStatus.confirmed,
       TransactionStatus.submitted,
       TransactionStatus.failed,
+      TransactionStatus.approved,
+      TransactionStatus.signed,
     ])(
       'includes direct moneyAccountDeposit with visible status %s',
       (status) => {
@@ -317,6 +320,8 @@ describe('useMoneyAccountTransactions', () => {
       TransactionStatus.confirmed,
       TransactionStatus.submitted,
       TransactionStatus.failed,
+      TransactionStatus.approved,
+      TransactionStatus.signed,
     ])(
       'includes EIP-7702 batch with nested moneyAccountDeposit and visible status %s',
       (status) => {
@@ -332,6 +337,22 @@ describe('useMoneyAccountTransactions', () => {
         );
         expect(result.current.allTransactions).toHaveLength(1);
         expect(result.current.deposits).toHaveLength(1);
+      },
+    );
+
+    it.each([
+      TransactionStatus.approved,
+      TransactionStatus.signed,
+      TransactionStatus.submitted,
+    ])(
+      'counts a moneyAccountDeposit with in-flight status %s as a submitted transaction',
+      (status) => {
+        const tx = makeTx(TransactionType.moneyAccountDeposit, { status });
+        const { result } = renderHookWithProvider(
+          () => useMoneyAccountTransactions(),
+          { state: engineState({ moneyActivityMockDataEnabled: false }, [tx]) },
+        );
+        expect(result.current.submittedTransactions).toHaveLength(1);
       },
     );
 

--- a/app/components/UI/Money/hooks/useMoneyAccountTransactions.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountTransactions.ts
@@ -22,6 +22,7 @@ import {
   ERC20_TRANSFER_CALLDATA_LENGTH,
   ERC20_TRANSFER_FROM_CALLDATA_LENGTH,
 } from '../constants/activityStyles';
+import { getMoneyActivityStatus } from '../utils/classifyMoneyActivity';
 
 // Statuses that should surface in money activity. `unapproved`/`approved`/
 // `signed` are mid-compose and shouldn't appear yet; `rejected`/`dropped`/
@@ -32,8 +33,21 @@ const VISIBLE_ACTIVITY_STATUSES: TransactionStatus[] = [
   TransactionStatus.failed,
 ];
 
+// Money account txs paid cross-chain are held by the MetaMask Pay publish
+// hook in `approved`/`signed` until the bridged funds arrive — already
+// user-confirmed and in-flight, so they must surface as pending rows.
+// `unapproved` stays hidden: the confirmation sheet is still open.
+const PAY_HELD_STATUSES: TransactionStatus[] = [
+  TransactionStatus.approved,
+  TransactionStatus.signed,
+];
+
 function hasVisibleStatus(tx: TransactionMeta): boolean {
   return VISIBLE_ACTIVITY_STATUSES.includes(tx.status);
+}
+
+function isMoneyAccountTxVisible(tx: TransactionMeta): boolean {
+  return hasVisibleStatus(tx) || PAY_HELD_STATUSES.includes(tx.status);
 }
 
 /**
@@ -72,7 +86,7 @@ function getErc20TransferRecipient(tx: TransactionMeta): string | undefined {
 }
 
 export interface UseMoneyAccountTransactionsResult {
-  /** Confirmed + submitted (filtered) merged, sorted by time descending */
+  /** Confirmed + in-flight (filtered) merged, sorted by time descending */
   allTransactions: TransactionMeta[];
   /** Confirmed deposits (incoming) and submitted incoming */
   deposits: TransactionMeta[];
@@ -121,7 +135,7 @@ export function useMoneyAccountTransactions(): UseMoneyAccountTransactionsResult
           tx.type === TransactionType.moneyAccountDeposit ||
           tx.type === TransactionType.moneyAccountWithdraw
         ) {
-          return hasVisibleStatus(tx);
+          return isMoneyAccountTxVisible(tx);
         }
         // EIP-7702 batch where a Money account call is a nested call.
         if (
@@ -131,7 +145,7 @@ export function useMoneyAccountTransactions(): UseMoneyAccountTransactionsResult
               nested.type === TransactionType.moneyAccountWithdraw,
           )
         ) {
-          return hasVisibleStatus(tx);
+          return isMoneyAccountTxVisible(tx);
         }
         if (moneyAddress === undefined) return false;
         // The inbound-mUSD and locally-signed mUSD branches below must skip
@@ -167,7 +181,7 @@ export function useMoneyAccountTransactions(): UseMoneyAccountTransactionsResult
       .sort((a, b) => (b?.time ?? 0) - (a?.time ?? 0));
 
     const submittedTransactions = moneyTransactions.filter(
-      (tx) => tx.status === TransactionStatus.submitted,
+      (tx) => getMoneyActivityStatus(tx) === 'pending',
     );
 
     return {

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -132,8 +132,30 @@ describe('useMoneyTransactionDisplayInfo — getLabelForTransactionType', () => 
     expect(result.current.label).toBe('money.transaction.deposited');
   });
 
-  it('returns deposited for moneyAccountDeposit type', () => {
+  it('returns converted for a crypto moneyAccountDeposit (conversion into mUSD)', () => {
     const tx = makeTx(TransactionType.moneyAccountDeposit);
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.label).toBe('money.transaction.converted');
+  });
+
+  it('returns deposited for a fiat on-ramp moneyAccountDeposit (e.g. Transak)', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { fiat: { orderId: 'order-1', provider: 'transak-native' } },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.label).toBe('money.transaction.deposited');
+  });
+
+  it('returns deposited for an mUSD-funded moneyAccountDeposit (top-up, not a conversion)', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: CHAIN_ID },
+    });
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
@@ -204,7 +226,7 @@ describe('useMoneyTransactionDisplayInfo — getLabelForTransactionType', () => 
     expect(result.current.label).toBe('money.transaction.received');
   });
 
-  it('derives label from nested type for an EIP-7702 batch deposit', () => {
+  it('derives converted from nested type for an EIP-7702 batch crypto deposit', () => {
     const tx = makeTx(TransactionType.batch, {
       nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
     });
@@ -212,7 +234,7 @@ describe('useMoneyTransactionDisplayInfo — getLabelForTransactionType', () => 
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
     );
-    expect(result.current.label).toBe('money.transaction.deposited');
+    expect(result.current.label).toBe('money.transaction.converted');
   });
 
   it('derives label from nested type for an EIP-7702 batch withdraw', () => {
@@ -276,17 +298,28 @@ describe('useMoneyTransactionDisplayInfo — titleKeyToIcon all keys', () => {
 // ---------------------------------------------------------------------------
 
 describe('useMoneyTransactionDisplayInfo — getIconForTransactionType', () => {
-  it('returns Arrow2Down when type is undefined', () => {
+  it('returns Add when type is undefined (defaults to the deposited kind)', () => {
     const tx = makeTx(TransactionType.moneyAccountDeposit, { type: undefined });
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
     );
-    expect(result.current.icon).toBe(IconName.Arrow2Down);
+    expect(result.current.icon).toBe(IconName.Add);
   });
 
-  it('returns Add for moneyAccountDeposit type', () => {
+  it('returns Refresh for a crypto moneyAccountDeposit (conversion into mUSD)', () => {
     const tx = makeTx(TransactionType.moneyAccountDeposit);
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.icon).toBe(IconName.Refresh);
+  });
+
+  it('returns Add for a fiat on-ramp moneyAccountDeposit', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { fiat: { orderId: 'order-1', provider: 'transak-native' } },
+    });
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
@@ -312,13 +345,13 @@ describe('useMoneyTransactionDisplayInfo — getIconForTransactionType', () => {
     expect(result.current.icon).toBe(IconName.Refresh);
   });
 
-  it('returns SwapHorizontal for moneyAccountWithdraw type', () => {
+  it('returns Arrow2UpRight for moneyAccountWithdraw type (the "Sent" row)', () => {
     const tx = makeTx(TransactionType.moneyAccountWithdraw);
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
     );
-    expect(result.current.icon).toBe(IconName.SwapHorizontal);
+    expect(result.current.icon).toBe(IconName.Arrow2UpRight);
   });
 
   it('returns Arrow2UpRight for simpleSend type', () => {
@@ -357,7 +390,7 @@ describe('useMoneyTransactionDisplayInfo — getIconForTransactionType', () => {
     expect(result.current.icon).toBe(IconName.Arrow2Down);
   });
 
-  it('returns Add for a batch tx with a nested moneyAccountDeposit', () => {
+  it('returns Refresh for a batch tx with a nested crypto moneyAccountDeposit', () => {
     const tx = makeTx(TransactionType.batch, {
       nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
     });
@@ -365,10 +398,10 @@ describe('useMoneyTransactionDisplayInfo — getIconForTransactionType', () => {
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
     );
-    expect(result.current.icon).toBe(IconName.Add);
+    expect(result.current.icon).toBe(IconName.Refresh);
   });
 
-  it('returns SwapHorizontal for a batch tx with a nested moneyAccountWithdraw', () => {
+  it('returns Arrow2UpRight for a batch tx with a nested moneyAccountWithdraw', () => {
     const tx = makeTx(TransactionType.batch, {
       nestedTransactions: [{ type: TransactionType.moneyAccountWithdraw }],
     });
@@ -376,310 +409,78 @@ describe('useMoneyTransactionDisplayInfo — getIconForTransactionType', () => {
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
     );
-    expect(result.current.icon).toBe(IconName.SwapHorizontal);
+    expect(result.current.icon).toBe(IconName.Arrow2UpRight);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Primary amount — ERC-20 (USDC)
+// Primary amount — denominated in mUSD (the money-account currency)
 // ---------------------------------------------------------------------------
 
-describe('useMoneyTransactionDisplayInfo — ERC-20 (stablecoin) primary amount', () => {
-  /**
-   * Builds state where USDC is a known ERC-20 with optional market data.
-   * Like every other ERC-20, USDC is priced via the Price API
-   * (token→ETH `price` × ETH→USD rate) — there is no $1 peg shortcut. The
-   * `USDC` symbol only affects *formatting* (2 fixed decimals).
-   */
-  function makeUsdcState(opts: {
-    tokenToEthPrice?: number;
-    ethUsdRate?: number;
-  }): ProviderValues['state'] {
-    const marketData =
-      opts.tokenToEthPrice === undefined
-        ? {}
-        : {
-            [CHAIN_ID]: {
-              [safeToChecksumAddress(USDC_ADDRESS) as string]: {
-                price: opts.tokenToEthPrice,
-              },
-            },
-          };
-    return {
-      engine: {
-        backgroundState: {
-          CurrencyRateController: {
-            currentCurrency: 'usd',
-            currencyRates:
-              opts.ethUsdRate === undefined
-                ? {}
-                : {
-                    ETH: {
-                      conversionRate: opts.ethUsdRate,
-                      usdConversionRate: opts.ethUsdRate,
-                    },
-                  },
-          },
-          TokenRatesController: { marketData },
-          TokensController: {
-            allTokens: {
-              [CHAIN_ID]: {
-                '0xSomeWallet': [
-                  {
-                    address: USDC_ADDRESS,
-                    symbol: 'USDC',
-                    decimals: 6,
-                    image: undefined,
-                  },
-                ],
-              },
-            },
-          },
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [CHAIN_ID]: { nativeCurrency: 'ETH' },
-            },
-          },
-        },
-      },
-    } as unknown as ProviderValues['state'];
+describe('useMoneyTransactionDisplayInfo — mUSD-denominated primary amount', () => {
+  // A conversion deposit is shown in mUSD, derived from the deposit target in
+  // `requiredAssets[0].amount` (6-decimal mUSD units, pegged 1:1 to USD). The
+  // pay token and its market price no longer affect the primary amount — see
+  // MUSD-956.
+
+  function makeDepositTx(amount: string, tokenAddress: Hex = USDC_ADDRESS) {
+    return makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { tokenAddress, chainId: CHAIN_ID },
+      requiredAssets: [{ address: tokenAddress, amount }],
+    });
   }
 
-  function makeUsdcDepositTx(): TransactionMeta {
-    // 1_000_000 → $1.00 (6-decimal USD value).
-    return makeTx(TransactionType.moneyAccountDeposit, {
+  it('renders the deposit target in mUSD with 2 decimals and grouping', () => {
+    // 1_000_000_000 / 1e6 = 1000 → "+1,000.00 mUSD"
+    const { result } = renderHookWithProvider(
+      () =>
+        useMoneyTransactionDisplayInfo(makeDepositTx('1000000000'), undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('+1,000.00 mUSD');
+  });
+
+  it('is independent of the pay token and its market price', () => {
+    // A native-ETH deposit with no market data at all still renders in mUSD.
+    const { result } = renderHookWithProvider(
+      () =>
+        useMoneyTransactionDisplayInfo(
+          makeDepositTx('1000000', ETH_ADDRESS),
+          undefined,
+        ),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
+  });
+
+  it('rounds the 6-decimal mUSD value to 2 decimals', () => {
+    // 998537 / 1e6 = 0.998537 → "+1.00 mUSD"
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(makeDepositTx('998537'), undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
+  });
+
+  it('leaves primaryAmount empty when there is no required asset', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000' }],
     });
-  }
-
-  it('prices USDC at its market value (~$1) and formats with 2 decimals', () => {
-    // USDC→ETH 0.0004 × ETH→USD 2500 = $1.00 per USDC.
-    // $1.00 / $1.00 = 1.00 USDC.
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeUsdcDepositTx(), undefined),
-      { state: makeUsdcState({ tokenToEthPrice: 0.0004, ethUsdRate: 2500 }) },
-    );
-
-    expect(result.current.primaryAmount).toBe('+1.00 USDC');
-  });
-
-  it('reflects a de-pegged market price rather than assuming $1', () => {
-    // USDC trading at $0.80: USDC→ETH 0.00032 × ETH→USD 2500 = $0.80 per USDC.
-    // $1.00 / $0.80 = 1.25 USDC — the Price API value, not the flat $1 peg.
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeUsdcDepositTx(), undefined),
-      { state: makeUsdcState({ tokenToEthPrice: 0.00032, ethUsdRate: 2500 }) },
-    );
-
-    expect(result.current.primaryAmount).toBe('+1.25 USDC');
-  });
-
-  it('leaves primaryAmount empty when stablecoin market data is unavailable', () => {
-    // No peg fallback: without market data we cannot price USDC, so we show
-    // nothing rather than a misleading "+1.00 USDC". The fiat line still renders.
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeUsdcDepositTx(), undefined),
-      { state: makeUsdcState({}) },
-    );
-
-    expect(result.current.primaryAmount).toBe('');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Primary amount — non-stable ERC-20 (LINK), regression for MUSD-857
-// ---------------------------------------------------------------------------
-
-describe('useMoneyTransactionDisplayInfo — non-stable ERC-20 primary amount', () => {
-  // Mainnet LINK: 18 decimals, NOT a USD-pegged stablecoin.
-  const LINK_ADDRESS: Hex = '0x514910771AF9Ca656af840dff83E8264EcF986CA';
-
-  /**
-   * Builds state where LINK is a known ERC-20 with optional market data.
-   *
-   * `requiredAssets[0].amount` is denominated in the mUSD deposit target
-   * (6 decimals / a USD value), NOT in the pay token's own minimal units —
-   * so it must be priced via the pay token's USD price, exactly like the
-   * native (ETH) path. `tokenMarketData` stores the token→ETH price; the
-   * USD price is `tokenToEth × ETH→USD`.
-   */
-  function makeLinkState(opts: {
-    tokenToEthPrice?: number;
-    ethUsdRate?: number;
-  }): ProviderValues['state'] {
-    const marketData =
-      opts.tokenToEthPrice === undefined
-        ? {}
-        : {
-            [CHAIN_ID]: {
-              [safeToChecksumAddress(LINK_ADDRESS) as string]: {
-                price: opts.tokenToEthPrice,
-              },
-            },
-          };
-    return {
-      engine: {
-        backgroundState: {
-          CurrencyRateController: {
-            currentCurrency: 'usd',
-            currencyRates:
-              opts.ethUsdRate === undefined
-                ? {}
-                : {
-                    ETH: {
-                      conversionRate: opts.ethUsdRate,
-                      usdConversionRate: opts.ethUsdRate,
-                    },
-                  },
-          },
-          TokenRatesController: { marketData },
-          TokensController: {
-            allTokens: {
-              [CHAIN_ID]: {
-                '0xSomeWallet': [
-                  {
-                    address: LINK_ADDRESS,
-                    symbol: 'LINK',
-                    decimals: 18,
-                    image: undefined,
-                  },
-                ],
-              },
-            },
-          },
-          NetworkController: {
-            networkConfigurationsByChainId: {
-              [CHAIN_ID]: { nativeCurrency: 'ETH' },
-            },
-          },
-        },
-      },
-    } as unknown as ProviderValues['state'];
-  }
-
-  function makeLinkDepositTx(): TransactionMeta {
-    // amount = 500000 → $0.50 (6-decimal USD value), the deposit shown in the
-    // bug screenshot as "+0.00 LINK".
-    return makeTx(TransactionType.moneyAccountDeposit, {
-      metamaskPay: { tokenAddress: LINK_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: LINK_ADDRESS, amount: '500000' }],
-    });
-  }
-
-  it('prices the 6-decimal USD amount via market data (LINK at $25 → +0.02 LINK)', () => {
-    // LINK→ETH price 0.01 × ETH→USD 2500 = $25 per LINK.
-    // $0.50 / $25 = 0.02 LINK.
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
-      { state: makeLinkState({ tokenToEthPrice: 0.01, ethUsdRate: 2500 }) },
-    );
-
-    expect(result.current.primaryAmount).toBe('+0.02 LINK');
-  });
-
-  it('leaves primaryAmount empty (not +0.00) when market data is unavailable', () => {
-    // No market data and no ETH rate → we cannot price LINK, so we must show
-    // nothing rather than a misleading "+0.00 LINK". Fiat still renders from
-    // its own pipeline.
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
-      { state: makeLinkState({}) },
-    );
-
-    expect(result.current.primaryAmount).toBe('');
-  });
-
-  it('leaves primaryAmount empty when token→ETH price exists but ETH→USD rate is missing', () => {
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
-      { state: makeLinkState({ tokenToEthPrice: 0.01 }) },
-    );
-
-    expect(result.current.primaryAmount).toBe('');
-  });
-
-  it('leaves primaryAmount empty (not +0) when the token amount underflows 6 decimals', () => {
-    // High-unit-value token: token→ETH 400 × ETH→USD 2500 = $1,000,000 per token.
-    // $0.50 / $1,000,000 = 0.0000005, which rounds down to "0.000000" at 6
-    // decimals. We must show nothing rather than a misleading "+0 LINK" — this
-    // is the same class of bug MUSD-857 fixed, just one decimal place over.
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(makeLinkDepositTx(), undefined),
-      { state: makeLinkState({ tokenToEthPrice: 400, ethUsdRate: 2500 }) },
-    );
-
-    expect(result.current.primaryAmount).toBe('');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Primary amount — native token (ETH)
-// ---------------------------------------------------------------------------
-
-describe('useMoneyTransactionDisplayInfo — native token (ETH) primary amount', () => {
-  /**
-   * requiredAssets[0].amount is stored as a 6-decimal USDC-equivalent
-   * (i.e. the USD value of the deposit).  Given amount=998537 ($0.998537)
-   * and ETH/USD rate=2242, the expected ETH amount is
-   * 0.998537 / 2242 ≈ 0.000445 ETH (rounded down to 6dp).
-   *
-   * Note: the code must use usdConversionRate (ETH→USD), not conversionRate
-   * (ETH→currentCurrency), because requiredAsset.amount is always in USD units.
-   */
-  it('converts 6-decimal USD amount to ETH via usdConversionRate', () => {
-    const tx = makeTx(TransactionType.moneyAccountDeposit, {
-      metamaskPay: { tokenAddress: ETH_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: ETH_ADDRESS, amount: '998537' }],
-    });
-
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),
-      {
-        state: makeState({
-          currencyRates: { ETH: { usdConversionRate: 2242 } },
-        }),
-      },
+      { state: makeState() },
     );
 
-    // 0.998537 / 2242 = 0.00044538... → toFixed(6, ROUND_DOWN) = "0.000445"
-    expect(result.current.primaryAmount).toBe('+0.000445 ETH');
+    expect(result.current.primaryAmount).toBe('');
   });
 
-  it('uses usdConversionRate not conversionRate — correct result in non-USD currency', () => {
-    // currentCurrency = EUR; ETH/EUR = 2000, ETH/USD = 2242
-    // requiredAsset.amount = 998537 (= $0.998537 USD)
-    // Correct:   0.998537 / 2242 ≈ 0.000445 ETH  (uses usdConversionRate)
-    // Incorrect: 0.998537 / 2000 ≈ 0.000499 ETH  (would use conversionRate)
-    const tx = makeTx(TransactionType.moneyAccountDeposit, {
-      metamaskPay: { tokenAddress: ETH_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: ETH_ADDRESS, amount: '998537' }],
-    });
-
+  it('leaves primaryAmount empty when the deposit amount is zero', () => {
     const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(tx, undefined),
-      {
-        state: makeState({
-          currentCurrency: 'eur',
-          currencyRates: {
-            ETH: { conversionRate: 2000, usdConversionRate: 2242 },
-          },
-        }),
-      },
-    );
-
-    expect(result.current.primaryAmount).toBe('+0.000445 ETH');
-  });
-
-  it('leaves primaryAmount empty when exchange rate is unavailable', () => {
-    const tx = makeTx(TransactionType.moneyAccountDeposit, {
-      metamaskPay: { tokenAddress: ETH_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: ETH_ADDRESS, amount: '998537' }],
-    });
-
-    const { result } = renderHookWithProvider(
-      () => useMoneyTransactionDisplayInfo(tx, undefined),
-      { state: makeState({ currencyRates: {} }) },
+      () => useMoneyTransactionDisplayInfo(makeDepositTx('0'), undefined),
+      { state: makeState() },
     );
 
     expect(result.current.primaryAmount).toBe('');
@@ -712,9 +513,10 @@ describe('useMoneyTransactionDisplayInfo — fiat amount fallback', () => {
 // ---------------------------------------------------------------------------
 
 describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () => {
-  it('leaves primaryAmount empty when token is not in state and address is not native', () => {
-    // USDC address but NOT present in TokensController state → not native, not erc-20
-    // → sourceTokenSymbol is undefined → primaryAmount stays empty
+  it('leaves the conversion subtitle bare when the token is neither in state nor native', () => {
+    // USDC address but NOT present in TokensController state → not native, not
+    // erc-20 → sourceTokenSymbol is undefined → no "<token> → mUSD" pair. The
+    // mUSD amount still renders, since it no longer depends on the pay token.
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
       requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000' }],
@@ -726,10 +528,11 @@ describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () =>
       { state: makeState() },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.description).toBeUndefined();
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
   });
 
-  it('leaves primaryAmount empty when getNativeTokenAddress throws for unknown chainId', () => {
+  it('does not crash when getNativeTokenAddress throws for an unknown chainId', () => {
     // Use a chainId our mock does not support → isNativeTokenAddress catch → returns false.
     // We also include the chain in networkConfigurationsByChainId so that
     // selectTickerByChainId does not error if the reselect stability check
@@ -761,7 +564,8 @@ describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () =>
       { state: stateWithPolygon },
     );
 
-    expect(result.current.primaryAmount).toBe('');
+    expect(result.current.description).toBeUndefined();
+    expect(result.current.primaryAmount).toBe('+1.00 mUSD');
   });
 });
 
@@ -783,8 +587,9 @@ describe('useMoneyTransactionDisplayInfo — description', () => {
     expect(result.current.description).toBe('My custom subtitle');
   });
 
-  it('falls back to sourceTokenSymbol as description when no moneySubtitle', () => {
-    // USDC in state so sourceTokenSymbol is 'USDC'
+  it('shows the "<token> → mUSD" pair for a crypto conversion deposit', () => {
+    // USDC in state so sourceTokenSymbol is 'USDC'; a crypto moneyAccountDeposit
+    // is a conversion, so the subtitle becomes the token pair.
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
     });
@@ -821,7 +626,7 @@ describe('useMoneyTransactionDisplayInfo — description', () => {
       { state: stateWithUsdc },
     );
 
-    expect(result.current.description).toBe('USDC');
+    expect(result.current.description).toBe('USDC → mUSD');
   });
 });
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -1,5 +1,6 @@
 import {
   type TransactionMeta,
+  TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { IconName } from '@metamask/design-system-react-native';
@@ -737,5 +738,129 @@ describe('useMoneyTransactionDisplayInfo — mUSD fiat formatting', () => {
     expect(result.current.fiatAmount).toMatch(/920/);
     expect(result.current.primaryAmount).toMatch(/1,000\.00/);
     expect(result.current.primaryAmount).toContain('mUSD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status — derived state + status-aware label
+// ---------------------------------------------------------------------------
+
+describe('useMoneyTransactionDisplayInfo — status', () => {
+  it.each([
+    [TransactionStatus.confirmed, 'confirmed'],
+    [TransactionStatus.submitted, 'pending'],
+    [TransactionStatus.failed, 'failed'],
+  ])('exposes status %s as %s', (status, expected) => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, { status });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.status).toBe(expected);
+  });
+
+  it('uses the present-tense label while a conversion is pending', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      status: TransactionStatus.submitted,
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.label).toBe('money.transaction.converting');
+  });
+
+  it('uses the failed label when a conversion fails', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      status: TransactionStatus.failed,
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.label).toBe('money.transaction.conversion_failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failed rows — zero amount, signed by direction (MUSD-956)
+// ---------------------------------------------------------------------------
+
+describe('useMoneyTransactionDisplayInfo — failed amount', () => {
+  it('shows +0.00 mUSD / +$0.00 for a failed (incoming) conversion', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      status: TransactionStatus.failed,
+      metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
+      requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000000' }],
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.primaryAmount).toBe('+0.00 mUSD');
+    expect(result.current.fiatAmount).toBe('+$0.00');
+  });
+
+  it('shows -0.00 mUSD / -$0.00 for a failed (outgoing) send', () => {
+    const tx = makeTx(TransactionType.moneyAccountWithdraw, {
+      status: TransactionStatus.failed,
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.primaryAmount).toBe('-0.00 mUSD');
+    expect(result.current.fiatAmount).toBe('-$0.00');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-kind subtitles
+// ---------------------------------------------------------------------------
+
+describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
+  it('received → "From: <sender>"', () => {
+    const tx = makeTx(TransactionType.incoming, {
+      txParams: { from: '0x2323100000000000000000000000000000012345' },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    // i18n mock returns the key; interpolation is exercised in integration.
+    expect(result.current.description).toBe('money.transaction.received_from');
+  });
+
+  it('sent → "mUSD → <destination token>"', () => {
+    const tx = makeTx(TransactionType.moneyAccountWithdraw, {
+      metamaskPay: { tokenAddress: ETH_ADDRESS, chainId: CHAIN_ID },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.description).toBe('mUSD → ETH');
+  });
+
+  it('deposited (fiat on-ramp) → provider name', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { fiat: { orderId: 'o-1', provider: 'transak-native' } },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.description).toBe('Transak');
+  });
+
+  it('deposited (mUSD top-up) → "mUSD"', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: CHAIN_ID },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.description).toBe('mUSD');
   });
 });

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -831,7 +831,7 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
     expect(result.current.description).toBe('money.transaction.received_from');
   });
 
-  it('sent → "mUSD → <destination token>"', () => {
+  it('sent → "mUSD → <destination token>" when the dest token resolves', () => {
     const tx = makeTx(TransactionType.moneyAccountWithdraw, {
       metamaskPay: { tokenAddress: ETH_ADDRESS, chainId: CHAIN_ID },
     });
@@ -840,6 +840,16 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
       { state: makeState() },
     );
     expect(result.current.description).toBe('mUSD → ETH');
+  });
+
+  it('sent → "mUSD → USDC" for a withdrawal whose dest token cannot be resolved', () => {
+    // No metamaskPay token → falls back to the known money withdraw token.
+    const tx = makeTx(TransactionType.moneyAccountWithdraw, {});
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.description).toBe('mUSD → USDC');
   });
 
   it('deposited (fiat on-ramp) → provider name', () => {

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -415,15 +415,19 @@ describe('useMoneyTransactionDisplayInfo — getIconForTransactionType', () => {
 // ---------------------------------------------------------------------------
 
 describe('useMoneyTransactionDisplayInfo — mUSD-denominated primary amount', () => {
-  // A conversion deposit is shown in mUSD, derived from the deposit target in
-  // `requiredAssets[0].amount` (6-decimal mUSD units, pegged 1:1 to USD). The
-  // pay token and its market price no longer affect the primary amount — see
-  // MUSD-956.
+  // A conversion deposit is shown in mUSD, derived from the mUSD entry in
+  // `requiredAssets` (6-decimal mUSD units, pegged 1:1 to USD). The pay token
+  // and its market price no longer affect the primary amount — see MUSD-956.
+  //
+  // Production declares the required asset as mUSD on the tx's chain (see
+  // `getMoneyAccountDepositAssetAddress`), so the fixture mirrors that shape.
 
   function makeDepositTx(amount: string, tokenAddress: Hex = USDC_ADDRESS) {
     return makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress, chainId: CHAIN_ID },
-      requiredAssets: [{ address: tokenAddress, amount }],
+      requiredAssets: [
+        { address: MUSD_TOKEN_ADDRESS, amount, standard: 'erc20' },
+      ],
     });
   }
 
@@ -482,6 +486,72 @@ describe('useMoneyTransactionDisplayInfo — mUSD-denominated primary amount', (
 
     expect(result.current.primaryAmount).toBe('');
   });
+
+  it('leaves primaryAmount empty (not "+0.00") for a sub-cent deposit', () => {
+    // 4999 / 1e6 = 0.004999 rounds to 0.00 at 2 decimals — rendering it would
+    // produce "+0.00 mUSD", the marker reserved for failed rows.
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(makeDepositTx('4999'), undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('');
+  });
+
+  it('renders the smallest amount visible at 2 decimals', () => {
+    // 5000 / 1e6 = 0.005 → "+0.01 mUSD" (half-up, matching Intl rounding).
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(makeDepositTx('5000'), undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('+0.01 mUSD');
+  });
+
+  it('parses the hex-encoded amount that production writes', () => {
+    // `RequiredAsset.amount` is typed `Hex` and written via `toHex(...)` (see
+    // useUpdateTransactionPayAmount) — 0x3b9aca00 = 1_000_000_000 → 1000 mUSD.
+    const { result } = renderHookWithProvider(
+      () =>
+        useMoneyTransactionDisplayInfo(makeDepositTx('0x3b9aca00'), undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('+1,000.00 mUSD');
+  });
+
+  it('ignores a required asset that is not mUSD on the tx chain', () => {
+    // The amount is only known to be mUSD-denominated when the asset is mUSD;
+    // rendering any other asset's raw amount as mUSD would mis-denominate it.
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
+      requiredAssets: [
+        { address: USDC_ADDRESS, amount: '1000000000', standard: 'erc20' },
+      ],
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('');
+  });
+
+  it('finds the mUSD required asset even when it is not first', () => {
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
+      requiredAssets: [
+        { address: USDC_ADDRESS, amount: '7', standard: 'erc20' },
+        { address: MUSD_TOKEN_ADDRESS, amount: '2500000', standard: 'erc20' },
+      ],
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+
+    expect(result.current.primaryAmount).toBe('+2.50 mUSD');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -516,7 +586,9 @@ describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () =>
     // mUSD amount still renders, since it no longer depends on the pay token.
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000' }],
+      requiredAssets: [
+        { address: MUSD_TOKEN_ADDRESS, amount: '1000000', standard: 'erc20' },
+      ],
     });
 
     const { result } = renderHookWithProvider(
@@ -537,7 +609,9 @@ describe('useMoneyTransactionDisplayInfo — token resolution edge cases', () =>
     const UNKNOWN_CHAIN: Hex = '0x89'; // Polygon (not in our mock)
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: UNKNOWN_CHAIN },
-      requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000' }],
+      requiredAssets: [
+        { address: MUSD_TOKEN_ADDRESS, amount: '1000000', standard: 'erc20' },
+      ],
     });
 
     const stateWithPolygon = {
@@ -787,7 +861,13 @@ describe('useMoneyTransactionDisplayInfo — failed amount', () => {
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       status: TransactionStatus.failed,
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
-      requiredAssets: [{ address: USDC_ADDRESS, amount: '1000000000' }],
+      requiredAssets: [
+        {
+          address: MUSD_TOKEN_ADDRESS,
+          amount: '1000000000',
+          standard: 'erc20',
+        },
+      ],
     });
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -93,13 +93,11 @@ function makeTx(
 
 describe('useMoneyTransactionDisplayInfo — titleKeyToLabel all keys', () => {
   const cases: [string, string][] = [
-    ['added', 'money.transaction.added'],
     ['deposited', 'money.transaction.deposited'],
     ['received', 'money.transaction.received'],
     ['card_transaction', 'money.transaction.card_transaction'],
     ['converted', 'money.transaction.converted'],
     ['sent', 'money.transaction.sent'],
-    ['transferred', 'money.transaction.transferred'],
     // unknown key hits the default branch → 'received'
     ['unknown_key_xyz', 'money.transaction.received'],
   ];
@@ -268,13 +266,11 @@ describe('useMoneyTransactionDisplayInfo — getLabelForTransactionType', () => 
 
 describe('useMoneyTransactionDisplayInfo — titleKeyToIcon all keys', () => {
   const cases: [string, IconName][] = [
-    ['added', IconName.Add],
     ['deposited', IconName.Add],
     ['received', IconName.Arrow2Down],
     ['card_transaction', IconName.Card],
     ['converted', IconName.Refresh],
     ['sent', IconName.Arrow2UpRight],
-    ['transferred', IconName.SwapHorizontal],
     // unknown key → default → Arrow2Down
     ['unknown_key_xyz', IconName.Arrow2Down],
   ];

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -3,13 +3,12 @@ import { useSelector } from 'react-redux';
 import {
   type TransactionMeta,
   type RequiredAsset,
-  TransactionType,
 } from '@metamask/transaction-controller';
 import { type Hex } from '@metamask/utils';
 import BigNumber from 'bignumber.js';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { IconName } from '@metamask/design-system-react-native';
-import I18n, { strings } from '../../../../../locales/i18n';
+import I18n from '../../../../../locales/i18n';
 import { getIntlNumberFormatter } from '../../../../util/intl';
 import {
   selectCurrencyRates,
@@ -23,19 +22,15 @@ import {
   getMusdDisplayAmountFromTransactionMeta,
   isIncomingMoneyTransactionMeta,
 } from '../constants/activityStyles';
-import {
-  buildMoneyActivityFiatLine,
-  getTokenToEthPrice,
-  type CurrencyRatesMap,
-  type TokenMarketDataMap,
-} from '../utils/moneyActivityFiat';
+import { buildMoneyActivityFiatLine } from '../utils/moneyActivityFiat';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
-import { isMusdToken } from '../../Earn/constants/musd';
-import { ETH_TICKER } from '../constants/moneyTokens';
-import type {
-  MoneyActivityTitleKey,
-  MoneyActivityTransactionMeta,
-} from '../constants/mockActivityData';
+import { MUSD_TOKEN } from '../../Earn/constants/musd';
+import type { MoneyActivityTransactionMeta } from '../constants/mockActivityData';
+import {
+  classifyMoneyActivity,
+  moneyActivityKindToIcon,
+  moneyActivityKindToLabel,
+} from '../utils/classifyMoneyActivity';
 
 export interface MoneyTransactionDisplayInfo {
   label: string;
@@ -46,136 +41,9 @@ export interface MoneyTransactionDisplayInfo {
   icon: IconName;
 }
 
-function titleKeyToLabel(key: MoneyActivityTitleKey): string {
-  switch (key) {
-    case 'added':
-      return strings('money.transaction.added');
-    case 'deposited':
-      return strings('money.transaction.deposited');
-    case 'received':
-      return strings('money.transaction.received');
-    case 'card_transaction':
-      return strings('money.transaction.card_transaction');
-    case 'converted':
-      return strings('money.transaction.converted');
-    case 'sent':
-      return strings('money.transaction.sent');
-    case 'transferred':
-      return strings('money.transaction.transferred');
-    default:
-      return strings('money.transaction.received');
-  }
-}
-
-function getLabelForTransactionType(type: TransactionType | undefined): string {
-  if (!type) {
-    return strings('money.transaction.deposited');
-  }
-  switch (type) {
-    case TransactionType.moneyAccountDeposit:
-      return strings('money.transaction.deposited');
-    case TransactionType.incoming:
-    case TransactionType.tokenMethodTransfer:
-    case TransactionType.tokenMethodTransferFrom:
-      return strings('money.transaction.received');
-    case TransactionType.moneyAccountWithdraw:
-    case TransactionType.simpleSend:
-      return strings('money.transaction.sent');
-    case TransactionType.musdConversion:
-      return strings('money.transaction.converted');
-    default:
-      return strings('money.transaction.received');
-  }
-}
-
 function getMoneySubtitle(tx: TransactionMeta): string | undefined {
   const extended = tx as MoneyActivityTransactionMeta;
   return extended.moneySubtitle;
-}
-
-function getLabel(tx: TransactionMeta): string {
-  const extended = tx as MoneyActivityTransactionMeta;
-  if (extended.moneyActivityTitleKey) {
-    return titleKeyToLabel(extended.moneyActivityTitleKey);
-  }
-  // For EIP-7702 batch transactions, derive the label from the most significant
-  // nested transaction type (e.g. moneyAccountDeposit, moneyAccountWithdraw).
-  if (tx.type === TransactionType.batch) {
-    const moneyNestedType = tx.nestedTransactions?.find(
-      (nested) =>
-        nested.type === TransactionType.moneyAccountDeposit ||
-        nested.type === TransactionType.moneyAccountWithdraw,
-    )?.type;
-    if (moneyNestedType) {
-      return getLabelForTransactionType(moneyNestedType);
-    }
-  }
-  return getLabelForTransactionType(tx.type);
-}
-
-function titleKeyToIcon(key: MoneyActivityTitleKey): IconName {
-  switch (key) {
-    case 'added':
-      return IconName.Add;
-    case 'deposited':
-      return IconName.Add;
-    case 'received':
-      return IconName.Arrow2Down;
-    case 'card_transaction':
-      return IconName.Card;
-    case 'converted':
-      return IconName.Refresh;
-    case 'sent':
-      return IconName.Arrow2UpRight;
-    case 'transferred':
-      return IconName.SwapHorizontal;
-    default:
-      return IconName.Arrow2Down;
-  }
-}
-
-function getIconForTransactionType(
-  type: TransactionType | undefined,
-): IconName {
-  if (!type) {
-    return IconName.Arrow2Down;
-  }
-  switch (type) {
-    case TransactionType.moneyAccountDeposit:
-      return IconName.Add;
-    case TransactionType.incoming:
-    case TransactionType.tokenMethodTransfer:
-    case TransactionType.tokenMethodTransferFrom:
-      return IconName.Arrow2Down;
-    case TransactionType.musdConversion:
-      return IconName.Refresh;
-    case TransactionType.moneyAccountWithdraw:
-      return IconName.SwapHorizontal;
-    case TransactionType.simpleSend:
-      return IconName.Arrow2UpRight;
-    default:
-      return IconName.Arrow2Down;
-  }
-}
-
-function getIcon(tx: TransactionMeta): IconName {
-  const extended = tx as MoneyActivityTransactionMeta;
-  if (extended.moneyActivityTitleKey) {
-    return titleKeyToIcon(extended.moneyActivityTitleKey);
-  }
-  // For EIP-7702 batch transactions, derive the icon from the most significant
-  // nested transaction type.
-  if (tx.type === TransactionType.batch) {
-    const moneyNestedType = tx.nestedTransactions?.find(
-      (nested) =>
-        nested.type === TransactionType.moneyAccountDeposit ||
-        nested.type === TransactionType.moneyAccountWithdraw,
-    )?.type;
-    if (moneyNestedType) {
-      return getIconForTransactionType(moneyNestedType);
-    }
-  }
-  return getIconForTransactionType(tx.type);
 }
 
 /**
@@ -186,112 +54,17 @@ function getRequiredAsset(tx: TransactionMeta): RequiredAsset | undefined {
 }
 
 /**
- * Symbols of major USD-pegged stablecoins. This set is used purely for *display
- * formatting* — stables render with 2 fixed decimals ("+1.00 USDC") while other
- * tokens use trimmed 6-decimal precision ("+0.02 LINK"). Pricing itself always
- * comes from the Price API (token→ETH market price × ETH→USD), the same path
- * every other token uses.
+ * Formats an incoming mUSD amount with 2 fixed decimals and grouping, e.g.
+ * "+1,000.00 mUSD". Used for MetaMask Pay conversion deposits, whose amount is
+ * the mUSD deposit target (always incoming, so a leading "+").
  */
-const USD_PEGGED_STABLE_SYMBOLS = new Set([
-  'USDC',
-  'USDT',
-  'DAI',
-  'MUSD',
-  'USDS',
-  'PYUSD',
-  'GUSD',
-  'TUSD',
-  'USDP',
-]);
-
-function isUsdPeggedStable(
-  tokenAddress: string | undefined,
-  symbol: string | undefined,
-): boolean {
-  if (isMusdToken(tokenAddress)) {
-    return true;
-  }
-  return symbol ? USD_PEGGED_STABLE_SYMBOLS.has(symbol.toUpperCase()) : false;
-}
-
-/**
- * USD price for one whole unit of the pay token, or `undefined` when it can't
- * be determined (in which case the primary amount is left blank rather than
- * shown as a misleading "0.00").
- *
- * - Native token (e.g. ETH) → its `usdConversionRate`.
- * - Other ERC-20s (including USD-pegged stablecoins) → the Price API value, i.e. token→ETH market price × ETH→USD rate.
- */
-function getPayTokenUsdPrice(args: {
-  isNative: boolean;
-  nativeTicker: string | undefined;
-  chainId: Hex | undefined;
-  tokenAddress: Hex | undefined;
-  currencyRates: CurrencyRatesMap | undefined;
-  tokenMarketData: TokenMarketDataMap | undefined;
-}): BigNumber | undefined {
-  const {
-    isNative,
-    nativeTicker,
-    chainId,
-    tokenAddress,
-    currencyRates,
-    tokenMarketData,
-  } = args;
-
-  const ethToUsdRate = currencyRates?.[ETH_TICKER]?.usdConversionRate;
-
-  if (isNative) {
-    const nativeToUsdRate = nativeTicker
-      ? currencyRates?.[nativeTicker]?.usdConversionRate
-      : undefined;
-    return nativeToUsdRate && nativeToUsdRate > 0
-      ? new BigNumber(nativeToUsdRate)
-      : undefined;
-  }
-
-  if (!chainId || !tokenAddress || !ethToUsdRate || ethToUsdRate <= 0) {
-    return undefined;
-  }
-  const tokenToEthPrice = getTokenToEthPrice(
-    tokenMarketData,
-    chainId,
-    tokenAddress,
-  );
-  if (!tokenToEthPrice || tokenToEthPrice <= 0) {
-    return undefined;
-  }
-  return new BigNumber(tokenToEthPrice).times(ethToUsdRate);
-}
-
-/**
- * Formats a token amount with symbol. USD-pegged stables use 2 fixed decimals
- * (e.g. "+1.00 USDC"); other tokens show up to 6 decimals with trailing zeros
- * trimmed (e.g. "+0.000445 ETH", "+0.02 LINK").
- *
- * Returns `''` when the amount is too small to represent at this precision
- * (it would render as "+0 TOKEN") since showing nothing is preferable to a misleading
- * zero.
- */
-function formatPrimaryTokenAmount(
-  amount: BigNumber,
-  symbol: string,
-  isStable: boolean,
-): string {
-  if (isStable) {
-    const formatted = getIntlNumberFormatter(I18n.locale, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-      useGrouping: true,
-    }).format(amount.toNumber());
-    return `+${formatted} ${symbol}`;
-  }
-  const fixed = amount.toFixed(6, BigNumber.ROUND_DOWN);
-  const trimmed = fixed.replace(/(\.\d*[1-9])0+$/, '$1').replace(/\.0+$/, '');
-  if (trimmed === '0') {
-    return '';
-  }
-  return `+${trimmed} ${symbol}`;
+function formatMusdDepositAmount(amount: BigNumber): string {
+  const formatted = getIntlNumberFormatter(I18n.locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    useGrouping: true,
+  }).format(amount.toNumber());
+  return `+${formatted} ${MUSD_TOKEN.symbol}`;
 }
 
 /**
@@ -345,55 +118,27 @@ export function useMoneyTransactionDisplayInfo(
   });
 
   return useMemo(() => {
-    const isNative = Boolean(nativeTicker);
-
     const sourceTokenSymbol = payToken?.symbol ?? nativeTicker;
 
     // --- Primary amount ---
-    // Prefer the mUSD transfer amount (set on simple confirmed txs / decoded
-    // from calldata). For batch deposits it's absent, so fall back to
-    // requiredAssets.
-    //
-    // `requiredAssets[0].amount` is always denominated in the mUSD deposit
-    // target (6 decimals), i.e. the *USD value* of the deposit — NOT in the pay
-    // token's own minimal units. So for every pay token (native or ERC-20) we
-    // convert that USD value into the pay token amount via the pay token's USD
-    // price. (Treating it as token minimal units is what produced the
-    // "+0.00 LINK" bug — see MUSD-857.)
-    //
-    // NOTE — historic vs. calculated value:
-    // For these MetaMask Pay deposit rows the pay-token amount is NOT a
-    // historic on-chain figure. The signed batch is `approve`/`deposit` of
-    // *mUSD* (the pay-token → mUSD conversion happens off-batch in Pay's
-    // routing), so the amount of LINK/ETH/etc. the user actually spent is
-    // never persisted on the tx. The authoritative value is the
-    // *fiat* (`targetFiat` / the mUSD target); the token amount below is
-    // calculated based on current token price and so will drift as the token
-    // price moves. This mirrors how the rest of the app renders Pay post-quote
-    // rows (see `getPostQuoteDisplay` in TransactionElement/utils.js).
+    // Money-account rows are denominated in mUSD (the account's currency).
+    // `getMusdDisplayAmountFromTransactionMeta` covers rows carrying an explicit
+    // mUSD transfer (received / sent / local transfers, with the correct +/-
+    // prefix). MetaMask Pay conversion deposits don't persist an mUSD transfer,
+    // so derive the amount from the deposit target in `requiredAssets[0].amount`
+    // — already denominated in mUSD (6 decimals), i.e. the USD value of the
+    // deposit, pegged 1:1. (Showing the mUSD value rather than the pay-token
+    // amount is the design decision in MUSD-956.)
     let primaryAmount = getMusdDisplayAmountFromTransactionMeta(tx);
-    if (!primaryAmount && sourceTokenSymbol) {
+    if (!primaryAmount) {
       const requiredAsset = getRequiredAsset(tx);
       if (requiredAsset) {
-        const usdValue = new BigNumber(requiredAsset.amount).dividedBy(1e6);
-        const usdPrice = getPayTokenUsdPrice({
-          isNative,
-          nativeTicker,
-          chainId: payTokenChainId,
-          tokenAddress: payTokenAddress,
-          currencyRates,
-          tokenMarketData,
-        });
-        if (usdValue.isGreaterThan(0) && usdPrice?.isGreaterThan(0)) {
-          const tokenAmount = usdValue.dividedBy(usdPrice);
-          primaryAmount = formatPrimaryTokenAmount(
-            tokenAmount,
-            sourceTokenSymbol,
-            isUsdPeggedStable(payTokenAddress, sourceTokenSymbol),
-          );
+        const musdAmount = new BigNumber(requiredAsset.amount).dividedBy(1e6);
+        if (musdAmount.isGreaterThan(0)) {
+          primaryAmount = formatMusdDepositAmount(musdAmount);
         }
-        // If the price isn't available, primaryAmount stays empty — the
-        // fiatAmount line below still shows the correct value.
+        // If there's no required asset / amount, primaryAmount stays empty —
+        // the fiatAmount line below still shows the correct value.
       }
     }
 
@@ -412,16 +157,26 @@ export function useMoneyTransactionDisplayInfo(
       }
     }
 
-    // Explicit moneySubtitle takes priority; otherwise use source token symbol
-    const description = subtitle ?? sourceTokenSymbol;
+    const kind = classifyMoneyActivity(tx);
+
+    // Explicit moneySubtitle wins. Otherwise a conversion shows the token pair
+    // it routed through (e.g. "ETH → mUSD"); everything else shows just the
+    // source token symbol.
+    let description = subtitle;
+    if (!description) {
+      description =
+        kind === 'converted' && sourceTokenSymbol
+          ? `${sourceTokenSymbol} → ${MUSD_TOKEN.symbol}`
+          : sourceTokenSymbol;
+    }
 
     return {
-      label: getLabel(tx),
+      label: moneyActivityKindToLabel(kind),
       description,
       primaryAmount,
       fiatAmount,
       isIncoming: isIncomingMoneyTransactionMeta(tx),
-      icon: getIcon(tx),
+      icon: moneyActivityKindToIcon(kind),
     };
   }, [
     tx,
@@ -430,8 +185,6 @@ export function useMoneyTransactionDisplayInfo(
     currencyRates,
     tokenMarketData,
     payToken,
-    payTokenAddress,
-    payTokenChainId,
     nativeTicker,
   ]);
 }

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -8,8 +8,9 @@ import { type Hex } from '@metamask/utils';
 import BigNumber from 'bignumber.js';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { IconName } from '@metamask/design-system-react-native';
-import I18n from '../../../../../locales/i18n';
+import I18n, { strings } from '../../../../../locales/i18n';
 import { getIntlNumberFormatter } from '../../../../util/intl';
+import { renderShortAddress } from '../../../../util/address';
 import {
   selectCurrencyRates,
   selectCurrentCurrency,
@@ -24,12 +25,15 @@ import {
 } from '../constants/activityStyles';
 import { buildMoneyActivityFiatLine } from '../utils/moneyActivityFiat';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
-import { MUSD_TOKEN } from '../../Earn/constants/musd';
+import { isMusdToken, MUSD_TOKEN } from '../../Earn/constants/musd';
 import type { MoneyActivityTransactionMeta } from '../constants/mockActivityData';
 import {
   classifyMoneyActivity,
+  getMoneyActivityStatus,
   moneyActivityKindToIcon,
-  moneyActivityKindToLabel,
+  moneyActivityLabel,
+  type MoneyActivityKind,
+  type MoneyActivityStatus,
 } from '../utils/classifyMoneyActivity';
 
 export interface MoneyTransactionDisplayInfo {
@@ -39,6 +43,7 @@ export interface MoneyTransactionDisplayInfo {
   fiatAmount: string;
   isIncoming: boolean;
   icon: IconName;
+  status: MoneyActivityStatus;
 }
 
 function getMoneySubtitle(tx: TransactionMeta): string | undefined {
@@ -54,17 +59,73 @@ function getRequiredAsset(tx: TransactionMeta): RequiredAsset | undefined {
 }
 
 /**
- * Formats an incoming mUSD amount with 2 fixed decimals and grouping, e.g.
- * "+1,000.00 mUSD". Used for MetaMask Pay conversion deposits, whose amount is
- * the mUSD deposit target (always incoming, so a leading "+").
+ * Formats an mUSD amount as a signed, symbol-suffixed string, e.g.
+ * "+1,000.00 mUSD" / "-0.00 mUSD". The sign follows the row's direction.
  */
-function formatMusdDepositAmount(amount: BigNumber): string {
+function formatMusdAmount(amount: BigNumber, isIncoming: boolean): string {
   const formatted = getIntlNumberFormatter(I18n.locale, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
     useGrouping: true,
   }).format(amount.toNumber());
-  return `+${formatted} ${MUSD_TOKEN.symbol}`;
+  return `${isIncoming ? '+' : '-'}${formatted} ${MUSD_TOKEN.symbol}`;
+}
+
+/**
+ * Human-friendly fiat on-ramp provider name from a provider code, e.g.
+ * "transak-native" → "Transak". Returns undefined when there's no provider.
+ */
+function prettifyFiatProvider(
+  provider: string | undefined,
+): string | undefined {
+  if (!provider) return undefined;
+  const base = provider.split('-')[0];
+  return base.charAt(0).toUpperCase() + base.slice(1);
+}
+
+/**
+ * The subtitle for a Money activity row, by kind. An explicit `moneySubtitle`
+ * always wins (mock / enriched rows). Otherwise:
+ * - converted → "{token} → mUSD"
+ * - sent      → "mUSD → {token}" (the withdraw destination token)
+ * - received  → "From: 0x…" (the sender)
+ * - deposited → fiat provider ("Transak"), else the funding token ("mUSD")
+ * - card / added / transferred → the source token symbol, if any
+ */
+function deriveSubtitle(
+  kind: MoneyActivityKind,
+  tx: TransactionMeta,
+  sourceTokenSymbol: string | undefined,
+  explicitSubtitle: string | undefined,
+): string | undefined {
+  if (explicitSubtitle) {
+    return explicitSubtitle;
+  }
+  switch (kind) {
+    case 'converted':
+      return sourceTokenSymbol
+        ? `${sourceTokenSymbol} → ${MUSD_TOKEN.symbol}`
+        : undefined;
+    case 'sent':
+      return sourceTokenSymbol
+        ? `${MUSD_TOKEN.symbol} → ${sourceTokenSymbol}`
+        : undefined;
+    case 'received': {
+      const sender = tx.txParams?.from;
+      return sender
+        ? strings('money.transaction.received_from', {
+            address: renderShortAddress(sender),
+          })
+        : undefined;
+    }
+    case 'deposited':
+      return (
+        prettifyFiatProvider(tx.metamaskPay?.fiat?.provider) ??
+        sourceTokenSymbol
+      );
+    default:
+      return sourceTokenSymbol;
+  }
 }
 
 /**
@@ -118,7 +179,15 @@ export function useMoneyTransactionDisplayInfo(
   });
 
   return useMemo(() => {
-    const sourceTokenSymbol = payToken?.symbol ?? nativeTicker;
+    // mUSD is often not in the token registry, so fall back to its symbol
+    // directly — this is what surfaces "mUSD" on an mUSD-funded top-up deposit.
+    const sourceTokenSymbol =
+      payToken?.symbol ??
+      nativeTicker ??
+      (isMusdToken(payTokenAddress) ? MUSD_TOKEN.symbol : undefined);
+    const kind = classifyMoneyActivity(tx);
+    const status = getMoneyActivityStatus(tx);
+    const isIncoming = isIncomingMoneyTransactionMeta(tx);
 
     // --- Primary amount ---
     // Money-account rows are denominated in mUSD (the account's currency).
@@ -135,7 +204,7 @@ export function useMoneyTransactionDisplayInfo(
       if (requiredAsset) {
         const musdAmount = new BigNumber(requiredAsset.amount).dividedBy(1e6);
         if (musdAmount.isGreaterThan(0)) {
-          primaryAmount = formatMusdDepositAmount(musdAmount);
+          primaryAmount = formatMusdAmount(musdAmount, isIncoming);
         }
         // If there's no required asset / amount, primaryAmount stays empty —
         // the fiatAmount line below still shows the correct value.
@@ -157,26 +226,27 @@ export function useMoneyTransactionDisplayInfo(
       }
     }
 
-    const kind = classifyMoneyActivity(tx);
-
-    // Explicit moneySubtitle wins. Otherwise a conversion shows the token pair
-    // it routed through (e.g. "ETH → mUSD"); everything else shows just the
-    // source token symbol.
-    let description = subtitle;
-    if (!description) {
-      description =
-        kind === 'converted' && sourceTokenSymbol
-          ? `${sourceTokenSymbol} → ${MUSD_TOKEN.symbol}`
-          : sourceTokenSymbol;
+    // Failed rows show a zero amount, signed by the row's direction (MUSD-956).
+    // To surface the attempted amount instead, drop this block — the computed
+    // primaryAmount/fiatAmount above already hold it.
+    if (status === 'failed') {
+      primaryAmount = formatMusdAmount(new BigNumber(0), isIncoming);
+      if (currentCurrency) {
+        fiatAmount = `${isIncoming ? '+' : '-'}${moneyFormatFiat(
+          new BigNumber(0),
+          currentCurrency,
+        )}`;
+      }
     }
 
     return {
-      label: moneyActivityKindToLabel(kind),
-      description,
+      label: moneyActivityLabel(kind, status),
+      description: deriveSubtitle(kind, tx, sourceTokenSymbol, subtitle),
       primaryAmount,
       fiatAmount,
-      isIncoming: isIncomingMoneyTransactionMeta(tx),
+      isIncoming,
       icon: moneyActivityKindToIcon(kind),
+      status,
     };
   }, [
     tx,
@@ -185,6 +255,7 @@ export function useMoneyTransactionDisplayInfo(
     currencyRates,
     tokenMarketData,
     payToken,
+    payTokenAddress,
     nativeTicker,
   ]);
 }

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -26,6 +26,8 @@ import {
 import { buildMoneyActivityFiatLine } from '../utils/moneyActivityFiat';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
 import { isMusdToken, MUSD_TOKEN } from '../../Earn/constants/musd';
+import { MONEY_WITHDRAW_TOKEN_SYMBOL } from '../constants/moneyTokens';
+import { isMoneyWithdrawTx } from '../utils/moneyTransactionGuards';
 import type { MoneyActivityTransactionMeta } from '../constants/mockActivityData';
 import {
   classifyMoneyActivity,
@@ -106,10 +108,15 @@ function deriveSubtitle(
       return sourceTokenSymbol
         ? `${sourceTokenSymbol} → ${MUSD_TOKEN.symbol}`
         : undefined;
-    case 'sent':
-      return sourceTokenSymbol
-        ? `${MUSD_TOKEN.symbol} → ${sourceTokenSymbol}`
-        : undefined;
+    case 'sent': {
+      // Prefer the resolved destination token; for a withdrawal (always paid
+      // out in USDC) fall back to that known symbol, since the dest token
+      // usually isn't in the registry.
+      const destSymbol =
+        sourceTokenSymbol ??
+        (isMoneyWithdrawTx(tx) ? MONEY_WITHDRAW_TOKEN_SYMBOL : undefined);
+      return destSymbol ? `${MUSD_TOKEN.symbol} → ${destSymbol}` : undefined;
+    }
     case 'received': {
       const sender = tx.txParams?.from;
       return sender

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -25,7 +25,12 @@ import {
 } from '../constants/activityStyles';
 import { buildMoneyActivityFiatLine } from '../utils/moneyActivityFiat';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
-import { isMusdToken, MUSD_TOKEN } from '../../Earn/constants/musd';
+import {
+  isMusdToken,
+  isMusdTokenOnChain,
+  MUSD_DECIMALS,
+  MUSD_TOKEN,
+} from '../../Earn/constants/musd';
 import { MONEY_WITHDRAW_TOKEN_SYMBOL } from '../constants/moneyTokens';
 import { isMoneyWithdrawTx } from '../utils/moneyTransactionGuards';
 import type { MoneyActivityTransactionMeta } from '../constants/mockActivityData';
@@ -54,10 +59,15 @@ function getMoneySubtitle(tx: TransactionMeta): string | undefined {
 }
 
 /**
- * Returns the first required asset from a pay transaction, if present.
+ * Returns the mUSD required asset from a pay transaction, if present. Money
+ * deposits declare their target as mUSD on the tx's chain (see
+ * `getMoneyAccountDepositAssetAddress`); any other asset is not an amount we
+ * can render as mUSD, so it is ignored rather than mis-denominated.
  */
-function getRequiredAsset(tx: TransactionMeta): RequiredAsset | undefined {
-  return tx.requiredAssets?.[0];
+function getMusdRequiredAsset(tx: TransactionMeta): RequiredAsset | undefined {
+  return tx.requiredAssets?.find((asset) =>
+    isMusdTokenOnChain(asset.address, tx.chainId),
+  );
 }
 
 /**
@@ -201,20 +211,24 @@ export function useMoneyTransactionDisplayInfo(
     // `getMusdDisplayAmountFromTransactionMeta` covers rows carrying an explicit
     // mUSD transfer (received / sent / local transfers, with the correct +/-
     // prefix). MetaMask Pay conversion deposits don't persist an mUSD transfer,
-    // so derive the amount from the deposit target in `requiredAssets[0].amount`
-    // — already denominated in mUSD (6 decimals), i.e. the USD value of the
-    // deposit, pegged 1:1. (Showing the mUSD value rather than the pay-token
-    // amount is the design decision in MUSD-956.)
+    // so derive the amount from the mUSD deposit target in `requiredAssets` —
+    // i.e. the USD value of the deposit, pegged 1:1. (Showing the mUSD value
+    // rather than the pay-token amount is the design decision in MUSD-956.)
     let primaryAmount = getMusdDisplayAmountFromTransactionMeta(tx);
     if (!primaryAmount) {
-      const requiredAsset = getRequiredAsset(tx);
+      const requiredAsset = getMusdRequiredAsset(tx);
       if (requiredAsset) {
-        const musdAmount = new BigNumber(requiredAsset.amount).dividedBy(1e6);
-        if (musdAmount.isGreaterThan(0)) {
+        const musdAmount = new BigNumber(requiredAsset.amount).shiftedBy(
+          -MUSD_DECIMALS,
+        );
+        // Render only amounts visible at 2 decimals: a dust amount would
+        // otherwise display as "+0.00 mUSD", which failed rows reserve as
+        // their "nothing moved" marker (below).
+        if (musdAmount.decimalPlaces(2).isGreaterThan(0)) {
           primaryAmount = formatMusdAmount(musdAmount, isIncoming);
         }
-        // If there's no required asset / amount, primaryAmount stays empty —
-        // the fiatAmount line below still shows the correct value.
+        // If there's no mUSD required asset / visible amount, primaryAmount
+        // stays empty — the fiatAmount line below still shows the value.
       }
     }
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -83,10 +83,6 @@ function formatMusdAmount(amount: BigNumber, isIncoming: boolean): string {
   return `${isIncoming ? '+' : '-'}${formatted} ${MUSD_TOKEN.symbol}`;
 }
 
-/**
- * Human-friendly fiat on-ramp provider name from a provider code, e.g.
- * "transak-native" → "Transak". Returns undefined when there's no provider.
- */
 function prettifyFiatProvider(
   provider: string | undefined,
 ): string | undefined {
@@ -96,8 +92,8 @@ function prettifyFiatProvider(
 }
 
 /**
- * The subtitle for a Money activity row, by kind. An explicit `moneySubtitle`
- * always wins (mock / enriched rows). Otherwise:
+ * Gets the subtitle for a Money activity row, by kind. An explicit
+ * `moneySubtitle` always wins (mock / enriched rows). Otherwise:
  * - converted → "{token} → mUSD"
  * - sent      → "mUSD → {token}" (the withdraw destination token)
  * - received  → "From: 0x…" (the sender)
@@ -196,8 +192,6 @@ export function useMoneyTransactionDisplayInfo(
   });
 
   return useMemo(() => {
-    // mUSD is often not in the token registry, so fall back to its symbol
-    // directly — this is what surfaces "mUSD" on an mUSD-funded top-up deposit.
     const sourceTokenSymbol =
       payToken?.symbol ??
       nativeTicker ??
@@ -206,14 +200,6 @@ export function useMoneyTransactionDisplayInfo(
     const status = getMoneyActivityStatus(tx);
     const isIncoming = isIncomingMoneyTransactionMeta(tx);
 
-    // --- Primary amount ---
-    // Money-account rows are denominated in mUSD (the account's currency).
-    // `getMusdDisplayAmountFromTransactionMeta` covers rows carrying an explicit
-    // mUSD transfer (received / sent / local transfers, with the correct +/-
-    // prefix). MetaMask Pay conversion deposits don't persist an mUSD transfer,
-    // so derive the amount from the mUSD deposit target in `requiredAssets` —
-    // i.e. the USD value of the deposit, pegged 1:1. (Showing the mUSD value
-    // rather than the pay-token amount is the design decision in MUSD-956.)
     let primaryAmount = getMusdDisplayAmountFromTransactionMeta(tx);
     if (!primaryAmount) {
       const requiredAsset = getMusdRequiredAsset(tx);
@@ -222,8 +208,7 @@ export function useMoneyTransactionDisplayInfo(
           -MUSD_DECIMALS,
         );
         // Render only amounts visible at 2 decimals: a dust amount would
-        // otherwise display as "+0.00 mUSD", which failed rows reserve as
-        // their "nothing moved" marker (below).
+        // otherwise display as "+0.00 mUSD"
         if (musdAmount.decimalPlaces(2).isGreaterThan(0)) {
           primaryAmount = formatMusdAmount(musdAmount, isIncoming);
         }
@@ -232,8 +217,6 @@ export function useMoneyTransactionDisplayInfo(
       }
     }
 
-    // --- Fiat amount ---
-    // Prefer calculated market-rate value.
     let fiatAmount = buildMoneyActivityFiatLine(
       tx,
       currencyRates,
@@ -247,9 +230,6 @@ export function useMoneyTransactionDisplayInfo(
       }
     }
 
-    // Failed rows show a zero amount, signed by the row's direction (MUSD-956).
-    // To surface the attempted amount instead, drop this block — the computed
-    // primaryAmount/fiatAmount above already hold it.
     if (status === 'failed') {
       primaryAmount = formatMusdAmount(new BigNumber(0), isIncoming);
       if (currentCurrency) {

--- a/app/components/UI/Money/utils/cardTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/utils/cardTransactionDisplayInfo.ts
@@ -29,5 +29,6 @@ export function cardTransactionDisplayInfo(
     fiatAmount,
     isIncoming: false,
     icon: IconName.Card,
+    status: 'confirmed', // card spends only surface once settled
   };
 }

--- a/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
@@ -1,0 +1,147 @@
+import {
+  type TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { IconName } from '@metamask/design-system-react-native';
+import type { Hex } from '@metamask/utils';
+import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
+import {
+  classifyMoneyActivity,
+  moneyActivityKindToIcon,
+  moneyActivityKindToLabel,
+  type MoneyActivityKind,
+} from './classifyMoneyActivity';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  __esModule: true,
+  default: { locale: 'en-US' },
+  strings: (key: string) => key,
+}));
+
+const CHAIN_ID: Hex = '0x1';
+const USDC_ADDRESS: Hex = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+function makeTx(extra: Record<string, unknown>): TransactionMeta {
+  return {
+    id: 'tx-1',
+    chainId: CHAIN_ID,
+    ...extra,
+  } as unknown as TransactionMeta;
+}
+
+describe('classifyMoneyActivity', () => {
+  it('classifies a crypto moneyAccountDeposit as a conversion', () => {
+    const tx = makeTx({
+      type: TransactionType.moneyAccountDeposit,
+      metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
+    });
+    expect(classifyMoneyActivity(tx)).toBe('converted');
+  });
+
+  it('classifies a bare moneyAccountDeposit (no pay metadata) as a conversion', () => {
+    const tx = makeTx({ type: TransactionType.moneyAccountDeposit });
+    expect(classifyMoneyActivity(tx)).toBe('converted');
+  });
+
+  it('classifies a fiat on-ramp moneyAccountDeposit as a deposit', () => {
+    const tx = makeTx({
+      type: TransactionType.moneyAccountDeposit,
+      metamaskPay: { fiat: { orderId: 'o-1', provider: 'transak-native' } },
+    });
+    expect(classifyMoneyActivity(tx)).toBe('deposited');
+  });
+
+  it('classifies an mUSD-funded moneyAccountDeposit as a deposit (top-up, not conversion)', () => {
+    const tx = makeTx({
+      type: TransactionType.moneyAccountDeposit,
+      metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: CHAIN_ID },
+    });
+    expect(classifyMoneyActivity(tx)).toBe('deposited');
+  });
+
+  it('classifies musdConversion as a conversion', () => {
+    expect(
+      classifyMoneyActivity(makeTx({ type: TransactionType.musdConversion })),
+    ).toBe('converted');
+  });
+
+  it.each([
+    TransactionType.incoming,
+    TransactionType.tokenMethodTransfer,
+    TransactionType.tokenMethodTransferFrom,
+  ])('classifies %s as received', (type) => {
+    expect(classifyMoneyActivity(makeTx({ type }))).toBe('received');
+  });
+
+  it.each([TransactionType.moneyAccountWithdraw, TransactionType.simpleSend])(
+    'classifies %s as sent',
+    (type) => {
+      expect(classifyMoneyActivity(makeTx({ type }))).toBe('sent');
+    },
+  );
+
+  it('resolves the nested type for an EIP-7702 batch crypto deposit', () => {
+    const tx = makeTx({
+      type: TransactionType.batch,
+      nestedTransactions: [{ type: TransactionType.moneyAccountDeposit }],
+    });
+    expect(classifyMoneyActivity(tx)).toBe('converted');
+  });
+
+  it('resolves the nested type for an EIP-7702 batch withdraw', () => {
+    const tx = makeTx({
+      type: TransactionType.batch,
+      nestedTransactions: [{ type: TransactionType.moneyAccountWithdraw }],
+    });
+    expect(classifyMoneyActivity(tx)).toBe('sent');
+  });
+
+  it('falls back to received for a batch with no money-type nested call', () => {
+    const tx = makeTx({
+      type: TransactionType.batch,
+      nestedTransactions: [{ type: TransactionType.swap }],
+    });
+    expect(classifyMoneyActivity(tx)).toBe('received');
+  });
+
+  it('defaults an undefined type to deposited', () => {
+    expect(classifyMoneyActivity(makeTx({ type: undefined }))).toBe(
+      'deposited',
+    );
+  });
+
+  it('lets an explicit moneyActivityTitleKey override the derived kind', () => {
+    const tx = makeTx({
+      // A crypto deposit would derive "converted"; the title key wins.
+      type: TransactionType.moneyAccountDeposit,
+      metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
+      moneyActivityTitleKey: 'added',
+    });
+    expect(classifyMoneyActivity(tx)).toBe('added');
+  });
+
+  it('maps the card_transaction title key to the card kind', () => {
+    const tx = makeTx({
+      type: TransactionType.moneyAccountWithdraw,
+      moneyActivityTitleKey: 'card_transaction',
+    });
+    expect(classifyMoneyActivity(tx)).toBe('card');
+  });
+});
+
+describe('moneyActivityKindToLabel / moneyActivityKindToIcon', () => {
+  const cases: [MoneyActivityKind, string, IconName][] = [
+    ['added', 'money.transaction.added', IconName.Add],
+    ['deposited', 'money.transaction.deposited', IconName.Add],
+    ['received', 'money.transaction.received', IconName.Arrow2Down],
+    ['converted', 'money.transaction.converted', IconName.Refresh],
+    ['sent', 'money.transaction.sent', IconName.Arrow2UpRight],
+    ['transferred', 'money.transaction.transferred', IconName.SwapHorizontal],
+    ['card', 'money.transaction.card_transaction', IconName.Card],
+  ];
+
+  it.each(cases)('kind "%s" → label %s, icon %s', (kind, label, icon) => {
+    expect(moneyActivityKindToLabel(kind)).toBe(label);
+    expect(moneyActivityKindToIcon(kind)).toBe(icon);
+  });
+});

--- a/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
@@ -117,9 +117,9 @@ describe('classifyMoneyActivity', () => {
       // A crypto deposit would derive "converted"; the title key wins.
       type: TransactionType.moneyAccountDeposit,
       metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
-      moneyActivityTitleKey: 'added',
+      moneyActivityTitleKey: 'deposited',
     });
-    expect(classifyMoneyActivity(tx)).toBe('added');
+    expect(classifyMoneyActivity(tx)).toBe('deposited');
   });
 
   it('maps the card_transaction title key to the card kind', () => {
@@ -144,12 +144,10 @@ describe('getMoneyActivityStatus', () => {
 
 describe('moneyActivityLabel — confirmed labels + icons', () => {
   const cases: [MoneyActivityKind, string, IconName][] = [
-    ['added', 'money.transaction.added', IconName.Add],
     ['deposited', 'money.transaction.deposited', IconName.Add],
     ['received', 'money.transaction.received', IconName.Arrow2Down],
     ['converted', 'money.transaction.converted', IconName.Refresh],
     ['sent', 'money.transaction.sent', IconName.Arrow2UpRight],
-    ['transferred', 'money.transaction.transferred', IconName.SwapHorizontal],
     ['card', 'money.transaction.card_transaction', IconName.Card],
   ];
 

--- a/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
@@ -1,5 +1,6 @@
 import {
   type TransactionMeta,
+  TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { IconName } from '@metamask/design-system-react-native';
@@ -7,8 +8,9 @@ import type { Hex } from '@metamask/utils';
 import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
 import {
   classifyMoneyActivity,
+  getMoneyActivityStatus,
   moneyActivityKindToIcon,
-  moneyActivityKindToLabel,
+  moneyActivityLabel,
   type MoneyActivityKind,
 } from './classifyMoneyActivity';
 
@@ -129,7 +131,18 @@ describe('classifyMoneyActivity', () => {
   });
 });
 
-describe('moneyActivityKindToLabel / moneyActivityKindToIcon', () => {
+describe('getMoneyActivityStatus', () => {
+  it.each([
+    [TransactionStatus.submitted, 'pending'],
+    [TransactionStatus.failed, 'failed'],
+    [TransactionStatus.confirmed, 'confirmed'],
+    [undefined, 'confirmed'],
+  ])('maps tx.status %s to %s', (status, expected) => {
+    expect(getMoneyActivityStatus(makeTx({ status }))).toBe(expected);
+  });
+});
+
+describe('moneyActivityLabel — confirmed labels + icons', () => {
   const cases: [MoneyActivityKind, string, IconName][] = [
     ['added', 'money.transaction.added', IconName.Add],
     ['deposited', 'money.transaction.deposited', IconName.Add],
@@ -141,7 +154,46 @@ describe('moneyActivityKindToLabel / moneyActivityKindToIcon', () => {
   ];
 
   it.each(cases)('kind "%s" → label %s, icon %s', (kind, label, icon) => {
-    expect(moneyActivityKindToLabel(kind)).toBe(label);
+    expect(moneyActivityLabel(kind, 'confirmed')).toBe(label);
     expect(moneyActivityKindToIcon(kind)).toBe(icon);
+  });
+});
+
+describe('moneyActivityLabel — pending (present-tense) labels', () => {
+  it.each([
+    ['deposited', 'money.transaction.depositing'],
+    ['converted', 'money.transaction.converting'],
+    ['sent', 'money.transaction.sending'],
+    ['received', 'money.transaction.receiving'],
+  ] as [MoneyActivityKind, string][])(
+    'kind "%s" pending → %s',
+    (kind, label) => {
+      expect(moneyActivityLabel(kind, 'pending')).toBe(label);
+    },
+  );
+
+  it('falls back to the confirmed label for kinds with no pending form', () => {
+    expect(moneyActivityLabel('card', 'pending')).toBe(
+      'money.transaction.card_transaction',
+    );
+  });
+});
+
+describe('moneyActivityLabel — failed labels', () => {
+  it.each([
+    ['deposited', 'money.transaction.deposit_failed'],
+    ['converted', 'money.transaction.conversion_failed'],
+    ['sent', 'money.transaction.send_failed'],
+  ] as [MoneyActivityKind, string][])(
+    'kind "%s" failed → %s',
+    (kind, label) => {
+      expect(moneyActivityLabel(kind, 'failed')).toBe(label);
+    },
+  );
+
+  it('falls back to the confirmed label for kinds with no failed form', () => {
+    expect(moneyActivityLabel('received', 'failed')).toBe(
+      'money.transaction.received',
+    );
   });
 });

--- a/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
@@ -133,6 +133,10 @@ describe('classifyMoneyActivity', () => {
 
 describe('getMoneyActivityStatus', () => {
   it.each([
+    // approved/signed = held by the MetaMask Pay publish hook while a
+    // cross-chain payment completes — in-flight, not mid-compose.
+    [TransactionStatus.approved, 'pending'],
+    [TransactionStatus.signed, 'pending'],
     [TransactionStatus.submitted, 'pending'],
     [TransactionStatus.failed, 'failed'],
     [TransactionStatus.confirmed, 'confirmed'],

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -1,0 +1,154 @@
+import {
+  type TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { IconName } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import { isMusdToken } from '../../Earn/constants/musd';
+import type {
+  MoneyActivityTitleKey,
+  MoneyActivityTransactionMeta,
+} from '../constants/mockActivityData';
+
+/**
+ * The semantic kind of a Money activity row, parsed once from a
+ * {@link TransactionMeta} so the rest of the display layer renders from a
+ * single well-typed value rather than re-deriving from raw transaction types.
+ *
+ * Mirrors the activity row types in the Money design (Converted / Deposited /
+ * Added / Received / Sent / Transferred). Card transactions are not
+ * {@link TransactionMeta}-backed and are classified separately — see
+ * `cardTransactionDisplayInfo` — but `'card'` is kept here so the explicit
+ * `moneyActivityTitleKey` override can still target it.
+ */
+export type MoneyActivityKind =
+  | 'added'
+  | 'deposited'
+  | 'received'
+  | 'converted'
+  | 'sent'
+  | 'transferred'
+  | 'card';
+
+const TITLE_KEY_TO_KIND: Record<MoneyActivityTitleKey, MoneyActivityKind> = {
+  added: 'added',
+  deposited: 'deposited',
+  received: 'received',
+  card_transaction: 'card',
+  converted: 'converted',
+  sent: 'sent',
+  transferred: 'transferred',
+};
+
+/**
+ * The most significant Money transaction type for `tx`. For EIP-7702 batches
+ * (e.g. the approve+deposit / withdraw+transfer pairs) the meaningful type
+ * lives on a nested call, so we surface that; otherwise the top-level type.
+ */
+function resolveMoneyTransactionType(
+  tx: TransactionMeta,
+): TransactionType | undefined {
+  if (tx.type === TransactionType.batch) {
+    const nestedMoneyType = tx.nestedTransactions?.find(
+      (nested) =>
+        nested.type === TransactionType.moneyAccountDeposit ||
+        nested.type === TransactionType.moneyAccountWithdraw,
+    )?.type;
+    if (nestedMoneyType) {
+      return nestedMoneyType;
+    }
+  }
+  return tx.type;
+}
+
+/** A `moneyAccountDeposit` funded by a fiat on-ramp (e.g. Transak), not crypto. */
+function isFiatDeposit(tx: TransactionMeta): boolean {
+  return Boolean(tx.metamaskPay?.fiat);
+}
+
+/** A `moneyAccountDeposit` paid with mUSD itself (a top-up / move, not a conversion). */
+function isMusdPayToken(tx: TransactionMeta): boolean {
+  return isMusdToken(tx.metamaskPay?.tokenAddress);
+}
+
+/**
+ * Parses a Money activity {@link TransactionMeta} into a single
+ * {@link MoneyActivityKind}. An explicit `moneyActivityTitleKey` (mock or
+ * enriched rows) always wins; otherwise the kind is derived from the
+ * transaction type.
+ *
+ * A `moneyAccountDeposit` paid with crypto is a *conversion* into mUSD (shown
+ * as e.g. "ETH → mUSD"), so it maps to `'converted'`. Fiat on-ramp deposits
+ * (Transak) and mUSD top-ups keep the `'deposited'` label.
+ */
+export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
+  const { moneyActivityTitleKey } = tx as MoneyActivityTransactionMeta;
+  if (moneyActivityTitleKey) {
+    return TITLE_KEY_TO_KIND[moneyActivityTitleKey] ?? 'received';
+  }
+
+  const type = resolveMoneyTransactionType(tx);
+  if (!type) {
+    return 'deposited';
+  }
+
+  switch (type) {
+    case TransactionType.moneyAccountDeposit:
+      if (isFiatDeposit(tx) || isMusdPayToken(tx)) {
+        return 'deposited';
+      }
+      return 'converted';
+    case TransactionType.musdConversion:
+      return 'converted';
+    case TransactionType.incoming:
+    case TransactionType.tokenMethodTransfer:
+    case TransactionType.tokenMethodTransferFrom:
+      return 'received';
+    case TransactionType.moneyAccountWithdraw:
+    case TransactionType.simpleSend:
+      return 'sent';
+    default:
+      return 'received';
+  }
+}
+
+export function moneyActivityKindToLabel(kind: MoneyActivityKind): string {
+  switch (kind) {
+    case 'added':
+      return strings('money.transaction.added');
+    case 'deposited':
+      return strings('money.transaction.deposited');
+    case 'received':
+      return strings('money.transaction.received');
+    case 'converted':
+      return strings('money.transaction.converted');
+    case 'sent':
+      return strings('money.transaction.sent');
+    case 'transferred':
+      return strings('money.transaction.transferred');
+    case 'card':
+      return strings('money.transaction.card_transaction');
+    default:
+      return strings('money.transaction.received');
+  }
+}
+
+export function moneyActivityKindToIcon(kind: MoneyActivityKind): IconName {
+  switch (kind) {
+    case 'added':
+    case 'deposited':
+      return IconName.Add;
+    case 'received':
+      return IconName.Arrow2Down;
+    case 'converted':
+      return IconName.Refresh;
+    case 'sent':
+      return IconName.Arrow2UpRight;
+    case 'transferred':
+      return IconName.SwapHorizontal;
+    case 'card':
+      return IconName.Card;
+    default:
+      return IconName.Arrow2Down;
+  }
+}

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -37,28 +37,24 @@ export function getMoneyActivityStatus(
  * single well-typed value rather than re-deriving from raw transaction types.
  *
  * Mirrors the activity row types in the Money design (Converted / Deposited /
- * Added / Received / Sent / Transferred). Card transactions are not
- * {@link TransactionMeta}-backed and are classified separately — see
- * `cardTransactionDisplayInfo` — but `'card'` is kept here so the explicit
- * `moneyActivityTitleKey` override can still target it.
+ * Received / Sent). Card transactions are not {@link TransactionMeta}-backed
+ * and are classified separately — see `cardTransactionDisplayInfo` — but
+ * `'card'` is kept here so the explicit `moneyActivityTitleKey` override can
+ * still target it.
  */
 export type MoneyActivityKind =
-  | 'added'
   | 'deposited'
   | 'received'
   | 'converted'
   | 'sent'
-  | 'transferred'
   | 'card';
 
 const TITLE_KEY_TO_KIND: Record<MoneyActivityTitleKey, MoneyActivityKind> = {
-  added: 'added',
   deposited: 'deposited',
   received: 'received',
   card_transaction: 'card',
   converted: 'converted',
   sent: 'sent',
-  transferred: 'transferred',
 };
 
 /**
@@ -134,12 +130,10 @@ export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
 }
 
 const KIND_LABEL_KEY: Record<MoneyActivityKind, string> = {
-  added: 'money.transaction.added',
   deposited: 'money.transaction.deposited',
   received: 'money.transaction.received',
   converted: 'money.transaction.converted',
   sent: 'money.transaction.sent',
-  transferred: 'money.transaction.transferred',
   card: 'money.transaction.card_transaction',
 };
 
@@ -176,7 +170,6 @@ export function moneyActivityLabel(
 
 export function moneyActivityKindToIcon(kind: MoneyActivityKind): IconName {
   switch (kind) {
-    case 'added':
     case 'deposited':
       return IconName.Add;
     case 'received':
@@ -185,8 +178,6 @@ export function moneyActivityKindToIcon(kind: MoneyActivityKind): IconName {
       return IconName.Refresh;
     case 'sent':
       return IconName.Arrow2UpRight;
-    case 'transferred':
-      return IconName.SwapHorizontal;
     case 'card':
       return IconName.Card;
     default:

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -1,5 +1,6 @@
 import {
   type TransactionMeta,
+  TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { IconName } from '@metamask/design-system-react-native';
@@ -9,6 +10,26 @@ import type {
   MoneyActivityTitleKey,
   MoneyActivityTransactionMeta,
 } from '../constants/mockActivityData';
+
+/**
+ * The lifecycle state of a Money activity row, as far as the display cares.
+ * `submitted` transactions are in-flight (`pending`), `failed` ones errored,
+ * and everything else surfaced in activity is treated as `confirmed`.
+ */
+export type MoneyActivityStatus = 'pending' | 'confirmed' | 'failed';
+
+export function getMoneyActivityStatus(
+  tx: TransactionMeta,
+): MoneyActivityStatus {
+  switch (tx.status) {
+    case TransactionStatus.submitted:
+      return 'pending';
+    case TransactionStatus.failed:
+      return 'failed';
+    default:
+      return 'confirmed';
+  }
+}
 
 /**
  * The semantic kind of a Money activity row, parsed once from a
@@ -112,25 +133,45 @@ export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
   }
 }
 
-export function moneyActivityKindToLabel(kind: MoneyActivityKind): string {
-  switch (kind) {
-    case 'added':
-      return strings('money.transaction.added');
-    case 'deposited':
-      return strings('money.transaction.deposited');
-    case 'received':
-      return strings('money.transaction.received');
-    case 'converted':
-      return strings('money.transaction.converted');
-    case 'sent':
-      return strings('money.transaction.sent');
-    case 'transferred':
-      return strings('money.transaction.transferred');
-    case 'card':
-      return strings('money.transaction.card_transaction');
-    default:
-      return strings('money.transaction.received');
-  }
+const KIND_LABEL_KEY: Record<MoneyActivityKind, string> = {
+  added: 'money.transaction.added',
+  deposited: 'money.transaction.deposited',
+  received: 'money.transaction.received',
+  converted: 'money.transaction.converted',
+  sent: 'money.transaction.sent',
+  transferred: 'money.transaction.transferred',
+  card: 'money.transaction.card_transaction',
+};
+
+// Present-tense labels for in-flight rows (e.g. "Depositing"). Kinds without an
+// entry fall back to their confirmed label.
+const KIND_PENDING_LABEL_KEY: Partial<Record<MoneyActivityKind, string>> = {
+  deposited: 'money.transaction.depositing',
+  converted: 'money.transaction.converting',
+  sent: 'money.transaction.sending',
+  received: 'money.transaction.receiving',
+};
+
+// Failed-state labels. Stems differ from the confirmed form ("Converted" →
+// "Conversion failed"), so they're enumerated rather than derived. Kinds
+// without an entry fall back to their confirmed label.
+const KIND_FAILED_LABEL_KEY: Partial<Record<MoneyActivityKind, string>> = {
+  deposited: 'money.transaction.deposit_failed',
+  converted: 'money.transaction.conversion_failed',
+  sent: 'money.transaction.send_failed',
+};
+
+export function moneyActivityLabel(
+  kind: MoneyActivityKind,
+  status: MoneyActivityStatus,
+): string {
+  const statusKey =
+    status === 'pending'
+      ? KIND_PENDING_LABEL_KEY[kind]
+      : status === 'failed'
+        ? KIND_FAILED_LABEL_KEY[kind]
+        : undefined;
+  return strings(statusKey ?? KIND_LABEL_KEY[kind]);
 }
 
 export function moneyActivityKindToIcon(kind: MoneyActivityKind): IconName {

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -11,11 +11,6 @@ import type {
   MoneyActivityTransactionMeta,
 } from '../constants/mockActivityData';
 
-/**
- * The lifecycle state of a Money activity row, as far as the display cares.
- * In-flight transactions are `pending`, `failed` ones errored, and everything
- * else surfaced in activity is treated as `confirmed`.
- */
 export type MoneyActivityStatus = 'pending' | 'confirmed' | 'failed';
 
 export function getMoneyActivityStatus(
@@ -24,8 +19,7 @@ export function getMoneyActivityStatus(
   switch (tx.status) {
     // `approved`/`signed` = user has confirmed but the tx is held by the
     // MetaMask Pay publish hook while a cross-chain payment (e.g. bridge)
-    // completes — in-flight from the user's perspective, and the status the
-    // tx keeps for nearly its whole pending life on cross-chain conversions.
+    // completes — in-flight from the user's perspective.
     case TransactionStatus.approved:
     case TransactionStatus.signed:
     case TransactionStatus.submitted:
@@ -37,17 +31,6 @@ export function getMoneyActivityStatus(
   }
 }
 
-/**
- * The semantic kind of a Money activity row, parsed once from a
- * {@link TransactionMeta} so the rest of the display layer renders from a
- * single well-typed value rather than re-deriving from raw transaction types.
- *
- * Mirrors the activity row types in the Money design (Converted / Deposited /
- * Received / Sent). Card transactions are not {@link TransactionMeta}-backed
- * and are classified separately — see `cardTransactionDisplayInfo` — but
- * `'card'` is kept here so the explicit `moneyActivityTitleKey` override can
- * still target it.
- */
 export type MoneyActivityKind =
   | 'deposited'
   | 'received'
@@ -63,11 +46,6 @@ const TITLE_KEY_TO_KIND: Record<MoneyActivityTitleKey, MoneyActivityKind> = {
   sent: 'sent',
 };
 
-/**
- * The most significant Money transaction type for `tx`. For EIP-7702 batches
- * (e.g. the approve+deposit / withdraw+transfer pairs) the meaningful type
- * lives on a nested call, so we surface that; otherwise the top-level type.
- */
 function resolveMoneyTransactionType(
   tx: TransactionMeta,
 ): TransactionType | undefined {
@@ -89,21 +67,11 @@ function isFiatDeposit(tx: TransactionMeta): boolean {
   return Boolean(tx.metamaskPay?.fiat);
 }
 
-/** A `moneyAccountDeposit` paid with mUSD itself (a top-up / move, not a conversion). */
+/** A `moneyAccountDeposit` paid with mUSD itself. */
 function isMusdPayToken(tx: TransactionMeta): boolean {
   return isMusdToken(tx.metamaskPay?.tokenAddress);
 }
 
-/**
- * Parses a Money activity {@link TransactionMeta} into a single
- * {@link MoneyActivityKind}. An explicit `moneyActivityTitleKey` (mock or
- * enriched rows) always wins; otherwise the kind is derived from the
- * transaction type.
- *
- * A `moneyAccountDeposit` paid with crypto is a *conversion* into mUSD (shown
- * as e.g. "ETH → mUSD"), so it maps to `'converted'`. Fiat on-ramp deposits
- * (Transak) and mUSD top-ups keep the `'deposited'` label.
- */
 export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
   const { moneyActivityTitleKey } = tx as MoneyActivityTransactionMeta;
   if (moneyActivityTitleKey) {
@@ -143,8 +111,8 @@ const KIND_LABEL_KEY: Record<MoneyActivityKind, string> = {
   card: 'money.transaction.card_transaction',
 };
 
-// Present-tense labels for in-flight rows (e.g. "Depositing"). Kinds without an
-// entry fall back to their confirmed label.
+// Present-tense labels for in-flight rows (e.g. "Depositing"). If there's
+// no entry entry we will fall back to the confirmed.
 const KIND_PENDING_LABEL_KEY: Partial<Record<MoneyActivityKind, string>> = {
   deposited: 'money.transaction.depositing',
   converted: 'money.transaction.converting',
@@ -152,9 +120,8 @@ const KIND_PENDING_LABEL_KEY: Partial<Record<MoneyActivityKind, string>> = {
   received: 'money.transaction.receiving',
 };
 
-// Failed-state labels. Stems differ from the confirmed form ("Converted" →
-// "Conversion failed"), so they're enumerated rather than derived. Kinds
-// without an entry fall back to their confirmed label.
+// Failed-state labels.
+// Kinds without an entry fall back to their confirmed label.
 const KIND_FAILED_LABEL_KEY: Partial<Record<MoneyActivityKind, string>> = {
   deposited: 'money.transaction.deposit_failed',
   converted: 'money.transaction.conversion_failed',

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -112,7 +112,7 @@ const KIND_LABEL_KEY: Record<MoneyActivityKind, string> = {
 };
 
 // Present-tense labels for in-flight rows (e.g. "Depositing"). If there's
-// no entry entry we will fall back to the confirmed.
+// no entry we will fall back to the confirmed.
 const KIND_PENDING_LABEL_KEY: Partial<Record<MoneyActivityKind, string>> = {
   deposited: 'money.transaction.depositing',
   converted: 'money.transaction.converting',

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -13,8 +13,8 @@ import type {
 
 /**
  * The lifecycle state of a Money activity row, as far as the display cares.
- * `submitted` transactions are in-flight (`pending`), `failed` ones errored,
- * and everything else surfaced in activity is treated as `confirmed`.
+ * In-flight transactions are `pending`, `failed` ones errored, and everything
+ * else surfaced in activity is treated as `confirmed`.
  */
 export type MoneyActivityStatus = 'pending' | 'confirmed' | 'failed';
 
@@ -22,6 +22,12 @@ export function getMoneyActivityStatus(
   tx: TransactionMeta,
 ): MoneyActivityStatus {
   switch (tx.status) {
+    // `approved`/`signed` = user has confirmed but the tx is held by the
+    // MetaMask Pay publish hook while a cross-chain payment (e.g. bridge)
+    // completes — in-flight from the user's perspective, and the status the
+    // tx keeps for nearly its whole pending life on cross-chain conversions.
+    case TransactionStatus.approved:
+    case TransactionStatus.signed:
     case TransactionStatus.submitted:
       return 'pending';
     case TransactionStatus.failed:

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7069,9 +7069,10 @@
       "title": "Activity",
       "view_all": "View all",
       "empty": "No activity yet",
+      "pending": "Pending",
       "filter_all": "All",
       "filter_deposits": "Deposits",
-      "filter_transfers": "Transfers"
+      "filter_sends": "Sends"
     },
     "condensed_cards": {
       "how_it_works_title": "How it works",
@@ -7082,11 +7083,9 @@
       "what_you_get_subtitle": "Explore your benefits"
     },
     "transaction": {
-      "added": "Added",
       "deposited": "Deposited",
       "received": "Received",
       "sent": "Sent",
-      "transferred": "Transferred",
       "card_transaction": "Card transaction",
       "converted": "Converted",
       "depositing": "Depositing",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7089,6 +7089,14 @@
       "transferred": "Transferred",
       "card_transaction": "Card transaction",
       "converted": "Converted",
+      "depositing": "Depositing",
+      "converting": "Converting",
+      "sending": "Sending",
+      "receiving": "Receiving",
+      "deposit_failed": "Deposit failed",
+      "conversion_failed": "Conversion failed",
+      "send_failed": "Send failed",
+      "received_from": "From: {{address}}",
       "failed": "Failed"
     },
     "card_details": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR implements the new designs for the money account activity list - which now include pending transactions.

As part of this PR I've extended the mock data for the activity list, so that you can turn it on to see all of the various types that can appear in the activity list all active at the same time.

Note that this includes rendering logic for transak deposits, but the full implementation for those deposits will be coming in #31401 

### Tracking changes
1. `label_en` changes for the activity filter (MONEY_BUTTON_CLICKED)

The third activity filter was renamed from **"Transfers"** to **"Sends"** (`money.activity.filter_transfers` → `money.activity.filter_sends`). `label_en`/`label_localized` are derived from that key, so filter-click events now report `label_en: "Sends"` where they previously reported `"Transfers"`.

- `component_name` is unchanged (`MONEY_ACTIVITY_FILTER_TRANSFERS`) 

2. `transaction_status` gains `approved` and `signed` values (MONEY_SURFACE_CLICKED via trackActivitySurfaceClicked)

This PR introduces incomplete transactions as clickable "Pending" rows in the activity list. The row-click event sends the raw transaction status, so:

- `transaction_status` could previously only be `confirmed`, `submitted`, or `failed`; it will now also emit `approved` and `signed`.


### Remaining open questions
What text should be shown for a failed 'received' transaction? 'Failed To Receive', 'Receipt Failed'?

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: implement new money account activity designs

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-956](https://consensyssoftware.atlassian.net/browse/MUSD-956)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: money account activity list

  Scenario: user creates a transaction
    Given user is on the money account home

    When user creates a transaction (e.g. deposit)
    Then they see a pending row in the activity list
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
<!-- [screenshots/recordings] -->
<img width="554" height="1041" alt="Screenshot 2026-06-12 at 12 38 18" src="https://github.com/user-attachments/assets/703273b7-b19a-404c-a1d1-38d684f12fee" />

<img width="554" height="1041" alt="Screenshot 2026-06-12 at 12 37 14" src="https://github.com/user-attachments/assets/3426b1df-fb9e-445f-afa5-61a7751567a2" />
<img width="554" height="1041" alt="Screenshot 2026-06-12 at 12 37 28" src="https://github.com/user-attachments/assets/ed8003e4-c8e1-4987-94f5-d490c63f7b0b" />

https://github.com/user-attachments/assets/c5c589a0-ed72-4b67-8a44-ee8a671ab052



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-956]: https://consensyssoftware.atlassian.net/browse/MUSD-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction filtering (approved/signed visibility), amount/label derivation for deposits and failures, and analytics filter copy; well-covered by tests but affects what users see for in-flight and failed Money txs.
> 
> **Overview**
> Implements the new Money account **activity list** UX: in-flight transactions appear in a top **Pending** section, rows show status-aware labels/icons/subtitles, and the third filter label changes from **Transfers** to **Sends**.
> 
> **List structure:** `MoneyActivityView` partitions on-chain items into pending vs settled, prepends a Pending section (`buildSections`), and uses `PENDING_HEADER` test IDs. Mock mode merges curated `MOCK_CARD_TRANSACTIONS` instead of dropping card rows entirely.
> 
> **Row UI:** `ActivityRowView` drives failed/pending from `display.status` (drops `isFailed` prop): red failure on the **label**, subtitle kept; **PendingSpinner** beside present-tense labels. New `classifyMoneyActivity` centralizes kind, status (`approved`/`signed`/`submitted` → pending), and i18n labels.
> 
> **Transaction visibility:** `useMoneyAccountTransactions` includes Pay-held `approved`/`signed` money deposits/withdraws and counts pending via `getMoneyActivityStatus`.
> 
> **Display logic (MUSD-956):** `useMoneyTransactionDisplayInfo` refactors to kind-based labels/icons, mUSD primary amounts from the mUSD `requiredAssets` entry (not pay-token market math), failed rows as signed ±0.00 mUSD/fiat, and richer subtitles (e.g. `USDC → mUSD`, Transak, `From: …`).
> 
> **Mocks & copy:** Expanded mock fixtures (pending/failed/confirmed), Monad chain for mUSD amounts, new en strings (`pending`, `depositing`, `filter_sends`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d3173bcc43aac5e517f311a15f71704f60a845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->