### PR TITLE
feat: enrich Wallet Setup Completed with deeplink UTMs before first send for SRP users

### DIFF
--- a/app/components/UI/OptinMetrics/MetaMetricsOptIn.testIds.ts
+++ b/app/components/UI/OptinMetrics/MetaMetricsOptIn.testIds.ts
@@ -9,4 +9,5 @@ export const MetaMetricsOptInSelectorsIDs = {
     'default-network-use-this-button-id',
   METAMETRICS_OPT_IN_CONTAINER_ID: 'meta-metrics-container',
   OPTIN_METRICS_METRICS_CHECKBOX: 'optin-metrics-metrics-checkbox',
+  OPTIN_METRICS_MARKETING_CHECKBOX: 'optin-metrics-marketing-checkbox',
 };

--- a/app/components/UI/OptinMetrics/index.test.tsx
+++ b/app/components/UI/OptinMetrics/index.test.tsx
@@ -10,6 +10,7 @@ import { AccountType } from '../../../constants/onboarding';
 import { createMockUseAnalyticsHook } from '../../../util/test/analyticsMock';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
+import { EVENT_NAME } from '../../../core/Analytics/MetaMetrics.events';
 
 const { InteractionManager } = jest.requireActual('react-native');
 
@@ -912,6 +913,112 @@ describe('OptinMetrics', () => {
       await waitFor(() => {
         expect(mockAnalytics.optIn).toHaveBeenCalled();
       });
+    });
+
+    it('strips utm params from buffered Wallet Setup Completed when marketing consent is off', async () => {
+      jest.useFakeTimers();
+      const mockEvents = [
+        [
+          AnalyticsEventBuilder.createEventBuilder({
+            name: EVENT_NAME.WALLET_SETUP_COMPLETED,
+            properties: {
+              wallet_setup_type: 'new',
+              utm_source: 'install',
+            },
+          }).build(),
+        ],
+      ];
+
+      renderScreen(
+        OptinMetrics,
+        { name: 'OptinMetrics' },
+        {
+          state: {
+            onboarding: { events: mockEvents },
+            security: { dataCollectionForMarketing: false },
+          },
+        },
+      );
+
+      const marketingCheckbox = screen.getByText(
+        strings('privacy_policy.checkbox_marketing'),
+      );
+      fireEvent.press(marketingCheckbox);
+      fireEvent.press(marketingCheckbox);
+
+      fireEvent.press(screen.getByText(strings('privacy_policy.continue')));
+
+      await waitFor(() => {
+        expect(mockAnalytics.optIn).toHaveBeenCalled();
+      });
+
+      jest.runAllTimers();
+
+      await waitFor(() => {
+        expect(mockAnalytics.trackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: EVENT_NAME.WALLET_SETUP_COMPLETED,
+            properties: expect.objectContaining({
+              wallet_setup_type: 'new',
+            }),
+          }),
+        );
+      });
+
+      const walletSetupCall = mockAnalytics.trackEvent.mock.calls.find(
+        ([event]) => event.name === EVENT_NAME.WALLET_SETUP_COMPLETED,
+      );
+      expect(walletSetupCall?.[0].properties?.utm_source).toBeUndefined();
+
+      jest.useRealTimers();
+    });
+
+    it('keeps utm params on buffered Wallet Setup Completed when marketing consent is on', async () => {
+      jest.useFakeTimers();
+      const mockEvents = [
+        [
+          AnalyticsEventBuilder.createEventBuilder({
+            name: EVENT_NAME.WALLET_SETUP_COMPLETED,
+            properties: {
+              wallet_setup_type: 'new',
+              utm_source: 'install',
+            },
+          }).build(),
+        ],
+      ];
+
+      renderScreen(
+        OptinMetrics,
+        { name: 'OptinMetrics' },
+        {
+          state: {
+            onboarding: { events: mockEvents },
+            security: { dataCollectionForMarketing: false },
+          },
+        },
+      );
+
+      const marketingCheckbox = screen.getByText(
+        strings('privacy_policy.checkbox_marketing'),
+      );
+      fireEvent.press(marketingCheckbox);
+
+      fireEvent.press(screen.getByText(strings('privacy_policy.continue')));
+
+      await waitFor(() => {
+        expect(mockAnalytics.optIn).toHaveBeenCalled();
+      });
+
+      jest.runAllTimers();
+
+      await waitFor(() => {
+        const walletSetupCall = mockAnalytics.trackEvent.mock.calls.find(
+          ([event]) => event.name === EVENT_NAME.WALLET_SETUP_COMPLETED,
+        );
+        expect(walletSetupCall?.[0].properties?.utm_source).toBe('install');
+      });
+
+      jest.useRealTimers();
     });
 
     it('should handle platform-specific scroll calculations', () => {

--- a/app/components/UI/OptinMetrics/index.test.tsx
+++ b/app/components/UI/OptinMetrics/index.test.tsx
@@ -919,13 +919,14 @@ describe('OptinMetrics', () => {
       jest.useFakeTimers();
       const mockEvents = [
         [
-          AnalyticsEventBuilder.createEventBuilder({
-            name: EVENT_NAME.WALLET_SETUP_COMPLETED,
-            properties: {
+          AnalyticsEventBuilder.createEventBuilder(
+            EVENT_NAME.WALLET_SETUP_COMPLETED,
+          )
+            .addProperties({
               wallet_setup_type: 'new',
               utm_source: 'install',
-            },
-          }).build(),
+            })
+            .build(),
         ],
       ];
 
@@ -977,13 +978,14 @@ describe('OptinMetrics', () => {
       jest.useFakeTimers();
       const mockEvents = [
         [
-          AnalyticsEventBuilder.createEventBuilder({
-            name: EVENT_NAME.WALLET_SETUP_COMPLETED,
-            properties: {
+          AnalyticsEventBuilder.createEventBuilder(
+            EVENT_NAME.WALLET_SETUP_COMPLETED,
+          )
+            .addProperties({
               wallet_setup_type: 'new',
               utm_source: 'install',
-            },
-          }).build(),
+            })
+            .build(),
         ],
       ];
 

--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -491,6 +491,9 @@ const OptinMetrics = () => {
               }
               onPress={handleMarketingToggle}
               disabled={isMarketingDisabled}
+              testID={
+                MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_MARKETING_CHECKBOX
+              }
             >
               <Box
                 flexDirection={BoxFlexDirection.Row}

--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -62,6 +62,7 @@ import {
 import type { RootState } from '../../../reducers';
 import { useOnboardingInterestQuestionnaireEligibility } from '../../Views/OnboardingInterestQuestionnaire/useOnboardingInterestQuestionnaireEligibility';
 import Logger from '../../../util/Logger';
+import { applyMarketingConsentToWalletSetupCompletedEvent } from '../../../util/analytics/pendingDeeplinkUtmParameters';
 
 /**
  * View that is displayed in the flow to agree to metrics
@@ -215,7 +216,7 @@ const OptinMetrics = () => {
 
     // track onboarding events that were stored before user opted in
     // only if the user eventually opts in.
-    if (events?.length) {
+    if (events?.length && isBasicUsageChecked) {
       let delay = 0; // Initialize delay
       const eventTrackingDelay = 200; // ms delay between each event
       events.forEach((eventArgs) => {
@@ -226,9 +227,10 @@ const OptinMetrics = () => {
         // as precision is only to the milisecond
         // and loop seems to runs faster than that
         setTimeout(() => {
-          const event = AnalyticsEventBuilder.createEventBuilder(
-            eventArgs[0],
-          ).build();
+          const event = applyMarketingConsentToWalletSetupCompletedEvent(
+            AnalyticsEventBuilder.createEventBuilder(eventArgs[0]).build(),
+            isMarketingChecked,
+          );
           metrics.trackEvent(event);
         }, delay);
         delay += eventTrackingDelay;

--- a/app/components/Views/ChoosePassword/index.tsx
+++ b/app/components/Views/ChoosePassword/index.tsx
@@ -32,7 +32,7 @@ import {
   HeaderStandard,
 } from '@metamask/design-system-react-native';
 import StorageWrapper from '../../../store/storage-wrapper';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { saveOnboardingEvent as saveEvent } from '../../../actions/onboarding';
 import {
   passwordSet as passwordSetAction,
@@ -92,8 +92,10 @@ import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { hasTestOverrides } from '../../../util/test/utils';
 import { AccountImportStrategy } from '@metamask/keyring-controller';
 import { setDataCollectionForMarketing } from '../../../actions/security';
-import { selectAttributionRecord } from '../../../selectors/attribution';
-import { getWalletSetupCompletedAttributionAnalyticsProps } from '../../../util/analytics/walletSetupCompletedAttribution';
+import {
+  clearOnboardingPendingDeeplinkIfNeeded,
+  getPendingDeeplinkUtmParameters,
+} from '../../../util/analytics/pendingDeeplinkUtmParameters';
 import { ChoosePasswordRouteParams } from './ChoosePassword.types';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { UserProfileProperty } from '../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
@@ -130,7 +132,6 @@ const ChoosePassword = () => {
     useRoute<RouteProp<{ params: ChoosePasswordRouteParams }, 'params'>>();
 
   const dispatch = useDispatch();
-  const attributionRecord = useSelector(selectAttributionRecord);
   const metrics = useAnalytics();
 
   const [isSelected, setIsSelected] = useState(false);
@@ -165,6 +166,19 @@ const ChoosePassword = () => {
       );
     },
     [dispatch],
+  );
+
+  const emitNewWalletSetupCompleted = useCallback(
+    (accountType: AccountType) => {
+      track(MetaMetricsEvents.WALLET_SETUP_COMPLETED, {
+        wallet_setup_type: 'new',
+        new_wallet: true,
+        account_type: accountType,
+        ...(getPendingDeeplinkUtmParameters() ?? {}),
+      });
+      clearOnboardingPendingDeeplinkIfNeeded();
+    },
+    [track],
   );
 
   const setSelection = useCallback(() => {
@@ -500,21 +514,14 @@ const ChoosePassword = () => {
 
       await handleWalletCreation(authType, previous_screen);
 
+      emitNewWalletSetupCompleted(accountType);
+
       foxRiveLoaderRef.current?.stop();
       await handlePostWalletCreation(authType);
 
       track(MetaMetricsEvents.WALLET_CREATED, {
         biometrics_enabled: Boolean(biometryType),
         account_type: accountType,
-      });
-      track(MetaMetricsEvents.WALLET_SETUP_COMPLETED, {
-        wallet_setup_type: 'new',
-        new_wallet: true,
-        account_type: accountType,
-        ...getWalletSetupCompletedAttributionAnalyticsProps(
-          attributionRecord,
-          isSelected,
-        ),
       });
       endTrace({ name: TraceName.OnboardingSRPAccountCreationTime });
     } catch (err) {
@@ -531,8 +538,7 @@ const ChoosePassword = () => {
     handlePostWalletCreation,
     handleWalletCreationError,
     metrics,
-    attributionRecord,
-    isSelected,
+    emitNewWalletSetupCompleted,
   ]);
 
   const onPasswordChange = useCallback(

--- a/app/core/AppStateEventListener.ts
+++ b/app/core/AppStateEventListener.ts
@@ -19,6 +19,7 @@ export class AppStateEventListener {
   public currentDeeplink: string | null = null;
   public pendingDeeplink: string | null = null;
   public pendingDeeplinkSource: string | null = null;
+  public onboardingInstallDeeplinkHandled = false;
   private lastAppState: AppStateStatus = AppState.currentState;
 
   constructor() {
@@ -49,6 +50,10 @@ export class AppStateEventListener {
   public clearPendingDeeplink() {
     this.pendingDeeplink = null;
     this.pendingDeeplinkSource = null;
+  }
+
+  public markOnboardingInstallDeeplinkHandled() {
+    this.onboardingInstallDeeplinkHandled = true;
   }
 
   private handleAppStateChange = (nextAppState: AppStateStatus) => {

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -332,6 +332,12 @@ export function* handleDeeplinkSaga() {
       AppConstants.DEEPLINKS.ORIGIN_DEEPLINK;
 
     if (deeplink) {
+      if (isOnboardingDeeplink(deeplink)) {
+        // Wallet creation dispatches LOGIN before Wallet Setup Completed.
+        // Keep the install deeplink until ChoosePassword reads UTMs from it.
+        continue;
+      }
+
       if (isSDKServiceDeeplink(deeplink)) {
         yield call(waitForSDKServicesInitialization);
       }

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -39,6 +39,7 @@ import { applyVaultInitialization } from '../../util/generateSkipOnboardingState
 import SDKConnect from '../../core/SDKConnect/SDKConnect';
 import WC2Manager from '../../core/WalletConnect/WalletConnectV2';
 import { selectExistingUser } from '../../reducers/user';
+import { isOnboardingDeeplink } from '../../util/analytics/pendingDeeplinkUtmParameters';
 import UrlParser from 'url-parse';
 import { isSDKServiceDeeplink } from '../../core/DeeplinkManager/util/deeplinks';
 import { rewardsBulkLinkSaga } from './rewardsBulkLinkAccountGroups';
@@ -300,14 +301,19 @@ export function* handleDeeplinkSaga() {
         AppStateEventProcessor.pendingDeeplinkSource ??
         AppConstants.DEEPLINKS.ORIGIN_DEEPLINK;
       // try handle fast onboarding if mobile existingUser flag is false and 'onboarding' present in deeplink
-      if (!existingUser && url.pathname === '/onboarding') {
+      if (
+        !existingUser &&
+        isOnboardingDeeplink(AppStateEventProcessor.pendingDeeplink)
+      ) {
         // New-user onboarding lives outside the post-login navigation tree.
-        setTimeout(() => {
-          SharedDeeplinkManager.parse(url.href, {
-            origin: storedSource,
-          });
-        }, 200);
-        AppStateEventProcessor.clearPendingDeeplink();
+        if (!AppStateEventProcessor.onboardingInstallDeeplinkHandled) {
+          setTimeout(() => {
+            SharedDeeplinkManager.parse(url.href, {
+              origin: storedSource,
+            });
+          }, 200);
+          AppStateEventProcessor.markOnboardingInstallDeeplinkHandled();
+        }
         continue;
       }
     }

--- a/app/store/sagas/sagas.test.ts
+++ b/app/store/sagas/sagas.test.ts
@@ -857,6 +857,41 @@ describe('handleDeeplinkSaga', () => {
           expect(SDKConnect.init).not.toHaveBeenCalled();
         });
 
+        it('preserves onboarding install deeplink after unlock for Wallet Setup Completed', async () => {
+          const onboardingLink =
+            'metamask://onboarding?utm_source=install&utm_campaign=test';
+          AppStateEventProcessor.pendingDeeplink = onboardingLink;
+          AppStateEventProcessor.onboardingInstallDeeplinkHandled = true;
+          Engine.context.KeyringController.isUnlocked = jest
+            .fn()
+            .mockReturnValue(true);
+
+          await expectSaga(handleDeeplinkSaga)
+            .withState({
+              onboarding: { completedOnboarding: true },
+              user: { existingUser: true },
+              engine: { backgroundState: {} },
+              confirmation: {},
+              navigation: {},
+              security: {},
+              sdk: {},
+              inpageProvider: {},
+              confirmationMetrics: {},
+              originThrottling: {},
+              notifications: {},
+              bridge: {},
+              banners: {},
+            })
+            .dispatch({ type: UserActionType.LOGIN })
+            .silentRun();
+
+          expect(SharedDeeplinkManager.parse).not.toHaveBeenCalled();
+          expect(
+            AppStateEventProcessor.clearPendingDeeplink,
+          ).not.toHaveBeenCalled();
+          expect(AppStateEventProcessor.pendingDeeplink).toBe(onboardingLink);
+        });
+
         it('parses non-SDK deeplinks without starting SDK services', async () => {
           const rewardsLink = 'https://link.metamask.io/rewards';
           AppStateEventProcessor.pendingDeeplink = rewardsLink;

--- a/app/store/sagas/sagas.test.ts
+++ b/app/store/sagas/sagas.test.ts
@@ -48,14 +48,29 @@ jest.mock('../../core/EngineService', () => ({
   start: jest.fn(),
 }));
 
-jest.mock('../../core/AppStateEventListener', () => ({
-  AppStateEventProcessor: {
+jest.mock('../../core/AppStateEventListener', () => {
+  const appStateEventProcessor = {
     start: jest.fn(),
-    pendingDeeplink: null,
-    pendingDeeplinkSource: null,
+    pendingDeeplink: null as string | null,
+    pendingDeeplinkSource: null as string | null,
+    onboardingInstallDeeplinkHandled: false,
     clearPendingDeeplink: jest.fn(),
-  },
-}));
+    markOnboardingInstallDeeplinkHandled: jest.fn(() => {
+      appStateEventProcessor.onboardingInstallDeeplinkHandled = true;
+    }),
+  };
+
+  return { AppStateEventProcessor: appStateEventProcessor };
+});
+
+const mockAppStateEventProcessor = jest.requireMock(
+  '../../core/AppStateEventListener',
+).AppStateEventProcessor as {
+  pendingDeeplink: string | null;
+  onboardingInstallDeeplinkHandled: boolean;
+  clearPendingDeeplink: jest.Mock;
+  markOnboardingInstallDeeplinkHandled: jest.Mock;
+};
 
 jest.mock('../../core/Analytics', () => ({
   __esModule: true,
@@ -667,6 +682,7 @@ describe('handleDeeplinkSaga', () => {
     __resetSDKServicesInitializationForTesting();
     AppStateEventProcessor.pendingDeeplink = null;
     AppStateEventProcessor.pendingDeeplinkSource = null;
+    AppStateEventProcessor.onboardingInstallDeeplinkHandled = false;
   });
 
   describe('without deeplink', () => {
@@ -945,6 +961,12 @@ describe('handleDeeplinkSaga', () => {
             .silentRun();
 
           expect(SharedDeeplinkManager.parse).toHaveBeenCalled();
+          expect(
+            AppStateEventProcessor.clearPendingDeeplink,
+          ).not.toHaveBeenCalled();
+          expect(
+            AppStateEventProcessor.markOnboardingInstallDeeplinkHandled,
+          ).toHaveBeenCalled();
         });
 
         it('does not wait for MainNavigator readiness before handling onboarding deeplinks', async () => {

--- a/app/util/analytics/analytics.ts
+++ b/app/util/analytics/analytics.ts
@@ -17,6 +17,7 @@ import {
   enrichWithABTests,
   getRemoteFeatureFlagsFromState,
 } from './enrichWithABTests';
+import { removeUtmPropertiesWithoutMarketingConsent } from './removeUtmPropertiesWithoutMarketingConsent';
 
 /**
  * Analytics helper interface
@@ -64,6 +65,21 @@ const trackEvent = (event: AnalyticsTrackingEvent): void => {
   } catch {
     enrichedEvent = event;
   }
+
+  const dataCollectionForMarketing =
+    store.getState().security?.dataCollectionForMarketing ?? null;
+
+  enrichedEvent = {
+    ...enrichedEvent,
+    properties: removeUtmPropertiesWithoutMarketingConsent(
+      enrichedEvent.properties,
+      dataCollectionForMarketing,
+    ),
+    sensitiveProperties: removeUtmPropertiesWithoutMarketingConsent(
+      enrichedEvent.sensitiveProperties,
+      dataCollectionForMarketing,
+    ),
+  };
 
   queueManager.queueOperation('trackEvent', enrichedEvent).catch((error) => {
     Logger.log('Analytics: Unhandled error in trackEvent', error);

--- a/app/util/analytics/pendingDeeplinkUtmParameters.test.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.test.ts
@@ -112,6 +112,27 @@ describe('getPendingDeeplinkUtmParameters', () => {
     );
   });
 
+  it('falls back to preloaded Redux attribution in E2E when deeplink has no utm params', () => {
+    mockTestUtils.hasTestOverrides = true;
+    mockAppStateEventProcessor.currentDeeplink = 'metamask://onboarding';
+    mockReduxGetState.mockReturnValue({
+      attribution: {
+        attribution: {
+          utm_source: 'e2e_wsc_utm_source',
+          utm_campaign: 'e2e_wsc_campaign',
+          attribution_id: 'e2e_wsc_attr_id',
+          capturedAt: Date.now(),
+        },
+      },
+    });
+
+    expect(getPendingDeeplinkUtmParameters()).toEqual({
+      utm_source: 'e2e_wsc_utm_source',
+      utm_campaign: 'e2e_wsc_campaign',
+      attribution_id: 'e2e_wsc_attr_id',
+    });
+  });
+
   it('falls back to preloaded Redux attribution in E2E when deeplink is absent', () => {
     mockTestUtils.hasTestOverrides = true;
     mockReduxGetState.mockReturnValue({

--- a/app/util/analytics/pendingDeeplinkUtmParameters.test.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.test.ts
@@ -5,10 +5,40 @@ jest.mock('../../core/AppStateEventListener', () => {
     clearPendingDeeplink: jest.fn(() => {
       appStateEventProcessor.pendingDeeplink = null;
     }),
+    setCurrentDeeplink: jest.fn((deeplink: string | null) => {
+      appStateEventProcessor.pendingDeeplink = deeplink;
+      appStateEventProcessor.currentDeeplink = deeplink;
+    }),
   };
 
   return { AppStateEventProcessor: appStateEventProcessor };
 });
+
+jest.mock('../test/utils', () => {
+  const testUtils = {
+    hasTestOverrides: false,
+    testConfig: {} as Record<string, unknown>,
+  };
+
+  return {
+    get hasTestOverrides() {
+      return testUtils.hasTestOverrides;
+    },
+    get testConfig() {
+      return testUtils.testConfig;
+    },
+    __testUtils: testUtils,
+  };
+});
+
+jest.mock('../../core/redux', () => ({
+  __esModule: true,
+  default: {
+    store: {
+      getState: jest.fn(() => ({ attribution: { attribution: null } })),
+    },
+  },
+}));
 
 const mockAppStateEventProcessor = jest.requireMock(
   '../../core/AppStateEventListener',
@@ -16,6 +46,15 @@ const mockAppStateEventProcessor = jest.requireMock(
   pendingDeeplink: string | null;
   currentDeeplink: string | null;
   clearPendingDeeplink: jest.Mock;
+  setCurrentDeeplink: jest.Mock;
+};
+
+const mockReduxGetState = jest.requireMock('../../core/redux').default.store
+  .getState as jest.Mock;
+
+const mockTestUtils = jest.requireMock('../test/utils').__testUtils as {
+  hasTestOverrides: boolean;
+  testConfig: Record<string, unknown>;
 };
 
 import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
@@ -32,6 +71,10 @@ describe('getPendingDeeplinkUtmParameters', () => {
     mockAppStateEventProcessor.pendingDeeplink = null;
     mockAppStateEventProcessor.currentDeeplink = null;
     mockAppStateEventProcessor.clearPendingDeeplink.mockClear();
+    mockAppStateEventProcessor.setCurrentDeeplink.mockClear();
+    mockReduxGetState.mockReturnValue({ attribution: { attribution: null } });
+    mockTestUtils.hasTestOverrides = false;
+    mockTestUtils.testConfig = {};
   });
 
   it('returns utm params from pending deeplink', () => {
@@ -54,6 +97,39 @@ describe('getPendingDeeplinkUtmParameters', () => {
 
   it('returns null when no deeplink is available', () => {
     expect(getPendingDeeplinkUtmParameters()).toBeNull();
+  });
+
+  it('hydrates pending deeplink from E2E launch arg when missing', () => {
+    mockTestUtils.hasTestOverrides = true;
+    mockTestUtils.testConfig.e2ePendingInstallDeeplink =
+      'metamask://onboarding?utm_source=e2e';
+
+    expect(getPendingDeeplinkUtmParameters()).toEqual({
+      utm_source: 'e2e',
+    });
+    expect(mockAppStateEventProcessor.setCurrentDeeplink).toHaveBeenCalledWith(
+      'metamask://onboarding?utm_source=e2e',
+    );
+  });
+
+  it('falls back to preloaded Redux attribution in E2E when deeplink is absent', () => {
+    mockTestUtils.hasTestOverrides = true;
+    mockReduxGetState.mockReturnValue({
+      attribution: {
+        attribution: {
+          utm_source: 'e2e_wsc_utm_source',
+          utm_campaign: 'e2e_wsc_campaign',
+          attribution_id: 'e2e_wsc_attr_id',
+          capturedAt: Date.now(),
+        },
+      },
+    });
+
+    expect(getPendingDeeplinkUtmParameters()).toEqual({
+      utm_source: 'e2e_wsc_utm_source',
+      utm_campaign: 'e2e_wsc_campaign',
+      attribution_id: 'e2e_wsc_attr_id',
+    });
   });
 });
 

--- a/app/util/analytics/pendingDeeplinkUtmParameters.test.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.test.ts
@@ -1,0 +1,141 @@
+jest.mock('../../core/AppStateEventListener', () => {
+  const appStateEventProcessor = {
+    pendingDeeplink: null as string | null,
+    currentDeeplink: null as string | null,
+    clearPendingDeeplink: jest.fn(() => {
+      appStateEventProcessor.pendingDeeplink = null;
+    }),
+  };
+
+  return { AppStateEventProcessor: appStateEventProcessor };
+});
+
+const mockAppStateEventProcessor = jest.requireMock(
+  '../../core/AppStateEventListener',
+).AppStateEventProcessor as {
+  pendingDeeplink: string | null;
+  currentDeeplink: string | null;
+  clearPendingDeeplink: jest.Mock;
+};
+
+import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
+import { AnalyticsEventBuilder } from './AnalyticsEventBuilder';
+import {
+  applyMarketingConsentToWalletSetupCompletedEvent,
+  clearOnboardingPendingDeeplinkIfNeeded,
+  getPendingDeeplinkUtmParameters,
+  isOnboardingDeeplink,
+} from './pendingDeeplinkUtmParameters';
+
+describe('getPendingDeeplinkUtmParameters', () => {
+  beforeEach(() => {
+    mockAppStateEventProcessor.pendingDeeplink = null;
+    mockAppStateEventProcessor.currentDeeplink = null;
+    mockAppStateEventProcessor.clearPendingDeeplink.mockClear();
+  });
+
+  it('returns utm params from pending deeplink', () => {
+    mockAppStateEventProcessor.pendingDeeplink =
+      'metamask://onboarding?utm_source=install';
+
+    expect(getPendingDeeplinkUtmParameters()).toEqual({
+      utm_source: 'install',
+    });
+  });
+
+  it('falls back to current deeplink when pending is cleared', () => {
+    mockAppStateEventProcessor.currentDeeplink =
+      'metamask://onboarding?utm_source=current';
+
+    expect(getPendingDeeplinkUtmParameters()).toEqual({
+      utm_source: 'current',
+    });
+  });
+
+  it('returns null when no deeplink is available', () => {
+    expect(getPendingDeeplinkUtmParameters()).toBeNull();
+  });
+});
+
+describe('clearOnboardingPendingDeeplinkIfNeeded', () => {
+  beforeEach(() => {
+    mockAppStateEventProcessor.pendingDeeplink = null;
+    mockAppStateEventProcessor.currentDeeplink = null;
+    mockAppStateEventProcessor.clearPendingDeeplink.mockClear();
+  });
+
+  it('clears pending deeplink for onboarding links', () => {
+    mockAppStateEventProcessor.pendingDeeplink =
+      'metamask://onboarding?utm_source=install';
+
+    clearOnboardingPendingDeeplinkIfNeeded();
+
+    expect(mockAppStateEventProcessor.clearPendingDeeplink).toHaveBeenCalled();
+  });
+
+  it('does not clear pending deeplink for non-onboarding links', () => {
+    mockAppStateEventProcessor.pendingDeeplink =
+      'metamask://swap?utm_source=install';
+
+    clearOnboardingPendingDeeplinkIfNeeded();
+
+    expect(
+      mockAppStateEventProcessor.clearPendingDeeplink,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe('isOnboardingDeeplink', () => {
+  it('returns true for onboarding pathname', () => {
+    expect(isOnboardingDeeplink('metamask://onboarding?utm_source=x')).toBe(
+      true,
+    );
+  });
+
+  it('returns false for other pathnames', () => {
+    expect(isOnboardingDeeplink('metamask://swap?utm_source=x')).toBe(false);
+  });
+});
+
+describe('applyMarketingConsentToWalletSetupCompletedEvent', () => {
+  const walletSetupCompletedEvent = AnalyticsEventBuilder.createEventBuilder(
+    EVENT_NAME.WALLET_SETUP_COMPLETED,
+  )
+    .addProperties({
+      wallet_setup_type: 'new',
+      utm_source: 'install',
+      utm_campaign: 'spring',
+    })
+    .build();
+
+  it('keeps utm params when marketing consent is granted', () => {
+    const result = applyMarketingConsentToWalletSetupCompletedEvent(
+      walletSetupCompletedEvent,
+      true,
+    );
+
+    expect(result.properties?.utm_source).toBe('install');
+    expect(result.properties?.utm_campaign).toBe('spring');
+  });
+
+  it('strips utm params when marketing consent is denied', () => {
+    const result = applyMarketingConsentToWalletSetupCompletedEvent(
+      walletSetupCompletedEvent,
+      false,
+    );
+
+    expect(result.properties?.utm_source).toBeUndefined();
+    expect(result.properties?.utm_campaign).toBeUndefined();
+    expect(result.properties?.wallet_setup_type).toBe('new');
+  });
+
+  it('returns other events unchanged', () => {
+    const otherEvent = AnalyticsEventBuilder.createEventBuilder('Other Event')
+      .addProperties({ utm_source: 'install' })
+      .build();
+
+    expect(
+      applyMarketingConsentToWalletSetupCompletedEvent(otherEvent, false),
+    ).toEqual(otherEvent);
+  });
+});

--- a/app/util/analytics/pendingDeeplinkUtmParameters.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.ts
@@ -7,6 +7,9 @@ import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
 import type { WalletSetupCompletedAttributionAnalyticsPayload } from './walletSetupCompletedAttribution';
 import { removeUtmPropertiesWithoutMarketingConsent } from './removeUtmPropertiesWithoutMarketingConsent';
 import { UTM_PARAMETERS, type UtmParameter } from './utmParameters';
+import { hasTestOverrides, testConfig } from '../test/utils';
+import ReduxService from '../../core/redux';
+import type { AttributionRecord } from '../../core/redux/slices/attribution';
 
 export { UTM_PARAMETERS, type UtmParameter };
 
@@ -15,6 +18,70 @@ function getDeeplinkForAttribution(): string | null {
     AppStateEventProcessor.pendingDeeplink ??
     AppStateEventProcessor.currentDeeplink
   );
+}
+
+function ensureE2eInstallDeeplinkFromTestConfig(): void {
+  if (!hasTestOverrides) {
+    return;
+  }
+
+  const deeplink =
+    typeof testConfig.e2ePendingInstallDeeplink === 'string'
+      ? testConfig.e2ePendingInstallDeeplink
+      : undefined;
+
+  if (deeplink && !getDeeplinkForAttribution()) {
+    AppStateEventProcessor.setCurrentDeeplink(deeplink);
+  }
+}
+
+function attributionRecordToPayload(
+  record: AttributionRecord,
+): WalletSetupCompletedAttributionAnalyticsPayload | null {
+  const payload: WalletSetupCompletedAttributionAnalyticsPayload = {};
+
+  if (record.utm_source?.trim()) {
+    payload.utm_source = record.utm_source.trim();
+  }
+  if (record.utm_medium?.trim()) {
+    payload.utm_medium = record.utm_medium.trim();
+  }
+  if (record.utm_campaign?.trim()) {
+    payload.utm_campaign = record.utm_campaign.trim();
+  }
+  if (record.utm_term?.trim()) {
+    payload.utm_term = record.utm_term.trim();
+  }
+  if (record.utm_content?.trim()) {
+    payload.utm_content = record.utm_content.trim();
+  }
+  if (record.attribution_id?.trim()) {
+    payload.attribution_id = record.attribution_id.trim();
+  }
+
+  return Object.keys(payload).length > 0 ? payload : null;
+}
+
+/**
+ * E2E fixtures preload Redux attribution; Android CI cannot read Detox launch args.
+ * Fall back to the persisted record when no install deeplink is available.
+ */
+function getE2eAttributionUtmFallback(): WalletSetupCompletedAttributionAnalyticsPayload | null {
+  if (!hasTestOverrides) {
+    return null;
+  }
+
+  try {
+    const record =
+      ReduxService.store.getState().attribution?.attribution ?? null;
+    if (!record) {
+      return null;
+    }
+
+    return attributionRecordToPayload(record);
+  } catch {
+    return null;
+  }
 }
 
 function getDeeplinkPathname(deeplink: string): string {
@@ -62,12 +129,14 @@ export function parseDeeplinkUtmParameters(
  * Reads acquisition params from the pending install deeplink at track time.
  */
 export function getPendingDeeplinkUtmParameters(): WalletSetupCompletedAttributionAnalyticsPayload | null {
+  ensureE2eInstallDeeplinkFromTestConfig();
+
   const deeplink = getDeeplinkForAttribution();
-  if (!deeplink) {
-    return null;
+  if (deeplink) {
+    return parseDeeplinkUtmParameters(deeplink);
   }
 
-  return parseDeeplinkUtmParameters(deeplink);
+  return getE2eAttributionUtmFallback();
 }
 
 /**

--- a/app/util/analytics/pendingDeeplinkUtmParameters.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.ts
@@ -133,7 +133,10 @@ export function getPendingDeeplinkUtmParameters(): WalletSetupCompletedAttributi
 
   const deeplink = getDeeplinkForAttribution();
   if (deeplink) {
-    return parseDeeplinkUtmParameters(deeplink);
+    const fromDeeplink = parseDeeplinkUtmParameters(deeplink);
+    if (fromDeeplink) {
+      return fromDeeplink;
+    }
   }
 
   return getE2eAttributionUtmFallback();

--- a/app/util/analytics/pendingDeeplinkUtmParameters.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.ts
@@ -6,16 +6,9 @@ import type { AnalyticsTrackingEvent } from './AnalyticsEventBuilder';
 import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
 import type { WalletSetupCompletedAttributionAnalyticsPayload } from './walletSetupCompletedAttribution';
 import { removeUtmPropertiesWithoutMarketingConsent } from './removeUtmPropertiesWithoutMarketingConsent';
+import { UTM_PARAMETERS, type UtmParameter } from './utmParameters';
 
-export const UTM_PARAMETERS = [
-  'utm_campaign',
-  'utm_content',
-  'utm_medium',
-  'utm_source',
-  'utm_term',
-] as const;
-
-export type UtmParameter = (typeof UTM_PARAMETERS)[number];
+export { UTM_PARAMETERS, type UtmParameter };
 
 function getDeeplinkForAttribution(): string | null {
   return (

--- a/app/util/analytics/pendingDeeplinkUtmParameters.ts
+++ b/app/util/analytics/pendingDeeplinkUtmParameters.ts
@@ -1,0 +1,117 @@
+import Logger from '../Logger';
+import UrlParser from 'url-parse';
+import { AppStateEventProcessor } from '../../core/AppStateEventListener';
+import { attributionPayloadFromDeeplink } from '../../core/redux/slices/attributionFromSources';
+import type { AnalyticsTrackingEvent } from './AnalyticsEventBuilder';
+import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
+import type { WalletSetupCompletedAttributionAnalyticsPayload } from './walletSetupCompletedAttribution';
+import { removeUtmPropertiesWithoutMarketingConsent } from './removeUtmPropertiesWithoutMarketingConsent';
+
+export const UTM_PARAMETERS = [
+  'utm_campaign',
+  'utm_content',
+  'utm_medium',
+  'utm_source',
+  'utm_term',
+] as const;
+
+export type UtmParameter = (typeof UTM_PARAMETERS)[number];
+
+function getDeeplinkForAttribution(): string | null {
+  return (
+    AppStateEventProcessor.pendingDeeplink ??
+    AppStateEventProcessor.currentDeeplink
+  );
+}
+
+function getDeeplinkPathname(deeplink: string): string {
+  try {
+    return new UrlParser(deeplink).pathname.replace(/\/$/, '') || '/';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * True when the deeplink targets onboarding (https path or metamask://onboarding host).
+ */
+export function isOnboardingDeeplink(deeplink: string): boolean {
+  const url = new UrlParser(deeplink);
+  const pathname = getDeeplinkPathname(deeplink);
+
+  if (pathname === '/onboarding') {
+    return true;
+  }
+
+  return (
+    url.protocol.startsWith('metamask') &&
+    url.hostname === 'onboarding' &&
+    (pathname === '/' || pathname === '')
+  );
+}
+
+/**
+ * Parses acquisition query params from a deeplink URL string.
+ */
+export function parseDeeplinkUtmParameters(
+  deeplink: string,
+): WalletSetupCompletedAttributionAnalyticsPayload | null {
+  try {
+    const payload = attributionPayloadFromDeeplink(deeplink);
+    return payload && Object.keys(payload).length > 0 ? payload : null;
+  } catch (error) {
+    Logger.error(error as Error, 'Failed to parse deeplink for UTM parameters');
+    return null;
+  }
+}
+
+/**
+ * Reads acquisition params from the pending install deeplink at track time.
+ */
+export function getPendingDeeplinkUtmParameters(): WalletSetupCompletedAttributionAnalyticsPayload | null {
+  const deeplink = getDeeplinkForAttribution();
+  if (!deeplink) {
+    return null;
+  }
+
+  return parseDeeplinkUtmParameters(deeplink);
+}
+
+/**
+ * Clears pending deeplink after wallet setup when the install link was onboarding-only.
+ */
+export function clearOnboardingPendingDeeplinkIfNeeded(): void {
+  const deeplink = getDeeplinkForAttribution();
+  if (!deeplink || !isOnboardingDeeplink(deeplink)) {
+    return;
+  }
+
+  AppStateEventProcessor.clearPendingDeeplink();
+}
+
+/**
+ * Keeps or strips acquisition params on a buffered Wallet Setup Completed event
+ * based on marketing consent at metrics opt-in.
+ */
+export function applyMarketingConsentToWalletSetupCompletedEvent(
+  event: AnalyticsTrackingEvent,
+  hasMarketingConsent: boolean,
+): AnalyticsTrackingEvent {
+  if (event.name !== EVENT_NAME.WALLET_SETUP_COMPLETED) {
+    return event;
+  }
+
+  const marketingConsent = !!hasMarketingConsent;
+
+  return {
+    ...event,
+    properties: removeUtmPropertiesWithoutMarketingConsent(
+      event.properties,
+      marketingConsent,
+    ),
+    sensitiveProperties: removeUtmPropertiesWithoutMarketingConsent(
+      event.sensitiveProperties,
+      marketingConsent,
+    ),
+  };
+}

--- a/app/util/analytics/removeUtmPropertiesWithoutMarketingConsent.test.ts
+++ b/app/util/analytics/removeUtmPropertiesWithoutMarketingConsent.test.ts
@@ -1,0 +1,35 @@
+import { removeUtmPropertiesWithoutMarketingConsent } from './removeUtmPropertiesWithoutMarketingConsent';
+
+describe('removeUtmPropertiesWithoutMarketingConsent', () => {
+  it('returns properties unchanged when marketing consent is granted', () => {
+    const properties = {
+      wallet_setup_type: 'new',
+      utm_source: 'install',
+    };
+
+    expect(
+      removeUtmPropertiesWithoutMarketingConsent(properties, true),
+    ).toEqual(properties);
+  });
+
+  it('strips utm and attribution_id when marketing consent is not granted', () => {
+    const properties = {
+      wallet_setup_type: 'new',
+      utm_source: 'install',
+      utm_campaign: 'spring',
+      attribution_id: 'abc',
+    };
+
+    expect(
+      removeUtmPropertiesWithoutMarketingConsent(properties, false),
+    ).toEqual({
+      wallet_setup_type: 'new',
+    });
+  });
+
+  it('returns undefined properties unchanged', () => {
+    expect(
+      removeUtmPropertiesWithoutMarketingConsent(undefined, false),
+    ).toBeUndefined();
+  });
+});

--- a/app/util/analytics/removeUtmPropertiesWithoutMarketingConsent.ts
+++ b/app/util/analytics/removeUtmPropertiesWithoutMarketingConsent.ts
@@ -1,0 +1,26 @@
+import type { AnalyticsEventProperties } from '@metamask/analytics-controller';
+import { UTM_PARAMETERS } from './pendingDeeplinkUtmParameters';
+
+/**
+ * Strips marketing UTM fields when the user has not granted marketing consent.
+ */
+export function removeUtmPropertiesWithoutMarketingConsent<
+  TProperties extends AnalyticsEventProperties | undefined,
+>(
+  properties: TProperties,
+  dataCollectionForMarketing: boolean | null,
+): TProperties {
+  if (!properties || dataCollectionForMarketing === true) {
+    return properties;
+  }
+
+  const sanitized = { ...properties };
+
+  for (const utmParam of UTM_PARAMETERS) {
+    delete sanitized[utmParam];
+  }
+
+  delete sanitized.attribution_id;
+
+  return sanitized as TProperties;
+}

--- a/app/util/analytics/removeUtmPropertiesWithoutMarketingConsent.ts
+++ b/app/util/analytics/removeUtmPropertiesWithoutMarketingConsent.ts
@@ -1,5 +1,5 @@
 import type { AnalyticsEventProperties } from '@metamask/analytics-controller';
-import { UTM_PARAMETERS } from './pendingDeeplinkUtmParameters';
+import { UTM_PARAMETERS } from './utmParameters';
 
 /**
  * Strips marketing UTM fields when the user has not granted marketing consent.

--- a/app/util/analytics/utmParameters.ts
+++ b/app/util/analytics/utmParameters.ts
@@ -1,0 +1,9 @@
+export const UTM_PARAMETERS = [
+  'utm_campaign',
+  'utm_content',
+  'utm_medium',
+  'utm_source',
+  'utm_term',
+] as const;
+
+export type UtmParameter = (typeof UTM_PARAMETERS)[number];

--- a/app/util/metrics/TrackOnboarding/trackOnboarding.test.ts
+++ b/app/util/metrics/TrackOnboarding/trackOnboarding.test.ts
@@ -1,11 +1,13 @@
 import trackOnboarding from './trackOnboarding';
 import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBuilder';
 import { analytics } from '../../../util/analytics/analytics';
+import { EVENT_NAME } from '../../../core/Analytics/MetaMetrics.events';
 
 const { InteractionManager } = jest.requireActual('react-native');
-InteractionManager.runAfterInteractions = jest.fn(async (callback) =>
+const mockRunAfterInteractions = jest.fn(async (callback: () => void) =>
   callback(),
 );
+InteractionManager.runAfterInteractions = mockRunAfterInteractions;
 
 const mockIsEnabled = jest.fn();
 const mockTrackEvent = jest.fn();
@@ -28,6 +30,20 @@ describe('trackOnboarding', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('does not defer Wallet Setup Completed via InteractionManager', () => {
+    mockIsEnabled.mockReturnValue(false);
+
+    const mockEvent = AnalyticsEventBuilder.createEventBuilder({
+      name: EVENT_NAME.WALLET_SETUP_COMPLETED,
+      properties: { wallet_setup_type: 'new' },
+    }).build();
+
+    trackOnboarding(mockEvent, mockSaveOnboardingEvent);
+
+    expect(mockRunAfterInteractions).not.toHaveBeenCalled();
+    expect(mockSaveOnboardingEvent).toHaveBeenCalled();
   });
 
   it('calls saveOnboardingEvent when metrics is not enabled', async () => {

--- a/app/util/metrics/TrackOnboarding/trackOnboarding.test.ts
+++ b/app/util/metrics/TrackOnboarding/trackOnboarding.test.ts
@@ -35,10 +35,11 @@ describe('trackOnboarding', () => {
   it('does not defer Wallet Setup Completed via InteractionManager', () => {
     mockIsEnabled.mockReturnValue(false);
 
-    const mockEvent = AnalyticsEventBuilder.createEventBuilder({
-      name: EVENT_NAME.WALLET_SETUP_COMPLETED,
-      properties: { wallet_setup_type: 'new' },
-    }).build();
+    const mockEvent = AnalyticsEventBuilder.createEventBuilder(
+      EVENT_NAME.WALLET_SETUP_COMPLETED,
+    )
+      .addProperties({ wallet_setup_type: 'new' })
+      .build();
 
     trackOnboarding(mockEvent, mockSaveOnboardingEvent);
 

--- a/app/util/metrics/TrackOnboarding/trackOnboarding.ts
+++ b/app/util/metrics/TrackOnboarding/trackOnboarding.ts
@@ -8,6 +8,31 @@ import {
   AnalyticsEventBuilder,
   type AnalyticsTrackingEvent,
 } from '../../../util/analytics/AnalyticsEventBuilder';
+import { EVENT_NAME } from '../../../core/Analytics/MetaMetrics.events';
+
+function isWalletSetupCompletedEvent(
+  event: IMetaMetricsEvent | ITrackingEvent | AnalyticsTrackingEvent,
+): boolean {
+  const builtEvent = AnalyticsEventBuilder.createEventBuilder(event).build();
+  return builtEvent.name === EVENT_NAME.WALLET_SETUP_COMPLETED;
+}
+
+function deliverOnboardingEvent(
+  event: IMetaMetricsEvent | ITrackingEvent | AnalyticsTrackingEvent,
+  saveOnboardingEvent?: (event: AnalyticsTrackingEvent) => void,
+): void {
+  const analyticsEvent =
+    AnalyticsEventBuilder.createEventBuilder(event).build();
+  const isOnboardingDelayedEvent =
+    !analytics.isEnabled() && Boolean(saveOnboardingEvent);
+
+  if (isOnboardingDelayedEvent) {
+    saveOnboardingEvent?.(analyticsEvent);
+    return;
+  }
+
+  analytics.trackEvent(analyticsEvent);
+}
 
 /**
  * track onboarding event or save it for when metrics are enabled
@@ -18,16 +43,15 @@ const trackOnboarding = (
   event: IMetaMetricsEvent | ITrackingEvent | AnalyticsTrackingEvent,
   saveOnboardingEvent?: (event: AnalyticsTrackingEvent) => void,
 ): void => {
-  InteractionManager.runAfterInteractions(async () => {
-    const analyticsEvent =
-      AnalyticsEventBuilder.createEventBuilder(event).build();
-    const isOnboardingDelayedEvent =
-      !analytics.isEnabled() && saveOnboardingEvent;
-    if (isOnboardingDelayedEvent) {
-      saveOnboardingEvent(analyticsEvent);
-    } else {
-      analytics.trackEvent(analyticsEvent);
-    }
+  // Wallet Setup Completed must not wait on InteractionManager — navigation away
+  // from ChoosePassword can defer or prevent the callback from running.
+  if (isWalletSetupCompletedEvent(event)) {
+    deliverOnboardingEvent(event, saveOnboardingEvent);
+    return;
+  }
+
+  InteractionManager.runAfterInteractions(() => {
+    deliverOnboardingEvent(event, saveOnboardingEvent);
   });
 };
 

--- a/shim.js
+++ b/shim.js
@@ -114,6 +114,9 @@ if (isTestEnvironment) {
   testConfig.commandQueueServerPort = raw?.commandQueueServerPort
     ? raw.commandQueueServerPort
     : FALLBACK_COMMAND_QUEUE_SERVER_PORT;
+  if (raw?.e2ePendingInstallDeeplink) {
+    testConfig.e2ePendingInstallDeeplink = raw.e2ePendingInstallDeeplink;
+  }
 }
 
 // Fix for https://github.com/facebook/react-native/issues/5667

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -186,6 +186,7 @@ export const closeOnboardingModals = async (
  * @param {string} [options.seedPhrase] - The secret recovery phrase to import the wallet. Defaults to a valid account's seed phrase.
  * @param {string} [options.password] - The password to set for the wallet. Defaults to a valid account's password.
  * @param {boolean} [options.optInToMetrics=true] - Whether to opt in to MetaMetrics. Defaults to true.
+ * @param {boolean} [options.optInToMarketing=false] - Whether to opt in to marketing on MetaMetrics.
  * @param {boolean} [options.fromResetWallet=false] - Whether the import is from a reset wallet flow. Defaults to false.
  * @returns {Promise<void>} Resolves when the wallet import process is complete.
  */
@@ -193,11 +194,13 @@ export const importWalletWithRecoveryPhrase = async ({
   seedPhrase,
   password,
   optInToMetrics = true,
+  optInToMarketing = false,
   fromResetWallet = false,
 }: {
   seedPhrase?: string;
   password?: string;
   optInToMetrics?: boolean;
+  optInToMarketing?: boolean;
   fromResetWallet?: boolean;
 }): Promise<void> => {
   // tap on import seed phrase button
@@ -235,6 +238,9 @@ export const importWalletWithRecoveryPhrase = async ({
     });
     if (!optInToMetrics) {
       await MetaMetricsOptInView.tapMetricsCheckbox();
+    }
+    if (optInToMarketing) {
+      await MetaMetricsOptInView.tapMarketingCheckbox();
     }
 
     await MetaMetricsOptInView.tapAgreeButton();
@@ -314,10 +320,12 @@ export const dismissProtectYourWalletModal = async (): Promise<void> => {
  * @async
  * @param {Object} [options={}] - Configuration options for wallet creation.
  * @param {boolean} [options.optInToMetrics=true] - Whether to opt in to MetaMetrics analytics.
+ * @param {boolean} [options.optInToMarketing=false] - Whether to opt in to marketing on MetaMetrics.
  * @returns {Promise<void>} Resolves when the wallet creation flow is complete.
  */
 export const CreateNewWallet = async ({
   optInToMetrics = true,
+  optInToMarketing = false,
 } = {}): Promise<void> => {
   //'should create new wallet'
   await OnboardingView.tapCreateWallet();
@@ -349,6 +357,9 @@ export const CreateNewWallet = async ({
   });
   if (!optInToMetrics) {
     await MetaMetricsOptInView.tapMetricsCheckbox();
+  }
+  if (optInToMarketing) {
+    await MetaMetricsOptInView.tapMarketingCheckbox();
   }
 
   await MetaMetricsOptInView.tapAgreeButton();

--- a/tests/framework/fixtures/FixtureBuilder.ts
+++ b/tests/framework/fixtures/FixtureBuilder.ts
@@ -46,6 +46,7 @@ import {
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { USDC_MAINNET, MUSD_MAINNET } from '../../constants/musd-mainnet.ts';
+import { buildE2EOnboardingInstallDeeplinkUrl } from '../../helpers/analytics/walletSetupAttributionE2eConstants';
 import type {
   Fixture,
   ProviderConfig,
@@ -2174,6 +2175,11 @@ class FixtureBuilder {
         _persist: { version: -1, rehydrated: true },
       },
     });
+    this.fixture.launchArgs = {
+      ...(this.fixture.launchArgs ?? {}),
+      e2ePendingInstallDeeplink:
+        buildE2EOnboardingInstallDeeplinkUrl(restFields),
+    };
     return this;
   }
 

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -616,9 +616,14 @@ export async function withFixtures(
       resolvedFixture = fixtureOption;
     }
 
+    const builtFixture: Fixture =
+      resolvedFixture instanceof FixtureBuilder
+        ? resolvedFixture.build()
+        : resolvedFixture;
+
     // Start fixture server
     await startResourceWithRetry(ResourceType.FIXTURE_SERVER, fixtureServer);
-    await loadFixture(fixtureServer, { fixture: resolvedFixture });
+    await loadFixture(fixtureServer, { fixture: builtFixture });
     logger.debug(
       'The fixture server is started, and the initial state is successfully loaded.',
     );
@@ -640,9 +645,11 @@ export async function withFixtures(
       const framework = FrameworkDetector.isDetox() ? 'Detox' : 'Appium';
 
       if (framework === 'Detox') {
+        const fixtureLaunchArgs = builtFixture.launchArgs ?? {};
         await TestHelpers.launchApp({
           delete: true,
           launchArgs: {
+            ...fixtureLaunchArgs,
             fixtureServerPort: isAndroid
               ? `${FALLBACK_FIXTURE_SERVER_PORT}`
               : `${getFixturesServerPort()}`,

--- a/tests/framework/fixtures/types.ts
+++ b/tests/framework/fixtures/types.ts
@@ -220,6 +220,8 @@ export interface FixtureState {
 export interface Fixture {
   state: FixtureState;
   asyncState: Record<string, string>;
+  /** Optional Detox launch args merged by FixtureHelper (e.g. E2E install deeplink). */
+  launchArgs?: Record<string, string>;
 }
 
 // ─── Method parameter types ───────────────────────────────────────────────────

--- a/tests/helpers/analytics/walletSetupAttributionE2eConstants.ts
+++ b/tests/helpers/analytics/walletSetupAttributionE2eConstants.ts
@@ -8,3 +8,23 @@ export const E2E_WALLET_SETUP_ATTRIBUTION_FIELDS = {
   utm_campaign: 'e2e_wsc_campaign',
   attribution_id: 'e2e_wsc_attr_id',
 } as const;
+
+/**
+ * Builds an onboarding install deeplink for E2E (mirrors production install links).
+ */
+export function buildE2EOnboardingInstallDeeplinkUrl(attributionFields: {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+  attribution_id?: string;
+}): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(attributionFields)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+  return `metamask://onboarding?${params.toString()}`;
+}

--- a/tests/helpers/analytics/withStrictWalletSetupAttributionMatch.ts
+++ b/tests/helpers/analytics/withStrictWalletSetupAttributionMatch.ts
@@ -6,8 +6,9 @@ import { onboardingEvents } from './helpers';
 import { E2E_WALLET_SETUP_ATTRIBUTION_FIELDS } from './walletSetupAttributionE2eConstants';
 
 /**
- * Strengthens `Wallet Setup Completed` to an exact property match that includes
- * persisted acquisition fields from `withWalletSetupAttributionForE2e`.
+ * Strengthens onboarding analytics expectations so `Wallet Setup Completed`
+ * includes persisted acquisition fields from `withWalletSetupAttributionForE2e`.
+ * Uses subset matching so enrichment (e.g. A/B tests) does not fail the spec.
  */
 export function withStrictWalletSetupAttributionMatch(
   base: AnalyticsExpectations,
@@ -15,14 +16,24 @@ export function withStrictWalletSetupAttributionMatch(
   return {
     ...base,
     events: base.events?.map((ev): AnalyticsEventExpectation => {
+      if (ev.name === onboardingEvents.ANALYTICS_PREFERENCE_SELECTED) {
+        return {
+          ...ev,
+          matchProperties: {
+            ...(ev.matchProperties ?? {}),
+            has_marketing_consent: true,
+          },
+        };
+      }
       if (ev.name !== onboardingEvents.WALLET_SETUP_COMPLETED) {
         return ev;
       }
-      const { containProperties: _unused, matchProperties, ...rest } = ev;
+      const { containProperties, matchProperties, ...rest } = ev;
       return {
         ...rest,
-        matchProperties: {
+        containProperties: {
           ...(matchProperties ?? {}),
+          ...(containProperties ?? {}),
           ...E2E_WALLET_SETUP_ATTRIBUTION_FIELDS,
         },
       };

--- a/tests/page-objects/Onboarding/MetaMetricsOptInView.ts
+++ b/tests/page-objects/Onboarding/MetaMetricsOptInView.ts
@@ -65,6 +65,12 @@ class MetaMetricsOptIn {
     );
   }
 
+  get marketingCheckbox(): EncapsulatedElementType {
+    return Matchers.getElementByID(
+      MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_MARKETING_CHECKBOX,
+    );
+  }
+
   async swipeContentUp(): Promise<void> {
     await encapsulatedAction({
       detox: async () => {
@@ -113,6 +119,27 @@ class MetaMetricsOptIn {
   async tapMetricsCheckbox(): Promise<void> {
     await Gestures.waitAndTap(this.metricsCheckbox, {
       elemDescription: 'Opt-in Metrics Metrics Checkbox',
+    });
+  }
+
+  async tapMarketingCheckbox(): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await this.swipeContentUp();
+        await Gestures.waitAndTap(asDetoxElement(this.marketingCheckbox), {
+          elemDescription: 'Opt-in Metrics Marketing Checkbox',
+        });
+      },
+      appium: async () => {
+        await PlaywrightGestures.waitAndTap(
+          await asPlaywrightElement(this.marketingCheckbox),
+          {
+            checkForDisplayed: true,
+            checkForEnabled: true,
+            timeout: 15_000,
+          },
+        );
+      },
     });
   }
 }

--- a/tests/smoke/wallet/analytics/import-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/import-wallet.spec.ts
@@ -116,6 +116,7 @@ describe(SmokeWalletPlatform('Analytics during import wallet flow'), () => {
           seedPhrase: IDENTITY_TEAM_SEED_PHRASE,
           password: IDENTITY_TEAM_PASSWORD,
           optInToMetrics: true,
+          optInToMarketing: true,
         });
       },
     );

--- a/tests/smoke/wallet/analytics/new-wallet.spec.ts
+++ b/tests/smoke/wallet/analytics/new-wallet.spec.ts
@@ -57,7 +57,7 @@ describe(SmokeWalletPlatform('Analytics during new wallet flow'), () => {
         ),
       },
       async () => {
-        await CreateNewWallet();
+        await CreateNewWallet({ optInToMarketing: true });
       },
     );
   });

--- a/tests/smoke/wallet/analytics/wallet-setup-completed-attribution.spec.ts
+++ b/tests/smoke/wallet/analytics/wallet-setup-completed-attribution.spec.ts
@@ -23,7 +23,7 @@ function walletSetupCompletedOnlyExpectations(
     events: [
       {
         name: onboardingEvents.WALLET_SETUP_COMPLETED,
-        matchProperties: {
+        containProperties: {
           wallet_setup_type: 'new',
           new_wallet: true,
           account_type: accountType,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section blocks the PR check.

Sections without a directive are checked for structural presence only.
-->

## **Description**
SRP new-wallet users fire Wallet Setup Completed at Choose Password, but marketing consent (and install deeplink UTMs) are only granted at Opt-in Metrics.

This PR backfills acquisition params from the pending install deeplink when marketing consent is granted, then attaches them to Wallet Setup Completed before its first trackEvent(), not after the analytics queue.

* Jira: https://consensyssoftware.atlassian.net/browse/TO-824
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-824

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet Setup Completed deeplink attribution

  Scenario: SRP user receives full UTMs on Wallet Setup Completed after opt-in
    Given a fresh app install
    And the app is opened via install deeplink with utm fields
    When the user completes SRP new-wallet onboarding
    And opts in to metrics and marketing at Opt-in Metrics
    Then Wallet Setup Completed is sent once with all deeplink UTM fields
    And the event timestamp aligns with Opt-in Metrics (replayed), not Choose Password
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="704" height="159" alt="Screenshot 2026-06-09 at 6 29 59 PM" src="https://github.com/user-attachments/assets/509b7c00-103f-46ed-89d4-09168ca1b63d" />

<img width="877" height="60" alt="Screenshot 2026-06-15 at 9 32 36 PM" src="https://github.com/user-attachments/assets/e8a5687c-c6ba-4a75-ac16-165cabbca04e" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
