### PR TITLE
fix: fix HD path derivation for Ledger

### DIFF
--- a/app/components/Views/LedgerSelectAccount/index.test.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.test.tsx
@@ -663,6 +663,44 @@ describe('LedgerSelectAccount', () => {
     });
   });
 
+  describe('HD Path Defaulting', () => {
+    it.each([LEDGER_BIP44_PATH, LEDGER_LEGACY_PATH])(
+      'always sets HD path to Ledger Live on mount regardless of previously stored path (%s)',
+      async (previousPath) => {
+        mockGetHDPath.mockResolvedValue(previousPath);
+        mockGetLedgerAccountsByOperation.mockResolvedValue(mockAccounts);
+
+        renderWithProvider(<LedgerSelectAccount />);
+
+        await waitFor(() => {
+          expect(mockSetHDPath).toHaveBeenCalledWith(LEDGER_LIVE_PATH);
+        });
+      },
+    );
+
+    it('sets HD path to Ledger Live before fetching accounts', async () => {
+      const callOrder: string[] = [];
+      mockSetHDPath.mockImplementation(async () => {
+        callOrder.push('setHDPath');
+      });
+      mockGetLedgerAccountsByOperation.mockImplementation(async () => {
+        callOrder.push('getLedgerAccountsByOperation');
+        return mockAccounts;
+      });
+
+      renderWithProvider(<LedgerSelectAccount />);
+
+      await waitFor(() => {
+        expect(callOrder).toContain('setHDPath');
+        expect(callOrder).toContain('getLedgerAccountsByOperation');
+      });
+
+      expect(callOrder.indexOf('setHDPath')).toBeLessThan(
+        callOrder.indexOf('getLedgerAccountsByOperation'),
+      );
+    });
+  });
+
   describe('getPathString', () => {
     it('correctly maps Ledger Live path constant', () => {
       expect(LEDGER_LIVE_PATH).toBe("m/44'/60'/0'/0/0");

--- a/app/components/Views/LedgerSelectAccount/index.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.tsx
@@ -161,10 +161,10 @@ const LedgerSelectAccount = () => {
           setTargetWalletType(HardwareWalletType.Ledger);
           const isReady = await ensureDeviceReady();
 
-          // We default to the Ledger Live path BEFORE fetching accounts.
-          await setHDPath(LEDGER_LIVE_PATH);
-
           if (isReady) {
+            // We default to the Ledger Live path BEFORE fetching accounts.
+            await setHDPath(LEDGER_LIVE_PATH);
+
             DevLogger.log(
               '[LedgerSelectAccount] Device ready - fetching accounts',
             );

--- a/app/components/Views/LedgerSelectAccount/index.tsx
+++ b/app/components/Views/LedgerSelectAccount/index.tsx
@@ -161,6 +161,9 @@ const LedgerSelectAccount = () => {
           setTargetWalletType(HardwareWalletType.Ledger);
           const isReady = await ensureDeviceReady();
 
+          // We default to the Ledger Live path BEFORE fetching accounts.
+          await setHDPath(LEDGER_LIVE_PATH);
+
           if (isReady) {
             DevLogger.log(
               '[LedgerSelectAccount] Device ready - fetching accounts',

--- a/app/core/Ledger/Ledger.test.ts
+++ b/app/core/Ledger/Ledger.test.ts
@@ -167,9 +167,8 @@ describe('Ledger core', () => {
       expect(value).toBe('appName');
     });
 
-    it('calls keyring.setHdPath and keyring.setDeviceId if deviceId is different', async () => {
+    it('calls keyring.setDeviceId if deviceId is different', async () => {
       await connectLedgerHardware(mockTransport, 'bar');
-      expect(ledgerKeyring.setHdPath).toHaveBeenCalled();
       expect(ledgerKeyring.setDeviceId).toHaveBeenCalled();
     });
 

--- a/app/core/Ledger/Ledger.ts
+++ b/app/core/Ledger/Ledger.ts
@@ -78,7 +78,6 @@ export const connectLedgerHardware = async (
   throwIfLedgerOperationAborted(abortSignal);
 
   const bridge = await withLedgerKeyring(async ({ keyring }) => {
-    keyring.setHdPath(LEDGER_LIVE_PATH);
     keyring.setDeviceId(deviceId);
 
     const ledgerBridge = keyring.bridge as LedgerMobileBridge;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixing a bug with Ledger where the HD path is auto-reset upon re-connecting (which can happen when selecting accounts). Resulting in the wrong accounts being derived (addressed picked in the UI won't match the account address that will be created).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug that would use different HD paths when deriving Ledger accounts (if a reconnects to the Ledger happen after submitting the accounts)

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1909

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Non-default HD path for Ledger accounts

  Scenario: user selects a different HD path in the UI
    Given we use a different HD path than the default "Ledger Live" one

    When user selects his accounts for a different HD path
    Then it gets the proper derived addresses
```

## **Screenshots/Recordings**

> [!NOTE]
> Recordings are pretty slow, this got tested on a Pixel 4A with a Ledger Nano X, in debug mode. The 2nd recording shows the account name edition page (because I did hit the account name before the account address, so that's not a regression). 

<!-- mms-check: type=screenshot required=true -->

### **Before**

https://github.com/user-attachments/assets/8e8c9fa5-230c-4aab-a8e7-208789b92bed

### **After**

https://github.com/user-attachments/assets/c047e509-8c10-4fd7-b072-4278cef8e336

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and where the Ledger keyring HD path is set, which directly affects which addresses are derived; scope is limited to Ledger flows and covered by new ordering/defaulting tests.
> 
> **Overview**
> Fixes Ledger account derivation when the device reconnects during account selection by **moving HD path initialization** out of `connectLedgerHardware` and into the **Ledger account selector** mount flow.
> 
> **`connectLedgerHardware`** no longer calls `setHdPath(LEDGER_LIVE_PATH)` on every connect, so a reconnect mid-flow does not overwrite a user-selected path (Legacy/BIP44) and cause the unlocked address to differ from what the UI showed.
> 
> **`LedgerSelectAccount`** now calls `setHDPath(LEDGER_LIVE_PATH)` after `ensureDeviceReady` and **before** the first account fetch, establishing a known default for listing while still allowing path changes via the dropdown (`onSelectedPathChanged`).
> 
> New tests assert Ledger Live is applied on mount even when a non-default path was stored, and that `setHDPath` runs before `getLedgerAccountsByOperation`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9935408eb5fe026fa083e31667264caf719cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->