### PR TITLE
fix: show informative error for Ledger V3 typed data signing

### DIFF
--- a/app/core/HardwareWallet/errors/mappings.test.ts
+++ b/app/core/HardwareWallet/errors/mappings.test.ts
@@ -26,6 +26,7 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
       ErrorCode.DeviceNotReady,
       ErrorCode.DeviceMissingCapability,
       ErrorCode.DeviceStateBlindSignNotSupported,
+      ErrorCode.DeviceStateOnlyV4Supported,
       ErrorCode.DeviceUnresponsive,
       ErrorCode.ConnectionClosed,
       ErrorCode.ConnectionTimeout,
@@ -136,6 +137,12 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
         MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateBlindSignNotSupported];
       const title = ext?.getLocalizedTitle();
       expect(title).toBe('hardware_wallet.error.blind_signing_disabled');
+    });
+
+    it('returns localized title for DeviceStateOnlyV4Supported', () => {
+      const ext = MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateOnlyV4Supported];
+      const title = ext?.getLocalizedTitle();
+      expect(title).toBe('hardware_wallet.error.unsupported_signature');
     });
 
     it('returns localized title for DeviceUnresponsive', () => {
@@ -284,6 +291,13 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
       expect(message).toBe('hardware_wallet.errors.blind_signing');
     });
 
+    it('returns localized message for DeviceStateOnlyV4Supported', () => {
+      const ext = MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateOnlyV4Supported];
+      const message = ext?.getLocalizedMessage(HardwareWalletType.Ledger);
+      expect(message).toContain('hardware_wallet.errors.only_v4_supported');
+      expect(message).toContain('device:');
+    });
+
     it('returns localized message for DeviceUnresponsive', () => {
       const ext = MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceUnresponsive];
       const message = ext?.getLocalizedMessage();
@@ -396,6 +410,10 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
       ).toBe(RecoveryAction.ACKNOWLEDGE);
       expect(
         MOBILE_ERROR_EXTENSIONS[ErrorCode.MobileNotSupported]?.recoveryAction,
+      ).toBe(RecoveryAction.ACKNOWLEDGE);
+      expect(
+        MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateOnlyV4Supported]
+          ?.recoveryAction,
       ).toBe(RecoveryAction.ACKNOWLEDGE);
     });
 

--- a/app/core/HardwareWallet/errors/mappings.ts
+++ b/app/core/HardwareWallet/errors/mappings.ts
@@ -108,6 +108,19 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
       strings('hardware_wallet.error.blind_signing_disabled'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.blind_signing'),
   },
+  [ErrorCode.DeviceStateOnlyV4Supported]: {
+    // Retrying cannot succeed: the dApp requested an unsupported signature
+    // type, so the user should just acknowledge the message.
+    recoveryAction: RecoveryAction.ACKNOWLEDGE,
+    icon: IconName.Danger,
+    iconColor: IconColor.Default,
+    getLocalizedTitle: () =>
+      strings('hardware_wallet.error.unsupported_signature'),
+    getLocalizedMessage: (walletType) =>
+      strings('hardware_wallet.errors.only_v4_supported', {
+        device: getHardwareWalletTypeName(walletType),
+      }),
+  },
   [ErrorCode.DeviceUnresponsive]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Clock,

--- a/app/core/HardwareWallet/errors/parser.test.ts
+++ b/app/core/HardwareWallet/errors/parser.test.ts
@@ -340,6 +340,16 @@ describe('parseErrorByType', () => {
       expect(result.code).toBe(ErrorCode.DeviceStateBlindSignNotSupported);
     });
 
+    it('parses "Only version 4 of typed data signing is supported" message', () => {
+      const error = new Error(
+        'Ledger: Only version 4 of typed data signing is supported',
+      );
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.DeviceStateOnlyV4Supported);
+    });
+
     it('parses "eth app" with "open" message', () => {
       const error = new Error('Please open the Ethereum app on your device');
 

--- a/app/core/HardwareWallet/errors/parser.ts
+++ b/app/core/HardwareWallet/errors/parser.ts
@@ -235,6 +235,13 @@ function parseErrorByMessage(
     condition?: (msg: string) => boolean;
   }[] = [
     {
+      // Ledger devices can only sign EIP-712 typed data with version V4.
+      // The keyring throws "Ledger: Only version 4 of typed data signing is
+      // supported" for V1/V3 requests.
+      patterns: ['version 4 of typed data', 'only version 4'],
+      code: ErrorCode.DeviceStateOnlyV4Supported,
+    },
+    {
       patterns: ['disconnected', 'disconnect', 'connection lost'],
       code: ErrorCode.DeviceDisconnected,
     },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9643,6 +9643,7 @@
       "bluetooth_connection_failed": "The connection to your device failed. Please try again",
       "camera_permission_denied": "Camera permission is required to scan QR codes. Please enable it in your device settings",
       "not_supported": "This operation is not supported",
+      "only_v4_supported": "Your {{device}} can only sign version 4 (V4) typed data. This site requested an older signature type that isn't supported",
       "unknown_error": "Make sure your {{device}} is set up with the Secret Recovery Phrase or passphrase for this account"
     },
     "error": {
@@ -9666,6 +9667,7 @@
       "nearby_devices_permission_denied": "Nearby Devices Permission Required",
       "scan_failed": "Scan Failed",
       "camera_permission_denied": "Camera Permission Required",
+      "unsupported_signature": "Signature not supported",
       "something_went_wrong": "Something went wrong"
     },
     "qr_scan_errors": {


### PR DESCRIPTION
## Summary

Fixes #29044 — Ledger users saw an uninformative "Something went wrong" error when a dApp requested **V3** (or V1) typed data (EIP-712) signing.

Ledger hardware only supports **V4** typed data. The keyring throws `Ledger: Only version 4 of typed data signing is supported` for V1/V3 requests, but the hardware-wallet error parser had no pattern for it, so it fell through to `ErrorCode.Unknown` and rendered the generic message.

## Changes

- **`parser.ts`** — added a message pattern mapping the keyring error to a dedicated `ErrorCode.DeviceStateOnlyV4Supported` (placed first so it matches before generic patterns).
- **`mappings.ts`** — added a `MOBILE_ERROR_EXTENSIONS` entry for `DeviceStateOnlyV4Supported`: informative localized title/message, Danger icon, and `RecoveryAction.ACKNOWLEDGE` (retrying cannot succeed for an unsupported signature type).
- **`en.json`** — added locale strings:
  - `hardware_wallet.errors.only_v4_supported`
  - `hardware_wallet.error.unsupported_signature`
- **Tests** — added cases to `parser.test.ts` and `mappings.test.ts`.

## Test plan

- [x] New/updated unit tests pass (`parser.test.ts`, `mappings.test.ts`)
- [x] ESLint clean on modified files
- [x] `en.json` validated as well-formed JSON
- [ ] Manual: request a V3 typed data signature on a Ledger account and confirm the informative error appears instead of "Something went wrong"

Made with [Cursor](https://cursor.com)