### PR TITLE
feat: prioritize viewed token's network in QuickBuy pay-with pills

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.test.tsx
@@ -19,8 +19,29 @@ jest.mock('../../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
 }));
 
+jest.mock('@metamask/bridge-controller', () => ({
+  formatChainIdToHex: (caipChainId: string) => {
+    const [namespace, reference] = caipChainId.split(':');
+    if (namespace !== 'eip155') {
+      throw new Error(`unsupported chain ${caipChainId}`);
+    }
+    return `0x${parseInt(reference, 10).toString(16)}`;
+  },
+  isNonEvmChainId: (chainId: string) =>
+    !chainId.startsWith('0x') && !chainId.startsWith('eip155:'),
+  isNativeAddress: () => false,
+  getNativeAssetForChainId: () => undefined,
+}));
+
+const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
 const getRowTestId = (token: BridgeToken): string =>
   `quick-buy-pay-with-row-${getTokenKey(token)}`;
+
+const getChainFilterOrder = (): string[] =>
+  screen
+    .getAllByTestId(/^quick-buy-chain-filter-/)
+    .map((node) => node.props.testID.replace('quick-buy-chain-filter-', ''));
 
 const createToken = (overrides: Partial<BridgeToken> = {}): BridgeToken => ({
   symbol: 'USDC',
@@ -35,6 +56,12 @@ const createToken = (overrides: Partial<BridgeToken> = {}): BridgeToken => ({
 
 const buildContext = (overrides: Record<string, unknown> = {}) => ({
   tradeMode: 'buy',
+  target: {
+    chain: 'eip155:1',
+    tokenAddress: '0x0000000000000000000000000000000000000000',
+    tokenSymbol: 'ETH',
+    tokenName: 'Ether',
+  },
   sourceTokenOptions: [createToken()],
   selectedSourceToken: createToken(),
   handleSelectSourceToken: jest.fn(),
@@ -126,6 +153,88 @@ describe('QuickBuyPayWithScreen', () => {
     expect(screen.getByTestId('quick-buy-chain-filter-all')).toBeOnTheScreen();
     expect(screen.getByTestId('quick-buy-chain-filter-0x1')).toBeOnTheScreen();
     expect(screen.getByTestId('quick-buy-chain-filter-0x38')).toBeOnTheScreen();
+  });
+
+  it("orders the viewed token's network first after All", () => {
+    const usdcToken = createToken({ symbol: 'USDC', chainId: '0x1' });
+    const usdtToken = createToken({
+      symbol: 'USDT',
+      chainId: '0x38',
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    });
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({
+        // Viewed token is on 0x38, even though the first held token is on 0x1.
+        target: {
+          chain: 'eip155:56',
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          tokenSymbol: 'BNB',
+          tokenName: 'BNB',
+        },
+        sourceTokenOptions: [usdcToken, usdtToken],
+        selectedSourceToken: usdcToken,
+        handleSelectSourceToken,
+        setActiveScreen,
+      }),
+    );
+
+    render(<QuickBuyPayWithScreen />);
+
+    expect(getChainFilterOrder()).toEqual(['all', '0x38', '0x1']);
+  });
+
+  it('orders a non-EVM viewed network first after All', () => {
+    const usdcToken = createToken({ symbol: 'USDC', chainId: '0x1' });
+    const solToken = createToken({
+      symbol: 'SOL',
+      chainId: SOLANA_CHAIN_ID,
+      address: `${SOLANA_CHAIN_ID}/slip44:501`,
+    });
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({
+        target: {
+          chain: SOLANA_CHAIN_ID,
+          tokenAddress: `${SOLANA_CHAIN_ID}/slip44:501`,
+          tokenSymbol: 'SOL',
+          tokenName: 'Solana',
+        },
+        sourceTokenOptions: [usdcToken, solToken],
+        selectedSourceToken: usdcToken,
+        handleSelectSourceToken,
+        setActiveScreen,
+      }),
+    );
+
+    render(<QuickBuyPayWithScreen />);
+
+    expect(getChainFilterOrder()).toEqual(['all', SOLANA_CHAIN_ID, '0x1']);
+  });
+
+  it('keeps the held-token order when the viewed network is not held', () => {
+    const usdcToken = createToken({ symbol: 'USDC', chainId: '0x1' });
+    const usdtToken = createToken({
+      symbol: 'USDT',
+      chainId: '0x38',
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    });
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({
+        target: {
+          chain: SOLANA_CHAIN_ID,
+          tokenAddress: `${SOLANA_CHAIN_ID}/slip44:501`,
+          tokenSymbol: 'SOL',
+          tokenName: 'Solana',
+        },
+        sourceTokenOptions: [usdcToken, usdtToken],
+        selectedSourceToken: usdcToken,
+        handleSelectSourceToken,
+        setActiveScreen,
+      }),
+    );
+
+    render(<QuickBuyPayWithScreen />);
+
+    expect(getChainFilterOrder()).toEqual(['all', '0x1', '0x38']);
   });
 
   it('hides the chain filter when all tokens are on the same chain', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyPayWithScreen.tsx
@@ -1,8 +1,10 @@
-import React, { useCallback } from 'react';
+import type { CaipChainId } from '@metamask/utils';
+import React, { useCallback, useMemo } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import QuickBuyTokenSelectList from './QuickBuyTokenSelectList';
 import { useQuickBuyContext } from './useQuickBuyContext';
+import { toFilterChainId } from './utils/toFilterChainId';
 
 /**
  * Buy mode "Pay with" screen: lets the user pick which token they hold to pay
@@ -11,11 +13,19 @@ import { useQuickBuyContext } from './useQuickBuyContext';
  */
 const QuickBuyPayWithScreen: React.FC = () => {
   const {
+    target,
     sourceTokenOptions,
     selectedSourceToken,
     handleSelectSourceToken,
     setActiveScreen,
   } = useQuickBuyContext();
+
+  // Surface the viewed token's network first in the chain filter pills. The
+  // list ignores it when no held token is on that chain.
+  const priorityChainId = useMemo(
+    () => toFilterChainId(target.chain as CaipChainId),
+    [target.chain],
+  );
 
   const handleBack = useCallback(
     () => setActiveScreen('amount'),
@@ -38,6 +48,7 @@ const QuickBuyPayWithScreen: React.FC = () => {
       selectedToken={selectedSourceToken}
       onSelect={handleSelect}
       onBack={handleBack}
+      priorityChainId={priorityChainId}
     />
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyReceiveScreen.tsx
@@ -1,13 +1,10 @@
-import {
-  formatChainIdToHex,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
 import type { CaipChainId } from '@metamask/utils';
 import React, { useCallback, useMemo } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import type { BridgeToken } from '../../../../../UI/Bridge/types';
 import QuickBuyTokenSelectList from './QuickBuyTokenSelectList';
 import { useQuickBuyContext } from './useQuickBuyContext';
+import { toFilterChainId } from './utils/toFilterChainId';
 
 /**
  * Sell mode "Receive" screen: lets the user pick which token (stablecoin or
@@ -28,19 +25,12 @@ const QuickBuyReceiveScreen: React.FC = () => {
   // receive candidate exists on it — avoids an immediately-empty list.
   const defaultChainId = useMemo(() => {
     // `target.chain` is already a CAIP id — `positionToQuickBuyTarget` does the
-    // chain-name → CAIP conversion when the target is built.
-    const caip = target.chain as CaipChainId;
-    // Receive candidates carry hex chain ids on EVM and CAIP ids on non-EVM
-    // (e.g. Solana), so the filter id must match the candidate format.
-    let chainFilterId: string;
-    if (isNonEvmChainId(caip)) {
-      chainFilterId = caip;
-    } else {
-      try {
-        chainFilterId = formatChainIdToHex(caip);
-      } catch {
-        return null;
-      }
+    // chain-name → CAIP conversion when the target is built. Receive candidates
+    // carry hex chain ids on EVM and CAIP ids on non-EVM (e.g. Solana), so the
+    // filter id must match the candidate format.
+    const chainFilterId = toFilterChainId(target.chain as CaipChainId);
+    if (chainFilterId === null) {
+      return null;
     }
     return sellDestTokenOptions.some((t) => t.chainId === chainFilterId)
       ? chainFilterId

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyTokenSelectList.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyTokenSelectList.tsx
@@ -32,6 +32,12 @@ export interface QuickBuyTokenSelectListProps {
   onBack: () => void;
   /** Chain to pre-select in the chain filter (null = "All"). */
   defaultChainId?: string | null;
+  /**
+   * Chain to surface first in the filter pills (right after "All"). Used to
+   * promote the currently viewed token's network. Ignored when no token is held
+   * on that chain.
+   */
+  priorityChainId?: string | null;
 }
 
 /**
@@ -48,16 +54,20 @@ const QuickBuyTokenSelectList: React.FC<QuickBuyTokenSelectListProps> = ({
   onSelect,
   onBack,
   defaultChainId = null,
+  priorityChainId = null,
 }) => {
   const tw = useTailwind();
   const [selectedChainId, setSelectedChainId] = useState<string | null>(
     defaultChainId,
   );
 
-  const uniqueChainIds = useMemo(
-    () => [...new Set(tokens.map((token) => token.chainId))],
-    [tokens],
-  );
+  const uniqueChainIds = useMemo(() => {
+    const ids: string[] = [...new Set(tokens.map((token) => token.chainId))];
+    if (priorityChainId === null || !ids.includes(priorityChainId)) {
+      return ids;
+    }
+    return [priorityChainId, ...ids.filter((id) => id !== priorityChainId)];
+  }, [tokens, priorityChainId]);
 
   const chainDisplayInfos = useChainDisplayInfos(uniqueChainIds);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/toFilterChainId.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/toFilterChainId.test.ts
@@ -1,0 +1,31 @@
+import type { CaipChainId } from '@metamask/utils';
+import { toFilterChainId } from './toFilterChainId';
+
+jest.mock('@metamask/bridge-controller', () => ({
+  formatChainIdToHex: (caipChainId: string) => {
+    const [namespace, reference] = caipChainId.split(':');
+    const parsed = parseInt(reference, 10);
+    if (namespace !== 'eip155' || Number.isNaN(parsed)) {
+      throw new Error(`unsupported chain ${caipChainId}`);
+    }
+    return `0x${parsed.toString(16)}`;
+  },
+  isNonEvmChainId: (chainId: string) =>
+    !chainId.startsWith('0x') && !chainId.startsWith('eip155:'),
+}));
+
+describe('toFilterChainId', () => {
+  it('converts an EVM CAIP chain id to hex', () => {
+    expect(toFilterChainId('eip155:1' as CaipChainId)).toBe('0x1');
+    expect(toFilterChainId('eip155:56' as CaipChainId)).toBe('0x38');
+  });
+
+  it('returns the original CAIP id for non-EVM chains', () => {
+    const solana = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as CaipChainId;
+    expect(toFilterChainId(solana)).toBe(solana);
+  });
+
+  it('returns null when the EVM hex conversion fails', () => {
+    expect(toFilterChainId('eip155:notanumber' as CaipChainId)).toBe(null);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/toFilterChainId.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/utils/toFilterChainId.ts
@@ -1,0 +1,22 @@
+import {
+  formatChainIdToHex,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
+import type { CaipChainId } from '@metamask/utils';
+
+/**
+ * Converts a CAIP chain id into the chain-id format carried by QuickBuy token
+ * lists: hex for EVM chains and the original CAIP id for non-EVM chains (e.g.
+ * Solana). Returns `null` when the EVM hex conversion fails so callers can
+ * treat it as "no matching chain".
+ */
+export function toFilterChainId(caip: CaipChainId): string | null {
+  if (isNonEvmChainId(caip)) {
+    return caip;
+  }
+  try {
+    return formatChainIdToHex(caip);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## **Description**

When building the QuickBuy "Pay with" network filter pills, the pills were ordered by the order in which held tokens appeared, so the network of the token the user is currently viewing could land anywhere in the list.

This change reorders the pills so the currently viewed token's network (`target.chain`) is surfaced first, right after the "All" pill. For example, when viewing SOL, the "Solana" pill now appears second (after "All") provided the user holds tokens on that network.

Implementation notes:
- A new shared helper `toFilterChainId` converts the target's CAIP chain id into the chain-id format the token list carries (hex for EVM, original CAIP for non-EVM like Solana), returning `null` when conversion fails.
- `QuickBuyReceiveScreen` was refactored to reuse this helper instead of its previous inline conversion.
- `QuickBuyTokenSelectList` gained an optional `priorityChainId` prop; when that chain is among the held tokens it is moved to the front of the pill list. It is a no-op when the user holds no tokens on that network (reorder only, never inserts).

## **Changelog**

CHANGELOG entry: Reordered the QuickBuy "Pay with" network filters so the currently viewed token's network appears first.

## **Related issues**

Fixes: Impractical order of network filters in the QuickBuy "Pay with"

## **Manual testing steps**

```gherkin
Feature: QuickBuy "Pay with" network pill ordering

  Scenario: viewed token's network is prioritized in the pills
    Given I hold tokens across several networks including the viewed token's network
    When I open a token (e.g. SOL) and open the QuickBuy "Pay with" sheet
    Then the first network pill is "All"
    And the second network pill is the viewed token's network (e.g. "Solana")

  Scenario: viewed network is not held
    Given I do not hold any token on the viewed token's network
    When I open the QuickBuy "Pay with" sheet
    Then the pills keep their held-token order and no extra pill is added
```

## **Screenshots/Recordings**

### **Before**

<img width="708" height="847" alt="image" src="https://github.com/user-attachments/assets/3d554803-1d53-4a4c-8f83-5b2d99b0ff86" />

### **After**

<img width="671" height="870" alt="image" src="https://github.com/user-attachments/assets/7a760fee-195e-42c0-ae14-22f10a4c72a5" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)