### PR TITLE
chore: expand pressable region to make selecting token easier in batchSell cp-7.82.0

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenRow.tsx
@@ -205,6 +205,10 @@ export function BatchSellTokenRow({
       </View>
     ) : undefined;
 
+  const pressTargetAccessibilityLabel = `${token.symbol} ${strings(
+    'bridge.batch_sell_checkbox_label',
+  )}`;
+
   return (
     <TokenSelectorItem
       token={token}
@@ -214,6 +218,8 @@ export function BatchSellTokenRow({
       isSelected={isSelected}
       shouldChangeSelectedStyle={false}
       shouldShowNetworkIcon={false}
+      shouldIncludeChildrenInPressTarget
+      pressTargetAccessibilityLabel={pressTargetAccessibilityLabel}
       secondaryRowContent={secondaryRowContent}
       balanceLayoutConfigOverride={
         TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS[
@@ -228,10 +234,11 @@ export function BatchSellTokenRow({
     >
       <Checkbox
         isSelected={isSelected}
-        onChange={() => onTokenPress(token)}
-        accessibilityLabel={`${token.symbol} ${strings(
-          'bridge.batch_sell_checkbox_label',
-        )}`}
+        // eslint-disable-next-line no-empty-function
+        onChange={() => {}}
+        pointerEvents="none"
+        importantForAccessibility="no-hide-descendants"
+        accessibilityElementsHidden
       />
     </TokenSelectorItem>
   );

--- a/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Text as RNText } from 'react-native';
+import { Text as RNText, View } from 'react-native';
 import { TokenSelectorItem, getSecurityTag } from './TokenSelectorItem';
 import { SecurityDataType } from '../types';
 import { ethers } from 'ethers';
@@ -46,6 +46,8 @@ jest.mock('../../../../component-library/hooks', () => {
       tokenSymbol: {},
       verifiedIcon: {},
       childrenWrapper: {},
+      pressTargetContent: { flex: 1 },
+      itemWrapperWithChildren: { alignItems: 'center' },
     },
   }));
 
@@ -364,6 +366,50 @@ describe('TokenSelectorItem', () => {
       );
 
       expect(UNSAFE_root).toBeTruthy();
+    });
+
+    it('routes presses on children through the row press target when shouldIncludeChildrenInPressTarget is true', () => {
+      const token = createMockTokenWithBalance();
+
+      const { getByTestId } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          shouldIncludeChildrenInPressTarget
+          pressTargetAccessibilityLabel="Select TEST"
+        >
+          <View testID="token-row-child" />
+        </TokenSelectorItem>,
+      );
+
+      fireEvent.press(getByTestId('token-row-child'));
+
+      expect(mockOnPress).toHaveBeenCalledWith(token);
+    });
+
+    it('uses checkbox accessibility on the row press target when shouldIncludeChildrenInPressTarget is true', () => {
+      const token = createMockTokenWithBalance();
+
+      const { getByTestId } = render(
+        <TokenSelectorItem
+          token={token}
+          onPress={mockOnPress}
+          isSelected
+          shouldIncludeChildrenInPressTarget
+          pressTargetAccessibilityLabel="Select TEST"
+        >
+          <View testID="token-row-child" />
+        </TokenSelectorItem>,
+      );
+
+      expect(getByTestId(`asset-${token.chainId}-${token.symbol}`)).toHaveProp(
+        'accessibilityRole',
+        'checkbox',
+      );
+      expect(getByTestId(`asset-${token.chainId}-${token.symbol}`)).toHaveProp(
+        'accessibilityState',
+        expect.objectContaining({ checked: true }),
+      );
     });
 
     it('renders network badge when networkImageSource is provided', () => {

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -156,6 +156,13 @@ const createStyles = ({
     childrenWrapper: {
       marginLeft: 12,
     },
+    pressTargetContent: {
+      flex: 1,
+      minWidth: 0,
+    },
+    itemWrapperWithChildren: {
+      alignItems: 'center',
+    },
   });
 
 interface BalanceTextProps {
@@ -178,6 +185,8 @@ interface TokenSelectorItemProps {
   balanceLayoutConfigOverride?: TokenSelectorBalanceLayoutConfig;
   shouldChangeSelectedStyle?: boolean;
   shouldShowNetworkIcon?: boolean;
+  shouldIncludeChildrenInPressTarget?: boolean;
+  pressTargetAccessibilityLabel?: string;
 }
 
 const isLoadingBalance = (balance?: string) =>
@@ -283,6 +292,8 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
   balanceLayoutConfigOverride,
   shouldChangeSelectedStyle = true,
   shouldShowNetworkIcon = true,
+  shouldIncludeChildrenInPressTarget = false,
+  pressTargetAccessibilityLabel,
 }) => {
   const shouldShowSelectedStyle = isSelected && shouldChangeSelectedStyle;
   const { styles } = useStyles(createStyles, {
@@ -355,7 +366,23 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
       <TouchableOpacity
         key={token.address}
         onPress={() => onPress(token)}
-        style={styles.itemWrapper}
+        style={[
+          styles.itemWrapper,
+          shouldIncludeChildrenInPressTarget && styles.itemWrapperWithChildren,
+        ]}
+        accessibilityRole={
+          shouldIncludeChildrenInPressTarget ? 'checkbox' : undefined
+        }
+        accessibilityState={
+          shouldIncludeChildrenInPressTarget
+            ? { checked: isSelected }
+            : undefined
+        }
+        accessibilityLabel={
+          shouldIncludeChildrenInPressTarget
+            ? pressTargetAccessibilityLabel
+            : undefined
+        }
         testID={getAssetTestId(`${token.chainId}-${token.symbol}`)}
       >
         <Box
@@ -363,6 +390,11 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
           flexDirection={FlexDirection.Row}
           alignItems={AlignItems.center}
           gap={4}
+          style={
+            shouldIncludeChildrenInPressTarget
+              ? styles.pressTargetContent
+              : undefined
+          }
         >
           {/* Token Icon */}
           {shouldShowNetworkIcon ? (
@@ -528,9 +560,16 @@ const TokenSelectorItemInner: React.FC<TokenSelectorItemProps> = ({
             {isStockToken(token as BridgeToken) && <StockBadge token={token} />}
           </Box>
         </Box>
+        {shouldIncludeChildrenInPressTarget && children ? (
+          <View style={styles.childrenWrapper} pointerEvents="none">
+            {children}
+          </View>
+        ) : null}
       </TouchableOpacity>
 
-      <View style={styles.childrenWrapper}>{children}</View>
+      {!shouldIncludeChildrenInPressTarget && children ? (
+        <View style={styles.childrenWrapper}>{children}</View>
+      ) : null}
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Users reported that selecting/deselecting tokens on the Batch Sell token-select screen felt unresponsive — taps on the checkbox frequently didn't register, requiring two or three attempts.

The root UX cause is hit-target size: the checkbox and the token row were two separate press targets, and the checkbox itself is only ~22px. Taps that landed just outside the checkbox were missed.

This PR makes the **entire token row a single press target**. The checkbox becomes display-only and the whole row (including the checkbox column) toggles selection through one `TouchableOpacity`. This is implemented as an opt-in capability on the shared `TokenSelectorItem` so other consumers are unaffected:

- `TokenSelectorItem` gains `shouldIncludeChildrenInPressTarget` and `pressTargetAccessibilityLabel`. When enabled, `children` render **inside** the row's `TouchableOpacity` (with `pointerEvents="none"`), and the row press target exposes `accessibilityRole="checkbox"`, `accessibilityState={{ checked }}`, and the provided label.
- `BatchSellTokenRow` opts in, and its `Checkbox` is now purely visual (`pointerEvents="none"`, hidden from the accessibility tree, no-op `onChange`).

Default behavior for all existing `TokenSelectorItem` callers is unchanged (the flag defaults to `false`).

Note: earlier exploratory changes (a `setSelectedTokens` functional-update refactor and row memoization) were intentionally reverted after analysis — they did not address the actual cause. This PR is scoped to the hit-target fix only.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed unresponsive token selection in Batch Sell by making the entire token row tappable instead of just the small checkbox.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [SWAPS-4616](https://github.com/MetaMask/metamask-mobile/issues/31675)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch Sell token selection

  Scenario: user toggles a token by tapping anywhere on its row
    Given Batch Sell is enabled and the user has multiple sellable tokens on a supported chain
    And the user is on the Batch Sell token-select screen

    When the user taps anywhere on a token row (token info, balance area, or the checkbox)
    Then the token's selection toggles on the first tap
    And the checkbox reflects the selected state

  Scenario: user selects and deselects quickly
    Given the user is on the Batch Sell token-select screen

    When the user taps several token rows in quick succession to select and deselect them
    Then every tap registers and the selection count / primary button label updates accordingly

  Scenario: accessibility
    Given a screen reader (VoiceOver/TalkBack) is enabled

    When focus lands on a token row
    Then it is announced as a checkbox with its checked state and the token label
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- Author: please attach a short screen recording of selecting/deselecting tokens, since this is a touch-responsiveness change. -->

### **Before**

<!-- [screen recording: tapping the checkbox often misses; selection needs 2–3 taps] -->

N/A

### **After**

<!-- [screen recording: tapping anywhere on the row toggles selection on the first tap] -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4616]: https://consensyssoftware.atlassian.net/browse/SWAPS-4616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ