### PR TITLE
fix: show informative error for Ledger V3 typed data signing

### DIFF
--- a/app/core/HardwareWallet/errors/mappings.test.ts
+++ b/app/core/HardwareWallet/errors/mappings.test.ts
@@ -26,6 +26,7 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
       ErrorCode.DeviceNotReady,
       ErrorCode.DeviceMissingCapability,
       ErrorCode.DeviceStateBlindSignNotSupported,
+      ErrorCode.DeviceStateOnlyV4Supported,
       ErrorCode.DeviceUnresponsive,
       ErrorCode.ConnectionClosed,
       ErrorCode.ConnectionTimeout,
@@ -136,6 +137,12 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
         MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateBlindSignNotSupported];
       const title = ext?.getLocalizedTitle();
       expect(title).toBe('hardware_wallet.error.blind_signing_disabled');
+    });
+
+    it('returns localized title for DeviceStateOnlyV4Supported', () => {
+      const ext = MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateOnlyV4Supported];
+      const title = ext?.getLocalizedTitle();
+      expect(title).toBe('hardware_wallet.error.unsupported_signature');
     });
 
     it('returns localized title for DeviceUnresponsive', () => {
@@ -284,6 +291,13 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
       expect(message).toBe('hardware_wallet.errors.blind_signing');
     });
 
+    it('returns localized message for DeviceStateOnlyV4Supported', () => {
+      const ext = MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateOnlyV4Supported];
+      const message = ext?.getLocalizedMessage(HardwareWalletType.Ledger);
+      expect(message).toContain('hardware_wallet.errors.only_v4_supported');
+      expect(message).toContain('device:');
+    });
+
     it('returns localized message for DeviceUnresponsive', () => {
       const ext = MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceUnresponsive];
       const message = ext?.getLocalizedMessage();
@@ -396,6 +410,10 @@ describe('MOBILE_ERROR_EXTENSIONS', () => {
       ).toBe(RecoveryAction.ACKNOWLEDGE);
       expect(
         MOBILE_ERROR_EXTENSIONS[ErrorCode.MobileNotSupported]?.recoveryAction,
+      ).toBe(RecoveryAction.ACKNOWLEDGE);
+      expect(
+        MOBILE_ERROR_EXTENSIONS[ErrorCode.DeviceStateOnlyV4Supported]
+          ?.recoveryAction,
       ).toBe(RecoveryAction.ACKNOWLEDGE);
     });
 

--- a/app/core/HardwareWallet/errors/mappings.ts
+++ b/app/core/HardwareWallet/errors/mappings.ts
@@ -108,6 +108,19 @@ export const MOBILE_ERROR_EXTENSIONS: Partial<
       strings('hardware_wallet.error.blind_signing_disabled'),
     getLocalizedMessage: () => strings('hardware_wallet.errors.blind_signing'),
   },
+  [ErrorCode.DeviceStateOnlyV4Supported]: {
+    // Retrying cannot succeed: the dApp requested an unsupported signature
+    // type, so the user should just acknowledge the message.
+    recoveryAction: RecoveryAction.ACKNOWLEDGE,
+    icon: IconName.Danger,
+    iconColor: IconColor.Default,
+    getLocalizedTitle: () =>
+      strings('hardware_wallet.error.unsupported_signature'),
+    getLocalizedMessage: (walletType) =>
+      strings('hardware_wallet.errors.only_v4_supported', {
+        device: getHardwareWalletTypeName(walletType),
+      }),
+  },
   [ErrorCode.DeviceUnresponsive]: {
     recoveryAction: RecoveryAction.RETRY,
     icon: IconName.Clock,

--- a/app/core/HardwareWallet/errors/parser.test.ts
+++ b/app/core/HardwareWallet/errors/parser.test.ts
@@ -340,6 +340,16 @@ describe('parseErrorByType', () => {
       expect(result.code).toBe(ErrorCode.DeviceStateBlindSignNotSupported);
     });
 
+    it('parses "Only version 4 of typed data signing is supported" message', () => {
+      const error = new Error(
+        'Ledger: Only version 4 of typed data signing is supported',
+      );
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.DeviceStateOnlyV4Supported);
+    });
+
     it('parses "eth app" with "open" message', () => {
       const error = new Error('Please open the Ethereum app on your device');
 

--- a/app/core/HardwareWallet/errors/parser.ts
+++ b/app/core/HardwareWallet/errors/parser.ts
@@ -235,6 +235,13 @@ function parseErrorByMessage(
     condition?: (msg: string) => boolean;
   }[] = [
     {
+      // Ledger devices can only sign EIP-712 typed data with version V4.
+      // The keyring throws "Ledger: Only version 4 of typed data signing is
+      // supported" for V1/V3 requests.
+      patterns: ['version 4 of typed data', 'only version 4'],
+      code: ErrorCode.DeviceStateOnlyV4Supported,
+    },
+    {
       patterns: ['disconnected', 'disconnect', 'connection lost'],
       code: ErrorCode.DeviceDisconnected,
     },

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9643,6 +9643,7 @@
       "bluetooth_connection_failed": "The connection to your device failed. Please try again",
       "camera_permission_denied": "Camera permission is required to scan QR codes. Please enable it in your device settings",
       "not_supported": "This operation is not supported",
+      "only_v4_supported": "Your {{device}} can only sign version 4 (V4) typed data. This site requested an older signature type that isn't supported",
       "unknown_error": "Make sure your {{device}} is set up with the Secret Recovery Phrase or passphrase for this account"
     },
     "error": {
@@ -9666,6 +9667,7 @@
       "nearby_devices_permission_denied": "Nearby Devices Permission Required",
       "scan_failed": "Scan Failed",
       "camera_permission_denied": "Camera Permission Required",
+      "unsupported_signature": "Signature not supported",
       "something_went_wrong": "Something went wrong"
     },
     "qr_scan_errors": {


### PR DESCRIPTION
Ledger only supports V4 EIP-712 typed data. When a dApp requested a V3 (or V1) signature, the keyring threw "Ledger: Only version 4 of typed data signing is supported", which the error parser did not recognize and fell through to a generic "Something went wrong" message.

Map this keyring error to a dedicated DeviceStateOnlyV4Supported code with an informative, localized message and an ACKNOWLEDGE recovery action (retry cannot succeed for an unsupported signature type).

Fixes #29044

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an uninformative "Something went wrong" error shown when signing version 3 (V3) typed data with a Ledger device; the app now explains that Ledger only supports version 4 (V4) typed data signatures.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

