### PR TITLE
refactor: elevate QR signing and hardware wallet sheets

### DIFF
--- a/app/components/UI/QRHardware/QRSigningModal/index.test.tsx
+++ b/app/components/UI/QRHardware/QRSigningModal/index.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { ViewProps } from 'react-native';
+import renderWithProvider, {
+  DeepPartial,
+} from '../../../../util/test/renderWithProvider';
+import QRSigningModal, { QR_SIGNING_MODAL_CONTENT_TEST_ID } from './index';
+import {
+  type QrScanRequest,
+  QrScanRequestType,
+} from '@metamask/eth-qr-keyring';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import type { RootState } from '../../../../reducers';
+
+const MOCK_ELEVATED_SURFACE_COLOR = 'mock-elevated-surface-color';
+
+jest.mock('../../../../util/theme/themeUtils', () => ({
+  getElevatedSurfaceColor: jest.fn(() => MOCK_ELEVATED_SURFACE_COLOR),
+}));
+
+jest.mock('../QRSigningDetails', () => {
+  const { View: MockView } = jest.requireActual('react-native');
+  return function MockQRSigningDetails(props: ViewProps) {
+    return <MockView testID="QRSigningDetails" {...props} />;
+  };
+});
+
+jest.mock('react-native-modal', () => {
+  const ReactMock = jest.requireActual('react');
+  const { View: MockView } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      isVisible,
+      children,
+    }: {
+      isVisible: boolean;
+      children: React.ReactNode;
+    }) =>
+      isVisible
+        ? ReactMock.createElement(MockView, { testID: 'modal' }, children)
+        : null,
+  };
+});
+
+describe('QRSigningModal', () => {
+  const mockPendingScanRequest: QrScanRequest = {
+    type: QrScanRequestType.SIGN,
+    request: {
+      requestId: 'req-123',
+      payload: {
+        type: 'transaction',
+        cbor: 'test-cbor-data',
+      },
+    },
+  };
+
+  const mockSelectedAccount: InternalAccount = {
+    address: '0x0987654321098765432109876543210987654321',
+    id: 'account-1',
+    metadata: {
+      name: 'Account 1',
+      keyring: {
+        type: 'QR Hardware Wallet',
+      },
+      importTime: 0,
+      lastSelected: 0,
+    },
+    scopes: [],
+    options: {},
+    methods: [],
+    type: 'eip155:eoa',
+  };
+
+  const initialState: DeepPartial<RootState> = {
+    engine: {
+      backgroundState: {
+        AccountsController: {
+          internalAccounts: {
+            accounts: { 'account-1': mockSelectedAccount },
+            selectedAccount: 'account-1',
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders content when visible', () => {
+    const { getByTestId } = renderWithProvider(
+      <QRSigningModal isVisible pendingScanRequest={mockPendingScanRequest} />,
+      { state: initialState },
+    );
+
+    expect(getByTestId('QRSigningDetails')).toBeOnTheScreen();
+  });
+
+  it('does not render content when not visible', () => {
+    const { queryByTestId } = renderWithProvider(
+      <QRSigningModal
+        isVisible={false}
+        pendingScanRequest={mockPendingScanRequest}
+      />,
+      { state: initialState },
+    );
+
+    expect(queryByTestId('QRSigningDetails')).toBeNull();
+  });
+
+  it('uses the elevated surface color for the modal content background', () => {
+    const { getByTestId } = renderWithProvider(
+      <QRSigningModal isVisible pendingScanRequest={mockPendingScanRequest} />,
+      { state: initialState },
+    );
+
+    expect(getByTestId(QR_SIGNING_MODAL_CONTENT_TEST_ID)).toHaveStyle({
+      backgroundColor: MOCK_ELEVATED_SURFACE_COLOR,
+    });
+  });
+
+  it('passes the selected account address to QRSigningDetails', () => {
+    const { getByTestId } = renderWithProvider(
+      <QRSigningModal isVisible pendingScanRequest={mockPendingScanRequest} />,
+      { state: initialState },
+    );
+
+    expect(getByTestId('QRSigningDetails').props.fromAddress).toBe(
+      mockSelectedAccount.address,
+    );
+  });
+});

--- a/app/components/UI/QRHardware/QRSigningModal/index.tsx
+++ b/app/components/UI/QRHardware/QRSigningModal/index.tsx
@@ -3,9 +3,13 @@ import Modal from 'react-native-modal';
 import { StyleSheet, View } from 'react-native';
 import QRSigningDetails from '../QRSigningDetails';
 import { useTheme } from '../../../../util/theme';
+import { Theme } from '../../../../util/theme/models';
+import { getElevatedSurfaceColor } from '../../../../util/theme/themeUtils';
 import { useSelector } from 'react-redux';
 import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import { QrScanRequest } from '@metamask/eth-qr-keyring';
+
+export const QR_SIGNING_MODAL_CONTENT_TEST_ID = 'qr-signing-modal-content';
 
 interface IQRSigningModalProps {
   isVisible: boolean;
@@ -15,9 +19,7 @@ interface IQRSigningModalProps {
   onFailure?: (error: string) => void;
 }
 
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createStyles = (colors: any) =>
+const createStyles = (theme: Theme) =>
   StyleSheet.create({
     modal: {
       margin: 0,
@@ -26,7 +28,7 @@ const createStyles = (colors: any) =>
     contentWrapper: {
       justifyContent: 'flex-end',
       height: 600,
-      backgroundColor: colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
       paddingTop: 24,
       borderTopLeftRadius: 24,
       borderTopRightRadius: 24,
@@ -40,8 +42,9 @@ const QRSigningModal = ({
   onCancel,
   onFailure,
 }: IQRSigningModalProps) => {
-  const { colors } = useTheme();
-  const styles = createStyles(colors);
+  const theme = useTheme();
+  const { colors } = theme;
+  const styles = createStyles(theme);
   const [isModalCompleteShow, setModalCompleteShow] = useState(false);
   const selectedAccount = useSelector(selectSelectedInternalAccount);
 
@@ -75,7 +78,10 @@ const QRSigningModal = ({
       }}
       propagateSwipe
     >
-      <View style={styles.contentWrapper}>
+      <View
+        style={styles.contentWrapper}
+        testID={QR_SIGNING_MODAL_CONTENT_TEST_ID}
+      >
         <QRSigningDetails
           pendingScanRequest={pendingScanRequest}
           showCancelButton

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx
@@ -7,6 +7,11 @@ jest.mock('../../../../util/theme', () => ({
   }),
 }));
 
+const MOCK_ELEVATED_SURFACE_COLOR = 'mock-elevated-surface-color';
+jest.mock('../../../../util/theme/themeUtils', () => ({
+  getElevatedSurfaceColor: jest.fn(() => MOCK_ELEVATED_SURFACE_COLOR),
+}));
+
 // Mutable state objects for tests to manipulate
 const mockConnectionState: Record<string, unknown> = { status: 'disconnected' };
 const mockDeviceSelection = {
@@ -75,17 +80,23 @@ jest.mock(
             children,
             testID,
             onClose,
+            style,
           }: {
             children: React.ReactNode;
             testID?: string;
             onClose?: () => void;
+            style?: unknown;
           },
           _ref: React.Ref<unknown>,
         ) => {
           // Test double: capture BottomSheet onClose for assertions (not production UI).
           // eslint-disable-next-line react-compiler/react-compiler -- intentional mock side effect
           mockLastBottomSheetOnCloseRef.current = onClose;
-          return <View testID={testID}>{children}</View>;
+          return (
+            <View testID={testID} style={style as undefined}>
+              {children}
+            </View>
+          );
         },
       ),
     };
@@ -265,6 +276,19 @@ describe('HardwareWalletBottomSheet', () => {
       expect(
         getByTestId(HARDWARE_WALLET_BOTTOM_SHEET_TEST_ID),
       ).toBeOnTheScreen();
+    });
+  });
+
+  describe('styling', () => {
+    it('uses the elevated surface color for the sheet background', () => {
+      mockConnectionState.status = ConnectionStatus.Scanning;
+      const { getByTestId } = render(
+        <HardwareWalletBottomSheet {...createDefaultProps()} />,
+      );
+
+      expect(getByTestId(HARDWARE_WALLET_BOTTOM_SHEET_TEST_ID)).toHaveStyle({
+        backgroundColor: MOCK_ELEVATED_SURFACE_COLOR,
+      });
     });
   });
 

--- a/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
+++ b/app/core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.tsx
@@ -6,6 +6,8 @@ import BottomSheet, {
 } from '../../../../component-library/components/BottomSheets/BottomSheet';
 
 import { useTheme } from '../../../../util/theme';
+import { Theme } from '../../../../util/theme/models';
+import { getElevatedSurfaceColor } from '../../../../util/theme/themeUtils';
 
 import {
   HardwareWalletType,
@@ -29,10 +31,10 @@ import DevLogger from '../../../SDKConnect/utils/DevLogger';
 export const HARDWARE_WALLET_BOTTOM_SHEET_TEST_ID =
   'hardware-wallet-bottom-sheet';
 
-const createStyles = (colors: { background: { default: string } }) =>
+const createStyles = (theme: Theme) =>
   StyleSheet.create({
     bottomSheet: {
-      backgroundColor: colors.background.default,
+      backgroundColor: getElevatedSurfaceColor(theme),
     },
   });
 
@@ -88,8 +90,8 @@ export const HardwareWalletBottomSheet: React.FC<
   onCTAClicked,
   onRetryQrScan,
 }) => {
-  const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const theme = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const [openQrScannerOnMount, setOpenQrScannerOnMount] = React.useState(false);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes elevated surfaces collapsing into the pure-black screen background when MM_PURE_BLACK_PREVIEW=true. The QR signing modal and hardware wallet bottom sheet now use getElevatedSurfaceColor() instead of background.default, so they render as visible elevated surfaces in pure-black dark mode. Light mode and flag-off behavior are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1866

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

- Set MM_PURE_BLACK_PREVIEW="true" in .js.env and rebuild the app.
- Switch the app to dark mode.
- Trigger a QR signing flow (Keystone / QR hardware wallet) and confirm the modal background is visibly elevated above the screen.
- Trigger a hardware wallet connect flow (e.g. Ledger) and confirm the bottom sheet background is visibly elevated above the screen.
- Disable the flag or switch to light mode and confirm both surfaces look the same as before.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
