### PR TITLE
fix: problematic dismissable ref

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -440,6 +440,61 @@ describe('PerpsTPSLView', () => {
         }
       },
     );
+
+    it.each([
+      [
+        'take profit',
+        () => getTakeProfitPriceInput(),
+        () => getTakeProfitPercentageInput(),
+        'handleTakeProfitPriceBlur',
+        'handleTakeProfitPercentageFocus',
+      ],
+      [
+        'stop loss',
+        () => getStopLossPriceInput(),
+        () => getStopLossPercentageInput(),
+        'handleStopLossPriceBlur',
+        'handleStopLossPercentageFocus',
+      ],
+    ])(
+      // Regression test for iOS focus/blur race: on iOS, when the user moves
+      // focus directly from the price field to the % field, the new field's
+      // onFocus fires before the old field's onBlur. The input-scoped
+      // programmaticDismissInputRef must NOT suppress the price field's blur
+      // in this scenario — only the focused field's own programmatic blur is
+      // suppressed.
+      'delivers %s price blur even when iOS dismiss guard is active for the percentage field',
+      (_description, getPriceInput, getPctInput, priceBlurHandler) => {
+        jest.useFakeTimers();
+        try {
+          const mockPriceBlur = jest.fn();
+          renderView({
+            handlers: {
+              ...defaultMockReturn.handlers,
+              [priceBlurHandler]: mockPriceBlur,
+            },
+          });
+
+          // Step 1: focus the price input to set it as the active field.
+          fireEvent(getPriceInput(), 'focus');
+
+          // Step 2: immediately focus the % input WITHOUT flushing the
+          // dismiss-guard timer (simulates iOS focus/blur ordering where
+          // new-field onFocus fires before old-field onBlur). The guard is
+          // now set to the % input's id.
+          fireEvent(getPctInput(), 'focus');
+
+          // Step 3: now the price input fires its onBlur. The guard is scoped
+          // to the % input's id, NOT the price input's id, so the price blur
+          // handler must still be called and tpPriceInputFocused must clear.
+          fireEvent(getPriceInput(), 'blur');
+
+          expect(mockPriceBlur).toHaveBeenCalled();
+        } finally {
+          jest.useRealTimers();
+        }
+      },
+    );
   });
 
   // ==================== Display Hook Data ====================

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -92,9 +92,12 @@ const PerpsTPSLView: React.FC = () => {
   const stopLossPercentageRef = useRef<TextInput>(null);
 
   // Guard: when we programmatically dismiss the native keyboard on iOS,
-  // the TextInput fires onBlur. This ref prevents that blur from hiding
-  // the custom keypad.
-  const isProgrammaticDismissRef = useRef(false);
+  // the TextInput fires onBlur. We store the *specific* input being
+  // dismissed so that only that field's blur is suppressed — other
+  // fields' genuine blurs (e.g. the previously-focused price field when
+  // the user taps the % field) are still delivered to the hook and clear
+  // their focus state correctly.
+  const programmaticDismissInputRef = useRef<string | null>(null);
 
   // Subscribe to real-time price only when we have an asset
   // Use throttle for TP/SL screen to reduce re-renders
@@ -297,15 +300,16 @@ const PerpsTPSLView: React.FC = () => {
       // still appears when a TextInput is focused. Dismiss it so that only
       // the custom keypad is visible and content stays within the viewport.
       //
-      // This runs inside the callback (not a useEffect) so it fires on
-      // every focus event, even when the same input is re-focused and
-      // React deduplicates the setFocusedInput call.
+      // We track the specific inputType being dismissed so that only this
+      // field's resulting onBlur is suppressed. Blurs from other fields
+      // (e.g. the previously-focused price field) are not suppressed and
+      // correctly update the hook's focus state.
       if (Platform.OS === 'ios') {
-        isProgrammaticDismissRef.current = true;
+        programmaticDismissInputRef.current = inputType;
         requestAnimationFrame(() => {
           Keyboard.dismiss();
           setTimeout(() => {
-            isProgrammaticDismissRef.current = false;
+            programmaticDismissInputRef.current = null;
           }, 150);
         });
       }
@@ -356,30 +360,38 @@ const PerpsTPSLView: React.FC = () => {
     ],
   );
 
-  const handleInputBlur = useCallback(() => {
-    // When we programmatically dismiss the native keyboard on iOS the
-    // TextInput fires onBlur. Ignore that blur so the custom keypad
-    // stays visible.
-    if (isProgrammaticDismissRef.current) return;
+  // inputType identifies which field is blurring so we can:
+  // 1. Suppress only the programmatic blur of that specific field (not
+  //    genuinely-blurring fields whose hook blur must run to clear focus state).
+  // 2. Only hide the keypad when the active/focused field is the one blurring
+  //    (prevents hiding the keypad when the user moves focus to another field).
+  const handleInputBlur = useCallback(
+    (inputType: string) => {
+      // Suppress only the programmatic blur triggered by Keyboard.dismiss()
+      // for this exact input. Other fields' genuine blurs are not suppressed.
+      if (programmaticDismissInputRef.current === inputType) return;
 
-    if (focusedInput === 'takeProfitPrice') {
-      handleTakeProfitPriceBlur();
-    } else if (focusedInput === 'takeProfitPercentage') {
-      handleTakeProfitPercentageBlur();
-    } else if (focusedInput === 'stopLossPrice') {
-      handleStopLossPriceBlur();
-    } else if (focusedInput === 'stopLossPercentage') {
-      handleStopLossPercentageBlur();
-    }
+      if (inputType === 'takeProfitPrice') {
+        handleTakeProfitPriceBlur();
+      } else if (inputType === 'takeProfitPercentage') {
+        handleTakeProfitPercentageBlur();
+      } else if (inputType === 'stopLossPrice') {
+        handleStopLossPriceBlur();
+      } else if (inputType === 'stopLossPercentage') {
+        handleStopLossPercentageBlur();
+      }
 
-    setFocusedInput(null);
-  }, [
-    focusedInput,
-    handleTakeProfitPriceBlur,
-    handleTakeProfitPercentageBlur,
-    handleStopLossPriceBlur,
-    handleStopLossPercentageBlur,
-  ]);
+      // Only clear the keypad when the field that is blurring is still the
+      // active one (i.e. the user isn't moving to another input).
+      setFocusedInput((prev) => (prev === inputType ? null : prev));
+    },
+    [
+      handleTakeProfitPriceBlur,
+      handleTakeProfitPercentageBlur,
+      handleStopLossPriceBlur,
+      handleStopLossPercentageBlur,
+    ],
+  );
 
   const dismissKeypad = useCallback(() => {
     // Blur the currently focused input to trigger onBlur events
@@ -665,10 +677,12 @@ const PerpsTPSLView: React.FC = () => {
                     handleInputFocus('takeProfitPrice');
                   }}
                   onBlur={() => {
-                    if (!isProgrammaticDismissRef.current) {
+                    if (
+                      programmaticDismissInputRef.current !== 'takeProfitPrice'
+                    ) {
                       handleTakeProfitPriceBlur();
                     }
-                    handleInputBlur();
+                    handleInputBlur('takeProfitPrice');
                   }}
                   selectionColor={colors.primary.default}
                   cursorColor={colors.primary.default}
@@ -699,10 +713,13 @@ const PerpsTPSLView: React.FC = () => {
                     handleInputFocus('takeProfitPercentage');
                   }}
                   onBlur={() => {
-                    if (!isProgrammaticDismissRef.current) {
+                    if (
+                      programmaticDismissInputRef.current !==
+                      'takeProfitPercentage'
+                    ) {
                       handleTakeProfitPercentageBlur();
                     }
-                    handleInputBlur();
+                    handleInputBlur('takeProfitPercentage');
                   }}
                   selectionColor={colors.primary.default}
                   cursorColor={colors.primary.default}
@@ -846,10 +863,12 @@ const PerpsTPSLView: React.FC = () => {
                     handleInputFocus('stopLossPrice');
                   }}
                   onBlur={() => {
-                    if (!isProgrammaticDismissRef.current) {
+                    if (
+                      programmaticDismissInputRef.current !== 'stopLossPrice'
+                    ) {
                       handleStopLossPriceBlur();
                     }
-                    handleInputBlur();
+                    handleInputBlur('stopLossPrice');
                   }}
                   selectionColor={colors.primary.default}
                   cursorColor={colors.primary.default}
@@ -880,10 +899,13 @@ const PerpsTPSLView: React.FC = () => {
                     handleInputFocus('stopLossPercentage');
                   }}
                   onBlur={() => {
-                    if (!isProgrammaticDismissRef.current) {
+                    if (
+                      programmaticDismissInputRef.current !==
+                      'stopLossPercentage'
+                    ) {
                       handleStopLossPercentageBlur();
                     }
-                    handleInputBlur();
+                    handleInputBlur('stopLossPercentage');
                   }}
                   selectionColor={colors.primary.default}
                   cursorColor={colors.primary.default}

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
@@ -819,29 +819,54 @@ describe('usePerpsTPSLForm', () => {
       );
     });
 
-    it('prevent price updates when price field is focused', () => {
+    // The percentage->price auto-fill intentionally ignores tpPriceInputFocused.
+    // When a user types a percentage, the percentage field is the active source of
+    // truth and the price must always be updated — even if the focus state flags
+    // are stale (e.g. due to the iOS focus/blur race). Only the price->percentage
+    // direction is still gated by focus state (via tpPercentInputFocused) to avoid
+    // overwriting the user's typed percentage while they are editing it.
+    it('still updates price from percentage even when price field previously focused', () => {
       const { result } = renderHook(() => usePerpsTPSLForm(defaultParams), {
         wrapper: createWrapper(),
       });
 
-      // Focus price field first
+      // Focus price field and enter a value — simulates the stale-focus scenario.
       act(() => {
         result.current.handlers.handleTakeProfitPriceFocus();
-      });
-
-      // Set initial price value
-      act(() => {
         result.current.handlers.handleTakeProfitPriceChange('55000');
       });
 
-      const initialPrice = result.current.formState.takeProfitPrice;
-
-      // Now change percentage - this should NOT update price while price field is focused
+      // Now change the percentage. The price field focus flag is still true (stale),
+      // but the auto-fill must still compute and set the new trigger price.
       act(() => {
-        result.current.handlers.handleTakeProfitPercentageChange('100');
+        result.current.handlers.handleTakeProfitPercentageChange('10');
       });
 
-      expect(result.current.formState.takeProfitPrice).toBe(initialPrice);
+      // Price must have been recomputed from the 10% RoE value, not left at 55000.
+      // 10% RoE with 10x leverage = 1% price change = 50000 * 1.01 = 50500
+      expect(result.current.formState.takeProfitPrice).not.toBe('55000');
+      expect(result.current.formState.takeProfitPrice).not.toBe('');
+    });
+
+    it('still updates stop loss price from percentage even when price field previously focused', () => {
+      const { result } = renderHook(() => usePerpsTPSLForm(defaultParams), {
+        wrapper: createWrapper(),
+      });
+
+      // Focus stop loss price field — simulates the stale-focus scenario.
+      act(() => {
+        result.current.handlers.handleStopLossPriceFocus();
+        result.current.handlers.handleStopLossPriceChange('46000');
+      });
+
+      // Type a stop loss percentage. The stale slPriceInputFocused must not block it.
+      act(() => {
+        result.current.handlers.handleStopLossPercentageChange('-10');
+      });
+
+      // Stop loss price must have been recomputed, not left at 46000.
+      expect(result.current.formState.stopLossPrice).not.toBe('46000');
+      expect(result.current.formState.stopLossPrice).not.toBe('');
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -396,12 +396,14 @@ export function usePerpsTPSLForm(
       // Set percentage as source of truth when user is actively typing
       setTpSourceOfTruth('percentage');
 
-      // Update price based on RoE percentage only if price field is not focused
+      // Always compute the trigger price when the user is typing a percentage.
+      // The percentage field is the active source of truth here, so we do not
+      // gate on tpPriceInputFocused — a stale true value (e.g. due to iOS
+      // focus/blur ordering) must not silently block the auto-fill.
       if (
         finalValue &&
         !Number.isNaN(Number.parseFloat(finalValue.replace(' ', ''))) &&
-        leverage &&
-        !tpPriceInputFocused
+        leverage
       ) {
         const roeValue = Number.parseFloat(finalValue.replace(' ', ''));
         const price = calculatePriceForRoE(roeValue, true, {
@@ -423,14 +425,7 @@ export function usePerpsTPSLForm(
       }
       setTpUsingPercentage(true); // User is using RoE percentage-based calculation
     },
-    [
-      currentPrice,
-      actualDirection,
-      leverage,
-      entryPrice,
-      tpPriceInputFocused,
-      takeProfitPercentage,
-    ],
+    [currentPrice, actualDirection, leverage, entryPrice, takeProfitPercentage],
   );
 
   const handleStopLossPriceChange = useCallback(
@@ -510,12 +505,14 @@ export function usePerpsTPSLForm(
       // Set percentage as source of truth when user is actively typing
       setSlSourceOfTruth('percentage');
 
-      // Update price based on RoE percentage only if price field is not focused
+      // Always compute the trigger price when the user is typing a percentage.
+      // The percentage field is the active source of truth here, so we do not
+      // gate on slPriceInputFocused — a stale true value (e.g. due to iOS
+      // focus/blur ordering) must not silently block the auto-fill.
       if (
         finalValue &&
         !Number.isNaN(Number.parseFloat(finalValue.replace(' ', ''))) &&
-        leverage &&
-        !slPriceInputFocused
+        leverage
       ) {
         const roeValue = Number.parseFloat(finalValue.replace(' ', ''));
         const price = calculatePriceForRoE(roeValue, false, {
@@ -537,14 +534,7 @@ export function usePerpsTPSLForm(
       }
       setSlUsingPercentage(true); // User is using RoE percentage-based calculation
     },
-    [
-      currentPrice,
-      actualDirection,
-      leverage,
-      entryPrice,
-      slPriceInputFocused,
-      stopLossPercentage,
-    ],
+    [currentPrice, actualDirection, leverage, entryPrice, stopLossPercentage],
   );
 
   // Focus/blur event handlers to manage source of truth and prevent input interference


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Problem**

When editing a position's TP/SL and tapping directly from the price field to the % gain/loss field, typing a percentage did not auto-fill the trigger price and the Set button stayed disabled. iOS-only bug.

**Root cause**

The iOS keyboard-dismiss fix introduced a boolean guard (`isProgrammaticDismissRef`) that was set synchronously on every input focus. On iOS, the new field's `onFocus` fires before the old field's `onBlur`, so the guard was active when the price field's blur arrived — suppressing it and leaving `tpPriceInputFocused` stuck `true`. The percentage→price auto-fill was gated on `!tpPriceInputFocused`, so it never ran.

**Fix**

Scoped the guard to a specific input — replaced the boolean ref with a string | null ref that stores the id of the field being dismissed. Only that field's programmatic blur is suppressed; all other fields' genuine blurs (including the previously-focused price field) are delivered normally and correctly clear focus state.

Hardened the hook — removed the `!tpPriceInputFocused` / `!slPriceInputFocused` gate from the percentage change handlers entirely. When the user is typing a percentage, that field is by definition the active source of truth and the trigger price must always be computed, regardless of stale focus flags.

**Tests**

Added a regression test for the iOS focus/blur race (focus % before blur on price, no timer flush) verifying the price field's blur handler still fires.

Updated and added hook-level tests confirming percentage→price auto-fill works even when a price field's focus flag is stale.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

Android:

https://github.com/user-attachments/assets/eb2b8f2a-4243-409b-9660-4c01a862237b

iOS:
https://github.com/user-attachments/assets/20902575-80bf-4a70-bf9b-d5c8a2d10bb1


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
