### PR TITLE
fix: e2e tests

### DIFF
--- a/tests/flows/perps.flow.ts
+++ b/tests/flows/perps.flow.ts
@@ -6,7 +6,6 @@ import {
   PlaywrightGestures,
 } from '../framework';
 import PerpsMarketDetailsView from '../page-objects/Perps/PerpsMarketDetailsView';
-import PerpsHomeView from '../page-objects/Perps/PerpsHomeView';
 import PerpsMarketListView from '../page-objects/Perps/PerpsMarketListView';
 import PerpsOnboarding from '../page-objects/Perps/PerpsOnboarding';
 import PerpsOrderView from '../page-objects/Perps/PerpsOrderView';
@@ -166,20 +165,22 @@ export const waitForOrderScreenVisible = async (
 
 export type PerpsPositionDirection = 'long' | 'short';
 
-export const openPosition = async (
+/**
+ * Opens Perps from the wallet home, selects a watchlist market, and taps Long/Short.
+ */
+export const navigateToPerpsOrderEntry = async (
   symbol: string,
   direction: PerpsPositionDirection,
 ): Promise<void> => {
   await WalletView.scrollAndTapPerpsSection();
-  await PerpsHomeView.tapExploreCryptoIfVisible();
+  await PerpsMarketListView.selectMarketAndTapOrderSide(symbol, direction);
+};
 
-  await PerpsMarketListView.selectMarket(symbol);
-  if (direction === 'long') {
-    await PerpsMarketDetailsView.tapLongButton();
-  } else {
-    await PerpsMarketDetailsView.tapShortButton();
-  }
-
+export const openPosition = async (
+  symbol: string,
+  direction: PerpsPositionDirection,
+): Promise<void> => {
+  await navigateToPerpsOrderEntry(symbol, direction);
   await PerpsOrderView.tapPlaceOrderButton();
   await PerpsMarketDetailsView.waitForScreenReady();
   await PerpsMarketDetailsView.expectClosePositionButtonVisible();

--- a/tests/page-objects/Perps/PerpsMarketListView.ts
+++ b/tests/page-objects/Perps/PerpsMarketListView.ts
@@ -13,6 +13,10 @@ import {
 } from '../../framework/EncapsulatedElement';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import { encapsulatedAction, PlaywrightGestures } from '../../framework';
+import Utilities from '../../framework/Utilities';
+import PerpsMarketDetailsView from './PerpsMarketDetailsView';
+
+export type PerpsOrderSide = 'long' | 'short';
 
 class PerpsMarketListView {
   // Main container
@@ -184,6 +188,29 @@ class PerpsMarketListView {
         await PlaywrightGestures.waitAndTap(marketElement);
       },
     });
+  }
+
+  /**
+   * Selects a market from the Perps home watchlist and taps Long or Short on
+   * market details. Retries until both steps succeed (watchlist can load slowly).
+   */
+  async selectMarketAndTapOrderSide(
+    marketName: string,
+    side: PerpsOrderSide,
+    options: { interval?: number; timeout?: number } = {},
+  ): Promise<void> {
+    const { interval = 1000, timeout = 30000 } = options;
+    await Utilities.executeWithRetry(
+      async () => {
+        await this.selectMarket(marketName);
+        if (side === 'long') {
+          await PerpsMarketDetailsView.tapLongButton();
+        } else {
+          await PerpsMarketDetailsView.tapShortButton();
+        }
+      },
+      { interval, timeout },
+    );
   }
 }
 

--- a/tests/page-objects/Perps/PerpsMarketListView.ts
+++ b/tests/page-objects/Perps/PerpsMarketListView.ts
@@ -1,7 +1,9 @@
 import {
+  PerpsHomeViewSelectorsIDs,
   PerpsMarketListViewSelectorsIDs,
   PerpsMarketRowItemSelectorsIDs,
   PerpsTokenSelectorSelectorsIDs,
+  PerpsWatchlistSelectorsIDs,
   getPerpsMarketRowItemSelector,
 } from '../../../app/components/UI/Perps/Perps.testIds';
 import Gestures from '../../framework/Gestures';
@@ -170,13 +172,96 @@ class PerpsMarketListView {
     await Gestures.waitAndTap(this.container);
   }
 
+  private getMarketRowElement(marketName: string) {
+    return Matchers.getElementByID(
+      `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`,
+    );
+  }
+
+  private get perpsHomeScrollView(): Promise<Detox.NativeMatcher> {
+    return Matchers.getIdentifier(PerpsHomeViewSelectorsIDs.SCROLL_CONTENT);
+  }
+
+  /**
+   * Scrolls the Perps home feed (or full market list) until the market row is visible.
+   * Avoids tapping Explore crypto, which is flaky when clipped on CI.
+   */
+  async scrollToMarketRow(marketName: string): Promise<void> {
+    const marketElement = this.getMarketRowElement(marketName);
+
+    if (await Utilities.isElementVisible(marketElement, 1500)) {
+      return;
+    }
+
+    const watchlistSection = Matchers.getElementByID(
+      PerpsWatchlistSelectorsIDs.SECTION,
+    );
+    const perpsHomeScrollVisible = await Utilities.isElementVisible(
+      Matchers.getElementByID(PerpsHomeViewSelectorsIDs.SCROLL_CONTENT),
+      1000,
+    );
+
+    if (perpsHomeScrollVisible) {
+      if (await Utilities.isElementVisible(watchlistSection, 1000)) {
+        await Gestures.scrollToElement(
+          watchlistSection,
+          this.perpsHomeScrollView,
+          {
+            direction: 'down',
+            scrollAmount: 200,
+            timeout: 10000,
+            elemDescription: 'Perps home watchlist section',
+          },
+        );
+      }
+
+      if (await Utilities.isElementVisible(marketElement, 1000)) {
+        return;
+      }
+
+      await Gestures.scrollToElement(marketElement, this.perpsHomeScrollView, {
+        direction: 'down',
+        scrollAmount: 200,
+        timeout: 10000,
+        elemDescription: `${marketName} market row on Perps home`,
+      });
+
+      if (await Utilities.isElementVisible(marketElement, 1000)) {
+        return;
+      }
+
+      await Gestures.scrollToElement(marketElement, this.perpsHomeScrollView, {
+        direction: 'up',
+        scrollAmount: 200,
+        timeout: 10000,
+        elemDescription: `${marketName} market row on Perps home (scroll up)`,
+      });
+
+      return;
+    }
+
+    const marketListVisible = await Utilities.isElementVisible(
+      this.container,
+      1000,
+    );
+    if (marketListVisible) {
+      await Gestures.scrollToElement(marketElement, this.scrollableContainer, {
+        direction: 'down',
+        scrollAmount: 200,
+        timeout: 10000,
+        elemDescription: `${marketName} market row in market list`,
+      });
+    }
+  }
+
   async selectMarket(marketName: string) {
     await encapsulatedAction({
       detox: async () => {
-        const marketElement = Matchers.getElementByID(
-          `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`,
-        );
-        await Gestures.waitAndTap(marketElement);
+        const marketElement = this.getMarketRowElement(marketName);
+        await this.scrollToMarketRow(marketName);
+        await Gestures.waitAndTap(marketElement, {
+          elemDescription: `${marketName} market row`,
+        });
       },
       appium: async () => {
         const marketSelector = `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`;
@@ -192,7 +277,7 @@ class PerpsMarketListView {
 
   /**
    * Selects a market from the Perps home watchlist and taps Long or Short on
-   * market details. Retries until both steps succeed (watchlist can load slowly).
+   * market details. Scrolls the home feed when needed; retries until both steps succeed.
    */
   async selectMarketAndTapOrderSide(
     marketName: string,

--- a/tests/smoke/perps/perps-limit-long-fill.spec.ts
+++ b/tests/smoke/perps/perps-limit-long-fill.spec.ts
@@ -6,18 +6,15 @@ import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
 } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
-import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView';
+import { navigateToPerpsOrderEntry } from '../../flows/perps.flow';
 import PerpsOrderView from '../../page-objects/Perps/PerpsOrderView';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
 import PerpsView from '../../page-objects/Perps/PerpsView';
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers';
 import { TestSuiteParams } from '../../framework/types';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import Utilities from '../../framework/Utilities';
+
 describe(SmokePerps('Perps - ETH limit long fill'), () => {
   it('creates ETH limit long at Mid, shows open order, then fills after -15%', async () => {
     await withFixtures(
@@ -64,18 +61,7 @@ describe(SmokePerps('Perps - ETH limit long fill'), () => {
         // This is needed due to disable animations
         await device.disableSynchronization();
 
-        // Navigate to Perps via homepage section (same click path as smoke perps tests)
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsHomeView.tapExploreCryptoIfVisible();
-
-        // Select ETH market and tap Long
-        await Utilities.executeWithRetry(
-          async () => {
-            await PerpsMarketListView.selectMarket('ETH');
-            await PerpsMarketDetailsView.tapLongButton();
-          },
-          { interval: 1000, timeout: 30000 },
-        );
+        await navigateToPerpsOrderEntry('ETH', 'long');
 
         // Open order type selector and select Limit using Page Object
         await PerpsOrderView.openOrderTypeSelector();

--- a/tests/smoke/perps/perps-position-liquidation.spec.ts
+++ b/tests/smoke/perps/perps-position-liquidation.spec.ts
@@ -113,13 +113,13 @@ const waitForCommandQueueToProcess = async (
   await commandQueueServer.getExportedState();
 };
 
-// Unblocking CI
-describe.skip(SmokePerps('Perps Position Liquidation'), () => {
+describe(SmokePerps('Perps Position Liquidation'), () => {
   it(`liquidates a ${POSITION_DIRECTION} position when mark price moves ${MARK_PRICE_BY_DIRECTION[POSITION_DIRECTION].liquidatingPriceDirection} liquidation price`, async () => {
     await withFixtures(
       {
         fixture: buildPerpsFixture(),
         restartDevice: true,
+        permissions: { notifications: 'YES' },
         testSpecificMock: setupPerpsMocks,
         useCommandQueueServer: true,
       },

--- a/tests/smoke/perps/perps-position-stop-loss.spec.ts
+++ b/tests/smoke/perps/perps-position-stop-loss.spec.ts
@@ -2,9 +2,7 @@ import { loginToApp } from '../../flows/wallet.flow';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SmokePerps } from '../../tags';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
+import { navigateToPerpsOrderEntry } from '../../flows/perps.flow';
 import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
@@ -28,7 +26,7 @@ const logger = createLogger({
 });
 
 describe(SmokePerps('Perps Position Stop Loss'), () => {
-  it.skip('opens a long with stop loss and closes when mark crosses the SL trigger', async () => {
+  it('opens a long with stop loss and closes when mark crosses the SL trigger', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -54,6 +52,7 @@ describe(SmokePerps('Perps Position Stop Loss'), () => {
           .withPopularNetworks()
           .build(),
         restartDevice: true,
+        permissions: { notifications: 'YES' },
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
@@ -73,11 +72,7 @@ describe(SmokePerps('Perps Position Stop Loss'), () => {
         await loginToApp();
         await device.disableSynchronization();
 
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsHomeView.tapExploreCryptoIfVisible();
-
-        await PerpsMarketListView.selectMarket('ETH');
-        await PerpsMarketDetailsView.tapLongButton();
+        await navigateToPerpsOrderEntry('ETH', 'long');
 
         await PerpsOrderView.tapTakeProfitButton();
         // Default ETH mock mark ~2500; SL below entry for a long

--- a/tests/smoke/perps/perps-position.spec.ts
+++ b/tests/smoke/perps/perps-position.spec.ts
@@ -2,9 +2,7 @@ import { loginToApp } from '../../flows/wallet.flow';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SmokePerps } from '../../tags';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
+import { navigateToPerpsOrderEntry } from '../../flows/perps.flow';
 import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
@@ -25,7 +23,7 @@ const logger = createLogger({
 });
 
 describe(SmokePerps('Perps Position'), () => {
-  it.skip('opens a long position with custom profit and closes it', async () => {
+  it('opens a long position with custom profit and closes it', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -51,6 +49,7 @@ describe(SmokePerps('Perps Position'), () => {
           .withPopularNetworks()
           .build(),
         restartDevice: true,
+        permissions: { notifications: 'YES' },
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
@@ -68,12 +67,7 @@ describe(SmokePerps('Perps Position'), () => {
         // streaming/network activity can block Detox idling.
         await device.disableSynchronization();
 
-        // Navigate to Perps via homepage section (same click path as smoke perps tests)
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsHomeView.tapExploreCryptoIfVisible();
-
-        await PerpsMarketListView.selectMarket('ETH');
-        await PerpsMarketDetailsView.tapLongButton();
+        await navigateToPerpsOrderEntry('ETH', 'long');
 
         // Custom TP trigger above mock ETH mark (~2500) for a long
         await PerpsOrderView.tapTakeProfitButton();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Re-enables three skipped Perps smoke E2E tests that were disabled after CI failures ([MMQA-1936](https://consensyssoftware.atlassian.net/browse/MMQA-1936)).

**Root cause:** navigation relied on **Explore crypto** (`tapExploreCryptoIfVisible`), which was clipped / not tappable on CI while ETH is already available on the Perps home watchlist.

**Changes (E2E only, no app changes):**
- Add `PerpsMarketListView.selectMarketAndTapOrderSide()` — selects a watchlist market and taps Long/Short with `executeWithRetry`.
- Update `openPosition` / add `navigateToPerpsOrderEntry` in `perps.flow.ts` to use the watchlist path (no Explore crypto).
- Re-enable `perps-position-liquidation`, `perps-position`, and `perps-position-stop-loss` specs.
- Align `perps-limit-long-fill` with the same navigation helper.
- Pre-grant notification permission on fresh installs (`permissions: { notifications: 'YES' }`) when `restartDevice: true`, so the OS push prompt does not block login.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MMQA-1936](https://consensyssoftware.atlassian.net/browse/MMQA-1936)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps position smoke E2E

  Scenario: open a long ETH position from the Perps home watchlist
    Given a logged-in wallet with Perps mocks on Arbitrum
    And notification permission is pre-granted on app launch

    When the test navigates to Perps from the wallet home
    And selects ETH from the watchlist and taps Long
    Then the order entry screen is shown without tapping Explore crypto

  Scenario: liquidation smoke verifies position closes when mark price triggers liquidation
    Given an open long ETH position
    When the mock mark price moves to a non-liquidating level
    Then the close position control remains visible
    When the mock mark price moves to a liquidating level
    Then the close position control is no longer visible
```

**Local run (use package.json scripts so `NODE_OPTIONS=--experimental-vm-modules` is set for Anvil):**

```bash
# Single spec (CI prebuilt app)
PREBUILT_IOS_APP_PATH=build/MetaMask.app yarn test:e2e:ios:main:ci -- tests/smoke/perps/perps-position-liquidation.spec.ts

# All affected specs (local debug build)
yarn test:e2e:ios:debug:run -- \
  tests/smoke/perps/perps-position.spec.ts \
  tests/smoke/perps/perps-position-stop-loss.spec.ts \
  tests/smoke/perps/perps-position-liquidation.spec.ts \
  tests/smoke/perps/perps-limit-long-fill.spec.ts
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — E2E test-only change; validation is via Detox smoke runs and CI artifacts.

### **Before**

CI smoke failures on Perps navigation (Explore crypto not tappable); three specs skipped.

### **After**

Specs re-enabled; navigation uses watchlist selection with retry.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMQA-1936]: https://consensyssoftware.atlassian.net/browse/MMQA-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Detox/page objects and smoke specs; no production app code is modified.
> 
> **Overview**
> **Re-enables three skipped Perps smoke E2E specs** by fixing CI-flaky navigation that depended on tapping **Explore crypto** when ETH is already on the Perps home watchlist.
> 
> **Navigation refactor (tests only):** `PerpsMarketListView` gains `scrollToMarketRow` (scrolls Perps home watchlist or market list until a row is visible) and `selectMarketAndTapOrderSide` (market pick + Long/Short with `executeWithRetry`). `perps.flow.ts` adds `navigateToPerpsOrderEntry` and routes `openPosition` through it instead of `PerpsHomeView.tapExploreCryptoIfVisible`.
> 
> **Spec updates:** `perps-position`, `perps-position-stop-loss`, and `perps-position-liquidation` are un-skipped; `perps-limit-long-fill` and the others use `navigateToPerpsOrderEntry('ETH', 'long')`. Fixtures with `restartDevice: true` now pass `permissions: { notifications: 'YES' }` so the OS push prompt does not block login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d936495623f6fddb40db18a88a459e29b37f46dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->