### PR TITLE
feat(money): handle balance unavailable states on Money Home (MUSD-961)

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.styles.ts
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.styles.ts
@@ -10,6 +10,18 @@ const styleSheet = (params: { theme: Theme }) =>
     scrollContent: {
       paddingBottom: 40,
     },
+    // The DSRN BannerAlert ships a 4px left accent bar, a small radius and an
+    // 8px left padding. The design uses a flat, fully-rounded banner with 16px
+    // horizontal / 12px vertical padding, so those are overridden here. Per-edge
+    // padding keys are used so they win over DSRN's `padding`/`paddingLeft`.
+    balanceUnavailableBanner: {
+      borderLeftWidth: 0,
+      borderRadius: 12,
+      paddingTop: 12,
+      paddingRight: 16,
+      paddingBottom: 12,
+      paddingLeft: 16,
+    },
   });
 
 export default styleSheet;

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -372,6 +372,8 @@ describe('MoneyHomeView', () => {
       isAggregatedBalanceLoading: false,
       isBalanceFetchError: false,
       isBalanceFetching: false,
+      isBalanceUnavailable: false,
+      lastKnownTotalFiatFormatted: undefined,
       refetchBalance: mockRefetchBalance,
       apyDecimal: 0.05,
       apyPercent: 5,
@@ -508,6 +510,8 @@ describe('MoneyHomeView', () => {
         isAggregatedBalanceLoading: false,
         isBalanceFetchError: true,
         isBalanceFetching: false,
+        isBalanceUnavailable: true,
+        lastKnownTotalFiatFormatted: undefined,
         refetchBalance: jest.fn(),
         apyDecimal: 0.05,
         apyPercent: 5,
@@ -555,13 +559,15 @@ describe('MoneyHomeView', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('error takes precedence over loading and balance', () => {
+    it('unavailable takes precedence over loading', () => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: undefined,
         totalFiatRaw: undefined,
         isAggregatedBalanceLoading: true,
         isBalanceFetchError: true,
         isBalanceFetching: false,
+        isBalanceUnavailable: true,
+        lastKnownTotalFiatFormatted: undefined,
         refetchBalance: jest.fn(),
         apyPercent: 5,
         vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
@@ -574,10 +580,13 @@ describe('MoneyHomeView', () => {
       );
 
       expect(
-        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_ERROR),
+        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_UNAVAILABLE),
       ).toBeOnTheScreen();
       expect(
         queryByTestId(MoneyBalanceSummaryTestIds.BALANCE),
+      ).not.toBeOnTheScreen();
+      expect(
+        queryByTestId(MoneyBalanceSummaryTestIds.BALANCE_SKELETON),
       ).not.toBeOnTheScreen();
     });
 
@@ -693,6 +702,8 @@ describe('MoneyHomeView', () => {
           isAggregatedBalanceLoading: false,
           isBalanceFetchError: false,
           isBalanceFetching: false,
+          isBalanceUnavailable: true,
+          lastKnownTotalFiatFormatted: undefined,
           refetchBalance: jest.fn(),
           apyPercent: 5,
           vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
@@ -782,6 +793,58 @@ describe('MoneyHomeView', () => {
       // hasBalanceValue is false in noAccount state, so unfunded sections are hidden.
       expect(
         queryByTestId(MoneyHowItWorksTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('balance unavailable banner', () => {
+    const unavailableMock = (lastKnownTotalFiatFormatted?: string) =>
+      ({
+        totalFiatFormatted: undefined,
+        totalFiatRaw: undefined,
+        isAggregatedBalanceLoading: false,
+        isBalanceFetchError: true,
+        isBalanceFetching: false,
+        isBalanceUnavailable: true,
+        lastKnownTotalFiatFormatted,
+        refetchBalance: jest.fn(),
+        apyPercent: 5,
+        vaultApyQuery: { data: { apy: 0.05 }, isLoading: false },
+        musdBalanceQuery: { data: undefined, isLoading: false },
+        musdEquivalentBalanceQuery: { data: undefined, isLoading: false },
+      }) as unknown as ReturnType<typeof useMoneyAccountBalance>;
+
+    it('shows the banner with a dash when no last known balance exists', () => {
+      mockUseMoneyAccountBalance.mockReturnValue(unavailableMock());
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        getByTestId(MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_UNAVAILABLE),
+      ).toHaveTextContent(strings('money.balance_unavailable_value'));
+    });
+
+    it('shows the banner alongside the last known balance when cached', () => {
+      mockUseMoneyAccountBalance.mockReturnValue(unavailableMock('$2,384.34'));
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        getByTestId(MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_UNAVAILABLE),
+      ).toHaveTextContent('$2,384.34');
+    });
+
+    it('hides the banner when the balance loads successfully', () => {
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        queryByTestId(MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER),
       ).not.toBeOnTheScreen();
     });
   });
@@ -876,10 +939,13 @@ describe('MoneyHomeView', () => {
     it('disables Transfer button when initial balance is loading', () => {
       mockUseMoneyAccountBalance.mockReturnValue({
         ...defaultMoneyAccountBalance,
+        totalFiatFormatted: undefined,
+        totalFiatRaw: undefined,
         tokenTotal: undefined,
         isAggregatedBalanceLoading: true,
         isBalanceFetchError: false,
         isBalanceFetching: true,
+        isBalanceUnavailable: false,
       } as unknown as ReturnType<typeof useMoneyAccountBalance>);
 
       const { getByTestId } = renderWithProvider(<MoneyHomeView />);

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -559,14 +559,13 @@ describe('MoneyHomeView', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('unavailable takes precedence over loading', () => {
+    it('renders the unavailable slot whenever there is no fresh balance', () => {
       mockUseMoneyAccountBalance.mockReturnValue({
         totalFiatFormatted: undefined,
         totalFiatRaw: undefined,
         isAggregatedBalanceLoading: true,
         isBalanceFetchError: true,
         isBalanceFetching: false,
-        isBalanceUnavailable: true,
         lastKnownTotalFiatFormatted: undefined,
         refetchBalance: jest.fn(),
         apyPercent: 5,
@@ -584,9 +583,6 @@ describe('MoneyHomeView', () => {
       ).toBeOnTheScreen();
       expect(
         queryByTestId(MoneyBalanceSummaryTestIds.BALANCE),
-      ).not.toBeOnTheScreen();
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.BALANCE_SKELETON),
       ).not.toBeOnTheScreen();
     });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.testIds.ts
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.testIds.ts
@@ -1,4 +1,5 @@
 export const MoneyHomeViewTestIds = {
   CONTAINER: 'money-home-view-container',
   SCROLL_VIEW: 'money-home-view-scroll-view',
+  BALANCE_UNAVAILABLE_BANNER: 'money-home-view-balance-unavailable-banner',
 } as const;

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -113,7 +113,6 @@ const MoneyHomeView = () => {
     totalFiatRaw,
     vaultApyQuery,
     isAggregatedBalanceLoading,
-    isBalanceUnavailable,
     lastKnownTotalFiatFormatted,
     refetchBalance,
     apyPercent,
@@ -174,17 +173,15 @@ const MoneyHomeView = () => {
   } else if (totalFiatFormatted !== undefined) {
     // A fresh balance always wins — the banner is hidden on success.
     displayState = { kind: 'balance', value: totalFiatFormatted };
-  } else if (isBalanceUnavailable) {
-    // Carry the cached balance (when valid for this account/currency) so it can
-    // be shown as a muted "last known" figure; otherwise the slot shows a dash.
+  } else {
+    // No fresh balance (loading, fetch error, or rate not ready). Carry the
+    // cached balance (when valid for this account/currency) so it renders as a
+    // muted "last known" figure; otherwise the slot shows a dash. Either way a
+    // BannerAlert accompanies it.
     displayState = {
       kind: 'unavailable',
       lastKnownValue: lastKnownTotalFiatFormatted,
     };
-  } else if (isAggregatedBalanceLoading) {
-    displayState = { kind: 'loading' };
-  } else {
-    displayState = { kind: 'unavailable' };
   }
 
   const showBalanceUnavailableBanner = displayState.kind === 'unavailable';
@@ -733,6 +730,7 @@ const MoneyHomeView = () => {
               showMetalCard={hasMetalCard}
               isLinkDisabled={isLinking}
               cardBalance={cardBalance}
+              isBalanceStale={showBalanceUnavailableBanner}
               apy={apyPercent}
               analyticsScreen={CardScreens.MONEY_HOME}
               analyticsEntryPoint={CardEntryPoint.MONEY_HOME_METAMASK_CARD}

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -625,6 +625,7 @@ const MoneyHomeView = () => {
               description={strings(
                 'money.balance_unavailable_banner_description',
               )}
+              style={styles.balanceUnavailableBanner}
               testID={MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER}
             />
           </Box>

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -10,7 +10,12 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  BannerAlert,
+  BannerAlertSeverity,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../hooks/useStyles';
 import MoneyHeader from '../../components/MoneyHeader';
 import MoneyBalanceSummary from '../../components/MoneyBalanceSummary';
@@ -108,8 +113,8 @@ const MoneyHomeView = () => {
     totalFiatRaw,
     vaultApyQuery,
     isAggregatedBalanceLoading,
-    isBalanceFetchError,
-    isBalanceFetching,
+    isBalanceUnavailable,
+    lastKnownTotalFiatFormatted,
     refetchBalance,
     apyPercent,
   } = useMoneyAccountBalance();
@@ -166,17 +171,23 @@ const MoneyHomeView = () => {
   let displayState: MoneyBalanceDisplayState;
   if (!hasMoneyAccount) {
     displayState = { kind: 'noAccount' };
-  } else if (isBalanceFetchError && isBalanceFetching) {
-    displayState = { kind: 'retrying' };
-  } else if (isBalanceFetchError) {
-    displayState = { kind: 'error', onRetry: refetchBalance };
+  } else if (totalFiatFormatted !== undefined) {
+    // A fresh balance always wins — the banner is hidden on success.
+    displayState = { kind: 'balance', value: totalFiatFormatted };
+  } else if (isBalanceUnavailable) {
+    // Carry the cached balance (when valid for this account/currency) so it can
+    // be shown as a muted "last known" figure; otherwise the slot shows a dash.
+    displayState = {
+      kind: 'unavailable',
+      lastKnownValue: lastKnownTotalFiatFormatted,
+    };
   } else if (isAggregatedBalanceLoading) {
     displayState = { kind: 'loading' };
-  } else if (totalFiatFormatted === undefined) {
-    displayState = { kind: 'unavailable' };
   } else {
-    displayState = { kind: 'balance', value: totalFiatFormatted };
+    displayState = { kind: 'unavailable' };
   }
+
+  const showBalanceUnavailableBanner = displayState.kind === 'unavailable';
 
   const hasBalanceValue = displayState.kind === 'balance';
   const hasSpendableBalance =
@@ -609,6 +620,18 @@ const MoneyHomeView = () => {
           />
         }
       >
+        {showBalanceUnavailableBanner && (
+          <Box twClassName="px-4 pt-2">
+            <BannerAlert
+              severity={BannerAlertSeverity.Warning}
+              title={strings('money.balance_unavailable')}
+              description={strings(
+                'money.balance_unavailable_banner_description',
+              )}
+              testID={MoneyHomeViewTestIds.BALANCE_UNAVAILABLE_BANNER}
+            />
+          </Box>
+        )}
         <MoneyBalanceSummary
           apy={apyPercent}
           displayState={displayState}

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
@@ -9,7 +9,6 @@ const balanceState = (value = '$0.00'): MoneyBalanceDisplayState => ({
   kind: 'balance',
   value,
 });
-const loadingState: MoneyBalanceDisplayState = { kind: 'loading' };
 const unavailableState = (
   lastKnownValue?: string,
 ): MoneyBalanceDisplayState => ({
@@ -44,30 +43,6 @@ describe('MoneyBalanceSummary', () => {
     expect(getByTestId(MoneyBalanceSummaryTestIds.BALANCE)).toHaveTextContent(
       '$123.45',
     );
-  });
-
-  it('renders the balance skeleton instead of the balance value when loading', () => {
-    const { getByTestId, queryByTestId } = render(
-      <MoneyBalanceSummary apy={4} displayState={loadingState} />,
-    );
-
-    expect(
-      getByTestId(MoneyBalanceSummaryTestIds.BALANCE_SKELETON),
-    ).toBeOnTheScreen();
-    expect(
-      queryByTestId(MoneyBalanceSummaryTestIds.BALANCE),
-    ).not.toBeOnTheScreen();
-  });
-
-  it('renders the APY skeleton instead of the APY text when loading', () => {
-    const { getByTestId, queryByTestId } = render(
-      <MoneyBalanceSummary apy={4} displayState={loadingState} />,
-    );
-
-    expect(
-      getByTestId(MoneyBalanceSummaryTestIds.APY_SKELETON),
-    ).toBeOnTheScreen();
-    expect(queryByTestId(MoneyBalanceSummaryTestIds.APY)).not.toBeOnTheScreen();
   });
 
   it('does not render the info button when no handler is provided', () => {
@@ -125,21 +100,6 @@ describe('MoneyBalanceSummary', () => {
     expect(
       getByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
     ).toBeOnTheScreen();
-  });
-
-  it('hides the APY tooltip button when in loading state', () => {
-    const mockInfoPress = jest.fn();
-    const { queryByTestId } = render(
-      <MoneyBalanceSummary
-        apy={4}
-        displayState={loadingState}
-        onApyInfoPress={mockInfoPress}
-      />,
-    );
-
-    expect(
-      queryByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
-    ).not.toBeOnTheScreen();
   });
 
   it('hides the APY text and info button when apy is negative', () => {

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.test.tsx
@@ -10,10 +10,11 @@ const balanceState = (value = '$0.00'): MoneyBalanceDisplayState => ({
   value,
 });
 const loadingState: MoneyBalanceDisplayState = { kind: 'loading' };
-const retryingState: MoneyBalanceDisplayState = { kind: 'retrying' };
-const errorState = (onRetry = jest.fn()): MoneyBalanceDisplayState => ({
-  kind: 'error',
-  onRetry,
+const unavailableState = (
+  lastKnownValue?: string,
+): MoneyBalanceDisplayState => ({
+  kind: 'unavailable',
+  lastKnownValue,
 });
 
 describe('MoneyBalanceSummary', () => {
@@ -157,96 +158,6 @@ describe('MoneyBalanceSummary', () => {
     ).not.toBeOnTheScreen();
   });
 
-  describe('error state', () => {
-    it('renders the balance-unavailable message when balance fetch fails', () => {
-      const { getByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={errorState()} />,
-      );
-
-      expect(
-        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_ERROR),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_ERROR),
-      ).toHaveTextContent(/Balance unavailable/);
-    });
-
-    it('renders the retry icon button', () => {
-      const { getByLabelText, getByTestId, queryByText } = render(
-        <MoneyBalanceSummary apy={4} displayState={errorState()} />,
-      );
-
-      expect(
-        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_RETRY),
-      ).toBeOnTheScreen();
-      expect(getByLabelText(strings('money.balance_retry'))).toBeOnTheScreen();
-      expect(queryByText(strings('money.balance_retry'))).not.toBeOnTheScreen();
-    });
-
-    it('calls onRetry when the retry icon button is pressed', () => {
-      const mockRetry = jest.fn();
-      const { getByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={errorState(mockRetry)} />,
-      );
-
-      fireEvent.press(getByTestId(MoneyBalanceSummaryTestIds.BALANCE_RETRY));
-
-      expect(mockRetry).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not render the balance text', () => {
-      const { queryByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={errorState()} />,
-      );
-
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.BALANCE),
-      ).not.toBeOnTheScreen();
-    });
-
-    it('hides the APY row', () => {
-      const { queryByTestId } = render(
-        <MoneyBalanceSummary
-          apy={4}
-          displayState={errorState()}
-          onApyInfoPress={jest.fn()}
-        />,
-      );
-
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.APY),
-      ).not.toBeOnTheScreen();
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
-      ).not.toBeOnTheScreen();
-    });
-  });
-
-  describe('retrying state', () => {
-    it('renders the balance skeleton', () => {
-      const { getByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={retryingState} />,
-      );
-
-      expect(
-        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_SKELETON),
-      ).toBeOnTheScreen();
-    });
-
-    it('does not render the balance text or error message', () => {
-      const { queryByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={retryingState} />,
-      );
-
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.BALANCE),
-      ).not.toBeOnTheScreen();
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.BALANCE_ERROR),
-      ).not.toBeOnTheScreen();
-    });
-  });
-
   describe('noAccount state', () => {
     const noAccountState: MoneyBalanceDisplayState = { kind: 'noAccount' };
 
@@ -289,31 +200,32 @@ describe('MoneyBalanceSummary', () => {
   });
 
   describe('unavailable state', () => {
-    const unavailableState: MoneyBalanceDisplayState = { kind: 'unavailable' };
-
-    it('renders the balance-unavailable message', () => {
+    it('renders a dash when there is no last known balance', () => {
       const { getByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={unavailableState} />,
+        <MoneyBalanceSummary apy={4} displayState={unavailableState()} />,
       );
 
       expect(
         getByTestId(MoneyBalanceSummaryTestIds.BALANCE_UNAVAILABLE),
-      ).toHaveTextContent(strings('money.balance_unavailable'));
+      ).toHaveTextContent(strings('money.balance_unavailable_value'));
     });
 
-    it('does not render a retry button (distinct from error kind)', () => {
-      const { queryByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={unavailableState} />,
+    it('renders the last known balance when one is available', () => {
+      const { getByTestId } = render(
+        <MoneyBalanceSummary
+          apy={4}
+          displayState={unavailableState('$2,384.34')}
+        />,
       );
 
       expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.BALANCE_RETRY),
-      ).not.toBeOnTheScreen();
+        getByTestId(MoneyBalanceSummaryTestIds.BALANCE_UNAVAILABLE),
+      ).toHaveTextContent('$2,384.34');
     });
 
-    it('does not render the balance text', () => {
+    it('does not render the regular balance text', () => {
       const { queryByTestId } = render(
-        <MoneyBalanceSummary apy={4} displayState={unavailableState} />,
+        <MoneyBalanceSummary apy={4} displayState={unavailableState()} />,
       );
 
       expect(
@@ -321,21 +233,19 @@ describe('MoneyBalanceSummary', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('hides the APY row', () => {
-      const { queryByTestId } = render(
+    it('keeps the APY row visible', () => {
+      const { getByTestId } = render(
         <MoneyBalanceSummary
           apy={4}
-          displayState={unavailableState}
+          displayState={unavailableState('$2,384.34')}
           onApyInfoPress={jest.fn()}
         />,
       );
 
+      expect(getByTestId(MoneyBalanceSummaryTestIds.APY)).toBeOnTheScreen();
       expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.APY),
-      ).not.toBeOnTheScreen();
-      expect(
-        queryByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
-      ).not.toBeOnTheScreen();
+        getByTestId(MoneyBalanceSummaryTestIds.APY_INFO_BUTTON),
+      ).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.testIds.ts
@@ -1,10 +1,8 @@
 export const MoneyBalanceSummaryTestIds = {
   CONTAINER: 'money-balance-summary-container',
   BALANCE: 'money-balance-summary-balance',
-  BALANCE_SKELETON: 'money-balance-summary-balance-skeleton',
   BALANCE_NO_ACCOUNT: 'money-balance-summary-balance-no-account',
   BALANCE_UNAVAILABLE: 'money-balance-summary-balance-unavailable',
   APY: 'money-balance-summary-apy',
   APY_INFO_BUTTON: 'money-balance-summary-apy-info-button',
-  APY_SKELETON: 'money-balance-summary-apy-skeleton',
 } as const;

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.testIds.ts
@@ -2,8 +2,6 @@ export const MoneyBalanceSummaryTestIds = {
   CONTAINER: 'money-balance-summary-container',
   BALANCE: 'money-balance-summary-balance',
   BALANCE_SKELETON: 'money-balance-summary-balance-skeleton',
-  BALANCE_ERROR: 'money-balance-summary-balance-error',
-  BALANCE_RETRY: 'money-balance-summary-balance-retry',
   BALANCE_NO_ACCOUNT: 'money-balance-summary-balance-no-account',
   BALANCE_UNAVAILABLE: 'money-balance-summary-balance-unavailable',
   APY: 'money-balance-summary-apy',

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
@@ -45,10 +45,13 @@ const MoneyBalanceSummary = ({
   apy,
   onApyInfoPress,
 }: MoneyBalanceSummaryProps) => {
-  const showApy = displayState.kind === 'balance';
+  // APY + mUSD label stays visible alongside the balance and in the
+  // unavailable states (dash / last known figure), but not while loading.
+  const showApy =
+    displayState.kind === 'balance' || displayState.kind === 'unavailable';
 
   const renderApySlot = () => {
-    if (displayState.kind === 'loading' || displayState.kind === 'retrying') {
+    if (displayState.kind === 'loading') {
       return (
         <Skeleton
           height={24}
@@ -78,7 +81,7 @@ const MoneyBalanceSummary = ({
             {strings('money.apy_currency_suffix')}
           </Text>
         </Text>
-        {onApyInfoPress && displayState.kind === 'balance' && (
+        {onApyInfoPress && (
           <ButtonIcon
             iconName={IconName.Info}
             iconProps={{ color: IconColor.IconAlternative, size: IconSize.Sm }}
@@ -96,32 +99,6 @@ const MoneyBalanceSummary = ({
     switch (displayState.kind) {
       case 'loading':
         return <BalanceSkeleton />;
-      case 'retrying':
-        return <BalanceSkeleton />;
-      case 'error':
-        return (
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            twClassName="mb-2 gap-2"
-            testID={MoneyBalanceSummaryTestIds.BALANCE_ERROR}
-          >
-            <Text
-              variant={TextVariant.BodyLg}
-              color={TextColor.TextAlternative}
-            >
-              {strings('money.balance_unavailable')}
-            </Text>
-            <ButtonIcon
-              iconName={IconName.Refresh}
-              iconProps={{ color: IconColor.InfoDefault, size: IconSize.Lg }}
-              size={ButtonIconSize.Sm}
-              onPress={displayState.onRetry}
-              accessibilityLabel={strings('money.balance_retry')}
-              testID={MoneyBalanceSummaryTestIds.BALANCE_RETRY}
-            />
-          </Box>
-        );
       case 'balance':
         return (
           <Text
@@ -145,14 +122,18 @@ const MoneyBalanceSummary = ({
           </Text>
         );
       case 'unavailable':
+        // A previously cached balance renders as a muted "last known" figure;
+        // with no cache the slot shows a dash. Both pair with the BannerAlert.
         return (
           <Text
-            variant={TextVariant.BodyLg}
+            variant={TextVariant.DisplayLg}
+            fontWeight={FontWeight.Bold}
             color={TextColor.TextAlternative}
             testID={MoneyBalanceSummaryTestIds.BALANCE_UNAVAILABLE}
             twClassName="mb-2"
           >
-            {strings('money.balance_unavailable')}
+            {displayState.lastKnownValue ??
+              strings('money.balance_unavailable_value')}
           </Text>
         );
       default:

--- a/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceSummary/MoneyBalanceSummary.tsx
@@ -9,7 +9,6 @@ import {
   IconColor,
   IconName,
   IconSize,
-  Skeleton,
   Text,
   TextColor,
   TextVariant,
@@ -31,36 +30,17 @@ interface MoneyBalanceSummaryProps {
   onApyInfoPress?: () => void;
 }
 
-const BalanceSkeleton = () => (
-  <Skeleton
-    height={48}
-    width={160}
-    twClassName="mb-2 rounded-md"
-    testID={MoneyBalanceSummaryTestIds.BALANCE_SKELETON}
-  />
-);
-
 const MoneyBalanceSummary = ({
   displayState,
   apy,
   onApyInfoPress,
 }: MoneyBalanceSummaryProps) => {
   // APY + mUSD label stays visible alongside the balance and in the
-  // unavailable states (dash / last known figure), but not while loading.
+  // unavailable states (dash / last known figure).
   const showApy =
     displayState.kind === 'balance' || displayState.kind === 'unavailable';
 
   const renderApySlot = () => {
-    if (displayState.kind === 'loading') {
-      return (
-        <Skeleton
-          height={24}
-          width={94}
-          twClassName="rounded-md"
-          testID={MoneyBalanceSummaryTestIds.APY_SKELETON}
-        />
-      );
-    }
     if (!showApy || !isPositiveNumberOrZero(apy)) {
       return null;
     }
@@ -97,8 +77,6 @@ const MoneyBalanceSummary = ({
 
   const renderBalanceSlot = () => {
     switch (displayState.kind) {
-      case 'loading':
-        return <BalanceSkeleton />;
       case 'balance':
         return (
           <Text

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import MoneyMetaMaskCard from './MoneyMetaMaskCard';
 import { MoneyMetaMaskCardTestIds } from './MoneyMetaMaskCard.testIds';
@@ -410,6 +411,25 @@ describe('MoneyMetaMaskCard', () => {
       expect(
         getByTestId(MoneyMetaMaskCardTestIds.MANAGE_BALANCE),
       ).toHaveTextContent('$2,342.86');
+    });
+
+    it('renders the available balance muted when the balance is stale', () => {
+      const { getByTestId, rerender } = render(
+        <MoneyMetaMaskCard {...props} />,
+      );
+      const balanceColor = () =>
+        StyleSheet.flatten(
+          getByTestId(MoneyMetaMaskCardTestIds.MANAGE_BALANCE).props.style,
+        ).color;
+      const defaultColor = balanceColor();
+
+      rerender(<MoneyMetaMaskCard {...props} isBalanceStale />);
+
+      expect(
+        getByTestId(MoneyMetaMaskCardTestIds.MANAGE_BALANCE),
+      ).toHaveTextContent('$2,342.86');
+      expect(balanceColor()).toBeDefined();
+      expect(balanceColor()).not.toBe(defaultColor);
     });
 
     it('calls onManagePress when Manage is tapped', () => {

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
@@ -57,6 +57,11 @@ interface MoneyMetaMaskCardProps {
   /** User's available card balance (manage mode only). */
   cardBalance?: string;
   /**
+   * When true, the real-time balance could not be retrieved, so the available
+   * balance is the last known value and is rendered muted (manage mode only).
+   */
+  isBalanceStale?: boolean;
+  /**
    * Live vault APY used to interpolate the link-mode subtitle and the APY
    * bullet. When `undefined`, the component falls back to APY-less copy
    * (drops the APY clause from the subtitle and omits the APY bullet).
@@ -231,6 +236,7 @@ const ManageRow = ({
   imageSource,
   title,
   subtitle,
+  isBalanceStale = false,
   cashbackPercentage,
   ctaLabel,
   onPress,
@@ -241,6 +247,7 @@ const ManageRow = ({
   imageSource: ImageSourcePropType;
   title: string;
   subtitle?: string;
+  isBalanceStale?: boolean;
   cashbackPercentage: string;
   ctaLabel: string;
   onPress: () => void;
@@ -270,6 +277,11 @@ const ManageRow = ({
             <Text
               variant={TextVariant.BodyMd}
               fontWeight={FontWeight.Medium}
+              color={
+                isBalanceStale
+                  ? TextColor.TextAlternative
+                  : TextColor.TextDefault
+              }
               testID={subtitleTestID}
             >
               {subtitle}
@@ -296,10 +308,12 @@ const ManageRow = ({
 
 const ManageContent = ({
   cardBalance,
+  isBalanceStale,
   onManagePress,
   showMetalCard,
 }: {
   cardBalance: string;
+  isBalanceStale: boolean;
   onManagePress: () => void;
   showMetalCard: boolean;
 }) => (
@@ -308,6 +322,7 @@ const ManageContent = ({
       imageSource={showMetalCard ? mmCardMetal : mmCardRegular}
       title={strings('money.metamask_card.avail_balance')}
       subtitle={cardBalance}
+      isBalanceStale={isBalanceStale}
       cashbackPercentage={showMetalCard ? '3' : '1'}
       ctaLabel={strings('money.metamask_card.manage_card')}
       onPress={onManagePress}
@@ -327,6 +342,7 @@ const MoneyMetaMaskCard = ({
   showMetalCard = false,
   isLinkDisabled = false,
   cardBalance,
+  isBalanceStale = false,
   apy,
   hideCardImage = false,
   analyticsScreen,
@@ -442,6 +458,7 @@ const MoneyMetaMaskCard = ({
     content = (
       <ManageContent
         cardBalance={cardBalance ?? ''}
+        isBalanceStale={isBalanceStale}
         onManagePress={handleManagePress}
         showMetalCard={showMetalCard}
       />

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -297,6 +297,43 @@ describe('useMoneyAccountBalance', () => {
     expect(result.current.totalFiatRaw).toBeUndefined();
   });
 
+  it('returns $0.00 (not unavailable) when the balance is zero and the rate is missing', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectPrimaryMoneyAccount) {
+        return { address: MOCK_ADDRESS };
+      }
+      if (selector === selectTokenMarketData) {
+        // No price data available → musdFiatRate cannot be computed.
+        return {};
+      }
+      if (selector === selectCurrencyRates) {
+        return MOCK_CURRENCY_RATES;
+      }
+      if (selector === selectNetworkConfigurations) {
+        return MOCK_NETWORK_CONFIGURATIONS;
+      }
+      if (selector === selectCurrentCurrency) {
+        return 'usd';
+      }
+      return undefined;
+    });
+    mockUseQueries.mockReturnValue(
+      makeQueryResults({
+        musdBalance: { data: { balance: '0' }, isLoading: false },
+        musdEquivalentBalance: {
+          data: { balanceOfInAssets: '0' },
+          isLoading: false,
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => useMoneyAccountBalance());
+
+    expect(result.current.totalFiatFormatted).toBe('$0.00');
+    expect(result.current.totalFiatRaw).toBe('0');
+    expect(result.current.isBalanceUnavailable).toBe(false);
+  });
+
   it('returns formatted total fiat when all data is available', () => {
     // musdFiatRate = price(0.0005) * conversionRate(2000) = 1.0
     // musd balance 1 * 1.0 = $1.00, musdSHFvd balance 2 * 1.0 = $2.00, total = $3.00

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.test.ts
@@ -4,6 +4,10 @@ import { useQueries } from '@tanstack/react-query';
 import useMoneyAccountBalance, {
   getLiveVedaVaultExchangeRate,
 } from './useMoneyAccountBalance';
+import {
+  selectLastKnownMoneyBalance,
+  setLastKnownMoneyBalance,
+} from '../../../../core/redux/slices/moneyBalance';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
 import {
@@ -13,9 +17,11 @@ import {
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
 import Engine from '../../../../core/Engine';
 
+const mockDispatch = jest.fn();
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
+  useDispatch: () => mockDispatch,
 }));
 
 jest.mock('@tanstack/react-query', () => ({
@@ -77,7 +83,16 @@ const MOCK_NETWORK_CONFIGURATIONS = {
   [MAINNET_CHAIN_ID]: { nativeCurrency: 'ETH' },
 };
 
-function setupDefaultSelectors() {
+function setupDefaultSelectors({
+  lastKnownBalance = null,
+}: {
+  lastKnownBalance?: {
+    address: string;
+    value: string;
+    currency: string;
+    updatedAt: number;
+  } | null;
+} = {}) {
   mockUseSelector.mockImplementation((selector) => {
     if (selector === selectPrimaryMoneyAccount) {
       return { address: MOCK_ADDRESS };
@@ -93,6 +108,9 @@ function setupDefaultSelectors() {
     }
     if (selector === selectCurrentCurrency) {
       return 'usd';
+    }
+    if (selector === selectLastKnownMoneyBalance) {
+      return lastKnownBalance;
     }
     return undefined;
   });
@@ -485,6 +503,87 @@ describe('useMoneyAccountBalance', () => {
 
       expect(mockMusdRefetch).toHaveBeenCalledTimes(1);
       expect(mockEquivalentRefetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('last known balance', () => {
+    const persistedBalance = {
+      address: MOCK_ADDRESS,
+      value: '$2,384.34',
+      currency: 'usd',
+      updatedAt: 1,
+    };
+
+    it('isBalanceUnavailable is false on a successful fetch', () => {
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.isBalanceUnavailable).toBe(false);
+    });
+
+    it('isBalanceUnavailable is true on a balance fetch error', () => {
+      mockUseQueries.mockReturnValue(
+        makeQueryResults({
+          musdBalance: { data: undefined, isLoading: false, isError: true },
+        }),
+      );
+
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.isBalanceUnavailable).toBe(true);
+    });
+
+    it('persists the balance on a successful fetch', () => {
+      renderHook(() => useMoneyAccountBalance());
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: setLastKnownMoneyBalance.type,
+          payload: expect.objectContaining({
+            address: MOCK_ADDRESS,
+            currency: 'usd',
+          }),
+        }),
+      );
+    });
+
+    it('does not persist the balance on a fetch error', () => {
+      mockUseQueries.mockReturnValue(
+        makeQueryResults({
+          musdBalance: { data: undefined, isLoading: false, isError: true },
+        }),
+      );
+
+      renderHook(() => useMoneyAccountBalance());
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('exposes the persisted balance when it matches the account and currency', () => {
+      setupDefaultSelectors({ lastKnownBalance: persistedBalance });
+
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.lastKnownTotalFiatFormatted).toBe('$2,384.34');
+    });
+
+    it('ignores a persisted balance from a different currency', () => {
+      setupDefaultSelectors({
+        lastKnownBalance: { ...persistedBalance, currency: 'eur' },
+      });
+
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.lastKnownTotalFiatFormatted).toBeUndefined();
+    });
+
+    it('ignores a persisted balance from a different account', () => {
+      setupDefaultSelectors({
+        lastKnownBalance: { ...persistedBalance, address: '0xother' },
+      });
+
+      const { result } = renderHook(() => useMoneyAccountBalance());
+
+      expect(result.current.lastKnownTotalFiatFormatted).toBeUndefined();
     });
   });
 });

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -1,5 +1,5 @@
-import { useSelector } from 'react-redux';
-import { useMemo, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useEffect, useMemo, useCallback } from 'react';
 import {
   type MusdEquivalentValueResponse,
   NormalizedVaultApyResponse,
@@ -23,6 +23,11 @@ import { toChecksumAddress } from '../../../../util/address';
 import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
 import Engine from '../../../../core/Engine';
 import useMoneyAccountInfo from './useMoneyAccountInfo';
+import {
+  isPersistedMoneyBalanceUsable,
+  selectLastKnownMoneyBalance,
+  setLastKnownMoneyBalance,
+} from '../../../../core/redux/slices/moneyBalance';
 
 const DEFAULT_REFETCH_INTERVAL = 30 * 1000; // 30 seconds
 
@@ -46,6 +51,7 @@ export const getLiveVedaVaultExchangeRate = async () =>
 const useMoneyAccountBalance = (
   refetchInterval: number = DEFAULT_REFETCH_INTERVAL,
 ) => {
+  const dispatch = useDispatch();
   const { primaryMoneyAccount } = useMoneyAccountInfo();
   const moneyAccountAddress = primaryMoneyAccount?.address;
 
@@ -53,6 +59,7 @@ const useMoneyAccountBalance = (
   const currencyRates = useSelector(selectCurrencyRates);
   const networkConfigurations = useSelector(selectNetworkConfigurations);
   const currentCurrency = useSelector(selectCurrentCurrency);
+  const lastKnownBalance = useSelector(selectLastKnownMoneyBalance);
 
   const [musdBalanceQuery, vaultApyQuery, musdEquivalentBalanceQuery] =
     useQueries({
@@ -222,6 +229,49 @@ const useMoneyAccountBalance = (
   const totalFiatRaw =
     !isBalanceFetchError && totalFiat ? totalFiat.toString() : undefined;
 
+  // Persist every successful balance so it can be shown as the "last known"
+  // figure (for the current account/currency) the next time the live balance
+  // is unavailable — including after an app restart.
+  useEffect(() => {
+    if (
+      moneyAccountAddress &&
+      !isBalanceFetchError &&
+      !isAggregatedBalanceLoading &&
+      totalFiatFormatted !== undefined
+    ) {
+      dispatch(
+        setLastKnownMoneyBalance({
+          address: moneyAccountAddress,
+          value: totalFiatFormatted,
+          currency: currentCurrency,
+          updatedAt: Date.now(),
+        }),
+      );
+    }
+  }, [
+    dispatch,
+    moneyAccountAddress,
+    isBalanceFetchError,
+    isAggregatedBalanceLoading,
+    totalFiatFormatted,
+    currentCurrency,
+  ]);
+
+  // True whenever the live balance cannot be shown — a fetch error or a
+  // missing formatting dependency once loading has settled.
+  const isBalanceUnavailable =
+    isBalanceFetchError ||
+    (!isAggregatedBalanceLoading && totalFiatFormatted === undefined);
+
+  // Last successfully fetched balance, but only when it still matches the
+  // account and currency in view; otherwise it would be misleading.
+  const lastKnownTotalFiatFormatted = isPersistedMoneyBalanceUsable(
+    lastKnownBalance,
+    { address: moneyAccountAddress, currency: currentCurrency },
+  )
+    ? lastKnownBalance.value
+    : undefined;
+
   const rawApy = vaultApyQuery.data?.apy;
 
   const apyDecimal = rawApy;
@@ -236,6 +286,8 @@ const useMoneyAccountBalance = (
     isAggregatedBalanceLoading,
     isBalanceFetchError,
     isBalanceFetching,
+    isBalanceUnavailable,
+    lastKnownTotalFiatFormatted,
     refetchBalance,
     musdFiatFormatted,
     musdSHFvdFiatFormatted,

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -175,15 +175,19 @@ const useMoneyAccountBalance = (
           : musdSHFvdDecimal;
 
       if (!musdFiatRate) {
+        // Undefined during loading or error so callers can distinguish from a genuine zero.
+        const settledTokenTotal =
+          isAggregatedBalanceLoading || isBalanceFetchError
+            ? undefined
+            : musdDecimal.plus(musdSHFvdDecimal);
         return {
           musdFiat: undefined,
           musdSHFvdFiat: undefined,
-          // Undefined during loading or error so callers can distinguish from a genuine zero.
-          tokenTotal:
-            isAggregatedBalanceLoading || isBalanceFetchError
-              ? undefined
-              : musdDecimal.plus(musdSHFvdDecimal),
-          totalFiat: undefined,
+          tokenTotal: settledTokenTotal,
+          // A zero balance is $0.00 regardless of the missing rate — 0 tokens
+          // convert to 0 fiat without one. Only a non-zero balance is genuinely
+          // unavailable when there's no rate to convert it.
+          totalFiat: settledTokenTotal?.isZero() ? new BigNumber(0) : undefined,
           withdrawableMusd: computedWithdrawableMusd,
         };
       }
@@ -257,11 +261,9 @@ const useMoneyAccountBalance = (
     currentCurrency,
   ]);
 
-  // True whenever the live balance cannot be shown — a fetch error or a
-  // missing formatting dependency once loading has settled.
-  const isBalanceUnavailable =
-    isBalanceFetchError ||
-    (!isAggregatedBalanceLoading && totalFiatFormatted === undefined);
+  // True whenever there is no fresh balance to show — still loading, a fetch
+  // error, or a missing formatting dependency (e.g. rate not ready).
+  const isBalanceUnavailable = totalFiatFormatted === undefined;
 
   // Last successfully fetched balance, but only when it still matches the
   // account and currency in view; otherwise it would be misleading.

--- a/app/components/UI/Money/types.ts
+++ b/app/components/UI/Money/types.ts
@@ -3,17 +3,16 @@
  * Exactly one kind is active at a time.
  *
  * Precedence (highest → lowest):
- * noAccount > balance > loading > unavailable
+ * noAccount > balance > unavailable
  *
- * `unavailable` covers any case where the live balance cannot be shown — a
- * fetch error or a missing dependency required to format the fiat balance
- * (e.g. `musdFiatRate`). When a previously fetched balance is cached for the
- * current account it is carried in `lastKnownValue` and rendered as a muted
- * "last known" figure; otherwise the slot shows a dash. A BannerAlert
+ * `unavailable` covers any case where a fresh balance cannot be shown — still
+ * loading, a fetch error, or a missing dependency required to format the fiat
+ * balance (e.g. `musdFiatRate`). When a previously fetched balance is cached
+ * for the current account it is carried in `lastKnownValue` and rendered as a
+ * muted "last known" figure; otherwise the slot shows a dash. A BannerAlert
  * accompanies this state at the view layer.
  */
 export type MoneyBalanceDisplayState =
   | { kind: 'noAccount' }
-  | { kind: 'loading' }
   | { kind: 'unavailable'; lastKnownValue?: string }
   | { kind: 'balance'; value: string };

--- a/app/components/UI/Money/types.ts
+++ b/app/components/UI/Money/types.ts
@@ -3,18 +3,17 @@
  * Exactly one kind is active at a time.
  *
  * Precedence (highest → lowest):
- * noAccount > error > retrying > loading > unavailable > balance
+ * noAccount > balance > loading > unavailable
  *
- * `unavailable` covers the case where balance queries succeeded but a
- * dependency required to render the fiat balance (e.g. `musdFiatRate`)
- * is missing. Distinct from `error` because no actionable retry exists
- * at the view layer — token market data / currency rates are owned by
- * their respective controllers and hydrate on their own tick.
+ * `unavailable` covers any case where the live balance cannot be shown — a
+ * fetch error or a missing dependency required to format the fiat balance
+ * (e.g. `musdFiatRate`). When a previously fetched balance is cached for the
+ * current account it is carried in `lastKnownValue` and rendered as a muted
+ * "last known" figure; otherwise the slot shows a dash. A BannerAlert
+ * accompanies this state at the view layer.
  */
 export type MoneyBalanceDisplayState =
   | { kind: 'noAccount' }
-  | { kind: 'error'; onRetry: () => void }
-  | { kind: 'retrying' }
   | { kind: 'loading' }
-  | { kind: 'unavailable' }
+  | { kind: 'unavailable'; lastKnownValue?: string }
   | { kind: 'balance'; value: string };

--- a/app/core/redux/slices/moneyBalance/index.test.ts
+++ b/app/core/redux/slices/moneyBalance/index.test.ts
@@ -1,0 +1,83 @@
+import reducer, {
+  initialState,
+  setLastKnownMoneyBalance,
+  clearLastKnownMoneyBalance,
+  selectLastKnownMoneyBalance,
+  isPersistedMoneyBalanceUsable,
+  PersistedMoneyBalance,
+  MoneyBalanceSliceState,
+} from '.';
+import { RootState } from '../../../../reducers';
+
+const balance: PersistedMoneyBalance = {
+  address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+  value: '$2,384.34',
+  currency: 'usd',
+  updatedAt: 1700000000000,
+};
+
+describe('moneyBalance slice', () => {
+  it('returns the initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual(initialState);
+    expect(initialState.lastKnownBalance).toBeNull();
+  });
+
+  it('setLastKnownMoneyBalance stores the balance', () => {
+    const state = reducer(initialState, setLastKnownMoneyBalance(balance));
+
+    expect(state.lastKnownBalance).toEqual(balance);
+  });
+
+  it('clearLastKnownMoneyBalance resets the balance to null', () => {
+    const populated: MoneyBalanceSliceState = { lastKnownBalance: balance };
+
+    const state = reducer(populated, clearLastKnownMoneyBalance());
+
+    expect(state.lastKnownBalance).toBeNull();
+  });
+
+  it('selectLastKnownMoneyBalance returns the stored balance', () => {
+    const state = {
+      moneyBalance: { lastKnownBalance: balance },
+    } as unknown as RootState;
+
+    expect(selectLastKnownMoneyBalance(state)).toEqual(balance);
+  });
+
+  describe('isPersistedMoneyBalanceUsable', () => {
+    const target = { address: balance.address, currency: 'usd' };
+
+    it('is true when address and currency match', () => {
+      expect(isPersistedMoneyBalanceUsable(balance, target)).toBe(true);
+    });
+
+    it('is false when there is no persisted balance', () => {
+      expect(isPersistedMoneyBalanceUsable(null, target)).toBe(false);
+      expect(isPersistedMoneyBalanceUsable(undefined, target)).toBe(false);
+    });
+
+    it('is false when the address differs', () => {
+      expect(
+        isPersistedMoneyBalanceUsable(balance, {
+          ...target,
+          address: '0xdifferent',
+        }),
+      ).toBe(false);
+    });
+
+    it('is false when the currency differs', () => {
+      expect(
+        isPersistedMoneyBalanceUsable(balance, { ...target, currency: 'eur' }),
+      ).toBe(false);
+    });
+
+    it('is false when no account address is in view', () => {
+      expect(
+        isPersistedMoneyBalanceUsable(balance, {
+          address: undefined,
+          currency: 'usd',
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/app/core/redux/slices/moneyBalance/index.ts
+++ b/app/core/redux/slices/moneyBalance/index.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
 import { RootState } from '../../../../reducers';
+import { areAddressesEqual } from '../../../../util/address';
 
 export interface PersistedMoneyBalance {
   /** Money account address this balance belongs to. */
@@ -62,7 +63,7 @@ export const isPersistedMoneyBalanceUsable = (
 ): persisted is PersistedMoneyBalance =>
   Boolean(persisted) &&
   Boolean(address) &&
-  persisted?.address === address &&
+  areAddressesEqual(persisted?.address ?? '', address ?? '') &&
   persisted?.currency === currency;
 
 export const { setLastKnownMoneyBalance, clearLastKnownMoneyBalance } = actions;

--- a/app/core/redux/slices/moneyBalance/index.ts
+++ b/app/core/redux/slices/moneyBalance/index.ts
@@ -1,0 +1,68 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSelector } from 'reselect';
+import { RootState } from '../../../../reducers';
+
+export interface PersistedMoneyBalance {
+  /** Money account address this balance belongs to. */
+  address: string;
+  /** Formatted fiat balance, e.g. "$2,384.34". */
+  value: string;
+  /** Currency code the value was formatted in, e.g. "USD". */
+  currency: string;
+  /** Epoch milliseconds when the balance was last successfully fetched. */
+  updatedAt: number;
+}
+
+export interface MoneyBalanceSliceState {
+  lastKnownBalance: PersistedMoneyBalance | null;
+}
+
+export const initialState: MoneyBalanceSliceState = {
+  lastKnownBalance: null,
+};
+
+const name = 'moneyBalance';
+
+const slice = createSlice({
+  name,
+  initialState,
+  reducers: {
+    setLastKnownMoneyBalance: (
+      state,
+      action: PayloadAction<PersistedMoneyBalance>,
+    ) => {
+      state.lastKnownBalance = action.payload;
+    },
+    clearLastKnownMoneyBalance: (state) => {
+      state.lastKnownBalance = null;
+    },
+  },
+});
+
+const { actions, reducer } = slice;
+
+export default reducer;
+
+const selectMoneyBalanceState = (state: RootState) => state[name];
+
+export const selectLastKnownMoneyBalance = createSelector(
+  selectMoneyBalanceState,
+  (moneyBalance) => moneyBalance.lastKnownBalance,
+);
+
+/**
+ * A persisted balance is only safe to show as the "last known" figure when it
+ * belongs to the account currently in view and was formatted in the currency
+ * currently selected — otherwise the figure would be stale in a misleading way
+ * (wrong account) or numerically wrong (different currency conversion).
+ */
+export const isPersistedMoneyBalanceUsable = (
+  persisted: PersistedMoneyBalance | null | undefined,
+  { address, currency }: { address?: string; currency: string },
+): persisted is PersistedMoneyBalance =>
+  Boolean(persisted) &&
+  Boolean(address) &&
+  persisted?.address === address &&
+  persisted?.currency === currency;
+
+export const { setLastKnownMoneyBalance, clearLastKnownMoneyBalance } = actions;

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -42,6 +42,7 @@ import performanceReducer, {
 import sampleCounterReducer from '../features/SampleFeature/reducers/sample-counter';
 ///: END:ONLY_INCLUDE_IF
 import cardReducer from '../core/redux/slices/card';
+import moneyBalanceReducer from '../core/redux/slices/moneyBalance';
 import rewardsReducer, { RewardsState } from './rewards';
 import { isTestEnvironment } from '../util/test/utils';
 import attributionReducer from '../core/redux/slices/attribution';
@@ -126,6 +127,7 @@ export interface RootState {
   qrKeyringScanner: StateFromReducer<typeof qrKeyringScannerReducer>;
   banners: BannersState;
   card: StateFromReducer<typeof cardReducer>;
+  moneyBalance: StateFromReducer<typeof moneyBalanceReducer>;
   performance?: PerformanceState;
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   sampleCounter: StateFromReducer<typeof sampleCounterReducer>;
@@ -168,6 +170,7 @@ const baseReducers = {
   bridge: bridgeReducer,
   banners: bannersReducer,
   card: cardReducer,
+  moneyBalance: moneyBalanceReducer,
   confirmationMetrics: confirmationMetricsReducer,
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   sampleCounter: sampleCounterReducer,

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -8,6 +8,7 @@ import { initialState as originThrottling } from '../../core/redux/slices/origin
 import { initialState as initialBridgeState } from '../../core/redux/slices/bridge';
 import { initialState as initialQrKeyringScannerState } from '../../core/redux/slices/qrKeyringScanner';
 import { initialState as initialCardState } from '../../core/redux/slices/card';
+import { initialState as initialMoneyBalanceState } from '../../core/redux/slices/moneyBalance';
 import initialBackgroundState from './initial-background-state.json';
 import { userInitialState } from '../../reducers/user';
 import { initialNavigationState } from '../../reducers/navigation';
@@ -74,6 +75,7 @@ const initialRootState: RootState = {
   },
   sampleCounter: initialSampleCounterState,
   card: initialCardState,
+  moneyBalance: initialMoneyBalanceState,
   rewards: initialRewardsState,
   networkConnectionBanner: initialNetworkConnectionBannerState,
   attribution: {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6906,6 +6906,8 @@
     "apy_currency_suffix": " • mUSD",
     "apy_info_label": "APY info",
     "balance_unavailable": "Balance unavailable",
+    "balance_unavailable_value": "$—",
+    "balance_unavailable_banner_description": "We’re temporarily unable to display your balance. Your funds are safe—please try again shortly.",
     "balance_retry": "Retry",
     "balance_no_account": "Money account not found",
     "onboarding": {


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When the Money Account balance can't be fetched (connectivity or data-loading issue), Money Home now communicates this clearly instead of silently dropping the balance.

A Warning `BannerAlert` is shown above the balance whenever the live balance is unavailable, and is hidden again as soon as the balance loads successfully. The balance slot itself handles two cases:

- **No cached balance** — the balance renders as a dash (`$—`).
- **Cached balance available** — the last known balance is shown, rendered muted to signal it may be stale.

The last successfully fetched balance is persisted (Redux + redux-persist), keyed by account address and currency, so it survives an app restart and is only reused when it still matches the account and currency currently in view. The APY • mUSD label stays visible in both unavailable states.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Money Home handling for unavailable balances — a banner now appears and the last known balance (or a dash) is shown until the balance loads again.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-961

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Home balance unavailable states

  Scenario: balance unavailable with no cached balance
    Given the user has a Money account
    And no balance has been successfully fetched before
    When the balance fetch fails
    Then a "Balance unavailable" banner is shown above the balance
    And the balance is displayed as a dash ($—)
    And the APY • mUSD label remains visible

  Scenario: balance unavailable with a cached balance
    Given the user has previously seen their balance
    When the balance fetch fails (including after an app restart)
    Then a "Balance unavailable" banner is shown above the balance
    And the last known balance is displayed in a muted style

  Scenario: balance recovers
    Given the balance was unavailable
    When the balance fetch succeeds
    Then the banner is dismissed
    And the balance is displayed as normal
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/aed2a0ca-3e97-4215-a526-c97276623c08

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
