### PR TITLE
fix: align ButtonIcon sizes with MMDS spec

### DIFF
--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts
@@ -13,9 +13,9 @@ import {
 
 // Mappings
 export const ICONSIZE_BY_BUTTONICONSIZE: IconSizeByButtonIconSize = {
-  [ButtonIconSizes.Sm]: IconSize.Sm,
-  [ButtonIconSizes.Md]: IconSize.Md,
-  [ButtonIconSizes.Lg]: IconSize.Lg,
+  [ButtonIconSizes.Sm]: IconSize.Md,
+  [ButtonIconSizes.Md]: IconSize.Lg,
+  [ButtonIconSizes.Lg]: IconSize.Xl,
 };
 
 // Defaults

--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.types.ts
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.types.ts
@@ -9,8 +9,8 @@ import { IconName, IconSize, IconColor } from '../../Icons/Icon';
  */
 export enum ButtonIconSizes {
   Sm = '24',
-  Md = '28',
-  Lg = '32',
+  Md = '32',
+  Lg = '40',
 }
 
 /**

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -135,10 +135,10 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
           "alignItems": "center",
           "borderRadius": 8,
           "flexShrink": 0,
-          "height": 28,
+          "height": 32,
           "justifyContent": "center",
           "opacity": 0.5,
-          "width": 28,
+          "width": 32,
         }
       }
       testID="snap-ui-address-input__clear-button"
@@ -146,15 +146,15 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
       <SvgMock
         color="#4459ff"
         fill="currentColor"
-        height={20}
+        height={24}
         name="Close"
         style={
           {
-            "height": 20,
-            "width": 20,
+            "height": 24,
+            "width": 24,
           }
         }
-        width={20}
+        width={24}
       />
     </View>
   </View>
@@ -303,15 +303,15 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
         <SvgMock
           color="#4459ff"
           fill="currentColor"
-          height={16}
+          height={20}
           name="Close"
           style={
             {
-              "height": 16,
-              "width": 16,
+              "height": 20,
+              "width": 20,
             }
           }
-          width={16}
+          width={20}
         />
       </View>
     </View>


### PR DESCRIPTION
## **Description**

Aligns the legacy `ButtonIcon` component-library sizes (Extension & Mobile) with the MetaMask Design System (MMDS) spec. The legacy values were smaller than the MMDS values on all three size variants.

| `ButtonIconSize` | Container before | Container after | Icon before | Icon after |
|-----------------|-----------------|-----------------|-------------|------------|
| `Sm`            | 24×24px         | 24×24px         | 16px        | 20px       |
| `Md`            | 28×28px         | 32×32px         | 20px        | 24px       |
| `Lg`            | 32×32px         | 40×40px         | 24px        | 32px       |

The MMDS target values (same on React and React Native):

| `ButtonIconSize` | Button container | Icon size |
|-----------------|-----------------|-----------|
| `Sm`            | 24×24px         | 20×20px   |
| `Md`            | 32×32px         | 24×24px   |
| `Lg`            | 40×40px         | 32×32px   |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: ButtonIcon size alignment

  Scenario: user inspects ButtonIcon sizes in Storybook
    Given the component-library Storybook is running

    When user views ButtonIcon stories for Sm, Md, and Lg sizes
    Then the container and icon dimensions match the MMDS spec table above
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/00f3a266-3e4d-4a9a-8289-20017b71abc0

### **After**

https://github.com/user-attachments/assets/a554de20-002c-4f91-b591-cc6a47fe7bb4

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.