### PR TITLE
chore: adds Quickbuy to the security & trust screen and extract into hook

### DIFF
--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -86,15 +86,8 @@ import {
 } from '@metamask/perps-controller';
 import { usePerpsEventTracking } from '../../../Perps/hooks/usePerpsEventTracking';
 import TokenDetailsStickyFooter from '../../../TokenDetails/components/TokenDetailsStickyFooter';
-import AssetDetailsQuickBuy from '../../../TokenDetails/components/AssetDetailsQuickBuy';
-import {
-  SOCIAL_AI_QUICK_BUY_AB_KEY,
-  SOCIAL_AI_QUICK_BUY_EXPOSURE_METADATA,
-  SOCIAL_AI_QUICK_BUY_VARIANTS,
-} from '../../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/abTestConfig';
 import type { TokenDetailsRouteParams } from '../../../TokenDetails/constants/constants';
-import { useABTest } from '../../../../../hooks/useABTest';
-import { ImpactMoment, playImpact } from '../../../../../util/haptics';
+import { useStickyQuickBuy } from '../../../TokenDetails/hooks/useStickyQuickBuy';
 
 const feedbackByDigest = new Map<string, 'up' | 'down'>();
 
@@ -232,15 +225,8 @@ const MarketInsightsView: React.FC = () => {
   );
 
   const isEligible = useSelector(selectPerpsEligibility);
-  const { variant: quickBuyVariant } = useABTest(
-    SOCIAL_AI_QUICK_BUY_AB_KEY,
-    SOCIAL_AI_QUICK_BUY_VARIANTS,
-    SOCIAL_AI_QUICK_BUY_EXPOSURE_METADATA,
-  );
-  const isQuickBuyEnabled = quickBuyVariant.showQuickBuy;
   const [isEligibilityModalVisible, setIsEligibilityModalVisible] =
     useState(false);
-  const [isQuickBuyVisible, setIsQuickBuyVisible] = useState(false);
   const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
   const { gate } = useComplianceGate(selectedAddress ?? '');
   const { track } = usePerpsEventTracking();
@@ -413,7 +399,6 @@ const MarketInsightsView: React.FC = () => {
   ]);
 
   const handleStickyQuickBuyPress = useCallback(() => {
-    playImpact(ImpactMoment.PrimaryCTA);
     const event = createEventBuilder(
       MetaMetricsEvents.MARKET_INSIGHTS_INTERACTION,
     )
@@ -425,7 +410,6 @@ const MarketInsightsView: React.FC = () => {
       })
       .build();
     trackEvent(event);
-    setIsQuickBuyVisible(true);
   }, [
     trackEvent,
     createEventBuilder,
@@ -434,9 +418,11 @@ const MarketInsightsView: React.FC = () => {
     routeSource,
   ]);
 
-  const handleQuickBuyClose = useCallback(() => {
-    setIsQuickBuyVisible(false);
-  }, []);
+  const { onQuickBuyPress, quickBuySheet } = useStickyQuickBuy({
+    token: stickyFooterToken ?? null,
+    source: 'market_insights',
+    onPress: handleStickyQuickBuyPress,
+  });
 
   const handleTrendPress = useCallback((trend: MarketInsightsTrend) => {
     const hasArticles = trend.articles.length > 0;
@@ -891,9 +877,7 @@ const MarketInsightsView: React.FC = () => {
               buyTestID={MarketInsightsSelectorsIDs.BUY_BUTTON}
               onSwapPress={handleStickySwapPress}
               onBuyPress={handleStickyBuyPress}
-              onQuickBuyPress={
-                isQuickBuyEnabled ? handleStickyQuickBuyPress : undefined
-              }
+              onQuickBuyPress={onQuickBuyPress}
               quickBuyTestID={MarketInsightsSelectorsIDs.QUICK_BUY_BUTTON}
               sourcePage="MarketInsightsView"
               isPricePositive={isPricePositive}
@@ -920,14 +904,7 @@ const MarketInsightsView: React.FC = () => {
         />
       ) : null}
 
-      {isQuickBuyEnabled && stickyFooterToken && (
-        <AssetDetailsQuickBuy
-          isVisible={isQuickBuyVisible}
-          token={stickyFooterToken}
-          onClose={handleQuickBuyClose}
-          source="market_insights"
-        />
-      )}
+      {quickBuySheet}
 
       {isEligibilityModalVisible && (
         // Android Compatibility: Wrap the <Modal> in a plain <View> component to prevent rendering issues and freezing.

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.test.tsx
@@ -150,10 +150,30 @@ jest.mock('../../TokenDetails/hooks/useTokenActions', () => ({
   })),
 }));
 
+jest.mock('../../TokenDetails/hooks/useStickyQuickBuy', () => ({
+  useStickyQuickBuy: jest.fn(() => ({
+    isQuickBuyEnabled: true,
+    onQuickBuyPress: jest.fn(),
+    quickBuySheet: null,
+  })),
+}));
+
+const getMockUseStickyQuickBuy = () =>
+  (
+    jest.requireMock('../../TokenDetails/hooks/useStickyQuickBuy') as {
+      useStickyQuickBuy: jest.Mock;
+    }
+  ).useStickyQuickBuy;
+
 describe('SecurityTrustScreen', () => {
   beforeEach(() => {
-    mockRouteParams = createDefaultRouteParams();
     jest.clearAllMocks();
+    mockRouteParams = createDefaultRouteParams();
+    getMockUseStickyQuickBuy().mockReturnValue({
+      isQuickBuyEnabled: true,
+      onQuickBuyPress: jest.fn(),
+      quickBuySheet: null,
+    });
   });
 
   it('renders without crashing', () => {
@@ -313,5 +333,43 @@ describe('SecurityTrustScreen', () => {
       solanaMint,
       solanaChainId,
     );
+  });
+
+  describe('Quick Buy', () => {
+    it('calls useStickyQuickBuy with the security_trust source and route token', () => {
+      render(<SecurityTrustScreen />);
+
+      expect(getMockUseStickyQuickBuy()).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'security_trust',
+          token: expect.objectContaining({
+            symbol: 'TEST',
+            chainId: '0x1',
+          }),
+        }),
+      );
+    });
+
+    it('passes onQuickBuyPress from the hook to TokenDetailsStickyFooter', () => {
+      const onQuickBuyPress = jest.fn();
+      getMockUseStickyQuickBuy().mockReturnValue({
+        isQuickBuyEnabled: true,
+        onQuickBuyPress,
+        quickBuySheet: null,
+      });
+
+      // Renders without errors — the footer (mocked) receives the prop.
+      expect(() => render(<SecurityTrustScreen />)).not.toThrow();
+    });
+
+    it('does not throw when quick-buy is disabled', () => {
+      getMockUseStickyQuickBuy().mockReturnValue({
+        isQuickBuyEnabled: false,
+        onQuickBuyPress: undefined,
+        quickBuySheet: null,
+      });
+
+      expect(() => render(<SecurityTrustScreen />)).not.toThrow();
+    });
   });
 });

--- a/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
+++ b/app/components/UI/SecurityTrust/Views/SecurityTrustScreen.tsx
@@ -40,6 +40,7 @@ import {
   getResultTypeConfig,
 } from '../utils/securityUtils';
 import TokenDetailsStickyFooter from '../../TokenDetails/components/TokenDetailsStickyFooter';
+import { useStickyQuickBuy } from '../../TokenDetails/hooks/useStickyQuickBuy';
 import useBlockExplorer from '../../../hooks/useBlockExplorer';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -89,6 +90,11 @@ const SecurityTrustScreen: React.FC = () => {
       nonEvmNetworkConfigurations,
     });
   }, [params?.chainId, evmNetworkConfigurations, nonEvmNetworkConfigurations]);
+
+  const { onQuickBuyPress, quickBuySheet } = useStickyQuickBuy({
+    token: params,
+    source: 'security_trust',
+  });
 
   // Track page view once
   useEffect(() => {
@@ -716,7 +722,9 @@ const SecurityTrustScreen: React.FC = () => {
         sourcePage="SecurityTrustView"
         isPricePositive={params.isPricePositive}
         useAmbientColor={params.useAmbientColor}
+        onQuickBuyPress={onQuickBuyPress}
       />
+      {quickBuySheet}
     </View>
   );
 };

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -21,7 +21,6 @@ import { TransactionDetailLocation } from '../../../../core/Analytics/events/tra
 import { useABTest } from '../../../../hooks/useABTest';
 import { RootState } from '../../../../reducers';
 import { selectNetworkConfigurationByChainId } from '../../../../selectors/networkController';
-import { ImpactMoment, playImpact } from '../../../../util/haptics';
 import { LIGHT_MODE_SUCCESS_GREEN, useTheme } from '../../../../util/theme';
 import { AppThemeKey } from '../../../../util/theme/models';
 import { TraceName, endTrace } from '../../../../util/trace';
@@ -39,12 +38,7 @@ import {
   AMBIENT_PRICE_COLOR_AB_KEY,
   AMBIENT_PRICE_COLOR_VARIANTS,
 } from '../components/abTestConfig';
-import {
-  SOCIAL_AI_QUICK_BUY_AB_KEY,
-  SOCIAL_AI_QUICK_BUY_EXPOSURE_METADATA,
-  SOCIAL_AI_QUICK_BUY_VARIANTS,
-} from '../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/abTestConfig';
-import AssetDetailsQuickBuy from '../components/AssetDetailsQuickBuy';
+import { useStickyQuickBuy } from '../hooks/useStickyQuickBuy';
 import AssetOverviewContent from '../components/AssetOverviewContent';
 import { TokenDetailsInlineHeader } from '../components/TokenDetailsInlineHeader';
 import TokenDetailsStickyFooter from '../components/TokenDetailsStickyFooter';
@@ -165,28 +159,15 @@ const TokenDetails: React.FC<{
   const navigation = useNavigation();
   const [isInsightsDisclaimerVisible, setIsInsightsDisclaimerVisible] =
     useState(false);
-  const [isQuickBuyVisible, setIsQuickBuyVisible] = useState(false);
-
-  const handleQuickBuyPress = useCallback(() => {
-    playImpact(ImpactMoment.PrimaryCTA);
-    setIsQuickBuyVisible(true);
-  }, []);
-
-  const handleQuickBuyClose = useCallback(() => {
-    setIsQuickBuyVisible(false);
-  }, []);
+  const { onQuickBuyPress, quickBuySheet } = useStickyQuickBuy({
+    token,
+    source: 'asset_details',
+  });
   const { variant: ambientColorVariant } = useABTest(
     AMBIENT_PRICE_COLOR_AB_KEY,
     AMBIENT_PRICE_COLOR_VARIANTS,
   );
   const useAmbientColor = ambientColorVariant.useAmbientPriceColor;
-
-  const { variant: quickBuyVariant } = useABTest(
-    SOCIAL_AI_QUICK_BUY_AB_KEY,
-    SOCIAL_AI_QUICK_BUY_VARIANTS,
-    SOCIAL_AI_QUICK_BUY_EXPOSURE_METADATA,
-  );
-  const isQuickBuyEnabled = quickBuyVariant.showQuickBuy;
 
   const caip19AssetId = useMemo((): CaipAssetType | null => {
     try {
@@ -406,7 +387,7 @@ const TokenDetails: React.FC<{
           useAmbientColor={useAmbientColor}
           onSwapPress={onCtaClicked}
           onBuyPress={onCtaClicked}
-          onQuickBuyPress={isQuickBuyEnabled ? handleQuickBuyPress : undefined}
+          onQuickBuyPress={onQuickBuyPress}
           quickBuyTestID={TokenOverviewSelectorsIDs.QUICK_BUY_BUTTON}
         />
       )}
@@ -415,13 +396,7 @@ const TokenDetails: React.FC<{
           onClose={() => setIsInsightsDisclaimerVisible(false)}
         />
       )}
-      {isQuickBuyEnabled && (
-        <AssetDetailsQuickBuy
-          isVisible={isQuickBuyVisible}
-          token={token}
-          onClose={handleQuickBuyClose}
-        />
-      )}
+      {quickBuySheet}
     </View>
   );
 };

--- a/app/components/UI/TokenDetails/hooks/useStickyQuickBuy.test.tsx
+++ b/app/components/UI/TokenDetails/hooks/useStickyQuickBuy.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useStickyQuickBuy } from './useStickyQuickBuy';
+import { SOCIAL_AI_QUICK_BUY_VARIANTS } from '../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/abTestConfig';
+import type { AssetDetailsQuickBuyProps } from '../components/AssetDetailsQuickBuy';
+import { TokenDetailsSource } from '../constants/constants';
+
+const mockPlayImpact = jest.fn();
+jest.mock('../../../../util/haptics', () => ({
+  playImpact: (...args: unknown[]) => mockPlayImpact(...args),
+  ImpactMoment: { PrimaryCTA: 'primaryCta' },
+}));
+
+let mockShowQuickBuy = false;
+jest.mock('../../../../hooks/useABTest', () => ({
+  useABTest: () => ({
+    variant: { showQuickBuy: mockShowQuickBuy },
+    variantName: mockShowQuickBuy ? 'treatment' : 'control',
+    isActive: mockShowQuickBuy,
+  }),
+}));
+
+jest.mock('../components/AssetDetailsQuickBuy', () => ({
+  __esModule: true,
+  default: (_props: unknown) => null,
+}));
+
+const defaultToken = {
+  address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+  chainId: '0x1',
+  symbol: 'DAI',
+  name: 'Dai Stablecoin',
+  decimals: 18,
+  balance: '100',
+  balanceFiat: '$100',
+  logo: '',
+  image: '',
+  isETH: false,
+  hasBalanceError: false,
+  aggregators: [],
+  source: TokenDetailsSource.MobileTokenList,
+};
+
+describe('useStickyQuickBuy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShowQuickBuy = false;
+  });
+
+  describe('when the quick-buy flag is off', () => {
+    it('returns onQuickBuyPress as undefined', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(result.current.onQuickBuyPress).toBeUndefined();
+    });
+
+    it('returns quickBuySheet as null', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(result.current.quickBuySheet).toBeNull();
+    });
+
+    it('returns isQuickBuyEnabled as false', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(result.current.isQuickBuyEnabled).toBe(false);
+    });
+  });
+
+  describe('when the quick-buy flag is on', () => {
+    beforeEach(() => {
+      mockShowQuickBuy = true;
+    });
+
+    it('returns isQuickBuyEnabled as true', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(result.current.isQuickBuyEnabled).toBe(true);
+    });
+
+    it('returns a defined onQuickBuyPress', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(result.current.onQuickBuyPress).toBeDefined();
+    });
+
+    it('returns a non-null quickBuySheet', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(result.current.quickBuySheet).not.toBeNull();
+    });
+
+    it('calls playImpact when onQuickBuyPress is invoked', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      act(() => {
+        result.current.onQuickBuyPress?.();
+      });
+
+      expect(mockPlayImpact).toHaveBeenCalledTimes(1);
+    });
+
+    it('invokes the optional onPress callback when onQuickBuyPress is called', () => {
+      const onPress = jest.fn();
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({
+          token: defaultToken,
+          source: 'asset_details',
+          onPress,
+        }),
+      );
+
+      act(() => {
+        result.current.onQuickBuyPress?.();
+      });
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a quickBuySheet that is a valid React element', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      expect(React.isValidElement(result.current.quickBuySheet)).toBe(true);
+    });
+
+    it('passes the correct source to the sheet element', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'security_trust' }),
+      );
+
+      const sheet = result.current
+        .quickBuySheet as React.ReactElement<AssetDetailsQuickBuyProps>;
+      expect(sheet.props.source).toBe('security_trust');
+    });
+
+    it('passes the token to the sheet element', () => {
+      const { result } = renderHook(() =>
+        useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+      );
+
+      const sheet = result.current
+        .quickBuySheet as React.ReactElement<AssetDetailsQuickBuyProps>;
+      expect(sheet.props.token).toEqual(defaultToken);
+    });
+  });
+
+  it('derives isQuickBuyEnabled from the A/B variant showQuickBuy flag', () => {
+    expect(SOCIAL_AI_QUICK_BUY_VARIANTS.control.showQuickBuy).toBe(false);
+    expect(SOCIAL_AI_QUICK_BUY_VARIANTS.treatment.showQuickBuy).toBe(true);
+
+    mockShowQuickBuy = true;
+    const { result } = renderHook(() =>
+      useStickyQuickBuy({ token: defaultToken, source: 'asset_details' }),
+    );
+
+    expect(result.current.isQuickBuyEnabled).toBe(true);
+  });
+});

--- a/app/components/UI/TokenDetails/hooks/useStickyQuickBuy.tsx
+++ b/app/components/UI/TokenDetails/hooks/useStickyQuickBuy.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useState } from 'react';
+import { useABTest } from '../../../../hooks/useABTest';
+import { ImpactMoment, playImpact } from '../../../../util/haptics';
+import {
+  SOCIAL_AI_QUICK_BUY_AB_KEY,
+  SOCIAL_AI_QUICK_BUY_EXPOSURE_METADATA,
+  SOCIAL_AI_QUICK_BUY_VARIANTS,
+} from '../../../Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/abTestConfig';
+import AssetDetailsQuickBuy from '../components/AssetDetailsQuickBuy';
+import type { QuickBuySheetSource } from '../../../Views/SocialLeaderboard/analytics';
+import type { TokenDetailsRouteParams } from '../constants/constants';
+
+interface UseStickyQuickBuyArgs {
+  token: TokenDetailsRouteParams | null | undefined;
+  source: QuickBuySheetSource;
+  /** Optional per-surface callback invoked after haptic feedback and before the sheet opens. Use for surface-specific analytics. */
+  onPress?: () => void;
+}
+
+interface UseStickyQuickBuyResult {
+  isQuickBuyEnabled: boolean;
+  /** Undefined when the quick-buy A/B flag is off; pass directly to TokenDetailsStickyFooter. */
+  onQuickBuyPress: (() => void) | undefined;
+  /** Null when the quick-buy A/B flag is off; render this node at the bottom of the screen. */
+  quickBuySheet: React.ReactNode;
+}
+
+/**
+ * Encapsulates all quick-buy wiring: A/B flag read, visibility state, haptic
+ * press handler, and the AssetDetailsQuickBuy sheet element.
+ */
+export function useStickyQuickBuy({
+  token,
+  source,
+  onPress,
+}: UseStickyQuickBuyArgs): UseStickyQuickBuyResult {
+  const { variant: quickBuyVariant } = useABTest(
+    SOCIAL_AI_QUICK_BUY_AB_KEY,
+    SOCIAL_AI_QUICK_BUY_VARIANTS,
+    SOCIAL_AI_QUICK_BUY_EXPOSURE_METADATA,
+  );
+  const isQuickBuyEnabled = quickBuyVariant.showQuickBuy;
+
+  const [isQuickBuyVisible, setIsQuickBuyVisible] = useState(false);
+
+  const handleQuickBuyPress = useCallback(() => {
+    playImpact(ImpactMoment.PrimaryCTA);
+    onPress?.();
+    setIsQuickBuyVisible(true);
+  }, [onPress]);
+
+  const handleQuickBuyClose = useCallback(() => {
+    setIsQuickBuyVisible(false);
+  }, []);
+
+  return {
+    isQuickBuyEnabled,
+    onQuickBuyPress: isQuickBuyEnabled ? handleQuickBuyPress : undefined,
+    quickBuySheet: isQuickBuyEnabled ? (
+      <AssetDetailsQuickBuy
+        isVisible={isQuickBuyVisible}
+        token={token ?? null}
+        onClose={handleQuickBuyClose}
+        source={source}
+      />
+    ) : null,
+  };
+}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.test.ts
@@ -10,6 +10,9 @@ describe('getQuickBuyFeatureId', () => {
     expect(getQuickBuyFeatureId('market_insights')).toBe(
       FeatureId.QUICK_BUY_TOKEN_DETAILS,
     );
+    expect(getQuickBuyFeatureId('security_trust')).toBe(
+      FeatureId.QUICK_BUY_TOKEN_DETAILS,
+    );
   });
 
   it('maps follow-trading surfaces to QUICK_BUY_FOLLOW_TRADING', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/getQuickBuyFeatureId.ts
@@ -6,6 +6,7 @@ export function getQuickBuyFeatureId(source?: QuickBuySheetSource): FeatureId {
   switch (source) {
     case 'asset_details':
     case 'market_insights':
+    case 'security_trust':
       return FeatureId.QUICK_BUY_TOKEN_DETAILS;
     case 'leaderboard':
     case 'profile_position':

--- a/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
+++ b/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
@@ -85,7 +85,8 @@ export type SocialLeaderboardSource =
   | 'trader_profile'
   | 'profile_position'
   | 'asset_details'
-  | 'market_insights';
+  | 'market_insights'
+  | 'security_trust';
 
 export type LeaderboardScreenViewedSource = Extract<
   SocialLeaderboardSource,
@@ -119,4 +120,5 @@ export type QuickBuySheetSource = Extract<
   | 'leaderboard'
   | 'asset_details'
   | 'market_insights'
+  | 'security_trust'
 >;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The quick-buy button was missing from the Security & Trust screen. Every call site of `TokenDetailsStickyFooter` was also duplicating the same four-piece wiring: A/B flag read, visibility state, press handler, and `AssetDetailsQuickBuy` mount.

This PR:

- Adds the missing quick-buy button to `SecurityTrustScreen`.
- Extracts a `useStickyQuickBuy` hook that owns the A/B flag, visibility state, haptic press handler, and the sheet element
- Refactors all three call sites (`TokenDetails, MarketInsightsView, SecurityTrustScreen`) to use the hook.

<img  height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-12 at 10 40 01" src="https://github.com/user-attachments/assets/e1f7ca8a-d669-42b1-996a-0ecd98871002" />

https://github.com/user-attachments/assets/88d4ef58-0166-4e55-9ebe-fd16cf3e580b



## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-661

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy from Security Trust screen

  Background:
    Given I am logged into MetaMask Mobile
    And the Quick Buy A/B flag is enabled for my account

  Scenario: Quick Buy sheet opens from Security Trust screen
    Given I navigate to a token's Security & Trust screen

    When I tap the "Buy" button in the sticky footer
    Then the Quick Buy bottom sheet should appear
    And haptic feedback should fire

    When I close the Quick Buy sheet
    Then the sheet should dismiss
    And I should remain on the Security & Trust screen
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor behind existing A/B gating with tests; no auth or payment flow changes beyond reusing the same quick-buy sheet.
> 
> **Overview**
> Introduces **`useStickyQuickBuy`** to centralize the Social AI quick-buy A/B flag, sheet visibility, haptic press handling, and **`AssetDetailsQuickBuy`** rendering. **Token Details**, **Market Insights**, and **Security & Trust** now consume the hook instead of duplicating that wiring.
> 
> **Security & Trust** gains quick buy on the sticky footer (previously missing). Market Insights still records its `quick_buy` analytics via the hook’s optional **`onPress`** callback.
> 
> Analytics/types treat **`security_trust`** as a quick-buy sheet source and map it to **`QUICK_BUY_TOKEN_DETAILS`** in **`getQuickBuyFeatureId`**. Hook and Security Trust quick-buy behavior are covered by new/updated tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb480831e651e6fc62e36ea8a59e681add517a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->