### PR TITLE
feat: allow editing and deleting alerts

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -316,6 +316,74 @@ describe('CreatePriceAlertView', () => {
   });
 });
 
+describe('CreatePriceAlertView — duplicate threshold validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSave.mockResolvedValue(undefined);
+    mockUseSavePriceAlert.mockImplementation(() => ({
+      save: mockSave,
+      isSubmitting: false,
+    }));
+    // Route has an existing alert at $1500
+    setRoute({
+      symbol: 'ETH',
+      ticker: 'ETH',
+      currentPrice: 1201.98,
+      currentCurrency: 'USD',
+      assetId: 'eip155:1/slip44:60',
+      fromManage: true,
+      existingThresholds: [1500],
+    });
+  });
+
+  it('shows the duplicate error text on the button and disables it when target matches an existing threshold', () => {
+    const { getByTestId, getByText } = renderWithToast();
+
+    // Type 1500 — matches the existing alert
+    fireEvent.press(getByTestId('keypad-key-1'));
+    fireEvent.press(getByTestId('keypad-key-5'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+
+    expect(
+      getByText('An alert at this price already exists.'),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
+  });
+
+  it('shows the normal Set button label and enables it for a different target price', () => {
+    const { getByTestId, getByText } = renderWithToast();
+
+    // Type 2000 — not a duplicate
+    fireEvent.press(getByTestId('keypad-key-2'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+
+    expect(getByText('Set price alert')).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
+  });
+
+  it('does not call save when Set button is pressed on a duplicate threshold', async () => {
+    const { getByTestId } = renderWithToast();
+
+    fireEvent.press(getByTestId('keypad-key-1'));
+    fireEvent.press(getByTestId('keypad-key-5'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+    fireEvent.press(getByTestId('keypad-key-0'));
+
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+    });
+
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+});
+
 describe('CreatePriceAlertView — tiny price token', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -114,8 +114,15 @@ const CreatePriceAlertView: React.FC = () => {
         'CreatePriceAlert'
       >
     >();
-  const { symbol, ticker, currentPrice, currentCurrency, assetId, fromManage } =
-    route.params;
+  const {
+    symbol,
+    ticker,
+    currentPrice,
+    currentCurrency,
+    assetId,
+    fromManage,
+    existingThresholds,
+  } = route.params;
 
   const displayTicker = ticker || symbol;
   const [alertType, setAlertType] = useState<PriceAlertType>(
@@ -152,6 +159,13 @@ const CreatePriceAlertView: React.FC = () => {
   }, [targetAmount]);
 
   const hasValidTarget = targetPrice > 0;
+
+  const isDuplicateThreshold = useMemo(
+    () =>
+      hasValidTarget &&
+      (existingThresholds ?? []).some((t) => t === targetPrice),
+    [hasValidTarget, existingThresholds, targetPrice],
+  );
 
   const percentDiff = useMemo(() => {
     if (!hasInput || currentPrice <= 0 || targetPrice <= 0) {
@@ -384,11 +398,15 @@ const CreatePriceAlertView: React.FC = () => {
                   variant={ButtonVariant.Primary}
                   onPress={handleSaveAlert}
                   isLoading={isSubmitting}
-                  isDisabled={isSubmitting || !hasValidTarget}
+                  isDisabled={
+                    isSubmitting || !hasValidTarget || isDuplicateThreshold
+                  }
                   testID={CreatePriceAlertTestIds.SET_ALERT_BUTTON}
                   twClassName="mb-3 w-full"
                 >
-                  {strings('price_alerts.set_price_alert')}
+                  {isDuplicateThreshold
+                    ? strings('price_alerts.duplicate_threshold')
+                    : strings('price_alerts.set_price_alert')}
                 </Button>
               ) : (
                 <Box

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
@@ -5,6 +5,7 @@ import { notifyManager } from '@tanstack/query-core';
 import ManagePriceAlertsView from './ManagePriceAlertsView';
 import { ManagePriceAlertsTestIds, type PriceAlert } from '../../constants';
 import Routes from '../../../../../../constants/navigation/Routes';
+import { ToastContext } from '../../../../../../component-library/components/Toast';
 
 // Prevents act() warnings caused by useQuery's internal batched updates
 notifyManager.setBatchNotifyFunction((callback: () => void) => {
@@ -20,14 +21,30 @@ const createWrapper = () => {
   return { Wrapper, queryClient };
 };
 
-const renderView = () => {
-  const { Wrapper } = createWrapper();
-  return render(<ManagePriceAlertsView />, { wrapper: Wrapper });
-};
-
 const mockGoBack = jest.fn();
 const mockReplace = jest.fn();
 const mockNavigate = jest.fn();
+const mockShowToast = jest.fn();
+
+function WithToast({ children }: { children: React.ReactNode }) {
+  const ref = React.useRef({ showToast: mockShowToast, closeToast: jest.fn() });
+  return (
+    <ToastContext.Provider value={{ toastRef: ref }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+const renderView = () => {
+  const { Wrapper } = createWrapper();
+  return render(
+    <Wrapper>
+      <WithToast>
+        <ManagePriceAlertsView />
+      </WithToast>
+    </Wrapper>,
+  );
+};
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -48,8 +65,12 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockFetchAlerts = jest.fn();
+const mockDeleteAlert = jest.fn();
+const mockUpdateAlert = jest.fn();
 jest.mock('../../api', () => ({
   fetchAlerts: (...args: unknown[]) => mockFetchAlerts(...args),
+  deleteAlert: (...args: unknown[]) => mockDeleteAlert(...args),
+  updateAlert: (...args: unknown[]) => mockUpdateAlert(...args),
 }));
 
 const makeAlert = (overrides: Partial<PriceAlert> = {}): PriceAlert => ({
@@ -75,8 +96,24 @@ const waitForLoaded = (screen: ReturnType<typeof render>) =>
     expect(screen.queryByTestId(ManagePriceAlertsTestIds.LOADING)).toBeNull();
   });
 
+const makeOkResponse = (status = 204) => ({
+  ok: true,
+  status,
+  json: jest.fn().mockResolvedValue({}),
+  text: jest.fn().mockResolvedValue(''),
+});
+
+const makeErrorResponse = (status = 500) => ({
+  ok: false,
+  status,
+  json: jest.fn().mockResolvedValue({}),
+  text: jest.fn().mockResolvedValue(''),
+});
+
 beforeEach(() => {
   jest.clearAllMocks();
+  mockDeleteAlert.mockResolvedValue(makeOkResponse(204));
+  mockUpdateAlert.mockResolvedValue(makeOkResponse(200));
 });
 
 describe('ManagePriceAlertsView', () => {
@@ -217,6 +254,202 @@ describe('ManagePriceAlertsView', () => {
           fromManage: true,
         }),
       );
+    });
+
+    it('passes existingThresholds of current alerts when navigating to Add alert', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(ManagePriceAlertsTestIds.ADD_ALERT_BUTTON),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.CREATE_PRICE_ALERT,
+        expect.objectContaining({
+          existingThresholds: expect.arrayContaining([3000, 1500]),
+        }),
+      );
+    });
+  });
+
+  describe('delete alert', () => {
+    beforeEach(() => {
+      mockFetchAlerts.mockResolvedValue(
+        makeFetchResponse([
+          makeAlert({ id: 'alert-1', threshold: 3000 }),
+          makeAlert({ id: 'alert-2', threshold: 1500 }),
+        ]),
+      );
+    });
+
+    it('removes the row optimistically when delete is pressed', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+          ),
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-alert-1`,
+          ),
+        ).toBeNull();
+      });
+      expect(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-alert-2`,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('calls deleteAlert with the correct id', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockDeleteAlert).toHaveBeenCalledWith('alert-1');
+      });
+    });
+
+    it('shows a success toast after deleting an alert', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            labelOptions: expect.arrayContaining([
+              expect.objectContaining({
+                label: 'Price alert deleted.',
+              }),
+            ]),
+            hasNoTimeout: false,
+          }),
+        );
+      });
+    });
+
+    it('navigates back to token details when last alert is deleted', async () => {
+      mockFetchAlerts.mockResolvedValue(
+        makeFetchResponse([makeAlert({ id: 'alert-1' })]),
+      );
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+          ),
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockGoBack).toHaveBeenCalledTimes(1);
+      });
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('restores the row when deleteAlert returns a non-ok response', async () => {
+      mockDeleteAlert.mockResolvedValueOnce(makeErrorResponse(500));
+      mockFetchAlerts
+        .mockResolvedValueOnce(
+          makeFetchResponse([
+            makeAlert({ id: 'alert-1', threshold: 3000 }),
+            makeAlert({ id: 'alert-2', threshold: 1500 }),
+          ]),
+        )
+        .mockResolvedValueOnce(
+          makeFetchResponse([
+            makeAlert({ id: 'alert-1', threshold: 3000 }),
+            makeAlert({ id: 'alert-2', threshold: 1500 }),
+          ]),
+        );
+
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-alert-1`,
+          ),
+        ).toBeOnTheScreen();
+      });
+    });
+  });
+
+  describe('toggle alert active state', () => {
+    beforeEach(() => {
+      mockFetchAlerts.mockResolvedValue(
+        makeFetchResponse([makeAlert({ id: 'alert-1', active: true })]),
+      );
+    });
+
+    it('calls updateAlert with the toggled active value', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+        ),
+        'valueChange',
+        false,
+      );
+
+      await waitFor(() => {
+        expect(mockUpdateAlert).toHaveBeenCalledWith('alert-1', {
+          active: false,
+        });
+      });
+    });
+
+    it('rolls back the toggle when updateAlert returns a non-ok response', async () => {
+      mockUpdateAlert.mockResolvedValueOnce(makeErrorResponse(500));
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+        ),
+        'valueChange',
+        false,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+          ),
+        ).toHaveProp('value', true);
+      });
     });
   });
 

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ActivityIndicator, FlatList, Switch, View } from 'react-native';
 import {
   useNavigation,
@@ -25,6 +25,10 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTheme } from '../../../../../../util/theme';
+import {
+  ToastContext,
+  ToastVariants,
+} from '../../../../../../component-library/components/Toast';
 import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { formatPriceWithSubscriptNotation } from '../../../../Predict/utils/format';
@@ -33,11 +37,15 @@ import {
   PriceAlert,
   PriceAlertRouteParams,
 } from '../../constants';
-import { fetchAlerts } from '../../api';
+import { fetchAlerts, deleteAlert, updateAlert } from '../../api';
+
+const priceAlertsQueryKey = (assetId: string) => ['priceAlerts', assetId];
 
 const ManagePriceAlertsView: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
+  const queryClient = useQueryClient();
+  const { toastRef } = useContext(ToastContext);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<StackNavigationProp<any>>();
   const route =
@@ -50,12 +58,14 @@ const ManagePriceAlertsView: React.FC = () => {
   const { symbol, ticker, currentPrice, currentCurrency, assetId } =
     route.params;
 
+  const hasResolvedInitialFetch = useRef(false);
+
   const {
     data: alerts = [],
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['priceAlerts', assetId],
+    queryKey: priceAlertsQueryKey(assetId),
     queryFn: async (): Promise<PriceAlert[]> => {
       const response = await fetchAlerts(assetId);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -67,7 +77,11 @@ const ManagePriceAlertsView: React.FC = () => {
   });
 
   useEffect(() => {
-    if (!isLoading && (isError || alerts.length === 0)) {
+    if (isLoading || hasResolvedInitialFetch.current) {
+      return;
+    }
+    hasResolvedInitialFetch.current = true;
+    if (isError || alerts.length === 0) {
       navigation.replace(Routes.CREATE_PRICE_ALERT, {
         symbol,
         ticker,
@@ -100,8 +114,73 @@ const ManagePriceAlertsView: React.FC = () => {
       currentCurrency,
       assetId,
       fromManage: true,
+      existingThresholds: alerts.map((a) => a.threshold),
     });
-  }, [navigation, symbol, ticker, currentPrice, currentCurrency, assetId]);
+  }, [
+    navigation,
+    symbol,
+    ticker,
+    currentPrice,
+    currentCurrency,
+    assetId,
+    alerts,
+  ]);
+
+  const handleDeleteAlert = useCallback(
+    async (id: string) => {
+      const queryKey = priceAlertsQueryKey(assetId);
+      const previous = queryClient.getQueryData<PriceAlert[]>(queryKey) ?? [];
+      const next = previous.filter((a) => a.id !== id);
+      const isEmpty = next.length === 0;
+      queryClient.setQueryData(queryKey, next);
+
+      try {
+        const response = await deleteAlert(id);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        toastRef?.current?.showToast({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Trash,
+          iconColor: colors.text.default,
+          labelOptions: [{ label: strings('price_alerts.delete_success') }],
+          hasNoTimeout: false,
+        });
+        if (isEmpty) {
+          navigation.goBack();
+        }
+      } catch {
+        const response = await fetchAlerts(assetId).catch(() => null);
+        if (response?.ok) {
+          const data: PriceAlert[] = await response.json().catch(() => []);
+          queryClient.setQueryData(queryKey, data);
+        } else {
+          queryClient.setQueryData(queryKey, previous);
+        }
+      }
+    },
+    [navigation, assetId, queryClient, toastRef, colors],
+  );
+
+  const handleToggleAlert = useCallback(
+    async (id: string, newValue: boolean) => {
+      const queryKey = priceAlertsQueryKey(assetId);
+      const previous = queryClient.getQueryData<PriceAlert[]>(queryKey) ?? [];
+      queryClient.setQueryData(
+        queryKey,
+        previous.map((a) => (a.id === id ? { ...a, active: newValue } : a)),
+      );
+
+      try {
+        const response = await updateAlert(id, { active: newValue });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      } catch {
+        queryClient.setQueryData(
+          queryKey,
+          previous.map((a) => (a.id === id ? { ...a, active: !newValue } : a)),
+        );
+      }
+    },
+    [assetId, queryClient],
+  );
 
   const renderItem = ({ item }: { item: PriceAlert }) => (
     <Box
@@ -128,9 +207,7 @@ const ManagePriceAlertsView: React.FC = () => {
       </Box>
 
       <ButtonIcon
-        onPress={() => {
-          // TODO: delete alert
-        }}
+        onPress={() => handleDeleteAlert(item.id)}
         size={ButtonIconSize.Md}
         iconName={IconName.Trash}
         testID={`${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-${item.id}`}
@@ -140,9 +217,7 @@ const ManagePriceAlertsView: React.FC = () => {
 
       <Switch
         value={item.active}
-        onValueChange={() => {
-          // TODO: toggle alert active state
-        }}
+        onValueChange={(v) => handleToggleAlert(item.id, v)}
         trackColor={{
           true: colors.primary.default,
           false: colors.border.muted,

--- a/app/components/UI/Assets/PriceAlerts/api.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.test.ts
@@ -2,7 +2,13 @@ import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { notifyManager } from '@tanstack/query-core';
-import { fetchAlerts, createAlert, useSavePriceAlert } from './api';
+import {
+  fetchAlerts,
+  createAlert,
+  deleteAlert,
+  updateAlert,
+  useSavePriceAlert,
+} from './api';
 
 // Prevents teardown crashes with unstable_batchedUpdates in Jest
 notifyManager.setBatchNotifyFunction((callback: () => void) => {
@@ -138,6 +144,60 @@ describe('createAlert', () => {
         recurring: true,
       }),
     ).toBe(response);
+  });
+});
+
+describe('deleteAlert', () => {
+  it('sends DELETE to /alerts/:id', async () => {
+    await deleteAlert('alert-42');
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ALERTS_URL}/alert-42`);
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('attaches auth and accept headers', async () => {
+    await deleteAlert('alert-42');
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer test-bearer-token',
+    );
+    expect((init.headers as Record<string, string>).Accept).toBe(
+      'application/json',
+    );
+  });
+
+  it('returns the raw Response from fetch', async () => {
+    const response = makeOkResponse();
+    mockFetch.mockResolvedValue(response);
+    expect(await deleteAlert('alert-42')).toBe(response);
+  });
+});
+
+describe('updateAlert', () => {
+  it('sends PATCH to /alerts/:id with a JSON-serialised body', async () => {
+    const params = { active: false };
+    await updateAlert('alert-42', params);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ALERTS_URL}/alert-42`);
+    expect(init.method).toBe('PATCH');
+    expect(init.body).toBe(JSON.stringify(params));
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json',
+    );
+  });
+
+  it('attaches auth headers', async () => {
+    await updateAlert('alert-42', { active: true });
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer test-bearer-token',
+    );
+  });
+
+  it('returns the raw Response from fetch', async () => {
+    const response = makeOkResponse({ id: 'alert-42', active: false });
+    mockFetch.mockResolvedValue(response);
+    expect(await updateAlert('alert-42', { active: false })).toBe(response);
   });
 });
 

--- a/app/components/UI/Assets/PriceAlerts/api.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import AppConstants from '../../../../core/AppConstants';
 import Engine from '../../../../core/Engine';
-import type { SaveAlertParams } from './constants';
+import type { SaveAlertParams, UpdateAlertParams } from './constants';
 
 const ALERTS_URL = `${AppConstants.PRICE_ALERTS_API.URL}/alerts`;
 
@@ -27,6 +27,19 @@ export const fetchAlerts = (assetId: string): Promise<Response> =>
 export const createAlert = (params: SaveAlertParams): Promise<Response> =>
   authenticatedFetch(ALERTS_URL, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+
+export const deleteAlert = (id: string): Promise<Response> =>
+  authenticatedFetch(`${ALERTS_URL}/${id}`, { method: 'DELETE' });
+
+export const updateAlert = (
+  id: string,
+  params: UpdateAlertParams,
+): Promise<Response> =>
+  authenticatedFetch(`${ALERTS_URL}/${id}`, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
   });

--- a/app/components/UI/Assets/PriceAlerts/constants.ts
+++ b/app/components/UI/Assets/PriceAlerts/constants.ts
@@ -17,6 +17,8 @@ export interface PriceAlertRouteParams {
 export interface CreatePriceAlertRouteParams extends PriceAlertRouteParams {
   /** When true the screen was opened from ManagePriceAlertsView; pop 2 on save to return to TokenDetails. */
   fromManage?: boolean;
+  /** Thresholds of existing alerts for this asset, used for duplicate-threshold validation. */
+  existingThresholds?: number[];
 }
 
 /** API response shape for a single price alert. */
@@ -47,6 +49,13 @@ export interface SaveAlertParams {
   asset: string;
   threshold: number;
   recurring: boolean;
+}
+
+/** Request body for updating an existing price alert via PATCH. At least one field is required. */
+export interface UpdateAlertParams {
+  active?: boolean;
+  threshold?: number;
+  recurring?: boolean;
 }
 
 export const CreatePriceAlertTestIds = {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4060,6 +4060,8 @@
     "price_change_under_development": "This experience is currently under development",
     "set_price_alert": "Set price alert",
     "save_success": "Price alert for {{ticker}} saved successfully.",
+    "delete_success": "Price alert deleted.",
+    "duplicate_threshold": "An alert at this price already exists.",
     "manage_title": "Price alerts",
     "add_alert": "Add alert",
     "reaches_threshold": "Reaches {{threshold}}",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Improve the price-alerts feature so that we allow users to edit and delete alerts

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: allow editing and deleting alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3356

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
