### PR TITLE
fix: expand crypto/fiat toggle tap target

### DIFF
--- a/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
@@ -82,6 +82,7 @@ const mockOnFocus = jest.fn();
 const mockOnBlur = jest.fn();
 const mockOnInputPress = jest.fn();
 const mockOnMaxPress = jest.fn();
+const mockOnAmountTypeTogglePress = jest.fn();
 
 describe('TokenInputArea', () => {
   beforeEach(() => {
@@ -861,6 +862,32 @@ describe('TokenInputArea', () => {
         undefined,
         undefined,
       );
+    });
+
+    it('toggles amount type when pressing the secondary denomination value', () => {
+      // Arrange
+      mockUseDisplayCurrencyValue.mockReturnValue('$100.00');
+
+      const { getByText } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Source}
+            token={mockToken}
+            amount="1"
+            onAmountTypeTogglePress={mockOnAmountTypeTogglePress}
+            amountTypeToggleTestID="amount-type-toggle"
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      // Act
+      fireEvent.press(getByText('$100.00'));
+
+      // Assert
+      expect(mockOnAmountTypeTogglePress).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -408,32 +408,29 @@ export const TokenInputArea = forwardRef<
             ) : (
               <>
                 <Box style={styles.currencyContainer}>
-                  {onAmountTypeTogglePress ? (
-                    <TouchableOpacity
-                      style={styles.secondaryValueContainer}
-                      onPress={onAmountTypeTogglePress}
-                      testID={amountTypeToggleTestID}
-                    >
-                      {shouldShowSecondaryAmount ? (
-                        <Text color={TextColor.Alternative}>
-                          {secondaryAmountDisplayValue}
-                        </Text>
-                      ) : null}
+                  <TouchableOpacity
+                    style={styles.secondaryValueContainer}
+                    onPress={onAmountTypeTogglePress}
+                    disabled={!onAmountTypeTogglePress}
+                    testID={
+                      onAmountTypeTogglePress
+                        ? amountTypeToggleTestID
+                        : undefined
+                    }
+                  >
+                    {shouldShowSecondaryAmount ? (
+                      <Text color={TextColor.Alternative}>
+                        {secondaryAmountDisplayValue}
+                      </Text>
+                    ) : null}
+                    {onAmountTypeTogglePress ? (
                       <Icon
                         name={IconName.SwapVertical}
                         size={IconSize.Sm}
                         color={IconColor.Alternative}
                       />
-                    </TouchableOpacity>
-                  ) : (
-                    <Box style={styles.secondaryValueContainer}>
-                      {shouldShowSecondaryAmount ? (
-                        <Text color={TextColor.Alternative}>
-                          {secondaryAmountDisplayValue}
-                        </Text>
-                      ) : null}
-                    </Box>
-                  )}
+                    ) : null}
+                  </TouchableOpacity>
                 </Box>
                 <Box
                   flexDirection={

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -109,10 +109,6 @@ const createStyles = ({
       alignItems: 'center',
       gap: 8,
     },
-    amountTypeToggle: {
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
     currencyContainer: {
       flex: 1,
     },
@@ -412,26 +408,32 @@ export const TokenInputArea = forwardRef<
             ) : (
               <>
                 <Box style={styles.currencyContainer}>
-                  <Box style={styles.secondaryValueContainer}>
-                    {shouldShowSecondaryAmount ? (
-                      <Text color={TextColor.Alternative}>
-                        {secondaryAmountDisplayValue}
-                      </Text>
-                    ) : null}
-                    {onAmountTypeTogglePress ? (
-                      <TouchableOpacity
-                        style={styles.amountTypeToggle}
-                        onPress={onAmountTypeTogglePress}
-                        testID={amountTypeToggleTestID}
-                      >
-                        <Icon
-                          name={IconName.SwapVertical}
-                          size={IconSize.Sm}
-                          color={IconColor.Alternative}
-                        />
-                      </TouchableOpacity>
-                    ) : null}
-                  </Box>
+                  {onAmountTypeTogglePress ? (
+                    <TouchableOpacity
+                      style={styles.secondaryValueContainer}
+                      onPress={onAmountTypeTogglePress}
+                      testID={amountTypeToggleTestID}
+                    >
+                      {shouldShowSecondaryAmount ? (
+                        <Text color={TextColor.Alternative}>
+                          {secondaryAmountDisplayValue}
+                        </Text>
+                      ) : null}
+                      <Icon
+                        name={IconName.SwapVertical}
+                        size={IconSize.Sm}
+                        color={IconColor.Alternative}
+                      />
+                    </TouchableOpacity>
+                  ) : (
+                    <Box style={styles.secondaryValueContainer}>
+                      {shouldShowSecondaryAmount ? (
+                        <Text color={TextColor.Alternative}>
+                          {secondaryAmountDisplayValue}
+                        </Text>
+                      ) : null}
+                    </Box>
+                  )}
                 </Box>
                 <Box
                   flexDirection={


### PR DESCRIPTION
## **Description**

Expands the Swap/Bridge amount input currency-mode toggle so users can tap the full secondary denomination row, including values like `$100.00` or `1 ETH`, instead of only the swap-arrow icon. This makes the crypto/fiat toggle easier to hit while preserving the existing secondary amount display when toggling is unavailable.

## **Changelog**

CHANGELOG entry: Fixed a bug that made the swaps crypto/fiat amount toggle difficult to tap

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4619

## **Manual testing steps**

```gherkin
Feature: Swap amount currency-mode toggle

  Scenario: user toggles the source amount display from the secondary denomination row
    Given the user is on the Swap screen with a source token selected and an entered amount
    And the secondary denomination value is visible below the primary amount
    When user taps the secondary denomination value, such as "$100.00" or "1 ETH"
    Then the source amount display toggles between crypto and fiat modes
```

## **Screenshots/Recordings**

N/A - interaction target change covered by focused unit and component view tests.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Testing**

- `yarn jest app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx --collectCoverage=false`
- `yarn jest -c jest.config.view.js app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx --runInBand --silent --coverage=false`
- `git diff --check`