### PR TITLE
feat: add bitcoin wallet-connect support

### DIFF
--- a/app/core/WalletConnect/multichain/bitcoin/adapter.test.ts
+++ b/app/core/WalletConnect/multichain/bitcoin/adapter.test.ts
@@ -1,0 +1,308 @@
+import { BtcScope } from '@metamask/keyring-api';
+import {
+  getCaipAccountIdsFromCaip25CaveatValue,
+  type Caip25CaveatValue,
+} from '@metamask/chain-agnostic-permission';
+import { PermissionDoesNotExistError } from '@metamask/permission-controller';
+import type { CaipAccountId, CaipChainId } from '@metamask/utils';
+
+import Engine from '../../../Engine';
+import { getPermittedCaipChainIds } from '../../../Permissions';
+import { createSnapCaller } from '../router';
+import {
+  enrichCaveatValue,
+  getScopedPermissions,
+  bitcoinAdapter,
+} from './adapter';
+
+jest.mock('@metamask/chain-agnostic-permission', () => ({
+  ...jest.requireActual('@metamask/chain-agnostic-permission'),
+  getCaipAccountIdsFromCaip25CaveatValue: jest.fn(),
+}));
+
+jest.mock('../../../Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      AccountTreeController: {
+        getAccountsFromSelectedAccountGroup: jest.fn().mockReturnValue([]),
+      },
+      PermissionController: {
+        getCaveat: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock('../../../Permissions', () => ({
+  getPermittedCaipChainIds: jest.fn(),
+}));
+
+jest.mock('../router', () => {
+  const snapCallerMock = jest.fn();
+  return {
+    createSnapCaller: () => snapCallerMock,
+  };
+});
+
+jest.mock('../../../SDKConnect/utils/DevLogger', () => ({
+  log: jest.fn(),
+}));
+
+const mockedGetAccountsFromSelectedAccountGroup = Engine.context
+  .AccountTreeController.getAccountsFromSelectedAccountGroup as jest.Mock;
+const mockedGetCaveat = Engine.context.PermissionController
+  .getCaveat as jest.Mock;
+const mockedGetPermittedCaipChainIds = getPermittedCaipChainIds as jest.Mock;
+const mockedCallBitcoinSnap = (
+  createSnapCaller as unknown as () => jest.Mock
+)();
+const mockedGetCaipAccountIdsFromCaip25CaveatValue =
+  getCaipAccountIdsFromCaip25CaveatValue as jest.Mock;
+
+describe('multichain/bitcoin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetAccountsFromSelectedAccountGroup.mockReturnValue([]);
+    mockedGetCaveat.mockReturnValue(undefined);
+    mockedGetPermittedCaipChainIds.mockResolvedValue([]);
+    mockedCallBitcoinSnap.mockResolvedValue(undefined);
+    mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+  });
+
+  describe('enrichCaveatValue', () => {
+    it('adds the Bitcoin optional scope when a proposal references Bitcoin', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              bip122: {
+                chains: [BtcScope.Mainnet],
+                methods: [],
+                events: [],
+              },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [BtcScope.Mainnet]: { accounts: [] },
+        },
+      });
+    });
+
+    it('falls back to Bitcoin Mainnet when only unsupported Bitcoin scopes are requested', () => {
+      const caveatValue = {
+        requiredScopes: {},
+        optionalScopes: {},
+        isMultichainOrigin: true,
+        sessionProperties: {},
+      } as Caip25CaveatValue;
+
+      expect(
+        enrichCaveatValue({
+          proposal: {
+            requiredNamespaces: {},
+            optionalNamespaces: {
+              bip122: {
+                chains: [BtcScope.Testnet],
+                methods: [],
+                events: [],
+              },
+            },
+          },
+          caveatValue,
+        }),
+      ).toStrictEqual({
+        ...caveatValue,
+        optionalScopes: {
+          [BtcScope.Mainnet]: { accounts: [] },
+        },
+      });
+    });
+  });
+
+  describe('getScopedPermissions', () => {
+    it('returns scoped permissions for permitted Bitcoin chains and accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([
+        'eip155:1',
+        BtcScope.Mainnet,
+      ]);
+      mockedGetCaveat.mockReturnValue({ value: {} });
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([
+        'eip155:1:0xabc',
+        `${BtcScope.Mainnet}:bc1qaddrA`,
+      ]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toStrictEqual({
+        chains: [BtcScope.Mainnet],
+        methods: [
+          'bitcoin_getAccountAddresses',
+          'bitcoin_signMessage',
+          'bitcoin_signPsbt',
+          'bitcoin_sendTransfer',
+        ],
+        events: [],
+        accounts: [`${BtcScope.Mainnet}:bc1qaddrA`],
+      });
+    });
+
+    it('returns undefined when there are no Bitcoin chains or accounts', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue(['eip155:1']);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+
+      mockedGetPermittedCaipChainIds.mockResolvedValue([BtcScope.Mainnet]);
+      mockedGetCaipAccountIdsFromCaip25CaveatValue.mockReturnValue([]);
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('continues when getCaveat throws PermissionDoesNotExistError', async () => {
+      mockedGetPermittedCaipChainIds.mockResolvedValue([BtcScope.Mainnet]);
+      mockedGetCaveat.mockImplementation(() => {
+        throw new PermissionDoesNotExistError('wc-topic', 'endowment:caip25');
+      });
+
+      await expect(
+        getScopedPermissions({ channelId: 'wc-topic' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('bitcoinAdapter', () => {
+    it('declares the Bitcoin CAIP namespace and approved methods', () => {
+      expect(bitcoinAdapter.namespace).toBe('bip122');
+      expect(bitcoinAdapter.redirectMethods).toStrictEqual([
+        'bitcoin_signMessage',
+        'bitcoin_signPsbt',
+        'bitcoin_sendTransfer',
+      ]);
+      expect(bitcoinAdapter.approvedMethods).toStrictEqual([
+        'bitcoin_getAccountAddresses',
+        'bitcoin_signMessage',
+        'bitcoin_signPsbt',
+        'bitcoin_sendTransfer',
+      ]);
+      expect(bitcoinAdapter.getSessionProperties).toBeUndefined();
+    });
+
+    it('returns connected account addresses for bitcoin_getAccountAddresses', async () => {
+      await expect(
+        bitcoinAdapter.handleRequest({
+          connectedAddresses: [
+            `${BtcScope.Mainnet}:bc1qaddrA` as CaipAccountId,
+            `${BtcScope.Mainnet}:bc1qaddrB` as CaipAccountId,
+          ],
+          scope: BtcScope.Mainnet as CaipChainId,
+          requestId: 1,
+          method: 'bitcoin_getAccountAddresses',
+          params: { account: 'bc1qaddrA' },
+        }),
+      ).resolves.toStrictEqual([
+        { address: 'bc1qaddrA' },
+        { address: 'bc1qaddrB' },
+      ]);
+
+      expect(mockedCallBitcoinSnap).not.toHaveBeenCalled();
+    });
+
+    it('handles bitcoin_signPsbt by mapping, routing, and normalizing the result', async () => {
+      mockedCallBitcoinSnap.mockResolvedValue({
+        psbt: 'signed-psbt',
+        txid: 'tx-id',
+      });
+
+      const result = await bitcoinAdapter.handleRequest({
+        connectedAddresses: [`${BtcScope.Mainnet}:bc1qaddrA` as CaipAccountId],
+        scope: BtcScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'bitcoin_signPsbt',
+        params: {
+          account: 'bc1qaddrA',
+          psbt: 'base64-psbt',
+          signInputs: [{ address: 'bc1qaddrA', index: 0 }],
+          broadcast: true,
+        },
+      });
+
+      expect(mockedCallBitcoinSnap).toHaveBeenCalledWith({
+        connectedAddresses: [`${BtcScope.Mainnet}:bc1qaddrA`],
+        scope: BtcScope.Mainnet,
+        requestId: 1,
+        request: {
+          method: 'signPsbt',
+          params: {
+            psbt: 'base64-psbt',
+            options: { fill: false, broadcast: true },
+          },
+        },
+      });
+      expect(mockedCallBitcoinSnap).toHaveBeenCalledWith(
+        expect.not.objectContaining({ origin: expect.anything() }),
+      );
+      expect(result).toStrictEqual({ psbt: 'signed-psbt', txid: 'tx-id' });
+    });
+
+    it('handles bitcoin_signMessage and returns the connected account address', async () => {
+      mockedCallBitcoinSnap.mockResolvedValue({ signature: 'hex-signature' });
+
+      const result = await bitcoinAdapter.handleRequest({
+        connectedAddresses: [`${BtcScope.Mainnet}:bc1qaddrA` as CaipAccountId],
+        scope: BtcScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'bitcoin_signMessage',
+        params: { account: 'bc1qaddrA', message: 'hello' },
+      });
+
+      expect(mockedCallBitcoinSnap).toHaveBeenCalledWith({
+        connectedAddresses: [`${BtcScope.Mainnet}:bc1qaddrA`],
+        scope: BtcScope.Mainnet,
+        requestId: 1,
+        request: {
+          method: 'signMessage',
+          params: { message: 'hello' },
+        },
+      });
+      expect(result).toStrictEqual({
+        address: 'bc1qaddrA',
+        signature: 'hex-signature',
+      });
+    });
+
+    it('rejects unsupported WalletConnect methods', async () => {
+      const args = {
+        connectedAddresses: [`${BtcScope.Mainnet}:bc1qaddrA` as CaipAccountId],
+        scope: BtcScope.Mainnet as CaipChainId,
+        requestId: 1,
+        method: 'bitcoin_unknownMethod',
+        params: {},
+      };
+
+      await expect(
+        // @ts-expect-error - misbehaving client sending an unapproved method
+        bitcoinAdapter.handleRequest(args),
+      ).rejects.toThrow(
+        'WalletConnect Bitcoin method bitcoin_unknownMethod is not supported',
+      );
+
+      expect(mockedCallBitcoinSnap).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/bitcoin/adapter.ts
+++ b/app/core/WalletConnect/multichain/bitcoin/adapter.ts
@@ -1,0 +1,183 @@
+import { BtcScope } from '@metamask/keyring-api';
+import { type CaipChainId, KnownCaipNamespace } from '@metamask/utils';
+import { type Caip25CaveatValue } from '@metamask/chain-agnostic-permission';
+
+import {
+  buildAdapterScopedPermissions,
+  enrichCaveatValueForNamespace,
+} from '../utils';
+import type {
+  AdapterHandleRequestArgs,
+  ChainAdapter,
+  NamespaceConfig,
+  ProposalParamsLight,
+  RpcMethod,
+  RpcResponse,
+} from '../types';
+import { createSnapCaller } from '../router';
+import {
+  mapAccountAddressesRequest,
+  mapSendTransferRequest,
+  mapSendTransferResponse,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignPsbtRequest,
+  mapSignPsbtResponse,
+} from './mapper';
+import type { BitcoinSnapSpec, BitcoinWalletConnectSpec } from './types';
+
+/**
+ * Snap caller bound to the Bitcoin Snap spec.
+ */
+const callBitcoinSnap = createSnapCaller<BitcoinSnapSpec>();
+
+/**
+ * WalletConnect methods the wallet exposes for the Bitcoin namespace.
+ */
+const BITCOIN_METHODS: readonly RpcMethod<BitcoinWalletConnectSpec>[] = [
+  'bitcoin_getAccountAddresses',
+  'bitcoin_signMessage',
+  'bitcoin_signPsbt',
+  'bitcoin_sendTransfer',
+];
+
+/**
+ * WalletConnect Bitcoin methods that should redirect users back to the dapp
+ * after handling. The read-only address method intentionally stays out.
+ */
+const BITCOIN_REDIRECT_METHODS: readonly RpcMethod<BitcoinWalletConnectSpec>[] =
+  ['bitcoin_signMessage', 'bitcoin_signPsbt', 'bitcoin_sendTransfer'];
+
+/**
+ * WalletConnect events the wallet may emit for the Bitcoin namespace.
+ */
+const BITCOIN_EVENTS: readonly string[] = [];
+
+/**
+ * CAIP-2 chain IDs we will seed into the CAIP-25 caveat.
+ *
+ * The Bitcoin Snap supports Mainnet, Testnet, Signet, and Regtest, but the
+ * mobile permission UI exposes only Mainnet today (testnets are gated out of
+ * `NON_EVM_CAIP_CHAIN_IDS` in `selectors/multichainNetworkController`, pending
+ * a feature flag). Any testnet scope we inject would be stripped by the
+ * approval UI when it rebuilds `optionalScopes` from `selectedChainIds`,
+ * leaving the Bitcoin namespace empty and breaking `approveSession`.
+ *
+ * Restricting to Mainnet keeps mainnet-only dapps working; testnet requests
+ * fall back to Mainnet via `enrichCaveatValue`. When the feature flag lands,
+ * widen this to `Object.values(BtcScope)`.
+ */
+const SUPPORTED_BITCOIN_SCOPES = new Set<CaipChainId>([
+  BtcScope.Mainnet as CaipChainId,
+]);
+
+/**
+ * Build the Bitcoin namespace slice from the wallet's current state.
+ */
+export async function getScopedPermissions({
+  channelId,
+}: {
+  channelId: string;
+}): Promise<NamespaceConfig | undefined> {
+  return buildAdapterScopedPermissions({
+    channelId,
+    namespace: KnownCaipNamespace.Bip122,
+    methods: BITCOIN_METHODS,
+    events: BITCOIN_EVENTS,
+  });
+}
+
+/**
+ * Seed Bitcoin scopes into the CAIP-25 caveat. One `optionalScope` per
+ * supported Bitcoin chain the proposal references.
+ *
+ * Only `SUPPORTED_BITCOIN_SCOPES` are carried through; unsupported testnets
+ * fall back to Mainnet. Widening `SUPPORTED_BITCOIN_SCOPES` later lets this
+ * function carry multi-chain requests end-to-end with no further change.
+ */
+export function enrichCaveatValue({
+  proposal,
+  caveatValue,
+}: {
+  proposal: ProposalParamsLight;
+  caveatValue: Caip25CaveatValue;
+}): Caip25CaveatValue {
+  return enrichCaveatValueForNamespace({
+    proposal,
+    caveatValue,
+    namespace: KnownCaipNamespace.Bip122,
+    supportedScopes: SUPPORTED_BITCOIN_SCOPES,
+    fallbackScope: BtcScope.Mainnet as CaipChainId,
+  });
+}
+
+/**
+ * Handle a WalletConnect request for the Bitcoin namespace by mapping it to
+ * the multichain routing service, then mapping the result back to the
+ * expected WalletConnect format for the dapp.
+ */
+export async function handleRequest({
+  connectedAddresses,
+  scope,
+  requestId,
+  method,
+  params,
+}: AdapterHandleRequestArgs<BitcoinWalletConnectSpec>): Promise<
+  RpcResponse<BitcoinWalletConnectSpec>
+> {
+  if (method === 'bitcoin_getAccountAddresses') {
+    return mapAccountAddressesRequest({ connectedAddresses });
+  }
+
+  if (method === 'bitcoin_signMessage') {
+    const result = await callBitcoinSnap({
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignMessageRequest({ params }),
+    });
+
+    return mapSignMessageResponse({ connectedAddresses, result });
+  }
+
+  if (method === 'bitcoin_signPsbt') {
+    const result = await callBitcoinSnap({
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSignPsbtRequest({ params }),
+    });
+
+    return mapSignPsbtResponse(result);
+  }
+
+  if (method === 'bitcoin_sendTransfer') {
+    const result = await callBitcoinSnap({
+      connectedAddresses,
+      scope,
+      requestId,
+      request: mapSendTransferRequest({ params }),
+    });
+
+    return mapSendTransferResponse(result);
+  }
+
+  throw new Error(
+    `WalletConnect Bitcoin method ${String(method)} is not supported`,
+  );
+}
+
+/**
+ * `ChainAdapter` for Bitcoin, registered in `multichain/registry.ts`.
+ */
+export const bitcoinAdapter: ChainAdapter<
+  KnownCaipNamespace.Bip122,
+  BitcoinWalletConnectSpec
+> = {
+  namespace: KnownCaipNamespace.Bip122,
+  redirectMethods: BITCOIN_REDIRECT_METHODS,
+  approvedMethods: BITCOIN_METHODS,
+  enrichCaveatValue,
+  getScopedPermissions,
+  handleRequest,
+};

--- a/app/core/WalletConnect/multichain/bitcoin/index.ts
+++ b/app/core/WalletConnect/multichain/bitcoin/index.ts
@@ -1,0 +1,1 @@
+export { bitcoinAdapter } from './adapter';

--- a/app/core/WalletConnect/multichain/bitcoin/mapper.test.ts
+++ b/app/core/WalletConnect/multichain/bitcoin/mapper.test.ts
@@ -1,0 +1,138 @@
+import { BtcScope } from '@metamask/keyring-api';
+import type { CaipAccountId } from '@metamask/utils';
+import {
+  mapAccountAddressesRequest,
+  mapSendTransferRequest,
+  mapSendTransferResponse,
+  mapSignMessageRequest,
+  mapSignMessageResponse,
+  mapSignPsbtRequest,
+  mapSignPsbtResponse,
+} from './mapper';
+
+const MAINNET_CAIP_ACCOUNT_A = `${BtcScope.Mainnet}:bc1qaddrA` as CaipAccountId;
+const MAINNET_CAIP_ACCOUNT_B = `${BtcScope.Mainnet}:bc1qaddrB` as CaipAccountId;
+
+describe('multichain/bitcoin - mapper', () => {
+  describe('mapAccountAddressesRequest', () => {
+    it('maps CAIP-10 account ids to WalletConnect Bitcoin address objects', () => {
+      expect(
+        mapAccountAddressesRequest({
+          connectedAddresses: [MAINNET_CAIP_ACCOUNT_A, MAINNET_CAIP_ACCOUNT_B],
+        }),
+      ).toStrictEqual([{ address: 'bc1qaddrA' }, { address: 'bc1qaddrB' }]);
+    });
+  });
+
+  describe('inbound request mappers', () => {
+    it('maps bitcoin_signMessage to the canonical signMessage payload', () => {
+      expect(
+        mapSignMessageRequest({
+          params: {
+            account: 'bc1qaddrA',
+            message: 'hello world',
+            address: 'bc1qaddrA',
+            protocol: 'bip322',
+          },
+        }),
+      ).toStrictEqual({
+        method: 'signMessage',
+        params: {
+          message: 'hello world',
+        },
+      });
+    });
+
+    it('maps bitcoin_signPsbt to the canonical signPsbt payload with fill disabled', () => {
+      expect(
+        mapSignPsbtRequest({
+          params: {
+            account: 'bc1qaddrA',
+            psbt: 'base64-psbt',
+            signInputs: [{ address: 'bc1qaddrA', index: 0 }],
+            broadcast: true,
+          },
+        }),
+      ).toStrictEqual({
+        method: 'signPsbt',
+        params: {
+          psbt: 'base64-psbt',
+          options: {
+            fill: false,
+            broadcast: true,
+          },
+        },
+      });
+    });
+
+    it('defaults broadcast to false when bitcoin_signPsbt omits it', () => {
+      expect(
+        mapSignPsbtRequest({
+          params: {
+            account: 'bc1qaddrA',
+            psbt: 'base64-psbt',
+            signInputs: [],
+          },
+        }),
+      ).toStrictEqual({
+        method: 'signPsbt',
+        params: {
+          psbt: 'base64-psbt',
+          options: {
+            fill: false,
+            broadcast: false,
+          },
+        },
+      });
+    });
+
+    it('maps bitcoin_sendTransfer to a single-recipient sendTransfer payload', () => {
+      expect(
+        mapSendTransferRequest({
+          params: {
+            account: 'bc1qaddrA',
+            recipientAddress: 'bc1qrecipient',
+            amount: '10000',
+            changeAddress: 'bc1qchange',
+            memo: 'deadbeef',
+          },
+        }),
+      ).toStrictEqual({
+        method: 'sendTransfer',
+        params: {
+          recipients: [{ address: 'bc1qrecipient', amount: '10000' }],
+        },
+      });
+    });
+  });
+
+  describe('outbound response mappers', () => {
+    it('maps the Snap signature and connected account to the signMessage response', () => {
+      expect(
+        mapSignMessageResponse({
+          connectedAddresses: [MAINNET_CAIP_ACCOUNT_A],
+          result: { signature: 'hex-signature' },
+        }),
+      ).toStrictEqual({
+        address: 'bc1qaddrA',
+        signature: 'hex-signature',
+      });
+    });
+
+    it('includes txid in the signPsbt response only when broadcast', () => {
+      expect(
+        mapSignPsbtResponse({ psbt: 'signed-psbt', txid: 'tx-id' }),
+      ).toStrictEqual({ psbt: 'signed-psbt', txid: 'tx-id' });
+
+      expect(
+        mapSignPsbtResponse({ psbt: 'signed-psbt', txid: null }),
+      ).toStrictEqual({ psbt: 'signed-psbt' });
+    });
+
+    it('maps the Snap txid to the sendTransfer response', () => {
+      expect(mapSendTransferResponse({ txid: 'tx-id' })).toStrictEqual({
+        txid: 'tx-id',
+      });
+    });
+  });
+});

--- a/app/core/WalletConnect/multichain/bitcoin/mapper.ts
+++ b/app/core/WalletConnect/multichain/bitcoin/mapper.ts
@@ -1,0 +1,130 @@
+import { type CaipAccountId, parseCaipAccountId } from '@metamask/utils';
+import type { RpcRequest } from '../types';
+import type { BitcoinSnapSpec, BitcoinWalletConnectSpec } from './types';
+
+/**
+ * Map connected CAIP-10 account ids to the WalletConnect Bitcoin account
+ * addresses response. Served locally by the adapter because it does not need
+ * Snap routing. `publicKey`, `path`, and `intention` are optional and left
+ * unset since they are not derivable from the session account ids.
+ */
+export function mapAccountAddressesRequest({
+  connectedAddresses,
+}: {
+  connectedAddresses: CaipAccountId[];
+}): BitcoinWalletConnectSpec['bitcoin_getAccountAddresses']['response'] {
+  return connectedAddresses.map((accountId) => {
+    const { address } = parseCaipAccountId(accountId);
+    return { address };
+  });
+}
+
+/**
+ * Convert WalletConnect sign message params into the canonical Bitcoin Snap
+ * request. The snap signs with the resolved account's key, so the optional
+ * `address` and `protocol` hints are not forwarded.
+ */
+export function mapSignMessageRequest({
+  params,
+}: {
+  params: BitcoinWalletConnectSpec['bitcoin_signMessage']['params'];
+}): RpcRequest<BitcoinSnapSpec, 'signMessage'> {
+  return {
+    method: 'signMessage',
+    params: {
+      message: params.message,
+    },
+  };
+}
+
+/**
+ * Forward the Bitcoin Snap signature in the WalletConnect `bitcoin_signMessage`
+ * response shape. The signing `address` is the connected account address; the
+ * snap returns only the signature.
+ */
+export function mapSignMessageResponse({
+  connectedAddresses,
+  result,
+}: {
+  connectedAddresses: CaipAccountId[];
+  result: BitcoinSnapSpec['signMessage']['response'];
+}): BitcoinWalletConnectSpec['bitcoin_signMessage']['response'] {
+  const { address } = parseCaipAccountId(connectedAddresses[0]);
+
+  return {
+    address,
+    signature: result.signature,
+  };
+}
+
+/**
+ * Convert WalletConnect `bitcoin_signPsbt` params into the canonical Bitcoin
+ * Snap request. The dapp supplies a complete PSBT, so `fill` is `false`. The
+ * snap signs every input it owns, so the per-input `signInputs` selection is
+ * not forwarded.
+ */
+export function mapSignPsbtRequest({
+  params,
+}: {
+  params: BitcoinWalletConnectSpec['bitcoin_signPsbt']['params'];
+}): RpcRequest<BitcoinSnapSpec, 'signPsbt'> {
+  return {
+    method: 'signPsbt',
+    params: {
+      psbt: params.psbt,
+      options: {
+        fill: false,
+        broadcast: params.broadcast ?? false,
+      },
+    },
+  };
+}
+
+/**
+ * Forward the Bitcoin Snap signed PSBT in the WalletConnect `bitcoin_signPsbt`
+ * response shape. `txid` is only present when the PSBT was broadcast.
+ */
+export function mapSignPsbtResponse(
+  result: BitcoinSnapSpec['signPsbt']['response'],
+): BitcoinWalletConnectSpec['bitcoin_signPsbt']['response'] {
+  return {
+    psbt: result.psbt,
+    ...(result.txid ? { txid: result.txid } : {}),
+  };
+}
+
+/**
+ * Convert WalletConnect `bitcoin_sendTransfer` params into the canonical
+ * Bitcoin Snap request. WalletConnect targets a single recipient; the snap
+ * takes a recipients array. Change is handled by the snap, so the optional
+ * `changeAddress` and `memo` (OP_RETURN) fields are not forwarded.
+ */
+export function mapSendTransferRequest({
+  params,
+}: {
+  params: BitcoinWalletConnectSpec['bitcoin_sendTransfer']['params'];
+}): RpcRequest<BitcoinSnapSpec, 'sendTransfer'> {
+  return {
+    method: 'sendTransfer',
+    params: {
+      recipients: [
+        {
+          address: params.recipientAddress,
+          amount: params.amount,
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Forward the Bitcoin Snap transaction id in the WalletConnect
+ * `bitcoin_sendTransfer` response shape.
+ */
+export function mapSendTransferResponse(
+  result: BitcoinSnapSpec['sendTransfer']['response'],
+): BitcoinWalletConnectSpec['bitcoin_sendTransfer']['response'] {
+  return {
+    txid: result.txid,
+  };
+}

--- a/app/core/WalletConnect/multichain/bitcoin/types.ts
+++ b/app/core/WalletConnect/multichain/bitcoin/types.ts
@@ -1,0 +1,127 @@
+/**
+ * WalletConnect Bitcoin RPC contract.
+ *
+ * Mirrors the four Reown Bitcoin methods. `bitcoin_getAccountAddresses` is
+ * served locally from the session accounts; the other three map to the
+ * Bitcoin Snap keyring (`signMessage`, `signPsbt`, `sendTransfer`).
+ *
+ * Some dapp-supplied fields have no equivalent in the Snap keyring API and are
+ * intentionally not forwarded (documented per mapper): `signMessage.protocol`,
+ * `signPsbt.signInputs`, `sendTransfer.changeAddress`, `sendTransfer.memo`.
+ *
+ * @see https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc
+ */
+export interface BitcoinWalletConnectSpec {
+  bitcoin_getAccountAddresses: {
+    params: {
+      account: string;
+      intentions?: string[];
+    };
+    response: {
+      address: string;
+      publicKey?: string;
+      path?: string;
+      intention?: string;
+    }[];
+  };
+  bitcoin_signMessage: {
+    params: {
+      account: string;
+      message: string;
+      address?: string;
+      protocol?: 'ecdsa' | 'bip322';
+    };
+    response: {
+      address: string;
+      signature: string;
+      messageHash?: string;
+    };
+  };
+  bitcoin_signPsbt: {
+    params: {
+      account: string;
+      /**
+       * Base64-encoded PSBT.
+       */
+      psbt: string;
+      signInputs: {
+        address: string;
+        index: number;
+        sighashTypes?: number[];
+      }[];
+      broadcast?: boolean;
+    };
+    response: {
+      /**
+       * Base64-encoded signed PSBT.
+       */
+      psbt: string;
+      txid?: string;
+    };
+  };
+  bitcoin_sendTransfer: {
+    params: {
+      account: string;
+      recipientAddress: string;
+      /**
+       * Amount in satoshis.
+       */
+      amount: string;
+      changeAddress?: string;
+      memo?: string;
+    };
+    response: {
+      txid: string;
+    };
+  };
+}
+
+/**
+ * Bitcoin Snap keyring RPC contract used by the snap. The signer account and
+ * scope are resolved by the routing service, so only the method params travel
+ * in the request.
+ */
+export interface BitcoinSnapSpec {
+  signMessage: {
+    params: {
+      message: string;
+    };
+    response: {
+      signature: string;
+    };
+  };
+  signPsbt: {
+    params: {
+      /**
+       * Base64-encoded PSBT.
+       */
+      psbt: string;
+      options: {
+        /**
+         * Whether the Snap funds the PSBT with its own inputs/outputs. Always
+         * `false` for WalletConnect: the dapp supplies a complete PSBT to sign.
+         */
+        fill: boolean;
+        broadcast: boolean;
+      };
+    };
+    response: {
+      psbt: string;
+      txid: string | null;
+    };
+  };
+  sendTransfer: {
+    params: {
+      recipients: {
+        address: string;
+        /**
+         * Amount in satoshis.
+         */
+        amount: string;
+      }[];
+    };
+    response: {
+      txid: string;
+    };
+  };
+}

--- a/app/core/WalletConnect/multichain/registry.test.ts
+++ b/app/core/WalletConnect/multichain/registry.test.ts
@@ -22,11 +22,16 @@ import {
   getAllAdapters,
   getAllRegisteredNamespaces,
 } from './registry';
+import { bitcoinAdapter } from './bitcoin';
 import { tronAdapter } from './tron';
 
 describe('multichain/registry', () => {
   it('registers the tron adapter under the tron CAIP-2 namespace', () => {
     expect(getAdapter('tron')).toBe(tronAdapter);
+  });
+
+  it('registers the bitcoin adapter under the bip122 CAIP-2 namespace', () => {
+    expect(getAdapter('bip122')).toBe(bitcoinAdapter);
   });
 
   it('returns undefined for namespaces that have no registered adapter', () => {
@@ -36,11 +41,13 @@ describe('multichain/registry', () => {
 
   it('exposes the tron namespace via getAllRegisteredNamespaces', () => {
     expect(getAllRegisteredNamespaces()).toContain('tron');
+    expect(getAllRegisteredNamespaces()).toContain('bip122');
   });
 
   it('exposes the tron adapter via getAllAdapters', () => {
     const adapters = getAllAdapters();
 
     expect(adapters).toContain(tronAdapter);
+    expect(adapters).toContain(bitcoinAdapter);
   });
 });

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -13,6 +13,7 @@ import type { AnyChainAdapter } from './types';
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { tronAdapter } from './tron';
 ///: END:ONLY_INCLUDE_IF
+import { bitcoinAdapter } from './bitcoin';
 
 // Keyed by raw namespace string so lookups accept whatever a dapp proposal
 // sent, which we don't trust upfront.
@@ -49,3 +50,4 @@ export function getAllRegisteredNamespaces(): KnownCaipNamespace[] {
 ///: BEGIN:ONLY_INCLUDE_IF(tron)
 registerAdapter(tronAdapter);
 ///: END:ONLY_INCLUDE_IF
+registerAdapter(bitcoinAdapter);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This PR adds the Bitcoin adapter to the WalletConnect non-EVM layer.

Why: WalletConnect dapps could not reach a user's Bitcoin account through MetaMask Mobile .

What changed: a new bitcoinAdapter (multichain/bitcoin/) implementing the ChainAdapter contract.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: add bitcoin wallet-connect support

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bitcoin WalletConnect signing

  Scenario: user connects a Bitcoin dapp over WalletConnect
    Given a dapp initiates a WalletConnect connection requesting the Bitcoin namespace
    When the user approves the session with a Bitcoin account

  Scenario: user signs a transaction
    Given an approved Bitcoin WalletConnect session on Mainnet
    When the dapp requests bitcoin_signXDR
    Then the wallet routes the request to the Bitcoin Snap
    And the dapp receives the expected signature(s)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no UI change.

### **After**

<!-- [screenshots/recordings] -->

N/A — no UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes Bitcoin signing, PSBT signing, and send-transfer over WalletConnect; behavior depends on snap routing and deliberate omission of some dapp fields (e.g. per-input `signInputs`), though the pattern matches the existing Tron adapter and is covered by tests.
> 
> **Overview**
> Adds **Bitcoin (`bip122`) support** to the WalletConnect multichain layer so dapps can connect and call Reown’s four Bitcoin RPC methods through MetaMask Mobile.
> 
> A new `bitcoinAdapter` implements the existing `ChainAdapter` contract: it seeds CAIP-25 optional scopes ( **Mainnet only** today, with unsupported testnet chains **falling back to Mainnet** so session approval still works with the current permission UI), builds namespace permissions from permitted chains/accounts, and routes signing/transfer requests to the **Bitcoin Snap** via the shared snap router. `bitcoin_getAccountAddresses` is answered locally from connected CAIP-10 accounts; sign/message, PSBT, and send-transfer calls are mapped between WalletConnect and snap shapes (e.g. PSBT `fill: false`, single-recipient `sendTransfer`, optional `txid` only when broadcast). Signing methods are marked for **post-handle redirect** back to the dapp.
> 
> The adapter is **registered in `multichain/registry.ts`** under `bip122`, with unit tests for the adapter, mappers, and registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d233c400cc7a4047705d1d8409e85f20d5834289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->