### PR TITLE
fix: show dapp domain in typed sign V3/V4 Request from for WalletConnect

### DIFF
--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/info-section-origin-and-details/info-section-origin-and-details.test.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/info-section-origin-and-details/info-section-origin-and-details.test.tsx
@@ -17,6 +17,45 @@ describe('InfoSectionOriginAndDetails', () => {
     expect(getByText('metamask.github.io')).toBeTruthy();
   });
 
+  it('renders the dapp url from request metadata instead of approvalRequest.origin (e.g. WalletConnect pairing topic)', () => {
+    const approvalController =
+      typedSignV4ConfirmationState.engine.backgroundState.ApprovalController;
+    const [approvalId, approval] = Object.entries(
+      approvalController.pendingApprovals,
+    )[0];
+    const pairingTopic =
+      'a7c9f3e1b8d6c2f4e9a1b3d5c7e9f1a3a7c9f3e1b8d6c2f4e9a1b3d5c7e9f1a3';
+
+    const walletConnectState = {
+      ...typedSignV4ConfirmationState,
+      engine: {
+        ...typedSignV4ConfirmationState.engine,
+        backgroundState: {
+          ...typedSignV4ConfirmationState.engine.backgroundState,
+          ApprovalController: {
+            ...approvalController,
+            pendingApprovals: {
+              [approvalId]: {
+                ...approval,
+                origin: pairingTopic,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { getByText, queryByText } = renderWithProvider(
+      <InfoSectionOriginAndDetails />,
+      {
+        state: walletConnectState,
+      },
+    );
+
+    expect(getByText('metamask.github.io')).toBeTruthy();
+    expect(queryByText(pairingTopic)).toBeNull();
+  });
+
   it('renders network', () => {
     const { getByText } = renderWithProvider(<InfoSectionOriginAndDetails />, {
       state: typedSignV4ConfirmationState,

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/info-section-origin-and-details/info-section-origin-and-details.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/info-section-origin-and-details/info-section-origin-and-details.tsx
@@ -31,7 +31,11 @@ import Text, {
 export const InfoSectionOriginAndDetails = () => {
   const { styles } = useStyles(styleSheet, {});
   const { approvalRequest } = useApprovalRequest();
-  const origin = approvalRequest?.origin as string;
+  // Prefer the dapp URL from the request metadata over `approvalRequest.origin`.
+  // For WalletConnect/SDK connections `origin` is the permission subject
+  // (pairing topic / channelId hex), not the dapp domain.
+  const origin = (approvalRequest?.requestData?.meta?.url ??
+    approvalRequest?.origin) as string;
 
   const signatureRequest = useSignatureRequest();
   const isPermit = isRecognizedPermit(signatureRequest);


### PR DESCRIPTION
## **Description**

When connecting a dapp via WalletConnect, the connection screen shows the correct dapp domain, but the `eth_signTypedData` (V3/V4) signature request screen showed a random long hex string in the "Request from" field. This caused user confusion and could trigger false deceptive/security warnings.

**Root cause:** The typed sign V3/V4 confirmation component (`InfoSectionOriginAndDetails`) read `approvalRequest.origin` for the "Request from" value. For WalletConnect (and SDK) connections, `origin` is the permission subject — the pairing topic / channelId hex — not the dapp domain. Other parts of the codebase (e.g. `useApprovalInfo`, `useOriginTrustSignalAlerts`) already derive the signature origin from `approvalRequest.requestData.meta.url`, which holds the dapp's self-reported URL.

**Solution:** Use `approvalRequest.requestData.meta.url` for the "Request from" field, falling back to `approvalRequest.origin` when the metadata URL is absent. This is consistent across connection types

## **Changelog**

CHANGELOG entry: Fixed an issue where signTypedData requests over WalletConnect showed a random hex string instead of the dapp domain in the "Request from" field

## **Related issues**

Fixes: #29072

## **Manual testing steps**

```gherkin
Feature: Signature request origin for WalletConnect

  Scenario: user signs typed data over WalletConnect
    Given a dapp is connected to MetaMask Mobile via WalletConnect
    And the connection screen showed the correct dapp domain

    When the dapp triggers an eth_signTypedData (V3/V4) request
    Then the signature request screen shows the dapp domain in "Request from"
    And no random hex/string is displayed
    And no false deceptive warning is triggered
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/43c84567-a9b2-4cce-992d-99efe909983a


<!-- "Request from" shows a long hex/pairing-topic string (see issue #29072) -->

### **After**

https://github.com/user-attachments/assets/0252e191-3112-4088-a356-a7ab7793e238


<!-- "Request from" shows the dapp domain, matching the connection screen -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.