### PR TITLE
chore: update @metamask/ramps-controller to version 14.2.0 and add @m…

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.1.0",
     "@metamask/profile-sync-controller": "^28.1.0",
-    "@metamask/ramps-controller": "^14.1.0",
+    "@metamask/ramps-controller": "^14.2.0",
     "@metamask/react-data-query": "^0.2.0",
     "@metamask/react-native-acm": "patch:@metamask/react-native-acm@npm%3A1.2.0#~/.yarn/patches/@metamask-react-native-acm-npm-1.2.0-944bf863eb.patch",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9638,19 +9638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^14.1.1":
-  version: 14.1.1
-  resolution: "@metamask/ramps-controller@npm:14.1.1"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
-  checksum: 10/f018f6514e2bd336d13225e1df1f48a07f487ea7de26cdd72b1fe03e337c1ce0473f9b025c01ee37f1936141e222039b99930dce0474aa7b74b65fa97aa373a6
-  languageName: node
-  linkType: hard
-
-"@metamask/ramps-controller@npm:^14.2.0":
+"@metamask/ramps-controller@npm:^14.1.1, @metamask/ramps-controller@npm:^14.2.0":
   version: 14.2.0
   resolution: "@metamask/ramps-controller@npm:14.2.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9638,7 +9638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^14.1.0, @metamask/ramps-controller@npm:^14.1.1":
+"@metamask/ramps-controller@npm:^14.1.1":
   version: 14.1.1
   resolution: "@metamask/ramps-controller@npm:14.1.1"
   dependencies:
@@ -9647,6 +9647,18 @@ __metadata:
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/profile-sync-controller": "npm:^28.1.1"
   checksum: 10/f018f6514e2bd336d13225e1df1f48a07f487ea7de26cdd72b1fe03e337c1ce0473f9b025c01ee37f1936141e222039b99930dce0474aa7b74b65fa97aa373a6
+  languageName: node
+  linkType: hard
+
+"@metamask/ramps-controller@npm:^14.2.0":
+  version: 14.2.0
+  resolution: "@metamask/ramps-controller@npm:14.2.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.2.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/profile-sync-controller": "npm:^28.1.1"
+  checksum: 10/2060910d94a168370a7a4e03fd059137ded2de688b9b3c7167db3ad78c101cf201641f59c55eb1172e3bc4d6243143bd67f5d0ce8f0fcff682cddf67f3ef91f5
   languageName: node
   linkType: hard
 
@@ -35333,7 +35345,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^3.1.0"
     "@metamask/profile-sync-controller": "npm:^28.1.0"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^14.1.0"
+    "@metamask/ramps-controller": "npm:^14.2.0"
     "@metamask/react-data-query": "npm:^0.2.0"
     "@metamask/react-native-acm": "patch:@metamask/react-native-acm@npm%3A1.2.0#~/.yarn/patches/@metamask-react-native-acm-npm-1.2.0-944bf863eb.patch"
     "@metamask/react-native-actionsheet": "npm:2.4.2"


### PR DESCRIPTION
## **Description**

This PR bumps `@metamask/ramps-controller` from `^14.1.0` to `^14.2.0`. The new controller version declares `@metamask/controller-utils@^12.2.0` as a dependency, which is resolved and added to `yarn.lock` as part of this upgrade. No application code changes are required — this is a dependency maintenance bump to keep the ramps controller current with its latest published release.

The reason for the change is to stay aligned with the latest `@metamask/ramps-controller` release and to pick up the dependency updates it ships with. The solution is a straightforward version bump in `package.json` with the corresponding `yarn.lock` resolution updates.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3502

## **Manual testing steps**

```gherkin
Feature: Ramps controller dependency bump

  Scenario: Buy/Sell flows continue to work after the controller upgrade
    Given the app is built with @metamask/ramps-controller@14.2.0
    And I have a wallet with at least one account

    When I open the Buy (Add funds) flow
    Then the supported payment methods and quotes load without errors

    When I open the Sell flow
    Then the supported sell options and quotes load without errors
```

## **Screenshots/Recordings**

N/A — dependency version bump only, no UI changes.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches buy/sell (ramps) controller logic indirectly via a minor version bump with no local code changes; regression risk is in upstream controller behavior rather than this repo’s diff.
> 
> **Overview**
> Bumps **`@metamask/ramps-controller`** from **`^14.1.0`** to **`^14.2.0`** in `package.json` and refreshes **`yarn.lock`** so the app resolves controller **14.2.0** (including its updated dependency tree, e.g. **`@metamask/controller-utils@^12.2.0`**).
> 
> There are **no app source changes**—only dependency maintenance to pick up the latest published ramps controller release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbab751f1fb055ffc05a06bf16bd7a9bd1f8a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->