### PR TITLE
ci: fix post-release-cut TestFlight upload OIDC auth (trigger on push to main)

### DIFF
--- a/.github/workflows/post-release-cut-testflight.yml
+++ b/.github/workflows/post-release-cut-testflight.yml
@@ -18,13 +18,19 @@
 #
 # Follows up the version bump made by merge-version-bump-pr.yml.
 #
+# Triggered by push to main (not pull_request) so the run's OIDC subject is
+# refs/heads/main, which the TestFlight AWS role trusts — a pull_request run's subject
+# (repo:...:pull_request) is rejected by the IAM trust policy. The release cut is the
+# only thing that changes package.json's version on main, so a changed version == cut.
+#
 ##############################################################################################
 name: Post-Release-Cut TestFlight Build
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - 'package.json'
 
 permissions:
   contents: read
@@ -33,30 +39,37 @@ permissions:
 jobs:
   compute-version:
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'version-bump/')
     outputs:
       next-version: ${{ steps.version.outputs.next }}
+      bumped: ${{ steps.version.outputs.bumped }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 1
+          fetch-depth: 2
 
       - name: Compute x+2 version
         id: version
         run: |
           CURRENT=$(node -p "require('./package.json').version")
+          git show HEAD~1:package.json > /tmp/prev-package.json
+          PREV=$(node -p "require('/tmp/prev-package.json').version")
+          if [ "$CURRENT" = "$PREV" ]; then
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($CURRENT) — not a release cut, skipping."
+            exit 0
+          fi
           MAJOR=$(echo "$CURRENT" | cut -d. -f1)
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
           NEXT="${MAJOR}.$((MINOR + 1)).0"
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "Current version: $CURRENT → TestFlight version: $NEXT"
+          echo "Release cut $PREV → $CURRENT → TestFlight version: $NEXT"
 
   generate-build-version:
     needs: [compute-version]
+    if: needs.compute-version.outputs.bumped == 'true'
     uses: ./.github/workflows/generate-build-version.yml
 
   build:

--- a/.github/workflows/post-release-cut-testflight.yml
+++ b/.github/workflows/post-release-cut-testflight.yml
@@ -43,10 +43,10 @@ jobs:
       next-version: ${{ steps.version.outputs.next }}
       bumped: ${{ steps.version.outputs.bumped }}
     steps:
-      - name: Checkout main
+      - name: Checkout pushed commit
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 2
 
       - name: Compute x+2 version


### PR DESCRIPTION
## Description

The **Post-Release-Cut TestFlight Build** workflow was failing at the TestFlight upload step with:

```
Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

### Root cause

The workflow was triggered by `pull_request: [closed]`. A `pull_request` run — even one that targets and merges into `main` — executes against `refs/pull/<N>/merge`, so GitHub mints the OIDC token with subject `repo:MetaMask/metamask-mobile:pull_request`. The `AWS_ROLE_APPLE_TESTFLIGHT` IAM trust policy only authorizes branch-ref subjects (`repo:...:ref:refs/heads/main`), so `sts:AssumeRoleWithWebIdentity` is rejected. (Reusable workflows inherit the caller run's OIDC context, so `upload-to-testflight.yml` couldn't fix this on its own — the trigger had to change.)

Every other workflow that uploads via this role runs in a branch-ref context (`schedule` on main, `workflow_dispatch`, or `push` to `release/*`), which is why only this one failed.

### Fix

Trigger on `push` to `main` instead. A PR merge into `main` **is** a `push` event on `refs/heads/main`, so the run now executes with the `refs/heads/main` OIDC subject the AWS role trusts — while still building the same x+2 inline version from `main`.

Detection of "this push is the release cut" is preserved by checking whether `package.json`'s `version` field changed (compare `HEAD` vs `HEAD~1`), which only the release-cut bump does. The `head.ref` check is no longer available on `push`, so this is the equivalent signal.

## Changes

- `on: pull_request: [closed]` → `on: push: branches: [main]`, path-filtered to `package.json`.
- Replace the `head.ref` job-level `if` with a `version`-field comparison inside the existing compute step, emitting a `bumped` output (`fetch-depth: 2` to read `HEAD~1`).
- Guard only `generate-build-version` with `if: bumped == 'true'`; `build` and `upload-ios-testflight` cascade-skip via their `needs:` and are otherwise unchanged.

## Manual testing steps

- Verified against [#31600](https://github.com/MetaMask/metamask-mobile/pull/31600) (release: Bump main version to 7.83.0): merged via the merge queue → fires a `push` on `main`; changed files are version-field-only (`package.json` etc.), so `bumped=true` and the build proceeds.
- Dependency PRs touch `package.json` (deps) but not the `version` field → `bumped=false` → downstream cascade-skips (no spurious TestFlight uploads).

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable (N/A — CI workflow change).
- [x] I've documented my code using JSDoc format if applicable (N/A).

Made with [Cursor](https://cursor.com)