### PR TITLE
fix: apply base currency selection when assetsUnifyState is enabled

### DIFF
--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -48,6 +48,9 @@ import { colors as staticColors } from '../../../../styles/common';
 import { enablePushNotifications } from '../../../../actions/notification/helpers';
 import { selectIsMetaMaskPushNotificationsEnabled } from '../../../../selectors/notifications';
 
+export const GENERAL_SETTINGS_CURRENCY_SELECTOR =
+  'general-settings-currency-selector';
+
 const diameter = 40;
 const spacing = 8;
 
@@ -228,8 +231,13 @@ class Settings extends PureComponent {
   };
 
   selectCurrency = async (currency) => {
-    const { CurrencyRateController } = Engine.context;
+    const { CurrencyRateController, AssetsController } = Engine.context;
     CurrencyRateController.setCurrentCurrency(currency);
+    // When the `assetsUnifyState` flag is enabled, the UI reads the active
+    // currency from AssetsController.selectedCurrency rather than from
+    // CurrencyRateController, so it must be updated here too. Otherwise the
+    // selection silently no-ops and the displayed currency stays unchanged.
+    AssetsController?.setSelectedCurrency?.(currency);
     updateUserTraitsWithCurrentCurrency(currency);
   };
 
@@ -358,6 +366,7 @@ class Settings extends PureComponent {
               </Text>
               <View style={styles.accessory}>
                 <SelectComponent
+                  testID={GENERAL_SETTINGS_CURRENCY_SELECTOR}
                   selectedValue={currentCurrency}
                   onValueChange={this.selectCurrency}
                   label={strings('app_settings.current_conversion')}

--- a/app/components/Views/Settings/GeneralSettings/index.test.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import GeneralSettings, {
+  GENERAL_SETTINGS_CURRENCY_SELECTOR,
   updateUserTraitsWithCurrentCurrency,
   updateUserTraitsWithCurrencyType,
 } from './';
@@ -13,6 +14,22 @@ import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyt
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { ThemeContext, mockTheme } from '../../../../util/theme';
 import { analytics } from '../../../../util/analytics/analytics';
+
+const mockSetCurrentCurrency = jest.fn();
+const mockSetSelectedCurrency = jest.fn();
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    CurrencyRateController: {
+      setCurrentCurrency: (...args: unknown[]) =>
+        mockSetCurrentCurrency(...args),
+    },
+    AssetsController: {
+      setSelectedCurrency: (...args: unknown[]) =>
+        mockSetSelectedCurrency(...args),
+    },
+  },
+}));
 
 jest.mock('../../../../core/Analytics');
 
@@ -99,6 +116,27 @@ describe('GeneralSettings', () => {
     fireEvent.press(backButton);
 
     expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GeneralSettings currency selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('updates both CurrencyRateController and AssetsController when a currency is selected', () => {
+    const { getByTestId, getByText } = renderComponent();
+
+    fireEvent.press(getByTestId(GENERAL_SETTINGS_CURRENCY_SELECTOR));
+    fireEvent.press(getByText('EUR - Euro'));
+
+    expect(mockSetCurrentCurrency).toHaveBeenCalledWith('eur');
+    expect(mockSetSelectedCurrency).toHaveBeenCalledWith('eur');
   });
 });
 

--- a/app/store/migrations/143.test.ts
+++ b/app/store/migrations/143.test.ts
@@ -1,0 +1,139 @@
+import { cloneDeep } from 'lodash';
+
+import { ensureValidState } from './util';
+import migrate from './143';
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const createTestState = (
+  selectedCurrency: string,
+  currentCurrency: string,
+) => ({
+  engine: {
+    backgroundState: {
+      AssetsController: {
+        selectedCurrency,
+      },
+      CurrencyRateController: {
+        currentCurrency,
+      },
+    },
+  },
+});
+
+describe('Migration 143: Carry over selected fiat currency', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    const state = { some: 'state' };
+    mockedEnsureValidState.mockReturnValue(false);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toBe(state);
+    expect(migratedState).toStrictEqual({ some: 'state' });
+  });
+
+  it('copies currentCurrency into selectedCurrency when they differ', () => {
+    const oldState = createTestState('usd', 'eur');
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(oldState) as typeof oldState;
+
+    expect(
+      migratedState.engine.backgroundState.AssetsController.selectedCurrency,
+    ).toBe('eur');
+  });
+
+  it('leaves selectedCurrency untouched when it already matches currentCurrency', () => {
+    const oldState = createTestState('eur', 'eur');
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(oldState) as typeof oldState;
+
+    expect(
+      migratedState.engine.backgroundState.AssetsController.selectedCurrency,
+    ).toBe('eur');
+  });
+
+  it.each([
+    {
+      currentCurrency: '',
+      test: 'empty currentCurrency',
+    },
+    {
+      currentCurrency: 123 as unknown as string,
+      test: 'non-string currentCurrency',
+    },
+  ])(
+    'does not modify selectedCurrency for invalid currentCurrency - $test',
+    ({ currentCurrency }) => {
+      const oldState = createTestState('usd', currentCurrency);
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const migratedState = migrate(oldState) as typeof oldState;
+
+      expect(
+        migratedState.engine.backgroundState.AssetsController.selectedCurrency,
+      ).toBe('usd');
+    },
+  );
+
+  it.each([
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            CurrencyRateController: { currentCurrency: 'eur' },
+          },
+        },
+      },
+      test: 'missing AssetsController',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            AssetsController: 'invalid',
+            CurrencyRateController: { currentCurrency: 'eur' },
+          },
+        },
+      },
+      test: 'invalid AssetsController state',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            AssetsController: { selectedCurrency: 'usd' },
+          },
+        },
+      },
+      test: 'missing CurrencyRateController',
+    },
+    {
+      state: {
+        engine: {
+          backgroundState: {
+            AssetsController: { selectedCurrency: 'usd' },
+            CurrencyRateController: 'invalid',
+          },
+        },
+      },
+      test: 'invalid CurrencyRateController state',
+    },
+  ])('does not modify state if the state is invalid - $test', ({ state }) => {
+    const orgState = cloneDeep(state);
+    mockedEnsureValidState.mockReturnValue(true);
+
+    const migratedState = migrate(state);
+
+    expect(migratedState).toStrictEqual(orgState);
+  });
+});

--- a/app/store/migrations/143.ts
+++ b/app/store/migrations/143.ts
@@ -1,0 +1,52 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { ensureValidState } from './util';
+
+/**
+ * Migration 143:
+ *
+ * Carry over the user's selected fiat currency from
+ * `CurrencyRateController.currentCurrency` into
+ * `AssetsController.selectedCurrency`.
+ *
+ * Migration 139 initialized `AssetsController.selectedCurrency` to the default
+ * `'usd'` without copying the user's existing currency. When the
+ * `assetsUnifyState` feature flag is enabled, the UI reads the active currency
+ * from `AssetsController.selectedCurrency`, so without this sync existing
+ * non-USD users would be silently reset to USD.
+ *
+ * @param state - The persisted Redux state.
+ * @returns The migrated state.
+ */
+const migration = (state: unknown): unknown => {
+  const migrationVersion = 143;
+
+  if (!ensureValidState(state, migrationVersion)) {
+    return state;
+  }
+
+  const { backgroundState } = state.engine;
+
+  if (
+    !hasProperty(backgroundState, 'AssetsController') ||
+    !isObject(backgroundState.AssetsController) ||
+    !hasProperty(backgroundState, 'CurrencyRateController') ||
+    !isObject(backgroundState.CurrencyRateController)
+  ) {
+    return state;
+  }
+
+  const { AssetsController, CurrencyRateController } = backgroundState;
+  const { currentCurrency } = CurrencyRateController;
+
+  if (
+    typeof currentCurrency === 'string' &&
+    currentCurrency.length > 0 &&
+    AssetsController.selectedCurrency !== currentCurrency
+  ) {
+    AssetsController.selectedCurrency = currentCurrency;
+  }
+
+  return state;
+};
+
+export default migration;

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -143,6 +143,7 @@ import migration139 from './139';
 import migration140 from './140';
 import migration141 from './141';
 import migration142 from './142';
+import migration143 from './143';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -305,6 +306,7 @@ export const migrationList: MigrationsList = {
   140: migration140,
   141: migration141,
   142: migration142,
+  143: migration143,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
## **Description**

When the `assetsUnifyState` feature flag is enabled, the active fiat currency shown across the UI is read from `AssetsController.selectedCurrency` (via `selectCurrentCurrency` -> `getCurrencyRateControllerCurrentCurrency`). However, the General Settings "Base currency" picker only wrote the selection to `CurrencyRateController.setCurrentCurrency`. Nothing ever wrote `AssetsController.selectedCurrency`, and the controller does not auto-sync from `CurrencyRateController`.

As a result, with the flag on, tapping a currency closed the picker but the selection silently no-opped and the displayed currency stayed on `USD`. With the flag off the UI reads `CurrencyRateController.currentCurrency`, so the bug did not reproduce.

This PR contains two changes:

1. `selectCurrency` now also calls `AssetsController.setSelectedCurrency(currency)`, so the selection applies regardless of the flag state. `setSelectedCurrency` updates `selectedCurrency` and triggers a price refetch in the new currency.
2. Migration `143` copies `CurrencyRateController.currentCurrency` into `AssetsController.selectedCurrency`. Migration `139` had defaulted `selectedCurrency` to `'usd'` without preserving the user's existing currency, so without this, enabling the flag would silently reset existing non-USD users to USD.

## **Changelog**

CHANGELOG entry: Fixed a bug where changing the base currency in General Settings had no effect.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Base currency selection in General Settings

  Scenario: user changes the base currency with assetsUnifyState enabled
    Given the assetsUnifyState feature flag is enabled
    And the user is on Settings > General
    When the user opens the "Base currency" picker
    And the user selects "EUR - Euro"
    Then the selected base currency updates to EUR
    And fiat values across the app are displayed in EUR

  Scenario: existing non-USD user upgrades with assetsUnifyState enabled
    Given a user had previously selected EUR as their base currency
    When the app upgrades and runs migration 143
    And the assetsUnifyState feature flag is enabled
    Then the user's base currency remains EUR (not reset to USD)
```

## **Screenshots/Recordings**

### **Before**

<!-- Selecting a currency closed the picker but it remained USD -->

### **After**

<!-- Selecting a currency now applies and persists -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.