### PR TITLE
fix(mmpay): route direct mUSD ramps order to MoneyAccount, not EOA

### DIFF
--- a/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessHost/HeadlessHost.tsx
@@ -119,7 +119,10 @@ function HeadlessHost() {
   const chainId = session
     ? (getChainIdFromAssetId(session.params.assetId) as CaipChainId | null)
     : null;
-  const walletAddress = useRampAccountAddress(chainId ?? ('' as CaipChainId));
+  const resolvedWalletAddress = useRampAccountAddress(
+    chainId ?? ('' as CaipChainId),
+  );
+  const walletAddress = session?.params.walletAddress ?? resolvedWalletAddress;
 
   // Auth-loop error path: OtpCode resets back to the Host with
   // `nativeFlowError` set when post-OTP routing fails. Forward to the

--- a/app/components/UI/Ramp/headless/types.ts
+++ b/app/components/UI/Ramp/headless/types.ts
@@ -132,14 +132,6 @@ export interface HeadlessBuyParams {
    * Override the destination wallet address the on-ramp order will be
    * created for. When omitted, the Host falls back to
    * `useRampAccountAddress(chainId)` — same EOA the BuildQuote screen uses.
-   *
-   * Used by the `directMoneyMusdEnabled` MetaMask Pay flow so the ramps
-   * order is created against the MoneyAccount (the same address that
-   * appears as `txParams.from` on the on-chain `moneyAccountDeposit`
-   * batch), rather than the user's selected EOA. Without this override
-   * the on-ramp top-up lands on the EOA and the on-chain leg fails with
-   * `Signer had insufficient balance` because it expects the funds on
-   * the MoneyAccount.
    */
   walletAddress?: string;
 }

--- a/app/components/UI/Ramp/headless/types.ts
+++ b/app/components/UI/Ramp/headless/types.ts
@@ -128,6 +128,20 @@ export interface HeadlessBuyParams {
    * the way it does today.
    */
   redirectUrl?: string;
+  /**
+   * Override the destination wallet address the on-ramp order will be
+   * created for. When omitted, the Host falls back to
+   * `useRampAccountAddress(chainId)` — same EOA the BuildQuote screen uses.
+   *
+   * Used by the `directMoneyMusdEnabled` MetaMask Pay flow so the ramps
+   * order is created against the MoneyAccount (the same address that
+   * appears as `txParams.from` on the on-chain `moneyAccountDeposit`
+   * batch), rather than the user's selected EOA. Without this override
+   * the on-ramp top-up lands on the EOA and the on-chain leg fails with
+   * `Signer had insufficient balance` because it expects the funds on
+   * the MoneyAccount.
+   */
+  walletAddress?: string;
 }
 
 /**

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -168,11 +168,14 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const { selectedPaymentMethod } = useRampsPaymentMethods();
 
   const { selected: selectedToken } = useSelector(selectTokens);
-  const headlessAssetId = getSession(headlessSessionId)?.params?.assetId;
+  const headlessSessionParams = getSession(headlessSessionId)?.params;
+  const headlessAssetId = headlessSessionParams?.assetId;
   const walletAddressChainId =
     (headlessAssetId ? getChainIdFromAssetId(headlessAssetId) : null) ??
     (selectedToken?.chainId as CaipChainId | undefined);
-  const walletAddress = useRampAccountAddress(walletAddressChainId);
+  const resolvedWalletAddress = useRampAccountAddress(walletAddressChainId);
+  const walletAddress =
+    headlessSessionParams?.walletAddress ?? resolvedWalletAddress;
 
   const fiatCurrency = userRegion?.country?.currency || '';
   const regionIsoCode = userRegion?.regionCode || '';

--- a/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
@@ -60,6 +60,7 @@ export function useFiatConfirm() {
         amount: totalAmountToBuy,
         paymentMethodId: fiatPayment?.selectedPaymentMethodId,
         currency: 'USD',
+        walletAddress: transactionMetadata?.txParams?.from,
       },
       {
         onOrderCreated: (orderIdFromCallback) => {
@@ -92,6 +93,7 @@ export function useFiatConfirm() {
     setIsHeadlessBuyInProgress,
     startHeadlessBuy,
     transactionMetadata?.id,
+    transactionMetadata?.txParams?.from,
   ]);
 
   return { onFiatConfirm, isFiatPaymentSelected, orderId };


### PR DESCRIPTION
## **Description**

When `directMoneyMusdEnabled` is on and the user pays for a Money Account deposit with fiat, the on-chain leg is authored with `txParams.from` set to the **MoneyAccount** address (see [`fiatStrategy.getFiatQuotes`](https://github.com/MetaMask/core/blob/main/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts#L53-L90) in `@metamask/transaction-pay-controller`). The ramps order, however, was being created against the user's **EOA** because every wallet-address resolver in the headless buy flow short-circuits to `selectSelectedInternalAccountByScope` → `getFormattedAddressFromInternalAccount`, which only knows about `InternalAccount`s and therefore always returns the EOA.

**Result on device:** the Transak top-up landed on the EOA, the subsequent `moneyAccountDeposit` / `relayDeposit` batches tried to spend from the MoneyAccount, and both failed with `Signer had insufficient balance`. Observed in a real run where:

- on-chain batch: `txParams.from = 0xd663…9282` (MoneyAccount), `nestedTransactions[1].type = "moneyAccountDeposit"`
- ramps order: `walletAddress = 0x6692…dBf` (EOA), `provider = /providers/transak-native`
- both follow-up batches: `error.message = "Signer had insufficient balance"`

### Fix

Thread an optional `walletAddress` override through the headless buy API so the ramps order targets the same address the on-chain leg will spend from:

1. **`HeadlessBuyParams`** gains an optional `walletAddress` field.
2. **`useFiatConfirm`** passes `transactionMetadata?.txParams?.from` into `startHeadlessBuy`. For non-direct-mUSD flows `txParams.from` equals the EOA, so behavior is unchanged.
3. **`HeadlessHost`** prefers `session.params.walletAddress` over `useRampAccountAddress(chainId)`, which feeds the widget branch via the existing `ctx.walletAddress` override slot in `useContinueWithQuote`.
4. **`useTransakRouting`** prefers `session.params.walletAddress` when present, which is the address that ends up in `generatePaymentWidgetUrl`, `transakCreateOrder`, `getOrder`, and `refreshOrder`. Without this, the native Transak provider path bypasses every override because it re-derives its own `walletAddress` from `useRampAccountAddress`.

The override flows through both provider branches (widget + native Transak), so any quote `useFiatConfirm` produces — Apple Pay, debit/credit card, manual bank transfer — gets the correct destination address.

### Why not read it off `rampsQuote`?

The `Quote` type from `@metamask/ramps-controller` carries no `walletAddress` / `receiver` / `recipient` field — the address is consumed by the provider at quote-time and only surfaces again on the `RampsOrder` after submission. The same applies to `TransactionFiatPayment` controller state: it stores `rampsQuote` and `caipAssetId` but not the `rampsWalletAddress` the controller used during quoting. `transactionMetadata.txParams.from` is the single mobile-side field that mirrors the controller's submit-side invariant (`fiat-submit.ts:getWalletAddress`), so both sides agree by reading the same source.

## **Changelog**

CHANGELOG entry: Fixed a bug where MetaMask Pay fiat top-ups for Money Account deposits were sent to the user's EOA instead of the Money Account, causing the deposit transaction to fail with insufficient balance.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: MetaMask Pay fiat top-up for Money Account deposit

  Scenario: Apple Pay deposit with directMoneyMusdEnabled
    Given the directMoneyMusdEnabled feature flag is on
    And the user has a Money Account with insufficient mUSD on Monad
    And the user opens a confirmation that triggers a moneyAccountDeposit

    When the user picks the fiat payment method (Apple Pay / Transak)
    And completes the Transak purchase

    Then the ramps order's walletAddress equals the MoneyAccount address
      (i.e. transaction.txParams.from, not the user's EOA)
    And the on-ramp top-up mUSD lands on the MoneyAccount
    And the subsequent moneyAccountDeposit + relayDeposit batches succeed

  Scenario: Non-direct-mUSD flow is unchanged
    Given the directMoneyMusdEnabled feature flag is off
      or the transaction is not a moneyAccountDeposit

    When the user completes a fiat top-up for the confirmation

    Then the ramps order's walletAddress equals the user's EOA
      (same behavior as before this PR)
```

### How to verify on device

1. Reproduce the original failure on `main`:
   - With `directMoneyMusdEnabled` on, trigger a Money Account deposit confirmation.
   - Pay with Apple Pay through Transak.
   - Inspect `RampsController.orders[0].walletAddress` and the failed `TransactionController.transactions[]` entries — order points to the EOA, deposit batches fail with `Signer had insufficient balance`.
2. Switch to this branch and repeat:
   - `RampsController.orders[0].walletAddress` should now equal `transaction.txParams.from` (the MoneyAccount).
   - The follow-up `moneyAccountDeposit` and `relayDeposit` batches should no longer report `Signer had insufficient balance`.
3. Smoke test the non-direct-mUSD path:
   - Standard fiat buy from BuildQuote (not via MMPay) → ramps order still targets the EOA.
   - Fiat buy for non-`moneyAccountDeposit` transactions → ramps order still targets the EOA.

## **Screenshots/Recordings**

### **Before**

N/A — bug is a state-level regression, not visual. Evidence is in `RampsController.orders[*].walletAddress` and `TransactionController.transactions[*].error.message` (`Signer had insufficient balance`) on the failing run captured in `controller states.json`.

### **After**

N/A — same as above, validated by inspecting controller state on a successful run.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which address receives on-ramp funds in MetaMask Pay fiat flows; mis-wiring could misroute deposits, but the override is optional and defaults preserve existing EOA behavior.
> 
> **Overview**
> Fixes MetaMask Pay fiat top-ups crediting the **EOA** while the on-chain deposit spends from the **Money Account**, which left follow-up batches failing with insufficient balance.
> 
> Adds an optional **`walletAddress`** on **`HeadlessBuyParams`**. **`useFiatConfirm`** passes **`transactionMetadata.txParams.from`** into **`startHeadlessBuy`** so ramps orders target the same signer as the confirmation (Money Account when direct mUSD is on; EOA otherwise). **`HeadlessHost`** and **`useTransakRouting`** use **`session.params.walletAddress`** when set instead of only **`useRampAccountAddress`**, covering both widget and native Transak order paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93deb36112607253e431e5bcef1fc3abdc3b966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->