### PR TITLE
chore: resolve native token dest setup from token details

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuySetup.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuySetup.ts
@@ -1,6 +1,7 @@
 import {
   formatAddressToAssetId,
   formatChainIdToHex,
+  isNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import {
@@ -70,7 +71,8 @@ export const useQuickBuySetup = (
   // are served from the chain's native asset registry. Token references
   // (`erc20`, `token`, `spl`, `trc20`, …) get their bare address forwarded to
   // `useAssetMetadata`. Bare hex/base58 addresses (legacy EVM shape) fall
-  // through unchanged.
+  // through unchanged — except the EVM native sentinel (`0x0…0`), which Token
+  // Details passes for natives like MON on Monad or HYPE on HyperEVM.
   const { metadataQuery, isNativeAsset, parsedTokenAddress } = useMemo(() => {
     const fallback = {
       metadataQuery: position?.tokenAddress ?? '',
@@ -82,6 +84,13 @@ export const useQuickBuySetup = (
     }
     const parsed = parseAssetType(position.tokenAddress);
     if (!parsed) {
+      if (isNativeAddress(position.tokenAddress)) {
+        return {
+          metadataQuery: '',
+          isNativeAsset: true,
+          parsedTokenAddress: undefined,
+        };
+      }
       return fallback;
     }
     if (parsed.namespace === 'slip44') {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuySetup.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuySetup.test.ts
@@ -1,11 +1,13 @@
 import { renderHook } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import type { CaipChainId } from '@metamask/utils';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import { zeroAddress } from 'ethereumjs-util';
 import {
   useAssetMetadata,
   AssetType,
 } from '../../../../../UI/Bridge/hooks/useAssetMetadata';
 import { selectIsBridgeEnabledSourceFactory } from '../../../../../../core/redux/slices/bridge';
+import { getNativeSourceToken } from '../../../../../UI/Bridge/utils/tokenUtils';
 import { useQuickBuySetup } from './hooks/useQuickBuySetup';
 import type { QuickBuyTarget } from './types';
 
@@ -19,14 +21,25 @@ jest.mock('../../../../../UI/Bridge/hooks/useAssetMetadata', () => ({
   useAssetMetadata: jest.fn(),
 }));
 
+jest.mock('../../../../../UI/Bridge/utils/tokenUtils', () => ({
+  ...jest.requireActual('../../../../../UI/Bridge/utils/tokenUtils'),
+  getNativeSourceToken: jest.fn(),
+}));
+
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseAssetMetadata = useAssetMetadata as jest.MockedFunction<
   typeof useAssetMetadata
 >;
 
 const BASE_CAIP: CaipChainId = 'eip155:8453';
+const MONAD_CAIP: CaipChainId = 'eip155:143';
+const HYPE_CAIP: CaipChainId = 'eip155:999';
 const SOLANA_CAIP: CaipChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 const UNMAPPED_CAIP = 'eip155:9999' as CaipChainId;
+
+const mockGetNativeSourceToken = getNativeSourceToken as jest.MockedFunction<
+  typeof getNativeSourceToken
+>;
 
 const createTarget = (
   overrides: Partial<QuickBuyTarget> = {},
@@ -42,6 +55,7 @@ const createTarget = (
 describe('useQuickBuySetup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetNativeSourceToken.mockReset();
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectIsBridgeEnabledSourceFactory) {
         return () => true;
@@ -183,4 +197,63 @@ describe('useQuickBuySetup', () => {
     expect(result.current.isLoading).toBe(true);
     expect(result.current.isUnsupportedChain).toBe(false);
   });
+
+  it.each<{
+    label: string;
+    chain: CaipChainId;
+    hexChainId: Hex;
+    tokenSymbol: string;
+    tokenName: string;
+    nativeSymbol: string;
+  }>([
+    {
+      label: 'MON on Monad',
+      chain: MONAD_CAIP,
+      hexChainId: '0x8f',
+      tokenSymbol: 'MON',
+      tokenName: 'Monad',
+      nativeSymbol: 'MON',
+    },
+    {
+      label: 'HYPE on HyperEVM',
+      chain: HYPE_CAIP,
+      hexChainId: '0x3e7',
+      tokenSymbol: 'HYPE',
+      tokenName: 'Hyperliquid',
+      nativeSymbol: 'HYPE',
+    },
+  ])(
+    'resolves $label from Token Details zero address without metadata fetch',
+    ({ chain, hexChainId, tokenSymbol, tokenName, nativeSymbol }) => {
+      mockGetNativeSourceToken.mockReturnValue({
+        address: zeroAddress(),
+        symbol: nativeSymbol,
+        name: tokenName,
+        decimals: 18,
+        image: 'https://example.com/native.png',
+        chainId: hexChainId,
+      });
+
+      const target = createTarget({
+        chain,
+        tokenAddress: zeroAddress(),
+        tokenSymbol,
+        tokenName,
+      });
+
+      const { result } = renderHook(() => useQuickBuySetup(target));
+
+      expect(mockUseAssetMetadata).toHaveBeenCalledWith('', false, hexChainId);
+      expect(mockGetNativeSourceToken).toHaveBeenCalledWith(hexChainId);
+      expect(result.current.destToken).toEqual({
+        address: zeroAddress(),
+        chainId: hexChainId,
+        decimals: 18,
+        image: 'https://example.com/native.png',
+        name: tokenName,
+        symbol: tokenSymbol,
+      });
+      expect(result.current.isLoading).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

QuickBuy failed to fetch quotes for native EVM tokens (MON on Monad, HYPE on HyperEVM).
Token Details passes natives as `0x000…0000`, but `useQuickBuySetup` only handled the CAIP `slip44` path. Bare zero addresses went through the metadata API, making `destToken` stay `undefined`, and quotes never ran.
We now detect that and build the destination token from the chain’s native registry instead of asking the metadata API for a fake ERC-20 address.

<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-12 at 18 26 13" src="https://github.com/user-attachments/assets/54caa5f9-16a7-4fbb-9cf1-a749518ff340" />


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-710

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: QuickBuy native token quotes from Token Details

  Scenario: user buys native MON from Token Details
    Given the user has a pay-with balance on Monad or another chain
    And the user opens Token Details for native MON on Monad
    When the user opens QuickBuy and releases the slider after selecting an amount
    Then a quote loads and the receive amount shows MON (not "0 MON")
    And the Buy button becomes enabled when the quote is valid
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
