### PR TITLE
fix: use MDS flash icon + hide hidden tokens in Quick Buy "Pay with" list

### DIFF
--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
@@ -82,8 +82,6 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
-jest.mock('./assets/flash-filled.svg', () => 'FlashFilledIcon');
-
 const mockOnBuy = jest.fn();
 const mockOnSwap = jest.fn();
 let mockHasEligibleSwapTokens = true;

--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
@@ -1,35 +1,35 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { View, StyleSheet } from 'react-native';
-import { useSelector } from 'react-redux';
-import { useNavigation } from '@react-navigation/native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { TokenSecurityData } from '@metamask/assets-controllers';
 import {
   Button,
   ButtonAnimated,
   ButtonVariant,
+  Icon,
   IconName,
   IconSize,
   TextColor,
 } from '@metamask/design-system-react-native';
-import type { TokenSecurityData } from '@metamask/assets-controllers';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
-import { useTheme, LIGHT_MODE_SUCCESS_GREEN } from '../../../../util/theme';
-import { AppThemeKey } from '../../../../util/theme/models';
-import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
-import useTokenBuyability from '../../Ramp/hooks/useTokenBuyability';
-import { AMBIENT_NEGATIVE_COLOR } from './abTestConfig';
-import { useStickyFooterTracking } from '../hooks/useStickyFooterTracking';
 import Routes from '../../../../constants/navigation/Routes';
-import type { BridgeToken } from '../../Bridge/types';
-import type { TokenDetailsRouteParams } from '../constants/constants';
 import { getDetectedGeolocation } from '../../../../reducers/fiatOrders';
 import { ONDO_RESTRICTED_COUNTRIES } from '../../../../util/ondoGeoRestrictions';
+import { LIGHT_MODE_SUCCESS_GREEN, useTheme } from '../../../../util/theme';
+import { AppThemeKey } from '../../../../util/theme/models';
+import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
+import type { BridgeToken } from '../../Bridge/types';
+import useTokenBuyability from '../../Ramp/hooks/useTokenBuyability';
+import { getResultTypeConfig } from '../../SecurityTrust/utils/securityUtils';
+import type { TokenDetailsRouteParams } from '../constants/constants';
+import { useStickyFooterTracking } from '../hooks/useStickyFooterTracking';
+import { useStickyTokenActions } from '../hooks/useStickyTokenActions';
+import { AMBIENT_NEGATIVE_COLOR } from './abTestConfig';
 import RwaUnavailableBottomSheet, {
   type RwaUnavailableBottomSheetRef,
 } from './RwaUnavailableBottomSheet/RwaUnavailableBottomSheet';
-import { useStickyTokenActions } from '../hooks/useStickyTokenActions';
-import { getResultTypeConfig } from '../../SecurityTrust/utils/securityUtils';
-import FlashFilledIcon from './assets/flash-filled.svg';
 
 const styles = StyleSheet.create({
   footer: {
@@ -356,11 +356,10 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
               );
             }}
           >
-            <FlashFilledIcon
-              name="FlashFilled"
-              width={20}
-              height={20}
-              fill={successColorHex}
+            <Icon
+              name={IconName.FlashFilled}
+              size={IconSize.Md}
+              twClassName={successText}
             />
           </ButtonAnimated>
         )}

--- a/app/components/UI/TokenDetails/components/assets/flash-filled.svg
+++ b/app/components/UI/TokenDetails/components/assets/flash-filled.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M10 21.8855V13.8855H7V1.8855H17L15 8.8855H19L10 21.8855Z"/></svg>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.test.ts
@@ -31,7 +31,7 @@ const baseSources: PayWithHiddenSources = {
   ignoredEvmTokens: {},
   ignoredNonEvmAssets: {},
   evmAccountAddress: EVM_ACCOUNT,
-  nonEvmAccountId: SOL_ACCOUNT_ID,
+  resolveNonEvmAccountId: () => SOL_ACCOUNT_ID,
 };
 
 describe('isPayWithTokenHidden', () => {
@@ -98,13 +98,41 @@ describe('isPayWithTokenHidden', () => {
     expect(isPayWithTokenHidden(solToken(SOL_ASSET), sources)).toBe(false);
   });
 
-  it('returns false for a non-EVM token when no non-EVM account id is available', () => {
+  it('returns false for a non-EVM token when no non-EVM account id is resolved', () => {
     const sources: PayWithHiddenSources = {
       ...baseSources,
-      nonEvmAccountId: undefined,
+      resolveNonEvmAccountId: () => undefined,
       ignoredNonEvmAssets: { [SOL_ACCOUNT_ID]: [SOL_ASSET] },
     };
 
+    expect(isPayWithTokenHidden(solToken(SOL_ASSET), sources)).toBe(false);
+  });
+
+  it('scopes the hidden check to the account that owns the token chain', () => {
+    const BTC_SCOPE = 'bip122:000000000019d6689c085ae165831e93';
+    const BTC_ACCOUNT_ID = 'btc-account-id';
+    const BTC_ASSET = `${BTC_SCOPE}/slip44:0`;
+    const btcToken = (address: string): BridgeToken =>
+      ({
+        address,
+        chainId: BTC_SCOPE,
+        symbol: 'BTC',
+        name: 'Bitcoin',
+        decimals: 8,
+      }) as BridgeToken;
+
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      resolveNonEvmAccountId: (chainId) =>
+        chainId === BTC_SCOPE ? BTC_ACCOUNT_ID : SOL_ACCOUNT_ID,
+      ignoredNonEvmAssets: {
+        // Hidden under the Bitcoin account, not the Solana account.
+        [BTC_ACCOUNT_ID]: [BTC_ASSET],
+      },
+    };
+
+    expect(isPayWithTokenHidden(btcToken(BTC_ASSET), sources)).toBe(true);
+    // The Solana token must not match the Bitcoin account's hidden list.
     expect(isPayWithTokenHidden(solToken(SOL_ASSET), sources)).toBe(false);
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.test.ts
@@ -1,0 +1,121 @@
+import { SolScope } from '@metamask/keyring-api';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import {
+  isPayWithTokenHidden,
+  type PayWithHiddenSources,
+} from './isPayWithTokenHidden';
+
+const evmToken = (address: string, chainId = '0x1'): BridgeToken =>
+  ({
+    address,
+    chainId,
+    symbol: 'POSI',
+    name: 'POSI',
+    decimals: 18,
+  }) as BridgeToken;
+
+const solToken = (address: string): BridgeToken =>
+  ({
+    address,
+    chainId: SolScope.Mainnet,
+    symbol: 'SPAM',
+    name: 'SPAM',
+    decimals: 9,
+  }) as BridgeToken;
+
+const EVM_ACCOUNT = '0xAccount';
+const SOL_ACCOUNT_ID = 'sol-account-id';
+const SOL_ASSET = `${SolScope.Mainnet}/token:abc123`;
+
+const baseSources: PayWithHiddenSources = {
+  ignoredEvmTokens: {},
+  ignoredNonEvmAssets: {},
+  evmAccountAddress: EVM_ACCOUNT,
+  nonEvmAccountId: SOL_ACCOUNT_ID,
+};
+
+describe('isPayWithTokenHidden', () => {
+  it('returns true when an EVM token is hidden under the selected account', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      ignoredEvmTokens: {
+        '0x1': { [EVM_ACCOUNT.toLowerCase()]: ['0xspam'] },
+      },
+    };
+
+    expect(isPayWithTokenHidden(evmToken('0xspam'), sources)).toBe(true);
+  });
+
+  it('matches EVM token and account addresses case-insensitively', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      ignoredEvmTokens: {
+        '0x1': { [EVM_ACCOUNT.toLowerCase()]: ['0xSPAM'] },
+      },
+    };
+
+    expect(isPayWithTokenHidden(evmToken('0xSpAm'), sources)).toBe(true);
+  });
+
+  it('returns false for an EVM token that is not hidden', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      ignoredEvmTokens: {
+        '0x1': { [EVM_ACCOUNT.toLowerCase()]: ['0xother'] },
+      },
+    };
+
+    expect(isPayWithTokenHidden(evmToken('0xspam'), sources)).toBe(false);
+  });
+
+  it('returns false for an EVM token when no account address is available', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      evmAccountAddress: undefined,
+      ignoredEvmTokens: {
+        '0x1': { [EVM_ACCOUNT.toLowerCase()]: ['0xspam'] },
+      },
+    };
+
+    expect(isPayWithTokenHidden(evmToken('0xspam'), sources)).toBe(false);
+  });
+
+  it('returns true when a non-EVM token is hidden under the selected account', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      ignoredNonEvmAssets: { [SOL_ACCOUNT_ID]: [SOL_ASSET] },
+    };
+
+    expect(isPayWithTokenHidden(solToken(SOL_ASSET), sources)).toBe(true);
+  });
+
+  it('returns false for a non-EVM token that is not hidden', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      ignoredNonEvmAssets: { [SOL_ACCOUNT_ID]: ['some:other/asset'] },
+    };
+
+    expect(isPayWithTokenHidden(solToken(SOL_ASSET), sources)).toBe(false);
+  });
+
+  it('returns false for a non-EVM token when no non-EVM account id is available', () => {
+    const sources: PayWithHiddenSources = {
+      ...baseSources,
+      nonEvmAccountId: undefined,
+      ignoredNonEvmAssets: { [SOL_ACCOUNT_ID]: [SOL_ASSET] },
+    };
+
+    expect(isPayWithTokenHidden(solToken(SOL_ASSET), sources)).toBe(false);
+  });
+
+  it('returns false when the ignored maps are empty or undefined', () => {
+    expect(isPayWithTokenHidden(evmToken('0xspam'), baseSources)).toBe(false);
+    expect(
+      isPayWithTokenHidden(evmToken('0xspam'), {
+        ...baseSources,
+        ignoredEvmTokens: undefined,
+        ignoredNonEvmAssets: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.ts
@@ -1,0 +1,52 @@
+import { isNonEvmChainId } from '@metamask/bridge-controller';
+import type { Hex } from '@metamask/utils';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+
+/**
+ * Hidden-token state, consolidated from the same selectors the main wallet list
+ * uses (see `app/selectors/assets/assets-migration.ts`). Both maps already merge
+ * the unified-assets `assetPreferences.hidden` flag with the legacy ignored
+ * collections, so consumers only need these two shapes.
+ */
+export interface PayWithHiddenSources {
+  /** EVM: chainId(hex) -> accountAddress(lowercased) -> tokenAddress(hex)[] */
+  ignoredEvmTokens:
+    | Record<string, Record<string, string[]> | undefined>
+    | undefined;
+  /** Non-EVM: accountId -> CAIP-19 assetId[] */
+  ignoredNonEvmAssets: Record<string, string[] | undefined> | undefined;
+  /** Selected EVM account address used to scope `ignoredEvmTokens`. */
+  evmAccountAddress: string | undefined;
+  /** Selected non-EVM account id used to scope `ignoredNonEvmAssets`. */
+  nonEvmAccountId: string | undefined;
+}
+
+/**
+ * Returns `true` when the user has hidden the given "Pay with" token, mirroring
+ * the visibility semantics of `useAssetVisibility.isHidden`. EVM tokens are
+ * matched case-insensitively by address under the selected EVM account (keyed by
+ * chainId); non-EVM tokens are matched by their CAIP-19 asset id (`token.address`)
+ * under the selected non-EVM account.
+ */
+export const isPayWithTokenHidden = (
+  token: BridgeToken,
+  {
+    ignoredEvmTokens,
+    ignoredNonEvmAssets,
+    evmAccountAddress,
+    nonEvmAccountId,
+  }: PayWithHiddenSources,
+): boolean => {
+  if (isNonEvmChainId(token.chainId)) {
+    if (!nonEvmAccountId) return false;
+    const ignored = ignoredNonEvmAssets?.[nonEvmAccountId];
+    return Boolean(ignored?.includes(token.address));
+  }
+
+  if (!evmAccountAddress) return false;
+  const ignored =
+    ignoredEvmTokens?.[token.chainId as Hex]?.[evmAccountAddress.toLowerCase()];
+  if (!ignored?.length) return false;
+  const target = token.address.toLowerCase();
+  return ignored.some((address) => address.toLowerCase() === target);
+};

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/isPayWithTokenHidden.ts
@@ -1,5 +1,5 @@
 import { isNonEvmChainId } from '@metamask/bridge-controller';
-import type { Hex } from '@metamask/utils';
+import type { CaipChainId, Hex } from '@metamask/utils';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 
 /**
@@ -17,8 +17,14 @@ export interface PayWithHiddenSources {
   ignoredNonEvmAssets: Record<string, string[] | undefined> | undefined;
   /** Selected EVM account address used to scope `ignoredEvmTokens`. */
   evmAccountAddress: string | undefined;
-  /** Selected non-EVM account id used to scope `ignoredNonEvmAssets`. */
-  nonEvmAccountId: string | undefined;
+  /**
+   * Resolves the owning non-EVM account id for a token's CAIP chain id. Hidden
+   * non-EVM assets are keyed per account (e.g. Solana and Bitcoin holdings live
+   * under different accounts), so the account must be resolved from the token's
+   * own chain rather than assuming a single account. Mirrors how
+   * `useAssetVisibility` scopes the account to the asset's chain.
+   */
+  resolveNonEvmAccountId: (chainId: CaipChainId) => string | undefined;
 }
 
 /**
@@ -26,7 +32,7 @@ export interface PayWithHiddenSources {
  * the visibility semantics of `useAssetVisibility.isHidden`. EVM tokens are
  * matched case-insensitively by address under the selected EVM account (keyed by
  * chainId); non-EVM tokens are matched by their CAIP-19 asset id (`token.address`)
- * under the selected non-EVM account.
+ * under the account that owns the token's chain.
  */
 export const isPayWithTokenHidden = (
   token: BridgeToken,
@@ -34,12 +40,13 @@ export const isPayWithTokenHidden = (
     ignoredEvmTokens,
     ignoredNonEvmAssets,
     evmAccountAddress,
-    nonEvmAccountId,
+    resolveNonEvmAccountId,
   }: PayWithHiddenSources,
 ): boolean => {
   if (isNonEvmChainId(token.chainId)) {
-    if (!nonEvmAccountId) return false;
-    const ignored = ignoredNonEvmAssets?.[nonEvmAccountId];
+    const accountId = resolveNonEvmAccountId(token.chainId as CaipChainId);
+    if (!accountId) return false;
+    const ignored = ignoredNonEvmAssets?.[accountId];
     return Boolean(ignored?.includes(token.address));
   }
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.test.ts
@@ -1,6 +1,11 @@
 import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import { useTokensWithBalance } from '../../../../../../UI/Bridge/hooks/useTokensWithBalance';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import { getTokensControllerAllIgnoredTokens } from '../../../../../../../selectors/assets/assets-migration';
+import { selectMultichainAssetsAllIgnoredAssets } from '../../../../../../../selectors/multichain/multichain';
+import { selectSelectedInternalAccountByScope } from '../../../../../../../selectors/multichainAccounts/accounts';
+import { EVM_SCOPE } from '../../../../../../UI/Earn/constants/networks';
 import { enrichTokenBalance } from './enrichTokenBalance';
 import { usePayWithTokens } from './usePayWithTokens';
 import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
@@ -13,6 +18,40 @@ jest.mock('../../../../../../UI/Bridge/hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: jest.fn(),
 }));
 
+jest.mock('../../../../../../../selectors/assets/assets-migration', () => ({
+  getTokensControllerAllIgnoredTokens: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/multichain/multichain', () => ({
+  selectMultichainBalances: jest.fn(),
+  selectMultichainAssetsRates: jest.fn(),
+  selectMultichainAssetsAllIgnoredAssets: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/accountTrackerController', () => ({
+  selectAccountsByChainId: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/tokenBalancesController', () => ({
+  selectTokensBalances: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/currencyRateController', () => ({
+  selectCurrencyRates: jest.fn(),
+}));
+
+jest.mock('../../../../../../../core/redux/slices/bridge', () => ({
+  selectSelectedSourceChainIds: jest.fn(),
+}));
+
 jest.mock('./enrichTokenBalance', () => ({
   enrichTokenBalance: jest.fn(),
 }));
@@ -21,9 +60,52 @@ jest.mock('./useNetworkEnabledPredicate', () => ({
   useNetworkEnabledPredicate: jest.fn(),
 }));
 
+const mockUseSelector = useSelector as jest.Mock;
 const mockUseTokensWithBalance = useTokensWithBalance as jest.Mock;
 const mockEnrich = enrichTokenBalance as jest.Mock;
 const mockUseNetworkEnabledPredicate = useNetworkEnabledPredicate as jest.Mock;
+const mockGetIgnoredTokens =
+  getTokensControllerAllIgnoredTokens as unknown as jest.Mock;
+const mockGetIgnoredAssets =
+  selectMultichainAssetsAllIgnoredAssets as unknown as jest.Mock;
+const mockAccountByScope =
+  selectSelectedInternalAccountByScope as unknown as jest.Mock;
+
+const FAKE_STATE = {
+  engine: {
+    backgroundState: {
+      NetworkController: { networkConfigurationsByChainId: {} },
+    },
+  },
+} as never;
+
+/**
+ * Resolves `useSelector` by invoking each selector against a minimal fake
+ * state. The mocked leaf selectors return whatever they are configured to,
+ * which lets the hook's inline `accountAddress` / `solanaAccount` selectors
+ * resolve through the mocked `selectSelectedInternalAccountByScope`.
+ */
+const setupSelectors = ({
+  allIgnoredTokens = {},
+  allIgnoredAssets = {},
+  evmAddress = '0xAccount',
+  solAccountId,
+}: {
+  allIgnoredTokens?: Record<string, Record<string, string[]>>;
+  allIgnoredAssets?: Record<string, string[]>;
+  evmAddress?: string;
+  solAccountId?: string;
+}) => {
+  mockGetIgnoredTokens.mockReturnValue(allIgnoredTokens);
+  mockGetIgnoredAssets.mockReturnValue(allIgnoredAssets);
+  mockAccountByScope.mockReturnValue((scope: string) => {
+    if (scope === EVM_SCOPE) return { address: evmAddress, id: 'evm' };
+    return solAccountId ? { id: solAccountId } : undefined;
+  });
+  mockUseSelector.mockImplementation((selector: (state: never) => unknown) =>
+    selector(FAKE_STATE),
+  );
+};
 
 const token = (symbol: string, chainId = '0x1'): BridgeToken =>
   ({
@@ -37,6 +119,7 @@ const token = (symbol: string, chainId = '0x1'): BridgeToken =>
 describe('usePayWithTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockImplementation(() => undefined);
     mockUseNetworkEnabledPredicate.mockReturnValue(() => true);
   });
 
@@ -151,5 +234,48 @@ describe('usePayWithTokens', () => {
       expect.objectContaining({ symbol: 'CAKE' }),
       expect.anything(),
     );
+  });
+
+  it('excludes tokens the user has hidden while keeping visible holdings', () => {
+    const posi = token('POSI');
+    const usdc = token('USDC');
+    mockUseTokensWithBalance.mockReturnValue([posi, usdc]);
+    setupSelectors({
+      allIgnoredTokens: {
+        '0x1': { '0xaccount': [posi.address.toUpperCase()] },
+      },
+    });
+    mockEnrich.mockImplementation((t: BridgeToken) => ({
+      balance: '10',
+      balanceFiat: '$10.00',
+      tokenFiatAmount: 10,
+      currencyExchangeRate: 1,
+    }));
+
+    const { result } = renderHook(() => usePayWithTokens());
+
+    expect(result.current.options.map((o) => o.symbol)).toEqual(['USDC']);
+    expect(mockEnrich).not.toHaveBeenCalledWith(
+      expect.objectContaining({ symbol: 'POSI' }),
+      expect.anything(),
+    );
+  });
+
+  it('keeps all holdings when nothing is hidden', () => {
+    mockUseTokensWithBalance.mockReturnValue([token('POSI'), token('USDC')]);
+    setupSelectors({ allIgnoredTokens: {} });
+    mockEnrich.mockImplementation(() => ({
+      balance: '10',
+      balanceFiat: '$10.00',
+      tokenFiatAmount: 10,
+      currencyExchangeRate: 1,
+    }));
+
+    const { result } = renderHook(() => usePayWithTokens());
+
+    expect(result.current.options.map((o) => o.symbol)).toEqual([
+      'POSI',
+      'USDC',
+    ]);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.test.ts
@@ -119,7 +119,13 @@ const token = (symbol: string, chainId = '0x1'): BridgeToken =>
 describe('usePayWithTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockImplementation(() => undefined);
+    // Resolve `useSelector` by invoking each (mocked) selector. `accountByScope`
+    // defaults to a resolver that finds no account, so tests that don't set up
+    // accounts behave as "nothing hidden" rather than crashing.
+    mockUseSelector.mockImplementation((selector: (state: never) => unknown) =>
+      selector(FAKE_STATE),
+    );
+    mockAccountByScope.mockReturnValue(() => undefined);
     mockUseNetworkEnabledPredicate.mockReturnValue(() => true);
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.ts
@@ -13,9 +13,12 @@ import { selectCurrencyRates } from '../../../../../../../selectors/currencyRate
 import {
   selectMultichainBalances,
   selectMultichainAssetsRates,
+  selectMultichainAssetsAllIgnoredAssets,
 } from '../../../../../../../selectors/multichain/multichain';
+import { getTokensControllerAllIgnoredTokens } from '../../../../../../../selectors/assets/assets-migration';
 import { EVM_SCOPE } from '../../../../../../UI/Earn/constants/networks';
 import { enrichTokenBalance } from './enrichTokenBalance';
+import { isPayWithTokenHidden } from './isPayWithTokenHidden';
 import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
 
 /**
@@ -52,6 +55,13 @@ export const usePayWithTokens = (): {
   const multichainBalances = useSelector(selectMultichainBalances);
   const multichainRates = useSelector(selectMultichainAssetsRates);
 
+  // Hidden-token state from the same consolidated selectors the main wallet
+  // list uses, so tokens hidden via "long tap -> hide" are excluded here too.
+  const ignoredEvmTokens = useSelector(getTokensControllerAllIgnoredTokens);
+  const ignoredNonEvmAssets = useSelector(
+    selectMultichainAssetsAllIgnoredAssets,
+  );
+
   const allNetworkConfigs = useSelector(
     (state: RootState) =>
       state.engine.backgroundState.NetworkController
@@ -78,6 +88,16 @@ export const usePayWithTokens = (): {
     for (const token of heldTokens) {
       // Scope holdings to networks the user has enabled in wallet settings.
       if (!isChainEnabled(token.chainId)) continue;
+      // Exclude tokens the user has hidden (TSA-649).
+      if (
+        isPayWithTokenHidden(token, {
+          ignoredEvmTokens,
+          ignoredNonEvmAssets,
+          evmAccountAddress: accountAddress,
+          nonEvmAccountId: solanaAccount?.id,
+        })
+      )
+        continue;
       const enrichment = enrichTokenBalance(token, deps);
       if (!enrichment) continue;
       result.push({ ...token, ...enrichment });
@@ -97,6 +117,8 @@ export const usePayWithTokens = (): {
     solanaAccount,
     multichainBalances,
     multichainRates,
+    ignoredEvmTokens,
+    ignoredNonEvmAssets,
   ]);
 
   return { options, isLoading: false };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/usePayWithTokens.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { SolScope } from '@metamask/keyring-api';
+import type { CaipChainId } from '@metamask/utils';
 import type { BridgeToken } from '../../../../../../UI/Bridge/types';
 import type { RootState } from '../../../../../../../reducers';
 import { useTokensWithBalance } from '../../../../../../UI/Bridge/hooks/useTokensWithBalance';
@@ -40,18 +41,14 @@ export const usePayWithTokens = (): {
   const heldTokens = useTokensWithBalance({ chainIds: sourceChainIds });
   const isChainEnabled = useNetworkEnabledPredicate();
 
-  const accountAddress = useSelector(
-    (state: RootState) =>
-      selectSelectedInternalAccountByScope(state)(EVM_SCOPE)?.address,
-  );
+  const accountByScope = useSelector(selectSelectedInternalAccountByScope);
+  const accountAddress = accountByScope(EVM_SCOPE)?.address;
   const accountsByChainId = useSelector(selectAccountsByChainId);
   const tokenBalances = useSelector(selectTokensBalances);
   const tokenMarketData = useSelector(selectTokenMarketData);
   const currencyRates = useSelector(selectCurrencyRates);
 
-  const solanaAccount = useSelector((state: RootState) =>
-    selectSelectedInternalAccountByScope(state)(SolScope.Mainnet),
-  );
+  const solanaAccount = accountByScope(SolScope.Mainnet);
   const multichainBalances = useSelector(selectMultichainBalances);
   const multichainRates = useSelector(selectMultichainAssetsRates);
 
@@ -94,7 +91,8 @@ export const usePayWithTokens = (): {
           ignoredEvmTokens,
           ignoredNonEvmAssets,
           evmAccountAddress: accountAddress,
-          nonEvmAccountId: solanaAccount?.id,
+          resolveNonEvmAccountId: (chainId: CaipChainId) =>
+            accountByScope(chainId)?.id,
         })
       )
         continue;
@@ -108,6 +106,7 @@ export const usePayWithTokens = (): {
   }, [
     heldTokens,
     isChainEnabled,
+    accountByScope,
     accountAddress,
     accountsByChainId,
     tokenBalances,


### PR DESCRIPTION
## **Description**

Tokens that the user has hidden via "long tap -> hide" in the wallet token list were still showing up in the Quick Buy **"Pay with"** source list.

**Reason:** the "Pay with" list (`usePayWithTokens`) sources held tokens from `useTokensWithBalance`, which reads EVM tokens from `allTokens`. Hiding a token does not remove it from `allTokens` — under unified-assets state it sets `AssetsController.assetPreferences[assetId].hidden`, and for non-EVM it lives in `MultichainAssetsController.allIgnoredAssets`. The main wallet list filters on those, the Quick Buy "Pay with" list did not.

**Solution:** filter hidden tokens out in `usePayWithTokens`, reusing the *same* consolidated ignored-token selectors the wallet list already relies on (`getTokensControllerAllIgnoredTokens` for EVM and `selectMultichainAssetsAllIgnoredAssets` for non-EVM — both already merge `assetPreferences.hidden` with the legacy ignored collections behind the unify flag). The per-token check lives in a small, pure, unit-tested `isPayWithTokenHidden` helper.

## **Changelog**

CHANGELOG entry: Fixed hidden tokens still appearing in the Quick Buy "Pay with" token list.

## **Related issues**

Fixes: [TSA-649](https://consensyssoftware.atlassian.net/browse/TSA-649)

## **Manual testing steps**

```gherkin
Feature: Hidden tokens are excluded from Quick Buy "Pay with"

  Scenario: a manually hidden token does not appear as a pay-with option
    Given I hold ETH plus a spam token (e.g. POSI) that I have hidden via long tap -> hide
    When I open Quick Buy on an asset and open the "Pay with" token picker
    Then the hidden token is not listed
    And my non-hidden holdings (e.g. ETH) are still listed
```

## **Screenshots/Recordings**

### **Before**

<img width="1244" height="816" alt="image" src="https://github.com/user-attachments/assets/d175d0e7-c03b-42aa-bf33-779d69059e4d" />

### **After**

<img width="497" height="838" alt="image" src="https://github.com/user-attachments/assets/caca1a6a-8627-4a75-b17e-9ac95dcc043b" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[TSA-649]: https://consensyssoftware.atlassian.net/browse/TSA-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ