### PR TITLE
feat: remove rank decorations from leaderboard rows

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -326,7 +326,7 @@ jobs:
           retention-days: 7
 
       - name: Upload failure screen recordings (Namespace)
-        if: ${{ (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider == 'namespace' }}
+        if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider == 'namespace' }}
         uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
         with:
           name: appium-smoke-videos-${{ inputs.test-suite-name }}
@@ -334,7 +334,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
       - name: Upload failure screen recordings (current)
-        if: ${{ (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider != 'namespace' }}
+        if: ${{ always() && (steps.run-tests-android.outcome == 'failure' || steps.run-tests-ios.outcome == 'failure') && inputs.runner_provider != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
           name: appium-smoke-videos-${{ inputs.test-suite-name }}

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.test.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.test.ts
@@ -2,11 +2,40 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import { PostTradeBottomSheet } from './index';
 import Routes from '../../../../../constants/navigation/Routes';
+import {
+  getPostTradeSuggestionPillTestId,
+  PostTradeBottomSheetTestIds,
+} from './PostTradeBottomSheet.testIds';
+import { PostTradeStatus } from './PostTradeBottomSheet.types';
 
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
 const mockResetState = jest.fn();
 const mockUpdateQuoteParams = jest.fn();
+let mockPostTradeStatus = PostTradeStatus.Failed;
+let mockPostTradeTrendingTokens = {
+  tokens: [] as unknown[],
+  isLoading: false,
+  error: null,
+  refetch: jest.fn(),
+};
+let mockParams = {
+  status: PostTradeStatus.Failed,
+  sourceAmount: '1.23456',
+  destAmount: '2.34567',
+  sourceToken: {
+    address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    symbol: 'ETH',
+    chainId: '0x1',
+    decimals: 18,
+  },
+  destToken: {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    symbol: 'USDC',
+    chainId: '0x1',
+    decimals: 6,
+  },
+};
 
 jest.mock('react-redux', () => ({ useDispatch: () => mockDispatch }));
 jest.mock('../../hooks/useBridgeQuoteRequest', () => ({
@@ -22,32 +51,137 @@ jest.mock('../../../../../core/Engine', () => ({
   },
 }));
 jest.mock('../../../../../util/navigation/navUtils', () => ({
-  useParams: () => ({
-    status: 'failed',
-    sourceAmount: '1.23456',
-    destAmount: '2.34567',
-    sourceToken: { symbol: 'ETH', chainId: '0x1' },
-    destToken: { symbol: 'USDC', chainId: '0x1' },
-  }),
+  useParams: () => mockParams,
 }));
 jest.mock('./usePostTradeTxStatus', () => ({
-  usePostTradeTxStatus: () => 'failed',
+  usePostTradeTxStatus: () => mockPostTradeStatus,
+}));
+jest.mock('./usePostTradeTrendingTokens', () => ({
+  usePostTradeTrendingTokens: () => mockPostTradeTrendingTokens,
 }));
 
-beforeEach(jest.clearAllMocks);
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPostTradeStatus = PostTradeStatus.Failed;
+  mockPostTradeTrendingTokens = {
+    tokens: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  };
+  mockParams = {
+    status: PostTradeStatus.Failed,
+    sourceAmount: '1.23456',
+    destAmount: '2.34567',
+    sourceToken: {
+      address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      symbol: 'ETH',
+      chainId: '0x1',
+      decimals: 18,
+    },
+    destToken: {
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      symbol: 'USDC',
+      chainId: '0x1',
+      decimals: 6,
+    },
+  };
+});
 
 describe('PostTradeBottomSheet', () => {
   it('runs failed-state actions', () => {
-    const { getByTestId } = render(React.createElement(PostTradeBottomSheet));
+    const { getByTestId, queryByTestId } = render(
+      React.createElement(PostTradeBottomSheet),
+    );
 
-    fireEvent.press(getByTestId('post-trade-bottom-sheet-try-again-button'));
+    expect(
+      queryByTestId(PostTradeBottomSheetTestIds.SUGGESTIONS_SECTION),
+    ).toBeNull();
+
+    fireEvent.press(getByTestId(PostTradeBottomSheetTestIds.TRY_AGAIN_BUTTON));
     fireEvent.press(
-      getByTestId('post-trade-bottom-sheet-view-activity-button'),
+      getByTestId(PostTradeBottomSheetTestIds.VIEW_ACTIVITY_BUTTON),
     );
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
     expect(mockResetState).toHaveBeenCalled();
     expect(mockUpdateQuoteParams).toHaveBeenCalled();
-    expect(mockDispatch.mock.calls[3][0].payload).toBe('1.23456');
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'bridge/setSourceAmount',
+        payload: '1.23456',
+      }),
+    );
+  });
+
+  it('shows skeleton suggestions while trending tokens load', () => {
+    mockPostTradeStatus = PostTradeStatus.InProgress;
+    mockPostTradeTrendingTokens = {
+      tokens: [],
+      isLoading: true,
+      error: null,
+      refetch: jest.fn(),
+    };
+
+    const { getAllByTestId, getByText } = render(
+      React.createElement(PostTradeBottomSheet),
+    );
+
+    expect(getByText('What to swap next')).toBeTruthy();
+    expect(getAllByTestId('section-pills-skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('sets up the swap form with an empty source amount when a suggestion is pressed', () => {
+    mockPostTradeStatus = PostTradeStatus.Success;
+    const suggestedToken = {
+      assetId: 'eip155:1/erc20:0x1111111111111111111111111111111111111111',
+      name: 'Uniswap',
+      symbol: 'UNI',
+      decimals: 18,
+      marketCap: 1000,
+      priceChangePct: { h24: '1.23' },
+    };
+    mockPostTradeTrendingTokens = {
+      tokens: [suggestedToken],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    };
+
+    const { getByTestId } = render(React.createElement(PostTradeBottomSheet));
+
+    fireEvent.press(
+      getByTestId(getPostTradeSuggestionPillTestId(suggestedToken.assetId)),
+    );
+
+    expect(mockResetState).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'bridge/setSourceToken',
+        payload: mockParams.sourceToken,
+      }),
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'bridge/setDestToken',
+        payload: expect.objectContaining({
+          address: '0x1111111111111111111111111111111111111111',
+          chainId: '0x1',
+          symbol: 'UNI',
+        }),
+      }),
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'bridge/setIsDestTokenManuallySet',
+        payload: true,
+      }),
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'bridge/setSourceAmount',
+        payload: undefined,
+      }),
+    );
   });
 });

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.testIds.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeBottomSheet.testIds.ts
@@ -1,0 +1,11 @@
+export const PostTradeBottomSheetTestIds = {
+  CLOSE_BUTTON: 'post-trade-bottom-sheet-close-button',
+  VIEW_ACTIVITY_BUTTON: 'post-trade-bottom-sheet-view-activity-button',
+  TRY_AGAIN_BUTTON: 'post-trade-bottom-sheet-try-again-button',
+  SUGGESTIONS_SECTION: 'post-trade-bottom-sheet-suggestions-section',
+  SUGGESTIONS_LIST: 'post-trade-bottom-sheet-suggestions-list',
+  SUGGESTION_PILL: 'post-trade-bottom-sheet-suggestion-pill',
+} as const;
+
+export const getPostTradeSuggestionPillTestId = (assetId: string) =>
+  `${PostTradeBottomSheetTestIds.SUGGESTION_PILL}-${assetId}`;

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeTokenSuggestions.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/PostTradeTokenSuggestions.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useMemo } from 'react';
+import type { TrendingAsset } from '@metamask/assets-controllers';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import type { ImageSourcePropType } from 'react-native';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { BridgeToken } from '../../types';
+import PillScrollList from '../../../Trending/components/PillScrollList/PillScrollList';
+import SectionPillsSkeleton from '../../../Trending/components/SectionPillsSkeleton/SectionPillsSkeleton';
+import ExplorePill from '../../../Trending/components/ExplorePill/ExplorePill';
+import TrendingTokenLogo from '../../../Trending/components/TrendingTokenLogo';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
+import { getNetworkBadgeSource } from '../../../Trending/components/TrendingTokenRowItem/utils';
+import { formatPercentChange } from '../../../Trending/utils/formatPercentChange';
+import { strings } from '../../../../../../locales/i18n';
+import { PostTradeStatus } from './PostTradeBottomSheet.types';
+import { usePostTradeTrendingTokens } from './usePostTradeTrendingTokens';
+import {
+  getPostTradeSuggestionPillTestId,
+  PostTradeBottomSheetTestIds,
+} from './PostTradeBottomSheet.testIds';
+
+interface PostTradeSuggestionPillProps {
+  token: TrendingAsset;
+  networkBadgeImageSource?: ImageSourcePropType;
+  onPress: (token: TrendingAsset) => void;
+}
+
+const PostTradeSuggestionPill = React.memo(
+  ({
+    token,
+    networkBadgeImageSource,
+    onPress,
+  }: PostTradeSuggestionPillProps) => {
+    const { changeLabel, changeTextColor } = useMemo(
+      () => formatPercentChange(token.priceChangePct?.h24),
+      [token.priceChangePct],
+    );
+
+    const leading = useMemo(
+      () => (
+        <BadgeWrapper
+          badgePosition={BadgePosition.BottomRight}
+          badgeElement={
+            <Badge
+              size={AvatarSize.Xs}
+              variant={BadgeVariant.Network}
+              imageSource={networkBadgeImageSource}
+              isScaled={false}
+            />
+          }
+        >
+          <TrendingTokenLogo
+            assetId={token.assetId}
+            symbol={token.symbol}
+            size={24}
+            recyclingKey={token.assetId}
+          />
+        </BadgeWrapper>
+      ),
+      [networkBadgeImageSource, token.assetId, token.symbol],
+    );
+
+    const handlePress = useCallback(() => {
+      onPress(token);
+    }, [onPress, token]);
+
+    return (
+      <ExplorePill
+        onPress={handlePress}
+        testID={getPostTradeSuggestionPillTestId(token.assetId)}
+        leading={leading}
+        title={token.symbol}
+        changeLabel={changeLabel}
+        changeTextColor={changeTextColor}
+      />
+    );
+  },
+);
+
+interface PostTradeTokenSuggestionsProps {
+  status: PostTradeStatus;
+  destToken?: BridgeToken;
+  onTokenPress: (token: TrendingAsset) => void;
+}
+
+export const PostTradeTokenSuggestions = ({
+  status,
+  destToken,
+  onTokenPress,
+}: PostTradeTokenSuggestionsProps) => {
+  const shouldShowSuggestions = status !== PostTradeStatus.Failed;
+  const { tokens, isLoading } = usePostTradeTrendingTokens({
+    destToken,
+    enabled: shouldShowSuggestions,
+  });
+  const networkBadgeImageSource = useMemo(
+    () =>
+      destToken?.chainId
+        ? getNetworkBadgeSource(formatChainIdToCaip(destToken.chainId))
+        : undefined,
+    [destToken?.chainId],
+  );
+
+  const renderItem = useCallback(
+    (token: TrendingAsset) => (
+      <PostTradeSuggestionPill
+        token={token}
+        networkBadgeImageSource={networkBadgeImageSource}
+        onPress={onTokenPress}
+      />
+    ),
+    [networkBadgeImageSource, onTokenPress],
+  );
+
+  if (!shouldShowSuggestions || (!isLoading && tokens.length === 0)) {
+    return null;
+  }
+
+  return (
+    <Box
+      twClassName="px-4 pb-2"
+      testID={PostTradeBottomSheetTestIds.SUGGESTIONS_SECTION}
+    >
+      <Text variant={TextVariant.HeadingMd} fontWeight={FontWeight.Bold}>
+        {strings('bridge.post_trade_modal.what_to_swap_next')}
+      </Text>
+      <PillScrollList
+        data={tokens}
+        isLoading={isLoading}
+        renderItem={renderItem}
+        keyExtractor={(token) => token.assetId}
+        Skeleton={SectionPillsSkeleton}
+        rowCount={2}
+        maxPills={20}
+        listTestId={PostTradeBottomSheetTestIds.SUGGESTIONS_LIST}
+        wrapperTwClassName="-mx-4 bg-transparent mt-3 mb-0"
+      />
+    </Box>
+  );
+};

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
+import type { TrendingAsset } from '@metamask/assets-controllers';
 import {
   AvatarIcon,
   AvatarIconSeverity,
@@ -27,8 +28,10 @@ import { useStyles } from '../../../../../component-library/hooks';
 import Engine from '../../../../../core/Engine';
 import {
   incrementBridgeBalanceRefreshKey,
+  setDestAmount,
   setDestToken,
   setIsDestTokenManuallySet,
+  setSelectedQuoteRequestId,
   setSourceAmount,
   setSourceToken,
 } from '../../../../../core/redux/slices/bridge';
@@ -44,6 +47,10 @@ import {
 import styleSheet from './PostTradeBottomSheet.styles';
 import { usePostTradeTxStatus } from './usePostTradeTxStatus';
 import { useBridgeQuoteRequest } from '../../hooks/useBridgeQuoteRequest';
+import { PostTradeTokenSuggestions } from './PostTradeTokenSuggestions';
+import { convertApiTokenToBridgeToken } from '../../utils/tokenUtils';
+import { getTrendingTokenImageUrl } from '../../../Trending/utils/getTrendingTokenImageUrl';
+import { PostTradeBottomSheetTestIds } from './PostTradeBottomSheet.testIds';
 import {
   hidePostTradeNotificationSurface,
   showPostTradeNotificationSurface,
@@ -194,6 +201,30 @@ export const PostTradeBottomSheet = () => {
     sheetRef.current?.onCloseBottomSheet();
   };
 
+  const handleSuggestionPress = (token: TrendingAsset) => {
+    let selectedDestToken;
+    try {
+      selectedDestToken = convertApiTokenToBridgeToken(
+        token,
+        getTrendingTokenImageUrl(token.assetId),
+      );
+    } catch {
+      return;
+    }
+
+    if (params.sourceToken) {
+      dispatch(setSourceToken(params.sourceToken));
+    }
+    dispatch(setDestToken(selectedDestToken));
+    dispatch(setIsDestTokenManuallySet(true));
+    dispatch(setSourceAmount(undefined));
+    dispatch(setDestAmount(undefined));
+    dispatch(setSelectedQuoteRequestId(undefined));
+
+    Engine.context.BridgeController?.resetState?.();
+    sheetRef.current?.onCloseBottomSheet();
+  };
+
   const footerButtonProps =
     status === PostTradeStatus.Failed
       ? {
@@ -201,13 +232,13 @@ export const PostTradeBottomSheet = () => {
             children: strings('bridge.post_trade_modal.view_activity'),
             size: ButtonSize.Lg,
             onPress: handleViewActivity,
-            testID: 'post-trade-bottom-sheet-view-activity-button',
+            testID: PostTradeBottomSheetTestIds.VIEW_ACTIVITY_BUTTON,
           },
           primaryButtonProps: {
             children: strings('bridge.post_trade_modal.try_again'),
             size: ButtonSize.Lg,
             onPress: handleTryAgain,
-            testID: 'post-trade-bottom-sheet-try-again-button',
+            testID: PostTradeBottomSheetTestIds.TRY_AGAIN_BUTTON,
           },
         }
       : undefined;
@@ -216,7 +247,7 @@ export const PostTradeBottomSheet = () => {
     <BottomSheet ref={sheetRef} goBack={() => navigation.goBack()}>
       <BottomSheetHeader
         onClose={handleClose}
-        closeButtonProps={{ testID: 'post-trade-bottom-sheet-close-button' }}
+        closeButtonProps={{ testID: PostTradeBottomSheetTestIds.CLOSE_BUTTON }}
       >
         <StatusIcon status={status} />
       </BottomSheetHeader>
@@ -234,6 +265,11 @@ export const PostTradeBottomSheet = () => {
           </Text>
         ) : null}
       </Box>
+      <PostTradeTokenSuggestions
+        status={status}
+        destToken={params.destToken}
+        onTokenPress={handleSuggestionPress}
+      />
       {footerButtonProps ? (
         <BottomSheetFooter
           buttonsAlignment={ButtonsAlignment.Vertical}

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.test.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.test.ts
@@ -1,0 +1,147 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  getTrendingTokens,
+  type TrendingAsset,
+} from '@metamask/assets-controllers';
+import {
+  POST_TRADE_TRENDING_TOKENS_LIMIT,
+  usePostTradeTrendingTokens,
+} from './usePostTradeTrendingTokens';
+import type { BridgeToken } from '../../types';
+
+jest.mock('@metamask/assets-controllers', () => ({
+  getTrendingTokens: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: () => unknown) => selector(),
+}));
+
+jest.mock('../../../../../selectors/currencyRateController', () => ({
+  selectCurrentCurrency: jest.fn(() => 'usd'),
+}));
+
+const mockGetTrendingTokens = getTrendingTokens as jest.MockedFunction<
+  typeof getTrendingTokens
+>;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, cacheTime: Infinity } },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return { Wrapper };
+};
+
+const createBridgeToken = (
+  overrides: Partial<BridgeToken> = {},
+): BridgeToken => ({
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  symbol: 'USDC',
+  decimals: 6,
+  chainId: '0x1',
+  ...overrides,
+});
+
+const createTrendingToken = (
+  assetId: string,
+  symbol: string,
+  marketCap?: number,
+): TrendingAsset =>
+  ({
+    assetId,
+    symbol,
+    name: symbol,
+    decimals: 18,
+    marketCap,
+    price: '1',
+    aggregatedUsdVolume: 1000,
+    priceChangePct: { h24: '1' },
+  }) as TrendingAsset;
+
+describe('usePostTradeTrendingTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetTrendingTokens.mockResolvedValue([]);
+  });
+
+  it('fetches, sorts by market cap descending, and caps results', async () => {
+    const { Wrapper } = createWrapper();
+    const tokens = [
+      createTrendingToken(
+        'eip155:137/erc20:0x0000000000000000000000000000000000000001',
+        'POLY',
+        5000,
+      ),
+      ...Array.from({ length: 25 }, (_, index) =>
+        createTrendingToken(
+          `eip155:1/erc20:0x${(index + 1).toString(16).padStart(40, '0')}`,
+          `ETH${index + 1}`,
+          index + 1,
+        ),
+      ),
+      createTrendingToken(
+        'eip155:1/erc20:0xffffffffffffffffffffffffffffffffffffffff',
+        'NOCAP',
+      ),
+    ];
+    mockGetTrendingTokens.mockResolvedValueOnce(tokens);
+
+    const { result } = renderHook(
+      () => usePostTradeTrendingTokens({ destToken: createBridgeToken() }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetTrendingTokens).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainIds: ['eip155:1'],
+        sort: 'h24_trending',
+      }),
+    );
+    expect(mockGetTrendingTokens).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeTokenSecurityData: true,
+      }),
+    );
+    expect(mockGetTrendingTokens).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        vsCurrency: expect.any(String),
+      }),
+    );
+    expect(result.current.tokens).toHaveLength(
+      POST_TRADE_TRENDING_TOKENS_LIMIT,
+    );
+    expect(result.current.tokens[0].symbol).toBe('POLY');
+    expect(result.current.tokens[1].symbol).toBe('ETH25');
+    expect(result.current.tokens[19].symbol).toBe('ETH7');
+    expect(
+      result.current.tokens.some((token) => token.symbol === 'NOCAP'),
+    ).toBe(false);
+  });
+
+  it('does not fetch when disabled', () => {
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        usePostTradeTrendingTokens({
+          destToken: createBridgeToken(),
+          enabled: false,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.tokens).toEqual([]);
+    expect(mockGetTrendingTokens).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.ts
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  getTrendingTokens,
+  type TrendingAsset,
+} from '@metamask/assets-controllers';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import type { BridgeToken } from '../../types';
+import {
+  getMinLiquidityForChains,
+  getMinVolume24hForChains,
+} from '../../../Trending/hooks/useTrendingRequest/useTrendingRequest';
+import {
+  PriceChangeOption,
+  SortDirection,
+} from '../../../Trending/components/TrendingTokensBottomSheet';
+import { sortTrendingTokens } from '../../../Trending/utils/sortTrendingTokens';
+
+export const POST_TRADE_TRENDING_TOKENS_LIMIT = 20;
+
+const STALE_TIME_MS = 5 * 60 * 1000;
+const POST_TRADE_TRENDING_TOKENS_QUERY_KEY =
+  'bridge-post-trade-trending-tokens';
+
+export const usePostTradeTrendingTokens = ({
+  destToken,
+  enabled = true,
+}: {
+  destToken?: BridgeToken;
+  enabled?: boolean;
+}) => {
+  const destinationCaipChainId = destToken?.chainId
+    ? formatChainIdToCaip(destToken.chainId)
+    : undefined;
+  const chainIds = destinationCaipChainId ? [destinationCaipChainId] : [];
+  const isQueryEnabled = enabled && Boolean(destinationCaipChainId);
+
+  const query = useQuery<TrendingAsset[], Error>({
+    queryKey: [POST_TRADE_TRENDING_TOKENS_QUERY_KEY, destinationCaipChainId],
+    queryFn: () => {
+      if (!destinationCaipChainId) {
+        return Promise.resolve([]);
+      }
+
+      return getTrendingTokens({
+        chainIds,
+        sort: 'h24_trending',
+        minLiquidity: getMinLiquidityForChains(chainIds),
+        minVolume24hUsd: getMinVolume24hForChains(chainIds),
+        minMarketCap: 0,
+        excludeLabels: ['stable_coin', 'blue_chip'],
+      });
+    },
+    enabled: isQueryEnabled,
+    staleTime: STALE_TIME_MS,
+    cacheTime: STALE_TIME_MS,
+  });
+
+  const tokens = useMemo(() => {
+    if (!query.data?.length) {
+      return [];
+    }
+
+    return sortTrendingTokens(
+      query.data,
+      PriceChangeOption.MarketCap,
+      SortDirection.Descending,
+    ).slice(0, POST_TRADE_TRENDING_TOKENS_LIMIT);
+  }, [query.data]);
+
+  return {
+    tokens,
+    isLoading: isQueryEnabled && query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};

--- a/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalances.ts
@@ -1,53 +1,9 @@
 import { useMemo } from 'react';
-import { CaipAssetType, parseCaipAssetType } from '@metamask/utils';
-import { constants } from 'ethers';
-import {
-  isNonEvmChainId,
-  formatChainIdToHex,
-} from '@metamask/bridge-controller';
+import { CaipAssetType } from '@metamask/utils';
+import { isNonEvmChainId } from '@metamask/bridge-controller';
 import type { BridgeToken, IncludeAsset, PopularToken } from '../types';
 import { BalancesByAssetId } from './useBalancesByAssetId';
-
-/**
- * Converts API tokens to BridgeTokens with proper address and chainId formatting
- * based on whether the chain is EVM or non-EVM
- */
-const convertAPITokensToBridgeTokens = (
-  apiTokens?: (PopularToken | IncludeAsset)[] | null,
-): (BridgeToken & { assetId: CaipAssetType })[] =>
-  (Array.isArray(apiTokens) ? apiTokens : []).map((token) => {
-    const { assetReference, chainId, assetNamespace } = parseCaipAssetType(
-      token.assetId,
-    );
-    const isNonEvm = isNonEvmChainId(chainId);
-    const isNative = assetNamespace === 'slip44';
-
-    // For non-EVM chains, keep the full assetId as the address to properly match balances
-    // For EVM native tokens, use the zero address (required by useLatestBalance)
-    // For EVM ERC20 tokens, use the asset reference (the actual contract address)
-    let address: string;
-    if (isNonEvm) {
-      address = token.assetId;
-    } else if (isNative) {
-      address = constants.AddressZero;
-    } else {
-      address = assetReference;
-    }
-
-    // For EVM chains, convert chainId to Hex format for useLatestBalance to work correctly
-    // For non-EVM chains, keep CAIP format
-    const formattedChainId = isNonEvm ? chainId : formatChainIdToHex(chainId);
-
-    // Destructure to exclude iconUrl from spread, prevents navigation issues
-    const { iconUrl, ...tokenWithoutIconUrl } = token;
-
-    return {
-      ...tokenWithoutIconUrl,
-      address,
-      chainId: formattedChainId,
-      image: iconUrl, // Map API's iconUrl to BridgeToken's image
-    };
-  });
+import { convertAPITokensToBridgeTokens } from '../utils/tokenUtils';
 
 /**
  * Merges API tokens with balance data from the selector

--- a/app/components/UI/Bridge/utils/tokenUtils.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.ts
@@ -13,9 +13,17 @@ import {
 } from '@metamask/bridge-controller';
 import { zeroAddress } from 'ethereumjs-util';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import type { BridgeToken, IncludeAsset } from '../types';
+import type { BridgeToken, IncludeAsset, PopularToken } from '../types';
 import { DefaultSwapDestTokens } from '../constants/default-swap-dest-tokens';
 import { POLYGON_NATIVE_TOKEN } from '../constants/assets';
+
+export interface ApiTokenForBridgeToken {
+  assetId: string;
+  name?: string;
+  symbol: string;
+  decimals: number;
+  iconUrl?: string;
+}
 
 /**
  * Normalizes chain-specific native token addresses to the zero address for the bridge flow.
@@ -88,6 +96,49 @@ export const getNativeSourceToken = (
 
   return nativeSourceTokenFormatted;
 };
+
+/**
+ * Converts API tokens to BridgeTokens with proper address and chainId formatting
+ * based on whether the chain is EVM or non-EVM.
+ */
+export const convertApiTokenToBridgeToken = <T extends ApiTokenForBridgeToken>(
+  token: T,
+  image?: string,
+): BridgeToken & { assetId: CaipAssetType } => {
+  const assetId = token.assetId as CaipAssetType;
+  const { assetReference, chainId, assetNamespace } =
+    parseCaipAssetType(assetId);
+  const isNonEvm = isNonEvmChainId(chainId);
+  const isNative = assetNamespace === 'slip44';
+
+  let address: string;
+  if (isNonEvm) {
+    address = assetId;
+  } else if (isNative) {
+    address = zeroAddress();
+  } else {
+    address = assetReference;
+  }
+
+  const formattedChainId = isNonEvm ? chainId : formatChainIdToHex(chainId);
+  const { iconUrl, ...tokenWithoutIconUrl } = token;
+
+  return {
+    ...tokenWithoutIconUrl,
+    assetId,
+    name: token.name ?? '',
+    address,
+    chainId: formattedChainId,
+    image: image ?? iconUrl,
+  } as BridgeToken & { assetId: CaipAssetType };
+};
+
+export const convertAPITokensToBridgeTokens = (
+  apiTokens?: (PopularToken | IncludeAsset)[] | null,
+): (BridgeToken & { assetId: CaipAssetType })[] =>
+  (Array.isArray(apiTokens) ? apiTokens : []).map((token) =>
+    convertApiTokenToBridgeToken(token),
+  );
 
 /**
  * Helper function to get default destination token, handling both hex and CAIP format chain IDs

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -139,7 +139,7 @@ describe('TopTradersSection', () => {
   it('navigates to the Top Traders view when the section header is pressed', () => {
     renderWithProvider(<TopTradersSection {...defaultProps} />);
 
-    fireEvent.press(screen.getByText('Top Traders'));
+    fireEvent.press(screen.getByText('Weekly Top Traders'));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.SOCIAL_LEADERBOARD.VIEW, {
       source: 'home_carousel',

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -25,13 +25,12 @@ describe('TopTraderCard', () => {
     jest.clearAllMocks();
   });
 
-  it('renders username and 30D PnL', () => {
+  it('renders username and PnL', () => {
     renderWithProvider(
       <TopTraderCard trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
     expect(screen.getByText('sniperliquid')).toBeOnTheScreen();
-    expect(screen.getByText('+$963K')).toBeOnTheScreen();
-    expect(screen.getByText(/30D/)).toBeOnTheScreen();
+    expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
   });
 
   it('does not display ROI percentage on the card', () => {
@@ -186,6 +185,6 @@ describe('TopTraderCard', () => {
         onFollowPress={mockOnFollowPress}
       />,
     );
-    expect(screen.getByText('-$500')).toBeOnTheScreen();
+    expect(screen.getByText('-$500.00')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -17,7 +17,6 @@ import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
-import { formatPnl } from '../utils/formatPnl';
 import { hasRealAvatar } from '../utils/avatarFallback';
 
 export interface TopTraderCardProps {
@@ -55,8 +54,12 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
 }) => {
   const tw = useTailwind();
 
-  const pnlText = formatPnl(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
+  const pnlSign = isPnlPositive ? '+' : '-';
+  const pnlAbs = Math.abs(trader.pnlValue);
+  const pnlParts = pnlAbs.toFixed(2).split('.');
+  pnlParts[0] = pnlParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const pnlText = `${pnlSign}$${pnlParts.join('.')}`;
 
   return (
     <Box
@@ -119,13 +122,6 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
                 }
               >
                 {pnlText}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                {' 30D'}
               </Text>
             </Text>
           </Box>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -27,11 +27,10 @@ describe('TraderRow', () => {
     jest.clearAllMocks();
   });
 
-  it('renders rank, username, and PnL', () => {
+  it('renders username and PnL', () => {
     renderWithProvider(
       <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
-    expect(screen.getByText('1')).toBeOnTheScreen();
     expect(screen.getByText('sniperliquid')).toBeOnTheScreen();
     expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
   });
@@ -203,24 +202,6 @@ describe('TraderRow', () => {
 
       expect(buttonWithMinWidth).not.toBeNull();
       expect(resolveMinWidth(buttonWithMinWidth as ReactTestInstance)).toBe(96);
-    });
-
-    it('renders the rank on a single line so the trailing dot does not wrap for double-digit ranks', () => {
-      const doubleDigitTrader: TopTrader = {
-        ...baseTrader,
-        rank: 20,
-        overallRank: 20,
-      };
-      renderWithProvider(
-        <TraderRow
-          trader={doubleDigitTrader}
-          onFollowPress={mockOnFollowPress}
-        />,
-      );
-
-      const rankText = screen.getByText('20');
-
-      expect(rankText.props.numberOfLines).toBe(1);
     });
 
     it('vertically centers the Follow button so it sits in the middle of the row (overrides ButtonBase self-start default)', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -27,14 +27,13 @@ describe('TraderRow', () => {
     jest.clearAllMocks();
   });
 
-  it('renders rank, username, ROI, and PnL', () => {
+  it('renders rank, username, and PnL', () => {
     renderWithProvider(
       <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
     expect(screen.getByText('1')).toBeOnTheScreen();
     expect(screen.getByText('sniperliquid')).toBeOnTheScreen();
-    expect(screen.getByText('+43.0%')).toBeOnTheScreen();
-    expect(screen.getByText('+$963K')).toBeOnTheScreen();
+    expect(screen.getByText('+$963,146.80')).toBeOnTheScreen();
   });
 
   it('renders avatar image when avatarUri is present', () => {
@@ -122,7 +121,7 @@ describe('TraderRow', () => {
     expect(mockOnTraderPress).not.toHaveBeenCalled();
   });
 
-  it('displays negative ROI and PnL values', () => {
+  it('displays negative PnL values', () => {
     const negativeTrader: TopTrader = {
       ...baseTrader,
       percentageChange: -15.3,
@@ -131,8 +130,7 @@ describe('TraderRow', () => {
     renderWithProvider(
       <TraderRow trader={negativeTrader} onFollowPress={mockOnFollowPress} />,
     );
-    expect(screen.getByText('-15.3%')).toBeOnTheScreen();
-    expect(screen.getByText('-$500')).toBeOnTheScreen();
+    expect(screen.getByText('-$500.00')).toBeOnTheScreen();
   });
 
   it('uses custom testID when provided', () => {
@@ -183,9 +181,9 @@ describe('TraderRow', () => {
         <TraderRow trader={trader} onFollowPress={mockOnFollowPress} />,
       );
 
-      const roiSegment = screen.getByText('+28233.0%');
+      const pnlSegment = screen.getByText('+$407,000.00');
       const statsText = findAncestor(
-        roiSegment,
+        pnlSegment,
         (node) => node.props?.numberOfLines === 1,
       );
 

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -20,7 +20,6 @@ import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { TopRankAvatar, TopRankIndicator } from '../topRank';
 import type { TopTrader } from '../types';
-import { formatPnl } from '../utils/formatPnl';
 import { hasRealAvatar } from '../utils/avatarFallback';
 
 const AVATAR_SIZE = 40;
@@ -54,11 +53,12 @@ const TraderRow: React.FC<TraderRowProps> = ({
 }) => {
   const tw = useTailwind();
 
-  const roiSign = trader.percentageChange >= 0 ? '+' : '';
-  const roiText = `${roiSign}${trader.percentageChange.toFixed(1)}%`;
-  const pnlText = formatPnl(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
-  const isRoiPositive = trader.percentageChange >= 0;
+  const pnlSign = isPnlPositive ? '+' : '-';
+  const pnlAbs = Math.abs(trader.pnlValue);
+  const pnlParts = pnlAbs.toFixed(2).split('.');
+  pnlParts[0] = pnlParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const pnlText = `${pnlSign}$${pnlParts.join('.')}`;
 
   return (
     <Box
@@ -121,40 +121,12 @@ const TraderRow: React.FC<TraderRowProps> = ({
             <Text
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
+              twClassName={
+                isPnlPositive ? 'text-success-default' : 'text-error-default'
+              }
               numberOfLines={1}
             >
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                twClassName={
-                  isRoiPositive ? 'text-success-default' : 'text-error-default'
-                }
-              >
-                {roiText}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
-              >
-                {' \u00B7 '}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                twClassName={
-                  isPnlPositive ? 'text-success-default' : 'text-error-default'
-                }
-              >
-                {pnlText}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextAlternative}
-              >
-                {' 30D'}
-              </Text>
+              {pnlText}
             </Text>
           </Box>
         </Box>

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -18,7 +18,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import { TopRankAvatar, TopRankIndicator } from '../topRank';
+import { TopRankAvatar } from '../topRank';
 import type { TopTrader } from '../types';
 import { hasRealAvatar } from '../utils/avatarFallback';
 
@@ -85,11 +85,6 @@ const TraderRow: React.FC<TraderRowProps> = ({
           alignItems={BoxAlignItems.Center}
           gap={3}
         >
-          <TopRankIndicator
-            rank={trader.rank}
-            podiumRank={trader.overallRank}
-          />
-
           <TopRankAvatar rank={trader.overallRank}>
             {hasRealAvatar(trader.avatarUri) ? (
               <Image

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -85,7 +85,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
           alignItems={BoxAlignItems.Center}
           gap={3}
         >
-          <TopRankAvatar rank={trader.overallRank}>
+          <TopRankAvatar>
             {hasRealAvatar(trader.avatarUri) ? (
               <Image
                 source={{ uri: trader.avatarUri }}

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -93,7 +93,7 @@ export const useTopTraders = (
       username: entry.name,
       avatarUri: entry.imageUrl ?? undefined,
       percentageChange: (entry.roiPercent30d ?? 0) * 100,
-      pnlValue: entry.pnl30d,
+      pnlValue: entry.pnl7d ?? entry.pnl30d,
       pnlPerChain: entry.pnlPerChain ?? {},
       isFollowing: isFollowing(entry.profileId),
     }));

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.test.tsx
@@ -14,21 +14,8 @@ const renderWithRank = (rank: number) =>
   );
 
 describe('TopRankAvatar', () => {
-  it.each([1, 2, 3])(
-    'wraps the avatar with a gradient ring and floating crown for rank %s',
-    (rank) => {
-      renderWithRank(rank);
-
-      expect(
-        screen.getByTestId(`top-rank-gradient-ring-${rank}`),
-      ).toBeOnTheScreen();
-      expect(screen.getByTestId(`top-rank-crown-${rank}`)).toBeOnTheScreen();
-      expect(screen.getByTestId('avatar-child')).toBeOnTheScreen();
-    },
-  );
-
-  it.each([0, 4, 5, 19, 100])(
-    'passes children through unchanged for non-podium rank %s',
+  it.each([1, 2, 3, 4, 5, 100])(
+    'passes children through unchanged for rank %s',
     (rank) => {
       renderWithRank(rank);
 

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.tsx
@@ -1,35 +1,12 @@
 import React from 'react';
-import GradientRing from './GradientRing';
-import CrownEmoji from './CrownEmoji';
-import { isTopRank } from './topRank.colors';
 
 interface TopRankAvatarProps {
-  /**
-   * Rank used to decide whether to decorate the avatar. Pass the trader's
-   * overall (unfiltered) rank so the gold/silver/bronze treatment only fires
-   * for true top-3 traders.
-   */
   rank: number;
   children: React.ReactNode;
 }
 
-/**
- * Wraps an avatar with the top-rank decoration for podium ranks (1–3): a
- * chrome gradient ring around the avatar plus a floating crown / medal emoji
- * above its top-right corner.
- *
- * For ranks > 3, `children` is rendered unchanged.
- */
-const TopRankAvatar: React.FC<TopRankAvatarProps> = ({ rank, children }) => {
-  if (!isTopRank(rank)) {
-    return <>{children}</>;
-  }
-
-  return (
-    <CrownEmoji rank={rank}>
-      <GradientRing rank={rank}>{children}</GradientRing>
-    </CrownEmoji>
-  );
-};
+const TopRankAvatar: React.FC<TopRankAvatarProps> = ({ children }) => (
+  <>{children}</>
+);
 
 export default TopRankAvatar;

--- a/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/topRank/TopRankAvatar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 interface TopRankAvatarProps {
-  rank: number;
   children: React.ReactNode;
 }
 

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -174,7 +174,7 @@ describe('TopTradersView', () => {
 
   it('renders the Top Traders title', () => {
     renderWithProvider(<TopTradersView />);
-    expect(screen.getByText('Top Traders')).toBeOnTheScreen();
+    expect(screen.getByText('Weekly Top Traders')).toBeOnTheScreen();
   });
 
   it('calls goBack when the back button is pressed', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -186,7 +186,7 @@ const fixtureProfile: TraderProfileResponse = {
     imageUrl: 'https://example.com/avatar.png',
   },
   stats: {
-    pnl30d: 20610,
+    pnl7d: 20610,
     winRate30d: 0.92,
     roiPercent30d: 1.5,
     tradeCount30d: 48,
@@ -859,10 +859,10 @@ describe('TraderProfileView', () => {
       expect(screen.getByText('+$7,500.00')).toBeOnTheScreen();
     });
 
-    it('falls back to the global stats.pnl30d when perChainPnl is empty', () => {
+    it('falls back to the global stats.pnl7d when perChainPnl is empty', () => {
       mockProfileResult.profile = {
         ...fixtureProfile,
-        stats: { ...fixtureProfile.stats, pnl30d: 20_610 },
+        stats: { ...fixtureProfile.stats, pnl7d: 20_610 },
         perChainBreakdown: {
           perChainPnl: {},
           perChainRoi: {},

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -381,7 +381,6 @@ const TraderProfileView = () => {
                 profile={profile.profile}
                 followerCount={profile.followerCount}
                 twitterHandle={profile.socialHandles?.twitter}
-                rank={traderRank}
               />
             )}
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -159,11 +159,11 @@ const TraderProfileView = () => {
     if (!perChainPnl || Object.keys(perChainPnl).length === 0) {
       return profile.stats;
     }
-    const spotPnl30d = SPOT_CHAINS.reduce(
+    const spotPnl7d = SPOT_CHAINS.reduce(
       (sum, chain) => sum + (perChainPnl[chain] ?? 0),
       0,
     );
-    return { ...profile.stats, pnl30d: spotPnl30d };
+    return { ...profile.stats, pnl7d: spotPnl7d };
   }, [profile]);
   // Fire Trader Profile Screen Viewed once profile resolves so we have an
   // accurate trader_address / is_following at the point the user lands.

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -72,7 +72,7 @@ describe('PositionRow', () => {
 
   it('renders unrealized $ PnL alongside the percent on the bottom-right', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
-    expect(screen.getByText('+$1,059.96 (+182%)')).toBeOnTheScreen();
+    expect(screen.getByText('+$1,059.96 (+182.00%)')).toBeOnTheScreen();
   });
 
   it('renders negative unrealized $ PnL with the percent', () => {
@@ -83,7 +83,7 @@ describe('PositionRow', () => {
     };
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('-$250.00 (-25%)')).toBeOnTheScreen();
+    expect(screen.getByText('-$250.00 (-25.00%)')).toBeOnTheScreen();
   });
 
   it('falls back to just the percent when pnlValueUsd is missing', () => {
@@ -93,7 +93,7 @@ describe('PositionRow', () => {
     } as unknown as Position;
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('+182%')).toBeOnTheScreen();
+    expect(screen.getByText('+182.00%')).toBeOnTheScreen();
   });
 
   it('renders dash when pnlPercent is null', () => {
@@ -127,7 +127,7 @@ describe('PositionRow', () => {
     };
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('$0.00 (+0%)')).toBeOnTheScreen();
+    expect(screen.getByText('$0.00 (+0.00%)')).toBeOnTheScreen();
   });
 
   it('renders negative USD value', () => {
@@ -224,8 +224,8 @@ describe('PositionRow', () => {
       renderWithProvider(<PositionRow position={closedPosition} />);
 
       // realizedPnl (300) / boughtUsd (1200) * 100 = 25%
-      expect(screen.getByText('25%')).toBeOnTheScreen();
-      expect(screen.queryByText('+25%')).toBeNull();
+      expect(screen.getByText('25.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('+25.00%')).toBeNull();
     });
 
     it('renders dash for PnL when boughtUsd is zero', () => {
@@ -242,8 +242,8 @@ describe('PositionRow', () => {
       renderWithProvider(<PositionRow position={position} />);
 
       // -300 / 1200 * 100 = -25%
-      expect(screen.getByText('25%')).toBeOnTheScreen();
-      expect(screen.queryByText('-25%')).toBeNull();
+      expect(screen.getByText('25.00%')).toBeOnTheScreen();
+      expect(screen.queryByText('-25.00%')).toBeNull();
     });
 
     it('uses realized PnL percent even when pnlPercent is 0', () => {
@@ -251,7 +251,7 @@ describe('PositionRow', () => {
 
       renderWithProvider(<PositionRow position={position} />);
 
-      expect(screen.getByText('25%')).toBeOnTheScreen();
+      expect(screen.getByText('25.00%')).toBeOnTheScreen();
     });
 
     it('renders break-even realized PnL with a neutral minus and 0% percent', () => {
@@ -262,7 +262,7 @@ describe('PositionRow', () => {
       expect(screen.getByText('$0.00')).toBeOnTheScreen();
       // U+2212 minus glyph, not a hyphen
       expect(screen.getByText('−')).toBeOnTheScreen();
-      expect(screen.getByText('0%')).toBeOnTheScreen();
+      expect(screen.getByText('0.00%')).toBeOnTheScreen();
     });
 
     it('renders realized PnL value when boughtUsd is zero (percent null)', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 import {
   Box,
   Text,
@@ -19,6 +19,10 @@ import {
   formatPercent,
   formatTradeDate,
 } from '../../utils/formatters';
+
+const styles = StyleSheet.create({
+  caret: { fontSize: 8 },
+});
 
 export interface PositionRowProps {
   position: Position;
@@ -79,7 +83,11 @@ const PositionRow: React.FC<PositionRowProps> = ({ position, onPress }) => {
           {'−'}
         </Text>
       ) : (
-        <Text variant={TextVariant.BodySm} twClassName={pnlColorClass}>
+        <Text
+          variant={TextVariant.BodyXs}
+          twClassName={pnlColorClass}
+          style={styles.caret}
+        >
           {isPnlPositive ? '▲' : '▼'}
         </Text>
       )}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -21,8 +21,6 @@ import { strings } from '../../../../../../locales/i18n';
 import type { TraderProfile } from '@metamask/social-controllers';
 import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { TopRankAvatar } from '../../../Homepage/Sections/TopTraders/topRank';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
 
 const AVATAR_SIZE = 40;
@@ -31,18 +29,12 @@ export interface ProfileHeaderProps {
   profile: TraderProfile;
   followerCount: number;
   twitterHandle?: string | null;
-  /**
-   * Optional leaderboard rank used to render the top-rank decoration
-   * (gradient ring + crown emoji) around the avatar for ranks 1-3.
-   */
-  rank?: number;
 }
 
 const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   profile,
   followerCount,
   twitterHandle,
-  rank,
 }) => {
   const tw = useTailwind();
 
@@ -60,24 +52,22 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
       gap={4}
       testID={TraderProfileViewSelectorsIDs.HEADER}
     >
-      <TopRankAvatar rank={rank ?? 0}>
-        {hasRealAvatar(profile.imageUrl) ? (
-          <Image
-            source={{ uri: profile.imageUrl }}
-            style={tw.style(
-              `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-            )}
-            resizeMode="cover"
-          />
-        ) : (
-          <AvatarAccount
-            variant={AvatarAccountVariant.Maskicon}
-            address={profile.address}
-            size={AvatarAccountSize.Lg}
-            twClassName="rounded-full"
-          />
-        )}
-      </TopRankAvatar>
+      {hasRealAvatar(profile.imageUrl) ? (
+        <Image
+          source={{ uri: profile.imageUrl }}
+          style={tw.style(
+            `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
+          )}
+          resizeMode="cover"
+        />
+      ) : (
+        <AvatarAccount
+          variant={AvatarAccountVariant.Maskicon}
+          address={profile.address}
+          size={AvatarAccountSize.Lg}
+          twClassName="rounded-full"
+        />
+      )}
 
       <Box twClassName="flex-1 min-w-0">
         <Box

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
@@ -6,7 +6,7 @@ import type { TraderStats } from '@metamask/social-controllers';
 import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
 
 const baseStats: TraderStats = {
-  pnl30d: 20610,
+  pnl7d: 20610,
   winRate30d: 0.92,
   roiPercent30d: 1.5,
   tradeCount30d: 48,
@@ -39,32 +39,32 @@ describe('StatsRow', () => {
     expect(screen.getByText('0%')).toBeOnTheScreen();
   });
 
-  it('renders formatted PnL when pnl30d is non-null and positive', () => {
+  it('renders formatted PnL when pnl7d is non-null and positive', () => {
     renderWithProvider(<StatsRow stats={baseStats} />);
     expect(screen.getByText('+$20,610.00')).toBeOnTheScreen();
   });
 
-  it('renders dash when pnl30d is null', () => {
-    const stats = { ...baseStats, pnl30d: null } as unknown as TraderStats;
+  it('renders dash when pnl7d is null', () => {
+    const stats = { ...baseStats, pnl7d: null } as unknown as TraderStats;
     renderWithProvider(<StatsRow stats={stats} />);
     const dashes = screen.getAllByText('\u2014');
     expect(dashes.length).toBeGreaterThanOrEqual(2);
   });
 
   it('renders negative PnL correctly', () => {
-    const stats = { ...baseStats, pnl30d: -5000 };
+    const stats = { ...baseStats, pnl7d: -5000 };
     renderWithProvider(<StatsRow stats={stats} />);
     expect(screen.getByText('-$5,000.00')).toBeOnTheScreen();
   });
 
   it('renders PnL for small values without K suffix', () => {
-    const stats = { ...baseStats, pnl30d: 500 };
+    const stats = { ...baseStats, pnl7d: 500 };
     renderWithProvider(<StatsRow stats={stats} />);
     expect(screen.getByText('+$500.00')).toBeOnTheScreen();
   });
 
   it('rounds decimal PnL values to two places', () => {
-    const stats = { ...baseStats, pnl30d: 500.236 };
+    const stats = { ...baseStats, pnl7d: 500.236 };
     renderWithProvider(<StatsRow stats={stats} />);
     expect(screen.getByText('+$500.24')).toBeOnTheScreen();
   });
@@ -73,7 +73,7 @@ describe('StatsRow', () => {
     const stats = {
       ...baseStats,
       winRate30d: null,
-      pnl30d: null,
+      pnl7d: null,
     } as unknown as TraderStats;
 
     renderWithProvider(<StatsRow stats={stats} />);

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
@@ -44,8 +44,22 @@ describe('StatsRow', () => {
     expect(screen.getByText('+$20,610.00')).toBeOnTheScreen();
   });
 
+  it('falls back to pnl30d when pnl7d is absent (backend transition)', () => {
+    const stats = {
+      ...baseStats,
+      pnl7d: undefined,
+      pnl30d: 15000,
+    } as unknown as TraderStats;
+    renderWithProvider(<StatsRow stats={stats} />);
+    expect(screen.getByText('+$15,000.00')).toBeOnTheScreen();
+  });
+
   it('renders dash when pnl7d is null', () => {
-    const stats = { ...baseStats, pnl7d: null } as unknown as TraderStats;
+    const stats = {
+      ...baseStats,
+      pnl7d: null,
+      pnl30d: undefined,
+    } as unknown as TraderStats;
     renderWithProvider(<StatsRow stats={stats} />);
     const dashes = screen.getAllByText('\u2014');
     expect(dashes.length).toBeGreaterThanOrEqual(2);

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.test.tsx
@@ -112,18 +112,18 @@ describe('StatsRow', () => {
   it('renders win rate label', () => {
     renderWithProvider(<StatsRow stats={baseStats} />);
 
-    expect(screen.getByText('win rate')).toBeOnTheScreen();
+    expect(screen.getByText('Win rate')).toBeOnTheScreen();
   });
 
-  it('renders 30D Return label', () => {
+  it('renders 7D Return label', () => {
     renderWithProvider(<StatsRow stats={baseStats} />);
 
-    expect(screen.getByText('30D Return')).toBeOnTheScreen();
+    expect(screen.getByText('7D Return')).toBeOnTheScreen();
   });
 
   it('renders hold time label', () => {
     renderWithProvider(<StatsRow stats={baseStats} />);
 
-    expect(screen.getByText('hold time')).toBeOnTheScreen();
+    expect(screen.getByText('Hold time')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.tsx
@@ -61,10 +61,9 @@ const StatsRow: React.FC<StatsRowProps> = ({ stats, holdTimeMinutes }) => {
       : '\u2014';
   const isWinRatePositive = (stats.winRate30d ?? 0) > 0;
 
-  const hasPnl = stats.pnl30d != null;
-  const pnl =
-    stats.pnl30d != null ? formatPnlWithCents(stats.pnl30d) : '\u2014';
-  const isPnlPositive = stats.pnl30d != null && stats.pnl30d >= 0;
+  const hasPnl = stats.pnl7d != null;
+  const pnl = stats.pnl7d != null ? formatPnlWithCents(stats.pnl7d) : '\u2014';
+  const isPnlPositive = stats.pnl7d != null && stats.pnl7d >= 0;
 
   return (
     <Box

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/StatsRow.tsx
@@ -61,9 +61,10 @@ const StatsRow: React.FC<StatsRowProps> = ({ stats, holdTimeMinutes }) => {
       : '\u2014';
   const isWinRatePositive = (stats.winRate30d ?? 0) > 0;
 
-  const hasPnl = stats.pnl7d != null;
-  const pnl = stats.pnl7d != null ? formatPnlWithCents(stats.pnl7d) : '\u2014';
-  const isPnlPositive = stats.pnl7d != null && stats.pnl7d >= 0;
+  const pnlValue = stats.pnl7d ?? stats.pnl30d;
+  const hasPnl = pnlValue != null;
+  const pnl = pnlValue != null ? formatPnlWithCents(pnlValue) : '\u2014';
+  const isPnlPositive = pnlValue != null && pnlValue >= 0;
 
   return (
     <Box

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -107,15 +107,15 @@ describe('formatTokenAmount', () => {
 
 describe('formatPercent', () => {
   it('formats positive percent with plus sign', () => {
-    expect(formatPercent(182)).toBe('+182%');
+    expect(formatPercent(182)).toBe('+182.00%');
   });
 
   it('formats negative percent', () => {
-    expect(formatPercent(-25)).toBe('-25%');
+    expect(formatPercent(-25)).toBe('-25.00%');
   });
 
   it('formats zero percent with plus sign', () => {
-    expect(formatPercent(0)).toBe('+0%');
+    expect(formatPercent(0)).toBe('+0.00%');
   });
 
   it('returns an em dash for null', () => {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -55,7 +55,7 @@ export function formatTokenAmount(value: number): string {
 
 export function formatPercent(value: number | null | undefined): string {
   if (value == null) return EM_DASH;
-  return formatPercentage(value, 0);
+  return formatPercentage(value, 2);
 }
 
 /**

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1074,9 +1074,9 @@
     "trader_profile": {
       "followers_count": "{{count}} follower",
       "followers_count_plural": "{{count}} followers",
-      "win_rate": "win rate",
-      "pnl_30d": "30D Return",
-      "hold_time": "hold time",
+      "win_rate": "Win rate",
+      "pnl_30d": "7D Return",
+      "hold_time": "Hold time",
       "hold_time_minutes": "{{count}}m",
       "hold_time_hours": "{{count}} hrs",
       "hold_time_days": "{{count}} days",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1041,7 +1041,7 @@
   },
   "social_leaderboard": {
     "top_traders_view": {
-      "title": "Top Traders",
+      "title": "Weekly Top Traders",
       "chain_filter": {
         "all": "All"
       }
@@ -9703,7 +9703,7 @@
       "related_assets": "Related Assets",
       "perpetuals": "Perpetuals",
       "predictions": "Predictions",
-      "top_traders": "Top Traders",
+      "top_traders": "Weekly Top Traders",
       "defi": "DeFi",
       "nfts": "NFTs",
       "trending_tokens": "Trending",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7781,6 +7781,7 @@
       "bridge_success": "Bridge complete",
       "bridge_failed": "Bridge failed",
       "trade_subtitle": "{{sourceAmount}} {{sourceSymbol}} → {{destAmount}} {{destSymbol}}",
+      "what_to_swap_next": "What to swap next",
       "view_activity": "View activity",
       "try_again": "Try again"
     },

--- a/tests/flows/perps.flow.ts
+++ b/tests/flows/perps.flow.ts
@@ -6,7 +6,6 @@ import {
   PlaywrightGestures,
 } from '../framework';
 import PerpsMarketDetailsView from '../page-objects/Perps/PerpsMarketDetailsView';
-import PerpsHomeView from '../page-objects/Perps/PerpsHomeView';
 import PerpsMarketListView from '../page-objects/Perps/PerpsMarketListView';
 import PerpsOnboarding from '../page-objects/Perps/PerpsOnboarding';
 import PerpsOrderView from '../page-objects/Perps/PerpsOrderView';
@@ -166,20 +165,22 @@ export const waitForOrderScreenVisible = async (
 
 export type PerpsPositionDirection = 'long' | 'short';
 
-export const openPosition = async (
+/**
+ * Opens Perps from the wallet home, selects a watchlist market, and taps Long/Short.
+ */
+export const navigateToPerpsOrderEntry = async (
   symbol: string,
   direction: PerpsPositionDirection,
 ): Promise<void> => {
   await WalletView.scrollAndTapPerpsSection();
-  await PerpsHomeView.tapExploreCryptoIfVisible();
+  await PerpsMarketListView.selectMarketAndTapOrderSide(symbol, direction);
+};
 
-  await PerpsMarketListView.selectMarket(symbol);
-  if (direction === 'long') {
-    await PerpsMarketDetailsView.tapLongButton();
-  } else {
-    await PerpsMarketDetailsView.tapShortButton();
-  }
-
+export const openPosition = async (
+  symbol: string,
+  direction: PerpsPositionDirection,
+): Promise<void> => {
+  await navigateToPerpsOrderEntry(symbol, direction);
   await PerpsOrderView.tapPlaceOrderButton();
   await PerpsMarketDetailsView.waitForScreenReady();
   await PerpsMarketDetailsView.expectClosePositionButtonVisible();

--- a/tests/page-objects/Perps/PerpsMarketListView.ts
+++ b/tests/page-objects/Perps/PerpsMarketListView.ts
@@ -1,7 +1,9 @@
 import {
+  PerpsHomeViewSelectorsIDs,
   PerpsMarketListViewSelectorsIDs,
   PerpsMarketRowItemSelectorsIDs,
   PerpsTokenSelectorSelectorsIDs,
+  PerpsWatchlistSelectorsIDs,
   getPerpsMarketRowItemSelector,
 } from '../../../app/components/UI/Perps/Perps.testIds';
 import Gestures from '../../framework/Gestures';
@@ -13,6 +15,10 @@ import {
 } from '../../framework/EncapsulatedElement';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import { encapsulatedAction, PlaywrightGestures } from '../../framework';
+import Utilities from '../../framework/Utilities';
+import PerpsMarketDetailsView from './PerpsMarketDetailsView';
+
+export type PerpsOrderSide = 'long' | 'short';
 
 class PerpsMarketListView {
   // Main container
@@ -166,13 +172,96 @@ class PerpsMarketListView {
     await Gestures.waitAndTap(this.container);
   }
 
+  private getMarketRowElement(marketName: string) {
+    return Matchers.getElementByID(
+      `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`,
+    );
+  }
+
+  private get perpsHomeScrollView(): Promise<Detox.NativeMatcher> {
+    return Matchers.getIdentifier(PerpsHomeViewSelectorsIDs.SCROLL_CONTENT);
+  }
+
+  /**
+   * Scrolls the Perps home feed (or full market list) until the market row is visible.
+   * Avoids tapping Explore crypto, which is flaky when clipped on CI.
+   */
+  async scrollToMarketRow(marketName: string): Promise<void> {
+    const marketElement = this.getMarketRowElement(marketName);
+
+    if (await Utilities.isElementVisible(marketElement, 1500)) {
+      return;
+    }
+
+    const watchlistSection = Matchers.getElementByID(
+      PerpsWatchlistSelectorsIDs.SECTION,
+    );
+    const perpsHomeScrollVisible = await Utilities.isElementVisible(
+      Matchers.getElementByID(PerpsHomeViewSelectorsIDs.SCROLL_CONTENT),
+      1000,
+    );
+
+    if (perpsHomeScrollVisible) {
+      if (await Utilities.isElementVisible(watchlistSection, 1000)) {
+        await Gestures.scrollToElement(
+          watchlistSection,
+          this.perpsHomeScrollView,
+          {
+            direction: 'down',
+            scrollAmount: 200,
+            timeout: 10000,
+            elemDescription: 'Perps home watchlist section',
+          },
+        );
+      }
+
+      if (await Utilities.isElementVisible(marketElement, 1000)) {
+        return;
+      }
+
+      await Gestures.scrollToElement(marketElement, this.perpsHomeScrollView, {
+        direction: 'down',
+        scrollAmount: 200,
+        timeout: 10000,
+        elemDescription: `${marketName} market row on Perps home`,
+      });
+
+      if (await Utilities.isElementVisible(marketElement, 1000)) {
+        return;
+      }
+
+      await Gestures.scrollToElement(marketElement, this.perpsHomeScrollView, {
+        direction: 'up',
+        scrollAmount: 200,
+        timeout: 10000,
+        elemDescription: `${marketName} market row on Perps home (scroll up)`,
+      });
+
+      return;
+    }
+
+    const marketListVisible = await Utilities.isElementVisible(
+      this.container,
+      1000,
+    );
+    if (marketListVisible) {
+      await Gestures.scrollToElement(marketElement, this.scrollableContainer, {
+        direction: 'down',
+        scrollAmount: 200,
+        timeout: 10000,
+        elemDescription: `${marketName} market row in market list`,
+      });
+    }
+  }
+
   async selectMarket(marketName: string) {
     await encapsulatedAction({
       detox: async () => {
-        const marketElement = Matchers.getElementByID(
-          `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`,
-        );
-        await Gestures.waitAndTap(marketElement);
+        const marketElement = this.getMarketRowElement(marketName);
+        await this.scrollToMarketRow(marketName);
+        await Gestures.waitAndTap(marketElement, {
+          elemDescription: `${marketName} market row`,
+        });
       },
       appium: async () => {
         const marketSelector = `${PerpsMarketRowItemSelectorsIDs.ROW_ITEM}-${marketName}`;
@@ -184,6 +273,29 @@ class PerpsMarketListView {
         await PlaywrightGestures.waitAndTap(marketElement);
       },
     });
+  }
+
+  /**
+   * Selects a market from the Perps home watchlist and taps Long or Short on
+   * market details. Scrolls the home feed when needed; retries until both steps succeed.
+   */
+  async selectMarketAndTapOrderSide(
+    marketName: string,
+    side: PerpsOrderSide,
+    options: { interval?: number; timeout?: number } = {},
+  ): Promise<void> {
+    const { interval = 1000, timeout = 30000 } = options;
+    await Utilities.executeWithRetry(
+      async () => {
+        await this.selectMarket(marketName);
+        if (side === 'long') {
+          await PerpsMarketDetailsView.tapLongButton();
+        } else {
+          await PerpsMarketDetailsView.tapShortButton();
+        }
+      },
+      { interval, timeout },
+    );
   }
 }
 

--- a/tests/smoke/perps/perps-limit-long-fill.spec.ts
+++ b/tests/smoke/perps/perps-limit-long-fill.spec.ts
@@ -6,18 +6,15 @@ import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
 } from '../../api-mocking/mock-responses/perps-arbitrum-mocks';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
-import PerpsMarketDetailsView from '../../page-objects/Perps/PerpsMarketDetailsView';
+import { navigateToPerpsOrderEntry } from '../../flows/perps.flow';
 import PerpsOrderView from '../../page-objects/Perps/PerpsOrderView';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
 import PerpsView from '../../page-objects/Perps/PerpsView';
 import { RampsRegions, RampsRegionsEnum } from '../../framework/Constants';
 import PerpsE2EModifiers from '../../helpers/perps/perps-modifiers';
 import { TestSuiteParams } from '../../framework/types';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import Utilities from '../../framework/Utilities';
+
 describe(SmokePerps('Perps - ETH limit long fill'), () => {
   it('creates ETH limit long at Mid, shows open order, then fills after -15%', async () => {
     await withFixtures(
@@ -64,18 +61,7 @@ describe(SmokePerps('Perps - ETH limit long fill'), () => {
         // This is needed due to disable animations
         await device.disableSynchronization();
 
-        // Navigate to Perps via homepage section (same click path as smoke perps tests)
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsHomeView.tapExploreCryptoIfVisible();
-
-        // Select ETH market and tap Long
-        await Utilities.executeWithRetry(
-          async () => {
-            await PerpsMarketListView.selectMarket('ETH');
-            await PerpsMarketDetailsView.tapLongButton();
-          },
-          { interval: 1000, timeout: 30000 },
-        );
+        await navigateToPerpsOrderEntry('ETH', 'long');
 
         // Open order type selector and select Limit using Page Object
         await PerpsOrderView.openOrderTypeSelector();

--- a/tests/smoke/perps/perps-position-liquidation.spec.ts
+++ b/tests/smoke/perps/perps-position-liquidation.spec.ts
@@ -113,13 +113,13 @@ const waitForCommandQueueToProcess = async (
   await commandQueueServer.getExportedState();
 };
 
-// Unblocking CI
-describe.skip(SmokePerps('Perps Position Liquidation'), () => {
+describe(SmokePerps('Perps Position Liquidation'), () => {
   it(`liquidates a ${POSITION_DIRECTION} position when mark price moves ${MARK_PRICE_BY_DIRECTION[POSITION_DIRECTION].liquidatingPriceDirection} liquidation price`, async () => {
     await withFixtures(
       {
         fixture: buildPerpsFixture(),
         restartDevice: true,
+        permissions: { notifications: 'YES' },
         testSpecificMock: setupPerpsMocks,
         useCommandQueueServer: true,
       },

--- a/tests/smoke/perps/perps-position-stop-loss.spec.ts
+++ b/tests/smoke/perps/perps-position-stop-loss.spec.ts
@@ -2,9 +2,7 @@ import { loginToApp } from '../../flows/wallet.flow';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SmokePerps } from '../../tags';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
+import { navigateToPerpsOrderEntry } from '../../flows/perps.flow';
 import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
@@ -28,7 +26,7 @@ const logger = createLogger({
 });
 
 describe(SmokePerps('Perps Position Stop Loss'), () => {
-  it.skip('opens a long with stop loss and closes when mark crosses the SL trigger', async () => {
+  it('opens a long with stop loss and closes when mark crosses the SL trigger', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -54,6 +52,7 @@ describe(SmokePerps('Perps Position Stop Loss'), () => {
           .withPopularNetworks()
           .build(),
         restartDevice: true,
+        permissions: { notifications: 'YES' },
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
@@ -73,11 +72,7 @@ describe(SmokePerps('Perps Position Stop Loss'), () => {
         await loginToApp();
         await device.disableSynchronization();
 
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsHomeView.tapExploreCryptoIfVisible();
-
-        await PerpsMarketListView.selectMarket('ETH');
-        await PerpsMarketDetailsView.tapLongButton();
+        await navigateToPerpsOrderEntry('ETH', 'long');
 
         await PerpsOrderView.tapTakeProfitButton();
         // Default ETH mock mark ~2500; SL below entry for a long

--- a/tests/smoke/perps/perps-position.spec.ts
+++ b/tests/smoke/perps/perps-position.spec.ts
@@ -2,9 +2,7 @@ import { loginToApp } from '../../flows/wallet.flow';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { SmokePerps } from '../../tags';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import WalletView from '../../page-objects/wallet/WalletView';
-import PerpsHomeView from '../../page-objects/Perps/PerpsHomeView';
-import PerpsMarketListView from '../../page-objects/Perps/PerpsMarketListView';
+import { navigateToPerpsOrderEntry } from '../../flows/perps.flow';
 import {
   PERPS_ARBITRUM_MOCKS,
   mockPerpsGeolocation,
@@ -25,7 +23,7 @@ const logger = createLogger({
 });
 
 describe(SmokePerps('Perps Position'), () => {
-  it.skip('opens a long position with custom profit and closes it', async () => {
+  it('opens a long position with custom profit and closes it', async () => {
     await withFixtures(
       {
         fixture: new FixtureBuilder()
@@ -51,6 +49,7 @@ describe(SmokePerps('Perps Position'), () => {
           .withPopularNetworks()
           .build(),
         restartDevice: true,
+        permissions: { notifications: 'YES' },
         testSpecificMock: async (mockServer: Mockttp) => {
           await setupRemoteFeatureFlagsMock(mockServer, {});
           await PERPS_ARBITRUM_MOCKS(mockServer);
@@ -68,12 +67,7 @@ describe(SmokePerps('Perps Position'), () => {
         // streaming/network activity can block Detox idling.
         await device.disableSynchronization();
 
-        // Navigate to Perps via homepage section (same click path as smoke perps tests)
-        await WalletView.scrollAndTapPerpsSection();
-        await PerpsHomeView.tapExploreCryptoIfVisible();
-
-        await PerpsMarketListView.selectMarket('ETH');
-        await PerpsMarketDetailsView.tapLongButton();
+        await navigateToPerpsOrderEntry('ETH', 'long');
 
         // Custom TP trigger above mock ETH mark (~2500) for a long
         await PerpsOrderView.tapTakeProfitButton();


### PR DESCRIPTION
## **Description**

Strips the rank decorations from the Top Traders leaderboard rows to clean up the UI:

- **Removed rank enumeration** — the numbered rank indicator (1, 2, 3 …) on the left side of each row is no longer shown
- **Removed gradient ring** — the gold/silver/bronze chrome border around top-3 avatars is gone
- **Removed medal badge overlays** — the floating 🥇🥈🥉 emoji badges above top-3 avatars are gone

Rows now show a plain avatar, username, PnL value, and follow button.

Note: badge/medal decoration for top-3 will be revisited — a cleaner implementation is planned as a follow-up by another team member.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open the app and navigate to the Top Traders leaderboard
2. Confirm no rank numbers appear to the left of any row
3. Confirm top-3 avatars have no gradient ring border
4. Confirm no medal emoji overlays appear above any avatar
5. Confirm Follow / Following buttons and PnL values still render correctly

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bridge suggestion taps reset swap state and dispatch multiple Redux updates; leaderboard PnL now prefers 7D metrics with formatting changes across several user-facing surfaces.
> 
> **Overview**
> **Top Traders / social leaderboard** strips podium UI (rank numbers, gradient rings, crowns) from list rows, cards, and trader profiles, and reframes the feature as **Weekly Top Traders** with **7D return** (`pnl7d`, falling back to `pnl30d` where needed). Row/card stats drop ROI and **30D** labels in favor of inline **full-dollar PnL with cents**; profile stats labels are title-cased and position percents use two decimals.
> 
> **Bridge post-trade** adds a **“What to swap next”** trending-pill section (hidden on failed trades) backed by `usePostTradeTrendingTokens`; tapping a pill resets bridge state and pre-fills source/dest tokens with an empty amount. API→`BridgeToken` conversion is centralized in `tokenUtils` (`convertApiTokenToBridgeToken` / `convertAPITokensToBridgeTokens`).
> 
> **Perps smoke tests** re-enable several skipped specs, grant notification permission, and route entry through `navigateToPerpsOrderEntry` with scroll-to-market helpers instead of **Explore crypto**. **Appium CI** uploads failure recordings when steps run under `always()` as well as on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2464890965128c76997e44d301e429dbaf600fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->