### PR TITLE
chore: format rate tag tiny rates with subscript notation

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -16,7 +16,6 @@ import {
   playErrorNotification,
   playImpact,
 } from '../../../../../../../util/haptics';
-import { getIntlNumberFormatter } from '../../../../../../../util/intl';
 import {
   dotAndCommaDecimalFormatter,
   isNumberValue,
@@ -41,6 +40,7 @@ import type {
 } from '../types';
 import { getTokenKey } from '../tokenKey';
 import { formatExchangeRate } from '../utils/formatExchangeRate';
+import { formatQuickBuyRateValue } from '../utils/formatQuickBuyRateValue';
 import { getMetamaskFeePercent } from '../utils/getMetamaskFeePercent';
 import { selectDefaultReceiveToken } from '../utils/selectDefaultReceiveToken';
 import { usePayWithTokens } from './usePayWithTokens';
@@ -702,12 +702,13 @@ export function useQuickBuyController(
     if (!sourceAmt || !destAmt || isNaN(sourceAmt) || isNaN(destAmt))
       return undefined;
     const rate = destAmt / sourceAmt;
-    const formatter = getIntlNumberFormatter(I18n.locale, {
-      ...(rate > 1
+    const formattedRateValue = formatQuickBuyRateValue(
+      rate,
+      rate > 1
         ? { minimumFractionDigits: 1, maximumFractionDigits: 2 }
-        : { minimumSignificantDigits: 2, maximumSignificantDigits: 3 }),
-    });
-    return `1 ${sourceToken.symbol} = ${formatter.format(rate)} ${destToken.symbol}`;
+        : { minimumSignificantDigits: 2, maximumSignificantDigits: 3 },
+    );
+    return `1 ${sourceToken.symbol} = ${formattedRateValue} ${destToken.symbol}`;
   }, [sourceToken, destToken, activeQuote, estimatedReceiveAmount]);
 
   const formattedPriceImpact = useMemo(() => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatExchangeRate.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatExchangeRate.test.ts
@@ -49,4 +49,11 @@ describe('formatExchangeRate', () => {
 
     expect(formatExchangeRate(dest, source)).toBe('1 TOKEN = 0.05 USDC');
   });
+
+  it('uses subscript notation for small rates with many leading zeros', () => {
+    const dest = createToken('GIGA', 0.006375);
+    const source = createToken('SOL', 150);
+
+    expect(formatExchangeRate(dest, source)).toBe('1 GIGA = 0.0₄425 SOL');
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatExchangeRate.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatExchangeRate.ts
@@ -1,7 +1,6 @@
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
-import { getIntlNumberFormatter } from '../../../../../../../util/intl';
 import { MINIMUM_DISPLAY_THRESHOLD } from '../../../../../../../util/number/bigint';
-import I18n from '../../../../../../../../locales/i18n';
+import { formatQuickBuyRateValue } from './formatQuickBuyRateValue';
 
 /**
  * Formats a human-readable exchange rate between destination and source tokens.
@@ -33,11 +32,12 @@ export function formatExchangeRate(
     return `1 ${destToken.symbol} = < ${MINIMUM_DISPLAY_THRESHOLD} ${sourceToken.symbol}`;
   }
 
-  const formatter = getIntlNumberFormatter(I18n.locale, {
-    ...(sourcePerDest > 1
+  const formattedRate = formatQuickBuyRateValue(
+    sourcePerDest,
+    sourcePerDest > 1
       ? { maximumFractionDigits: 2 }
-      : { maximumSignificantDigits: 3 }),
-  });
+      : { maximumSignificantDigits: 3 },
+  );
 
-  return `1 ${destToken.symbol} = ${formatter.format(sourcePerDest)} ${sourceToken.symbol}`;
+  return `1 ${destToken.symbol} = ${formattedRate} ${sourceToken.symbol}`;
 }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatQuickBuyRateValue.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatQuickBuyRateValue.test.ts
@@ -1,0 +1,34 @@
+import { MINIMUM_DISPLAY_THRESHOLD } from '../../../../../../../util/number/bigint';
+import { formatQuickBuyRateValue } from './formatQuickBuyRateValue';
+
+describe('formatQuickBuyRateValue', () => {
+  it('uses subscript notation for small rates at or above the dust threshold', () => {
+    expect(
+      formatQuickBuyRateValue(0.0000425, { maximumSignificantDigits: 3 }),
+    ).toBe('0.0₄425');
+  });
+
+  it('falls back to Intl formatting when subscript notation does not apply', () => {
+    expect(formatQuickBuyRateValue(0.05, { maximumSignificantDigits: 3 })).toBe(
+      '0.05',
+    );
+
+    expect(formatQuickBuyRateValue(1862.12, { maximumFractionDigits: 2 })).toBe(
+      '1,862.12',
+    );
+  });
+
+  it('does not use subscript notation below the dust threshold', () => {
+    expect(
+      formatQuickBuyRateValue(0.000008, { maximumSignificantDigits: 3 }),
+    ).toBe('0.000008');
+  });
+
+  it('formats exactly at the dust threshold with subscript when applicable', () => {
+    expect(
+      formatQuickBuyRateValue(MINIMUM_DISPLAY_THRESHOLD, {
+        maximumSignificantDigits: 3,
+      }),
+    ).toBe('0.0₄1');
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatQuickBuyRateValue.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/formatQuickBuyRateValue.ts
@@ -1,0 +1,32 @@
+import { MINIMUM_DISPLAY_THRESHOLD } from '../../../../../../../util/number/bigint';
+import { formatSubscriptNotation } from '../../../../../../../util/number/subscriptNotation';
+import { getIntlNumberFormatter } from '../../../../../../../util/intl';
+import I18n from '../../../../../../../../locales/i18n';
+
+export type QuickBuyRateIntlOptions = Pick<
+  Intl.NumberFormatOptions,
+  | 'minimumFractionDigits'
+  | 'maximumFractionDigits'
+  | 'minimumSignificantDigits'
+  | 'maximumSignificantDigits'
+>;
+
+/**
+ * Formats the numeric portion of a Quick Buy exchange rate.
+ * Uses subscript notation for very small rates (matching asset prices),
+ * while preserving the dust threshold display for sub-micro values.
+ */
+export function formatQuickBuyRateValue(
+  rate: number,
+  intlOptions: QuickBuyRateIntlOptions,
+  locale: string = I18n.locale,
+): string {
+  if (rate >= MINIMUM_DISPLAY_THRESHOLD) {
+    const subscript = formatSubscriptNotation(rate);
+    if (subscript) {
+      return subscript;
+    }
+  }
+
+  return getIntlNumberFormatter(locale, intlOptions).format(rate);
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Quick Buy rate labels (toolbar pill and quote details) showed long zero runs for very small rates (`0.0000425`). Therefore we reuse the existing `formatSubscriptNotation` helper via a shared `formatQuickBuyRateValue` util so rates match asset price formatting (`0.0₄425`).


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-711

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy

 Scenario: pre-quote rate pill uses subscript notation for tiny rates
    Given I am on a trader position with a very low-value token (many leading zeros in the rate, e.g. GIGA/SOL)
    And I open Quick Buy
    When the sheet loads before a quote is fetched
    Then the rate pill shows subscript notation (e.g. "1 GIGA = 0.0₄425 SOL")
    And it does not show a long string of leading zeros
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="394" height="80" alt="Screenshot 2026-06-15 at 10 30 12" src="https://github.com/user-attachments/assets/0b81634b-5a74-4854-888c-621377f4d9c3" />

### **After**

<img width="416" height="87" alt="Screenshot 2026-06-15 at 10 20 40" src="https://github.com/user-attachments/assets/295469ab-8a9e-4550-8ad9-addac95c15d2" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
