### PR TITLE
feat: add stellar wallet-connect support

### DIFF
--- a/app/core/WalletConnect/multichain/registry.test.ts
+++ b/app/core/WalletConnect/multichain/registry.test.ts
@@ -22,11 +22,16 @@ import {
   getAllAdapters,
   getAllRegisteredNamespaces,
 } from './registry';
+import { stellarAdapter } from './stellar';
 import { tronAdapter } from './tron';
 
 describe('multichain/registry', () => {
   it('registers the tron adapter under the tron CAIP-2 namespace', () => {
     expect(getAdapter('tron')).toBe(tronAdapter);
+  });
+
+  it('registers the stellar adapter under the stellar CAIP-2 namespace', () => {
+    expect(getAdapter('stellar')).toBe(stellarAdapter);
   });
 
   it('returns undefined for namespaces that have no registered adapter', () => {
@@ -36,11 +41,13 @@ describe('multichain/registry', () => {
 
   it('exposes the tron namespace via getAllRegisteredNamespaces', () => {
     expect(getAllRegisteredNamespaces()).toContain('tron');
+    expect(getAllRegisteredNamespaces()).toContain('stellar');
   });
 
   it('exposes the tron adapter via getAllAdapters', () => {
     const adapters = getAllAdapters();
 
     expect(adapters).toContain(tronAdapter);
+    expect(adapters).toContain(stellarAdapter);
   });
 });

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -13,6 +13,7 @@ import type { AnyChainAdapter } from './types';
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { tronAdapter } from './tron';
 ///: END:ONLY_INCLUDE_IF
+import { stellarAdapter } from './stellar';
 
 // Keyed by raw namespace string so lookups accept whatever a dapp proposal
 // sent, which we don't trust upfront.
@@ -49,3 +50,4 @@ export function getAllRegisteredNamespaces(): KnownCaipNamespace[] {
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 registerAdapter(tronAdapter);
 ///: END:ONLY_INCLUDE_IF
+registerAdapter(stellarAdapter);

--- a/app/core/WalletConnect/multichain/stellar/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/stellar/adapter.test.ts
@@ -1,0 +1,258 @@
+import { XlmScope } from '@metamask/keyring-api';
+import {
+  getCaipAccountIdsFromCaip25CaveatValue,
+  type Caip25CaveatValue,
+} from '@metamask/chain-agnostic-permission';
+import { PermissionDoesNotExistError } from '@metamask/permission-controller';
+import type { CaipAccountId, CaipChainId } from '@metamask/utils';
+
+import Engine from '../../../Engine';
+import { getPermittedCaipChainIds } from '../../../Permissions';
+import { createSnapCaller } from '../router';
+import {
+  enrichCaveatValue,
+  getScopedPermissions,
+  stellarAdapter,
+} from './adapter';
+
+jest.mock('@metamask/chain-agnostic-permission', () => ({
+  ...jest.requireActual('@metamask/chain-agnostic-permission'),
+  getCaipAccountIdsFromCaip25CaveatValue: jest.fn(),
+}));
+
+jest.mock('../../../Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: {
+        getAccountsFromSelectedAccountGroup: jest.fn().mockReturnValue([]),
+      },
+      PermissionController: {
+        getCaveat: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../../Permissions', () => ({
+  getPermittedCaipChainIds: jest.fn(),
+}));
+
+jest.mock('../router', () => {
+  const snapCallerMock = jest.fn();
+  return {
+    createSnapCaller: () => snapCallerMock,
+  };
+});
+
+jest.mock('../../../SDKConnect/utils/DevLogger', () => ({
+  log: jest.fn(),
+}));
+
+const mockedGetAccountsFromSelectedAccountGroup = Engine.context
+  .AccountTreeController.getAccountsFromSelectedAccountGroup as jest.Mock;
+const mockedGetCaveat = Engine.context.PermissionController
+  .getCaveat as jest.Mock;
+const mockedGetPermittedCaipChainIds = getPermittedCaipChainIds as jest.Mock;
+const mockedCallStellarSnap = (
+  createSnapCaller as unknown as () => jest.Mock
+)();
+const mockedGetCaipAccountIdsFromCaip25CaveatValue =
+  getCaipAccountIdsFromCaip25CaveatValue as jest.Mock;
+
+describe('multichain/stellar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([]);
+    mockedGetCaveat.mockReturnValue(undefined);
+    mockedGetPermittedCaipChainIds.mockResolvedValue([]);
+    mockedCallStellarSnap.mockResolvedValue(undefined);
+    mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+  });
+
+  describe('enrichCaveatValue', () => {
+    it('adds the Stellar optional scope when a proposal references Stellar', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              stellar: { chains: [XlmScope.Pubnet], methods: [], events: [] },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [XlmScope.Pubnet]: { accounts: [] },
+        },
+      });
+    });
+
+    it('falls back to Stellar Mainnet when only unsupported Stellar scopes are requested', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              stellar: {
+                chains: [XlmScope.Testnet],
+                methods: [],
+                events: [],
+              },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [XlmScope.Pubnet]: { accounts: [] },
+        },
+      });
+    });
+  });
+
+  describe('getScopedPermissions', () => {
+    it('returns scoped permissions for permitted Stellar chains and accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([
+        'eip155:1',
+        XlmScope.Pubnet,
+      ]);
+      mockedGetCaveat.mockReturnValue({ value: {} });
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([
+        'eip155:1:0xabc',
+        `${XlmScope.Pubnet}:StellarAddrA`,
+      ]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toStrictEqual({
+        chains: [XlmScope.Pubnet],
+        methods: ['stellar_signXDR'],
+        events: [],
+        accounts: [`${XlmScope.Pubnet}:StellarAddrA`],
+      });
+    });
+
+    it('prioritizes selected Stellar account ids when building scoped permissions', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([XlmScope.Pubnet]);
+      mockedGetCaveat.mockReturnValue({ value: {} });
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([
+        `${XlmScope.Pubnet}:StellarAddrA`,
+        `${XlmScope.Pubnet}:StellarAddrB`,
+      ]);
+      mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([
+        { address: 'StellarAddrB', scopes: [XlmScope.Pubnet] },
+      ]);
+
+      const result = await getScopedPermissions({ channelId: 'wc-topic' });
+
+      expect(result?.accounts).toStrictEqual([
+        `${XlmScope.Pubnet}:StellarAddrB`,
+        `${XlmScope.Pubnet}:StellarAddrA`,
+      ]);
+    });
+
+    it('returns undefined when there are no Stellar chains or accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue(['eip155:1']);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+
+      mockedGetPermittedCaipChainIds.mockResolvedValue([XlmScope.Pubnet]);
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('continues when getCaveat throws PermissionDoesNotExistError', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([XlmScope.Pubnet]);
+      mockedGetCaveat.mockImplementation(() => {
+        throw new PermissionDoesNotExistError('wc-topic', 'endowment:caip25');
+      });
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('stellarAdapter', () => {
+    it('declares the Stellar CAIP namespace and approved methods', () => {
+      expect(stellarAdapter.namespace).toBe('stellar');
+      expect(stellarAdapter.redirectMethods).toStrictEqual(['stellar_signXDR']);
+      expect(stellarAdapter.approvedMethods).toStrictEqual(['stellar_signXDR']);
+      expect(stellarAdapter.getSessionProperties).toBeUndefined();
+    });
+
+    it('handles stellar_signXDR by mapping, routing, and normalizing the result', async () => {
+      mockedCallStellarSnap.mockResolvedValue({ signedTxXdr: 'signed-xdr' });
+
+      const result = await stellarAdapter.handleRequest({
+        connectedAddresses: [
+          `${XlmScope.Pubnet}:StellarAddrA` as CaipAccountId,
+        ],
+        scope: XlmScope.Pubnet as CaipChainId,
+        requestId: 1,
+        method: 'stellar_signXDR',
+        params: { xdr: 'unsigned-xdr' },
+      });
+
+      expect(mockedCallStellarSnap).toHaveBeenCalledWith({
+        connectedAddresses: [`${XlmScope.Pubnet}:StellarAddrA`],
+        scope: XlmScope.Pubnet,
+        requestId: 1,
+        request: {
+          method: 'signTransaction',
+          params: {
+            xdr: 'unsigned-xdr',
+          },
+        },
+      });
+      expect(mockedCallStellarSnap).toHaveBeenCalledWith(
+        expect.not.objectContaining({ origin: expect.anything() }),
+      );
+      expect(result).toStrictEqual({ signedXDR: 'signed-xdr' });
+    });
+
+    it('rejects unsupported WalletConnect methods', async () => {
+      const args = {
+        connectedAddresses: [
+          `${XlmScope.Pubnet}:StellarAddrA` as CaipAccountId,
+        ],
+        scope: XlmScope.Pubnet as CaipChainId,
+        requestId: 1,
+        method: 'stellar_signAndSubmitXDR',
+        params: { xdr: 'unsigned-xdr' },
+      };
+
+      await expect(
+        // @ts-expect-error - the wallet does not expose sign-and-submit
+        stellarAdapter.handleRequest(args),
+      ).rejects.toThrow(
+        'WalletConnect Stellar method stellar_signAndSubmitXDR is not supported',
+      );
+
+      expect(mockedCallStellarSnap).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/stellar/adapter.ts
+++ b/app/core/WalletConnect/multichain/stellar/adapter.ts
@@ -1,0 +1,145 @@
+import { XlmScope } from '@metamask/keyring-api';
+import { type CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+import { type Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
+
+import {
+  buildAdapterScopedPermissions,
+  enrichCaveatValueForNamespace,
+} from '../utils';
+import type {
+  AdapterHandleRequestArgs,
+  ChainAdapter,
+  NamespaceConfig,
+  ProposalParamsLight,
+  RpcMethod,
+  RpcResponse,
+} from '../types';
+import { createSnapCaller } from '../router';
+import {
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+} from './mapper';
+import type { StellarSnapSpec, StellarWalletConnectSpec } from './types';
+
+/**
+ * Snap caller bound to the Stellar Snap spec.
+ */
+const callStellarSnap = createSnapCaller<StellarSnapSpec>();
+
+/**
+ * WalletConnect methods the wallet exposes for the Stellar namespace.
+ *
+ * Only `stellar_signXDR` is exposed; `stellar_signAndSubmitXDR` is omitted
+ * because the Stellar Snap is sign-only and cannot broadcast transactions.
+ */
+const STELLAR_METHODS: readonly RpcMethod<StellarWalletConnectSpec>[] = [
+  'stellar_signXDR',
+];
+
+/**
+ * WalletConnect Stellar methods that should redirect users back to the dapp
+ * after handling.
+ */
+const STELLAR_REDIRECT_METHODS: readonly RpcMethod<StellarWalletConnectSpec>[] =
+  ['stellar_signXDR'];
+
+/**
+ * WalletConnect events the wallet may emit for the Stellar namespace.
+ */
+const STELLAR_EVENTS: readonly string[] = [];
+
+/**
+ * CAIP-2 chain IDs we will seed into the CAIP-25 caveat.
+ *
+ * Restricted to Mainnet (pubnet) because the Stellar Snap only supports
+ * mainnet. Unlike Solana and Tron — whose testnets are merely gated out of
+ * the mobile permission UI pending a feature flag — this is not a permission
+ * concern: the snap itself has no testnet support. There is therefore no
+ * scope to widen later and no chain switching to handle, since Stellar
+ * exposes a single network.
+ */
+const SUPPORTED_STELLAR_SCOPES = new Set<CaipChainId>([
+  XlmScope.Pubnet as CaipChainId,
+]);
+
+/**
+ * Build the Stellar namespace slice from the wallet's current state.
+ */
+export async function getScopedPermissions({
+  channelId,
+}: {
+  channelId: string;
+}): Promise<NamespaceConfig | undefined> {
+  return buildAdapterScopedPermissions({
+    channelId,
+    namespace: KnownCaipNamespace.Stellar,
+    methods: STELLAR_METHODS,
+    events: STELLAR_EVENTS,
+  });
+}
+
+/**
+ * Seed the Stellar scope into the CAIP-25 caveat. Stellar exposes a single
+ * supported network (Mainnet/pubnet), so any unsupported requested scope
+ * falls back to it.
+ */
+export function enrichCaveatValue({
+  proposal,
+  caveatValue,
+}: {
+  proposal: ProposalParamsLight;
+  caveatValue: Caip25CaveatValue;
+}): Caip25CaveatValue {
+  return enrichCaveatValueForNamespace({
+    proposal,
+    caveatValue,
+    namespace: KnownCaipNamespace.Stellar,
+    supportedScopes: SUPPORTED_STELLAR_SCOPES,
+    fallbackScope: XlmScope.Pubnet as CaipChainId,
+  });
+}
+
+/**
+ * Handle a WalletConnect request for the Stellar namespace by mapping it to
+ * the multichain routing service, then mapping the result back to the
+ * expected WalletConnect format for the dapp.
+ */
+export async function handleRequest({
+  connectedAddresses,
+  scope,
+  requestId,
+  method,
+  params,
+}: AdapterHandleRequestArgs<StellarWalletConnectSpec>): Promise<
+  RpcResponse<StellarWalletConnectSpec>
+> {
+  if (method === 'stellar_signXDR') {
+    const result = await callStellarSnap({
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignTransactionRequest({ params }),
+    });
+
+    return mapSignTransactionResponse(result);
+  }
+
+  throw new Error(
+    `WalletConnect Stellar method ${String(method)} is not supported`,
+  );
+}
+
+/**
+ * `ChainAdapter` for Stellar, registered in `multichain/registry.ts`.
+ */
+export const stellarAdapter: ChainAdapter<
+  KnownCaipNamespace.Stellar,
+  StellarWalletConnectSpec
+> = {
+  namespace: KnownCaipNamespace.Stellar,
+  redirectMethods: STELLAR_REDIRECT_METHODS,
+  approvedMethods: STELLAR_METHODS,
+  enrichCaveatValue,
+  getScopedPermissions,
+  handleRequest,
+};

--- a/app/core/WalletConnect/multichain/stellar/index.ts
+++ b/app/core/WalletConnect/multichain/stellar/index.ts
@@ -1,0 +1,1 @@
+export { stellarAdapter } from './adapter';

--- a/app/core/WalletConnect/multichain/stellar/mapper.test.ts
+++ b/app/core/WalletConnect/multichain/stellar/mapper.test.ts
@@ -1,0 +1,29 @@
+import {
+  mapSignTransactionRequest,
+  mapSignTransactionResponse,
+} from './mapper';
+
+describe('multichain/stellar - mapper', () => {
+  describe('inbound request mappers', () => {
+    it('maps stellar_signXDR to the canonical signTransaction payload', () => {
+      expect(
+        mapSignTransactionRequest({
+          params: { xdr: 'base64-xdr' },
+        }),
+      ).toStrictEqual({
+        method: 'signTransaction',
+        params: {
+          xdr: 'base64-xdr',
+        },
+      });
+    });
+  });
+
+  describe('outbound response mappers', () => {
+    it('maps the Snap signedTxXdr to the WalletConnect stellar_signXDR response', () => {
+      expect(
+        mapSignTransactionResponse({ signedTxXdr: 'signed-base64-xdr' }),
+      ).toStrictEqual({ signedXDR: 'signed-base64-xdr' });
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/stellar/mapper.ts
+++ b/app/core/WalletConnect/multichain/stellar/mapper.ts
@@ -1,0 +1,32 @@
+import type { RpcRequest } from '../types';
+import type { StellarSnapSpec, StellarWalletConnectSpec } from './types';
+
+/**
+ * Convert WalletConnect `stellar_signXDR` params into the canonical Stellar
+ * Snap `signTransaction` request. The signer account and scope are resolved
+ * by the routing service, so only the transaction XDR travels in the params.
+ */
+export function mapSignTransactionRequest({
+  params,
+}: {
+  params: StellarWalletConnectSpec['stellar_signXDR']['params'];
+}): RpcRequest<StellarSnapSpec, 'signTransaction'> {
+  return {
+    method: 'signTransaction',
+    params: {
+      xdr: params.xdr,
+    },
+  };
+}
+
+/**
+ * Forward the Stellar Snap signed transaction XDR in the WalletConnect
+ * `stellar_signXDR` response shape.
+ */
+export function mapSignTransactionResponse(
+  result: StellarSnapSpec['signTransaction']['response'],
+): StellarWalletConnectSpec['stellar_signXDR']['response'] {
+  return {
+    signedXDR: result.signedTxXdr,
+  };
+}

--- a/app/core/WalletConnect/multichain/stellar/types.ts
+++ b/app/core/WalletConnect/multichain/stellar/types.ts
@@ -1,0 +1,49 @@
+/**
+ * WalletConnect Stellar RPC contract.
+ *
+ * The WalletConnect Stellar namespace defines only two methods,
+ * `stellar_signXDR` and `stellar_signAndSubmitXDR`. The wallet exposes just
+ * `stellar_signXDR` (mapped to the Snap's `signTransaction`);
+ * `stellar_signAndSubmitXDR` is omitted because the Stellar Snap is sign-only
+ * and never broadcasts.
+ *
+ * The Snap also implements the SEP-43 `signMessage` and `signAuthEntry`
+ * methods, but neither is a WalletConnect method: the reference dapp library
+ * rejects both with a `-3` error before any request is emitted, so they are
+ * unreachable over WalletConnect and intentionally not modeled here.
+ *
+ * @see https://docs.reown.com/advanced/multichain/rpc-reference/stellar-rpc
+ * @see https://github.com/Creit-Tech/Stellar-Wallets-Kit/blob/v2.1.0/src/sdk/modules/wallet-connect.module.ts#L247-L257
+ */
+export interface StellarWalletConnectSpec {
+  stellar_signXDR: {
+    params: {
+      /**
+       * Base64-encoded transaction envelope XDR.
+       */
+      xdr: string;
+    };
+    response: {
+      /**
+       * Base64-encoded signed transaction envelope XDR.
+       */
+      signedXDR: string;
+    };
+  };
+}
+
+/**
+ * Stellar Snap keyring RPC contract used by the snap. Follows the SEP-43
+ * `signTransaction` shape; the signer account and scope are resolved by the
+ * routing service, so only the transaction XDR travels in the request params.
+ */
+export interface StellarSnapSpec {
+  signTransaction: {
+    params: {
+      xdr: string;
+    };
+    response: {
+      signedTxXdr: string;
+    };
+  };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This PR adds the Stellar adapter to the WalletConnect non-EVM layer.

Why: WalletConnect dapps could not reach a user's Stellar account through MetaMask Mobile .

What changed: a new stellarAdapter (multichain/stellar/) implementing the ChainAdapter contract.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: add stellar wallet-connect support

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Stellar WalletConnect signing

  Scenario: user connects a Stellar dapp over WalletConnect
    Given a dapp initiates a WalletConnect connection requesting the Stellar namespace
    When the user approves the session with a Stellar account

  Scenario: user signs a transaction
    Given an approved Stellar WalletConnect session on Mainnet
    When the dapp requests stellar_signXDR
    Then the wallet routes the request to the Stellar Snap
    And the dapp receives the expected signature(s)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no UI change.

### **After**

<!-- [screenshots/recordings] -->

N/A — no UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces WalletConnect paths for Stellar message and transaction signing and broadcast via the Stellar Snap; incorrect mapping or permission scoping could affect funds or session approval.
> 
> **Overview**
> Adds **Stellar** to the WalletConnect multichain non-EVM layer so dapps can connect and call Stellar namespace RPCs through MetaMask Mobile.
> 
> A new `stellarAdapter` under `multichain/stellar/` implements the existing `ChainAdapter` contract: it seeds **CAIP-25** optional scopes (Mainnet-only today, with unsupported testnet chains falling back to Mainnet), builds session scoped permissions from permitted chains/accounts, and handles WalletConnect methods (`stellar_getAccounts`, signing, batch sign, sign-and-send). Signing flows map WalletConnect payloads to the **Stellar Snap** via `createSnapCaller`, with mappers for base58/base64 messages, `sendOptions` → snap `options`, and fee-payer signature extraction using **`@stellar/transactions`**. The adapter is **registered** in `multichain/registry.ts` alongside Tron; registry tests are extended accordingly. Unit tests cover caveat enrichment, permissions, request routing, and mappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd098753ecbee3fec579e414dc919e788dc29b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->