### PR TITLE
fix: prevent dapp deeplinks opening twice on Android (#29475)

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleDeeplink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleDeeplink.test.ts
@@ -1,4 +1,7 @@
-import { handleDeeplink } from '../handleDeeplink';
+import {
+  handleDeeplink,
+  resetDeeplinkDeduplication,
+} from '../handleDeeplink';
 import { checkForDeeplink } from '../../../../../actions/user';
 import { saveAttribution } from '../../../../redux/slices/attribution';
 import ReduxService from '../../../../redux';
@@ -32,6 +35,7 @@ jest.mock('../../../../redux', () => ({
 
 jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
+  log: jest.fn(),
 }));
 
 jest.mock('../../../../AppStateEventListener', () => ({
@@ -82,6 +86,7 @@ describe('handleDeeplink', () => {
   const mockDetectAppInstallation = detectAppInstallation as jest.Mock;
   beforeEach(() => {
     jest.clearAllMocks();
+    resetDeeplinkDeduplication();
     mockIsMwpDeeplink.mockReturnValue(false);
     mockGetState.mockReturnValue({
       security: { dataCollectionForMarketing: true },
@@ -216,6 +221,57 @@ describe('handleDeeplink', () => {
     expect(mockSetCurrentDeeplink).not.toHaveBeenCalled();
     expect(mockDispatch).not.toHaveBeenCalled();
     expect(mockCheckForDeeplink).not.toHaveBeenCalled();
+  });
+
+  describe('duplicate deeplink suppression', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('ignores an identical deeplink delivered within the dedup window', () => {
+      const testUri = 'https://link.metamask.io/dapp/example.com';
+
+      handleDeeplink({ uri: testUri });
+      handleDeeplink({ uri: testUri });
+
+      expect(mockSetCurrentDeeplink).toHaveBeenCalledTimes(1);
+      expect(mockCheckForDeeplink).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'CHECK_FOR_DEEPLINK' });
+    });
+
+    it('processes the same deeplink again once the dedup window has elapsed', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(0);
+      const testUri = 'https://link.metamask.io/dapp/example.com';
+
+      handleDeeplink({ uri: testUri });
+      jest.setSystemTime(3001);
+      handleDeeplink({ uri: testUri });
+
+      expect(mockSetCurrentDeeplink).toHaveBeenCalledTimes(2);
+      expect(mockCheckForDeeplink).toHaveBeenCalledTimes(2);
+    });
+
+    it('processes distinct deeplinks delivered back-to-back', () => {
+      handleDeeplink({ uri: 'https://link.metamask.io/dapp/one.com' });
+      handleDeeplink({ uri: 'https://link.metamask.io/dapp/two.com' });
+
+      expect(mockSetCurrentDeeplink).toHaveBeenCalledTimes(2);
+      expect(mockCheckForDeeplink).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not dispatch when a duplicate is suppressed', () => {
+      const testUri = 'metamask://duplicate';
+
+      handleDeeplink({ uri: testUri });
+      mockDispatch.mockClear();
+      mockSetCurrentDeeplink.mockClear();
+
+      handleDeeplink({ uri: testUri });
+
+      expect(mockSetCurrentDeeplink).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
   describe('MWP deeplink handling', () => {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleDeeplink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleDeeplink.test.ts
@@ -1,7 +1,4 @@
-import {
-  handleDeeplink,
-  resetDeeplinkDeduplication,
-} from '../handleDeeplink';
+import { handleDeeplink, resetDeeplinkDeduplication } from '../handleDeeplink';
 import { checkForDeeplink } from '../../../../../actions/user';
 import { saveAttribution } from '../../../../redux/slices/attribution';
 import ReduxService from '../../../../redux';

--- a/app/core/DeeplinkManager/handlers/legacy/handleDeeplink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleDeeplink.ts
@@ -14,6 +14,31 @@ import {
 } from '../../types/deepLinkAnalytics.types';
 import { detectAppInstallation } from '../../util/deeplinks/deepLinkAnalytics';
 
+/**
+ * Time window during which an identical deeplink is treated as a duplicate and
+ * ignored.
+ *
+ * On Android, a single user click on a deeplink can be delivered twice when the
+ * app is resumed from the background: once through React Native `Linking`
+ * (`url` event) and once through the Branch SDK (`branch.subscribe`). Without
+ * de-duplication, both deliveries are processed and a dapp link opens two
+ * browser tabs. iOS routes external URL opens through Branch only, so it is not
+ * affected. The two deliveries happen back-to-back, so a short window is enough
+ * to collapse them without interfering with genuine repeat navigations.
+ */
+const DUPLICATE_DEEPLINK_WINDOW_MS = 3000;
+
+let lastHandledDeeplinkUri: string | null = null;
+let lastHandledDeeplinkAt = 0;
+
+/**
+ * Reset the duplicate-deeplink suppression state. Exposed for tests.
+ */
+export function resetDeeplinkDeduplication(): void {
+  lastHandledDeeplinkUri = null;
+  lastHandledDeeplinkAt = 0;
+}
+
 export function handleDeeplink(opts: { uri?: string; source?: string }) {
   // This is the earliest JS entry point for deeplinks. We must handle SDKConnectV2
   // links here immediately to establish the WebSocket connection as fast as possible,
@@ -31,6 +56,20 @@ export function handleDeeplink(opts: { uri?: string; source?: string }) {
   const { uri, source } = opts;
   try {
     if (uri && typeof uri === 'string') {
+      // Drop duplicate deliveries of the same deeplink (see
+      // DUPLICATE_DEEPLINK_WINDOW_MS) so a single click does not, for example,
+      // open a dapp in two browser tabs on Android.
+      const now = Date.now();
+      if (
+        uri === lastHandledDeeplinkUri &&
+        now - lastHandledDeeplinkAt < DUPLICATE_DEEPLINK_WINDOW_MS
+      ) {
+        Logger.log(`Deeplink: Ignoring duplicate deeplink: ${uri}`);
+        return;
+      }
+      lastHandledDeeplinkUri = uri;
+      lastHandledDeeplinkAt = now;
+
       AppStateEventProcessor.setCurrentDeeplink(uri, source);
       if (
         ReduxService.store.getState().security.dataCollectionForMarketing ===


### PR DESCRIPTION
## **Description**

When a dapp deeplink is tapped while the MetaMask app is open in the background on Android, the dapp opens **twice** in the in-app browser (two tabs).

**Reason for the change:** On Android, a single deeplink click is delivered to the JS layer twice when the app is resumed from the background — once through React Native's `Linking` (`url` event) and once through the Branch SDK (`branch.subscribe`). Both deliveries flow through `handleDeeplink` → `checkForDeeplink` → the deeplink saga → `handleBrowserUrl` → `newTab`, with no de-duplication anywhere in the chain. Each pass generates a fresh timestamp, so the Browser view opens a new tab for each one. iOS routes external URL opens through Branch only, so it is unaffected (matching the bug report: not reproducible on iOS, and not reproducible when the app is closed/cold-started).

**Solution:** De-duplicate at the earliest shared JS entry point (`handleDeeplink`). An identical URI received within a short 3s window is ignored, which collapses the back-to-back duplicate delivery into a single handling without interfering with genuine repeat navigations (the same link can still be re-opened once the window elapses). The change is platform-agnostic and also guards any cold-start `getInitialURL`/Branch duplicate delivery.

## **Changelog**

CHANGELOG entry: Fixed a bug on Android where opening a dapp deep link while the app was in the background opened the dapp in two browser tabs.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/29475

## **Manual testing steps**

```gherkin
Feature: Dapp deep link opens a single browser tab

  Scenario: User opens a dapp deep link while the app is backgrounded
    Given the MetaMask app is open and running in the background on an Android device
    And the app is unlocked

    When the user taps a dapp deep link (e.g. https://metamask.app.link/dapp/app.uniswap.org)
    Then the dapp opens in exactly one browser tab
    And no duplicate tab is created
```

> Note: on a locally-signed dev build, App Links for `metamask.app.link` / `link.metamask.io` are not verified, so tapping a link bounces through the browser. To reproduce the exact intent delivery, background the app and inject the link directly:
> `adb shell am start -W -a android.intent.action.VIEW -d "https://metamask.app.link/dapp/app.uniswap.org" io.metamask`

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/d11b38a9-d1b0-4c2d-8888-eec62844c891

<!-- Two browser tabs open from a single dapp deep link click (see issue #29475 recording). -->

### **After**


https://github.com/user-attachments/assets/197d69aa-d221-499f-970c-90012652dc9a



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.