### PR TITLE
fix(perps): remove preselected filter from market detail search navigation

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -2673,7 +2673,7 @@ describe('PerpsMarketDetailsView', () => {
   });
 
   describe('Category search shortcut', () => {
-    it('navigates to market list with crypto category when search button is pressed', () => {
+    it('navigates to market list without filters when search button is pressed', () => {
       const { getByTestId } = renderWithProvider(
         <PerpsConnectionProvider>
           <PerpsMarketDetailsView />
@@ -2690,7 +2690,6 @@ describe('PerpsMarketDetailsView', () => {
 
       expect(mockNavigateToMarketList).toHaveBeenCalledWith({
         source: 'magnifying_glass',
-        defaultMarketTypeFilter: 'crypto',
       });
     });
   });

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -31,7 +31,6 @@ import {
   PERPS_EVENT_VALUE,
   PERPS_CONSTANTS,
   getPerpsDisplaySymbol,
-  getMarketTypeFilter,
   type Position,
   type PerpsMarketData,
   type TPSLTrackingData,
@@ -730,8 +729,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const handleCategorySearchPress = useCallback(() => {
     if (!market) return;
 
-    const resolvedCategory = getMarketTypeFilter(market);
-
     track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
       [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
         PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
@@ -740,12 +737,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
         PERPS_EVENT_VALUE.BUTTON_LOCATION.PERP_MARKET_DETAILS,
       [PERPS_EVENT_PROPERTY.ASSET]: market.symbol,
-      [PERPS_EVENT_PROPERTY.MARKET_CATEGORY]: resolvedCategory,
     });
 
     navigateToMarketList({
       source: PERPS_EVENT_VALUE.SOURCE.MAGNIFYING_GLASS,
-      defaultMarketTypeFilter: resolvedCategory,
     });
   }, [market, track, navigateToMarketList]);
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -31,7 +31,6 @@ import {
   PERPS_EVENT_VALUE,
   PERPS_CONSTANTS,
   getPerpsDisplaySymbol,
-  getMarketTypeFilter,
   type Position,
   type PerpsMarketData,
   type TPSLTrackingData,
@@ -738,7 +737,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
         PERPS_EVENT_VALUE.BUTTON_LOCATION.PERP_MARKET_DETAILS,
       [PERPS_EVENT_PROPERTY.ASSET]: market.symbol,
-      [PERPS_EVENT_PROPERTY.MARKET_CATEGORY]: getMarketTypeFilter(market),
     });
 
     navigateToMarketList({

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -31,6 +31,7 @@ import {
   PERPS_EVENT_VALUE,
   PERPS_CONSTANTS,
   getPerpsDisplaySymbol,
+  getMarketTypeFilter,
   type Position,
   type PerpsMarketData,
   type TPSLTrackingData,
@@ -737,6 +738,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
         PERPS_EVENT_VALUE.BUTTON_LOCATION.PERP_MARKET_DETAILS,
       [PERPS_EVENT_PROPERTY.ASSET]: market.symbol,
+      [PERPS_EVENT_PROPERTY.MARKET_CATEGORY]: getMarketTypeFilter(market),
     });
 
     navigateToMarketList({


### PR DESCRIPTION
## **Description**

The magnifying glass icon on the Perps market detail screen was navigating to the market list with the current market's category filter (`defaultMarketTypeFilter`) preselected. This caused users to see a filtered subset of markets instead of the full list.

This change removes the category filter from the navigation parameters so users land on an unfiltered market list when tapping the search icon. The `MARKET_CATEGORY` analytics property and unused `getMarketTypeFilter` import were also removed.

## **Changelog**

CHANGELOG entry: Fixed magnifying glass on perps market detail screen to open market list without preselected filters

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3358

## **Manual testing steps**

```gherkin
Feature: Perps market detail search navigation

  Scenario: user taps magnifying glass icon on market detail screen
    Given the user is viewing a perps market detail screen (e.g. BTC-PERP)

    When user taps the magnifying glass icon in the header
    Then the market list screen opens without any category filter applied
    And all available markets are shown (not filtered to crypto/forex/etc.)
```

## **Screenshots/Recordings**

N/A — no visual change, only navigation parameter behavior.

### **Before**

### **After**

https://github.com/user-attachments/assets/2efb178e-9ae4-4f26-b332-845559b3104f


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
