### PR TITLE
fix(predict): live price updates for Polymarket World Cup markets

### DIFF
--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Image, Pressable, ScrollView } from 'react-native';
 import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 import {
@@ -35,20 +35,69 @@ const PredictChipList: React.FC<PredictChipListProps> = ({
   useGestureHandlerScrollView = false,
 }) => {
   const tw = useTailwind();
+  const activeChipIndex = useMemo(
+    () => chips.findIndex((chip) => chip.key === activeChipKey),
+    [activeChipKey, chips],
+  );
   const {
     scrollViewRef,
     handleScrollViewLayout,
     handleChipLayout,
     scrollToChipAtIndex,
   } = useChipScrollList(chips.length);
+  const pendingUserSelectedChipKeyRef = useRef<string | null>(null);
 
   const handlePress = useCallback(
     (key: string, index: number) => {
+      pendingUserSelectedChipKeyRef.current =
+        key === activeChipKey ? null : key;
       onChipSelect(key);
-      scrollToChipAtIndex(index);
+      scrollToChipAtIndex(index, true);
     },
-    [onChipSelect, scrollToChipAtIndex],
+    [activeChipKey, onChipSelect, scrollToChipAtIndex],
   );
+
+  const syncActiveChipScroll = useCallback(
+    (animated = false) => {
+      if (activeChipIndex === -1) {
+        return;
+      }
+
+      scrollToChipAtIndex(activeChipIndex, animated);
+    },
+    [activeChipIndex, scrollToChipAtIndex],
+  );
+
+  const handleContainerLayout = useCallback(
+    (event: Parameters<typeof handleScrollViewLayout>[0]) => {
+      handleScrollViewLayout(event);
+      if (pendingUserSelectedChipKeyRef.current) {
+        return;
+      }
+      syncActiveChipScroll(false);
+    },
+    [handleScrollViewLayout, syncActiveChipScroll],
+  );
+
+  const handleChipItemLayout = useCallback(
+    (index: number, event: Parameters<typeof handleChipLayout>[1]) => {
+      handleChipLayout(index, event);
+      if (pendingUserSelectedChipKeyRef.current) {
+        return;
+      }
+      syncActiveChipScroll(false);
+    },
+    [handleChipLayout, syncActiveChipScroll],
+  );
+
+  useEffect(() => {
+    const shouldAnimate =
+      pendingUserSelectedChipKeyRef.current === activeChipKey;
+    syncActiveChipScroll(shouldAnimate);
+    if (shouldAnimate) {
+      pendingUserSelectedChipKeyRef.current = null;
+    }
+  }, [activeChipKey, syncActiveChipScroll]);
 
   if (chips.length === 0) {
     return null;
@@ -60,7 +109,7 @@ const PredictChipList: React.FC<PredictChipListProps> = ({
       <Pressable
         key={chip.key}
         onPress={() => handlePress(chip.key, index)}
-        onLayout={(event) => handleChipLayout(index, event)}
+        onLayout={(event) => handleChipItemLayout(index, event)}
         style={tw.style(
           chipTwClassName,
           isActive ? 'bg-icon-default' : 'bg-muted',
@@ -97,7 +146,7 @@ const PredictChipList: React.FC<PredictChipListProps> = ({
     horizontal: true as const,
     showsHorizontalScrollIndicator: false,
     contentContainerStyle: tw.style('px-4 gap-2'),
-    onLayout: handleScrollViewLayout,
+    onLayout: handleContainerLayout,
   };
 
   return (

--- a/app/components/UI/Predict/components/PredictChipList/useChipScrollList.ts
+++ b/app/components/UI/Predict/components/PredictChipList/useChipScrollList.ts
@@ -22,7 +22,7 @@ export function useChipScrollList(chipCount: number) {
   );
 
   const scrollToChipAtIndex = useCallback(
-    (chipIndex: number) => {
+    (chipIndex: number, animated = true) => {
       const scrollView = scrollViewRef.current;
       const viewportWidth = viewportWidthRef.current;
       if (!scrollView || viewportWidth === 0) {
@@ -39,7 +39,7 @@ export function useChipScrollList(chipCount: number) {
         return;
       }
 
-      scrollView.scrollTo({ x: scrollX, animated: true });
+      scrollView.scrollTo({ x: scrollX, animated });
     },
     [chipCount],
   );

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.test.tsx
@@ -142,6 +142,30 @@ jest.mock('../PredictPicks/PredictPicks', () => {
   };
 });
 
+const mockPredictGameDetailsOutcomesList = jest.fn();
+jest.mock('./PredictGameDetailsOutcomesList', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: function MockPredictGameDetailsOutcomesList(props: {
+      activeChipKey?: string;
+      enabled?: boolean;
+      groupMap?: Map<string, unknown>;
+      listHeaderComponent?: React.ReactElement;
+    }) {
+      mockPredictGameDetailsOutcomesList(props);
+      return (
+        <View
+          testID="mock-game-details-outcomes-list"
+          accessibilityHint={`enabled:${props.enabled ? 'true' : 'false'},groupCount:${props.groupMap?.size ?? 0},activeChip:${props.activeChipKey ?? ''}`}
+        >
+          {props.listHeaderComponent}
+        </View>
+      );
+    },
+  };
+});
+
 const mockGetRefHandlers = jest.fn(() => ({
   onOpenBottomSheet: jest.fn(),
   onCloseBottomSheet: jest.fn(),
@@ -750,7 +774,7 @@ describe('PredictGameDetailsContent', () => {
   });
 
   describe('tab bar rendering', () => {
-    it('renders sticky controls and outcomes content from the details content', () => {
+    it('uses the FlashList outcomes path when extended outcome groups are available', () => {
       (useGameDetailsTabs as jest.Mock).mockReturnValue({
         enabled: true,
         showTabBar: true,
@@ -768,7 +792,51 @@ describe('PredictGameDetailsContent', () => {
 
       const market = createMockMarket();
 
-      const { UNSAFE_getByType, getByTestId } = render(
+      const { getByTestId } = render(
+        <PredictGameDetailsContent
+          market={market}
+          onBack={mockOnBack}
+          onRefresh={mockOnRefresh}
+          onBetPress={mockOnBetPress}
+          refreshing={false}
+        />,
+      );
+
+      const outcomesList = getByTestId('mock-game-details-outcomes-list');
+
+      expect(outcomesList).toBeOnTheScreen();
+      expect(outcomesList.props.accessibilityHint).toBe(
+        'enabled:true,groupCount:1,activeChip:game_lines',
+      );
+      expect(mockPredictGameDetailsOutcomesList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeChipKey: 'game_lines',
+          enabled: true,
+          showChips: true,
+          showTabBar: true,
+        }),
+      );
+      expect(getByTestId('game-scoreboard')).toBeOnTheScreen();
+      expect(getByTestId('game-chart')).toBeOnTheScreen();
+    });
+
+    it('keeps the ScrollView path when extended sports has no outcome groups', () => {
+      (useGameDetailsTabs as jest.Mock).mockReturnValue({
+        enabled: true,
+        showTabBar: true,
+        tabs: [{ label: 'Outcomes', key: 'outcomes' }],
+        activeTab: 0,
+        handleTabPress: jest.fn(),
+        chips: [{ key: 'game_lines', label: 'Game Lines' }],
+        groupMap: new Map(),
+        activeChipKey: 'game_lines',
+        handleChipSelect: jest.fn(),
+        showChips: true,
+      });
+
+      const market = createMockMarket();
+
+      const { UNSAFE_getByType, getByTestId, queryByTestId } = render(
         <PredictGameDetailsContent
           market={market}
           onBack={mockOnBack}
@@ -781,6 +849,7 @@ describe('PredictGameDetailsContent', () => {
       const { ScrollView } = jest.requireActual('react-native');
       const scrollView = UNSAFE_getByType(ScrollView);
 
+      expect(queryByTestId('mock-game-details-outcomes-list')).toBeNull();
       expect(scrollView.props.stickyHeaderIndices).toEqual([2]);
       expect(getByTestId('game-scoreboard')).toBeOnTheScreen();
       expect(getByTestId('game-chart')).toBeOnTheScreen();

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -104,27 +104,33 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
     [showStickyHeader],
   );
 
+  const gameDetailsHeader = useMemo<React.ReactElement | undefined>(() => {
+    if (!game) {
+      return undefined;
+    }
+
+    return (
+      <>
+        <Box twClassName="px-4 py-2">
+          <PredictSportScoreboard
+            game={game}
+            testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_SCOREBOARD}
+          />
+        </Box>
+
+        <Box twClassName="mt-4">
+          <PredictGameChart
+            market={market}
+            testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_CHART}
+          />
+        </Box>
+      </>
+    );
+  }, [game, market]);
+
   if (!outcome || !game) {
     return null;
   }
-
-  const gameDetailsHeader = (
-    <>
-      <Box twClassName="px-4 py-2">
-        <PredictSportScoreboard
-          game={game}
-          testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_SCOREBOARD}
-        />
-      </Box>
-
-      <Box twClassName="mt-4">
-        <PredictGameChart
-          market={market}
-          testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_CHART}
-        />
-      </Box>
-    </>
-  );
 
   return (
     <SafeAreaView

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsContent.tsx
@@ -29,6 +29,7 @@ import PredictShareButton from '../PredictShareButton/PredictShareButton';
 import PredictSportScoreboard from '../PredictSportScoreboard';
 import PredictMarketDetailsTabBar from '../../views/PredictMarketDetails/components/PredictMarketDetailsTabBar';
 import PredictGameDetailsTabsContent from './PredictGameDetailsTabsContent';
+import PredictGameDetailsOutcomesList from './PredictGameDetailsOutcomesList';
 import { useGameDetailsTabs } from '../../hooks/useGameDetailsTabs';
 import { PredictGameDetailsContentProps } from './PredictGameDetailsContent.types';
 import { useTheme } from '../../../../../util/theme';
@@ -107,6 +108,24 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
     return null;
   }
 
+  const gameDetailsHeader = (
+    <>
+      <Box twClassName="px-4 py-2">
+        <PredictSportScoreboard
+          game={game}
+          testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_SCOREBOARD}
+        />
+      </Box>
+
+      <Box twClassName="mt-4">
+        <PredictGameChart
+          market={market}
+          testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_CHART}
+        />
+      </Box>
+    </>
+  );
+
   return (
     <SafeAreaView
       testID={PredictMarketDetailsSelectorsIDs.SCREEN}
@@ -147,65 +166,75 @@ const PredictGameDetailsContent: React.FC<PredictGameDetailsContentProps> = ({
         <PredictShareButton marketId={market.id} marketSlug={market.slug} />
       </Box>
 
-      <ScrollView
-        style={tw.style('flex-1')}
-        contentContainerStyle={tw.style('pb-4')}
-        stickyHeaderIndices={stickyHeaderIndices}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-            tintColor={colors.primary.default}
-            colors={[colors.primary.default]}
-          />
-        }
-      >
-        <Box twClassName="px-4 py-2">
-          <PredictSportScoreboard
-            game={game}
-            testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_SCOREBOARD}
-          />
-        </Box>
-
-        <Box twClassName="mt-4">
-          <PredictGameChart
-            market={market}
-            testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_CHART}
-          />
-        </Box>
-
-        {showStickyHeader && (
-          <Box twClassName="bg-default">
-            {showTabBar && (
-              <PredictMarketDetailsTabBar
-                tabs={tabs}
-                activeTab={activeTab}
-                onTabPress={handleTabPress}
-              />
-            )}
-            {showChips && (
-              <PredictChipList
-                chips={chips}
-                activeChipKey={activeChipKey}
-                onChipSelect={handleChipSelect}
-              />
-            )}
-          </Box>
-        )}
-
-        <PredictGameDetailsTabsContent
+      {hasExtendedOutcomes ? (
+        <PredictGameDetailsOutcomesList
           market={market}
-          activeTab={activeTab}
-          tabs={tabs}
           enabled={tabsEnabled}
-          showTabBar={showTabBar}
-          activePositions={activePositions}
-          claimablePositions={claimablePositions}
           groupMap={groupMap}
           activeChipKey={activeChipKey}
           onBetPress={onBetPress}
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          showTabBar={showTabBar}
+          tabs={tabs}
+          activeTab={activeTab}
+          onTabPress={handleTabPress}
+          showChips={showChips}
+          chips={chips}
+          onChipSelect={handleChipSelect}
+          activePositions={activePositions}
+          claimablePositions={claimablePositions}
+          listHeaderComponent={gameDetailsHeader}
         />
-      </ScrollView>
+      ) : (
+        <ScrollView
+          style={tw.style('flex-1')}
+          contentContainerStyle={tw.style('pb-4')}
+          stickyHeaderIndices={stickyHeaderIndices}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.primary.default}
+              colors={[colors.primary.default]}
+            />
+          }
+        >
+          {gameDetailsHeader}
+
+          {showStickyHeader && (
+            <Box twClassName="bg-default">
+              {showTabBar && (
+                <PredictMarketDetailsTabBar
+                  tabs={tabs}
+                  activeTab={activeTab}
+                  onTabPress={handleTabPress}
+                />
+              )}
+              {showChips && (
+                <PredictChipList
+                  chips={chips}
+                  activeChipKey={activeChipKey}
+                  onChipSelect={handleChipSelect}
+                />
+              )}
+            </Box>
+          )}
+
+          <PredictGameDetailsTabsContent
+            market={market}
+            activeTab={activeTab}
+            tabs={tabs}
+            enabled={tabsEnabled}
+            showTabBar={showTabBar}
+            activePositions={activePositions}
+            claimablePositions={claimablePositions}
+            groupMap={groupMap}
+            activeChipKey={activeChipKey}
+            onBetPress={onBetPress}
+          />
+        </ScrollView>
+      )}
 
       {showFooter && (
         <PredictGameDetailsFooter

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.test.tsx
@@ -16,6 +16,7 @@ import PredictGameDetailsOutcomesList from './PredictGameDetailsOutcomesList';
 
 let mockVisibleItemKeys: string[] | null = null;
 let mockLatestFlashListExtraData: unknown;
+let mockFlashListMountCount = 0;
 
 jest.mock('@shopify/flash-list', () => {
   const ReactActual = jest.requireActual('react');
@@ -41,6 +42,10 @@ jest.mock('@shopify/flash-list', () => {
       testID?: string;
     }) => {
       mockLatestFlashListExtraData = extraData;
+
+      ReactActual.useEffect(() => {
+        mockFlashListMountCount += 1;
+      }, []);
 
       ReactActual.useEffect(() => {
         const visibleItems = mockVisibleItemKeys
@@ -304,6 +309,7 @@ describe('PredictGameDetailsOutcomesList', () => {
     jest.useFakeTimers();
     mockVisibleItemKeys = null;
     mockLatestFlashListExtraData = undefined;
+    mockFlashListMountCount = 0;
     capturedPriceCallback = jest.fn();
     mockGetPrices.mockResolvedValue({ providerId: 'polymarket', results: [] });
     mockSubscribeToMarketPrices.mockImplementation((_, callback) => {
@@ -464,5 +470,22 @@ describe('PredictGameDetailsOutcomesList', () => {
         priceVersion: 1,
       }),
     );
+  });
+
+  it('does not remount FlashList when tab scope changes', () => {
+    const commonProps = createDefaultProps({
+      showChips: false,
+      tabs: [
+        { key: 'outcomes', label: 'Outcomes' },
+        { key: 'positions', label: 'Positions' },
+      ],
+    });
+    const { rerender } = render(
+      <PredictGameDetailsOutcomesList {...commonProps} activeTab={0} />,
+    );
+
+    rerender(<PredictGameDetailsOutcomesList {...commonProps} activeTab={1} />);
+
+    expect(mockFlashListMountCount).toBe(1);
   });
 });

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.test.tsx
@@ -1,0 +1,468 @@
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { View } from 'react-native';
+import Engine from '../../../../../core/Engine';
+import type {
+  PredictMarket,
+  PredictMarketGame,
+  PredictOutcome,
+  PredictOutcomeGroup,
+  PredictOutcomeToken,
+  PriceUpdate,
+} from '../../types';
+import { TEST_HEX_COLORS } from '../../testUtils/mockColors';
+import { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS } from './PredictGameDetailsContent.testIds';
+import PredictGameDetailsOutcomesList from './PredictGameDetailsOutcomesList';
+
+let mockVisibleItemKeys: string[] | null = null;
+let mockLatestFlashListExtraData: unknown;
+
+jest.mock('@shopify/flash-list', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View: ActualView } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    FlashList: ({
+      data = [],
+      extraData,
+      keyExtractor,
+      onViewableItemsChanged,
+      renderItem,
+      testID,
+    }: {
+      data?: unknown[];
+      extraData?: unknown;
+      keyExtractor?: (item: unknown, index: number) => string;
+      onViewableItemsChanged?: (params: {
+        viewableItems: { item: unknown; key: string; index: number }[];
+      }) => void;
+      renderItem: (params: { item: unknown; index: number }) => React.ReactNode;
+      testID?: string;
+    }) => {
+      mockLatestFlashListExtraData = extraData;
+
+      ReactActual.useEffect(() => {
+        const visibleItems = mockVisibleItemKeys
+          ? data.filter((item, index) =>
+              mockVisibleItemKeys?.includes(
+                keyExtractor ? keyExtractor(item, index) : `${index}`,
+              ),
+            )
+          : data;
+
+        onViewableItemsChanged?.({
+          viewableItems: visibleItems.map((item, index) => ({
+            item,
+            key: keyExtractor ? keyExtractor(item, index) : `${index}`,
+            index,
+          })),
+        });
+      }, [data, keyExtractor, onViewableItemsChanged]);
+
+      return (
+        <ActualView testID={testID ?? 'mock-flash-list'}>
+          {data.map((item, index) => (
+            <ReactActual.Fragment
+              key={keyExtractor ? keyExtractor(item, index) : index}
+            >
+              {renderItem({ item, index })}
+            </ReactActual.Fragment>
+          ))}
+        </ActualView>
+      );
+    },
+  };
+});
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      getPrices: jest.fn(),
+      subscribeToMarketPrices: jest.fn(),
+      getConnectionStatus: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const translations: Record<string, string> = {
+      'predict.market_details.your_picks': 'Your picks',
+      'predict.sports_market_types.soccer_player_goals': 'Goals',
+      'predict.sports_market_types.total_corners': 'Corners',
+    };
+    return translations[key] ?? key;
+  }),
+}));
+
+jest.mock('../../../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      primary: {
+        default: 'blue',
+      },
+    },
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(() => []),
+}));
+
+jest.mock('../../hooks/usePredictCashOut', () => ({
+  usePredictCashOut: () => ({
+    onCashOut: jest.fn(),
+  }),
+}));
+
+const createToken = (
+  overrides: Partial<PredictOutcomeToken> = {},
+): PredictOutcomeToken => {
+  const tokenId = overrides.id ?? 'token-1';
+
+  return {
+    id: tokenId,
+    title: tokenId,
+    shortTitle: tokenId,
+    price: 0.5,
+    ...overrides,
+  } as PredictOutcomeToken;
+};
+
+const createOutcome = (
+  overrides: Partial<PredictOutcome> = {},
+): PredictOutcome =>
+  ({
+    id: 'outcome-1',
+    providerId: 'polymarket',
+    marketId: 'market-1',
+    title: 'Outcome',
+    description: '',
+    image: '',
+    groupItemTitle: 'Outcome',
+    status: 'open',
+    volume: 1000,
+    sportsMarketType: 'soccer_player_goals',
+    tokens: [createToken({ id: 'over' }), createToken({ id: 'under' })],
+    ...overrides,
+  }) as PredictOutcome;
+
+const mockGame: PredictMarketGame = {
+  id: 'game-1',
+  homeTeam: {
+    id: 'home',
+    name: 'Home',
+    abbreviation: 'HOM',
+    color: TEST_HEX_COLORS.PURE_BLACK,
+    alias: 'Home',
+    logo: '',
+  },
+  awayTeam: {
+    id: 'away',
+    name: 'Away',
+    abbreviation: 'AWY',
+    color: TEST_HEX_COLORS.WHITE_FULL,
+    alias: 'Away',
+    logo: '',
+  },
+  startTime: '2024-12-31T20:00:00Z',
+  status: 'scheduled',
+  league: 'epl',
+  elapsed: null,
+  period: null,
+  score: null,
+};
+
+const createMarket = (overrides: Partial<PredictMarket> = {}): PredictMarket =>
+  ({
+    id: 'market-1',
+    providerId: 'polymarket',
+    slug: 'market-1',
+    title: 'Market',
+    description: '',
+    image: '',
+    status: 'open',
+    recurrence: 'one-time',
+    category: 'sports',
+    tags: [],
+    outcomes: [createOutcome()],
+    liquidity: 1000,
+    volume: 1000,
+    game: mockGame,
+    ...overrides,
+  }) as PredictMarket;
+
+const createSingleOutcomeGroup = ({
+  groupKey = 'mixed',
+  subgroupKey,
+  outcome,
+}: {
+  groupKey?: string;
+  subgroupKey: string;
+  outcome: PredictOutcome;
+}): PredictOutcomeGroup => ({
+  key: groupKey,
+  outcomes: [],
+  subgroups: [
+    {
+      key: subgroupKey,
+      title: subgroupKey,
+      outcomes: [outcome],
+    },
+  ],
+});
+
+const createLineGroup = (): PredictOutcomeGroup => ({
+  key: 'game_lines',
+  outcomes: [],
+  subgroups: [
+    {
+      key: 'total_corners',
+      title: 'Corners',
+      outcomes: [
+        createOutcome({
+          id: 'line-85',
+          groupItemTitle: 'Total Corners: O/U 8.5',
+          sportsMarketType: 'total_corners',
+          line: 8.5,
+          volume: 1000,
+          tokens: [
+            createToken({ id: 'over-85', shortTitle: 'O 8.5' }),
+            createToken({ id: 'under-85', shortTitle: 'U 8.5' }),
+          ],
+        }),
+        createOutcome({
+          id: 'line-95',
+          groupItemTitle: 'Total Corners: O/U 9.5',
+          sportsMarketType: 'total_corners',
+          line: 9.5,
+          volume: 5000,
+          tokens: [
+            createToken({ id: 'over-95', shortTitle: 'O 9.5' }),
+            createToken({ id: 'under-95', shortTitle: 'U 9.5' }),
+          ],
+        }),
+      ],
+    },
+  ],
+});
+
+const createDefaultProps = (
+  overrides: Partial<
+    React.ComponentProps<typeof PredictGameDetailsOutcomesList>
+  > = {},
+): React.ComponentProps<typeof PredictGameDetailsOutcomesList> => {
+  const group = createSingleOutcomeGroup({
+    subgroupKey: 'visible_card',
+    outcome: createOutcome({
+      id: 'visible-outcome',
+      tokens: [
+        createToken({ id: 'visible-over' }),
+        createToken({ id: 'visible-under' }),
+      ],
+    }),
+  });
+
+  return {
+    market: createMarket(),
+    enabled: true,
+    groupMap: new Map([[group.key, group]]),
+    activeChipKey: group.key,
+    onBetPress: jest.fn(),
+    refreshing: false,
+    onRefresh: jest.fn(),
+    showTabBar: true,
+    tabs: [{ key: 'outcomes', label: 'Outcomes' }],
+    activeTab: 0,
+    onTabPress: jest.fn(),
+    showChips: true,
+    chips: [{ key: group.key, label: 'Mixed' }],
+    onChipSelect: jest.fn(),
+    activePositions: [],
+    claimablePositions: [],
+    ...overrides,
+  };
+};
+
+const settleVisibility = () => {
+  act(() => {
+    jest.advanceTimersByTime(200);
+  });
+};
+
+describe('PredictGameDetailsOutcomesList', () => {
+  const mockGetPrices = Engine.context.PredictController.getPrices as jest.Mock;
+  const mockSubscribeToMarketPrices = Engine.context.PredictController
+    .subscribeToMarketPrices as jest.Mock;
+  const mockGetConnectionStatus = Engine.context.PredictController
+    .getConnectionStatus as jest.Mock;
+  let capturedPriceCallback: (updates: PriceUpdate[]) => void = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockVisibleItemKeys = null;
+    mockLatestFlashListExtraData = undefined;
+    capturedPriceCallback = jest.fn();
+    mockGetPrices.mockResolvedValue({ providerId: 'polymarket', results: [] });
+    mockSubscribeToMarketPrices.mockImplementation((_, callback) => {
+      capturedPriceCallback = callback;
+      return jest.fn();
+    });
+    mockGetConnectionStatus.mockReturnValue({
+      sportsConnected: false,
+      marketConnected: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the list header, sticky controls, and outcome content', () => {
+    const props = createDefaultProps({
+      listHeaderComponent: <View testID="list-header" />,
+    });
+
+    const { getByTestId } = render(
+      <PredictGameDetailsOutcomesList {...props} />,
+    );
+
+    expect(getByTestId('list-header')).toBeOnTheScreen();
+    expect(
+      getByTestId(PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.OUTCOMES_CONTENT),
+    ).toBeOnTheScreen();
+    expect(getByTestId('predict-chip-mixed')).toBeOnTheScreen();
+    expect(getByTestId('mixed-visible_card')).toBeOnTheScreen();
+  });
+
+  it('renders positions content for the positions tab', () => {
+    const props = createDefaultProps({
+      showChips: false,
+      tabs: [{ key: 'positions', label: 'Positions' }],
+      activeTab: 0,
+    });
+
+    const { getByTestId } = render(
+      <PredictGameDetailsOutcomesList {...props} />,
+    );
+
+    expect(
+      getByTestId(PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.TAB_CONTENT),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_PICK),
+    ).toBeOnTheScreen();
+  });
+
+  it('subscribes only to visible rendered-button token IDs', async () => {
+    const visibleGroup = createSingleOutcomeGroup({
+      subgroupKey: 'visible_card',
+      outcome: createOutcome({
+        id: 'visible-outcome',
+        tokens: [
+          createToken({ id: 'visible-over' }),
+          createToken({ id: 'visible-under' }),
+        ],
+      }),
+    });
+    const hiddenGroup = createSingleOutcomeGroup({
+      subgroupKey: 'hidden_card',
+      outcome: createOutcome({
+        id: 'hidden-outcome',
+        tokens: [
+          createToken({ id: 'hidden-over' }),
+          createToken({ id: 'hidden-under' }),
+        ],
+      }),
+    });
+    const mixedGroup: PredictOutcomeGroup = {
+      key: 'mixed',
+      outcomes: [],
+      subgroups: [
+        ...(visibleGroup.subgroups ?? []),
+        ...(hiddenGroup.subgroups ?? []),
+      ],
+    };
+    mockVisibleItemKeys = ['game-details-outcome-visible-outcome'];
+
+    render(
+      <PredictGameDetailsOutcomesList
+        {...createDefaultProps({
+          groupMap: new Map([[mixedGroup.key, mixedGroup]]),
+          activeChipKey: mixedGroup.key,
+          chips: [{ key: mixedGroup.key, label: 'Mixed' }],
+        })}
+      />,
+    );
+    settleVisibility();
+
+    await waitFor(() => {
+      expect(mockSubscribeToMarketPrices).toHaveBeenCalledWith(
+        ['visible-over', 'visible-under'],
+        expect.any(Function),
+      );
+    });
+    expect(mockSubscribeToMarketPrices).not.toHaveBeenCalledWith(
+      ['hidden-over', 'hidden-under'],
+      expect.any(Function),
+    );
+  });
+
+  it('subscribes only to the default selected line tokens for visible line cards', async () => {
+    const lineGroup = createLineGroup();
+    mockVisibleItemKeys = ['game-details-outcome-total_corners'];
+
+    render(
+      <PredictGameDetailsOutcomesList
+        {...createDefaultProps({
+          groupMap: new Map([[lineGroup.key, lineGroup]]),
+          activeChipKey: lineGroup.key,
+          chips: [{ key: lineGroup.key, label: 'Game Lines' }],
+        })}
+      />,
+    );
+    settleVisibility();
+
+    await waitFor(() => {
+      expect(mockSubscribeToMarketPrices).toHaveBeenCalledWith(
+        ['over-95', 'under-95'],
+        expect.any(Function),
+      );
+    });
+    expect(mockSubscribeToMarketPrices).not.toHaveBeenCalledWith(
+      ['over-85', 'under-85', 'over-95', 'under-95'],
+      expect.any(Function),
+    );
+  });
+
+  it('passes price version changes through FlashList extraData', async () => {
+    mockVisibleItemKeys = ['game-details-outcome-visible-outcome'];
+    render(<PredictGameDetailsOutcomesList {...createDefaultProps()} />);
+    settleVisibility();
+    await waitFor(() => {
+      expect(mockSubscribeToMarketPrices).toHaveBeenCalledWith(
+        ['visible-over', 'visible-under'],
+        expect.any(Function),
+      );
+    });
+
+    act(() => {
+      capturedPriceCallback([
+        {
+          tokenId: 'visible-over',
+          price: 0.72,
+          bestBid: 0.71,
+          bestAsk: 0.73,
+        },
+      ]);
+    });
+
+    expect(mockLatestFlashListExtraData).toEqual(
+      expect.objectContaining({
+        priceVersion: 1,
+      }),
+    );
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.tsx
@@ -310,7 +310,6 @@ const PredictGameDetailsOutcomesList = memo(
         twClassName="flex-1"
       >
         <FlashList
-          key={visibilityScopeKey}
           data={listData}
           extraData={extraData}
           keyExtractor={keyExtractor}

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameDetailsOutcomesList.tsx
@@ -1,0 +1,345 @@
+import React, { memo, useCallback, useMemo } from 'react';
+import { FlashList, type ListRenderItem } from '@shopify/flash-list';
+import { RefreshControl } from 'react-native';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../locales/i18n';
+import type { PredictMarketDetailsTabKey } from '../../Predict.testIds';
+import type {
+  PredictMarket,
+  PredictOutcome,
+  PredictOutcomeGroup,
+  PredictOutcomeToken,
+  PredictPosition,
+} from '../../types';
+import { useTheme } from '../../../../../util/theme';
+import { usePredictLivePrices } from '../../hooks/usePredictLivePrices';
+import PredictChipList, { type PredictChipItem } from '../PredictChipList';
+import PredictMarketDetailsTabBar from '../../views/PredictMarketDetails/components/PredictMarketDetailsTabBar';
+import PredictPicks from '../PredictPicks/PredictPicks';
+import PredictGameOutcomeCard, {
+  type BuyHandler,
+  type OutcomeCardModel,
+} from './PredictGameOutcomeCard';
+import { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS } from './PredictGameDetailsContent.testIds';
+import { usePredictGameOutcomeRows } from './usePredictGameOutcomeRows';
+import { usePredictVisibleOutcomes } from './usePredictVisibleOutcomes';
+
+type PredictGameDetailsListItem =
+  | {
+      type: 'header';
+      key: string;
+      element: React.ReactElement;
+    }
+  | {
+      type: 'controls';
+      key: string;
+    }
+  | {
+      type: 'positions';
+      key: string;
+      showHeading: boolean;
+    }
+  | {
+      type: 'outcome-card';
+      key: string;
+      cardModel: OutcomeCardModel;
+    };
+
+export interface PredictGameDetailsOutcomesListProps {
+  market: PredictMarket;
+  enabled: boolean;
+  groupMap: Map<string, PredictOutcomeGroup>;
+  activeChipKey: string;
+  onBetPress: (token: PredictOutcomeToken) => void;
+  refreshing: boolean;
+  onRefresh: () => void;
+  showTabBar: boolean;
+  tabs: { label: string; key: PredictMarketDetailsTabKey }[];
+  activeTab: number;
+  onTabPress: (tabIndex: number) => void;
+  showChips: boolean;
+  chips: PredictChipItem[];
+  onChipSelect: (key: string) => void;
+  activePositions: PredictPosition[];
+  claimablePositions: PredictPosition[];
+  listHeaderComponent?: React.ReactElement;
+}
+
+const getVisibleCardKey = (
+  item: PredictGameDetailsListItem,
+): string | undefined =>
+  item.type === 'outcome-card' ? item.cardModel.key : undefined;
+
+const keyExtractor = (item: PredictGameDetailsListItem): string => item.key;
+
+const PredictGameDetailsOutcomesList = memo(
+  ({
+    market,
+    enabled,
+    groupMap,
+    activeChipKey,
+    onBetPress,
+    refreshing,
+    onRefresh,
+    showTabBar,
+    tabs,
+    activeTab,
+    onTabPress,
+    showChips,
+    chips,
+    onChipSelect,
+    activePositions,
+    claimablePositions,
+    listHeaderComponent,
+  }: PredictGameDetailsOutcomesListProps) => {
+    const tw = useTailwind();
+    const { colors } = useTheme();
+    const selectedGroup = groupMap.get(activeChipKey);
+    const { cardModels } = usePredictGameOutcomeRows(selectedGroup);
+    const currentTabKey = showTabBar ? tabs[activeTab]?.key : 'outcomes';
+    const hasPositions =
+      activePositions.length > 0 || claimablePositions.length > 0;
+    const showDisabledPositions = !enabled && hasPositions;
+    const showPositions =
+      showDisabledPositions || (enabled && currentTabKey === 'positions');
+    const showOutcomes =
+      enabled && currentTabKey === 'outcomes' && Boolean(selectedGroup);
+    const showStickyHeader = showTabBar || showChips;
+    const visibilityScopeKey = `${currentTabKey ?? 'none'}:${activeChipKey}`;
+
+    const {
+      onMomentumScrollBegin,
+      onMomentumScrollEnd,
+      onScroll,
+      onScrollBeginDrag,
+      onScrollEndDrag,
+      onSelectedLineIndexChange,
+      onViewableItemsChanged,
+      selectedLineIndices,
+      viewabilityConfig,
+      visibleCardKeys,
+      visiblePriceQueries,
+      visibleTokenIds,
+    } = usePredictVisibleOutcomes<PredictGameDetailsListItem>({
+      cardModels,
+      enabled: showOutcomes,
+      getVisibleCardKey,
+      resetKey: visibilityScopeKey,
+    });
+    const { getPrice, priceVersion } = usePredictLivePrices(
+      visiblePriceQueries,
+      {
+        enabled: showOutcomes,
+      },
+    );
+
+    const listData = useMemo<PredictGameDetailsListItem[]>(() => {
+      const items: PredictGameDetailsListItem[] = [];
+
+      if (listHeaderComponent) {
+        items.push({
+          type: 'header',
+          key: 'game-details-header',
+          element: listHeaderComponent,
+        });
+      }
+
+      if (showStickyHeader) {
+        items.push({
+          type: 'controls',
+          key: 'game-details-controls',
+        });
+      }
+
+      if (showPositions) {
+        items.push({
+          type: 'positions',
+          key: 'game-details-positions',
+          showHeading: showDisabledPositions,
+        });
+      }
+
+      if (showOutcomes) {
+        cardModels.forEach((cardModel) => {
+          items.push({
+            type: 'outcome-card',
+            key: `game-details-outcome-${cardModel.key}`,
+            cardModel,
+          });
+        });
+      }
+
+      return items;
+    }, [
+      cardModels,
+      listHeaderComponent,
+      showDisabledPositions,
+      showOutcomes,
+      showPositions,
+      showStickyHeader,
+    ]);
+
+    const stickyHeaderIndices = useMemo(() => {
+      const controlsIndex = listData.findIndex(
+        (item) => item.type === 'controls',
+      );
+
+      return controlsIndex === -1 ? undefined : [controlsIndex];
+    }, [listData]);
+
+    const handleBuyPress = useCallback<BuyHandler>(
+      (_outcome: PredictOutcome, token: PredictOutcomeToken) => {
+        onBetPress(token);
+      },
+      [onBetPress],
+    );
+
+    const visibleTokenIdsKey = useMemo(
+      () => JSON.stringify(visibleTokenIds),
+      [visibleTokenIds],
+    );
+    const extraData = useMemo(
+      () => ({
+        activeChipKey,
+        activeTab,
+        priceVersion,
+        selectedLineIndices,
+        visibleCardKeys,
+        visibleTokenIdsKey,
+      }),
+      [
+        activeChipKey,
+        activeTab,
+        priceVersion,
+        selectedLineIndices,
+        visibleCardKeys,
+        visibleTokenIdsKey,
+      ],
+    );
+
+    const renderItem = useCallback<ListRenderItem<PredictGameDetailsListItem>>(
+      ({ item }) => {
+        switch (item.type) {
+          case 'header':
+            return item.element;
+          case 'controls':
+            return (
+              <Box twClassName="bg-default">
+                {showTabBar && (
+                  <PredictMarketDetailsTabBar
+                    tabs={tabs}
+                    activeTab={activeTab}
+                    onTabPress={onTabPress}
+                  />
+                )}
+                {showChips && (
+                  <PredictChipList
+                    chips={chips}
+                    activeChipKey={activeChipKey}
+                    onChipSelect={onChipSelect}
+                  />
+                )}
+              </Box>
+            );
+          case 'positions':
+            return (
+              <Box
+                twClassName={item.showHeading ? 'px-4 py-2' : 'px-4'}
+                testID={
+                  item.showHeading
+                    ? undefined
+                    : PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.TAB_CONTENT
+                }
+              >
+                {item.showHeading && (
+                  <Text
+                    variant={TextVariant.HeadingMd}
+                    twClassName="font-medium pt-8"
+                  >
+                    {strings('predict.market_details.your_picks')}
+                  </Text>
+                )}
+                <PredictPicks
+                  market={market}
+                  positions={activePositions}
+                  claimablePositions={claimablePositions}
+                  testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.GAME_PICK}
+                />
+              </Box>
+            );
+          case 'outcome-card':
+            return (
+              <Box twClassName="px-4">
+                <PredictGameOutcomeCard
+                  cardModel={item.cardModel}
+                  onBuyPress={handleBuyPress}
+                  game={market.game}
+                  getPrice={getPrice}
+                  selectedLineIndex={selectedLineIndices[item.cardModel.key]}
+                  onSelectedLineIndexChange={(nextIndex) =>
+                    onSelectedLineIndexChange(item.cardModel.key, nextIndex)
+                  }
+                />
+              </Box>
+            );
+        }
+      },
+      [
+        activeChipKey,
+        activePositions,
+        activeTab,
+        chips,
+        claimablePositions,
+        getPrice,
+        handleBuyPress,
+        market,
+        onChipSelect,
+        onSelectedLineIndexChange,
+        onTabPress,
+        selectedLineIndices,
+        showChips,
+        showTabBar,
+        tabs,
+      ],
+    );
+
+    return (
+      <Box
+        testID={PREDICT_GAME_DETAILS_CONTENT_TEST_IDS.OUTCOMES_CONTENT}
+        twClassName="flex-1"
+      >
+        <FlashList
+          key={visibilityScopeKey}
+          data={listData}
+          extraData={extraData}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          style={tw.style('flex-1')}
+          contentContainerStyle={tw.style('pb-4')}
+          stickyHeaderIndices={stickyHeaderIndices}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.primary.default}
+              colors={[colors.primary.default]}
+            />
+          }
+          showsVerticalScrollIndicator={false}
+          onMomentumScrollBegin={onMomentumScrollBegin}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onScroll={onScroll}
+          onScrollBeginDrag={onScrollBeginDrag}
+          onScrollEndDrag={onScrollEndDrag}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={viewabilityConfig}
+        />
+      </Box>
+    );
+  },
+);
+
+PredictGameDetailsOutcomesList.displayName = 'PredictGameDetailsOutcomesList';
+
+export default PredictGameDetailsOutcomesList;

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCard.tsx
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomeCard.tsx
@@ -249,11 +249,18 @@ const LineOutcomeCard = memo(
 
     const [uncontrolledSelectedIdx, setUncontrolledSelectedIdx] =
       useState(initialSelectedIdx);
+    const [animateLineSelection, setAnimateLineSelection] = useState(false);
+    const pendingUserLineSelectionRef = React.useRef(false);
 
     useEffect(() => {
       if (selectedLineIndex === undefined) {
         setUncontrolledSelectedIdx(initialSelectedIdx);
       }
+      if (pendingUserLineSelectionRef.current) {
+        pendingUserLineSelectionRef.current = false;
+        return;
+      }
+      setAnimateLineSelection(false);
     }, [initialSelectedIdx, selectedLineIndex]);
 
     const resolvedSelectedIdx =
@@ -265,6 +272,8 @@ const LineOutcomeCard = memo(
 
     const handleSelectLine = useCallback(
       (_line: number, indexInLines: number) => {
+        pendingUserLineSelectionRef.current = true;
+        setAnimateLineSelection(true);
         if (selectedLineIndex === undefined) {
           setUncontrolledSelectedIdx(indexInLines);
         }
@@ -293,6 +302,7 @@ const LineOutcomeCard = memo(
         lines={lines}
         selectedLine={lines[safeSelectedIdx]}
         selectedIndex={safeSelectedIdx}
+        animateLineSelection={animateLineSelection}
         onSelectLine={handleSelectLine}
         testID={testID}
       />

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/usePredictVisibleOutcomes.test.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/usePredictVisibleOutcomes.test.ts
@@ -1,0 +1,366 @@
+import { act, renderHook } from '@testing-library/react-native';
+import type { PredictOutcome } from '../../types';
+import type { OutcomeCardModel } from './PredictGameOutcomeCard';
+import {
+  PREDICT_OUTCOME_VIEWABILITY_CONFIG,
+  resolveVisibleOutcomePriceQueries,
+  usePredictVisibleOutcomes,
+} from './usePredictVisibleOutcomes';
+
+type TestListItem =
+  | {
+      type: 'header';
+      key: string;
+    }
+  | {
+      type: 'outcome-card';
+      key: string;
+      cardModel: OutcomeCardModel;
+    };
+
+const createOutcome = (
+  id: string,
+  tokenIds: string[],
+  overrides: Partial<PredictOutcome> = {},
+): PredictOutcome =>
+  ({
+    id,
+    providerId: 'polymarket',
+    marketId: `market-${id}`,
+    title: id,
+    description: '',
+    image: '',
+    status: 'open',
+    tokens: tokenIds.map((tokenId) => ({
+      id: tokenId,
+      title: tokenId,
+      price: 0.5,
+    })),
+    volume: 1000,
+    groupItemTitle: id,
+    ...overrides,
+  }) as PredictOutcome;
+
+const createSimpleCard = (
+  key: string,
+  tokenIds: string[],
+): OutcomeCardModel => {
+  const outcome = createOutcome(`outcome-${key}`, tokenIds);
+
+  return {
+    kind: 'simple',
+    key,
+    title: key,
+    testID: key,
+    outcome,
+    pricing: {
+      kind: 'shared',
+      tokenIds,
+    },
+  };
+};
+
+const createMoneylineCard = (): OutcomeCardModel => ({
+  kind: 'moneyline',
+  key: 'moneyline-card',
+  title: 'Moneyline',
+  testID: 'moneyline-card',
+  outcomes: [
+    createOutcome('home', ['home-yes', 'home-no']),
+    createOutcome('draw', ['draw-yes', 'draw-no']),
+    createOutcome('away', ['away-yes', 'away-no']),
+  ],
+  pricing: {
+    kind: 'shared',
+    tokenIds: [
+      'home-yes',
+      'home-no',
+      'draw-yes',
+      'draw-no',
+      'away-yes',
+      'away-no',
+    ],
+  },
+});
+
+const createLineCard = (): OutcomeCardModel => ({
+  kind: 'line',
+  key: 'line-card',
+  title: 'Line',
+  testID: 'line-card',
+  sportsMarketType: 'total_corners',
+  outcomes: [
+    createOutcome('line-95', ['over-95', 'under-95'], {
+      line: 9.5,
+      volume: 5000,
+    }),
+    createOutcome('line-85', ['over-85', 'under-85'], {
+      line: 8.5,
+      volume: 1000,
+    }),
+  ],
+  pricing: {
+    kind: 'selected-line',
+  },
+});
+
+const createOutcomeItem = (cardModel: OutcomeCardModel): TestListItem => ({
+  type: 'outcome-card',
+  key: `item-${cardModel.key}`,
+  cardModel,
+});
+
+const createHeaderItem = (): TestListItem => ({
+  type: 'header',
+  key: 'header',
+});
+
+const getVisibleCardKey = (item: TestListItem): string | undefined =>
+  item.type === 'outcome-card' ? item.cardModel.key : undefined;
+
+const settleVisibility = () => {
+  act(() => {
+    jest.advanceTimersByTime(200);
+  });
+};
+
+describe('resolveVisibleOutcomePriceQueries', () => {
+  it('returns simple card queries for all rendered outcome tokens', () => {
+    const simpleCard = createSimpleCard('simple-card', [
+      'simple-yes',
+      'simple-no',
+    ]);
+
+    const result = resolveVisibleOutcomePriceQueries({
+      cardModels: [simpleCard],
+      selectedLineIndices: {},
+      visibleCardKeys: new Set(['simple-card']),
+    });
+
+    expect(result).toEqual([
+      {
+        marketId: 'market-outcome-simple-card',
+        outcomeId: 'outcome-simple-card',
+        outcomeTokenId: 'simple-yes',
+      },
+      {
+        marketId: 'market-outcome-simple-card',
+        outcomeId: 'outcome-simple-card',
+        outcomeTokenId: 'simple-no',
+      },
+    ]);
+  });
+
+  it('returns moneyline queries for rendered yes tokens only', () => {
+    const moneylineCard = createMoneylineCard();
+
+    const result = resolveVisibleOutcomePriceQueries({
+      cardModels: [moneylineCard],
+      selectedLineIndices: {},
+      visibleCardKeys: new Set(['moneyline-card']),
+    });
+
+    expect(result.map((query) => query.outcomeTokenId)).toEqual([
+      'home-yes',
+      'draw-yes',
+      'away-yes',
+    ]);
+  });
+
+  it('returns default selected line queries from the highest-volume line', () => {
+    const lineCard = createLineCard();
+
+    const result = resolveVisibleOutcomePriceQueries({
+      cardModels: [lineCard],
+      selectedLineIndices: {},
+      visibleCardKeys: new Set(['line-card']),
+    });
+
+    expect(result.map((query) => query.outcomeTokenId)).toEqual([
+      'over-95',
+      'under-95',
+    ]);
+  });
+
+  it('returns selected line queries when line index is set', () => {
+    const lineCard = createLineCard();
+
+    const result = resolveVisibleOutcomePriceQueries({
+      cardModels: [lineCard],
+      selectedLineIndices: {
+        'line-card': 0,
+      },
+      visibleCardKeys: new Set(['line-card']),
+    });
+
+    expect(result.map((query) => query.outcomeTokenId)).toEqual([
+      'over-85',
+      'under-85',
+    ]);
+  });
+
+  it('deduplicates queries by outcome token ID', () => {
+    const firstCard = createSimpleCard('first-card', ['shared-token']);
+    const secondCard = createSimpleCard('second-card', ['shared-token']);
+
+    const result = resolveVisibleOutcomePriceQueries({
+      cardModels: [firstCard, secondCard],
+      selectedLineIndices: {},
+      visibleCardKeys: new Set(['first-card', 'second-card']),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].outcomeTokenId).toBe('shared-token');
+  });
+});
+
+describe('usePredictVisibleOutcomes', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns configured FlashList viewability thresholds', () => {
+    const simpleCard = createSimpleCard('simple-card', ['simple-token']);
+
+    const { result } = renderHook(() =>
+      usePredictVisibleOutcomes<TestListItem>({
+        cardModels: [simpleCard],
+        getVisibleCardKey,
+      }),
+    );
+
+    expect(result.current.viewabilityConfig).toBe(
+      PREDICT_OUTCOME_VIEWABILITY_CONFIG,
+    );
+  });
+
+  it('settles visible card token IDs after the visibility delay', () => {
+    const visibleCard = createSimpleCard('visible-card', ['visible-token']);
+    const hiddenCard = createSimpleCard('hidden-card', ['hidden-token']);
+    const { result } = renderHook(() =>
+      usePredictVisibleOutcomes<TestListItem>({
+        cardModels: [visibleCard, hiddenCard],
+        getVisibleCardKey,
+      }),
+    );
+
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [
+          { item: createHeaderItem() },
+          { item: createOutcomeItem(visibleCard) },
+        ],
+      });
+    });
+
+    expect(result.current.visibleTokenIds).toEqual([]);
+
+    settleVisibility();
+
+    expect(result.current.visibleTokenIds).toEqual(['visible-token']);
+    expect(result.current.visibleCardKeys).toEqual(new Set(['visible-card']));
+  });
+
+  it('updates visible line queries when selected line changes', () => {
+    const lineCard = createLineCard();
+    const { result } = renderHook(() =>
+      usePredictVisibleOutcomes<TestListItem>({
+        cardModels: [lineCard],
+        getVisibleCardKey,
+      }),
+    );
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [{ item: createOutcomeItem(lineCard) }],
+      });
+    });
+    settleVisibility();
+
+    act(() => {
+      result.current.onSelectedLineIndexChange('line-card', 0);
+    });
+
+    expect(result.current.selectedLineIndices).toEqual({
+      'line-card': 0,
+    });
+    expect(result.current.visibleTokenIds).toEqual(['over-85', 'under-85']);
+  });
+
+  it('clears visibility and selected lines when reset key changes', () => {
+    const lineCard = createLineCard();
+    const { result, rerender } = renderHook(
+      ({ resetKey }) =>
+        usePredictVisibleOutcomes<TestListItem>({
+          cardModels: [lineCard],
+          getVisibleCardKey,
+          resetKey,
+        }),
+      { initialProps: { resetKey: 'outcomes:game-lines' } },
+    );
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [{ item: createOutcomeItem(lineCard) }],
+      });
+    });
+    settleVisibility();
+    act(() => {
+      result.current.onSelectedLineIndexChange('line-card', 0);
+    });
+
+    rerender({ resetKey: 'positions:game-lines' });
+
+    expect(result.current.visibleTokenIds).toEqual([]);
+    expect(result.current.visibleCardKeys).toEqual(new Set());
+    expect(result.current.selectedLineIndices).toEqual({});
+  });
+
+  it('commits next viewability update immediately after reset key changes', () => {
+    const simpleCard = createSimpleCard('simple-card', ['simple-token']);
+    const { result, rerender } = renderHook(
+      ({ resetKey }) =>
+        usePredictVisibleOutcomes<TestListItem>({
+          cardModels: [simpleCard],
+          getVisibleCardKey,
+          resetKey,
+        }),
+      { initialProps: { resetKey: 'outcomes:game-lines' } },
+    );
+
+    rerender({ resetKey: 'outcomes:props' });
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [{ item: createOutcomeItem(simpleCard) }],
+      });
+    });
+
+    expect(result.current.visibleTokenIds).toEqual(['simple-token']);
+  });
+
+  it('clears visible token IDs when disabled', () => {
+    const simpleCard = createSimpleCard('simple-card', ['simple-token']);
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        usePredictVisibleOutcomes<TestListItem>({
+          cardModels: [simpleCard],
+          enabled,
+          getVisibleCardKey,
+        }),
+      { initialProps: { enabled: true } },
+    );
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [{ item: createOutcomeItem(simpleCard) }],
+      });
+    });
+    settleVisibility();
+
+    rerender({ enabled: false });
+
+    expect(result.current.visibleTokenIds).toEqual([]);
+    expect(result.current.visibleCardKeys).toEqual(new Set());
+  });
+});

--- a/app/components/UI/Predict/components/PredictGameDetailsContent/usePredictVisibleOutcomes.ts
+++ b/app/components/UI/Predict/components/PredictGameDetailsContent/usePredictVisibleOutcomes.ts
@@ -1,0 +1,389 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { PredictOutcome, PriceQuery } from '../../types';
+import type { OutcomeCardModel } from './PredictGameOutcomeCard';
+
+const DEFAULT_SETTLE_DELAY_MS = 200;
+
+export const PREDICT_OUTCOME_VIEWABILITY_CONFIG = {
+  itemVisiblePercentThreshold: 50,
+  minimumViewTime: 100,
+};
+
+interface UsePredictVisibleOutcomesParams<TItem> {
+  cardModels: OutcomeCardModel[];
+  enabled?: boolean;
+  getVisibleCardKey: (item: TItem) => string | undefined;
+  getCardVisibleKey?: (cardModel: OutcomeCardModel) => string;
+  resetKey?: string;
+  settleDelayMs?: number;
+}
+
+export interface UsePredictVisibleOutcomesResult<TItem> {
+  onMomentumScrollBegin: () => void;
+  onMomentumScrollEnd: () => void;
+  onScroll: () => void;
+  onScrollBeginDrag: () => void;
+  onScrollEndDrag: () => void;
+  onSelectedLineIndexChange: (cardKey: string, nextIndex: number) => void;
+  onViewableItemsChanged: ({
+    viewableItems,
+  }: {
+    viewableItems: { item?: TItem | null }[];
+  }) => void;
+  selectedLineIndices: Record<string, number | undefined>;
+  viewabilityConfig: typeof PREDICT_OUTCOME_VIEWABILITY_CONFIG;
+  visibleCardKeys: Set<string>;
+  visiblePriceQueries: PriceQuery[];
+  visibleTokenIds: string[];
+}
+
+const defaultGetCardVisibleKey = (cardModel: OutcomeCardModel): string =>
+  cardModel.key;
+
+const areSetsEqual = <T>(first: Set<T>, second: Set<T>): boolean => {
+  if (first.size !== second.size) {
+    return false;
+  }
+
+  for (const value of first) {
+    if (!second.has(value)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const toPriceQuery = (
+  outcome: PredictOutcome,
+  outcomeTokenId: string,
+): PriceQuery => ({
+  marketId: outcome.marketId,
+  outcomeId: outcome.id,
+  outcomeTokenId,
+});
+
+const getLineIndices = (outcomes: PredictOutcome[]): number[] =>
+  outcomes
+    .map((outcome, index) => (outcome.line != null ? index : -1))
+    .filter((index) => index !== -1)
+    .sort((a, b) => {
+      const lineA = outcomes[a].line ?? 0;
+      const lineB = outcomes[b].line ?? 0;
+      return lineA - lineB;
+    });
+
+const getDefaultSelectedLineIndex = (
+  outcomes: PredictOutcome[],
+  lineIndices: number[],
+): number => {
+  if (lineIndices.length === 0) {
+    return 0;
+  }
+
+  return lineIndices.reduce((bestIndex, outcomeIndex, currentIndex) => {
+    const bestVolume = outcomes[lineIndices[bestIndex]]?.volume ?? 0;
+    const currentVolume = outcomes[outcomeIndex]?.volume ?? 0;
+
+    return currentVolume > bestVolume ? currentIndex : bestIndex;
+  }, 0);
+};
+
+const getSelectedLineOutcome = (
+  cardModel: Extract<OutcomeCardModel, { kind: 'line' }>,
+  selectedLineIndex: number | undefined,
+): PredictOutcome | undefined => {
+  const lineIndices = getLineIndices(cardModel.outcomes);
+  const defaultSelectedLineIndex = getDefaultSelectedLineIndex(
+    cardModel.outcomes,
+    lineIndices,
+  );
+  const resolvedSelectedLineIndex =
+    selectedLineIndex ?? defaultSelectedLineIndex;
+  const safeSelectedLineIndex =
+    lineIndices[resolvedSelectedLineIndex] === undefined
+      ? defaultSelectedLineIndex
+      : resolvedSelectedLineIndex;
+
+  return cardModel.outcomes[lineIndices[safeSelectedLineIndex]];
+};
+
+const getCardPriceQueries = (
+  cardModel: OutcomeCardModel,
+  selectedLineIndex: number | undefined,
+): PriceQuery[] => {
+  if (cardModel.kind === 'simple') {
+    return cardModel.outcome.tokens.map((token) =>
+      toPriceQuery(cardModel.outcome, token.id),
+    );
+  }
+
+  if (cardModel.kind === 'moneyline') {
+    return cardModel.outcomes.flatMap((outcome) => {
+      const token = outcome.tokens[0];
+      return token ? [toPriceQuery(outcome, token.id)] : [];
+    });
+  }
+
+  const selectedOutcome = getSelectedLineOutcome(cardModel, selectedLineIndex);
+  if (!selectedOutcome) {
+    return [];
+  }
+
+  return selectedOutcome.tokens.map((token) =>
+    toPriceQuery(selectedOutcome, token.id),
+  );
+};
+
+export const resolveVisibleOutcomePriceQueries = ({
+  cardModels,
+  getCardVisibleKey = defaultGetCardVisibleKey,
+  selectedLineIndices,
+  visibleCardKeys,
+}: {
+  cardModels: OutcomeCardModel[];
+  getCardVisibleKey?: (cardModel: OutcomeCardModel) => string;
+  selectedLineIndices: Record<string, number | undefined>;
+  visibleCardKeys: Set<string>;
+}): PriceQuery[] => {
+  const queriesByTokenId = new Map<string, PriceQuery>();
+
+  cardModels
+    .filter((cardModel) => visibleCardKeys.has(getCardVisibleKey(cardModel)))
+    .flatMap((cardModel) =>
+      getCardPriceQueries(cardModel, selectedLineIndices[cardModel.key]),
+    )
+    .forEach((query) => {
+      if (!queriesByTokenId.has(query.outcomeTokenId)) {
+        queriesByTokenId.set(query.outcomeTokenId, query);
+      }
+    });
+
+  return [...queriesByTokenId.values()];
+};
+
+export const usePredictVisibleOutcomes = <TItem>({
+  cardModels,
+  enabled = true,
+  getVisibleCardKey,
+  getCardVisibleKey = defaultGetCardVisibleKey,
+  resetKey,
+  settleDelayMs = DEFAULT_SETTLE_DELAY_MS,
+}: UsePredictVisibleOutcomesParams<TItem>): UsePredictVisibleOutcomesResult<TItem> => {
+  const [visibleCardKeys, setVisibleCardKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [selectedLineIndices, setSelectedLineIndices] = useState<
+    Record<string, number | undefined>
+  >({});
+  const latestVisibleCardKeysRef = useRef<Set<string>>(new Set());
+  const isScrollActiveRef = useRef(false);
+  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previousResetKeyRef = useRef(resetKey);
+  const shouldCommitNextViewabilityImmediatelyRef = useRef(false);
+
+  const clearSettleTimer = useCallback(() => {
+    if (settleTimerRef.current) {
+      clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
+    }
+  }, []);
+
+  const clearScrollIdleTimer = useCallback(() => {
+    if (scrollIdleTimerRef.current) {
+      clearTimeout(scrollIdleTimerRef.current);
+      scrollIdleTimerRef.current = null;
+    }
+  }, []);
+
+  const applyLatestVisibleCardKeys = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const nextVisibleCardKeys = new Set(latestVisibleCardKeysRef.current);
+    setVisibleCardKeys((previousVisibleCardKeys) =>
+      areSetsEqual(previousVisibleCardKeys, nextVisibleCardKeys)
+        ? previousVisibleCardKeys
+        : nextVisibleCardKeys,
+    );
+  }, [enabled]);
+
+  const commitLatestVisibleCardKeys = useCallback(() => {
+    clearSettleTimer();
+
+    if (!enabled) {
+      return;
+    }
+
+    settleTimerRef.current = setTimeout(() => {
+      applyLatestVisibleCardKeys();
+      settleTimerRef.current = null;
+    }, settleDelayMs);
+  }, [applyLatestVisibleCardKeys, clearSettleTimer, enabled, settleDelayMs]);
+
+  const clearVisibleState = useCallback(() => {
+    clearSettleTimer();
+    clearScrollIdleTimer();
+    isScrollActiveRef.current = false;
+    latestVisibleCardKeysRef.current = new Set();
+    setVisibleCardKeys((previousVisibleCardKeys) =>
+      previousVisibleCardKeys.size === 0 ? previousVisibleCardKeys : new Set(),
+    );
+    setSelectedLineIndices((previousSelectedLineIndices) =>
+      Object.keys(previousSelectedLineIndices).length === 0
+        ? previousSelectedLineIndices
+        : {},
+    );
+  }, [clearScrollIdleTimer, clearSettleTimer]);
+
+  const onScrollStart = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    isScrollActiveRef.current = true;
+    clearSettleTimer();
+    clearScrollIdleTimer();
+  }, [clearScrollIdleTimer, clearSettleTimer, enabled]);
+
+  const onScrollEnd = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    isScrollActiveRef.current = false;
+    clearScrollIdleTimer();
+    commitLatestVisibleCardKeys();
+  }, [clearScrollIdleTimer, commitLatestVisibleCardKeys, enabled]);
+
+  const onScroll = useCallback(() => {
+    if (!enabled) {
+      return;
+    }
+
+    isScrollActiveRef.current = true;
+    clearSettleTimer();
+    clearScrollIdleTimer();
+
+    scrollIdleTimerRef.current = setTimeout(() => {
+      isScrollActiveRef.current = false;
+      applyLatestVisibleCardKeys();
+      scrollIdleTimerRef.current = null;
+    }, settleDelayMs);
+  }, [
+    applyLatestVisibleCardKeys,
+    clearScrollIdleTimer,
+    clearSettleTimer,
+    enabled,
+    settleDelayMs,
+  ]);
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: { item?: TItem | null }[] }) => {
+      if (!enabled) {
+        return;
+      }
+
+      latestVisibleCardKeysRef.current = new Set(
+        viewableItems
+          .map((viewableItem) =>
+            viewableItem.item
+              ? getVisibleCardKey(viewableItem.item)
+              : undefined,
+          )
+          .filter((key): key is string => Boolean(key)),
+      );
+
+      if (!isScrollActiveRef.current) {
+        if (shouldCommitNextViewabilityImmediatelyRef.current) {
+          shouldCommitNextViewabilityImmediatelyRef.current = false;
+          clearSettleTimer();
+          applyLatestVisibleCardKeys();
+          return;
+        }
+
+        commitLatestVisibleCardKeys();
+      }
+    },
+    [
+      applyLatestVisibleCardKeys,
+      clearSettleTimer,
+      commitLatestVisibleCardKeys,
+      enabled,
+      getVisibleCardKey,
+    ],
+  );
+
+  const onSelectedLineIndexChange = useCallback(
+    (cardKey: string, nextIndex: number) => {
+      setSelectedLineIndices((previousSelectedLineIndices) =>
+        previousSelectedLineIndices[cardKey] === nextIndex
+          ? previousSelectedLineIndices
+          : {
+              ...previousSelectedLineIndices,
+              [cardKey]: nextIndex,
+            },
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (enabled) {
+      return;
+    }
+
+    clearVisibleState();
+  }, [clearVisibleState, enabled]);
+
+  useEffect(() => {
+    if (previousResetKeyRef.current === resetKey) {
+      return;
+    }
+
+    previousResetKeyRef.current = resetKey;
+    clearVisibleState();
+    shouldCommitNextViewabilityImmediatelyRef.current = true;
+  }, [clearVisibleState, resetKey]);
+
+  useEffect(
+    () => () => {
+      clearSettleTimer();
+      clearScrollIdleTimer();
+    },
+    [clearScrollIdleTimer, clearSettleTimer],
+  );
+
+  const visiblePriceQueries = useMemo(
+    () =>
+      resolveVisibleOutcomePriceQueries({
+        cardModels,
+        getCardVisibleKey,
+        selectedLineIndices,
+        visibleCardKeys,
+      }),
+    [cardModels, getCardVisibleKey, selectedLineIndices, visibleCardKeys],
+  );
+
+  const visibleTokenIds = useMemo(
+    () => visiblePriceQueries.map((query) => query.outcomeTokenId),
+    [visiblePriceQueries],
+  );
+
+  return {
+    onMomentumScrollBegin: onScrollStart,
+    onMomentumScrollEnd: onScrollEnd,
+    onScroll,
+    onScrollBeginDrag: onScrollStart,
+    onScrollEndDrag: onScrollEnd,
+    onSelectedLineIndexChange,
+    onViewableItemsChanged,
+    selectedLineIndices,
+    viewabilityConfig: PREDICT_OUTCOME_VIEWABILITY_CONFIG,
+    visibleCardKeys,
+    visiblePriceQueries,
+    visibleTokenIds,
+  };
+};

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
 import PredictSportLineSelector from './PredictSportLineSelector';
 import { PREDICT_SPORT_LINE_SELECTOR_TEST_IDS } from './PredictSportLineSelector.testIds';
-const mockWithTiming = jest.fn((v: number) => v);
 
 jest.mock('react-native-reanimated', () => {
   const { View } = jest.requireActual('react-native');
   const { useRef } = jest.requireActual('react');
+  const withTiming = jest.fn((v: number) => v);
   return {
     __esModule: true,
     default: {
@@ -19,7 +19,7 @@ jest.mock('react-native-reanimated', () => {
       return ref.current;
     },
     useAnimatedStyle: (fn: () => object) => fn(),
-    withTiming: mockWithTiming,
+    withTiming,
     Easing: { inOut: (fn: unknown) => fn, ease: jest.fn() },
   };
 });
@@ -47,6 +47,9 @@ const arrowRightId = `${TEST_ID}-${IDS.ARROW_RIGHT}`;
 const lineId = (index: number, value: number) =>
   `${TEST_ID}-${IDS.LINE_PREFIX}${index}-${value}`;
 
+const getMockWithTiming = () =>
+  jest.requireMock('react-native-reanimated').withTiming as jest.Mock;
+
 describe('PredictSportLineSelector', () => {
   const defaultProps = {
     lines: [4, 4.5, 5, 5.5, 6],
@@ -57,6 +60,7 @@ describe('PredictSportLineSelector', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    getMockWithTiming().mockClear();
   });
 
   it('renders all lines', () => {
@@ -205,6 +209,52 @@ describe('PredictSportLineSelector', () => {
         <PredictSportLineSelector {...defaultProps} selectedLine={5.5} />,
       );
     }).not.toThrow();
+  });
+
+  it('does not animate selected index changes when animation is disabled', () => {
+    const { rerender, UNSAFE_getAllByType } = render(
+      <PredictSportLineSelector {...defaultProps} animateSelection={false} />,
+    );
+    const Box = jest.requireActual('@metamask/design-system-react-native').Box;
+    const layoutBox = UNSAFE_getAllByType(Box).find(
+      (b: { props: { onLayout?: unknown } }) => b.props.onLayout,
+    );
+    act(() => {
+      layoutBox?.props.onLayout({
+        nativeEvent: { layout: { width: 300 } },
+      });
+    });
+    getMockWithTiming().mockClear();
+
+    rerender(
+      <PredictSportLineSelector
+        {...defaultProps}
+        selectedLine={5.5}
+        animateSelection={false}
+      />,
+    );
+
+    expect(getMockWithTiming()).not.toHaveBeenCalled();
+  });
+
+  it('animates selected index changes when animation is enabled', () => {
+    const { rerender, UNSAFE_getAllByType } = render(
+      <PredictSportLineSelector {...defaultProps} />,
+    );
+    const Box = jest.requireActual('@metamask/design-system-react-native').Box;
+    const layoutBox = UNSAFE_getAllByType(Box).find(
+      (b: { props: { onLayout?: unknown } }) => b.props.onLayout,
+    );
+    act(() => {
+      layoutBox?.props.onLayout({
+        nativeEvent: { layout: { width: 300 } },
+      });
+    });
+    getMockWithTiming().mockClear();
+
+    rerender(<PredictSportLineSelector {...defaultProps} selectedLine={5.5} />);
+
+    expect(getMockWithTiming()).toHaveBeenCalled();
   });
 
   it('fires haptic feedback on line tap', () => {

--- a/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
+++ b/app/components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx
@@ -28,6 +28,7 @@ interface PredictSportLineSelectorProps {
   lines: number[];
   selectedLine: number;
   selectedIndex?: number;
+  animateSelection?: boolean;
   onSelectLine: (line: number, index: number) => void;
   testID?: string;
 }
@@ -40,6 +41,7 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
   lines,
   selectedLine,
   selectedIndex: selectedIndexProp,
+  animateSelection = true,
   onSelectLine,
   testID,
 }) => {
@@ -72,11 +74,23 @@ const PredictSportLineSelector: React.FC<PredictSportLineSelectorProps> = ({
   useEffect(() => {
     if (containerWidth.value === 0) return;
 
-    translateX.value = withTiming(
-      computeTranslateX(selectedIndex, containerWidth.value),
-      { duration: ANIMATION_DURATION, easing: Easing.inOut(Easing.ease) },
+    const nextTranslateX = computeTranslateX(
+      selectedIndex,
+      containerWidth.value,
     );
-  }, [selectedIndex, computeTranslateX, containerWidth, translateX]);
+    translateX.value = animateSelection
+      ? withTiming(nextTranslateX, {
+          duration: ANIMATION_DURATION,
+          easing: Easing.inOut(Easing.ease),
+        })
+      : nextTranslateX;
+  }, [
+    animateSelection,
+    selectedIndex,
+    computeTranslateX,
+    containerWidth,
+    translateX,
+  ]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],

--- a/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
+++ b/app/components/UI/Predict/components/PredictSportOutcomeCard/PredictSportOutcomeCard.tsx
@@ -28,6 +28,7 @@ interface PredictSportOutcomeCardProps {
   lines?: number[];
   selectedLine?: number;
   selectedIndex?: number;
+  animateLineSelection?: boolean;
   onSelectLine?: (line: number, index: number) => void;
   buttonLayout?: 'inline' | 'inlineNoSeparator' | 'stacked';
   disabled?: boolean;
@@ -41,6 +42,7 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
   lines,
   selectedLine,
   selectedIndex,
+  animateLineSelection,
   onSelectLine,
   buttonLayout = 'inline',
   disabled = false,
@@ -103,6 +105,7 @@ const PredictSportOutcomeCard: React.FC<PredictSportOutcomeCardProps> = ({
             lines={lines}
             selectedLine={selectedLine}
             selectedIndex={selectedIndex}
+            animateSelection={animateLineSelection}
             onSelectLine={onSelectLine}
             testID={PREDICT_SPORT_OUTCOME_CARD_TEST_IDS.LINE_SELECTOR}
           />

--- a/app/components/UI/Predict/hooks/usePredictLivePrices.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictLivePrices.test.ts
@@ -1,0 +1,363 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import Engine from '../../../../core/Engine';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import type { GetPriceResponse, PriceQuery, PriceUpdate } from '../types';
+import { usePredictLivePrices } from './usePredictLivePrices';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      getPrices: jest.fn(),
+      subscribeToMarketPrices: jest.fn(),
+      getConnectionStatus: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: {
+    log: jest.fn(),
+  },
+}));
+
+const createPriceQuery = (
+  outcomeTokenId: string,
+  overrides: Partial<PriceQuery> = {},
+): PriceQuery => ({
+  marketId: `market-${outcomeTokenId}`,
+  outcomeId: `outcome-${outcomeTokenId}`,
+  outcomeTokenId,
+  ...overrides,
+});
+
+const createPriceResponse = (
+  tokenPrices: Record<string, { buy: number; sell: number }>,
+): GetPriceResponse => ({
+  providerId: 'polymarket',
+  results: Object.entries(tokenPrices).map(([tokenId, entry]) => ({
+    marketId: `market-${tokenId}`,
+    outcomeId: `outcome-${tokenId}`,
+    outcomeTokenId: tokenId,
+    entry,
+  })),
+});
+
+const createLivePrice = (
+  tokenId: string,
+  overrides: Partial<PriceUpdate> = {},
+): PriceUpdate => ({
+  tokenId,
+  price: 0.7,
+  bestBid: 0.69,
+  bestAsk: 0.71,
+  ...overrides,
+});
+
+const flushPromises = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('usePredictLivePrices', () => {
+  const mockGetPrices = Engine.context.PredictController.getPrices as jest.Mock;
+  const mockSubscribeToMarketPrices = Engine.context.PredictController
+    .subscribeToMarketPrices as jest.Mock;
+  const mockGetConnectionStatus = Engine.context.PredictController
+    .getConnectionStatus as jest.Mock;
+  const mockUnsubscribe = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockGetPrices.mockResolvedValue(createPriceResponse({}));
+    mockSubscribeToMarketPrices.mockReturnValue(mockUnsubscribe);
+    mockGetConnectionStatus.mockReturnValue({
+      sportsConnected: false,
+      marketConnected: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('warm-up fetching', () => {
+    it('starts warm-up fetch before websocket subscription', () => {
+      const queries = [createPriceQuery('token-1')];
+
+      renderHook(() => usePredictLivePrices(queries));
+
+      expect(mockGetPrices).toHaveBeenCalledWith({ queries });
+      expect(mockSubscribeToMarketPrices).toHaveBeenCalledWith(
+        ['token-1'],
+        expect.any(Function),
+      );
+      expect(mockGetPrices.mock.invocationCallOrder[0]).toBeLessThan(
+        mockSubscribeToMarketPrices.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('fetches only newly visible queries when token IDs change', async () => {
+      const tokenOneQuery = createPriceQuery('token-1');
+      const tokenTwoQuery = createPriceQuery('token-2');
+      const { rerender } = renderHook(
+        ({ queries }) => usePredictLivePrices(queries),
+        { initialProps: { queries: [tokenOneQuery] } },
+      );
+
+      await waitFor(() => {
+        expect(mockGetPrices).toHaveBeenCalledTimes(1);
+      });
+      mockGetPrices.mockClear();
+
+      rerender({ queries: [tokenOneQuery, tokenTwoQuery] });
+
+      expect(mockGetPrices).toHaveBeenCalledWith({
+        queries: [tokenTwoQuery],
+      });
+    });
+
+    it('normalizes REST warm-up prices into live price map entries', async () => {
+      mockGetPrices.mockResolvedValue(
+        createPriceResponse({ 'token-1': { buy: 0.62, sell: 0.61 } }),
+      );
+      const { result } = renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')]),
+      );
+
+      await waitFor(() => {
+        expect(result.current.getPrice('token-1')).toEqual({
+          tokenId: 'token-1',
+          price: 0.62,
+          bestBid: 0.61,
+          bestAsk: 0.62,
+        });
+      });
+
+      expect(result.current.priceVersion).toBe(1);
+      expect(result.current.lastUpdateTime).not.toBeNull();
+    });
+
+    it('skips warm-up fetch when disabled', () => {
+      renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')], {
+          enabled: false,
+        }),
+      );
+
+      expect(mockGetPrices).not.toHaveBeenCalled();
+      expect(mockSubscribeToMarketPrices).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscription management', () => {
+    it('subscribes to visible token IDs', () => {
+      renderHook(() =>
+        usePredictLivePrices([
+          createPriceQuery('token-2'),
+          createPriceQuery('token-1'),
+        ]),
+      );
+
+      expect(mockSubscribeToMarketPrices).toHaveBeenCalledWith(
+        ['token-1', 'token-2'],
+        expect.any(Function),
+      );
+    });
+
+    it('unsubscribes when token IDs change', () => {
+      const { rerender } = renderHook(
+        ({ queries }) => usePredictLivePrices(queries),
+        { initialProps: { queries: [createPriceQuery('token-1')] } },
+      );
+
+      rerender({ queries: [createPriceQuery('token-2')] });
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(mockSubscribeToMarketPrices).toHaveBeenLastCalledWith(
+        ['token-2'],
+        expect.any(Function),
+      );
+    });
+
+    it('unsubscribes on unmount', () => {
+      const { unmount } = renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')]),
+      );
+
+      unmount();
+
+      expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not resubscribe when query order changes without token changes', () => {
+      const { rerender } = renderHook(
+        ({ queries }) => usePredictLivePrices(queries),
+        {
+          initialProps: {
+            queries: [createPriceQuery('token-2'), createPriceQuery('token-1')],
+          },
+        },
+      );
+
+      rerender({
+        queries: [createPriceQuery('token-1'), createPriceQuery('token-2')],
+      });
+
+      expect(mockSubscribeToMarketPrices).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('price updates', () => {
+    it('updates prices from websocket callbacks', () => {
+      let capturedCallback: (updates: PriceUpdate[]) => void = jest.fn();
+      mockSubscribeToMarketPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+      const { result } = renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')]),
+      );
+
+      act(() => {
+        capturedCallback([
+          createLivePrice('token-1', {
+            price: 0.81,
+            bestBid: 0.8,
+            bestAsk: 0.82,
+          }),
+        ]);
+      });
+
+      expect(result.current.getPrice('token-1')).toEqual({
+        tokenId: 'token-1',
+        price: 0.81,
+        bestBid: 0.8,
+        bestAsk: 0.82,
+      });
+      expect(result.current.priceVersion).toBe(1);
+    });
+
+    it('keeps previously seen prices after tokens leave the visible set', () => {
+      let capturedCallback: (updates: PriceUpdate[]) => void = jest.fn();
+      mockSubscribeToMarketPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+      const { result, rerender } = renderHook(
+        ({ queries }) => usePredictLivePrices(queries),
+        { initialProps: { queries: [createPriceQuery('token-1')] } },
+      );
+      act(() => {
+        capturedCallback([createLivePrice('token-1', { price: 0.74 })]);
+      });
+
+      rerender({ queries: [] });
+
+      expect(result.current.getPrice('token-1')?.price).toBe(0.74);
+      expect(result.current.prices.size).toBe(1);
+      expect(result.current.isConnected).toBe(false);
+    });
+
+    it('ignores REST warm-up results when websocket updates arrive first', async () => {
+      let resolveWarmup: (value: GetPriceResponse) => void = jest.fn();
+      mockGetPrices.mockReturnValue(
+        new Promise<GetPriceResponse>((resolve) => {
+          resolveWarmup = resolve;
+        }),
+      );
+      let capturedCallback: (updates: PriceUpdate[]) => void = jest.fn();
+      mockSubscribeToMarketPrices.mockImplementation((_, callback) => {
+        capturedCallback = callback;
+        return mockUnsubscribe;
+      });
+      const { result } = renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')]),
+      );
+      act(() => {
+        capturedCallback([
+          createLivePrice('token-1', {
+            price: 0.82,
+            bestBid: 0.81,
+            bestAsk: 0.83,
+          }),
+        ]);
+      });
+
+      await act(async () => {
+        resolveWarmup(
+          createPriceResponse({ 'token-1': { buy: 0.61, sell: 0.6 } }),
+        );
+      });
+      await flushPromises();
+
+      expect(result.current.getPrice('token-1')).toEqual({
+        tokenId: 'token-1',
+        price: 0.82,
+        bestBid: 0.81,
+        bestAsk: 0.83,
+      });
+    });
+  });
+
+  describe('connection status', () => {
+    it('reflects market websocket connection status', () => {
+      mockGetConnectionStatus.mockReturnValue({
+        sportsConnected: false,
+        marketConnected: false,
+      });
+
+      const { result } = renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')]),
+      );
+
+      expect(result.current.isConnected).toBe(false);
+    });
+
+    it('refreshes market websocket connection status on interval', () => {
+      mockGetConnectionStatus
+        .mockReturnValueOnce({ sportsConnected: false, marketConnected: true })
+        .mockReturnValueOnce({
+          sportsConnected: false,
+          marketConnected: false,
+        });
+      const { result } = renderHook(() =>
+        usePredictLivePrices([createPriceQuery('token-1')]),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.isConnected).toBe(false);
+    });
+  });
+
+  describe('error logging', () => {
+    it('logs warm-up fetch errors without clearing retained prices', async () => {
+      const fetchError = new Error('price fetch failed');
+      mockGetPrices
+        .mockResolvedValueOnce(
+          createPriceResponse({ 'token-1': { buy: 0.7, sell: 0.69 } }),
+        )
+        .mockRejectedValueOnce(fetchError);
+      const { result, rerender } = renderHook(
+        ({ queries }) => usePredictLivePrices(queries),
+        { initialProps: { queries: [createPriceQuery('token-1')] } },
+      );
+      await waitFor(() => {
+        expect(result.current.getPrice('token-1')?.price).toBe(0.7);
+      });
+
+      rerender({ queries: [createPriceQuery('token-2')] });
+      await flushPromises();
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        'usePredictLivePrices: Error fetching prices',
+        fetchError,
+      );
+      expect(result.current.getPrice('token-1')?.price).toBe(0.7);
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictLivePrices.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictLivePrices.test.ts
@@ -136,7 +136,6 @@ describe('usePredictLivePrices', () => {
       });
 
       expect(result.current.priceVersion).toBe(1);
-      expect(result.current.lastUpdateTime).not.toBeNull();
     });
 
     it('skips warm-up fetch when disabled', () => {

--- a/app/components/UI/Predict/hooks/usePredictLivePrices.ts
+++ b/app/components/UI/Predict/hooks/usePredictLivePrices.ts
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Engine from '../../../../core/Engine';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import type { PriceQuery, PriceResult, PriceUpdate } from '../types';
+
+export interface UsePredictLivePricesOptions {
+  enabled?: boolean;
+}
+
+export interface UsePredictLivePricesResult {
+  prices: Map<string, PriceUpdate>;
+  getPrice: (tokenId: string) => PriceUpdate | undefined;
+  isConnected: boolean;
+  lastUpdateTime: number | null;
+  priceVersion: number;
+}
+
+const normalizePriceResult = (result: PriceResult): PriceUpdate => ({
+  tokenId: result.outcomeTokenId,
+  price: result.entry.buy,
+  bestBid: result.entry.sell,
+  bestAsk: result.entry.buy,
+});
+
+const getNormalizedQueries = (queries: PriceQuery[]): PriceQuery[] => {
+  const queriesByTokenId = new Map<string, PriceQuery>();
+
+  queries.forEach((query) => {
+    if (!query.outcomeTokenId || queriesByTokenId.has(query.outcomeTokenId)) {
+      return;
+    }
+
+    queriesByTokenId.set(query.outcomeTokenId, query);
+  });
+
+  return [...queriesByTokenId.values()].sort((a, b) => {
+    const tokenCompare = a.outcomeTokenId.localeCompare(b.outcomeTokenId);
+    if (tokenCompare !== 0) {
+      return tokenCompare;
+    }
+
+    const marketCompare = a.marketId.localeCompare(b.marketId);
+    if (marketCompare !== 0) {
+      return marketCompare;
+    }
+
+    return a.outcomeId.localeCompare(b.outcomeId);
+  });
+};
+
+/**
+ * Subscribes to live Predict market prices for the currently visible price
+ * queries, with a one-shot REST warm-up for newly visible tokens.
+ */
+export const usePredictLivePrices = (
+  queries: PriceQuery[],
+  options: UsePredictLivePricesOptions = {},
+): UsePredictLivePricesResult => {
+  const { enabled = true } = options;
+  const [prices, setPrices] = useState<Map<string, PriceUpdate>>(
+    () => new Map(),
+  );
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastUpdateTime, setLastUpdateTime] = useState<number | null>(null);
+  const [priceVersion, setPriceVersion] = useState(0);
+
+  const activeTokenIdsRef = useRef<Set<string>>(new Set());
+  const activeTokenEpochsRef = useRef<Map<string, number>>(new Map());
+  const isMountedRef = useRef(true);
+  const priceVersionRef = useRef(0);
+  const tokenEpochRef = useRef(0);
+  const websocketGenerationRef = useRef(0);
+  const websocketTokenGenerationsRef = useRef<Map<string, number>>(new Map());
+
+  const normalizedQueries = useMemo(
+    () => getNormalizedQueries(queries),
+    [queries],
+  );
+  const queriesKey = useMemo(
+    () => JSON.stringify(normalizedQueries),
+    [normalizedQueries],
+  );
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+      activeTokenIdsRef.current = new Set();
+      activeTokenEpochsRef.current.clear();
+    },
+    [],
+  );
+
+  const commitPriceUpdates = useCallback((updates: PriceUpdate[]) => {
+    if (!isMountedRef.current || updates.length === 0) {
+      return;
+    }
+
+    const updatedAt = Date.now();
+
+    setPrices((previousPrices) => {
+      const nextPrices = new Map(previousPrices);
+      updates.forEach((update) => {
+        nextPrices.set(update.tokenId, update);
+      });
+      return nextPrices;
+    });
+    setLastUpdateTime(updatedAt);
+    setPriceVersion((previousVersion) => {
+      const nextVersion = previousVersion + 1;
+      priceVersionRef.current = nextVersion;
+      return nextVersion;
+    });
+  }, []);
+
+  const fetchWarmupPrices = useCallback(
+    async (
+      newlyVisibleQueries: PriceQuery[],
+      tokenEpochsAtRequest: Map<string, number>,
+      websocketGenerationAtRequest: number,
+    ) => {
+      if (newlyVisibleQueries.length === 0) {
+        return;
+      }
+
+      try {
+        const response = await Engine.context.PredictController.getPrices({
+          queries: newlyVisibleQueries,
+        });
+
+        const updates = response.results
+          .filter((result) => {
+            const tokenId = result.outcomeTokenId;
+            const currentTokenEpoch = activeTokenEpochsRef.current.get(tokenId);
+            const requestTokenEpoch = tokenEpochsAtRequest.get(tokenId);
+            const websocketTokenGeneration =
+              websocketTokenGenerationsRef.current.get(tokenId) ?? 0;
+
+            return (
+              activeTokenIdsRef.current.has(tokenId) &&
+              currentTokenEpoch === requestTokenEpoch &&
+              websocketTokenGeneration <= websocketGenerationAtRequest
+            );
+          })
+          .map(normalizePriceResult);
+
+        commitPriceUpdates(updates);
+      } catch (error) {
+        DevLogger.log('usePredictLivePrices: Error fetching prices', error);
+      }
+    },
+    [commitPriceUpdates],
+  );
+
+  const handlePriceUpdates = useCallback(
+    (updates: PriceUpdate[]) => {
+      const activeUpdates = updates.filter((update) =>
+        activeTokenIdsRef.current.has(update.tokenId),
+      );
+
+      if (activeUpdates.length === 0) {
+        return;
+      }
+
+      websocketGenerationRef.current += 1;
+      activeUpdates.forEach((update) => {
+        websocketTokenGenerationsRef.current.set(
+          update.tokenId,
+          websocketGenerationRef.current,
+        );
+      });
+
+      commitPriceUpdates(activeUpdates);
+    },
+    [commitPriceUpdates],
+  );
+
+  useEffect(() => {
+    const currentTokenIds = normalizedQueries.map(
+      (query) => query.outcomeTokenId,
+    );
+    const currentTokenIdSet = new Set(currentTokenIds);
+    const previousTokenIdSet = activeTokenIdsRef.current;
+
+    previousTokenIdSet.forEach((tokenId) => {
+      if (!currentTokenIdSet.has(tokenId)) {
+        activeTokenEpochsRef.current.delete(tokenId);
+      }
+    });
+
+    if (!enabled || currentTokenIds.length === 0) {
+      activeTokenIdsRef.current = new Set();
+      setIsConnected(false);
+      return;
+    }
+
+    const newlyVisibleQueries = normalizedQueries.filter(
+      (query) => !previousTokenIdSet.has(query.outcomeTokenId),
+    );
+    const tokenEpochsAtRequest = new Map<string, number>();
+
+    newlyVisibleQueries.forEach((query) => {
+      tokenEpochRef.current += 1;
+      activeTokenEpochsRef.current.set(
+        query.outcomeTokenId,
+        tokenEpochRef.current,
+      );
+      tokenEpochsAtRequest.set(query.outcomeTokenId, tokenEpochRef.current);
+    });
+
+    activeTokenIdsRef.current = currentTokenIdSet;
+
+    fetchWarmupPrices(
+      newlyVisibleQueries,
+      tokenEpochsAtRequest,
+      websocketGenerationRef.current,
+    );
+
+    const { PredictController } = Engine.context;
+    const unsubscribe = PredictController.subscribeToMarketPrices(
+      currentTokenIds,
+      handlePriceUpdates,
+    );
+
+    const checkConnection = () => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const status = PredictController.getConnectionStatus();
+      setIsConnected(status.marketConnected);
+    };
+
+    checkConnection();
+    const intervalId = setInterval(checkConnection, 1000);
+
+    return () => {
+      unsubscribe();
+      clearInterval(intervalId);
+    };
+    // eslint-disable-next-line react-compiler/react-compiler
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, fetchWarmupPrices, handlePriceUpdates, queriesKey]);
+
+  const getPrice = useCallback(
+    (tokenId: string): PriceUpdate | undefined => prices.get(tokenId),
+    [prices],
+  );
+
+  return {
+    prices,
+    getPrice,
+    isConnected,
+    lastUpdateTime,
+    priceVersion,
+  };
+};

--- a/app/components/UI/Predict/hooks/usePredictLivePrices.ts
+++ b/app/components/UI/Predict/hooks/usePredictLivePrices.ts
@@ -11,7 +11,6 @@ export interface UsePredictLivePricesResult {
   prices: Map<string, PriceUpdate>;
   getPrice: (tokenId: string) => PriceUpdate | undefined;
   isConnected: boolean;
-  lastUpdateTime: number | null;
   priceVersion: number;
 }
 
@@ -61,13 +60,11 @@ export const usePredictLivePrices = (
     () => new Map(),
   );
   const [isConnected, setIsConnected] = useState(false);
-  const [lastUpdateTime, setLastUpdateTime] = useState<number | null>(null);
   const [priceVersion, setPriceVersion] = useState(0);
 
   const activeTokenIdsRef = useRef<Set<string>>(new Set());
   const activeTokenEpochsRef = useRef<Map<string, number>>(new Map());
   const isMountedRef = useRef(true);
-  const priceVersionRef = useRef(0);
   const tokenEpochRef = useRef(0);
   const websocketGenerationRef = useRef(0);
   const websocketTokenGenerationsRef = useRef<Map<string, number>>(new Map());
@@ -81,21 +78,21 @@ export const usePredictLivePrices = (
     [normalizedQueries],
   );
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    isMountedRef.current = true;
+    const activeTokenEpochs = activeTokenEpochsRef.current;
+
+    return () => {
       isMountedRef.current = false;
       activeTokenIdsRef.current = new Set();
-      activeTokenEpochsRef.current.clear();
-    },
-    [],
-  );
+      activeTokenEpochs.clear();
+    };
+  }, []);
 
   const commitPriceUpdates = useCallback((updates: PriceUpdate[]) => {
     if (!isMountedRef.current || updates.length === 0) {
       return;
     }
-
-    const updatedAt = Date.now();
 
     setPrices((previousPrices) => {
       const nextPrices = new Map(previousPrices);
@@ -104,12 +101,7 @@ export const usePredictLivePrices = (
       });
       return nextPrices;
     });
-    setLastUpdateTime(updatedAt);
-    setPriceVersion((previousVersion) => {
-      const nextVersion = previousVersion + 1;
-      priceVersionRef.current = nextVersion;
-      return nextVersion;
-    });
+    setPriceVersion((previousVersion) => previousVersion + 1);
   }, []);
 
   const fetchWarmupPrices = useCallback(
@@ -250,7 +242,6 @@ export const usePredictLivePrices = (
     prices,
     getPrice,
     isConnected,
-    lastUpdateTime,
     priceVersion,
   };
 };

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -2926,7 +2926,7 @@ describe('PredictMarketDetails', () => {
       ).toBeOnTheScreen();
     });
 
-    it('resets to Outcomes when selected tab becomes invalid after tabs change on closed market', async () => {
+    it('keeps the user-selected About tab when the positions tab disappears on a closed market', async () => {
       const closedMarket = createMockMarket({
         status: 'closed',
       });
@@ -2970,12 +2970,11 @@ describe('PredictMarketDetails', () => {
 
       rerender(<PredictMarketDetails />);
 
+      // The positions tab is removed, which shifts indices. The user's About
+      // selection must be preserved by key instead of silently switching tabs.
       await waitFor(() => {
         expect(
-          screen.queryByText('predict.market_details.volume'),
-        ).not.toBeOnTheScreen();
-        expect(
-          screen.getByTestId(PredictMarketDetailsSelectorsIDs.OUTCOMES_TAB),
+          screen.getByText('predict.market_details.volume'),
         ).toBeOnTheScreen();
       });
     });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -354,6 +354,7 @@ jest.mock('../../utils/cryptoUpDown', () => ({
 }));
 
 let mockSelectPredictUpDownEnabledFlag = false;
+let mockSelectExtendedSportsMarketsLeagues: string[] = [];
 const mockSelectPredictFeeCollectionFlag = {
   enabled: true,
   collector: '0xe6a2026d58eaff3c7ad7ba9386fb143388002382',
@@ -367,6 +368,9 @@ const mockSelectPredictFeeCollectionFlag = {
 jest.mock('../../selectors/featureFlags', () => ({
   selectPredictUpDownEnabledFlag: jest.fn(
     () => mockSelectPredictUpDownEnabledFlag,
+  ),
+  selectExtendedSportsMarketsLeagues: jest.fn(
+    () => mockSelectExtendedSportsMarketsLeagues,
   ),
   selectPredictFeeCollectionFlag: jest.fn(
     () => mockSelectPredictFeeCollectionFlag,
@@ -777,6 +781,7 @@ describe('PredictMarketDetails', () => {
     jest.clearAllMocks();
     mockRunAfterInteractions.mockReset();
     mockIsBuySheetOpen = false;
+    mockSelectExtendedSportsMarketsLeagues = [];
   });
 
   afterAll(() => {
@@ -3898,6 +3903,84 @@ describe('PredictMarketDetails', () => {
         ),
       ).toBeOnTheScreen();
       expect(screen.getByText('NFL: Team A vs Team B')).toBeOnTheScreen();
+    });
+
+    it('disables open outcome price polling for extended sports game markets', () => {
+      mockSelectExtendedSportsMarketsLeagues = ['epl'];
+      const gameMarket = createMockMarket({
+        title: 'EPL: Team A vs Team B',
+        game: {
+          homeTeam: { name: 'Team A', abbreviation: 'TA' },
+          awayTeam: { name: 'Team B', abbreviation: 'TB' },
+          startTime: '2024-12-31T20:00:00Z',
+          status: 'scheduled',
+          league: 'epl',
+        },
+        outcomeGroups: [{ key: 'game_lines', outcomes: [] }],
+      });
+
+      setupPredictMarketDetailsTest(gameMarket);
+
+      const { usePredictPrices } = jest.requireMock(
+        '../../hooks/usePredictPrices',
+      );
+      expect(usePredictPrices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: false,
+        }),
+      );
+    });
+
+    it('preserves open outcome price polling for sports games outside extended leagues', () => {
+      mockSelectExtendedSportsMarketsLeagues = ['nba'];
+      const gameMarket = createMockMarket({
+        title: 'EPL: Team A vs Team B',
+        game: {
+          homeTeam: { name: 'Team A', abbreviation: 'TA' },
+          awayTeam: { name: 'Team B', abbreviation: 'TB' },
+          startTime: '2024-12-31T20:00:00Z',
+          status: 'scheduled',
+          league: 'epl',
+        },
+        outcomeGroups: [{ key: 'game_lines', outcomes: [] }],
+      });
+
+      setupPredictMarketDetailsTest(gameMarket);
+
+      const { usePredictPrices } = jest.requireMock(
+        '../../hooks/usePredictPrices',
+      );
+      expect(usePredictPrices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+        }),
+      );
+    });
+
+    it('preserves open outcome price polling for extended-league games without outcome groups', () => {
+      mockSelectExtendedSportsMarketsLeagues = ['epl'];
+      const gameMarket = createMockMarket({
+        title: 'EPL: Team A vs Team B',
+        game: {
+          homeTeam: { name: 'Team A', abbreviation: 'TA' },
+          awayTeam: { name: 'Team B', abbreviation: 'TB' },
+          startTime: '2024-12-31T20:00:00Z',
+          status: 'scheduled',
+          league: 'epl',
+        },
+        outcomeGroups: [],
+      });
+
+      setupPredictMarketDetailsTest(gameMarket);
+
+      const { usePredictPrices } = jest.requireMock(
+        '../../hooks/usePredictPrices',
+      );
+      expect(usePredictPrices).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+        }),
+      );
     });
 
     it('threads childMarketIds to usePredictPositions for both active and claimable queries', () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -4,7 +4,13 @@ import {
   useNavigation,
   useRoute,
 } from '@react-navigation/native';
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import React, {
+  useMemo,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react';
 import { InteractionManager, RefreshControl, ScrollView } from 'react-native';
 import {
   SafeAreaView,
@@ -66,6 +72,8 @@ import { usePredictPreviewSheet } from '../../contexts';
 
 interface PredictMarketDetailsProps {}
 
+type TabKey = 'positions' | 'outcomes' | 'about';
+
 const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
@@ -77,6 +85,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const tw = useTailwind();
   const [activeTab, setActiveTab] = useState<number | null>(null);
   const [userSelectedTab, setUserSelectedTab] = useState<boolean>(false);
+  // Tracks the user's selected tab by key so the selection survives changes to
+  // the tabs array (e.g. the positions tab being prepended once positions load,
+  // which shifts the index-based activeTab).
+  const selectedTabKeyRef = useRef<TabKey | null>(null);
   const insets = useSafeAreaInsets();
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [isResolvedExpanded, setIsResolvedExpanded] = useState<boolean>(false);
@@ -304,8 +316,32 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     );
   };
 
+  const tabs = useMemo(() => {
+    const result: { label: string; key: TabKey }[] = [];
+    // positions first if user has any
+    if (activePositions.length > 0 || claimablePositions.length > 0) {
+      result.push({
+        label: strings('predict.tabs.positions'),
+        key: 'positions',
+      });
+    }
+    // outcomes next if market has multiple outcomes or is closed
+    if (multipleOutcomes || market?.status === PredictMarketStatus.CLOSED) {
+      result.push({ label: strings('predict.tabs.outcomes'), key: 'outcomes' });
+    }
+    // about last (always present)
+    result.push({ label: strings('predict.tabs.about'), key: 'about' });
+    return result;
+  }, [
+    activePositions.length,
+    claimablePositions.length,
+    multipleOutcomes,
+    market?.status,
+  ]);
+
   const handleTabPress = (tabIndex: number) => {
     setUserSelectedTab(true);
+    selectedTabKeyRef.current = tabs[tabIndex]?.key ?? null;
     setActiveTab(tabIndex);
   };
 
@@ -340,8 +376,6 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     });
   }, [navigation]);
 
-  type TabKey = 'positions' | 'outcomes' | 'about';
-
   const trackMarketDetailsOpened = useCallback(
     (tabKey: TabKey) => {
       if (!market) return;
@@ -373,33 +407,26 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
       transactionActiveAbTests,
     ],
   );
-  const tabs = useMemo(() => {
-    const result: { label: string; key: TabKey }[] = [];
-    // positions first if user has any
-    if (activePositions.length > 0 || claimablePositions.length > 0) {
-      result.push({
-        label: strings('predict.tabs.positions'),
-        key: 'positions',
-      });
-    }
-    // outcomes next if market has multiple outcomes or is closed
-    if (multipleOutcomes || market?.status === PredictMarketStatus.CLOSED) {
-      result.push({ label: strings('predict.tabs.outcomes'), key: 'outcomes' });
-    }
-    // about last (always present)
-    result.push({ label: strings('predict.tabs.about'), key: 'about' });
-    return result;
-  }, [
-    activePositions.length,
-    claimablePositions.length,
-    multipleOutcomes,
-    market?.status,
-  ]);
 
   useEffect(() => {
     if (!tabsReady) return;
 
     const outcomesIndex = tabs.findIndex((t) => t.key === 'outcomes');
+
+    // Keep the user's selection pinned to its tab key. The tabs array can grow
+    // once positions resolve, which shifts indices; without this the selected
+    // tab would silently change to whatever now sits at the same index.
+    if (userSelectedTab && selectedTabKeyRef.current) {
+      const preservedIndex = tabs.findIndex(
+        (t) => t.key === selectedTabKeyRef.current,
+      );
+      if (preservedIndex >= 0) {
+        if (preservedIndex !== activeTab) {
+          setActiveTab(preservedIndex);
+        }
+        return;
+      }
+    }
 
     // for closed markets, display 'outcomes' by default until the user selects a tab
     if (market?.status === PredictMarketStatus.CLOSED) {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -49,6 +49,7 @@ import { isCryptoUpDown } from '../../utils/cryptoUpDown';
 import {
   selectPredictUpDownEnabledFlag,
   selectPredictFeeCollectionFlag,
+  selectExtendedSportsMarketsLeagues,
 } from '../../selectors/featureFlags';
 import PredictMarketDetailsStatus from './components/PredictMarketDetailsStatus';
 import PredictMarketDetailsHeader from './components/PredictMarketDetailsHeader';
@@ -81,6 +82,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const [isResolvedExpanded, setIsResolvedExpanded] = useState<boolean>(false);
 
   const upDownEnabled = useSelector(selectPredictUpDownEnabledFlag);
+  const extendedSportsMarketsLeagues = useSelector(
+    selectExtendedSportsMarketsLeagues,
+  );
   const {
     marketId,
     series,
@@ -228,8 +232,16 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     timeframes,
   } = useChartData({ market, hasAnyOutcomeToken });
 
+  const gameLeague = market?.game?.league;
+  const isExtendedSportsGameMarket = Boolean(
+    gameLeague &&
+      extendedSportsMarketsLeagues.includes(gameLeague) &&
+      market?.outcomeGroups?.length,
+  );
   const shouldRefreshOpenOutcomePrices =
-    market?.status === PredictMarketStatus.OPEN && !isBuySheetOpen;
+    market?.status === PredictMarketStatus.OPEN &&
+    !isBuySheetOpen &&
+    !isExtendedSportsGameMarket;
 
   const { closedOutcomes, openOutcomes, yesPercentage } = useOpenOutcomes({
     market,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

World Cup and other extended sports game-detail screens can show dozens of outcome cards across many market types (corners, player props, team totals, etc.). Subscribing to live prices for every token on those screens was expensive and did not reliably update the cards users actually see.

This PR fixes live price updates for Polymarket extended sports markets by:

1. **Viewport-scoped live pricing** — Adds `usePredictLivePrices`, which subscribes only to tokens for currently visible outcome cards, with a one-shot REST warm-up for newly visible tokens. `usePredictVisibleOutcomes` tracks FlashList viewability and selected line indices so price queries stay in sync while scrolling or switching lines.
2. **Extended sports outcomes list** — Introduces `PredictGameDetailsOutcomesList` (FlashList-based) for extended sports game details, replacing the previous scroll-view layout. Outcome cards are extracted into `PredictGameOutcomeCard` with row-building logic in `usePredictGameOutcomeRows`.
3. **Richer sports market grouping** — Expands sports constants and Polymarket grouping logic to support corners, player props, soccer half/team markets, and other World Cup market types. Unsupported types are filtered and logged once per session.
4. **Targeted price refresh** — Skips the bulk open-outcome price refresh on extended sports game markets (they use the new viewport hook instead) while preserving it for regular markets.
5. **UI polish** — Fixes chip-list scroll animation, line-selector initial animation, chart re-render on tab change, and restores missing Outcomes/About tabs for non-extended markets.

## **Changelog**

CHANGELOG entry: Fixed live price updates on Predict World Cup and extended sports game detail screens

## **Related issues**

Fixes: PRED-958

## **Manual testing steps**

```gherkin
Feature: Predict extended sports live prices

  Scenario: World Cup game details show live prices for visible outcomes
    Given extended sports markets are enabled for the World Cup league
    And the user opens a World Cup game with many outcome groups (e.g. corners, player props)

    When the user scrolls through the Outcomes tab
    Then visible outcome cards display prices that update in real time
    And prices for off-screen cards are not eagerly subscribed

  Scenario: Line selector updates live prices for the selected line
    Given a spread or totals card with multiple lines is visible

    When the user switches the line selector
    Then the card shows prices for the newly selected line's token

  Scenario: Regular (non-extended) markets still refresh open outcome prices
    Given a standard Predict market without extended sports outcome groups

    When the user opens market details
    Then open outcome prices continue to refresh via the existing bulk refresh path
    And Outcomes and About tabs are both available

  Scenario: Tab and chip navigation remains stable
    Given a World Cup game details screen with Outcomes and About tabs

    When the user switches tabs or scrolls the chip list
    Then the chart does not flash or overlap content
    And chip-list scroll animation behaves smoothly
```

## **Screenshots/Recordings**

N/A — manual verification on device/simulator recommended for live price movement and scroll behavior.

### **Before**

<!-- Outcome cards on World Cup game details did not reliably update prices; bulk subscriptions were inefficient for large outcome lists. -->

### **After**

<!-- Visible outcome cards receive live WebSocket price updates; scrolling and line selection scope subscriptions to visible tokens only. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
