### PR TITLE
feat(confirmations): surface no-fee sponsored tokens in MM Pay payment picker

### DIFF
--- a/app/components/Views/confirmations/components/UI/no-fee-tag/index.ts
+++ b/app/components/Views/confirmations/components/UI/no-fee-tag/index.ts
@@ -1,0 +1,1 @@
+export { NoFeeTag } from './no-fee-tag';

--- a/app/components/Views/confirmations/components/UI/no-fee-tag/no-fee-tag.test.tsx
+++ b/app/components/Views/confirmations/components/UI/no-fee-tag/no-fee-tag.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NoFeeTag } from './no-fee-tag';
+
+describe('NoFeeTag', () => {
+  it('renders the "No fee" label', () => {
+    const { getByText } = render(<NoFeeTag />);
+
+    expect(getByText('No fee')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/confirmations/components/UI/no-fee-tag/no-fee-tag.tsx
+++ b/app/components/Views/confirmations/components/UI/no-fee-tag/no-fee-tag.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Tag, TagSeverity } from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+
+export function NoFeeTag() {
+  return (
+    <Box twClassName="shrink-0">
+      <Tag severity={TagSeverity.Info}>
+        {strings('money.potential_earnings.no_fee')}
+      </Tag>
+    </Box>
+  );
+}

--- a/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.test.tsx
+++ b/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.test.tsx
@@ -155,4 +155,50 @@ describe('PaymentMethodRow', () => {
       JSON.stringify(unselectedStyle),
     );
   });
+
+  it('renders No fee tag when isNoFee is true', () => {
+    const { getByTestId } = render(<PaymentMethodRow {...baseProps} isNoFee />);
+
+    expect(getByTestId('payment-method-row-usdc-no-fee-tag')).toBeOnTheScreen();
+  });
+
+  it('does not render No fee tag when isNoFee is false', () => {
+    const { queryByTestId } = render(<PaymentMethodRow {...baseProps} />);
+
+    expect(
+      queryByTestId('payment-method-row-usdc-no-fee-tag'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders No fee tag with localised string', () => {
+    const { getByTestId } = render(<PaymentMethodRow {...baseProps} isNoFee />);
+
+    expect(getByTestId('payment-method-row-usdc-no-fee-tag')).toHaveTextContent(
+      'money.potential_earnings.no_fee',
+    );
+  });
+
+  it('renders No fee tag instead of Last used tag when both isNoFee and isLastUsed are true', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PaymentMethodRow {...baseProps} isNoFee isLastUsed />,
+    );
+
+    expect(getByTestId('payment-method-row-usdc-no-fee-tag')).toBeOnTheScreen();
+    expect(
+      queryByTestId('payment-method-row-usdc-last-used-tag'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders Last used tag when only isLastUsed is true', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PaymentMethodRow {...baseProps} isLastUsed />,
+    );
+
+    expect(
+      getByTestId('payment-method-row-usdc-last-used-tag'),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId('payment-method-row-usdc-no-fee-tag'),
+    ).not.toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.tsx
+++ b/app/components/Views/confirmations/components/UI/payment-method-row/payment-method-row.tsx
@@ -62,6 +62,7 @@ const PaymentMethodRow = ({
   subtitle,
   isSelected,
   isLastUsed,
+  isNoFee,
   trailingElement,
   onPress,
   disabled,
@@ -97,7 +98,14 @@ const PaymentMethodRow = ({
           >
             {title}
           </Text>
-          {isLastUsed ? (
+          {isNoFee ? (
+            <Tag
+              severity={TagSeverity.Info}
+              testID={`${resolvedTestID}-no-fee-tag`}
+            >
+              {strings('money.potential_earnings.no_fee')}
+            </Tag>
+          ) : isLastUsed ? (
             <Tag
               severity={TagSeverity.Info}
               testID={`${resolvedTestID}-last-used-tag`}

--- a/app/components/Views/confirmations/components/UI/token/token.test.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.test.tsx
@@ -179,4 +179,43 @@ describe('Token', () => {
 
     expect(mockOnPress).not.toHaveBeenCalled();
   });
+
+  it('renders No fee tag when isNoFee is true', () => {
+    const mockToken = createMockToken({
+      symbol: 'ETH',
+      name: 'Ethereum',
+    });
+
+    const { getByText } = renderWithProvider(
+      <Token asset={mockToken} isNoFee onPress={mockOnPress} />,
+    );
+
+    expect(getByText('No fee')).toBeOnTheScreen();
+  });
+
+  it('does not render No fee tag when isNoFee is false', () => {
+    const mockToken = createMockToken({
+      symbol: 'ETH',
+      name: 'Ethereum',
+    });
+
+    const { queryByText } = renderWithProvider(
+      <Token asset={mockToken} isNoFee={false} onPress={mockOnPress} />,
+    );
+
+    expect(queryByText('No fee')).not.toBeOnTheScreen();
+  });
+
+  it('does not render No fee tag when isNoFee is undefined', () => {
+    const mockToken = createMockToken({
+      symbol: 'ETH',
+      name: 'Ethereum',
+    });
+
+    const { queryByText } = renderWithProvider(
+      <Token asset={mockToken} onPress={mockOnPress} />,
+    );
+
+    expect(queryByText('No fee')).not.toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/confirmations/components/UI/token/token.test.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { BtcAccountType } from '@metamask/keyring-api';
 
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { AssetType } from '../../../types/token';
-import { Token } from './token';
+import { Token, TokenTagRenderer } from './token';
 import { act, fireEvent } from '@testing-library/react-native';
 
 jest.mock(
@@ -180,33 +181,40 @@ describe('Token', () => {
     expect(mockOnPress).not.toHaveBeenCalled();
   });
 
-  it('renders No fee tag when isNoFee is true', () => {
+  it('renders tag from first matching tagRenderer', () => {
     const mockToken = createMockToken({
       symbol: 'ETH',
       name: 'Ethereum',
     });
 
+    const renderer: TokenTagRenderer = () =>
+      React.createElement(Text, null, 'No fee');
+
     const { getByText } = renderWithProvider(
-      <Token asset={mockToken} isNoFee onPress={mockOnPress} />,
+      <Token
+        asset={mockToken}
+        tagRenderers={[renderer]}
+        onPress={mockOnPress}
+      />,
     );
 
     expect(getByText('No fee')).toBeOnTheScreen();
   });
 
-  it('does not render No fee tag when isNoFee is false', () => {
+  it('does not render tag when tagRenderers is empty', () => {
     const mockToken = createMockToken({
       symbol: 'ETH',
       name: 'Ethereum',
     });
 
     const { queryByText } = renderWithProvider(
-      <Token asset={mockToken} isNoFee={false} onPress={mockOnPress} />,
+      <Token asset={mockToken} tagRenderers={[]} onPress={mockOnPress} />,
     );
 
     expect(queryByText('No fee')).not.toBeOnTheScreen();
   });
 
-  it('does not render No fee tag when isNoFee is undefined', () => {
+  it('does not render tag when no tagRenderers provided', () => {
     const mockToken = createMockToken({
       symbol: 'ETH',
       name: 'Ethereum',
@@ -217,5 +225,29 @@ describe('Token', () => {
     );
 
     expect(queryByText('No fee')).not.toBeOnTheScreen();
+  });
+
+  it('renders first non-null tag when multiple renderers provided', () => {
+    const mockToken = createMockToken({
+      symbol: 'ETH',
+      name: 'Ethereum',
+    });
+
+    const nullRenderer: TokenTagRenderer = () => null;
+    const tagRenderer: TokenTagRenderer = () =>
+      React.createElement(Text, null, 'Winner');
+    const lateRenderer: TokenTagRenderer = () =>
+      React.createElement(Text, null, 'Loser');
+
+    const { getByText, queryByText } = renderWithProvider(
+      <Token
+        asset={mockToken}
+        tagRenderers={[nullRenderer, tagRenderer, lateRenderer]}
+        onPress={mockOnPress}
+      />,
+    );
+
+    expect(getByText('Winner')).toBeOnTheScreen();
+    expect(queryByText('Loser')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/confirmations/components/UI/token/token.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.tsx
@@ -2,6 +2,8 @@ import React, { useCallback } from 'react';
 import { Pressable } from 'react-native';
 import {
   Box,
+  Tag,
+  TagSeverity,
   Text,
   TextVariant,
   FontWeight,
@@ -27,10 +29,11 @@ import AssetLogo from '../../../../../UI/Assets/components/AssetLogo/AssetLogo';
 
 interface TokenProps {
   asset: AssetType;
+  isNoFee?: boolean;
   onPress: (asset: AssetType) => void;
 }
 
-export function Token({ asset, onPress }: TokenProps) {
+export function Token({ asset, isNoFee, onPress }: TokenProps) {
   const tw = useTailwind();
 
   const handlePress = useCallback(() => {
@@ -83,14 +86,22 @@ export function Token({ asset, onPress }: TokenProps) {
         </Box>
 
         <Box twClassName="ml-4 h-12 justify-center flex-1 min-w-0">
-          <Box twClassName="flex-row items-center">
+          <Box twClassName="flex-row items-center gap-2">
             <Text
               variant={TextVariant.BodyMd}
               fontWeight={FontWeight.Medium}
               numberOfLines={1}
+              twClassName="shrink"
             >
               {asset.name || asset.symbol || 'Unknown Token'}
             </Text>
+            {isNoFee ? (
+              <Box twClassName="shrink-0">
+                <Tag severity={TagSeverity.Info}>
+                  {I18n.t('money.potential_earnings.no_fee')}
+                </Tag>
+              </Box>
+            ) : null}
             <AccountTypeLabel label={typeLabel} />
           </Box>
           <Text

--- a/app/components/Views/confirmations/components/UI/token/token.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.tsx
@@ -1,9 +1,7 @@
-import React, { useCallback } from 'react';
+import React, { ReactNode, useCallback } from 'react';
 import { Pressable } from 'react-native';
 import {
   Box,
-  Tag,
-  TagSeverity,
   Text,
   TextVariant,
   FontWeight,
@@ -27,13 +25,15 @@ import { formatAmount } from '../../../../../../components/UI/SimulationDetails/
 import { ACCOUNT_TYPE_LABELS } from '../../../../../../constants/account-type-labels';
 import AssetLogo from '../../../../../UI/Assets/components/AssetLogo/AssetLogo';
 
+export type TokenTagRenderer = (token: AssetType) => ReactNode;
+
 interface TokenProps {
   asset: AssetType;
-  isNoFee?: boolean;
   onPress: (asset: AssetType) => void;
+  tagRenderers?: TokenTagRenderer[];
 }
 
-export function Token({ asset, isNoFee, onPress }: TokenProps) {
+export function Token({ asset, tagRenderers, onPress }: TokenProps) {
   const tw = useTailwind();
 
   const handlePress = useCallback(() => {
@@ -95,13 +95,10 @@ export function Token({ asset, isNoFee, onPress }: TokenProps) {
             >
               {asset.name || asset.symbol || 'Unknown Token'}
             </Text>
-            {isNoFee ? (
-              <Box twClassName="shrink-0">
-                <Tag severity={TagSeverity.Info}>
-                  {I18n.t('money.potential_earnings.no_fee')}
-                </Tag>
-              </Box>
-            ) : null}
+            {tagRenderers?.reduce<ReactNode>(
+              (found, render) => found ?? render(asset),
+              null,
+            )}
             <AccountTypeLabel label={typeLabel} />
           </Box>
           <Text

--- a/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
+++ b/app/components/Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet.types.ts
@@ -17,6 +17,7 @@ export interface PayWithRowConfig {
   subtitle?: string;
   isSelected?: boolean;
   isLastUsed?: boolean;
+  isNoFee?: boolean;
   trailingElement?: PayWithRowTrailingVariant | ReactElement;
   onPress?: () => void;
   disabled?: boolean;

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -36,6 +36,7 @@ import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredi
 import { usePredictBalanceTokenFilter } from '../../../../../UI/Predict/hooks/usePredictBalanceTokenFilter';
 
 const mockAddTokens = jest.fn().mockResolvedValue(undefined);
+const mockRenderNoFeeTag = jest.fn(() => null);
 const mockFindNetworkClientIdByChainId = jest
   .fn()
   .mockReturnValue('network-client-1');
@@ -56,6 +57,7 @@ jest.mock('../../../hooks/pay/usePayWithNoFeeToken', () => ({
   usePayWithNoFeeToken: () => ({
     noFeeToken: undefined,
     isNoFeeToken: () => false,
+    renderNoFeeTag: mockRenderNoFeeTag,
   }),
 }));
 jest.mock('../../../hooks/pay/useTransactionPayToken');
@@ -436,6 +438,28 @@ describe('PayWithModal', () => {
 
       expect(withdrawFilterFn).toHaveBeenCalledWith(expect.any(Array));
       expect(getAvailableTokensMock).not.toHaveBeenCalled();
+    });
+
+    it('does not render no-fee tags for withdrawal transactions', async () => {
+      const withdrawToken = {
+        accountType: EthAccountType.Eoa,
+        address: '0xWithdrawToken',
+        balance: '1',
+        balanceInSelectedCurrency: '$1.00',
+        chainId: CHAIN_ID_1_MOCK,
+        decimals: 6,
+        name: 'Withdraw Token',
+        standard: TokenStandard.ERC20,
+        symbol: 'WITHDRAW',
+      } as AssetType;
+      useWithdrawTokenFilterMock.mockReturnValue(
+        jest.fn(() => [withdrawToken]),
+      );
+
+      const { findByText } = render();
+
+      expect(await findByText('Withdraw Token')).toBeOnTheScreen();
+      expect(mockRenderNoFeeTag).not.toHaveBeenCalled();
     });
 
     it('awaits addTokens before calling setPayToken for zero-balance withdraw token', async () => {

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -52,6 +52,12 @@ jest.mock('../../../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('../../../hooks/pay/usePayWithNoFeeToken', () => ({
+  usePayWithNoFeeToken: () => ({
+    noFeeToken: undefined,
+    isNoFeeToken: () => false,
+  }),
+}));
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPayWithdraw');

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { HeaderStandard } from '@metamask/design-system-react-native';
 import { Hex } from '@metamask/utils';
 import { StackActions, useNavigation } from '@react-navigation/native';
@@ -86,10 +86,10 @@ export function PayWithModal() {
     isPredictContext ? resetSelectedPaymentToken : undefined,
   );
 
-  const { isNoFeeToken: isNoFeeTokenCheck } = usePayWithNoFeeToken();
-  const isNoFeeToken = useCallback(
-    (token: AssetType) => isNoFeeTokenCheck(token.address, token.chainId ?? ''),
-    [isNoFeeTokenCheck],
+  const { renderNoFeeTag } = usePayWithNoFeeToken();
+  const tagRenderers = useMemo(
+    () => (isWithdraw ? undefined : [renderNoFeeTag]),
+    [isWithdraw, renderNoFeeTag],
   );
 
   const close = useCallback((onClosed?: () => void) => {
@@ -273,7 +273,7 @@ export function PayWithModal() {
         hideNfts
         hideHeader
         tokenFilter={tokenFilter}
-        isNoFeeToken={isNoFeeToken}
+        tagRenderers={tagRenderers}
         onTokenSelect={handleTokenSelect}
         hideNetworkFilter={hideNetworkFilter}
       />

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -37,6 +37,7 @@ import { usePerpsBalanceTokenFilter } from '../../../../../UI/Perps/hooks/usePer
 import { usePerpsPaymentToken } from '../../../../../UI/Perps/hooks/usePerpsPaymentToken';
 import { usePredictBalanceTokenFilter } from '../../../../../UI/Predict/hooks/usePredictBalanceTokenFilter';
 import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredictPaymentToken';
+import { usePayWithNoFeeToken } from '../../../hooks/pay/usePayWithNoFeeToken';
 
 interface PayWithModalParams {
   /**
@@ -83,6 +84,12 @@ export function PayWithModal() {
   const predictBalanceTokenFilter = usePredictBalanceTokenFilter(
     isPredictContext,
     isPredictContext ? resetSelectedPaymentToken : undefined,
+  );
+
+  const { isNoFeeToken: isNoFeeTokenCheck } = usePayWithNoFeeToken();
+  const isNoFeeToken = useCallback(
+    (token: AssetType) => isNoFeeTokenCheck(token.address, token.chainId ?? ''),
+    [isNoFeeTokenCheck],
   );
 
   const close = useCallback((onClosed?: () => void) => {
@@ -266,6 +273,7 @@ export function PayWithModal() {
         hideNfts
         hideHeader
         tokenFilter={tokenFilter}
+        isNoFeeToken={isNoFeeToken}
         onTokenSelect={handleTokenSelect}
         hideNetworkFilter={hideNetworkFilter}
       />

--- a/app/components/Views/confirmations/components/send/asset/asset.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.tsx
@@ -15,6 +15,7 @@ import { useAssetSelectionMetrics } from '../../../hooks/send/metrics/useAssetSe
 import { useSendNavbar } from '../../../hooks/send/useSendNavbar';
 import { useTokenSearch } from '../../../hooks/send/useTokenSearch';
 import { TokenList } from '../../token-list';
+import { TokenTagRenderer } from '../../UI/token';
 import { NftList } from '../../nft-list';
 
 import {
@@ -37,7 +38,7 @@ export interface AssetProps {
   includeNoBalance?: boolean;
   onTokenSelect?: (token: AssetType) => void;
   tokenFilter?: (assets: AssetType[]) => TokenListItem[];
-  isNoFeeToken?: (token: AssetType) => boolean;
+  tagRenderers?: TokenTagRenderer[];
   hideNetworkFilter?: boolean;
   // Hides the in-body send navbar. Set by consumers that render their own
   // header (e.g. pay-with-modal) while reusing this asset picker.
@@ -57,7 +58,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
     includeNoBalance = false,
     onTokenSelect,
     tokenFilter,
-    isNoFeeToken,
+    tagRenderers,
     hideNetworkFilter = false,
     hideHeader = false,
   } = props;
@@ -283,7 +284,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
               tokens={filteredTokens}
               highlightedAssets={filteredHighlightedItemsInAssetList}
               onSelect={onTokenSelect}
-              isNoFeeToken={isNoFeeToken}
+              tagRenderers={tagRenderers}
             />
             {!hideNfts && (
               <>

--- a/app/components/Views/confirmations/components/send/asset/asset.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.tsx
@@ -37,6 +37,7 @@ export interface AssetProps {
   includeNoBalance?: boolean;
   onTokenSelect?: (token: AssetType) => void;
   tokenFilter?: (assets: AssetType[]) => TokenListItem[];
+  isNoFeeToken?: (token: AssetType) => boolean;
   hideNetworkFilter?: boolean;
   // Hides the in-body send navbar. Set by consumers that render their own
   // header (e.g. pay-with-modal) while reusing this asset picker.
@@ -56,6 +57,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
     includeNoBalance = false,
     onTokenSelect,
     tokenFilter,
+    isNoFeeToken,
     hideNetworkFilter = false,
     hideHeader = false,
   } = props;
@@ -281,6 +283,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
               tokens={filteredTokens}
               highlightedAssets={filteredHighlightedItemsInAssetList}
               onSelect={onTokenSelect}
+              isNoFeeToken={isNoFeeToken}
             />
             {!hideNfts && (
               <>

--- a/app/components/Views/confirmations/components/token-list/token-list.tsx
+++ b/app/components/Views/confirmations/components/token-list/token-list.tsx
@@ -13,7 +13,7 @@ import {
 import { useSendContext } from '../../context/send-context';
 import { useSendScreenNavigation } from '../../hooks/send/useSendScreenNavigation';
 import { useAssetSelectionMetrics } from '../../hooks/send/metrics/useAssetSelectionMetrics';
-import { Token } from '../UI/token';
+import { Token, TokenTagRenderer } from '../UI/token';
 import { HighlightedItem } from '../UI/highlighted-item';
 
 const TOKEN_COUNT_PER_PAGE = 20;
@@ -21,14 +21,14 @@ interface TokenListProps {
   onSelect?: (token: AssetType) => void;
   tokens: AssetType[];
   highlightedAssets?: HighlightedItemType[];
-  isNoFeeToken?: (token: AssetType) => boolean;
+  tagRenderers?: TokenTagRenderer[];
 }
 
 export function TokenList({
   onSelect,
   tokens,
   highlightedAssets = [],
-  isNoFeeToken,
+  tagRenderers,
 }: TokenListProps) {
   const { gotToSendScreen } = useSendScreenNavigation();
   const {
@@ -92,7 +92,7 @@ export function TokenList({
           <Token
             key={`${token.chainId}-${token.address}`}
             asset={token}
-            isNoFee={isNoFeeToken?.(token)}
+            tagRenderers={tagRenderers}
             onPress={handleTokenPress}
           />
         ))}

--- a/app/components/Views/confirmations/components/token-list/token-list.tsx
+++ b/app/components/Views/confirmations/components/token-list/token-list.tsx
@@ -21,12 +21,14 @@ interface TokenListProps {
   onSelect?: (token: AssetType) => void;
   tokens: AssetType[];
   highlightedAssets?: HighlightedItemType[];
+  isNoFeeToken?: (token: AssetType) => boolean;
 }
 
 export function TokenList({
   onSelect,
   tokens,
   highlightedAssets = [],
+  isNoFeeToken,
 }: TokenListProps) {
   const { gotToSendScreen } = useSendScreenNavigation();
   const {
@@ -90,6 +92,7 @@ export function TokenList({
           <Token
             key={`${token.chainId}-${token.address}`}
             asset={token}
+            isNoFee={isNoFeeToken?.(token)}
             onPress={handleTokenPress}
           />
         ))}

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -1043,4 +1043,199 @@ describe('usePayWithCryptoSection', () => {
       expect(setTransactionConfigMock).not.toHaveBeenCalled();
     });
   });
+
+  describe('no-fee token row', () => {
+    it('renders no-fee token row when noFeeToken is available', () => {
+      const noFeeTokenMock = {
+        address: '0xnoFee' as Hex,
+        chainId: '0x1' as Hex,
+        symbol: 'USDT',
+        balanceUsd: '10',
+      };
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: noFeeTokenMock,
+        isNoFeeToken: jest.fn().mockReturnValue(false),
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      expect(result.current?.rows).toHaveLength(3);
+      const noFeeRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-no-fee-token',
+      );
+      expect(noFeeRow).toEqual(
+        expect.objectContaining({
+          id: 'crypto-no-fee-token',
+          isNoFee: true,
+          title: 'USDT',
+          testID: 'pay-with-crypto-section-no-fee-token-row',
+        }),
+      );
+    });
+
+    it('does not render no-fee token row when noFeeToken is undefined', () => {
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: undefined,
+        isNoFeeToken: jest.fn().mockReturnValue(false),
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      expect(result.current?.rows).toHaveLength(2);
+      const noFeeRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-no-fee-token',
+      );
+      expect(noFeeRow).toBeUndefined();
+    });
+
+    it('sets isNoFee on preferred token when it is a no-fee token', () => {
+      const isNoFeeTokenMock = jest
+        .fn()
+        .mockImplementation(
+          (address, chainId) =>
+            address === TOKEN_MOCK.address && chainId === TOKEN_MOCK.chainId,
+        );
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: undefined,
+        isNoFeeToken: isNoFeeTokenMock,
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      const preferredRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-preferred-token',
+      );
+      expect(preferredRow).toEqual(
+        expect.objectContaining({
+          isNoFee: true,
+        }),
+      );
+    });
+
+    it('sorts token rows by balance descending', () => {
+      const noFeeTokenMock = {
+        address: '0xnoFee' as Hex,
+        chainId: '0x1' as Hex,
+        symbol: 'USDT',
+        balanceUsd: '15',
+      };
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: noFeeTokenMock,
+        isNoFeeToken: jest.fn().mockReturnValue(false),
+      });
+      usePayWithPreferredTokenMock.mockReturnValue({
+        hasTokens: true,
+        preferredToken: {
+          ...TOKEN_MOCK,
+          balanceUsd: '5',
+        },
+        selectedToken: {
+          ...TOKEN_MOCK,
+          balanceUsd: '5',
+        },
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      expect(result.current?.rows).toHaveLength(3);
+      expect(result.current?.rows[0].id).toBe('crypto-no-fee-token');
+      expect(result.current?.rows[1].id).toBe('crypto-preferred-token');
+      expect(result.current?.rows[2].id).toBe('crypto-other-assets');
+    });
+
+    it('pressing the no-fee token row calls setPayToken and navigates back', () => {
+      const noFeeTokenMock = {
+        address: '0xnoFee' as Hex,
+        chainId: '0x1' as Hex,
+        symbol: 'USDT',
+        balanceUsd: '10',
+      };
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: noFeeTokenMock,
+        isNoFeeToken: jest.fn().mockReturnValue(false),
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      const noFeeRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-no-fee-token',
+      );
+
+      act(() => {
+        noFeeRow?.onPress?.();
+      });
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: noFeeTokenMock.address,
+        chainId: noFeeTokenMock.chainId,
+      });
+      expect(goBackMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render no-fee token row when it duplicates the selected token', () => {
+      const noFeeTokenMock = {
+        address: SELECTED_TOKEN_MOCK.address,
+        chainId: SELECTED_TOKEN_MOCK.chainId,
+        symbol: SELECTED_TOKEN_MOCK.symbol,
+        balanceUsd: SELECTED_TOKEN_MOCK.balanceUsd,
+      };
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: noFeeTokenMock,
+        isNoFeeToken: jest.fn().mockReturnValue(false),
+      });
+      usePayWithSelectedTokenMock.mockReturnValue({
+        isSelectedDistinctFromAutomatic: true,
+        selectedToken: SELECTED_TOKEN_MOCK,
+        selectToken: selectTokenMock,
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      const noFeeRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-no-fee-token',
+      );
+      expect(noFeeRow).toBeUndefined();
+    });
+
+    it('sets isNoFee on selected token row when it is a no-fee token', () => {
+      const isNoFeeTokenMock = jest
+        .fn()
+        .mockImplementation(
+          (address, chainId) =>
+            address === SELECTED_TOKEN_MOCK.address &&
+            chainId === SELECTED_TOKEN_MOCK.chainId,
+        );
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: undefined,
+        isNoFeeToken: isNoFeeTokenMock,
+      });
+      const distinctSelectedToken = {
+        ...TOKEN_MOCK,
+        address: SELECTED_TOKEN_MOCK.address,
+        symbol: SELECTED_TOKEN_MOCK.symbol,
+        balanceUsd: SELECTED_TOKEN_MOCK.balanceUsd,
+      };
+      usePayWithPreferredTokenMock.mockReturnValue({
+        hasTokens: true,
+        preferredToken: TOKEN_MOCK,
+        selectedToken: distinctSelectedToken,
+      });
+      usePayWithSelectedTokenMock.mockReturnValue({
+        isSelectedDistinctFromAutomatic: true,
+        selectedToken: SELECTED_TOKEN_MOCK,
+        selectToken: selectTokenMock,
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      const selectedRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-selected-token',
+      );
+      expect(selectedRow).toEqual(
+        expect.objectContaining({
+          isNoFee: true,
+        }),
+      );
+    });
+  });
 });

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -123,6 +123,7 @@ describe('usePayWithCryptoSection', () => {
     usePayWithNoFeeTokenMock.mockReturnValue({
       noFeeToken: undefined,
       isNoFeeToken: jest.fn().mockReturnValue(false),
+      renderNoFeeTag: jest.fn().mockReturnValue(null),
     });
 
     useNavigationMock.mockReturnValue({
@@ -1055,6 +1056,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: noFeeTokenMock,
         isNoFeeToken: jest.fn().mockReturnValue(false),
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
 
       const { result } = renderHook(() => usePayWithCryptoSection());
@@ -1077,6 +1079,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: undefined,
         isNoFeeToken: jest.fn().mockReturnValue(false),
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
 
       const { result } = renderHook(() => usePayWithCryptoSection());
@@ -1086,6 +1089,35 @@ describe('usePayWithCryptoSection', () => {
         (row) => row.id === 'crypto-no-fee-token',
       );
       expect(noFeeRow).toBeUndefined();
+    });
+
+    it('does not render no-fee row or tags in withdraw flows', () => {
+      const noFeeTokenMock = {
+        address: '0xnoFee' as Hex,
+        chainId: '0x1' as Hex,
+        symbol: 'USDT',
+        balanceUsd: '10',
+      };
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: noFeeTokenMock,
+        isNoFeeToken: jest.fn().mockReturnValue(true),
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
+      });
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.perpsWithdraw,
+        txParams: {},
+      } as never);
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      expect(
+        result.current?.rows.find((row) => row.id === 'crypto-no-fee-token'),
+      ).toBeUndefined();
+      expect(
+        result.current?.rows.some(
+          (row) => row.id !== 'crypto-other-assets' && row.isNoFee,
+        ),
+      ).toBe(false);
     });
 
     it('sets isNoFee on preferred token when it is a no-fee token', () => {
@@ -1098,6 +1130,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: undefined,
         isNoFeeToken: isNoFeeTokenMock,
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
 
       const { result } = renderHook(() => usePayWithCryptoSection());
@@ -1122,6 +1155,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: noFeeTokenMock,
         isNoFeeToken: jest.fn().mockReturnValue(false),
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
       usePayWithPreferredTokenMock.mockReturnValue({
         hasTokens: true,
@@ -1153,6 +1187,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: noFeeTokenMock,
         isNoFeeToken: jest.fn().mockReturnValue(false),
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
 
       const { result } = renderHook(() => usePayWithCryptoSection());
@@ -1182,6 +1217,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: noFeeTokenMock,
         isNoFeeToken: jest.fn().mockReturnValue(false),
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
       usePayWithSelectedTokenMock.mockReturnValue({
         isSelectedDistinctFromAutomatic: true,
@@ -1208,6 +1244,7 @@ describe('usePayWithCryptoSection', () => {
       usePayWithNoFeeTokenMock.mockReturnValue({
         noFeeToken: undefined,
         isNoFeeToken: isNoFeeTokenMock,
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
       });
       const distinctSelectedToken = {
         ...TOKEN_MOCK,

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -82,7 +82,7 @@ const TOKEN_MOCK: TransactionPaymentToken = {
 
 const SELECTED_TOKEN_MOCK = {
   address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex,
-  balanceUsd: '20',
+  balanceUsd: '5',
   chainId: '0x1' as Hex,
   symbol: 'POL',
 };
@@ -359,7 +359,7 @@ describe('usePayWithCryptoSection', () => {
     expect(result.current?.rows[1]).toEqual(
       expect.objectContaining({
         id: 'crypto-selected-token',
-        subtitle: '$20.00',
+        subtitle: '$5.00',
       }),
     );
     expect(result.current?.rows[2]).toEqual(
@@ -463,7 +463,7 @@ describe('usePayWithCryptoSection', () => {
       expect.objectContaining({
         id: 'crypto-selected-token',
         title: SELECTED_TOKEN_MOCK.symbol,
-        subtitle: '$20.00 available',
+        subtitle: '$5.00 available',
         isSelected: true,
         trailingElement: 'checkmark',
         testID: 'pay-with-crypto-section-selected-token-row',

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -17,6 +17,7 @@ import { useIsPerpsBalanceSelected } from '../../../../../UI/Perps/hooks/useIsPe
 import { usePerpsPaymentToken } from '../../../../../UI/Perps/hooks/usePerpsPaymentToken';
 import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredictPaymentToken';
 import { useLastUsedPaymentMethod } from '../useLastUsedPaymentMethod';
+import { usePayWithNoFeeToken } from '../usePayWithNoFeeToken';
 import { usePayWithPreferredToken } from '../usePayWithPreferredToken';
 import { usePayWithSelectedToken } from '../usePayWithSelectedToken';
 import { useTransactionPayFiatPayment } from '../useTransactionPayData';
@@ -62,6 +63,7 @@ jest.mock('../../../../../UI/Perps/hooks/useIsPerpsBalanceSelected');
 jest.mock('../../../../../UI/Perps/hooks/usePerpsPaymentToken');
 jest.mock('../../../../../UI/Predict/hooks/usePredictPaymentToken');
 jest.mock('../useLastUsedPaymentMethod');
+jest.mock('../usePayWithNoFeeToken');
 jest.mock('../usePayWithPreferredToken');
 jest.mock('../usePayWithSelectedToken');
 jest.mock('../useTransactionPayData');
@@ -93,6 +95,7 @@ describe('usePayWithCryptoSection', () => {
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
+  const usePayWithNoFeeTokenMock = jest.mocked(usePayWithNoFeeToken);
   const usePayWithPreferredTokenMock = jest.mocked(usePayWithPreferredToken);
   const usePayWithSelectedTokenMock = jest.mocked(usePayWithSelectedToken);
   const useLastUsedPaymentMethodMock = jest.mocked(useLastUsedPaymentMethod);
@@ -116,6 +119,11 @@ describe('usePayWithCryptoSection', () => {
     jest.resetAllMocks();
 
     useSelectorMock.mockReturnValue(undefined);
+
+    usePayWithNoFeeTokenMock.mockReturnValue({
+      noFeeToken: undefined,
+      isNoFeeToken: jest.fn().mockReturnValue(false),
+    });
 
     useNavigationMock.mockReturnValue({
       navigate: navigateMock,

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
@@ -210,7 +210,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       return null;
     }
 
-    const rows: PayWithRowConfig[] = [];
+    const tokenRows: (PayWithRowConfig & { _balanceUsd: number })[] = [];
 
     const isPreferredTokenMoneyAccountToken =
       isMoneyAccountSelected &&
@@ -232,7 +232,8 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
         preferredToken.chainId,
       );
 
-      rows.push({
+      tokenRows.push({
+        _balanceUsd: parseFloat(preferredToken.balanceUsd) || 0,
         id: 'crypto-preferred-token',
         icon: React.createElement(TokenIcon, {
           address: preferredToken.address,
@@ -259,7 +260,8 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       selectedTokenDisplay &&
       !isDedicatedSectionOwningSelection
     ) {
-      rows.push({
+      tokenRows.push({
+        _balanceUsd: parseFloat(selectedTokenDisplay.balanceUsd) || 0,
         id: 'crypto-selected-token',
         icon: React.createElement(TokenIcon, {
           address: selectedTokenDisplay.address,
@@ -301,7 +303,8 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
         noFeeToken,
       );
 
-      rows.push({
+      tokenRows.push({
+        _balanceUsd: parseFloat(noFeeToken.balanceUsd) || 0,
         id: 'crypto-no-fee-token',
         icon: React.createElement(TokenIcon, {
           address: noFeeToken.address,
@@ -321,6 +324,12 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
         testID: PAY_WITH_CRYPTO_NO_FEE_TOKEN_ROW_TEST_ID,
       });
     }
+
+    tokenRows.sort((a, b) => b._balanceUsd - a._balanceUsd);
+
+    const rows: PayWithRowConfig[] = tokenRows.map(
+      ({ _balanceUsd: _, ...row }) => row,
+    );
 
     rows.push({
       id: 'crypto-other-assets',

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
@@ -35,6 +35,7 @@ import {
 import { MUSD_TOKEN_ADDRESS } from '../../../../../UI/Earn/constants/musd';
 import { SetPayTokenRequest } from '../useAutomaticTransactionPayToken';
 import { useLastUsedPaymentMethod } from '../useLastUsedPaymentMethod';
+import { usePayWithNoFeeToken } from '../usePayWithNoFeeToken';
 import { usePayWithPreferredToken } from '../usePayWithPreferredToken';
 import { usePayWithSelectedToken } from '../usePayWithSelectedToken';
 import { useTransactionPayFiatPayment } from '../useTransactionPayData';
@@ -51,6 +52,8 @@ export const PAY_WITH_CRYPTO_PREFERRED_TOKEN_ROW_TEST_ID =
   'pay-with-crypto-section-preferred-token-row';
 export const PAY_WITH_CRYPTO_SELECTED_TOKEN_ROW_TEST_ID =
   'pay-with-crypto-section-selected-token-row';
+export const PAY_WITH_CRYPTO_NO_FEE_TOKEN_ROW_TEST_ID =
+  'pay-with-crypto-section-no-fee-token-row';
 export const PAY_WITH_CRYPTO_OTHER_ASSETS_ROW_TEST_ID =
   'pay-with-crypto-section-other-assets-row';
 
@@ -84,6 +87,11 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     isPredictBalanceSelected,
   } = usePredictPaymentToken();
   const { isLastUsed } = useLastUsedPaymentMethod();
+  const { noFeeToken, isNoFeeToken } = usePayWithNoFeeToken({
+    excludeToken: preferredToken
+      ? { address: preferredToken.address, chainId: preferredToken.chainId }
+      : undefined,
+  });
   const isPerpsBalanceSelected = useIsPerpsBalanceSelected();
   const isPerpsDepositAndOrder = hasTransactionType(transactionMeta, [
     TransactionType.perpsDepositAndOrder,
@@ -153,9 +161,43 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     setPayToken,
   ]);
 
+  const handleNoFeeTokenPress = useCallback(() => {
+    if (!noFeeToken) {
+      return;
+    }
+    const target = {
+      address: noFeeToken.address,
+      chainId: noFeeToken.chainId,
+    };
+    if (isPerpsDepositAndOrder) {
+      onPerpsPaymentTokenChange(target);
+    } else if (isPredictDepositAndOrder) {
+      onPredictPaymentTokenChange(target);
+      setPayToken(target);
+    } else {
+      setPayToken(target);
+    }
+    clearPaymentOverride();
+    navigation.goBack();
+  }, [
+    clearPaymentOverride,
+    isPerpsDepositAndOrder,
+    isPredictDepositAndOrder,
+    navigation,
+    noFeeToken,
+    onPerpsPaymentTokenChange,
+    onPredictPaymentTokenChange,
+    setPayToken,
+  ]);
+
   const preferredTokenBalance = useMemo(
     () => formatFiat(new BigNumber(preferredToken?.balanceUsd ?? '0')),
     [formatFiat, preferredToken?.balanceUsd],
+  );
+
+  const noFeeTokenBalance = useMemo(
+    () => formatFiat(new BigNumber(noFeeToken?.balanceUsd ?? '0')),
+    [formatFiat, noFeeToken?.balanceUsd],
   );
 
   const selectedTokenBalance = useMemo(
@@ -178,19 +220,17 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       });
 
     if (preferredToken && !isPreferredTokenMoneyAccountToken) {
-      // When a dedicated section "owns" the selection — Perps balance is the
-      // implicit default in a perpsDepositAndOrder flow, Predict balance is
-      // the implicit default in a predictDepositAndOrder flow, OR a fiat
-      // payment method has been picked — the Crypto section's preferred-token
-      // row must not render a misleading checkmark, and the user-selected-
-      // token row is hidden below. When the user explicitly picks a crypto
-      // token via "Other assets" in a perps/predict flow, the respective
-      // controller also stores it as `selectedPaymentToken`, and we honor that
-      // selection with a checkmark (handled by `is*BalanceImplicitlySelected`
-      // being false in that case).
+      // Suppress the checkmark when another section owns the selection
+      // (perps/predict balance or fiat). The flag flips back to false when the
+      // user explicitly picks a crypto token via "Other assets".
       const isPreferredTokenSelected =
         !isDedicatedSectionOwningSelection &&
         isMatchingPayToken(selectedToken, preferredToken);
+
+      const preferredIsNoFee = isNoFeeToken(
+        preferredToken.address,
+        preferredToken.chainId,
+      );
 
       rows.push({
         id: 'crypto-preferred-token',
@@ -207,6 +247,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
           : preferredTokenBalance,
         isSelected: isPreferredTokenSelected,
         isLastUsed: isLastUsed(preferredToken.address, preferredToken.chainId),
+        isNoFee: preferredIsNoFee,
         trailingElement: isPreferredTokenSelected ? 'checkmark' : 'none',
         onPress: handlePreferredTokenPress,
         testID: PAY_WITH_CRYPTO_PREFERRED_TOKEN_ROW_TEST_ID,
@@ -236,8 +277,48 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
           selectedTokenDisplay.address,
           selectedTokenDisplay.chainId,
         ),
+        isNoFee: isNoFeeToken(
+          selectedTokenDisplay.address,
+          selectedTokenDisplay.chainId,
+        ),
         trailingElement: 'checkmark',
         testID: PAY_WITH_CRYPTO_SELECTED_TOKEN_ROW_TEST_ID,
+      });
+    }
+
+    const noFeeTokenDuplicatesSelectedRow =
+      isSelectedDistinctFromAutomatic &&
+      selectedTokenDisplay &&
+      isMatchingPayToken(selectedTokenDisplay, noFeeToken);
+
+    if (
+      noFeeToken &&
+      !isDedicatedSectionOwningSelection &&
+      !noFeeTokenDuplicatesSelectedRow
+    ) {
+      const isNoFeeTokenSelected = isMatchingPayToken(
+        selectedToken,
+        noFeeToken,
+      );
+
+      rows.push({
+        id: 'crypto-no-fee-token',
+        icon: React.createElement(TokenIcon, {
+          address: noFeeToken.address,
+          chainId: noFeeToken.chainId,
+          variant: TokenIconVariant.Row,
+        }),
+        title: noFeeToken.symbol,
+        subtitle: isDeposit
+          ? strings('confirm.pay_with_bottom_sheet.available_balance', {
+              balance: noFeeTokenBalance,
+            })
+          : noFeeTokenBalance,
+        isSelected: isNoFeeTokenSelected,
+        isNoFee: true,
+        trailingElement: isNoFeeTokenSelected ? 'checkmark' : 'none',
+        onPress: handleNoFeeTokenPress,
+        testID: PAY_WITH_CRYPTO_NO_FEE_TOKEN_ROW_TEST_ID,
       });
     }
 
@@ -266,6 +347,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       rows,
     };
   }, [
+    handleNoFeeTokenPress,
     handleOtherAssetsPress,
     handlePreferredTokenPress,
     hasTokens,
@@ -273,8 +355,11 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     isDeposit,
     isLastUsed,
     isMoneyAccountSelected,
+    isNoFeeToken,
     isSelectedDistinctFromAutomatic,
     isWithdraw,
+    noFeeToken,
+    noFeeTokenBalance,
     preferredToken,
     preferredTokenBalance,
     selectedToken,

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
@@ -124,6 +124,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     TransactionType.predictDeposit,
   ]);
   const isWithdraw = isTransactionPayWithdraw(transactionMeta);
+  const shouldShowNoFeeTokens = !isWithdraw;
 
   const handleOtherAssetsPress = useCallback(() => {
     clearPaymentOverride();
@@ -227,10 +228,9 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
         !isDedicatedSectionOwningSelection &&
         isMatchingPayToken(selectedToken, preferredToken);
 
-      const preferredIsNoFee = isNoFeeToken(
-        preferredToken.address,
-        preferredToken.chainId,
-      );
+      const preferredIsNoFee =
+        shouldShowNoFeeTokens &&
+        isNoFeeToken(preferredToken.address, preferredToken.chainId);
 
       tokenRows.push({
         _balanceUsd: parseFloat(preferredToken.balanceUsd) || 0,
@@ -279,10 +279,12 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
           selectedTokenDisplay.address,
           selectedTokenDisplay.chainId,
         ),
-        isNoFee: isNoFeeToken(
-          selectedTokenDisplay.address,
-          selectedTokenDisplay.chainId,
-        ),
+        isNoFee:
+          shouldShowNoFeeTokens &&
+          isNoFeeToken(
+            selectedTokenDisplay.address,
+            selectedTokenDisplay.chainId,
+          ),
         trailingElement: 'checkmark',
         testID: PAY_WITH_CRYPTO_SELECTED_TOKEN_ROW_TEST_ID,
       });
@@ -294,6 +296,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       isMatchingPayToken(selectedTokenDisplay, noFeeToken);
 
     if (
+      shouldShowNoFeeTokens &&
       noFeeToken &&
       !isDedicatedSectionOwningSelection &&
       !noFeeTokenDuplicatesSelectedRow
@@ -374,5 +377,6 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     selectedToken,
     selectedTokenBalance,
     selectedTokenDisplay,
+    shouldShowNoFeeTokens,
   ]);
 }

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -14,6 +14,8 @@ import {
   MetaMaskPayTokensFlags,
   selectMetaMaskPayTokensFlags,
 } from '../../../../../selectors/featureFlagController/confirmations';
+import { selectMoneyNoFeeTokens } from '../../../../UI/Money/selectors/featureFlags';
+import { WildcardTokenList } from '../../../../UI/Earn/utils/wildcardTokenList';
 import {
   isHardwareAccount,
   isQRHardwareAccount,
@@ -64,6 +66,9 @@ jest.mock(
     selectMetaMaskPayTokensFlags: jest.fn(),
   }),
 );
+jest.mock('../../../../UI/Money/selectors/featureFlags', () => ({
+  selectMoneyNoFeeTokens: jest.fn(),
+}));
 
 const TOKEN_ADDRESS_1_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
 const TOKEN_ADDRESS_2_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
@@ -124,6 +129,7 @@ describe('useAutomaticTransactionPayToken', () => {
   const selectMetaMaskPayTokensFlagsMock = jest.mocked(
     selectMetaMaskPayTokensFlags,
   );
+  const selectMoneyNoFeeTokensMock = jest.mocked(selectMoneyNoFeeTokens);
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
@@ -164,6 +170,8 @@ describe('useAutomaticTransactionPayToken', () => {
         overrides: {},
       },
     } as MetaMaskPayTokensFlags);
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({});
 
     useTransactionMetadataRequestMock.mockReturnValue({
       id: transactionIdMock,
@@ -1300,6 +1308,188 @@ describe('useAutomaticTransactionPayToken', () => {
     expect(setPayTokenMock).toHaveBeenCalledWith({
       address: MUSD_TOKEN_ADDRESS,
       chainId: CHAIN_IDS.MONAD,
+    });
+  });
+
+  describe('no-fee token preference', () => {
+    it('selects no-fee token over first available when no preferred tokens match', () => {
+      selectMetaMaskPayTokensFlagsMock.mockReturnValue({
+        preferredTokens: { default: [], overrides: {} },
+        minimumRequiredTokenBalance: 5,
+        blockedTokens: {
+          default: {
+            chainIds: [],
+            tokens: [],
+          },
+          overrides: {},
+        },
+      } as MetaMaskPayTokensFlags);
+
+      selectMoneyNoFeeTokensMock.mockReturnValue({
+        '*': ['USDC'],
+      } as WildcardTokenList);
+
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [
+          {
+            address: TOKEN_ADDRESS_1_MOCK,
+            chainId: CHAIN_ID_1_MOCK,
+            symbol: 'ETH',
+            fiat: { balance: 10 },
+          },
+          {
+            address: TOKEN_ADDRESS_2_MOCK,
+            chainId: CHAIN_ID_2_MOCK,
+            symbol: 'USDC',
+            fiat: { balance: 10 },
+          },
+        ] as AssetType[],
+        hasTokens: true,
+      });
+
+      runHook();
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      });
+    });
+
+    it('does not select no-fee token when balance below minimum', () => {
+      selectMetaMaskPayTokensFlagsMock.mockReturnValue({
+        preferredTokens: { default: [], overrides: {} },
+        minimumRequiredTokenBalance: 15,
+        blockedTokens: {
+          default: {
+            chainIds: [],
+            tokens: [],
+          },
+          overrides: {},
+        },
+      } as MetaMaskPayTokensFlags);
+
+      selectMoneyNoFeeTokensMock.mockReturnValue({
+        '*': ['USDC'],
+      } as WildcardTokenList);
+
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [
+          {
+            address: TOKEN_ADDRESS_1_MOCK,
+            chainId: CHAIN_ID_1_MOCK,
+            symbol: 'ETH',
+            fiat: { balance: 10 },
+          },
+          {
+            address: TOKEN_ADDRESS_2_MOCK,
+            chainId: CHAIN_ID_2_MOCK,
+            symbol: 'USDC',
+            fiat: { balance: 10 },
+          },
+        ] as AssetType[],
+        hasTokens: true,
+      });
+
+      runHook();
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      });
+    });
+
+    it('selects preferred flag tokens over no-fee tokens', () => {
+      selectMetaMaskPayTokensFlagsMock.mockReturnValue({
+        preferredTokens: {
+          default: [],
+          overrides: {
+            perpsDeposit: [
+              {
+                address: TOKEN_ADDRESS_1_MOCK,
+                chainId: CHAIN_ID_1_MOCK,
+                successRate: 0.95,
+              },
+            ],
+          },
+        },
+        minimumRequiredTokenBalance: 5,
+        blockedTokens: {
+          default: {
+            chainIds: [],
+            tokens: [],
+          },
+          overrides: {},
+        },
+      } as MetaMaskPayTokensFlags);
+
+      selectMoneyNoFeeTokensMock.mockReturnValue({
+        '*': ['USDC'],
+      } as WildcardTokenList);
+
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [
+          {
+            address: TOKEN_ADDRESS_1_MOCK,
+            chainId: CHAIN_ID_1_MOCK,
+            symbol: 'ETH',
+            fiat: { balance: 10 },
+          },
+          {
+            address: TOKEN_ADDRESS_2_MOCK,
+            chainId: CHAIN_ID_2_MOCK,
+            symbol: 'USDC',
+            fiat: { balance: 10 },
+          },
+        ] as AssetType[],
+        hasTokens: true,
+      });
+
+      runHook();
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      });
+    });
+
+    it('does not select no-fee token for withdraw flows', () => {
+      selectMetaMaskPayTokensFlagsMock.mockReturnValue({
+        preferredTokens: { default: [], overrides: {} },
+        minimumRequiredTokenBalance: 5,
+        blockedTokens: {
+          default: {
+            chainIds: [],
+            tokens: [],
+          },
+          overrides: {},
+        },
+      } as MetaMaskPayTokensFlags);
+
+      selectMoneyNoFeeTokensMock.mockReturnValue({
+        '*': ['USDC'],
+      } as WildcardTokenList);
+
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: transactionIdMock,
+        type: TransactionType.perpsWithdraw,
+        txParams: { from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164' },
+      } as never);
+
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [
+          {
+            address: TOKEN_ADDRESS_2_MOCK,
+            chainId: CHAIN_ID_2_MOCK,
+            symbol: 'USDC',
+            fiat: { balance: 10 },
+          },
+        ] as AssetType[],
+        hasTokens: true,
+      });
+
+      runHook();
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -31,6 +31,12 @@ import {
   PreferredToken,
   getPreferredTokensForTransactionType,
 } from '../../../../../selectors/featureFlagController/confirmations';
+import { selectMoneyNoFeeTokens } from '../../../../UI/Money/selectors/featureFlags';
+import {
+  isTokenInWildcardList,
+  WildcardTokenList,
+} from '../../../../UI/Earn/utils/wildcardTokenList';
+import { safeFormatChainIdToHex } from '../../../../UI/Card/util/safeFormatChainIdToHex';
 import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
 import { RootState } from '../../../../../reducers';
@@ -64,6 +70,7 @@ export function useAutomaticTransactionPayToken({
   const requiredTokens = useTransactionPayRequiredTokens();
   const { availableTokens } = useTransactionPayAvailableTokens();
   const payTokensFlags = useSelector(selectMetaMaskPayTokensFlags);
+  const noFeeTokenList = useSelector(selectMoneyNoFeeTokens);
 
   const transactionMetaRequest = useTransactionMetadataRequest();
   const transactionMeta = useMemo(
@@ -135,6 +142,7 @@ export function useAutomaticTransactionPayToken({
         isWithdraw,
         lastWithdrawToken,
         minimumRequiredTokenBalance: payTokensFlags.minimumRequiredTokenBalance,
+        noFeeTokenList,
         preferredToken,
         preferredTokensFromFlags,
         targetToken,
@@ -148,6 +156,7 @@ export function useAutomaticTransactionPayToken({
       isQRWallet,
       isWithdraw,
       lastWithdrawToken,
+      noFeeTokenList,
       payTokensFlags.minimumRequiredTokenBalance,
       preferredToken,
       preferredTokensFromFlags,
@@ -304,6 +313,7 @@ function getBestToken({
   isWithdraw,
   lastWithdrawToken,
   minimumRequiredTokenBalance,
+  noFeeTokenList,
   preferredToken,
   preferredTokensFromFlags,
   targetToken,
@@ -317,6 +327,7 @@ function getBestToken({
   isWithdraw: boolean;
   lastWithdrawToken?: SetPayTokenRequest;
   minimumRequiredTokenBalance: number;
+  noFeeTokenList: WildcardTokenList;
   preferredToken?: SetPayTokenRequest;
   preferredTokensFromFlags: PreferredToken[];
   targetToken?: { address: Hex; chainId: Hex };
@@ -411,6 +422,26 @@ function getBestToken({
           };
         }
       }
+    }
+  }
+
+  if (tokens?.length && !isWithdraw) {
+    const noFeeMatch = tokens.find((token) => {
+      if (!token.chainId) return false;
+      const fiatBalance = token.fiat?.balance ?? 0;
+      if (fiatBalance < minimumRequiredTokenBalance) return false;
+      return isTokenInWildcardList(
+        token.symbol,
+        noFeeTokenList,
+        safeFormatChainIdToHex(token.chainId),
+      );
+    });
+
+    if (noFeeMatch) {
+      return {
+        address: noFeeMatch.address as Hex,
+        chainId: noFeeMatch.chainId as Hex,
+      };
     }
   }
 

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -426,21 +426,23 @@ function getBestToken({
   }
 
   if (tokens?.length && !isWithdraw) {
-    const noFeeMatch = tokens.find((token) => {
-      if (!token.chainId) return false;
-      const fiatBalance = token.fiat?.balance ?? 0;
-      if (fiatBalance < minimumRequiredTokenBalance) return false;
-      return isTokenInWildcardList(
-        token.symbol,
-        noFeeTokenList,
-        safeFormatChainIdToHex(token.chainId),
-      );
-    });
+    const noFeeCandidates = tokens
+      .filter((token) => {
+        if (!token.chainId) return false;
+        const fiatBalance = token.fiat?.balance ?? 0;
+        if (fiatBalance < minimumRequiredTokenBalance) return false;
+        return isTokenInWildcardList(
+          token.symbol,
+          noFeeTokenList,
+          safeFormatChainIdToHex(token.chainId),
+        );
+      })
+      .sort((a, b) => (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0));
 
-    if (noFeeMatch) {
+    if (noFeeCandidates.length) {
       return {
-        address: noFeeMatch.address as Hex,
-        chainId: noFeeMatch.chainId as Hex,
+        address: noFeeCandidates[0].address as Hex,
+        chainId: noFeeCandidates[0].chainId as Hex,
       };
     }
   }

--- a/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.test.ts
@@ -1,0 +1,404 @@
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { usePayWithNoFeeToken } from './usePayWithNoFeeToken';
+import { selectMoneyNoFeeTokens } from '../../../../UI/Money/selectors/featureFlags';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { AssetType } from '../../types/token';
+import { Hex } from '@metamask/utils';
+import { WildcardTokenList } from '../../../../UI/Earn/types/wildcardTokenList';
+
+jest.mock('../../../../UI/Money/selectors/featureFlags');
+jest.mock('./useTransactionPayAvailableTokens');
+
+const STATE_MOCK = {
+  engine: {
+    backgroundState: {
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {},
+      },
+    },
+  },
+};
+
+describe('usePayWithNoFeeToken', () => {
+  const selectMoneyNoFeeTokensMock = jest.mocked(selectMoneyNoFeeTokens);
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
+
+  const createMockToken = (
+    address: string,
+    symbol: string,
+    chainId: string,
+    fiatBalance: number,
+    disabled = false,
+  ): AssetType =>
+    ({
+      address: address as Hex,
+      chainId: chainId as Hex,
+      symbol,
+      fiat: { balance: fiatBalance },
+      disabled,
+      balance: `${fiatBalance}`,
+      decimals: 6,
+      image: '',
+      isETH: false,
+      logo: undefined,
+      name: symbol,
+    }) as AssetType;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({} as WildcardTokenList);
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [],
+      hasTokens: false,
+    });
+  });
+
+  it('returns undefined noFeeToken when no tokens are available', () => {
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toBeUndefined();
+  });
+
+  it('returns undefined noFeeToken when no tokens match no-fee list', () => {
+    const tokens = [
+      createMockToken('0x123', 'DAI', '0x1', 100),
+      createMockToken('0x456', 'POL', '0x1', 200),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toBeUndefined();
+  });
+
+  it('returns highest balance no-fee token', () => {
+    const tokens = [
+      createMockToken('0x123', 'USDC', '0x1', 100),
+      createMockToken('0x456', 'USDT', '0x1', 200),
+      createMockToken('0x789', 'DAI', '0x1', 300),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toEqual({
+      address: '0x456',
+      balanceUsd: '200',
+      chainId: '0x1',
+      symbol: 'USDT',
+    });
+  });
+
+  it('excludes the specified token from results', () => {
+    const tokens = [
+      createMockToken('0x123', 'USDC', '0x1', 100),
+      createMockToken('0x456', 'USDT', '0x1', 200),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        usePayWithNoFeeToken({
+          excludeToken: { address: '0x456', chainId: '0x1' },
+        }),
+      {
+        state: STATE_MOCK,
+      },
+    );
+
+    expect(result.current.noFeeToken).toEqual({
+      address: '0x123',
+      balanceUsd: '100',
+      chainId: '0x1',
+      symbol: 'USDC',
+    });
+  });
+
+  it('returns undefined when only available no-fee token is excluded', () => {
+    const tokens = [
+      createMockToken('0x123', 'USDC', '0x1', 100),
+      createMockToken('0x456', 'DAI', '0x1', 200),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        usePayWithNoFeeToken({
+          excludeToken: { address: '0x123', chainId: '0x1' },
+        }),
+      {
+        state: STATE_MOCK,
+      },
+    );
+
+    expect(result.current.noFeeToken).toBeUndefined();
+  });
+
+  it('skips disabled tokens', () => {
+    const tokens = [
+      createMockToken('0x123', 'USDC', '0x1', 100, true),
+      createMockToken('0x456', 'USDT', '0x1', 200),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toEqual({
+      address: '0x456',
+      balanceUsd: '200',
+      chainId: '0x1',
+      symbol: 'USDT',
+    });
+  });
+
+  it('isNoFeeToken returns true for matching token', () => {
+    const tokens = [createMockToken('0x123', 'USDC', '0x1', 100)];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.isNoFeeToken('0x123', '0x1')).toBe(true);
+  });
+
+  it('isNoFeeToken returns false for non-matching token', () => {
+    const tokens = [createMockToken('0x123', 'USDC', '0x1', 100)];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.isNoFeeToken('0x123', '0x1')).toBe(false);
+  });
+
+  it('handles chain-specific no-fee token lists', () => {
+    const tokens = [
+      createMockToken('0x123', 'USDC', '0x1', 100),
+      createMockToken('0x456', 'USDC', '0x89', 200),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '0x1': ['USDC'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toEqual({
+      address: '0x123',
+      balanceUsd: '100',
+      chainId: '0x1',
+      symbol: 'USDC',
+    });
+  });
+
+  it('handles case-insensitive address and chainId matching', () => {
+    const tokens = [createMockToken('0xABC', 'USDC', '0x1', 100)];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.isNoFeeToken('0xabc', '0x1')).toBe(true);
+  });
+
+  it('handles case-insensitive excludeToken matching', () => {
+    const tokens = [
+      createMockToken('0xABC', 'USDC', '0x1', 100),
+      createMockToken('0xDEF', 'USDT', '0x1', 50),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        usePayWithNoFeeToken({
+          excludeToken: { address: '0xabc', chainId: '0x1' },
+        }),
+      {
+        state: STATE_MOCK,
+      },
+    );
+
+    expect(result.current.noFeeToken).toEqual({
+      address: '0xDEF',
+      balanceUsd: '50',
+      chainId: '0x1',
+      symbol: 'USDT',
+    });
+  });
+
+  it('returns undefined when token has no chainId', () => {
+    const tokens = [
+      {
+        address: '0x123' as Hex,
+        symbol: 'USDC',
+        fiat: { balance: 100 },
+        disabled: false,
+      } as AssetType,
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toBeUndefined();
+  });
+
+  it('isNoFeeToken returns false when token has no chainId', () => {
+    const tokens = [
+      {
+        address: '0x123' as Hex,
+        symbol: 'USDC',
+        fiat: { balance: 100 },
+        disabled: false,
+      } as AssetType,
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.isNoFeeToken('0x123', '0x1')).toBe(false);
+  });
+
+  it('handles tokens with zero fiat balance', () => {
+    const tokens = [
+      createMockToken('0x123', 'USDC', '0x1', 0),
+      createMockToken('0x456', 'USDT', '0x1', 100),
+    ];
+
+    selectMoneyNoFeeTokensMock.mockReturnValue({
+      '*': ['USDC', 'USDT'],
+    } as WildcardTokenList);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: tokens,
+      hasTokens: true,
+    });
+
+    const { result } = renderHookWithProvider(() => usePayWithNoFeeToken(), {
+      state: STATE_MOCK,
+    });
+
+    expect(result.current.noFeeToken).toEqual({
+      address: '0x456',
+      balanceUsd: '100',
+      chainId: '0x1',
+      symbol: 'USDT',
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.test.ts
@@ -4,7 +4,7 @@ import { selectMoneyNoFeeTokens } from '../../../../UI/Money/selectors/featureFl
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { AssetType } from '../../types/token';
 import { Hex } from '@metamask/utils';
-import { WildcardTokenList } from '../../../../UI/Earn/types/wildcardTokenList';
+import { WildcardTokenList } from '../../../../UI/Earn/utils/wildcardTokenList';
 
 jest.mock('../../../../UI/Money/selectors/featureFlags');
 jest.mock('./useTransactionPayAvailableTokens');

--- a/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
+import { selectMoneyNoFeeTokens } from '../../../../UI/Money/selectors/featureFlags';
+import { isTokenInWildcardList } from '../../../../UI/Earn/utils/wildcardTokenList';
+import { safeFormatChainIdToHex } from '../../../../UI/Card/util/safeFormatChainIdToHex';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { AssetType } from '../../types/token';
+
+export interface NoFeeTokenResult {
+  address: Hex;
+  balanceUsd: string;
+  chainId: Hex;
+  symbol: string;
+}
+
+/**
+ * Finds the highest-balance no-fee token among available payment tokens.
+ *
+ * Accepts an optional `excludeToken` to de-duplicate against the preferred
+ * token row — when the preferred token is already a no-fee token, this hook
+ * returns the next-highest-balance no-fee token instead.
+ */
+export function usePayWithNoFeeToken({
+  excludeToken,
+}: {
+  excludeToken?: { address: string; chainId: string };
+} = {}): {
+  noFeeToken: NoFeeTokenResult | undefined;
+  isNoFeeToken: (address: string, chainId: string) => boolean;
+} {
+  const noFeeTokenList = useSelector(selectMoneyNoFeeTokens);
+  const { availableTokens } = useTransactionPayAvailableTokens();
+
+  const isNoFeeToken = useCallback(
+    (address: string, chainId: string): boolean => {
+      const token = availableTokens.find(
+        (t) =>
+          t.address.toLowerCase() === address.toLowerCase() &&
+          t.chainId?.toLowerCase() === chainId.toLowerCase(),
+      );
+
+      if (!token?.chainId) return false;
+
+      return isTokenInWildcardList(
+        token.symbol,
+        noFeeTokenList,
+        safeFormatChainIdToHex(token.chainId),
+      );
+    },
+    [availableTokens, noFeeTokenList],
+  );
+
+  const noFeeToken = useMemo(() => {
+    const enabledTokens = availableTokens.filter((t) => !t.disabled);
+
+    const eligible = enabledTokens.filter((token: AssetType) => {
+      if (!token.chainId) return false;
+
+      return isTokenInWildcardList(
+        token.symbol,
+        noFeeTokenList,
+        safeFormatChainIdToHex(token.chainId),
+      );
+    });
+
+    const sorted = [...eligible].sort(
+      (a, b) => (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0),
+    );
+
+    const match = sorted.find((token) => {
+      if (!excludeToken) return true;
+
+      return !(
+        token.address.toLowerCase() === excludeToken.address.toLowerCase() &&
+        token.chainId?.toLowerCase() === excludeToken.chainId.toLowerCase()
+      );
+    });
+
+    if (!match?.chainId) return undefined;
+
+    return {
+      address: match.address as Hex,
+      balanceUsd: `${match.fiat?.balance ?? 0}`,
+      chainId: match.chainId as Hex,
+      symbol: match.symbol,
+    };
+  }, [availableTokens, excludeToken, noFeeTokenList]);
+
+  return { noFeeToken, isNoFeeToken };
+}

--- a/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
+++ b/app/components/Views/confirmations/hooks/pay/usePayWithNoFeeToken.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { selectMoneyNoFeeTokens } from '../../../../UI/Money/selectors/featureFlags';
@@ -6,6 +6,8 @@ import { isTokenInWildcardList } from '../../../../UI/Earn/utils/wildcardTokenLi
 import { safeFormatChainIdToHex } from '../../../../UI/Card/util/safeFormatChainIdToHex';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { AssetType } from '../../types/token';
+import { NoFeeTag } from '../../components/UI/no-fee-tag';
+import { TokenTagRenderer } from '../../components/UI/token';
 
 export interface NoFeeTokenResult {
   address: Hex;
@@ -28,9 +30,22 @@ export function usePayWithNoFeeToken({
 } = {}): {
   noFeeToken: NoFeeTokenResult | undefined;
   isNoFeeToken: (address: string, chainId: string) => boolean;
+  renderNoFeeTag: TokenTagRenderer;
 } {
   const noFeeTokenList = useSelector(selectMoneyNoFeeTokens);
   const { availableTokens } = useTransactionPayAvailableTokens();
+
+  const matchesNoFeeList = useCallback(
+    (symbol: string, chainId: string | undefined): boolean => {
+      if (!chainId) return false;
+      return isTokenInWildcardList(
+        symbol,
+        noFeeTokenList,
+        safeFormatChainIdToHex(chainId),
+      );
+    },
+    [noFeeTokenList],
+  );
 
   const isNoFeeToken = useCallback(
     (address: string, chainId: string): boolean => {
@@ -40,29 +55,18 @@ export function usePayWithNoFeeToken({
           t.chainId?.toLowerCase() === chainId.toLowerCase(),
       );
 
-      if (!token?.chainId) return false;
+      if (!token) return false;
 
-      return isTokenInWildcardList(
-        token.symbol,
-        noFeeTokenList,
-        safeFormatChainIdToHex(token.chainId),
-      );
+      return matchesNoFeeList(token.symbol, token.chainId);
     },
-    [availableTokens, noFeeTokenList],
+    [availableTokens, matchesNoFeeList],
   );
 
   const noFeeToken = useMemo(() => {
-    const enabledTokens = availableTokens.filter((t) => !t.disabled);
-
-    const eligible = enabledTokens.filter((token: AssetType) => {
-      if (!token.chainId) return false;
-
-      return isTokenInWildcardList(
-        token.symbol,
-        noFeeTokenList,
-        safeFormatChainIdToHex(token.chainId),
-      );
-    });
+    const eligible = availableTokens.filter(
+      (token: AssetType) =>
+        !token.disabled && matchesNoFeeList(token.symbol, token.chainId),
+    );
 
     const sorted = [...eligible].sort(
       (a, b) => (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0),
@@ -85,7 +89,17 @@ export function usePayWithNoFeeToken({
       chainId: match.chainId as Hex,
       symbol: match.symbol,
     };
-  }, [availableTokens, excludeToken, noFeeTokenList]);
+  }, [availableTokens, excludeToken, matchesNoFeeList]);
 
-  return { noFeeToken, isNoFeeToken };
+  const renderNoFeeTag: TokenTagRenderer = useCallback(
+    (token: AssetType) => {
+      if (!matchesNoFeeList(token.symbol, token.chainId)) {
+        return null;
+      }
+      return <NoFeeTag />;
+    },
+    [matchesNoFeeList],
+  );
+
+  return { noFeeToken, isNoFeeToken, renderNoFeeTag };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

No-fee (sponsored) tokens were available in the Money Account deposit flow but not discoverable in the MM Pay payment picker. Users had to dig into "Other assets" to find them, and the "No fee" labels were easy to miss.

This PR makes sponsored tokens more discoverable by:
1. Adding a dedicated **no-fee token row** in the payment picker bottom sheet (CRYPTO section) showing the highest-balance no-fee eligible token
2. Adding **"No fee" tags** on eligible tokens in both the bottom sheet rows and the "Other assets" full token list
3. Updating the **default token selection** to prefer no-fee tokens over the generic first-available fallback
4. Establishing **tag priority**: "No fee" takes precedence over "Last used" when both apply

The no-fee token list is sourced from the existing `earn-money-deposit-no-fee-tokens` LaunchDarkly flag via `selectMoneyNoFeeTokens`.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added no-fee token discovery in payment picker with dedicated row, tags, and default selection preference

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1515

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: No-fee token discovery in payment picker

  Scenario: user sees no-fee token row in payment picker
    Given the user has tokens with balances including at least one no-fee eligible token (e.g. USDC, USDT, aTokens)
    When user opens a deposit flow and taps the payment token selector
    Then the CRYPTO section shows the highest-balance token row AND a second row with the highest-balance no-fee token with a "No fee" tag
    And an "Other assets" row below both

  Scenario: no-fee tag appears in Other assets list
    Given the user has no-fee eligible tokens
    When user taps "Other assets" in the payment picker
    Then no-fee eligible tokens display a "No fee" tag next to their name
    And long token names truncate with ellipsis to keep the tag on the same line

  Scenario: no-fee tag priority over last used
    Given a token is both no-fee eligible and last used
    When user opens the payment picker
    Then only the "No fee" tag is shown (not "Last used")

  Scenario: default selection prefers no-fee token
    Given the user has no-fee eligible tokens with sufficient balance
    And no preferred token is set via feature flags
    When user opens a deposit flow
    Then a no-fee token is automatically selected as the default payment token

  Scenario: de-duplication when preferred token is no-fee
    Given the highest balance token is also a no-fee token
    When user opens the payment picker
    Then row 1 shows that token with "No fee" tag
    And row 2 shows the next highest-balance no-fee token (or is omitted if none exists)
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/a763cd52-92ec-4902-aa63-392c24c8760b


<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default payment token selection and pay-with UI across deposit flows; withdraw paths are guarded but automatic token logic is business-critical.
> 
> **Overview**
> Surfaces **no-fee (sponsored) tokens** in MM Pay using the existing `selectMoneyNoFeeTokens` flag, so users see them in the payment picker without digging through “Other assets.”
> 
> Adds **`usePayWithNoFeeToken`** (eligibility, highest-balance pick with optional exclude, `renderNoFeeTag`) and a reusable **`NoFeeTag`**. The pay-with **crypto section** can show a dedicated no-fee row, sorts token rows by balance, sets **`isNoFee`** on preferred/selected rows, and skips no-fee UI on **withdraw** flows. **`PaymentMethodRow`** shows a “No fee” tag when **`isNoFee`** is set, **ahead of** “Last used.”
> 
> **`Token` / `TokenList` / `Asset`** accept optional **`tagRenderers`** so **PayWithModal** can label eligible tokens in the full list (with layout tweaks for truncation). **`getBestToken`** in automatic pay-token selection now prefers eligible no-fee tokens (min balance, not withdraw) after feature-flag preferred tokens and before the generic first-token fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06ceaf86381e5ae5e0ba8d2d25f5651c3c2e82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->