### PR TITLE
fix(card): gate MM Card <> Money account linking on VERIFIED status for authenticated Card users

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -6298,7 +6298,6 @@ describe('CardHome Component', () => {
       mockUseMoneyAccountCardLinkage.mockReturnValue({
         hasMoneyAccountRequirements: true,
         isCardAuthenticated: true,
-        isCardVerified: true,
         primaryMoneyAccount: undefined,
         moneyAccountCardToken: null,
         canLink: true,

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -6298,6 +6298,7 @@ describe('CardHome Component', () => {
       mockUseMoneyAccountCardLinkage.mockReturnValue({
         hasMoneyAccountRequirements: true,
         isCardAuthenticated: true,
+        isCardVerified: true,
         primaryMoneyAccount: undefined,
         moneyAccountCardToken: null,
         canLink: true,

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -742,6 +742,25 @@ describe('useMoneyAccountCardLinkage', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
+    it.each(['idle', 'loading'] as const)(
+      'keeps the pending flag while card data is still %s and verification is unknown',
+      (cardHomeDataStatus) => {
+        applySelectorMocks(
+          buildSelectors({
+            pendingMoneyAccountCardLink: CardEntryPoint.MONEY_LINK_CARD_SHEET,
+            isCardVerified: false,
+            cardHomeDataStatus,
+          }),
+        );
+        renderLinkageHook();
+
+        expect(mockDispatch).not.toHaveBeenCalledWith(
+          setPendingMoneyAccountCardLink(null),
+        );
+        expect(mockNavigate).not.toHaveBeenCalled();
+      },
+    );
+
     it('opens the Link Card sheet and clears the flag when authenticated and canLink', () => {
       applySelectorMocks(
         buildSelectors({

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -11,6 +11,7 @@ import {
   selectCardDelegationSettings,
   selectCardHomeDataStatus,
   selectIsCardAuthenticated,
+  selectIsCardVerified,
   selectIsCardholder,
   selectIsMoneyAccountCardLinkInProgress,
   selectIsMoneyAccountDelegatedForCard,
@@ -158,6 +159,7 @@ const buildSelectors = (
     vaultConfig?: { chainId?: string } | undefined;
     isMoneyAccountEnabled?: boolean;
     isCardAuthenticated?: boolean;
+    isCardVerified?: boolean;
     isCardholder?: boolean;
     delegationSettings?: unknown;
     isAlreadyDelegated?: boolean;
@@ -173,6 +175,7 @@ const buildSelectors = (
   vaultConfig: { chainId: '0x8f' },
   isMoneyAccountEnabled: true,
   isCardAuthenticated: true,
+  isCardVerified: true,
   isCardholder: false,
   delegationSettings: { ok: true },
   isAlreadyDelegated: false,
@@ -214,6 +217,7 @@ const applySelectorMocks = (state: ReturnType<typeof buildSelectors>) => {
       return state.isMoneyAccountEnabled;
     if (selector === selectIsCardAuthenticated)
       return state.isCardAuthenticated;
+    if (selector === selectIsCardVerified) return state.isCardVerified;
     if (selector === selectIsCardholder) return state.isCardholder;
     if (selector === selectCardDelegationSettings)
       return state.delegationSettings;
@@ -288,6 +292,18 @@ describe('useMoneyAccountCardLinkage', () => {
       applySelectorMocks(buildSelectors({ isCardAuthenticated: false }));
       const { result } = renderLinkageHook();
       expect(result.current.canLink).toBe(false);
+    });
+
+    it('reports canLink=false when the card user is not VERIFIED', () => {
+      applySelectorMocks(buildSelectors({ isCardVerified: false }));
+      const { result } = renderLinkageHook();
+      expect(result.current.canLink).toBe(false);
+      expect(result.current.isCardVerified).toBe(false);
+    });
+
+    it('reports isCardVerified=true when verification status is VERIFIED', () => {
+      const { result } = renderLinkageHook();
+      expect(result.current.isCardVerified).toBe(true);
     });
 
     it('reports canLink=false when there is no Money account', () => {
@@ -544,6 +560,19 @@ describe('useMoneyAccountCardLinkage', () => {
       expect(mockShowToast).not.toHaveBeenCalled();
     });
 
+    it('no-ops when the user is authenticated but not VERIFIED', () => {
+      applySelectorMocks(buildSelectors({ isCardVerified: false }));
+      const { result } = renderLinkageHook();
+
+      act(() => {
+        result.current.startLinkFlow(ORIGIN);
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
     it('no-ops when the user is authenticated and the Money Account is already delegated', () => {
       applySelectorMocks(buildSelectors({ isAlreadyDelegated: true }));
       const { result } = renderLinkageHook();
@@ -698,6 +727,21 @@ describe('useMoneyAccountCardLinkage', () => {
   });
 
   describe('resume effect (pendingMoneyAccountCardLink)', () => {
+    it('clears the pending flag without opening the sheet when authenticated but not VERIFIED', () => {
+      applySelectorMocks(
+        buildSelectors({
+          pendingMoneyAccountCardLink: CardEntryPoint.MONEY_LINK_CARD_SHEET,
+          isCardVerified: false,
+        }),
+      );
+      renderLinkageHook();
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setPendingMoneyAccountCardLink(null),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
     it('opens the Link Card sheet and clears the flag when authenticated and canLink', () => {
       applySelectorMocks(
         buildSelectors({

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -33,6 +33,7 @@ import {
   selectCardDelegationSettings,
   selectCardHomeDataStatus,
   selectIsCardAuthenticated,
+  selectIsCardVerified,
   selectIsCardholder,
   selectIsMoneyAccountCardLinkInProgress,
   selectIsMoneyAccountDelegatedForCard,
@@ -79,6 +80,7 @@ export interface LinkFlowOrigin {
 export interface UseMoneyAccountCardLinkageReturn {
   hasMoneyAccountRequirements: boolean;
   isCardAuthenticated: boolean;
+  isCardVerified: boolean;
   isCardLinkedToMoneyAccount: boolean;
   primaryMoneyAccount: MoneyAccount | undefined;
   moneyAccountCardToken: CardFundingToken | null;
@@ -119,6 +121,7 @@ export const useMoneyAccountCardLinkage =
       selectMoneyEnableMoneyAccountFlag,
     );
     const isCardAuthenticated = useSelector(selectIsCardAuthenticated);
+    const isCardVerified = useSelector(selectIsCardVerified);
     const isCardholder = useSelector(selectIsCardholder);
     const delegationSettings = useSelector(selectCardDelegationSettings);
     const vedaConfig = useSelector(selectMoneyAccountVedaTokenConfig);
@@ -163,6 +166,7 @@ export const useMoneyAccountCardLinkage =
     const canSubmitDelegation = Boolean(
       hasRequirements &&
         isCardAuthenticated &&
+        isCardVerified &&
         moneyAccountCardToken &&
         isMonadSponsorshipEnabled,
     );
@@ -309,6 +313,10 @@ export const useMoneyAccountCardLinkage =
         }
 
         if (isCardAuthenticated) {
+          if (!isCardVerified) {
+            return;
+          }
+
           if (isAlreadyDelegated) {
             return;
           }
@@ -352,6 +360,7 @@ export const useMoneyAccountCardLinkage =
         moneyAccountCardToken,
         primaryMoneyAccount?.address,
         isCardAuthenticated,
+        isCardVerified,
         isAlreadyDelegated,
         isCardholder,
         openLinkCardSheet,
@@ -364,6 +373,11 @@ export const useMoneyAccountCardLinkage =
     useEffect(() => {
       if (!pendingMoneyAccountCardLinkEntryPoint) return;
       if (!isCardAuthenticated) return;
+
+      if (!isCardVerified) {
+        dispatch(setPendingMoneyAccountCardLink(null));
+        return;
+      }
 
       if (!hasRequirements || !primaryMoneyAccount?.address) {
         dispatch(setPendingMoneyAccountCardLink(null));
@@ -391,6 +405,7 @@ export const useMoneyAccountCardLinkage =
     }, [
       pendingMoneyAccountCardLinkEntryPoint,
       isCardAuthenticated,
+      isCardVerified,
       hasRequirements,
       moneyAccountCardToken,
       primaryMoneyAccount?.address,
@@ -524,6 +539,7 @@ export const useMoneyAccountCardLinkage =
     return {
       hasMoneyAccountRequirements: hasRequirements,
       isCardAuthenticated,
+      isCardVerified,
       isCardLinkedToMoneyAccount: isAlreadyDelegated,
       primaryMoneyAccount,
       moneyAccountCardToken,

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -375,7 +375,12 @@ export const useMoneyAccountCardLinkage =
       if (!isCardAuthenticated) return;
 
       if (!isCardVerified) {
-        dispatch(setPendingMoneyAccountCardLink(null));
+        if (
+          cardHomeDataStatus === 'success' ||
+          cardHomeDataStatus === 'error'
+        ) {
+          dispatch(setPendingMoneyAccountCardLink(null));
+        }
         return;
       }
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -173,6 +173,7 @@ jest.mock('../../../Card/hooks/useMoneyAccountCardLinkage', () => ({
   useMoneyAccountCardLinkage: jest.fn(() => ({
     hasMoneyAccountRequirements: false,
     isCardAuthenticated: false,
+    isCardVerified: false,
     isCardLinkedToMoneyAccount: false,
     primaryMoneyAccount: undefined,
     moneyAccountCardToken: null,
@@ -343,6 +344,7 @@ describe('MoneyHomeView', () => {
     mockUseMoneyAccountCardLinkage.mockReturnValue({
       hasMoneyAccountRequirements: false,
       isCardAuthenticated: false,
+      isCardVerified: false,
       isCardLinkedToMoneyAccount: false,
       primaryMoneyAccount: undefined,
       moneyAccountCardToken: null,
@@ -1434,6 +1436,7 @@ describe('MoneyHomeView', () => {
         mockUseMoneyAccountCardLinkage.mockReturnValue({
           hasMoneyAccountRequirements: true,
           isCardAuthenticated: true,
+          isCardVerified: true,
           isCardLinkedToMoneyAccount: false,
           primaryMoneyAccount: { address: '0xabc' },
           moneyAccountCardToken: { symbol: 'USDC' },
@@ -1947,11 +1950,12 @@ describe('MoneyHomeView', () => {
       ).toBeOnTheScreen();
     });
 
-    it('selects mode="link" when card-authenticated even if selected wallet is not a cardholder account', () => {
+    it('selects mode="link" when card-authenticated and VERIFIED even if selected wallet is not a cardholder account', () => {
       mockSelectIsCardholder.mockReturnValue(false);
       mockUseMoneyAccountCardLinkage.mockReturnValue({
         hasMoneyAccountRequirements: true,
         isCardAuthenticated: true,
+        isCardVerified: true,
         isCardLinkedToMoneyAccount: false,
         primaryMoneyAccount: { address: '0xabc' },
         moneyAccountCardToken: { symbol: 'USDC' },
@@ -1969,6 +1973,31 @@ describe('MoneyHomeView', () => {
       expect(
         getByTestId(MoneyMetaMaskCardTestIds.LINK_CONTAINER),
       ).toBeOnTheScreen();
+    });
+
+    it('hides the MetaMask Card section when authenticated but not VERIFIED', () => {
+      mockSelectIsCardholder.mockReturnValue(false);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: true,
+        isCardAuthenticated: true,
+        isCardVerified: false,
+        isCardLinkedToMoneyAccount: false,
+        primaryMoneyAccount: { address: '0xabc' },
+        moneyAccountCardToken: { symbol: 'USDC' },
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
+
+      const { queryByTestId } = renderWithProvider(<MoneyHomeView />);
+
+      expect(
+        queryByTestId(MoneyMetaMaskCardTestIds.CONTAINER),
+      ).not.toBeOnTheScreen();
     });
 
     it('disables the link button when linkage is in progress', () => {

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -158,6 +158,7 @@ const MoneyHomeView = () => {
   const {
     startLinkFlow,
     isCardAuthenticated,
+    isCardVerified,
     isCardLinkedToMoneyAccount,
     isLinking,
     hasMoneyAccountRequirements,
@@ -573,8 +574,10 @@ const MoneyHomeView = () => {
   let metamaskCardMode: 'upsell' | 'link' | 'manage' | null;
   if (isCardLinkedToMoneyAccount) {
     metamaskCardMode = 'manage';
-  } else if (isCardAuthenticated || isCardholder) {
+  } else if (isCardholder || (isCardAuthenticated && isCardVerified)) {
     metamaskCardMode = hasMoneyAccountRequirements ? 'link' : null;
+  } else if (isCardAuthenticated) {
+    metamaskCardMode = null;
   } else {
     metamaskCardMode = 'upsell';
   }

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -101,6 +101,7 @@ interface SetupOptions {
   currentStep?: number;
   isCardholder?: boolean;
   isCardAuthenticated?: boolean;
+  isCardVerified?: boolean;
   isCardLinkedToMoneyAccount?: boolean;
   isAggregatedBalanceLoading?: boolean;
   tokenTotal?: BigNumber;
@@ -110,6 +111,7 @@ const setupDefaultMocks = ({
   currentStep = 0,
   isCardholder = false,
   isCardAuthenticated = false,
+  isCardVerified = false,
   isCardLinkedToMoneyAccount = false,
   isAggregatedBalanceLoading = false,
   tokenTotal = new BigNumber(0),
@@ -129,6 +131,7 @@ const setupDefaultMocks = ({
   (mockUseMoneyAccountCardLinkage as jest.Mock).mockReturnValue({
     startLinkFlow: mockStartLinkFlow,
     isCardAuthenticated,
+    isCardVerified,
     isCardLinkedToMoneyAccount,
     isLinking: false,
   });
@@ -591,6 +594,26 @@ describe('MoneyOnboardingCard', () => {
     });
   });
 
+  describe('step 2 — authenticated but not VERIFIED', () => {
+    it('renders the no-card step instead of the link-card step', () => {
+      setupDefaultMocks({
+        currentStep: 1,
+        isCardAuthenticated: true,
+        isCardVerified: false,
+        isCardLinkedToMoneyAccount: false,
+      });
+
+      const { getByTestId } = render(<MoneyOnboardingCard />);
+
+      expect(getByTestId('money-onboarding-card-title')).toHaveTextContent(
+        strings('money.onboarding.step_2.no_card_account.title'),
+      );
+      expect(getByTestId('money-onboarding-card-cta-button')).toHaveTextContent(
+        strings('money.onboarding.step_2.no_card_account.cta_primary'),
+      );
+    });
+  });
+
   describe('steps memo guard — card hidden', () => {
     it('renders null and shows no step content when currentStep equals MONEY_ONBOARDING_TOTAL_STEPS', () => {
       setupDefaultMocks({ currentStep: MONEY_ONBOARDING_TOTAL_STEPS });
@@ -652,6 +675,7 @@ describe('MoneyOnboardingCard', () => {
     it('calls trackOnboardingEvent with LINK_CARD when CTA is pressed for authenticated but unlinked cardholder at step 2', () => {
       setupDefaultMocks({
         currentStep: 1,
+        isCardholder: true,
         isCardAuthenticated: true,
         isCardLinkedToMoneyAccount: false,
       });

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -57,6 +57,7 @@ const MoneyOnboardingCard = () => {
   const {
     startLinkFlow,
     isCardAuthenticated,
+    isCardVerified,
     isCardLinkedToMoneyAccount,
     isLinking,
   } = useMoneyAccountCardLinkage();
@@ -76,7 +77,8 @@ const MoneyOnboardingCard = () => {
   });
 
   const shouldShowLinkCardAction =
-    isCardholder || (isCardAuthenticated && !isCardLinkedToMoneyAccount);
+    isCardholder ||
+    (isCardAuthenticated && isCardVerified && !isCardLinkedToMoneyAccount);
 
   const handleRedirectToCryptoDeposit = useCallback(async () => {
     await initiateDeposit().catch(() => undefined);

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -385,7 +385,9 @@ describe('selectCardVerificationStatus', () => {
 
   it('returns null when account is missing', () => {
     const state = createMockRootState({
-      cardHomeData: { account: null } as unknown as CardHomeData,
+      cardHomeData: {
+        account: null,
+      } as unknown as CardControllerState['cardHomeData'],
     });
     expect(selectCardVerificationStatus(state)).toBeNull();
   });
@@ -394,7 +396,7 @@ describe('selectCardVerificationStatus', () => {
     const state = createMockRootState({
       cardHomeData: {
         account: { verificationStatus: 'PENDING' },
-      } as unknown as CardHomeData,
+      } as unknown as CardControllerState['cardHomeData'],
     });
     expect(selectCardVerificationStatus(state)).toBe('PENDING');
   });
@@ -405,7 +407,7 @@ describe('selectIsCardVerified', () => {
     const state = createMockRootState({
       cardHomeData: {
         account: { verificationStatus: 'VERIFIED' },
-      } as unknown as CardHomeData,
+      } as unknown as CardControllerState['cardHomeData'],
     });
     expect(selectIsCardVerified(state)).toBe(true);
   });
@@ -416,7 +418,7 @@ describe('selectIsCardVerified', () => {
       const state = createMockRootState({
         cardHomeData: {
           account: verificationStatus ? { verificationStatus } : null,
-        } as unknown as CardHomeData,
+        } as unknown as CardControllerState['cardHomeData'],
       });
       expect(selectIsCardVerified(state)).toBe(false);
     },

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -10,6 +10,8 @@ import {
   selectCardUserLocation,
   selectCardHomeData,
   selectCardHomeDataStatus,
+  selectCardVerificationStatus,
+  selectIsCardVerified,
   selectHasMetalCard,
   selectCardPrimaryToken,
   selectCardAvailableTokens,
@@ -372,6 +374,60 @@ describe('selectCardHomeData', () => {
       engine: { backgroundState: {} },
     } as unknown as RootState;
     expect(selectCardHomeData(state)).toBeNull();
+  });
+});
+
+describe('selectCardVerificationStatus', () => {
+  it('returns null when cardHomeData is missing', () => {
+    const state = createMockRootState();
+    expect(selectCardVerificationStatus(state)).toBeNull();
+  });
+
+  it('returns null when account is missing', () => {
+    const state = createMockRootState({
+      cardHomeData: { account: null } as unknown as CardHomeData,
+    });
+    expect(selectCardVerificationStatus(state)).toBeNull();
+  });
+
+  it('returns the account verification status when present', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        account: { verificationStatus: 'PENDING' },
+      } as unknown as CardHomeData,
+    });
+    expect(selectCardVerificationStatus(state)).toBe('PENDING');
+  });
+});
+
+describe('selectIsCardVerified', () => {
+  it('returns true only when verification status is VERIFIED', () => {
+    const state = createMockRootState({
+      cardHomeData: {
+        account: { verificationStatus: 'VERIFIED' },
+      } as unknown as CardHomeData,
+    });
+    expect(selectIsCardVerified(state)).toBe(true);
+  });
+
+  it.each(['PENDING', 'UNVERIFIED', 'REJECTED', null] as const)(
+    'returns false when verification status is %s',
+    (verificationStatus) => {
+      const state = createMockRootState({
+        cardHomeData: {
+          account: verificationStatus ? { verificationStatus } : null,
+        } as unknown as CardHomeData,
+      });
+      expect(selectIsCardVerified(state)).toBe(false);
+    },
+  );
+
+  it('returns false when cardHomeData is missing even if user is a cardholder', () => {
+    const state = createMockRootState({
+      cardholderAccounts: ['eip155:1:0xabc'],
+      cardHomeData: null,
+    });
+    expect(selectIsCardVerified(state)).toBe(false);
   });
 });
 

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -137,6 +137,21 @@ export const selectCardHomeData = createSelector(
     (cardState?.cardHomeData as unknown as CardHomeData | null) ?? null,
 );
 
+export const selectCardVerificationStatus = createSelector(
+  selectCardHomeData,
+  (data): string | null => data?.account?.verificationStatus ?? null,
+);
+
+/**
+ * Strict authenticated KYC gate: true only when the logged-in Card user's
+ * verification outcome is VERIFIED. Does not include the on-chain
+ * `isCardholder` signal (that drives CTA visibility, not link gating).
+ */
+export const selectIsCardVerified = createSelector(
+  selectCardVerificationStatus,
+  (status) => status === 'VERIFIED',
+);
+
 export const selectCardHomeDataStatus = createSelector(
   selectCardControllerState,
   (cardState: CardControllerState | undefined): CardHomeDataStatus =>

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -142,11 +142,6 @@ export const selectCardVerificationStatus = createSelector(
   (data): string | null => data?.account?.verificationStatus ?? null,
 );
 
-/**
- * Strict authenticated KYC gate: true only when the logged-in Card user's
- * verification outcome is VERIFIED. Does not include the on-chain
- * `isCardholder` signal (that drives CTA visibility, not link gating).
- */
 export const selectIsCardVerified = createSelector(
   selectCardVerificationStatus,
   (status) => status === 'VERIFIED',


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

A Card user who is authenticated but whose KYC verification has not yet resolved to `VERIFIED` (e.g. `PENDING`, `UNVERIFIED`, `REJECTED`) was being shown the Money Account ↔ Card linking UI and could attempt to link, even though the backend cannot complete delegation for them. This produced a dead-end/error flow for users who are not yet eligible.

This PR introduces a strict KYC gate based on the logged-in Card user's verification outcome and threads it through the linking logic and the UI surfaces that expose the link/upsell CTAs:

- Adds `selectCardVerificationStatus` and `selectIsCardVerified` selectors. `selectIsCardVerified` is `true` only when the account's `verificationStatus === 'VERIFIED'`. It intentionally does **not** include the on-chain `isCardholder` signal (that drives CTA visibility, not link gating).
- `useMoneyAccountCardLinkage` now exposes `isCardVerified` and requires it for `canLink`/`canSubmitDelegation`. The `startLinkFlow` and resume (`pendingMoneyAccountCardLink`) effects no-op (and clear the pending flag) when the user is authenticated but not verified.
- `MoneyHomeView` hides the MetaMask Card section for authenticated-but-unverified users (`metamaskCardMode = null`) instead of showing `link`.
- `MoneyOnboardingCard` only shows the link-card action when the authenticated user is also verified, falling back to the no-card step otherwise.

Tests were added/updated across the selectors, the hook, and both views to cover the new not-`VERIFIED` paths.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the MetaMask Card linking flow so that authenticated Card users who are not yet verified no longer see the Money Account card-linking CTA.

## **Related issues**

Fixes: CARD-428

## **Manual testing steps**

```gherkin
Feature: MetaMask Card linking gated on verification status

  Scenario: Authenticated Card user who is not VERIFIED
    Given I am an authenticated Card user
    And my Card account verification status is PENDING (or UNVERIFIED/REJECTED)
    When I open the Money home view
    Then the MetaMask Card section is not displayed
    And the Money onboarding card shows the no-card step instead of the link-card step
    And no card linking flow can be started

  Scenario: Authenticated and VERIFIED Card user
    Given I am an authenticated Card user
    And my Card account verification status is VERIFIED
    And I have the Money account requirements
    When I open the Money home view
    Then the MetaMask Card section is displayed in "link" mode
    And I can start the card linking flow

  Scenario: Cardholder account (on-chain)
    Given my selected wallet is a cardholder account
    When I open the Money home view
    Then the MetaMask Card section is displayed and the link CTA remains available
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
