### PR TITLE
fix: add missing debug's keystore

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -286,6 +286,12 @@ android {
         keyAlias 'androiddebugkey'
         keyPassword 'android'
       }
+      debug {
+        storeFile file('../keystores/debug.keystore')
+        storePassword 'android'
+        keyAlias 'androiddebugkey'
+        keyPassword 'android'
+      }
     }
 
     buildTypes {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Local debug APK builds (`prodDebug`, etc.) were signed with the machine-local default Android debug keystore (`~/.android/debug.keystore`) instead of the shared `android/keystores/debug.keystore` checked into the repo.

Android Gradle Plugin always applies the built-in `debug` signing config for debug build types, which overrides the flavor-level `mainDev` config even when `METAMASK_ENVIRONMENT=dev`. That produced a different certificate fingerprint per developer machine, breaking integrations that key off the team debug certificate (e.g. Google Sign-In / OAuth redirect validation).

This PR adds an explicit `debug` signing config in `android/app/build.gradle` that points to `../keystores/debug.keystore`, so all debug variants use the repo keystore and produce a consistent SHA fingerprint.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — local Android debug signing configuration

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Debug build signing

  Scenario: prodDebug APK uses the repo debug keystore
    Given a clean Android build tree
    And METAMASK_ENVIRONMENT=dev

    When I build a debug APK (e.g. yarn start:android or ./gradlew app:assembleProdDebug)
    And I run apksigner verify --print-certs on the output APK
    Then the APK SHA-256 fingerprint matches android/keystores/debug.keystore
    And it does not match ~/.android/debug.keystore
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — build/signing configuration change only; verification is via `apksigner` / `keytool` fingerprint comparison.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.