### PR TITLE
feat(ramp): headless deposit funnel analytics (TRAM-3623)

### DIFF
--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -1,3 +1,11 @@
+/**
+ * Headless ramps surface the event was triggered from. Set on every event
+ * emitted on the headless deposit path (TRAM-3623) so the funnel can be sliced
+ * by which product feature initiated the buy. Optional and empty for all
+ * non-headless (UB2 / native Deposit) events, keeping the change additive.
+ */
+export type RampSurface = 'money_account' | 'perps' | 'prediction';
+
 interface RampsButtonClicked {
   quote_session_id?: string;
   ramp_type: 'DEPOSIT' | 'SELL' | 'BUY' | 'UNIFIED_BUY' | 'UNIFIED_BUY_2';
@@ -120,8 +128,10 @@ interface RampsOtpConfirmed {
 interface RampsOtpFailed {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
+  error_message?: string;
 }
 
 interface RampsOtpResent {
@@ -157,7 +167,8 @@ interface RampsAddressEntered {
 
 interface RampsTransactionConfirmed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
   amount_destination: number;
@@ -167,6 +178,7 @@ interface RampsTransactionConfirmed {
   total_fee: number;
   payment_method_id: string;
   country: string;
+  region?: string;
   chain_id: string;
   currency_destination: string;
   currency_destination_symbol?: string;
@@ -217,9 +229,12 @@ interface RampsTransactionFailed {
 
 interface RampsKycApplicationFailed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
+  region?: string;
+  error_message?: string;
 }
 
 interface RampsKycApplicationApproved {
@@ -260,7 +275,9 @@ interface RampsUserDetailsFetched {
 
 interface RampsScreenViewed {
   location: string;
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
+  region?: string;
 }
 
 interface RampsBackButtonClicked {
@@ -393,7 +410,9 @@ interface RampsToastButtonClicked {
 interface RampsCheckoutFunnelBase {
   checkout_session_id: string;
   location: 'Checkout';
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
+  region?: string;
   provider_name?: string;
 }
 
@@ -421,6 +440,7 @@ interface RampsCheckoutHttpErrorReceived extends RampsCheckoutFunnelBase {
   url_path: string;
   status_code: number;
   is_initial_url: boolean;
+  error_message?: string;
 }
 
 interface RampsCheckoutCallbackDetected extends RampsCheckoutFunnelBase {

--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -97,7 +97,8 @@ interface RampsOrderSelected {
 
 interface RampsOrderFailed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
   amount_destination: number;
@@ -152,7 +153,8 @@ interface RampsKycStarted {
 interface RampsBasicInfoEntered {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
 }
@@ -160,7 +162,8 @@ interface RampsBasicInfoEntered {
 interface RampsAddressEntered {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
 }
@@ -208,7 +211,8 @@ interface RampsTransactionCompleted {
 
 interface RampsTransactionFailed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
   amount_destination: number;
@@ -239,7 +243,8 @@ interface RampsKycApplicationFailed {
 
 interface RampsKycApplicationApproved {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
 }

--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -29,7 +29,8 @@ interface RampsDepositCashButtonClicked {
 
 interface RampsPaymentMethodSelected {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT' | 'UNIFIED_BUY_2';
+  ramp_type: 'DEPOSIT' | 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   region: string;
   payment_method_id: string;
@@ -61,7 +62,8 @@ interface RampsRegionSelected {
 
 interface RampsOrderProposed {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
   amount_destination: number;
@@ -78,7 +80,8 @@ interface RampsOrderProposed {
 
 interface RampsOrderSelected {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   amount_source: number;
   amount_destination: number;
@@ -115,14 +118,16 @@ interface RampsOrderFailed {
 
 interface RampsEmailSubmitted {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
 }
 
 interface RampsOtpConfirmed {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
 }
 
@@ -138,14 +143,16 @@ interface RampsOtpFailed {
 interface RampsOtpResent {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
 }
 
 interface RampsKycStarted {
   quote_session_id?: string;
   region: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   user_id?: string;
   kyc_type: string;
 }
@@ -287,7 +294,8 @@ interface RampsScreenViewed {
 
 interface RampsBackButtonClicked {
   location: string;
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
 }
 
 interface RampsNetworkFilterClicked {
@@ -317,7 +325,8 @@ interface RampsSettingOptionClicked {
 interface RampsPaymentMethodSelectorClicked {
   current_payment_method?: string;
   location: string;
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
 }
 
 interface RampsQuickAmountClicked {
@@ -341,7 +350,8 @@ interface RampsProviderSelected {
 }
 
 interface RampsContinueButtonClicked {
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
   amount_source: number;
   amount_destination?: number;
   payment_method_id: string;
@@ -362,14 +372,16 @@ interface RampsContinueButtonClicked {
 
 interface RampsTermsConsentClicked {
   location: string;
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
 }
 
 interface RampsExternalLinkClicked {
   location: string;
   external_link_description: string;
   url_domain?: string;
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
 }
 
 interface RampsCloseButtonClicked {
@@ -384,7 +396,8 @@ interface RampsQuoteError {
   currency_destination?: string;
   payment_method_id?: string;
   chain_id?: string;
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
 }
 
 interface RampsQuoteErrorTooltipClicked {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -32,6 +32,7 @@ import {
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import useRampsUnifiedV2Enabled from '../../hooks/useRampsUnifiedV2Enabled';
+import { useRampsUserRegion } from '../../hooks/useRampsUserRegion';
 import { showV2OrderToast } from '../../utils/v2OrderToast';
 import {
   closeSession,
@@ -105,6 +106,7 @@ const Checkout = () => {
     useRampsOrders();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const isV2Enabled = useRampsUnifiedV2Enabled();
+  const { userRegion } = useRampsUserRegion();
 
   const {
     url: uri,
@@ -119,6 +121,36 @@ const Checkout = () => {
     headlessSessionId,
   } = params ?? {};
   const effectiveOrderId = (orderIdParam ?? customOrderId)?.trim() || null;
+
+  // Headless deposit (TRAM-3623): when a headless session drives this
+  // Checkout, every webview funnel event built via `buildBaseProps` is tagged
+  // `ramp_type: 'HEADLESS'` plus the seeded `ramp_surface` and the user's
+  // `region` (RampsController). For non-headless UB2 traffic these stay
+  // undefined, so `buildBaseProps` keeps its `UNIFIED_BUY_2` defaults.
+  const headlessRampSurface = getSession(headlessSessionId)?.params
+    ?.ramp_surface;
+  const regionCode = userRegion?.regionCode || undefined;
+  const headlessBaseOverrides = useMemo(
+    () =>
+      headlessSessionId
+        ? {
+            rampType: 'HEADLESS' as const,
+            rampSurface: headlessRampSurface,
+            region: regionCode,
+          }
+        : {},
+    [headlessSessionId, headlessRampSurface, regionCode],
+  );
+  // The non-`buildBaseProps` Checkout emits (RAMPS_SCREEN_VIEWED,
+  // RAMPS_CLOSE_BUTTON_CLICKED) default to 'UNIFIED_BUY_2'; flip them the same
+  // way (TRAM-3623).
+  const headlessRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessRampSurface }
+        : { ramp_type: 'UNIFIED_BUY_2' as const },
+    [headlessSessionId, headlessRampSurface],
+  );
 
   const initialUriRef = useRef(uri);
   const registeredOrderIdsRef = useRef<Set<string>>(new Set());
@@ -165,7 +197,8 @@ const Checkout = () => {
         createEventBuilder(MetaMetricsEvents.RAMPS_SCREEN_VIEWED)
           .addProperties({
             location: 'Checkout',
-            ramp_type: 'UNIFIED_BUY_2',
+            ...headlessRampProps,
+            ...(headlessSessionId ? { region: regionCode } : {}),
           })
           .build(),
       );
@@ -175,6 +208,7 @@ const Checkout = () => {
             ...buildBaseProps({
               checkoutSessionId,
               providerName,
+              ...headlessBaseOverrides,
             }),
             initial_url_path: redactUrlForAnalytics(uri),
             has_callback_flow: hasCallbackFlow,
@@ -191,6 +225,10 @@ const Checkout = () => {
     providerName,
     hasCallbackFlow,
     effectiveOrderId,
+    headlessRampProps,
+    headlessBaseOverrides,
+    headlessSessionId,
+    regionCode,
   ]);
 
   const dismissActiveHeadlessFlow = useCallback(() => {
@@ -199,17 +237,56 @@ const Checkout = () => {
 
   const failHeadlessCheckout = useCallback(
     (checkoutError: unknown) => {
-      if (
-        hasTerminatedHeadlessSessionRef.current ||
-        !failSession(headlessSessionId, checkoutError)
-      ) {
+      if (hasTerminatedHeadlessSessionRef.current) {
         return false;
+      }
+      // Snapshot the session BEFORE failSession tears it down so the HEADLESS
+      // RAMPS_ORDER_FAILED event (TRAM-3623 §7) can carry the seeded
+      // ramp_surface and the quote/amount context. The non-React failSession
+      // helper can't emit analytics itself, so this React host does it.
+      const session = getSession(headlessSessionId);
+      if (!failSession(headlessSessionId, checkoutError)) {
+        return false;
+      }
+      if (session) {
+        const quoteRecord = session.params?.quote?.quote;
+        trackEvent(
+          createEventBuilder(MetaMetricsEvents.RAMPS_ORDER_FAILED)
+            .addProperties({
+              ramp_type: 'HEADLESS',
+              ramp_surface: session.params?.ramp_surface,
+              amount_source: Number(
+                quoteRecord?.amountIn ?? session.params?.amount ?? 0,
+              ),
+              amount_destination: Number(quoteRecord?.amountOut ?? 0),
+              payment_method_id: quoteRecord?.paymentMethod ?? '',
+              region: regionCode ?? '',
+              chain_id: network ?? '',
+              currency_destination: params?.cryptocurrency ?? '',
+              currency_source: params?.currency ?? '',
+              error_message:
+                checkoutError instanceof Error
+                  ? checkoutError.message
+                  : String(checkoutError),
+              is_authenticated: true,
+            })
+            .build(),
+        );
       }
       hasTerminatedHeadlessSessionRef.current = true;
       dismissActiveHeadlessFlow();
       return true;
     },
-    [headlessSessionId, dismissActiveHeadlessFlow],
+    [
+      headlessSessionId,
+      dismissActiveHeadlessFlow,
+      trackEvent,
+      createEventBuilder,
+      regionCode,
+      network,
+      params?.cryptocurrency,
+      params?.currency,
+    ],
   );
 
   useEffect(() => {
@@ -258,6 +335,7 @@ const Checkout = () => {
             ...buildBaseProps({
               checkoutSessionId,
               providerName,
+              ...headlessBaseOverrides,
             }),
             url_path: redacted,
             previous_url_path: urlHistoryRef.current.previous ?? undefined,
@@ -275,6 +353,7 @@ const Checkout = () => {
       checkoutSessionId,
       providerName,
       effectiveOrderId,
+      headlessBaseOverrides,
     ],
   );
 
@@ -297,6 +376,7 @@ const Checkout = () => {
             ...buildBaseProps({
               checkoutSessionId,
               providerName,
+              ...headlessBaseOverrides,
             }),
             url_path: redactUrlForAnalytics(navState.url),
             order_id: effectiveOrderId ?? undefined,
@@ -415,6 +495,7 @@ const Checkout = () => {
       checkoutSessionId,
       providerName,
       effectiveOrderId,
+      headlessBaseOverrides,
     ],
   );
 
@@ -424,11 +505,11 @@ const Checkout = () => {
       createEventBuilder(MetaMetricsEvents.RAMPS_CLOSE_BUTTON_CLICKED)
         .addProperties({
           location: 'Checkout',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [createEventBuilder, trackEvent]);
+  }, [createEventBuilder, trackEvent, headlessRampProps]);
   const handleClosePress = useCallback(() => {
     handleCancelPress();
     if (headlessSessionId) {
@@ -482,6 +563,7 @@ const Checkout = () => {
             ...buildBaseProps({
               checkoutSessionId,
               providerName,
+              ...headlessBaseOverrides,
             }),
             url_path: redactedLoadedUrl,
             load_duration_ms: durationMs,
@@ -497,6 +579,7 @@ const Checkout = () => {
       providerName,
       headlessSessionId,
       navigation,
+      headlessBaseOverrides,
     ],
   );
 
@@ -532,6 +615,7 @@ const Checkout = () => {
           ...buildBaseProps({
             checkoutSessionId,
             providerName,
+            ...headlessBaseOverrides,
           }),
           close_source: closeSourceRef.current ?? 'background',
           order_id: effectiveOrderId ?? undefined,
@@ -632,10 +716,15 @@ const Checkout = () => {
                   ...buildBaseProps({
                     checkoutSessionId,
                     providerName,
+                    ...headlessBaseOverrides,
                   }),
                   url_path: redactUrlForAnalytics(errorUrl),
                   status_code: nativeEvent.statusCode,
                   is_initial_url: isInitialUrl,
+                  error_message: strings(
+                    'fiat_on_ramp_aggregator.webview_received_error',
+                    { code: nativeEvent.statusCode },
+                  ),
                 })
                 .build(),
             );

--- a/app/components/UI/Ramp/Views/HeadlessPlayground/HeadlessPlayground.test.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessPlayground/HeadlessPlayground.test.tsx
@@ -1100,6 +1100,8 @@ describe('HeadlessPlayground', () => {
         assetId: HEADLESS_SIM_ASSET_ID,
         amount: 25,
         currency: mockUserRegion.country?.currency,
+        // Playground sandbox passes a default money_account surface (TRAM-3623).
+        ramp_surface: 'money_account',
       });
       expect(typeof callbacks.onOrderCreated).toBe('function');
       expect(typeof callbacks.onError).toBe('function');

--- a/app/components/UI/Ramp/Views/HeadlessPlayground/HeadlessPlayground.tsx
+++ b/app/components/UI/Ramp/Views/HeadlessPlayground/HeadlessPlayground.tsx
@@ -499,6 +499,9 @@ function HeadlessPlayground() {
         assetId: effectiveAssetId,
         amount: headlessAmountAsNumber,
         currency: fiatCurrency,
+        // Sandbox default: the playground simulates the Money "Add funds"
+        // consumer, so tag the headless analytics surface accordingly.
+        ramp_surface: 'money_account' as const,
       };
       const session = startHeadlessBuy(params, {
         onOrderCreated: (orderId) => {

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
@@ -47,6 +47,7 @@ import { useRampsUserRegion } from '../../hooks/useRampsUserRegion';
 import type { TransakBuyQuote } from '@metamask/ramps-controller';
 import type { AddressFormData } from '../../Deposit/Views/EnterAddress/EnterAddress';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { getSession } from '../../headless/sessionRegistry';
 import { BASIC_INFO_TEST_IDS } from './BasicInfo.testIds';
 import { createV2EnterEmailNavDetails } from './EnterEmail';
 
@@ -82,6 +83,18 @@ const V2BasicInfo = (): JSX.Element => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isPhoneRegisteredError, setIsPhoneRegisteredError] = useState(false);
+
+  // Headless deposit (TRAM-3623): tag RAMPS_BASIC_INFO_ENTERED with
+  // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when this screen is
+  // part of a headless buy flow; keep 'DEPOSIT' otherwise.
+  const headlessSurface = getSession(headlessSessionId)?.params?.ramp_surface;
+  const headlessDepositRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'DEPOSIT' as const },
+    [headlessSessionId, headlessSurface],
+  );
 
   const firstNameInputRef = useRef<TextInput>(null);
   const lastNameInputRef = useRef<TextInput>(null);
@@ -176,7 +189,7 @@ const V2BasicInfo = (): JSX.Element => {
 
     trackEvent('RAMPS_BASIC_INFO_ENTERED', {
       region: regionIsoCode,
-      ramp_type: 'DEPOSIT',
+      ...headlessDepositRampProps,
       kyc_type: 'SIMPLE',
     });
 
@@ -249,6 +262,7 @@ const V2BasicInfo = (): JSX.Element => {
     headlessSessionId,
     regionIsoCode,
     trackEvent,
+    headlessDepositRampProps,
   ]);
 
   const enterEmailParamsForLogout = useMemo(

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx
@@ -32,6 +32,7 @@ import type { TransakBuyQuote } from '@metamask/ramps-controller';
 import Routes from '../../../../../constants/navigation/Routes';
 import type { BasicInfoFormData } from './BasicInfo';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { getSession } from '../../headless/sessionRegistry';
 import { ENTER_ADDRESS_TEST_IDS } from './EnterAddress.testIds';
 import StateSelector from './StateSelector';
 
@@ -63,6 +64,18 @@ const V2EnterAddress = (): JSX.Element => {
   const trackEvent = useAnalytics();
 
   const regionIsoCode = userRegion?.country?.isoCode || '';
+
+  // Headless deposit (TRAM-3623): tag RAMPS_ADDRESS_ENTERED with
+  // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when this screen is
+  // part of a headless buy flow; keep 'DEPOSIT' otherwise.
+  const headlessSurface = getSession(headlessSessionId)?.params?.ramp_surface;
+  const headlessDepositRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'DEPOSIT' as const },
+    [headlessSessionId, headlessSurface],
+  );
 
   const transakRoutingConfig = useMemo(
     () =>
@@ -204,7 +217,7 @@ const V2EnterAddress = (): JSX.Element => {
 
     trackEvent('RAMPS_ADDRESS_ENTERED', {
       region: regionIsoCode,
-      ramp_type: 'DEPOSIT',
+      ...headlessDepositRampProps,
       kyc_type: 'SIMPLE',
     });
 
@@ -238,6 +251,7 @@ const V2EnterAddress = (): JSX.Element => {
     routeAfterAuthentication,
     regionIsoCode,
     trackEvent,
+    headlessDepositRampProps,
   ]);
 
   return (

--- a/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { TextInput, View } from 'react-native';
 import {
   Text,
@@ -28,6 +34,7 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useTransakController } from '../../hooks/useTransakController';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { getSession } from '../../headless/sessionRegistry';
 import { EnterEmailSelectorsIDs } from './EnterEmail.testIds';
 
 export interface V2EnterEmailParams {
@@ -57,17 +64,40 @@ const V2EnterEmail = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { sendUserOtp } = useTransakController();
 
+  // Headless deposit (TRAM-3623): when this screen is part of a headless buy
+  // flow, every analytics emit is tagged `ramp_type: 'HEADLESS'` (overriding
+  // the UB2/DEPOSIT literals) plus the seeded `ramp_surface`, sourced from the
+  // per-screen `headlessSessionId` so non-headless UB2 traffic is unaffected.
+  const headlessSessionId = params?.headlessSessionId;
+  const headlessSurface = getSession(headlessSessionId)?.params?.ramp_surface;
+  const headlessRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'UNIFIED_BUY_2' as const },
+    [headlessSessionId, headlessSurface],
+  );
+  // For events whose non-headless literal is 'DEPOSIT' (e.g. EMAIL_SUBMITTED),
+  // keep 'DEPOSIT' when not headless and flip to HEADLESS otherwise.
+  const headlessDepositRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'DEPOSIT' as const },
+    [headlessSessionId, headlessSurface],
+  );
+
   const handleHeaderBack = useCallback(() => {
     navigation.goBack();
     trackEvent(
       createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
         .addProperties({
           location: 'Enter Email',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [navigation, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder, headlessRampProps]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {
@@ -77,11 +107,11 @@ const V2EnterEmail = () => {
       createEventBuilder(MetaMetricsEvents.RAMPS_SCREEN_VIEWED)
         .addProperties({
           location: 'Enter Email',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [trackEvent, createEventBuilder]);
+  }, [trackEvent, createEventBuilder, headlessRampProps]);
 
   const emailInputRef = useRef<TextInput>(null);
 
@@ -109,7 +139,7 @@ const V2EnterEmail = () => {
         trackEvent(
           createEventBuilder(MetaMetricsEvents.RAMPS_EMAIL_SUBMITTED)
             .addProperties({
-              ramp_type: 'DEPOSIT',
+              ...headlessDepositRampProps,
             })
             .build(),
         );
@@ -132,7 +162,15 @@ const V2EnterEmail = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [email, navigation, sendUserOtp, trackEvent, createEventBuilder, params]);
+  }, [
+    email,
+    navigation,
+    sendUserOtp,
+    trackEvent,
+    createEventBuilder,
+    params,
+    headlessDepositRampProps,
+  ]);
 
   return (
     <ScreenLayout>

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.test.tsx
@@ -6,12 +6,15 @@ import { ThemeContext, mockTheme } from '../../../../../util/theme';
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
+let mockRouteParams: Record<string, unknown> = {};
+
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => ({
     navigate: mockNavigate,
     goBack: mockGoBack,
   }),
+  useRoute: () => ({ params: mockRouteParams }),
   useFocusEffect: (cb: () => void) => {
     const { useEffect } = jest.requireActual('react');
     useEffect(cb, [cb]);
@@ -45,6 +48,16 @@ jest.mock('../../hooks/useTransakRouting', () => ({
   }),
 }));
 
+let mockUserRegion: { regionCode?: string } | null = { regionCode: 'us-ca' };
+jest.mock('../../hooks/useRampsUserRegion', () => ({
+  __esModule: true,
+  useRampsUserRegion: () => ({ userRegion: mockUserRegion }),
+}));
+
+jest.mock('../../headless/sessionRegistry', () => ({
+  getSession: jest.fn(() => undefined),
+}));
+
 const mockTrackEvent = jest.fn();
 jest.mock('../../hooks/useAnalytics', () => ({
   __esModule: true,
@@ -75,6 +88,8 @@ describe('V2KycProcessing', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockRouteParams = {};
+    mockUserRegion = { regionCode: 'us-ca' };
     mockBuyQuote = { quoteId: 'test-quote-id', fiatAmount: 100 };
     mockGetAdditionalRequirements.mockResolvedValue({
       formsRequired: [],
@@ -245,6 +260,41 @@ describe('V2KycProcessing', () => {
         'RAMPS_KYC_APPLICATION_FAILED',
         expect.objectContaining({
           ramp_type: 'DEPOSIT',
+        }),
+      );
+    });
+  });
+
+  it('flips KYC events to HEADLESS with surface/region/error_message in a headless flow (TRAM-3623 §2/§7)', async () => {
+    mockRouteParams = { headlessSessionId: 'hs-1' };
+    const { getSession } = jest.requireMock('../../headless/sessionRegistry');
+    (getSession as jest.Mock).mockReturnValue({
+      id: 'hs-1',
+      status: 'continued',
+      params: { ramp_surface: 'money_account' },
+    });
+    mockGetAdditionalRequirements.mockResolvedValue({ formsRequired: [] });
+    mockGetUserDetails.mockResolvedValue({
+      kyc: { status: 'REJECTED', type: 'SIMPLE' },
+    });
+
+    renderWithTheme(<V2KycProcessing />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(100);
+    });
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_KYC_APPLICATION_FAILED',
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: 'us-ca',
+          error_message: expect.any(String),
         }),
       );
     });

--- a/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import styleSheet from '../../Deposit/Views/KycProcessing/KycProcessing.styles';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
@@ -27,18 +33,45 @@ import { useTransakController } from '../../hooks/useTransakController';
 import { useTransakRouting } from '../../hooks/useTransakRouting';
 import type { TransakUserDetails } from '@metamask/ramps-controller';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { getSession } from '../../headless/sessionRegistry';
+import { useRampsUserRegion } from '../../hooks/useRampsUserRegion';
+import { useParams } from '../../../../../util/navigation/navUtils';
 import { KYC_PROCESSING_TEST_IDS } from './KycProcessing.testIds';
+
+export interface V2KycProcessingParams {
+  /**
+   * Threaded from `useTransakRouting` resets when the KYC step is part of a
+   * headless buy flow (TRAM-3623). Used to flip the KYC analytics to
+   * `ramp_type: 'HEADLESS'` + the seeded `ramp_surface`.
+   */
+  headlessSessionId?: string;
+}
 
 const V2KycProcessing = () => {
   const navigation = useNavigation();
   const { styles, theme } = useStyles(styleSheet, {});
   const trackEvent = useAnalytics();
+  const { headlessSessionId } = useParams<V2KycProcessingParams>();
+
+  // Headless deposit (TRAM-3623): flip the KYC outcome events to
+  // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when in a headless
+  // flow; keep 'DEPOSIT' otherwise.
+  const headlessSurface = getSession(headlessSessionId)?.params?.ramp_surface;
+  const headlessDepositRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'DEPOSIT' as const },
+    [headlessSessionId, headlessSurface],
+  );
 
   const {
     getAdditionalRequirements,
     getUserDetails,
     buyQuote: quote,
   } = useTransakController();
+  const { userRegion } = useRampsUserRegion();
+  const regionIsoCode = userRegion?.regionCode || '';
   const { routeAfterAuthentication } = useTransakRouting({
     screenLocation: 'V2 KycProcessing Screen',
   });
@@ -156,16 +189,26 @@ const V2KycProcessing = () => {
   useEffect(() => {
     if (kycStatus === KycStatus.REJECTED) {
       trackEvent('RAMPS_KYC_APPLICATION_FAILED', {
-        ramp_type: 'DEPOSIT',
+        ...headlessDepositRampProps,
         kyc_type: userDetails?.kyc?.type || '',
+        region: regionIsoCode,
+        error_message:
+          error || strings('deposit.kyc_processing.error_description'),
       });
     } else if (kycStatus === KycStatus.APPROVED) {
       trackEvent('RAMPS_KYC_APPLICATION_APPROVED', {
-        ramp_type: 'DEPOSIT',
+        ...headlessDepositRampProps,
         kyc_type: userDetails?.kyc?.type || '',
       });
     }
-  }, [kycStatus, trackEvent, userDetails?.kyc?.type]);
+  }, [
+    kycStatus,
+    trackEvent,
+    userDetails?.kyc?.type,
+    headlessDepositRampProps,
+    regionIsoCode,
+    error,
+  ]);
 
   if (error || kycStatus === KycStatus.REJECTED || hasPendingForms) {
     return (

--- a/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/OtpCode.tsx
@@ -47,6 +47,7 @@ import { useTransakController } from '../../hooks/useTransakController';
 import { useTransakRouting } from '../../hooks/useTransakRouting';
 import { useRampsController } from '../../hooks/useRampsController';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
+import { getSession } from '../../headless/sessionRegistry';
 import { OtpCodeSelectorsIDs } from './OtpCode.testIds';
 import { hasTestOverrides } from '../../../../../util/test/utils';
 
@@ -98,6 +99,27 @@ const V2OtpCode = () => {
     useParams<V2OtpCodeParams>();
   const { trackEvent, createEventBuilder } = useAnalytics();
 
+  // Headless deposit (TRAM-3623): tag every emit on this screen with
+  // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when a headless session
+  // drives the flow, sourced from the per-screen `headlessSessionId`. Two
+  // variants because some events default to 'UNIFIED_BUY_2' and others (OTP_*)
+  // to 'DEPOSIT' when not headless.
+  const headlessSurface = getSession(headlessSessionId)?.params?.ramp_surface;
+  const headlessRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'UNIFIED_BUY_2' as const },
+    [headlessSessionId, headlessSurface],
+  );
+  const headlessDepositRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'DEPOSIT' as const },
+    [headlessSessionId, headlessSurface],
+  );
+
   const {
     setAuthToken,
     verifyUserOtp,
@@ -141,11 +163,11 @@ const V2OtpCode = () => {
       createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
         .addProperties({
           location: 'OTP Code',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [navigation, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder, headlessRampProps]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {
@@ -155,11 +177,11 @@ const V2OtpCode = () => {
       createEventBuilder(MetaMetricsEvents.RAMPS_SCREEN_VIEWED)
         .addProperties({
           location: 'OTP Code',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [trackEvent, createEventBuilder]);
+  }, [trackEvent, createEventBuilder, headlessRampProps]);
 
   const [value, setValue] = useState('');
 
@@ -211,7 +233,7 @@ const V2OtpCode = () => {
       trackEvent(
         createEventBuilder(MetaMetricsEvents.RAMPS_OTP_RESENT)
           .addProperties({
-            ramp_type: 'DEPOSIT',
+            ...headlessDepositRampProps,
             region: userRegion?.regionCode || '',
           })
           .build(),
@@ -230,6 +252,7 @@ const V2OtpCode = () => {
     userRegion?.regionCode,
     trackEvent,
     createEventBuilder,
+    headlessDepositRampProps,
   ]);
 
   const handleContactSupport = useCallback(() => {
@@ -261,7 +284,7 @@ const V2OtpCode = () => {
         trackEvent(
           createEventBuilder(MetaMetricsEvents.RAMPS_OTP_CONFIRMED)
             .addProperties({
-              ramp_type: 'DEPOSIT',
+              ...headlessDepositRampProps,
               region: userRegion?.regionCode || '',
             })
             .build(),
@@ -310,8 +333,12 @@ const V2OtpCode = () => {
         trackEvent(
           createEventBuilder(MetaMetricsEvents.RAMPS_OTP_FAILED)
             .addProperties({
-              ramp_type: 'DEPOSIT',
+              ...headlessDepositRampProps,
               region: userRegion?.regionCode || '',
+              error_message: parseUserFacingError(
+                e,
+                strings('deposit.otp_code.error'),
+              ),
             })
             .build(),
         );
@@ -340,6 +367,7 @@ const V2OtpCode = () => {
     selectedPaymentMethod?.id,
     routeAfterAuthentication,
     headlessSessionId,
+    headlessDepositRampProps,
   ]);
 
   const handleValueChange = useCallback(

--- a/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/VerifyIdentity.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Image, Linking, ScrollView } from 'react-native';
 import {
   Text,
@@ -32,6 +32,7 @@ import {
 } from '../../../../../util/navigation/navUtils';
 import { useDispatch } from 'react-redux';
 import { createV2EnterEmailNavDetails } from './EnterEmail';
+import { getSession } from '../../headless/sessionRegistry';
 import { VerifyIdentitySelectorsIDs } from './VerifyIdentity.testIds';
 import { setHasAgreedTransakNativePolicy } from '../../../../../reducers/fiatOrders';
 
@@ -61,6 +62,18 @@ const V2VerifyIdentity = () => {
 
   const regionIsoCode = userRegion?.country?.isoCode || '';
 
+  // Headless deposit (TRAM-3623): flip every emit on this screen to
+  // `ramp_type: 'HEADLESS'` + the seeded `ramp_surface` when a headless
+  // session drives the flow. All emits here default to 'UNIFIED_BUY_2'.
+  const headlessSurface = getSession(headlessSessionId)?.params?.ramp_surface;
+  const headlessRampProps = useMemo(
+    () =>
+      headlessSessionId
+        ? { ramp_type: 'HEADLESS' as const, ramp_surface: headlessSurface }
+        : { ramp_type: 'UNIFIED_BUY_2' as const },
+    [headlessSessionId, headlessSurface],
+  );
+
   const navigateToEnterEmail = useCallback(() => {
     navigation.navigate(
       ...createV2EnterEmailNavDetails({
@@ -78,11 +91,11 @@ const V2VerifyIdentity = () => {
       createEventBuilder(MetaMetricsEvents.RAMPS_BACK_BUTTON_CLICKED)
         .addProperties({
           location: 'Verify Identity',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [navigation, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder, headlessRampProps]);
 
   const hasTrackedScreenViewRef = useRef(false);
   useEffect(() => {
@@ -92,24 +105,30 @@ const V2VerifyIdentity = () => {
       createEventBuilder(MetaMetricsEvents.RAMPS_SCREEN_VIEWED)
         .addProperties({
           location: 'Verify Identity',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
-  }, [trackEvent, createEventBuilder]);
+  }, [trackEvent, createEventBuilder, headlessRampProps]);
 
   const handleSubmit = useCallback(() => {
     trackEvent(
       createEventBuilder(MetaMetricsEvents.RAMPS_TERMS_CONSENT_CLICKED)
         .addProperties({
           location: 'Verify Identity',
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
     dispatch(setHasAgreedTransakNativePolicy(true));
     navigateToEnterEmail();
-  }, [dispatch, navigateToEnterEmail, trackEvent, createEventBuilder]);
+  }, [
+    dispatch,
+    navigateToEnterEmail,
+    trackEvent,
+    createEventBuilder,
+    headlessRampProps,
+  ]);
 
   const handleTransakLink = useCallback(() => {
     let urlDomain: string = TRANSAK_URL;
@@ -124,12 +143,12 @@ const V2VerifyIdentity = () => {
           location: 'Verify Identity',
           external_link_description: 'Transak',
           url_domain: urlDomain,
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
     Linking.openURL(TRANSAK_URL);
-  }, [trackEvent, createEventBuilder]);
+  }, [trackEvent, createEventBuilder, headlessRampProps]);
 
   const handlePrivacyPolicyLink = useCallback(() => {
     let urlDomain: string = CONSENSYS_PRIVACY_POLICY_URL;
@@ -144,12 +163,12 @@ const V2VerifyIdentity = () => {
           location: 'Verify Identity',
           external_link_description: 'Privacy Policy',
           url_domain: urlDomain,
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
     Linking.openURL(CONSENSYS_PRIVACY_POLICY_URL);
-  }, [trackEvent, createEventBuilder]);
+  }, [trackEvent, createEventBuilder, headlessRampProps]);
 
   const handleTransakTermsLink = useCallback(() => {
     const termsUrl =
@@ -166,12 +185,12 @@ const V2VerifyIdentity = () => {
           location: 'Verify Identity',
           external_link_description: 'Transak Terms',
           url_domain: urlDomain,
-          ramp_type: 'UNIFIED_BUY_2',
+          ...headlessRampProps,
         })
         .build(),
     );
     Linking.openURL(termsUrl);
-  }, [regionIsoCode, trackEvent, createEventBuilder]);
+  }, [regionIsoCode, trackEvent, createEventBuilder, headlessRampProps]);
 
   return (
     <ScreenLayout>

--- a/app/components/UI/Ramp/headless/types.ts
+++ b/app/components/UI/Ramp/headless/types.ts
@@ -8,6 +8,7 @@ import type {
   UserRegion,
 } from '@metamask/ramps-controller';
 import type { Quote } from '../types';
+import type { RampSurface } from '../Deposit/types/analytics';
 
 /**
  * Public input for {@link useHeadlessBuy}'s `getQuotes`.
@@ -134,6 +135,14 @@ export interface HeadlessBuyParams {
    * `useRampAccountAddress(chainId)` — same EOA the BuildQuote screen uses.
    */
   walletAddress?: string;
+  /**
+   * Which product surface initiated this headless buy (TRAM-3623 analytics).
+   * Stored on the session so every downstream emit (auth loop, KYC, checkout,
+   * terminal events) can tag `ramp_surface` consistently without re-deriving
+   * it. Set by the confirmations Money-deposit caller via a tx-type map; the
+   * playground passes a sensible default.
+   */
+  ramp_surface?: RampSurface;
 }
 
 /**

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -1666,9 +1666,12 @@ describe('useTransakRouting', () => {
           ]),
         }),
       );
+      // Headless webview-redirect terminal event is flipped to HEADLESS and
+      // carries region (TRAM-3623 §4/§5); the session mock has no params so
+      // ramp_surface is undefined here.
       expect(mockTrackEvent).toHaveBeenCalledWith(
         'RAMPS_TRANSACTION_CONFIRMED',
-        expect.objectContaining({ ramp_type: 'DEPOSIT' }),
+        expect.objectContaining({ ramp_type: 'HEADLESS', region: 'us-ca' }),
       );
       expect(mockReset).not.toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1676,6 +1679,39 @@ describe('useTransakRouting', () => {
         }),
       );
       expect(mockShowV2OrderToast).not.toHaveBeenCalled();
+    });
+
+    it('carries ramp_surface from the live session on the HEADLESS terminal event', async () => {
+      const onOrderCreated = jest.fn();
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        params: { ramp_surface: 'money_account' },
+        callbacks: {
+          onOrderCreated,
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_TRANSACTION_CONFIRMED',
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: 'us-ca',
+        }),
+      );
     });
 
     it('swallows consumer onOrderCreated errors and still closes + pops', async () => {
@@ -1768,6 +1804,42 @@ describe('useTransakRouting', () => {
       expect(mockParentPop).toHaveBeenCalled();
     });
 
+    it('emits a HEADLESS RAMPS_ORDER_FAILED when a headless checkout processing failure occurs (TRAM-3623 §7)', async () => {
+      mockGetSession.mockReturnValue({
+        id: 'hs-1',
+        status: 'continued',
+        params: { ramp_surface: 'money_account', amount: 100 },
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onError: jest.fn(),
+          onClose: jest.fn(),
+        },
+      });
+      mockFailSession.mockReturnValue({ code: 'UNKNOWN', message: 'boom' });
+
+      const handler = await runApprovedFlowHeadless();
+      expect(handler).not.toBeNull();
+      if (!handler) return;
+
+      mockGetOrder.mockRejectedValue(new Error('Network error'));
+
+      await act(async () => {
+        await handler({
+          url: 'https://redirect.example.com?orderId=order-hs',
+        });
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_ORDER_FAILED',
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: 'us-ca',
+          error_message: expect.any(String),
+        }),
+      );
+    });
+
     it('treats a Transak redirect without orderId as user dismissal when headless', async () => {
       const handler = await runApprovedFlowHeadless();
       expect(handler).not.toBeNull();
@@ -1792,6 +1864,7 @@ describe('useTransakRouting', () => {
       mockGetSession.mockReturnValue({
         id: 'hs-1',
         status: 'continued',
+        params: { ramp_surface: 'money_account' },
         callbacks: {
           onOrderCreated,
           onError: jest.fn(),
@@ -1834,6 +1907,16 @@ describe('useTransakRouting', () => {
       });
       expect(mockShowV2OrderToast).not.toHaveBeenCalled();
       expect(mockParentPop).toHaveBeenCalled();
+      // Manual-bank headless branch now fires a HEADLESS terminal confirmed
+      // event (TRAM-3623 §4) that previously did not exist.
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_TRANSACTION_CONFIRMED',
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: 'us-ca',
+        }),
+      );
     });
 
     it('falls back to the regular order-details reset + toast when session id is present but session is missing from registry', async () => {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.test.ts
@@ -242,6 +242,12 @@ describe('useTransakRouting', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedHandleNavigationStateChange = null;
+    // clearAllMocks resets call records but not return values set via
+    // mockReturnValue, so explicitly default getSession back to "no session"
+    // (matching the bare jest.fn() default) to stop per-test sessions leaking.
+    (
+      jest.requireMock('../headless/sessionRegistry').getSession as jest.Mock
+    ).mockReturnValue(undefined);
     mockUserRegion = {
       country: { currency: 'USD', isoCode: 'US' },
       regionCode: 'us-ca',
@@ -301,6 +307,64 @@ describe('useTransakRouting', () => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         'RAMPS_KYC_STARTED',
         expect.objectContaining({ ramp_type: 'DEPOSIT' }),
+      );
+      // Non-headless stays DEPOSIT and carries no surface (TRAM-3623).
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        'RAMPS_KYC_STARTED',
+        expect.objectContaining({ ramp_type: 'HEADLESS' }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_KYC_STARTED',
+        expect.objectContaining({ ramp_surface: undefined }),
+      );
+    });
+
+    it('emits HEADLESS RAMPS_KYC_STARTED with ramp_surface when the session is headless (NOT_SUBMITTED)', async () => {
+      const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+        .getSession as jest.Mock;
+      mockGetSession.mockReturnValue({
+        id: 'hs-kyc',
+        params: { ramp_surface: 'perps' },
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onClose: jest.fn(),
+          onError: jest.fn(),
+        },
+      });
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        mobileNumber: '+1234567890',
+        dob: '1990-01-01',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'NOT_SUBMITTED',
+        kycType: 'SIMPLE',
+      });
+
+      const { result } = renderHook(() =>
+        useTransakRouting({
+          baseRoute: 'RampHeadlessHost',
+          baseRouteParams: { headlessSessionId: 'hs-kyc' },
+        }),
+      );
+
+      await act(async () => {
+        await result.current.routeAfterAuthentication(
+          mockQuote as never,
+          mockQuote.fiatAmount,
+        );
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_KYC_STARTED',
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'perps',
+          kyc_type: 'SIMPLE',
+          region: 'us-ca',
+        }),
       );
     });
 
@@ -701,6 +765,69 @@ describe('useTransakRouting', () => {
               }),
             }),
           ],
+        }),
+      );
+      // Non-headless IDPROOF KYC_STARTED stays DEPOSIT (TRAM-3623).
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_KYC_STARTED',
+        expect.objectContaining({ ramp_type: 'DEPOSIT', kyc_type: 'STANDARD' }),
+      );
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        'RAMPS_KYC_STARTED',
+        expect.objectContaining({ ramp_type: 'HEADLESS' }),
+      );
+    });
+
+    it('emits HEADLESS RAMPS_KYC_STARTED with ramp_surface for the IDPROOF path when headless', async () => {
+      const mockGetSession = jest.requireMock('../headless/sessionRegistry')
+        .getSession as jest.Mock;
+      mockGetSession.mockReturnValue({
+        id: 'hs-idproof',
+        params: { ramp_surface: 'prediction' },
+        callbacks: {
+          onOrderCreated: jest.fn(),
+          onClose: jest.fn(),
+          onError: jest.fn(),
+        },
+      });
+      mockGetUserDetails.mockResolvedValue({
+        firstName: 'John',
+        address: {},
+      });
+      mockGetKycRequirement.mockResolvedValue({
+        status: 'ADDITIONAL_FORMS_REQUIRED',
+        kycType: 'STANDARD',
+      });
+      mockGetAdditionalRequirements.mockResolvedValue({
+        formsRequired: [
+          {
+            type: 'IDPROOF',
+            metadata: {
+              kycUrl: 'https://kyc.example.com',
+              workFlowRunId: 'wf-123',
+            },
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useTransakRouting({
+          baseRoute: 'RampHeadlessHost',
+          baseRouteParams: { headlessSessionId: 'hs-idproof' },
+        }),
+      );
+
+      await act(async () => {
+        await result.current.routeAfterAuthentication(mockQuote as never, 25);
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'RAMPS_KYC_STARTED',
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'prediction',
+          kyc_type: 'STANDARD',
+          region: 'us-ca',
         }),
       );
     });

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -793,15 +793,22 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
             }
           }
 
-          case 'NOT_SUBMITTED':
+          case 'NOT_SUBMITTED': {
+            // Snapshot the headless session BEFORE navigating so the KYC_STARTED
+            // event carries `ramp_type: 'HEADLESS'` + the seeded `ramp_surface`
+            // on the headless path (TRAM-3623), matching the terminal events in
+            // this file. No-op for the regular flow, which keeps `'DEPOSIT'`.
+            const kycStartedSession = getSession(headlessSessionId);
             trackEvent('RAMPS_KYC_STARTED', {
-              ramp_type: 'DEPOSIT',
+              ramp_type: kycStartedSession ? 'HEADLESS' : 'DEPOSIT',
+              ramp_surface: kycStartedSession?.params?.ramp_surface,
               kyc_type: requirements.kycType || '',
               region: regionIsoCode,
             });
 
             navigateToBasicInfoCallback({ quote, previousFormData, amount });
             return;
+          }
 
           case 'ADDITIONAL_FORMS_REQUIRED': {
             const additionalRequirements = await getAdditionalRequirements(
@@ -835,8 +842,13 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
                 throw new Error('Missing ID proof metadata');
               }
 
+              // Same headless snapshot as the NOT_SUBMITTED branch above
+              // (TRAM-3623): flip to HEADLESS + ramp_surface on the headless
+              // path, otherwise stay DEPOSIT.
+              const idProofKycSession = getSession(headlessSessionId);
               trackEvent('RAMPS_KYC_STARTED', {
-                ramp_type: 'DEPOSIT',
+                ramp_type: idProofKycSession ? 'HEADLESS' : 'DEPOSIT',
+                ramp_surface: idProofKycSession?.params?.ramp_surface,
                 kyc_type: 'STANDARD',
                 region: regionIsoCode,
               });

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -63,7 +63,7 @@ interface RampStackParamList {
     /** User-entered fiat from BuildQuote; used when resetting stack so amount screen keeps the typed value. */
     amount?: number;
   };
-  RampKycProcessing: undefined;
+  RampKycProcessing: { headlessSessionId?: string } | undefined;
   RampEnterEmail: undefined;
   Checkout: {
     url: string;
@@ -180,6 +180,54 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
   const fiatCurrency = userRegion?.country?.currency || '';
   const regionIsoCode = userRegion?.regionCode || '';
 
+  /**
+   * Emits a HEADLESS `RAMPS_ORDER_FAILED` for headless buy failures (TRAM-3623
+   * §7). These events were previously unwired on the headless path - the
+   * non-React `failSession` registry helper can't read region or fire
+   * analytics, so the React host (this hook) emits here right before/around the
+   * `failSession` call. No-op when there is no live headless session, so the
+   * regular (non-headless) flow is unaffected and stays additive.
+   *
+   * `quote` is passed when the caller has one in scope (KYC/limits path); the
+   * amount falls back to it, while token / payment-method / region come from
+   * the already-resolved controller selections.
+   */
+  const emitHeadlessOrderFailed = useCallback(
+    (error: unknown, quote?: TransakBuyQuote) => {
+      const session = getSession(headlessSessionId);
+      if (!session) {
+        return;
+      }
+      trackEvent('RAMPS_ORDER_FAILED', {
+        ramp_type: 'HEADLESS',
+        ramp_surface: session.params?.ramp_surface,
+        amount_source: Number(quote?.fiatAmount ?? session.params?.amount ?? 0),
+        amount_destination: 0,
+        payment_method_id: selectedPaymentMethod?.id || '',
+        region: regionIsoCode,
+        chain_id: (selectedToken?.chainId as string) || '',
+        currency_destination: selectedToken?.assetId || '',
+        currency_destination_symbol: selectedToken?.symbol || undefined,
+        currency_source: quote?.fiatCurrency || fiatCurrency || '',
+        error_message: parseUserFacingError(
+          error,
+          strings('deposit.buildQuote.unexpectedError'),
+        ),
+        is_authenticated: true,
+      });
+    },
+    [
+      headlessSessionId,
+      trackEvent,
+      selectedPaymentMethod?.id,
+      regionIsoCode,
+      selectedToken?.chainId,
+      selectedToken?.assetId,
+      selectedToken?.symbol,
+      fiatCurrency,
+    ],
+  );
+
   const checkUserLimits = useCallback(
     async (quote: TransakBuyQuote, kycType: string) => {
       try {
@@ -251,16 +299,27 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         }
       } catch (error) {
         if (error instanceof LimitExceededError) {
+          // Surfaced to the Headless Host as recoverable data, not a terminal
+          // failure - intentionally no RAMPS_ORDER_FAILED here.
           throw error;
         }
         if (headlessSessionId) {
+          // Infra failure during the limits check: emit the HEADLESS failure
+          // event (TRAM-3623 §7) before failSession closes the session.
+          emitHeadlessOrderFailed(error, quote);
           failSession(headlessSessionId, error);
           throw error;
         }
         Logger.error(error as Error, 'Failed to check user limits');
       }
     },
-    [getUserLimits, fiatCurrency, selectedPaymentMethod?.id, headlessSessionId],
+    [
+      getUserLimits,
+      fiatCurrency,
+      selectedPaymentMethod?.id,
+      headlessSessionId,
+      emitHeadlessOrderFailed,
+    ],
   );
 
   const navigateToVerifyIdentityCallback = useCallback(
@@ -444,7 +503,16 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         // flow — the consumer handles its own notification UI. Keep
         // `addOrder` and the analytics event in both modes so Redux
         // state + telemetry parity is preserved.
-        if (!getSession(headlessSessionId)) {
+        //
+        // Snapshot headless context BEFORE navigateToOrderProcessingCallback
+        // below `closeSession`s the session (TRAM-3623 §4): the terminal
+        // RAMPS_TRANSACTION_CONFIRMED event must carry `ramp_type: 'HEADLESS'`
+        // and the seeded `ramp_surface`, but the session is gone by the time
+        // we emit otherwise.
+        const confirmSession = getSession(headlessSessionId);
+        const wasHeadless = Boolean(confirmSession);
+        const rampSurface = confirmSession?.params?.ramp_surface;
+        if (!wasHeadless) {
           showV2OrderToast({
             orderId: rampsOrder.providerOrderId,
             cryptocurrency: rampsOrder.cryptoCurrency?.symbol ?? '',
@@ -458,7 +526,8 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         });
 
         trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
-          ramp_type: 'DEPOSIT',
+          ramp_type: wasHeadless ? 'HEADLESS' : 'DEPOSIT',
+          ramp_surface: rampSurface,
           amount_source: Number(rampsOrder.fiatAmount),
           amount_destination: Number(rampsOrder.cryptoAmount),
           exchange_rate: Number(rampsOrder.exchangeRate),
@@ -469,6 +538,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
           total_fee: Number(rampsOrder.totalFeesFiat),
           payment_method_id: rampsOrder.paymentMethod?.id || '',
           country: regionIsoCode,
+          region: regionIsoCode,
           chain_id: rampsOrder.network?.chainId || '',
           currency_destination: rampsOrder.cryptoCurrency?.assetId || '',
           currency_destination_symbol: rampsOrder.cryptoCurrency?.symbol || '',
@@ -480,6 +550,9 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
         Logger.error(error as Error, {
           message: 'useTransakRouting: Failed to process order after checkout',
         });
+        // Emit the HEADLESS failure event BEFORE failSession tears the session
+        // down (TRAM-3623 §7) so the surface snapshot is still available.
+        emitHeadlessOrderFailed(error);
         if (failSession(headlessSessionId, error)) {
           dismissActiveHeadlessFlow();
         }
@@ -495,6 +568,7 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       trackEvent,
       headlessSessionId,
       dismissActiveHeadlessFlow,
+      emitHeadlessOrderFailed,
     ],
   );
 
@@ -525,10 +599,19 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
       const baseEntry = buildBaseRouteEntry({ amount });
       navigation.reset({
         index: 1,
-        routes: [baseEntry, { name: Routes.RAMP.KYC_PROCESSING }],
+        routes: [
+          baseEntry,
+          {
+            name: Routes.RAMP.KYC_PROCESSING,
+            // Thread the headless session id so KycProcessing can flip its
+            // KYC analytics to `ramp_type: 'HEADLESS'` (TRAM-3623). The screen
+            // has no params of its own, so we forward it here.
+            params: headlessSessionId ? { headlessSessionId } : undefined,
+          },
+        ],
       });
     },
-    [navigation, buildBaseRouteEntry],
+    [navigation, buildBaseRouteEntry, headlessSessionId],
   );
 
   const navigateToKycWebviewCallback = useCallback(
@@ -556,12 +639,15 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
           buildBaseRouteEntry({ amount }),
           {
             name: Routes.RAMP.KYC_PROCESSING,
+            // Thread the headless session id (TRAM-3623) - see
+            // navigateToKycProcessingCallback.
+            params: headlessSessionId ? { headlessSessionId } : undefined,
           },
           { name: routeName, params: routeParams },
         ],
       });
     },
-    [navigation, buildBaseRouteEntry],
+    [navigation, buildBaseRouteEntry, headlessSessionId],
   );
 
   const routeAfterAuthentication = useCallback(
@@ -619,9 +705,42 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
                   paymentDetails: depositOrder.paymentDetails,
                 });
 
-                if (getSession(headlessSessionId)) {
+                // Manual-bank-transfer headless branch (TRAM-3623 §4): this
+                // path historically fired NO confirmed event because headless
+                // diverts to navigateToOrderProcessingCallback and returns.
+                // Snapshot the surface BEFORE that call closes the session,
+                // then emit a HEADLESS terminal RAMPS_TRANSACTION_CONFIRMED so
+                // the funnel sees the same terminal signal as the webview path.
+                const manualBankSession = getSession(headlessSessionId);
+                if (manualBankSession) {
+                  const rampSurface = manualBankSession.params?.ramp_surface;
                   navigateToOrderProcessingCallback({
                     orderId: rampsOrder.providerOrderId,
+                  });
+                  trackEvent('RAMPS_TRANSACTION_CONFIRMED', {
+                    ramp_type: 'HEADLESS',
+                    ramp_surface: rampSurface,
+                    amount_source: Number(rampsOrder.fiatAmount),
+                    amount_destination: Number(rampsOrder.cryptoAmount),
+                    exchange_rate: Number(rampsOrder.exchangeRate),
+                    gas_fee: rampsOrder.networkFees
+                      ? Number(rampsOrder.networkFees)
+                      : 0,
+                    processing_fee: rampsOrder.partnerFees
+                      ? Number(rampsOrder.partnerFees)
+                      : 0,
+                    total_fee: Number(rampsOrder.totalFeesFiat),
+                    payment_method_id: rampsOrder.paymentMethod?.id || '',
+                    country: regionIsoCode,
+                    region: regionIsoCode,
+                    chain_id: rampsOrder.network?.chainId || '',
+                    currency_destination:
+                      rampsOrder.cryptoCurrency?.assetId || '',
+                    currency_destination_symbol:
+                      rampsOrder.cryptoCurrency?.symbol || '',
+                    currency_destination_network:
+                      rampsOrder.network?.name || '',
+                    currency_source: rampsOrder.fiatCurrency?.symbol || '',
                   });
                   return true;
                 }

--- a/app/components/UI/Ramp/utils/webviewFunnelAnalytics.test.ts
+++ b/app/components/UI/Ramp/utils/webviewFunnelAnalytics.test.ts
@@ -23,6 +23,35 @@ describe('webviewFunnelAnalytics', () => {
       expect(result.ramp_type).toBe('UNIFIED_BUY_2');
       expect(result.provider_name).toBeUndefined();
     });
+
+    it('defaults to UNIFIED_BUY_2 with no surface/region (non-headless)', () => {
+      const result = buildBaseProps({
+        checkoutSessionId: 'session-3',
+        providerName: 'Transak',
+      });
+      expect(result.ramp_type).toBe('UNIFIED_BUY_2');
+      expect(result.ramp_surface).toBeUndefined();
+      expect(result.region).toBeUndefined();
+    });
+
+    it('applies HEADLESS overrides (ramp_type, ramp_surface, region)', () => {
+      expect(
+        buildBaseProps({
+          checkoutSessionId: 'session-4',
+          providerName: 'Transak',
+          rampType: 'HEADLESS',
+          rampSurface: 'money_account',
+          region: 'us-ca',
+        }),
+      ).toEqual({
+        checkout_session_id: 'session-4',
+        location: 'Checkout',
+        ramp_type: 'HEADLESS',
+        ramp_surface: 'money_account',
+        region: 'us-ca',
+        provider_name: 'Transak',
+      });
+    });
   });
 
   describe('extractHostname', () => {

--- a/app/components/UI/Ramp/utils/webviewFunnelAnalytics.ts
+++ b/app/components/UI/Ramp/utils/webviewFunnelAnalytics.ts
@@ -1,3 +1,4 @@
+import type { RampSurface } from '../Deposit/types/analytics';
 import { redactUrlForAnalytics } from './redactUrlForAnalytics';
 
 export type CloseSource =
@@ -10,22 +11,39 @@ export type CloseSource =
 export interface FunnelBaseProps {
   checkout_session_id: string;
   location: 'Checkout';
-  ramp_type: 'UNIFIED_BUY_2';
+  ramp_type: 'UNIFIED_BUY_2' | 'HEADLESS';
+  ramp_surface?: RampSurface;
+  region?: string;
   provider_name?: string;
 }
 
 export interface BuildBaseArgs {
   checkoutSessionId: string;
   providerName?: string;
+  /**
+   * Headless deposit overrides (TRAM-3623). When a `headlessSessionId` drives
+   * the Checkout, the host passes `rampType: 'HEADLESS'` plus the seeded
+   * `rampSurface`/`region` so every webview funnel event is tagged
+   * consistently. Defaults keep the UB2 behavior (`UNIFIED_BUY_2`, no surface)
+   * so non-headless callers are unchanged.
+   */
+  rampType?: 'UNIFIED_BUY_2' | 'HEADLESS';
+  rampSurface?: RampSurface;
+  region?: string;
 }
 
 export const buildBaseProps = ({
   checkoutSessionId,
   providerName,
+  rampType = 'UNIFIED_BUY_2',
+  rampSurface,
+  region,
 }: BuildBaseArgs): FunnelBaseProps => ({
   checkout_session_id: checkoutSessionId,
   location: 'Checkout',
-  ramp_type: 'UNIFIED_BUY_2',
+  ramp_type: rampType,
+  ramp_surface: rampSurface,
+  region,
   provider_name: providerName ?? undefined,
 });
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -44,6 +44,7 @@ import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayW
 import { useTransactionAccountOverride } from '../../../hooks/transactions/useTransactionAccountOverride';
 import Logger from '../../../../../../util/Logger';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
 jest.mock('../../../hooks/tokens/useTokenFiatRates');
@@ -105,14 +106,41 @@ jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
     setConfirmationMetric: jest.fn(),
   }),
 }));
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn((_properties: Record<string, unknown>) => ({
+  build: () => 'built-event',
+}));
+const mockCreateEventBuilder = jest.fn((_event: unknown) => ({
+  addProperties: mockAddProperties,
+}));
 jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
-    trackEvent: jest.fn(),
-    createEventBuilder: jest.fn(() => ({
-      addProperties: jest.fn(() => ({ build: jest.fn() })),
-    })),
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
   }),
 }));
+
+const mockUseRampsUserRegion = jest.fn(() => ({
+  userRegion: { regionCode: 'us-ca' },
+  setUserRegion: jest.fn(),
+}));
+jest.mock('../../../../../UI/Ramp/hooks/useRampsUserRegion', () => ({
+  useRampsUserRegion: () => mockUseRampsUserRegion(),
+}));
+
+/** Returns the addProperties payload for the first emit of `event`. */
+function emittedPayloadFor(event: unknown): Record<string, unknown> | undefined {
+  const callIndex = mockCreateEventBuilder.mock.calls.findIndex(
+    ([arg]) => arg === event,
+  );
+  if (callIndex === -1) {
+    return undefined;
+  }
+  return mockAddProperties.mock.calls[callIndex]?.[0] as Record<
+    string,
+    unknown
+  >;
+}
 
 const mockGoToBuy = jest.fn();
 
@@ -232,6 +260,16 @@ describe('CustomAmountInfo', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    // resetAllMocks clears implementations; restore the analytics capture mocks.
+    mockAddProperties.mockImplementation(() => ({ build: () => 'built-event' }));
+    mockCreateEventBuilder.mockImplementation(() => ({
+      addProperties: mockAddProperties,
+    }));
+    mockUseRampsUserRegion.mockReturnValue({
+      userRegion: { regionCode: 'us-ca' },
+      setUserRegion: jest.fn(),
+    });
 
     useRouteMock.mockReturnValue({
       key: 'mock-route',
@@ -789,6 +827,158 @@ describe('CustomAmountInfo', () => {
       await pressDone(getByText);
 
       expect(getByTestId('bridge-fee-row')).toBeOnTheScreen();
+    });
+  });
+
+  // TRAM-3623 headless ramps funnel wiring through the shared screen.
+  describe('TRAM-3623 funnel events', () => {
+    function setMoneyDeposit() {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: 'tx-1',
+        type: TransactionType.moneyAccountDeposit,
+        txParams: { from: '0x123' },
+      } as never);
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: '/payments/debit-credit-card',
+        amountFiat: '100',
+        caipAssetId: 'eip155:1/slip44:60',
+      } as never);
+    }
+
+    it('emits RAMPS_ORDER_PROPOSED on Done press for moneyAccountDeposit', async () => {
+      setMoneyDeposit();
+
+      const { getByText } = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      await act(async () => {
+        fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+      });
+
+      expect(emittedPayloadFor(MetaMetricsEvents.RAMPS_ORDER_PROPOSED)).toEqual(
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: 'us-ca',
+          amount_source: 100,
+        }),
+      );
+    });
+
+    it('emits RAMPS_CONTINUE_BUTTON_CLICKED on confirm press for moneyAccountDeposit', async () => {
+      setMoneyDeposit();
+      useConfirmActionsMock.mockReturnValue({
+        onConfirm: jest.fn(),
+        onReject: jest.fn(),
+      });
+
+      const { getByText } = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      // Commit the amount first to dismiss the keyboard and reveal the CTA.
+      await act(async () => {
+        fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+      });
+      await act(async () => {
+        fireEvent.press(getByText(strings('confirm.deposit_edit_amount_done')));
+      });
+
+      expect(
+        emittedPayloadFor(MetaMetricsEvents.RAMPS_CONTINUE_BUTTON_CLICKED),
+      ).toEqual(
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: 'us-ca',
+        }),
+      );
+    });
+
+    it('emits RAMPS_ORDER_SELECTED reactively when a usable quote is present', () => {
+      setMoneyDeposit();
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: '/payments/debit-credit-card',
+        amountFiat: '100',
+        caipAssetId: 'eip155:1/slip44:60',
+        rampsQuote: {
+          provider: '/providers/transak',
+          quote: {
+            amountIn: 100,
+            amountOut: 0.05,
+            paymentMethod: '/payments/debit-credit-card',
+            totalFees: 5,
+            networkFee: 2,
+            providerFee: 3,
+          },
+        },
+      } as never);
+
+      render({ transactionType: TransactionType.moneyAccountDeposit });
+
+      expect(emittedPayloadFor(MetaMetricsEvents.RAMPS_ORDER_SELECTED)).toEqual(
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          amount_destination: 0.05,
+          total_fee: 5,
+        }),
+      );
+    });
+
+    // Cross-flow isolation: the shared screen also serves these flows; none of
+    // the money RAMPS funnel events may fire for them.
+    it.each([
+      TransactionType.perpsDeposit,
+      TransactionType.predictDeposit,
+      TransactionType.moneyAccountWithdraw,
+      TransactionType.musdConversion,
+    ])('fires no money RAMPS funnel events for %s on Done press', async (type) => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        id: 'tx-1',
+        type,
+        txParams: { from: '0x123' },
+      } as never);
+      useTransactionPayFiatPaymentMock.mockReturnValue({
+        selectedPaymentMethodId: '/payments/debit-credit-card',
+        amountFiat: '100',
+        caipAssetId: 'eip155:1/slip44:60',
+        rampsQuote: {
+          provider: '/providers/transak',
+          quote: { amountIn: 100, amountOut: 0.05 },
+        },
+      } as never);
+      useAlertsMock.mockReturnValue({
+        alerts: [
+          {
+            key: AlertKeys.NoPayTokenQuotes,
+            severity: Severity.Danger,
+            isBlocking: true,
+          },
+        ] as Alert[],
+        generalAlerts: [] as Alert[],
+        fieldAlerts: [] as Alert[],
+      } as AlertsContextParams);
+
+      const { getByText } = render({ transactionType: type });
+
+      await act(async () => {
+        fireEvent.press(getByText(strings('confirm.edit_amount_done')));
+      });
+
+      const moneyRampEvents = [
+        MetaMetricsEvents.RAMPS_ORDER_PROPOSED,
+        MetaMetricsEvents.RAMPS_ORDER_SELECTED,
+        MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTED,
+        MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTOR_CLICKED,
+        MetaMetricsEvents.RAMPS_QUOTE_ERROR,
+        MetaMetricsEvents.RAMPS_CONTINUE_BUTTON_CLICKED,
+        MetaMetricsEvents.RAMPS_SCREEN_VIEWED,
+      ];
+      for (const event of moneyRampEvents) {
+        expect(emittedPayloadFor(event)).toBeUndefined();
+      }
     });
   });
 });

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -74,6 +74,7 @@ import { PredictAccountPickerRow } from '../../rows/predict-account-picker-row';
 import { useTransactionAccountOverride } from '../../../hooks/transactions/useTransactionAccountOverride';
 import { CustomAmountInfoTestIds } from './custom-amount-info.testIds';
 import { useConfirmationContext } from '../../../context/confirmation-context';
+import { useMoneyDepositFunnelMetrics } from './useMoneyDepositFunnelMetrics';
 
 export interface CustomAmountInfoProps {
   autoSelectFiatPayment?: boolean;
@@ -133,6 +134,12 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     });
     useTransactionPayMetrics();
     useTransactionPayPostQuote(); // Set isPostQuote=true for post-quote transactions
+
+    // TRAM-3623 headless ramps funnel telemetry. All emits are gated on
+    // moneyAccountDeposit inside the hook, so this is inert for the other flows
+    // (perps / predict / withdraw / mUSD) that also render this shared screen.
+    const { trackAmountCommitted, trackPaymentSelectorOpened, trackContinue } =
+      useMoneyDepositFunnelMetrics();
 
     const { isNative: isNativePayToken } = useTransactionPayToken();
     const { styles } = useStyles(styleSheet, {});
@@ -214,6 +221,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       } finally {
         EngineService.flushState();
         setIsKeyboardVisible(false);
+        // Amount committed (pre-quote) funnel event; no-op for non-money flows.
+        trackAmountCommitted();
         onAmountSubmit?.();
       }
     }, [
@@ -221,6 +230,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       isMoneyAccountDeposit,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
+      trackAmountCommitted,
       transactionId,
       updateTokenAmount,
     ]);
@@ -272,7 +282,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               <PerpsAccountPickerRow />
               <PredictAccountPickerRow />
               {disablePay !== true &&
-                (hasPaymentOption || hasAccountNoFunds) && <PayWithRow />}
+                (hasPaymentOption || hasAccountNoFunds) && (
+                  <PayWithRow onSelectorOpen={trackPaymentSelectorOpened} />
+                )}
             </>
           )}
           {isResultReady && (
@@ -283,7 +295,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               <PerpsAccountPickerRow />
               <PredictAccountPickerRow />
               {disablePay !== true && hasPaymentOption && (
-                <PayWithRow isResultReady />
+                <PayWithRow
+                  isResultReady
+                  onSelectorOpen={trackPaymentSelectorOpened}
+                />
               )}
               {showPaymentDetails && (
                 <>
@@ -328,6 +343,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             <ConfirmButton
               alertTitle={alertTitle}
               disableConfirm={disableConfirm || isAccountSelectionNeeded}
+              onContinue={trackContinue}
             />
           )}
         </Box>
@@ -414,7 +430,12 @@ function BuySection() {
 function ConfirmButton({
   alertTitle,
   disableConfirm,
-}: Readonly<{ alertTitle: string | undefined; disableConfirm?: boolean }>) {
+  onContinue,
+}: Readonly<{
+  alertTitle: string | undefined;
+  disableConfirm?: boolean;
+  onContinue?: () => void;
+}>) {
   const { styles } = useStyles(styleSheet, {});
   const { hasBlockingAlerts } = useAlerts();
   const { isHeadlessBuyInProgress, setIsConfirmationSubmitting } =
@@ -430,13 +451,15 @@ function ConfirmButton({
 
   const handleConfirm = useCallback(async () => {
     setIsConfirmationSubmitting(true);
+    // Continue / Add Funds CTA funnel event; no-op for non-money flows.
+    onContinue?.();
     try {
       await onConfirm();
     } catch (error) {
       setIsConfirmationSubmitting(false);
       throw error;
     }
-  }, [onConfirm, setIsConfirmationSubmitting]);
+  }, [onConfirm, onContinue, setIsConfirmationSubmitting]);
 
   return (
     <Button

--- a/app/components/Views/confirmations/components/info/custom-amount-info/useMoneyDepositFunnelMetrics.test.ts
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/useMoneyDepositFunnelMetrics.test.ts
@@ -1,0 +1,318 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { TransactionType } from '@metamask/transaction-controller';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { AlertKeys } from '../../../constants/alerts';
+import { useMoneyDepositFunnelMetrics } from './useMoneyDepositFunnelMetrics';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { useTransactionPayFiatPayment } from '../../../hooks/pay/useTransactionPayData';
+import { useAlerts } from '../../../context/alert-system-context';
+import { useRampsUserRegion } from '../../../../../UI/Ramp/hooks/useRampsUserRegion';
+
+jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
+jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../context/alert-system-context');
+jest.mock('../../../../../UI/Ramp/hooks/useRampsUserRegion');
+
+const mockTrackEvent = jest.fn();
+const mockBuild = jest.fn(() => 'built-event');
+const mockAddProperties = jest.fn(
+  (_properties: Record<string, unknown>) => ({ build: mockBuild }),
+);
+const mockCreateEventBuilder = jest.fn((_event: unknown) => ({
+  addProperties: mockAddProperties,
+}));
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+const useTransactionMetadataRequestMock = jest.mocked(
+  useTransactionMetadataRequest,
+);
+const useTransactionPayFiatPaymentMock = jest.mocked(
+  useTransactionPayFiatPayment,
+);
+const useAlertsMock = jest.mocked(useAlerts);
+const useRampsUserRegionMock = jest.mocked(useRampsUserRegion);
+
+const REGION = 'us-ca';
+
+const FIAT_PAYMENT_MOCK = {
+  selectedPaymentMethodId: '/payments/debit-credit-card',
+  amountFiat: '100',
+  caipAssetId: 'eip155:1/slip44:60',
+};
+
+const RAMPS_QUOTE_MOCK = {
+  provider: '/providers/transak',
+  quote: {
+    amountIn: 100,
+    amountOut: 0.05,
+    paymentMethod: '/payments/debit-credit-card',
+    totalFees: 5,
+    networkFee: 2,
+    providerFee: 3,
+  },
+};
+
+/**
+ * Returns the addProperties payload for the first emit of `event`, or
+ * undefined if it was never emitted.
+ */
+function payloadFor(event: unknown): Record<string, unknown> | undefined {
+  const callIndex = mockCreateEventBuilder.mock.calls.findIndex(
+    ([arg]) => arg === event,
+  );
+  if (callIndex === -1) {
+    return undefined;
+  }
+  return mockAddProperties.mock.calls[callIndex]?.[0] as Record<
+    string,
+    unknown
+  >;
+}
+
+function setMocks({
+  type = TransactionType.moneyAccountDeposit,
+  fiatPayment = FIAT_PAYMENT_MOCK,
+  alerts = [],
+}: {
+  type?: TransactionType;
+  fiatPayment?: Record<string, unknown> | undefined;
+  alerts?: { key: string; message?: string }[];
+} = {}) {
+  useTransactionMetadataRequestMock.mockReturnValue({
+    id: 'tx-1',
+    type,
+    txParams: { from: '0x123' },
+  } as never);
+  useTransactionPayFiatPaymentMock.mockReturnValue(fiatPayment as never);
+  useAlertsMock.mockReturnValue({ alerts } as never);
+  useRampsUserRegionMock.mockReturnValue({
+    userRegion: { regionCode: REGION },
+    setUserRegion: jest.fn(),
+  } as never);
+}
+
+const NON_MONEY_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.predictDeposit,
+  TransactionType.moneyAccountWithdraw,
+  TransactionType.musdConversion,
+];
+
+describe('useMoneyDepositFunnelMetrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMocks();
+  });
+
+  describe('moneyAccountDeposit (HEADLESS / money_account)', () => {
+    it('emits RAMPS_ORDER_SELECTED reactively when a usable quote is present', () => {
+      setMocks({
+        fiatPayment: { ...FIAT_PAYMENT_MOCK, rampsQuote: RAMPS_QUOTE_MOCK },
+      });
+
+      renderHook(() => useMoneyDepositFunnelMetrics());
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_ORDER_SELECTED)).toEqual({
+        ramp_type: 'HEADLESS',
+        ramp_surface: 'money_account',
+        region: REGION,
+        amount_source: 100,
+        amount_destination: 0.05,
+        total_fee: 5,
+        gas_fee: 2,
+        processing_fee: 3,
+        payment_method_id: '/payments/debit-credit-card',
+        currency_destination: 'eip155:1/slip44:60',
+        currency_source: 'usd',
+      });
+    });
+
+    it('emits RAMPS_PAYMENT_METHOD_SELECTED reactively when a method is selected', () => {
+      renderHook(() => useMoneyDepositFunnelMetrics());
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTED)).toEqual(
+        {
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: REGION,
+          payment_method_id: '/payments/debit-credit-card',
+        },
+      );
+    });
+
+    it('emits RAMPS_QUOTE_ERROR reactively on the no-quotes alert', () => {
+      setMocks({
+        alerts: [
+          { key: AlertKeys.NoPayTokenQuotes, message: 'No quotes available' },
+        ],
+      });
+
+      renderHook(() => useMoneyDepositFunnelMetrics());
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_QUOTE_ERROR)).toEqual({
+        ramp_type: 'HEADLESS',
+        ramp_surface: 'money_account',
+        error_message: 'No quotes available',
+        amount: 100,
+        currency_source: 'usd',
+        currency_destination: 'eip155:1/slip44:60',
+        payment_method_id: '/payments/debit-credit-card',
+      });
+    });
+
+    it('emits RAMPS_QUOTE_ERROR reactively on the fiat buy-limit alert', () => {
+      setMocks({
+        alerts: [
+          { key: AlertKeys.FiatBuyAmountLimit, message: 'Over the limit' },
+        ],
+      });
+
+      renderHook(() => useMoneyDepositFunnelMetrics());
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_QUOTE_ERROR)).toEqual(
+        expect.objectContaining({
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          error_message: 'Over the limit',
+        }),
+      );
+    });
+
+    it('emits RAMPS_ORDER_PROPOSED when trackAmountCommitted is called with a valid amount', () => {
+      const { result } = renderHook(() => useMoneyDepositFunnelMetrics());
+
+      act(() => {
+        result.current.trackAmountCommitted();
+      });
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_ORDER_PROPOSED)).toEqual({
+        ramp_type: 'HEADLESS',
+        ramp_surface: 'money_account',
+        region: REGION,
+        amount_source: 100,
+        payment_method_id: '/payments/debit-credit-card',
+        currency_destination: 'eip155:1/slip44:60',
+        currency_source: 'usd',
+      });
+    });
+
+    it('does not emit RAMPS_ORDER_PROPOSED when the committed amount is zero', () => {
+      setMocks({ fiatPayment: { ...FIAT_PAYMENT_MOCK, amountFiat: '0' } });
+
+      const { result } = renderHook(() => useMoneyDepositFunnelMetrics());
+
+      act(() => {
+        result.current.trackAmountCommitted();
+      });
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_ORDER_PROPOSED)).toBeUndefined();
+    });
+
+    it('emits RAMPS_PAYMENT_METHOD_SELECTOR_CLICKED when trackPaymentSelectorOpened is called', () => {
+      const { result } = renderHook(() => useMoneyDepositFunnelMetrics());
+
+      act(() => {
+        result.current.trackPaymentSelectorOpened();
+      });
+
+      expect(
+        payloadFor(MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTOR_CLICKED),
+      ).toEqual({
+        ramp_type: 'HEADLESS',
+        ramp_surface: 'money_account',
+        region: REGION,
+        location: 'Amount Input',
+        current_payment_method: '/payments/debit-credit-card',
+      });
+    });
+
+    it('emits RAMPS_CONTINUE_BUTTON_CLICKED when trackContinue is called', () => {
+      const { result } = renderHook(() => useMoneyDepositFunnelMetrics());
+
+      act(() => {
+        result.current.trackContinue();
+      });
+
+      expect(payloadFor(MetaMetricsEvents.RAMPS_CONTINUE_BUTTON_CLICKED)).toEqual(
+        {
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region: REGION,
+          amount_source: 100,
+          payment_method_id: '/payments/debit-credit-card',
+          currency_destination: 'eip155:1/slip44:60',
+          currency_source: 'usd',
+        },
+      );
+    });
+
+    it('routes every emit through trackEvent', () => {
+      setMocks({
+        fiatPayment: { ...FIAT_PAYMENT_MOCK, rampsQuote: RAMPS_QUOTE_MOCK },
+      });
+
+      renderHook(() => useMoneyDepositFunnelMetrics());
+
+      expect(mockTrackEvent).toHaveBeenCalledWith('built-event');
+    });
+  });
+
+  describe('dedupe (fire once per occurrence)', () => {
+    it('does not re-emit RAMPS_ORDER_SELECTED for the same quote across re-renders', () => {
+      setMocks({
+        fiatPayment: { ...FIAT_PAYMENT_MOCK, rampsQuote: RAMPS_QUOTE_MOCK },
+      });
+
+      const { rerender } = renderHook(() => useMoneyDepositFunnelMetrics());
+      rerender({});
+
+      const selectedCalls = mockCreateEventBuilder.mock.calls.filter(
+        ([event]) => event === MetaMetricsEvents.RAMPS_ORDER_SELECTED,
+      );
+      expect(selectedCalls).toHaveLength(1);
+    });
+
+    it('does not re-emit RAMPS_PAYMENT_METHOD_SELECTED for the same method across re-renders', () => {
+      const { rerender } = renderHook(() => useMoneyDepositFunnelMetrics());
+      rerender({});
+
+      const selectedCalls = mockCreateEventBuilder.mock.calls.filter(
+        ([event]) => event === MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTED,
+      );
+      expect(selectedCalls).toHaveLength(1);
+    });
+  });
+
+  // Cross-flow isolation: the shared screen serves perps / predict / withdraw /
+  // mUSD too. None of the money RAMPS funnel events may fire for those.
+  describe.each(NON_MONEY_TYPES)('cross-flow isolation: %s', (type) => {
+    it('emits no money RAMPS funnel events (reactive or imperative)', () => {
+      setMocks({
+        type,
+        fiatPayment: {
+          ...FIAT_PAYMENT_MOCK,
+          rampsQuote: RAMPS_QUOTE_MOCK,
+        },
+        alerts: [
+          { key: AlertKeys.NoPayTokenQuotes, message: 'No quotes available' },
+        ],
+      });
+
+      const { result } = renderHook(() => useMoneyDepositFunnelMetrics());
+
+      act(() => {
+        result.current.trackAmountCommitted();
+        result.current.trackPaymentSelectorOpened();
+        result.current.trackContinue();
+      });
+
+      expect(mockCreateEventBuilder).not.toHaveBeenCalled();
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/Views/confirmations/components/info/custom-amount-info/useMoneyDepositFunnelMetrics.ts
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/useMoneyDepositFunnelMetrics.ts
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import type {
+  AnalyticsUnfilteredProperties,
+  IMetaMetricsEvent,
+} from '../../../../../../util/analytics/analytics.types';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { useRampsUserRegion } from '../../../../../UI/Ramp/hooks/useRampsUserRegion';
+import type { RampSurface } from '../../../../../UI/Ramp/Deposit/types/analytics';
+import type { Quote } from '../../../../../UI/Ramp/types';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { hasTransactionType } from '../../../utils/transaction';
+import { useTransactionPayFiatPayment } from '../../../hooks/pay/useTransactionPayData';
+import { useAlerts } from '../../../context/alert-system-context';
+import { AlertKeys } from '../../../constants/alerts';
+
+/**
+ * TRAM-3623 headless ramps funnel telemetry for the Money "Add funds" deposit
+ * flow.
+ *
+ * `custom-amount-info` is shared across perps / predict / withdraw / mUSD
+ * confirmations, so every emit here is gated on
+ * `TransactionType.moneyAccountDeposit`. The money-account-deposit confirmation
+ * always leads to the headless buy, so each event is tagged with
+ * `ramp_type: 'HEADLESS'`, `ramp_surface: 'money_account'`, and the user's
+ * `region` (from `RampsController`, matching how the foundation tags Checkout).
+ *
+ * These reuse the existing `Ramps`-prefixed events via the loose
+ * `createEventBuilder(...).addProperties(...)` path (not the typed Ramp hook),
+ * to avoid coupling confirmations to the Ramp typed analytics interfaces.
+ *
+ * The buy funnel (`RAMPS_*`) is intentionally distinct from the Money-surface
+ * telemetry (`mm_pay_*`, `MONEY_SURFACE_VIEWED`); this hook does not touch the
+ * latter.
+ */
+
+const RAMP_TYPE_HEADLESS = 'HEADLESS' as const;
+const RAMP_SURFACE_MONEY_ACCOUNT: RampSurface = 'money_account';
+const CURRENCY_SOURCE = 'usd';
+
+/** Reads a numeric field that the SDK may type as `number | string`. */
+function toNumber(value: number | string | undefined): number {
+  return Number(value ?? 0) || 0;
+}
+
+export function useMoneyDepositFunnelMetrics() {
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const transactionMeta = useTransactionMetadataRequest();
+  const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
+    TransactionType.moneyAccountDeposit,
+  ]);
+
+  const fiatPayment = useTransactionPayFiatPayment();
+  const { alerts } = useAlerts();
+  const { userRegion } = useRampsUserRegion();
+  const region = userRegion?.regionCode ?? '';
+
+  const selectedPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
+  const rampsQuote = fiatPayment?.rampsQuote as Quote | undefined;
+  const amountFiat = fiatPayment?.amountFiat;
+  const assetId = fiatPayment?.caipAssetId;
+
+  // Base properties shared by every funnel event so the stream can be sliced by
+  // headless surface and region.
+  const baseProps = useMemo(
+    () => ({
+      ramp_type: RAMP_TYPE_HEADLESS,
+      ramp_surface: RAMP_SURFACE_MONEY_ACCOUNT,
+      region,
+    }),
+    [region],
+  );
+
+  const emit = useCallback(
+    (event: IMetaMetricsEvent, properties: AnalyticsUnfilteredProperties) => {
+      trackEvent(createEventBuilder(event).addProperties(properties).build());
+    },
+    [trackEvent, createEventBuilder],
+  );
+
+  // Dedupe guards so each semantic event fires once per occurrence on re-render.
+  const lastSelectedPaymentMethodRef = useRef<string | undefined>(undefined);
+  const lastQuoteSelectedKeyRef = useRef<string | undefined>(undefined);
+  const lastQuoteErrorKeyRef = useRef<string | undefined>(undefined);
+
+  // Amount committed (pre-quote). Fired imperatively from the Done handler when
+  // a valid amount has been committed. Reuses RAMPS_ORDER_PROPOSED.
+  const trackAmountCommitted = useCallback(() => {
+    if (!isMoneyAccountDeposit) {
+      return;
+    }
+
+    const amount = toNumber(amountFiat);
+    if (amount <= 0) {
+      return;
+    }
+
+    emit(MetaMetricsEvents.RAMPS_ORDER_PROPOSED, {
+      ...baseProps,
+      amount_source: amount,
+      payment_method_id: selectedPaymentMethodId ?? '',
+      currency_destination: assetId ?? '',
+      currency_source: CURRENCY_SOURCE,
+    });
+  }, [
+    isMoneyAccountDeposit,
+    amountFiat,
+    assetId,
+    baseProps,
+    emit,
+    selectedPaymentMethodId,
+  ]);
+
+  // Payment selector opened. Fired imperatively when the PayWith selector is
+  // opened. Reuses RAMPS_PAYMENT_METHOD_SELECTOR_CLICKED. May not fire when the
+  // #31641 auto-select flag short-circuits the selector (expected/acceptable).
+  const trackPaymentSelectorOpened = useCallback(() => {
+    if (!isMoneyAccountDeposit) {
+      return;
+    }
+
+    emit(MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTOR_CLICKED, {
+      ...baseProps,
+      location: 'Amount Input',
+      current_payment_method: selectedPaymentMethodId,
+    });
+  }, [isMoneyAccountDeposit, baseProps, emit, selectedPaymentMethodId]);
+
+  // Continue / Add Funds CTA. Fired imperatively from the confirm handler.
+  // Reuses RAMPS_CONTINUE_BUTTON_CLICKED. Note: in the headless flow the usable
+  // quote (RAMPS_ORDER_SELECTED) arrives reactively before this CTA fires.
+  const trackContinue = useCallback(() => {
+    if (!isMoneyAccountDeposit) {
+      return;
+    }
+
+    emit(MetaMetricsEvents.RAMPS_CONTINUE_BUTTON_CLICKED, {
+      ...baseProps,
+      amount_source: toNumber(amountFiat),
+      payment_method_id: selectedPaymentMethodId ?? '',
+      currency_destination: assetId ?? '',
+      currency_source: CURRENCY_SOURCE,
+    });
+  }, [
+    isMoneyAccountDeposit,
+    amountFiat,
+    assetId,
+    baseProps,
+    emit,
+    selectedPaymentMethodId,
+  ]);
+
+  // Payment method changed. Reactive: fires once each time the selected fiat
+  // payment method id transitions to a new defined value. Reuses
+  // RAMPS_PAYMENT_METHOD_SELECTED.
+  useEffect(() => {
+    if (!isMoneyAccountDeposit || !selectedPaymentMethodId) {
+      return;
+    }
+
+    if (lastSelectedPaymentMethodRef.current === selectedPaymentMethodId) {
+      return;
+    }
+
+    lastSelectedPaymentMethodRef.current = selectedPaymentMethodId;
+    emit(MetaMetricsEvents.RAMPS_PAYMENT_METHOD_SELECTED, {
+      ...baseProps,
+      payment_method_id: selectedPaymentMethodId,
+    });
+  }, [isMoneyAccountDeposit, selectedPaymentMethodId, baseProps, emit]);
+
+  // Usable quote received. Reactive: fires once each time fiatPayment.rampsQuote
+  // becomes usable. Reuses RAMPS_ORDER_SELECTED with the full fee breakdown.
+  useEffect(() => {
+    if (!isMoneyAccountDeposit || !rampsQuote) {
+      return;
+    }
+
+    const quoteDetails = rampsQuote.quote;
+    const quoteKey = `${rampsQuote.provider ?? ''}:${
+      quoteDetails?.amountIn ?? ''
+    }:${quoteDetails?.amountOut ?? ''}`;
+
+    if (lastQuoteSelectedKeyRef.current === quoteKey) {
+      return;
+    }
+
+    lastQuoteSelectedKeyRef.current = quoteKey;
+    emit(MetaMetricsEvents.RAMPS_ORDER_SELECTED, {
+      ...baseProps,
+      amount_source: toNumber(quoteDetails?.amountIn),
+      amount_destination: toNumber(quoteDetails?.amountOut),
+      total_fee: toNumber(quoteDetails?.totalFees),
+      gas_fee: toNumber(quoteDetails?.networkFee),
+      processing_fee: toNumber(quoteDetails?.providerFee),
+      payment_method_id:
+        quoteDetails?.paymentMethod ?? selectedPaymentMethodId ?? '',
+      currency_destination: assetId ?? '',
+      currency_source: CURRENCY_SOURCE,
+    });
+  }, [
+    isMoneyAccountDeposit,
+    rampsQuote,
+    assetId,
+    baseProps,
+    emit,
+    selectedPaymentMethodId,
+  ]);
+
+  // Quote failure. Reactive: fires once each time the no-quotes or buy-limit
+  // alert becomes active. Reuses RAMPS_QUOTE_ERROR.
+  const quoteErrorAlert = alerts.find(
+    (candidate) =>
+      candidate.key === AlertKeys.NoPayTokenQuotes ||
+      candidate.key === AlertKeys.FiatBuyAmountLimit,
+  );
+  useEffect(() => {
+    if (!isMoneyAccountDeposit) {
+      return;
+    }
+
+    if (!quoteErrorAlert) {
+      // Reset so a later re-occurrence of the same alert key emits again.
+      lastQuoteErrorKeyRef.current = undefined;
+      return;
+    }
+
+    const amount = toNumber(amountFiat);
+    const errorKey = `${quoteErrorAlert.key}:${amount}:${
+      selectedPaymentMethodId ?? ''
+    }`;
+    if (lastQuoteErrorKeyRef.current === errorKey) {
+      return;
+    }
+
+    lastQuoteErrorKeyRef.current = errorKey;
+    emit(MetaMetricsEvents.RAMPS_QUOTE_ERROR, {
+      ramp_type: RAMP_TYPE_HEADLESS,
+      ramp_surface: RAMP_SURFACE_MONEY_ACCOUNT,
+      error_message:
+        typeof quoteErrorAlert.message === 'string'
+          ? quoteErrorAlert.message
+          : undefined,
+      amount,
+      currency_source: CURRENCY_SOURCE,
+      currency_destination: assetId ?? '',
+      payment_method_id: selectedPaymentMethodId ?? '',
+    });
+  }, [
+    isMoneyAccountDeposit,
+    quoteErrorAlert,
+    amountFiat,
+    assetId,
+    emit,
+    selectedPaymentMethodId,
+  ]);
+
+  return {
+    trackAmountCommitted,
+    trackPaymentSelectorOpened,
+    trackContinue,
+  };
+}

--- a/app/components/Views/confirmations/components/info/money-account-deposit-info/money-account-deposit-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/money-account-deposit-info/money-account-deposit-info.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import {
   MoneyAccountDepositInfo,
   MONEY_ACCOUNT_CURRENCY,
@@ -8,6 +9,25 @@ import {
 const mockUseParams = jest.fn();
 jest.mock('../../../../../../util/navigation/navUtils', () => ({
   useParams: () => mockUseParams(),
+}));
+
+const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn((_properties: Record<string, unknown>) => ({
+  build: () => 'built-event',
+}));
+const mockCreateEventBuilder = jest.fn((_event: unknown) => ({
+  addProperties: mockAddProperties,
+}));
+jest.mock('../../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+const mockUseRampsUserRegion = jest.fn();
+jest.mock('../../../../../UI/Ramp/hooks/useRampsUserRegion', () => ({
+  useRampsUserRegion: () => mockUseRampsUserRegion(),
 }));
 
 const mockUseNavbar = jest.fn();
@@ -42,6 +62,10 @@ describe('MoneyAccountDepositInfo', () => {
     mockCustomAmountInfo.mockClear();
     mockUseNavbar.mockReturnValue(undefined);
     mockUseParams.mockReturnValue({});
+    mockUseRampsUserRegion.mockReturnValue({
+      userRegion: { regionCode: 'us-ca' },
+      setUserRegion: jest.fn(),
+    });
   });
 
   it('renders CustomAmountInfo with usd currency', () => {
@@ -114,5 +138,44 @@ describe('MoneyAccountDepositInfo', () => {
       ][0];
     expect(lastCall.autoSelectFiatPayment).toBeUndefined();
     expect(lastCall.hideAccountSelector).toBeUndefined();
+  });
+
+  // TRAM-3623 headless ramps funnel: amount screen viewed.
+  it('emits RAMPS_SCREEN_VIEWED with HEADLESS / money_account / region on mount', () => {
+    render(<MoneyAccountDepositInfo />);
+
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.RAMPS_SCREEN_VIEWED,
+    );
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      location: 'Amount Input',
+      ramp_type: 'HEADLESS',
+      ramp_surface: 'money_account',
+      region: 'us-ca',
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith('built-event');
+  });
+
+  it('emits the screen-viewed event only once across re-renders', () => {
+    const { rerender } = render(<MoneyAccountDepositInfo />);
+    rerender(<MoneyAccountDepositInfo />);
+
+    const screenViewedCalls = mockCreateEventBuilder.mock.calls.filter(
+      ([event]) => event === MetaMetricsEvents.RAMPS_SCREEN_VIEWED,
+    );
+    expect(screenViewedCalls).toHaveLength(1);
+  });
+
+  it('falls back to an empty region when the user region is unavailable', () => {
+    mockUseRampsUserRegion.mockReturnValue({
+      userRegion: null,
+      setUserRegion: jest.fn(),
+    });
+
+    render(<MoneyAccountDepositInfo />);
+
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({ region: '' }),
+    );
   });
 });

--- a/app/components/Views/confirmations/components/info/money-account-deposit-info/money-account-deposit-info.tsx
+++ b/app/components/Views/confirmations/components/info/money-account-deposit-info/money-account-deposit-info.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { CustomAmountInfo } from '../custom-amount-info';
 import { strings } from '../../../../../../../locales/i18n';
 import useNavbar from '../../../hooks/ui/useNavbar';
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import { ConfirmationParams } from '../../confirm/confirm-component';
+import { MetaMetricsEvents } from '../../../../../../core/Analytics';
+import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import { useRampsUserRegion } from '../../../../../UI/Ramp/hooks/useRampsUserRegion';
 
 export const MONEY_ACCOUNT_CURRENCY = 'usd';
 
@@ -13,6 +16,31 @@ export function MoneyAccountDepositInfo() {
 
   const params = useParams<ConfirmationParams>();
   const autoFiat = params?.autoSelectFiatPayment;
+
+  // TRAM-3623 funnel: the amount screen was viewed. This wrapper is
+  // money-account-deposit only, so the event is unconditionally tagged with the
+  // headless money_account surface (the deposit always leads to the headless
+  // buy). Fired once on mount.
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const { userRegion } = useRampsUserRegion();
+  const region = userRegion?.regionCode ?? '';
+  const hasTrackedScreenViewRef = useRef(false);
+  useEffect(() => {
+    if (hasTrackedScreenViewRef.current) {
+      return;
+    }
+    hasTrackedScreenViewRef.current = true;
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.RAMPS_SCREEN_VIEWED)
+        .addProperties({
+          location: 'Amount Input',
+          ramp_type: 'HEADLESS',
+          ramp_surface: 'money_account',
+          region,
+        })
+        .build(),
+    );
+  }, [trackEvent, createEventBuilder, region]);
 
   return (
     <CustomAmountInfo

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -62,7 +62,8 @@ interface PayWithRouteParams {
 
 export function PayWithRow({
   isResultReady,
-}: { isResultReady?: boolean } = {}) {
+  onSelectorOpen,
+}: { isResultReady?: boolean; onSelectorOpen?: () => void } = {}) {
   const transactionMeta = useTransactionMetadataRequest();
   const transactionId = transactionMeta?.id ?? '';
   const paymentOverride = useSelector((state: RootState) =>
@@ -88,10 +89,10 @@ export function PayWithRow({
     paymentOverride === PaymentOverride.MoneyAccount ||
     (isDefaultMoneyAccount && !overrideApplied.current)
   ) {
-    return <PayWithRowMoneyAccount />;
+    return <PayWithRowMoneyAccount onSelectorOpen={onSelectorOpen} />;
   }
 
-  return <PayWithRowInteractive />;
+  return <PayWithRowInteractive onSelectorOpen={onSelectorOpen} />;
 }
 
 function PayWithRowLayout({
@@ -146,7 +147,11 @@ function PayWithRowLayout({
   );
 }
 
-function PayWithRowInteractive() {
+function PayWithRowInteractive({
+  onSelectorOpen,
+}: {
+  onSelectorOpen?: () => void;
+} = {}) {
   const navigation = useNavigation();
   const { payToken } = useTransactionPayToken();
   const { isWithdraw } = useTransactionPayWithdraw();
@@ -176,10 +181,17 @@ function PayWithRowInteractive() {
         mm_pay_token_list_opened: true,
       },
     });
+    onSelectorOpen?.();
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET, {
       preferredPaymentToken,
     });
-  }, [isDisabled, navigation, preferredPaymentToken, setConfirmationMetric]);
+  }, [
+    isDisabled,
+    navigation,
+    onSelectorOpen,
+    preferredPaymentToken,
+    setConfirmationMetric,
+  ]);
 
   const label = isWithdraw
     ? strings('confirm.label.receive_as')
@@ -336,7 +348,11 @@ function PayWithRowEmpty({
   );
 }
 
-function PayWithRowMoneyAccount() {
+function PayWithRowMoneyAccount({
+  onSelectorOpen,
+}: {
+  onSelectorOpen?: () => void;
+} = {}) {
   const navigation = useNavigation();
   const { payToken } = useTransactionPayToken();
   const { isWithdraw } = useTransactionPayWithdraw();
@@ -348,10 +364,11 @@ function PayWithRowMoneyAccount() {
     setConfirmationMetric({
       properties: { mm_pay_token_list_opened: true },
     });
+    onSelectorOpen?.();
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_BOTTOM_SHEET, {
       preferredPaymentToken,
     });
-  }, [navigation, preferredPaymentToken, setConfirmationMetric]);
+  }, [navigation, onSelectorOpen, preferredPaymentToken, setConfirmationMetric]);
 
   if (!payToken) {
     return <PayWithRowSkeleton />;

--- a/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { createProjectLogger } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
 import BigNumber from 'bignumber.js';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -7,6 +8,7 @@ import {
   type HeadlessBuyError,
 } from '../../../../UI/Ramp/headless';
 import type { Quote } from '../../../../UI/Ramp/types';
+import type { RampSurface } from '../../../../UI/Ramp/Deposit/types/analytics';
 import Engine from '../../../../../core/Engine';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import {
@@ -17,6 +19,21 @@ import {
 import { useConfirmationContext } from '../../context/confirmation-context';
 
 const log = createProjectLogger('fiat-confirm');
+
+/**
+ * Maps a confirmation transaction type to the headless ramps `ramp_surface`
+ * (TRAM-3623). Only deposit flows that route through the headless buy belong
+ * here. `musdConversion` and withdraw transaction types are intentionally
+ * omitted: they are not money/perps/prediction deposits, so they get an
+ * `undefined` surface and stay untagged.
+ */
+const TRANSACTION_TYPE_TO_RAMP_SURFACE: Partial<
+  Record<TransactionType, RampSurface>
+> = {
+  [TransactionType.moneyAccountDeposit]: 'money_account',
+  [TransactionType.perpsDeposit]: 'perps',
+  [TransactionType.predictDeposit]: 'prediction',
+};
 
 export function useFiatConfirm() {
   const transactionMetadata = useTransactionMetadataRequest();
@@ -53,6 +70,10 @@ export function useFiatConfirm() {
       .minus(new BigNumber(totals?.fees.providerFiat?.usd ?? 0))
       .toNumber();
 
+    const rampSurface = transactionMetadata?.type
+      ? TRANSACTION_TYPE_TO_RAMP_SURFACE[transactionMetadata.type]
+      : undefined;
+
     startHeadlessBuy(
       {
         quote: rampsQuote,
@@ -61,6 +82,7 @@ export function useFiatConfirm() {
         paymentMethodId: fiatPayment?.selectedPaymentMethodId,
         currency: 'USD',
         walletAddress: transactionMetadata?.txParams?.from,
+        ramp_surface: rampSurface,
       },
       {
         onOrderCreated: (orderIdFromCallback) => {
@@ -94,6 +116,7 @@ export function useFiatConfirm() {
     startHeadlessBuy,
     transactionMetadata?.id,
     transactionMetadata?.txParams?.from,
+    transactionMetadata?.type,
   ]);
 
   return { onFiatConfirm, isFiatPaymentSelected, orderId };


### PR DESCRIPTION
## Summary
Instruments the headless Money / "Add funds" deposit funnel (TRAM-3623) so the product team can measure conversion and capture failures. Additive: the regular Buy (UB2) and the other confirmation flows are unchanged.

Jira: https://consensyssoftware.atlassian.net/browse/TRAM-3623

## What changed
- New `ramp_type` value `HEADLESS` and new field `ramp_surface` (`money_account | perps | prediction`), reusing existing `Ramps`-prefixed events (no new taxonomy).
- `ramp_type=HEADLESS` single-sourced off the per-screen `headlessSessionId` (never a global lookup), so the value stays consistent across the whole headless flow (fixes the prior `UNIFIED_BUY_2` to `DEPOSIT` flip mid-flow).
- `ramp_surface=money_account` seeded on the headless session and tagged on every event in the flow.
- `region` added (from the Ramps controller) on events that were missing it; terminal events snapshot the surface before the session is torn down.
- Failure events (`Ramps Order Failed`, `Ramps OTP Failed`, `Ramps KYC Application Failed`, `Ramps Checkout HTTP Error Received`) carry `error_message` and the HEADLESS tags, emitted from React hosts.
- Funnel click/screen events on the MM Pay deposit screen, gated to `TransactionType.moneyAccountDeposit` so they do not fire for the perps/predict/withdraw/mUSD flows that share the screen.

## Funnel mapping
Amount screen viewed = `Ramps Screen Viewed`; amount committed = `Ramps Order Proposed`; usable quote = `Ramps Order Selected`; quote failure = `Ramps Quote Error`; continue = `Ramps Continue Button Clicked`.

## Paired schema change (required)
Adds `HEADLESS` + `ramp_surface` to the metamask-mobile-ramps deposit events in `Consensys/segment-schema` (branch `tram-3623-headless-ramp-surface`). Must land together, or events fail schema validation. Schema PR link to follow.

## Open item (non-blocking)
Confirm the `Order Proposed` (amount committed) vs `Order Selected` (usable quote) step naming with analytics owners; renameable without code changes.

## Testing
- `yarn lint:tsc` clean; unit tests green, including cross-flow isolation (no events for perps/predict/withdraw/mUSD) and no UB2 regression.
- Manual: Money to Add funds, walk the funnel; verify consistent `HEADLESS` / `ramp_surface=money_account` / `region`, and failure events with `error_message`.
