### PR TITLE
feat: emit predict_deposit_and_order metrics for PWAT deposit-and-order (CONF-1551)

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -234,6 +234,27 @@ describe('useTransactionPayMetrics', () => {
     });
   });
 
+  it('includes simulation_sending_assets_total_value for predict deposit and order', async () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: noop,
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    runHook({ type: TransactionType.predictDepositAndOrder });
+
+    await act(async () => noop());
+
+    expect(updateConfirmationMetricMock).toHaveBeenCalledWith({
+      id: transactionIdMock,
+      params: {
+        properties: expect.objectContaining({
+          simulation_sending_assets_total_value: 1.23,
+        }),
+        sensitiveProperties: {},
+      },
+    });
+  });
+
   it('includes simulation_sending_assets_total_value for money account deposit', async () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -89,6 +89,9 @@ export function useTransactionPayMetrics() {
     (hasTransactionType(transactionMeta, [TransactionType.perpsDeposit]) ||
       hasTransactionType(transactionMeta, [TransactionType.predictDeposit]) ||
       hasTransactionType(transactionMeta, [
+        TransactionType.predictDepositAndOrder,
+      ]) ||
+      hasTransactionType(transactionMeta, [
         TransactionType.moneyAccountDeposit,
       ]))
   ) {

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.test.ts
@@ -151,4 +151,30 @@ describe('getTransactionTypeValue', () => {
   ])('returns %s for standalone relay deposit type %s', (expected, txType) => {
     expect(getTransactionTypeValue(txType)).toBe(expected);
   });
+
+  it.each([
+    [
+      'standalone predictDepositAndOrder',
+      {
+        type: TransactionType.predictDepositAndOrder,
+      } as TransactionMeta,
+    ],
+    [
+      'PWAT batch with nested predictDepositAndOrder',
+      {
+        type: TransactionType.batch,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.predictDepositAndOrder },
+        ],
+      } as TransactionMeta,
+    ],
+  ])(
+    'returns predict_deposit_and_order for %s',
+    (_name, mockTransactionMeta) => {
+      expect(
+        getTransactionTypeValue(mockTransactionMeta.type, mockTransactionMeta),
+      ).toBe('predict_deposit_and_order');
+    },
+  );
 });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts
@@ -62,6 +62,14 @@ export function getTransactionTypeValue(
     return 'predict_deposit';
   }
 
+  if (
+    hasTransactionType(transactionMeta, [
+      TransactionType.predictDepositAndOrder,
+    ])
+  ) {
+    return 'predict_deposit_and_order';
+  }
+
   if (hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])) {
     return 'predict_withdraw';
   }

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -482,6 +482,38 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
+  it('sets polymarket_account_created as true for PWAT deposit-and-order with matching nested transaction', () => {
+    request.transactionMeta.nestedTransactions = [
+      { type: TransactionType.predictDepositAndOrder },
+      { data: '0xa1884d2c1234' },
+    ];
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        polymarket_account_created: true,
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('sets polymarket_account_created as false for PWAT deposit-and-order with no matching nested transaction', () => {
+    request.transactionMeta.nestedTransactions = [
+      { type: TransactionType.predictDepositAndOrder },
+      { data: '0xa1884d2d' },
+    ];
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        polymarket_account_created: false,
+      },
+      sensitiveProperties: {},
+    });
+  });
+
   it('derives base properties from metamaskPay metadata', () => {
     request.transactionMeta.metamaskPay = {
       chainId: '0x3',
@@ -638,6 +670,35 @@ describe('Metamask Pay Metrics', () => {
     expect(result).toStrictEqual({
       properties: expect.objectContaining({
         mm_pay_use_case: 'predict_withdraw',
+      }),
+      sensitiveProperties: {},
+    });
+  });
+
+  it('derives mm_pay and mm_pay_use_case for PWAT batch with nested predictDepositAndOrder', () => {
+    request.transactionMeta.type = TransactionType.batch;
+    request.transactionMeta.nestedTransactions = [
+      { type: TransactionType.predictDepositAndOrder },
+    ];
+    request.transactionMeta.metamaskPay = {
+      chainId: '0x89',
+      tokenAddress: '0x123',
+    };
+
+    getStateMock.mockReturnValue({
+      engine: {
+        backgroundState: {
+          TokensController: { allTokens: {} },
+        },
+      },
+    } as never);
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: expect.objectContaining({
+        mm_pay: true,
+        mm_pay_use_case: 'predict_deposit_and_order',
       }),
       sensitiveProperties: {},
     });

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -25,12 +25,14 @@ const PAY_TYPES = [
   TransactionType.perpsDeposit,
   TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
+  TransactionType.predictDepositAndOrder,
   TransactionType.predictWithdraw,
 ];
 
 const USE_CASE_MAP: [TransactionType[], string][] = [
   [[TransactionType.predictWithdraw], 'predict_withdraw'],
   [[TransactionType.predictDeposit], 'predict_deposit'],
+  [[TransactionType.predictDepositAndOrder], 'predict_deposit_and_order'],
   [[TransactionType.perpsDeposit], 'perps_deposit'],
   [[TransactionType.perpsWithdraw], 'perps_withdraw'],
   [[TransactionType.moneyAccountDeposit], 'money_account_deposit'],
@@ -52,7 +54,12 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
     tx.requiredTransactionIds?.includes(transactionId),
   );
 
-  if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
+  if (
+    hasTransactionType(transactionMeta, [
+      TransactionType.predictDeposit,
+      TransactionType.predictDepositAndOrder,
+    ])
+  ) {
     properties.polymarket_account_created = (
       transactionMeta?.nestedTransactions ?? []
     ).some((t) => t.data?.startsWith(FOUR_BYTE_SAFE_PROXY_CREATE));


### PR DESCRIPTION
## **Description**

Predict pay-with-any-token (PWAT) / deposit-and-order flows (`TransactionType.predictDepositAndOrder`) are submitted as batch transactions whose nested txs are typed `predictDepositAndOrder` (overridden in `PredictController.initPayWithAnyToken`). They were mis-tagged in analytics: `transaction_type = batch`, `mm_pay_use_case` undefined, and `polymarket_account_created` never set — making them impossible to query in Mixpanel without brittle proxy filters (`batch` + `mm_pay` + Polygon + error string).

This aligns PWAT deposit-and-order metrics with the other MM Pay flows (mirroring the existing `perps_deposit_and_order`):

- `base.ts`: map `predictDepositAndOrder` (standalone and batch-nested) to `transaction_type = predict_deposit_and_order`.
- `metamask-pay.ts`: add `predictDepositAndOrder` to `PAY_TYPES` and `USE_CASE_MAP` so `mm_pay = true` and `mm_pay_use_case = predict_deposit_and_order` are emitted; detect `polymarket_account_created` for PWAT batches via the Safe-proxy-create selector (`0xa1884d2c`) in nested transactions.
- `useTransactionPayMetrics.ts`: attribute `simulation_sending_assets_total_value` to PWAT like other deposit flows.

Standard `predict_deposit` metrics are unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1551

## **Manual testing steps**

```gherkin
Feature: Predict pay-with-any-token deposit-and-order metrics

  Scenario: PWAT deposit-and-order emits Predict-specific analytics
    Given I hold a token other than the Polymarket deposit token on a supported chain
    When I place a Predict order paying with that token (deposit-and-order)
    And the batch transaction finalizes
    Then the "Transaction Finalized" event has transaction_type = predict_deposit_and_order
    And the event has mm_pay = true and mm_pay_use_case = predict_deposit_and_order
    And polymarket_account_created is true when the Safe is deployed within the batch
```

Verified via unit tests in `base.test.ts`, `metamask-pay.test.ts`, and `useTransactionPayMetrics.test.ts`.

## **Screenshots/Recordings**

N/A — analytics-only change with no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.