### PR TITLE
feat: show payment details in transak deposits

### DIFF
--- a/app/components/UI/Money/hooks/useFiatPaymentMethodName.test.ts
+++ b/app/components/UI/Money/hooks/useFiatPaymentMethodName.test.ts
@@ -1,7 +1,12 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react-hooks';
 import { type TransactionMeta } from '@metamask/transaction-controller';
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
 
 import Engine from '../../../../core/Engine';
+import {
+  renderHookWithProvider,
+  type ProviderValues,
+} from '../../../../util/test/renderWithProvider';
 import { useFiatPaymentMethodName } from './useFiatPaymentMethodName';
 
 jest.mock('../../../../core/Engine', () => ({
@@ -27,6 +32,39 @@ function makeTx(fiat?: {
   } as unknown as TransactionMeta;
 }
 
+function makeOrder(overrides: Partial<RampsOrder> = {}): RampsOrder {
+  return {
+    isOnlyLink: false,
+    success: true,
+    cryptoAmount: '1',
+    fiatAmount: 1,
+    providerOrderId: 'o-1',
+    providerOrderLink: 'https://example.com/o-1',
+    createdAt: 0,
+    totalFeesFiat: 0,
+    txHash: '0xabc',
+    walletAddress: WALLET,
+    status: RampsOrderStatus.Completed,
+    network: { name: 'Ethereum', chainId: 'eip155:1' },
+    canBeUpdated: false,
+    idHasExpired: false,
+    excludeFromPurchases: false,
+    timeDescriptionPending: '5-10 minutes',
+    orderType: 'BUY',
+    ...overrides,
+  } as RampsOrder;
+}
+
+function makeState(orders: RampsOrder[] = []): ProviderValues['state'] {
+  return {
+    engine: {
+      backgroundState: {
+        RampsController: { orders },
+      },
+    },
+  } as unknown as ProviderValues['state'];
+}
+
 function flushPromises() {
   return act(async () => {
     await Promise.resolve();
@@ -38,103 +76,150 @@ describe('useFiatPaymentMethodName', () => {
     jest.resetAllMocks();
   });
 
-  it('does not call getOrder when the order id is missing', () => {
-    renderHook(() => useFiatPaymentMethodName(makeTx({ provider: 'transak' })));
+  it('does not fetch when the order id is missing', () => {
+    renderHookWithProvider(
+      () => useFiatPaymentMethodName(makeTx({ provider: 'transak' })),
+      { state: makeState() },
+    );
     expect(getOrderMock).not.toHaveBeenCalled();
   });
 
-  it('does not call getOrder when the provider is missing', () => {
-    renderHook(() => useFiatPaymentMethodName(makeTx({ orderId: 'o-1' })));
-    expect(getOrderMock).not.toHaveBeenCalled();
-  });
-
-  it('does not call getOrder when the wallet address is missing', () => {
+  it('does not fetch when the wallet address is missing', () => {
     const tx = {
       id: 'tx-1',
       txParams: {},
       metamaskPay: { fiat: { orderId: 'o-1', provider: 'transak' } },
     } as unknown as TransactionMeta;
-    renderHook(() => useFiatPaymentMethodName(tx));
+    renderHookWithProvider(() => useFiatPaymentMethodName(tx), {
+      state: makeState(),
+    });
     expect(getOrderMock).not.toHaveBeenCalled();
   });
 
-  it('does not call getOrder for a non-fiat deposit', () => {
-    renderHook(() => useFiatPaymentMethodName(makeTx()));
+  it('does not fetch for a non-fiat deposit', () => {
+    renderHookWithProvider(() => useFiatPaymentMethodName(makeTx()), {
+      state: makeState(),
+    });
     expect(getOrderMock).not.toHaveBeenCalled();
   });
 
-  it('returns undefined before the order resolves', () => {
-    getOrderMock.mockReturnValue(new Promise(() => undefined));
+  it('returns the cached payment-method name without fetching', () => {
+    const orders = [
+      makeOrder({
+        providerOrderId: 'o-1',
+        paymentMethod: { id: 'pm', name: 'Apple Pay' },
+      }),
+    ];
 
-    const { result } = renderHook(() =>
-      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    const { result } = renderHookWithProvider(
+      () =>
+        useFiatPaymentMethodName(
+          makeTx({ orderId: 'o-1', provider: 'transak' }),
+        ),
+      { state: makeState(orders) },
     );
 
-    expect(result.current).toBeUndefined();
+    expect(result.current).toBe('Apple Pay');
+    expect(getOrderMock).not.toHaveBeenCalled();
   });
 
-  it('fetches the order with (provider, orderId, wallet) and returns the payment-method name', async () => {
-    getOrderMock.mockResolvedValue({
-      paymentMethod: { id: 'pm', name: 'Apple Pay' },
-    } as Awaited<ReturnType<typeof getOrderMock>>);
+  it('matches the cached order by providerOrderId, ignoring others', () => {
+    const orders = [
+      makeOrder({
+        providerOrderId: 'other',
+        paymentMethod: { id: 'pm', name: 'Debit Card' },
+      }),
+      makeOrder({
+        providerOrderId: 'o-1',
+        paymentMethod: { id: 'pm', name: 'Apple Pay' },
+      }),
+    ];
 
-    const { result } = renderHook(() =>
-      useFiatPaymentMethodName(
-        makeTx({ orderId: 'o-1', provider: 'transak-native' }),
-      ),
+    const { result } = renderHookWithProvider(
+      () =>
+        useFiatPaymentMethodName(
+          makeTx({ orderId: 'o-1', provider: 'transak' }),
+        ),
+      { state: makeState(orders) },
+    );
+
+    expect(result.current).toBe('Apple Pay');
+    expect(getOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches with (provider, orderId, wallet) on a cache miss', async () => {
+    getOrderMock.mockResolvedValue(
+      makeOrder() as Awaited<ReturnType<typeof getOrderMock>>,
+    );
+
+    renderHookWithProvider(
+      () =>
+        useFiatPaymentMethodName(
+          makeTx({ orderId: 'o-1', provider: 'transak-native' }),
+        ),
+      { state: makeState() },
     );
 
     await flushPromises();
 
     expect(getOrderMock).toHaveBeenCalledWith('transak-native', 'o-1', WALLET);
-    expect(result.current).toBe('Apple Pay');
   });
 
-  it('returns undefined when the order has no payment method', async () => {
+  it('returns undefined on a cache miss until the fetched order lands in state', async () => {
+    // The fetch writes the order into controller state; this test store is
+    // static, so the selector keeps returning undefined.
     getOrderMock.mockResolvedValue(
-      {} as Awaited<ReturnType<typeof getOrderMock>>,
+      makeOrder({
+        paymentMethod: { id: 'pm', name: 'Apple Pay' },
+      }) as Awaited<ReturnType<typeof getOrderMock>>,
     );
 
-    const { result } = renderHook(() =>
-      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    const { result } = renderHookWithProvider(
+      () =>
+        useFiatPaymentMethodName(
+          makeTx({ orderId: 'o-1', provider: 'transak' }),
+        ),
+      { state: makeState() },
     );
 
     await flushPromises();
 
     expect(result.current).toBeUndefined();
+  });
+
+  it('still fetches when a cached order has no payment method', () => {
+    getOrderMock.mockResolvedValue(
+      makeOrder() as Awaited<ReturnType<typeof getOrderMock>>,
+    );
+    const orders = [
+      makeOrder({ providerOrderId: 'o-1', paymentMethod: undefined }),
+    ];
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useFiatPaymentMethodName(
+          makeTx({ orderId: 'o-1', provider: 'transak' }),
+        ),
+      { state: makeState(orders) },
+    );
+
+    expect(result.current).toBeUndefined();
+    expect(getOrderMock).toHaveBeenCalledWith('transak', 'o-1', WALLET);
   });
 
   it('swallows lookup failures and returns undefined', async () => {
     getOrderMock.mockRejectedValue(new Error('network'));
 
-    const { result } = renderHook(() =>
-      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    const { result } = renderHookWithProvider(
+      () =>
+        useFiatPaymentMethodName(
+          makeTx({ orderId: 'o-1', provider: 'transak' }),
+        ),
+      { state: makeState() },
     );
 
     await flushPromises();
 
-    expect(result.current).toBeUndefined();
-  });
-
-  it('does not set state after unmount (no late update)', async () => {
-    let resolveOrder!: (value: unknown) => void;
-    getOrderMock.mockReturnValue(
-      new Promise((resolve) => {
-        resolveOrder = resolve;
-      }) as ReturnType<typeof getOrderMock>,
-    );
-
-    const { result, unmount } = renderHook(() =>
-      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
-    );
-
-    unmount();
-    await act(async () => {
-      resolveOrder({ paymentMethod: { id: 'pm', name: 'Apple Pay' } });
-      await Promise.resolve();
-    });
-
-    // Unmounted before resolution: the cancelled guard prevents the update.
     expect(result.current).toBeUndefined();
   });
 });

--- a/app/components/UI/Money/hooks/useFiatPaymentMethodName.test.ts
+++ b/app/components/UI/Money/hooks/useFiatPaymentMethodName.test.ts
@@ -1,0 +1,140 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { type TransactionMeta } from '@metamask/transaction-controller';
+
+import Engine from '../../../../core/Engine';
+import { useFiatPaymentMethodName } from './useFiatPaymentMethodName';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    RampsController: {
+      getOrder: jest.fn(),
+    },
+  },
+}));
+
+const getOrderMock = jest.mocked(Engine.context.RampsController.getOrder);
+
+const WALLET = '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B';
+
+function makeTx(fiat?: {
+  orderId?: string;
+  provider?: string;
+}): TransactionMeta {
+  return {
+    id: 'tx-1',
+    txParams: { from: WALLET },
+    metamaskPay: fiat ? { fiat } : undefined,
+  } as unknown as TransactionMeta;
+}
+
+function flushPromises() {
+  return act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('useFiatPaymentMethodName', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not call getOrder when the order id is missing', () => {
+    renderHook(() => useFiatPaymentMethodName(makeTx({ provider: 'transak' })));
+    expect(getOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call getOrder when the provider is missing', () => {
+    renderHook(() => useFiatPaymentMethodName(makeTx({ orderId: 'o-1' })));
+    expect(getOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call getOrder when the wallet address is missing', () => {
+    const tx = {
+      id: 'tx-1',
+      txParams: {},
+      metamaskPay: { fiat: { orderId: 'o-1', provider: 'transak' } },
+    } as unknown as TransactionMeta;
+    renderHook(() => useFiatPaymentMethodName(tx));
+    expect(getOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call getOrder for a non-fiat deposit', () => {
+    renderHook(() => useFiatPaymentMethodName(makeTx()));
+    expect(getOrderMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined before the order resolves', () => {
+    getOrderMock.mockReturnValue(new Promise(() => undefined));
+
+    const { result } = renderHook(() =>
+      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('fetches the order with (provider, orderId, wallet) and returns the payment-method name', async () => {
+    getOrderMock.mockResolvedValue({
+      paymentMethod: { id: 'pm', name: 'Apple Pay' },
+    } as Awaited<ReturnType<typeof getOrderMock>>);
+
+    const { result } = renderHook(() =>
+      useFiatPaymentMethodName(
+        makeTx({ orderId: 'o-1', provider: 'transak-native' }),
+      ),
+    );
+
+    await flushPromises();
+
+    expect(getOrderMock).toHaveBeenCalledWith('transak-native', 'o-1', WALLET);
+    expect(result.current).toBe('Apple Pay');
+  });
+
+  it('returns undefined when the order has no payment method', async () => {
+    getOrderMock.mockResolvedValue(
+      {} as Awaited<ReturnType<typeof getOrderMock>>,
+    );
+
+    const { result } = renderHook(() =>
+      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    );
+
+    await flushPromises();
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('swallows lookup failures and returns undefined', async () => {
+    getOrderMock.mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() =>
+      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    );
+
+    await flushPromises();
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('does not set state after unmount (no late update)', async () => {
+    let resolveOrder!: (value: unknown) => void;
+    getOrderMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveOrder = resolve;
+      }) as ReturnType<typeof getOrderMock>,
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useFiatPaymentMethodName(makeTx({ orderId: 'o-1', provider: 'transak' })),
+    );
+
+    unmount();
+    await act(async () => {
+      resolveOrder({ paymentMethod: { id: 'pm', name: 'Apple Pay' } });
+      await Promise.resolve();
+    });
+
+    // Unmounted before resolution: the cancelled guard prevents the update.
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/app/components/UI/Money/hooks/useFiatPaymentMethodName.ts
+++ b/app/components/UI/Money/hooks/useFiatPaymentMethodName.ts
@@ -1,16 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { type TransactionMeta } from '@metamask/transaction-controller';
 import Engine from '../../../../core/Engine';
+import { selectRampsOrders } from '../../../../selectors/rampsController';
+import type { RootState } from '../../../../reducers';
 
 /**
  * Resolves the human-readable payment-method name (e.g. "Apple Pay", "Debit
- * Card") for a fiat-funded money deposit by fetching its ramp order.
+ * Card") for a fiat-funded money deposit by reading its ramp order.
  *
- * This is a one-shot lookup: the payment method is fixed for the lifetime of an
- * order, so — unlike {@link useFiatOrderStatus}, which polls for status — we
- * fetch once. Returns `undefined` while loading, when the tx isn't a fiat
- * deposit, or if the order lookup fails; callers should fall back to a
- * synchronous label (e.g. the provider name).
+ * The payment method is fixed for the lifetime of an order, so this prefers the
+ * order already cached in `RampsController` state and falls back to a one-shot
+ * `getOrder` fetch only on a cache miss
+ * Returns `undefined` while the order is unresolved, when the tx isn't a fiat
+ * deposit, or when the order has no payment method.
  */
 export function useFiatPaymentMethodName(
   tx: TransactionMeta,
@@ -19,29 +22,25 @@ export function useFiatPaymentMethodName(
   const provider = tx.metamaskPay?.fiat?.provider;
   const walletAddress = tx.txParams?.from;
 
-  const [paymentMethodName, setPaymentMethodName] = useState<
-    string | undefined
-  >();
+  const paymentMethodName = useSelector((state: RootState) =>
+    orderId
+      ? selectRampsOrders(state).find(
+          (order) => order.providerOrderId === orderId,
+        )?.paymentMethod?.name
+      : undefined,
+  );
 
   useEffect(() => {
-    if (!orderId || !provider || !walletAddress) {
-      setPaymentMethodName(undefined);
-      return undefined;
+    // Already cached, or not a fiat deposit — nothing to fetch.
+    if (paymentMethodName || !orderId || !provider || !walletAddress) {
+      return;
     }
-
-    let cancelled = false;
-    Engine.context.RampsController.getOrder(provider, orderId, walletAddress)
-      .then((order) => {
-        if (!cancelled) {
-          setPaymentMethodName(order.paymentMethod?.name);
-        }
-      })
-      .catch(() => undefined);
-
-    return () => {
-      cancelled = true;
-    };
-  }, [orderId, provider, walletAddress]);
+    Engine.context.RampsController.getOrder(
+      provider,
+      orderId,
+      walletAddress,
+    ).catch(() => undefined);
+  }, [paymentMethodName, orderId, provider, walletAddress]);
 
   return paymentMethodName;
 }

--- a/app/components/UI/Money/hooks/useFiatPaymentMethodName.ts
+++ b/app/components/UI/Money/hooks/useFiatPaymentMethodName.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { type TransactionMeta } from '@metamask/transaction-controller';
+import Engine from '../../../../core/Engine';
+
+/**
+ * Resolves the human-readable payment-method name (e.g. "Apple Pay", "Debit
+ * Card") for a fiat-funded money deposit by fetching its ramp order.
+ *
+ * This is a one-shot lookup: the payment method is fixed for the lifetime of an
+ * order, so — unlike {@link useFiatOrderStatus}, which polls for status — we
+ * fetch once. Returns `undefined` while loading, when the tx isn't a fiat
+ * deposit, or if the order lookup fails; callers should fall back to a
+ * synchronous label (e.g. the provider name).
+ */
+export function useFiatPaymentMethodName(
+  tx: TransactionMeta,
+): string | undefined {
+  const orderId = tx.metamaskPay?.fiat?.orderId;
+  const provider = tx.metamaskPay?.fiat?.provider;
+  const walletAddress = tx.txParams?.from;
+
+  const [paymentMethodName, setPaymentMethodName] = useState<
+    string | undefined
+  >();
+
+  useEffect(() => {
+    if (!orderId || !provider || !walletAddress) {
+      setPaymentMethodName(undefined);
+      return undefined;
+    }
+
+    let cancelled = false;
+    Engine.context.RampsController.getOrder(provider, orderId, walletAddress)
+      .then((order) => {
+        if (!cancelled) {
+          setPaymentMethodName(order.paymentMethod?.name);
+        }
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orderId, provider, walletAddress]);
+
+  return paymentMethodName;
+}

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -18,9 +18,8 @@ import { useFiatPaymentMethodName } from './useFiatPaymentMethodName';
 // Mocks
 // ---------------------------------------------------------------------------
 
-// The async ramp-order lookup is exercised in useFiatPaymentMethodName.test.ts;
-// here we control its resolved value directly. Defaults to undefined so deposit
-// rows fall back to the synchronous provider label.
+// The async ramp-order lookup is tested in useFiatPaymentMethodName.test.ts;
+// here we defaults to undefined so deposit rows fall back to the default label.
 jest.mock('./useFiatPaymentMethodName', () => ({
   useFiatPaymentMethodName: jest.fn(),
 }));

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -12,10 +12,24 @@ import {
 import { safeToChecksumAddress } from '../../../../util/address';
 import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
 import { useMoneyTransactionDisplayInfo } from './useMoneyTransactionDisplayInfo';
+import { useFiatPaymentMethodName } from './useFiatPaymentMethodName';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
+
+// The async ramp-order lookup is exercised in useFiatPaymentMethodName.test.ts;
+// here we control its resolved value directly. Defaults to undefined so deposit
+// rows fall back to the synchronous provider label.
+jest.mock('./useFiatPaymentMethodName', () => ({
+  useFiatPaymentMethodName: jest.fn(),
+}));
+
+const mockUseFiatPaymentMethodName = jest.mocked(useFiatPaymentMethodName);
+
+beforeEach(() => {
+  mockUseFiatPaymentMethodName.mockReturnValue(undefined);
+});
 
 jest.mock('../../../../../locales/i18n', () => ({
   __esModule: true,
@@ -928,7 +942,7 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
     expect(result.current.description).toBe('mUSD → USDC');
   });
 
-  it('deposited (fiat on-ramp) → provider name', () => {
+  it('deposited (fiat on-ramp) → provider name when the payment method is unresolved', () => {
     const tx = makeTx(TransactionType.moneyAccountDeposit, {
       metamaskPay: { fiat: { orderId: 'o-1', provider: 'transak-native' } },
     });
@@ -937,6 +951,19 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
       { state: makeState() },
     );
     expect(result.current.description).toBe('Transak');
+  });
+
+  it('deposited (fiat on-ramp) → payment-method name when resolved', () => {
+    // The payment method (e.g. "Apple Pay") is preferred over the provider name.
+    mockUseFiatPaymentMethodName.mockReturnValue('Apple Pay');
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { fiat: { orderId: 'o-1', provider: 'transak-native' } },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.description).toBe('Apple Pay');
   });
 
   it('deposited (mUSD top-up) → "mUSD"', () => {

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -23,6 +23,7 @@ import {
   getMusdDisplayAmountFromTransactionMeta,
   isIncomingMoneyTransactionMeta,
 } from '../constants/activityStyles';
+import { useFiatPaymentMethodName } from './useFiatPaymentMethodName';
 import { buildMoneyActivityFiatLine } from '../utils/moneyActivityFiat';
 import { moneyFormatFiat } from '../utils/moneyFormatFiat';
 import {
@@ -97,7 +98,7 @@ function prettifyFiatProvider(
  * - converted → "{token} → mUSD"
  * - sent      → "mUSD → {token}" (the withdraw destination token)
  * - received  → "From: 0x…" (the sender)
- * - deposited → fiat provider ("Transak"), else the funding token ("mUSD")
+ * - deposited → fiat payment method ("Apple Pay"), else provider ("Transak"), else funding token ("mUSD")
  * - card / added / transferred → the source token symbol, if any
  */
 function deriveSubtitle(
@@ -105,6 +106,7 @@ function deriveSubtitle(
   tx: TransactionMeta,
   sourceTokenSymbol: string | undefined,
   explicitSubtitle: string | undefined,
+  paymentMethodName: string | undefined,
 ): string | undefined {
   if (explicitSubtitle) {
     return explicitSubtitle;
@@ -133,6 +135,7 @@ function deriveSubtitle(
     }
     case 'deposited':
       return (
+        paymentMethodName ??
         prettifyFiatProvider(tx.metamaskPay?.fiat?.provider) ??
         sourceTokenSymbol
       );
@@ -162,6 +165,7 @@ export function useMoneyTransactionDisplayInfo(
   _moneyAddress: string | undefined,
 ): MoneyTransactionDisplayInfo {
   const subtitle = getMoneySubtitle(tx);
+  const paymentMethodName = useFiatPaymentMethodName(tx);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const currencyRates = useSelector(selectCurrencyRates);
   const tokenMarketData = useSelector(selectTokenMarketData);
@@ -242,7 +246,13 @@ export function useMoneyTransactionDisplayInfo(
 
     return {
       label: moneyActivityLabel(kind, status),
-      description: deriveSubtitle(kind, tx, sourceTokenSymbol, subtitle),
+      description: deriveSubtitle(
+        kind,
+        tx,
+        sourceTokenSymbol,
+        subtitle,
+        paymentMethodName,
+      ),
       primaryAmount,
       fiatAmount,
       isIncoming,
@@ -252,6 +262,7 @@ export function useMoneyTransactionDisplayInfo(
   }, [
     tx,
     subtitle,
+    paymentMethodName,
     currentCurrency,
     currencyRates,
     tokenMarketData,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR ensures that money deposit rows now show the **payment method** (e.g. "Apple Pay", "Debit Card") instead of just the provider name when one is available.

We've added a new hook `useFiatPaymentMethodName` which fetches the ramp order for the deposit, and returns the method name included in that order. This hook attempts to use cached state from RampsController when available, but otherwise makes a request to get the data.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show method name in money account deposits

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-980

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: deposits show method name

  Scenario: user deposits with apple pay or credit card
    Given user has an active money account

    When user makes a money account deposit with apple pay / credit card
    Then the resulting activity row shows the apple pay / credit card as it's subtitle
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="590" height="551" alt="image" src="https://github.com/user-attachments/assets/d0aa0244-d053-47a2-ae0c-01a841c4aaae" />

<!-- [screenshots/recordings] -->

### **After**
<img width="414" height="492" alt="Screenshot 2026-06-15 at 19 44 03" src="https://github.com/user-attachments/assets/3b257cbe-5ad4-4a8a-9807-ce6f5f6cb612" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
