### PR TITLE
fix(money): always show Add CTA on Money balance card (MUSD-987)

### DIFF
--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -195,17 +195,12 @@ describe('MoneyBalanceCard', () => {
       expect(queryByText('$0.00')).not.toBeOnTheScreen();
     });
 
-    it('renders the Add button (not the Earn upsell)', () => {
-      const { getByTestId, queryByTestId } = renderWithProvider(
-        <MoneyBalanceCard />,
-      );
+    it('renders the Add button', () => {
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
       expect(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON)).toHaveTextContent(
         strings('money.balance_card.add'),
       );
-      expect(
-        queryByTestId(MoneyBalanceCardTestIds.EARN_BUTTON),
-      ).not.toBeOnTheScreen();
     });
 
     it('does not render the empty or new-user container', () => {
@@ -301,23 +296,18 @@ describe('MoneyBalanceCard', () => {
       );
     });
 
-    it('renders the Earn button (not the Add button)', () => {
-      const { getByTestId, queryByTestId } = renderWithProvider(
-        <MoneyBalanceCard />,
-      );
-
-      expect(
-        getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON),
-      ).toHaveTextContent(strings('homepage.sections.money_empty_state.earn'));
-      expect(
-        queryByTestId(MoneyBalanceCardTestIds.ADD_BUTTON),
-      ).not.toBeOnTheScreen();
-    });
-
-    it('routes add money when Earn is pressed', () => {
+    it('renders the Add button', () => {
       const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON));
+      expect(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON)).toHaveTextContent(
+        strings('money.balance_card.add'),
+      );
+    });
+
+    it('routes add money when Add is pressed', () => {
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
+
+      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
 
       expect(mockInitiateDeposit).toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
@@ -325,15 +315,15 @@ describe('MoneyBalanceCard', () => {
       });
     });
 
-    it('tracks the Earn click with the empty-state label key', () => {
+    it('tracks the Add click with the deposit redirect target', () => {
       const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON));
+      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
 
       expect(mockTrackButtonClicked).toHaveBeenCalledWith({
         button_type: MONEY_BUTTON_TYPES.TEXT,
         button_intent: MONEY_BUTTON_INTENTS.ADD_MONEY,
-        label_key: 'homepage.sections.money_empty_state.earn',
+        label_key: 'money.balance_card.add',
         redirect_target: SCREEN_NAMES.MONEY_DEPOSIT,
       });
     });
@@ -358,12 +348,10 @@ describe('MoneyBalanceCard', () => {
       ).toBeOnTheScreen();
     });
 
-    it('does not render the Add button', () => {
-      const { queryByTestId } = renderWithProvider(<MoneyBalanceCard />);
+    it('renders the Add button', () => {
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-      expect(
-        queryByTestId(MoneyBalanceCardTestIds.ADD_BUTTON),
-      ).not.toBeOnTheScreen();
+      expect(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON)).toBeOnTheScreen();
     });
 
     describe('when the wallet-home onboarding stepper is not displayed', () => {
@@ -371,16 +359,14 @@ describe('MoneyBalanceCard', () => {
         mockSelectWalletHomeOnboardingFlowVisible.mockReturnValue(false);
       });
 
-      it('renders the Earn button with the earn label', () => {
+      it('renders the Add button with the add label', () => {
         const { getByTestId, queryByTestId } = renderWithProvider(
           <MoneyBalanceCard />,
         );
 
         expect(
-          getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON),
-        ).toHaveTextContent(
-          strings('homepage.sections.money_empty_state.earn'),
-        );
+          getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON),
+        ).toHaveTextContent(strings('money.balance_card.add'));
         expect(
           queryByTestId(MoneyBalanceCardTestIds.GET_STARTED_BUTTON),
         ).not.toBeOnTheScreen();
@@ -394,10 +380,10 @@ describe('MoneyBalanceCard', () => {
         ).toBeOnTheScreen();
       });
 
-      it('routes add money when Earn is pressed', () => {
+      it('routes add money when Add is pressed', () => {
         const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-        fireEvent.press(getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON));
+        fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
 
         expect(mockInitiateDeposit).toHaveBeenCalled();
         expect(mockNavigateToMoneyHome).not.toHaveBeenCalled();
@@ -409,16 +395,14 @@ describe('MoneyBalanceCard', () => {
         mockSelectWalletHomeOnboardingFlowVisible.mockReturnValue(true);
       });
 
-      it('renders the Earn button (never Get started) when the stepper is visible', () => {
+      it('renders the Add button (never Get started) when the stepper is visible', () => {
         const { getByTestId, queryByTestId } = renderWithProvider(
           <MoneyBalanceCard />,
         );
 
         expect(
-          getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON),
-        ).toHaveTextContent(
-          strings('homepage.sections.money_empty_state.earn'),
-        );
+          getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON),
+        ).toHaveTextContent(strings('money.balance_card.add'));
         expect(
           queryByTestId(MoneyBalanceCardTestIds.GET_STARTED_BUTTON),
         ).not.toBeOnTheScreen();
@@ -432,10 +416,10 @@ describe('MoneyBalanceCard', () => {
         ).toBeOnTheScreen();
       });
 
-      it('routes add money when Earn is pressed', () => {
+      it('routes add money when Add is pressed', () => {
         const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-        fireEvent.press(getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON));
+        fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
 
         expect(mockInitiateDeposit).toHaveBeenCalled();
       });
@@ -459,17 +443,12 @@ describe('MoneyBalanceCard', () => {
       );
     });
 
-    it('renders the Add button with the add label and not the Earn button', () => {
-      const { getByTestId, queryByTestId } = renderWithProvider(
-        <MoneyBalanceCard />,
-      );
+    it('renders the Add button with the add label', () => {
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
       expect(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON)).toHaveTextContent(
         strings('money.balance_card.add'),
       );
-      expect(
-        queryByTestId(MoneyBalanceCardTestIds.EARN_BUTTON),
-      ).not.toBeOnTheScreen();
     });
 
     it('renders the APY tag', () => {
@@ -516,7 +495,7 @@ describe('MoneyBalanceCard', () => {
       });
     });
 
-    it('routes add money (and not the Money home) when Earn is pressed in empty state', () => {
+    it('routes add money (and not the Money home) when Add is pressed in empty state', () => {
       mockUseMoneyAccountBalance.mockReturnValue(
         createBalanceMock({
           totalFiatRaw: '0',
@@ -526,7 +505,7 @@ describe('MoneyBalanceCard', () => {
 
       const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
-      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.EARN_BUTTON));
+      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
 
       expect(mockInitiateDeposit).toHaveBeenCalled();
       expect(mockNavigateToMoneyHome).not.toHaveBeenCalled();
@@ -639,23 +618,23 @@ describe('MoneyBalanceCard', () => {
         mockSelectMoneyOnboardingSeen.mockReturnValue(true);
       });
 
-      it('renders Earn as Secondary when the onboarding stepper is visible', () => {
+      it('renders Add as Secondary when the onboarding stepper is visible', () => {
         mockSelectWalletHomeOnboardingFlowVisible.mockReturnValue(true);
 
         const { UNSAFE_getByProps } = renderWithProvider(<MoneyBalanceCard />);
 
         expect(
-          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.EARN_BUTTON),
+          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.ADD_BUTTON),
         ).toBe(ButtonVariant.Secondary);
       });
 
-      it('renders Earn as Primary when no other primary CTA is on Home', () => {
+      it('renders Add as Primary when no other primary CTA is on Home', () => {
         mockSelectWalletHomeOnboardingFlowVisible.mockReturnValue(false);
 
         const { UNSAFE_getByProps } = renderWithProvider(<MoneyBalanceCard />);
 
         expect(
-          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.EARN_BUTTON),
+          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.ADD_BUTTON),
         ).toBe(ButtonVariant.Primary);
       });
     });
@@ -693,23 +672,23 @@ describe('MoneyBalanceCard', () => {
         mockSelectMoneyOnboardingSeen.mockReturnValue(false);
       });
 
-      it('renders Earn as Primary when no other primary CTA is on Home', () => {
+      it('renders Add as Primary when no other primary CTA is on Home', () => {
         mockSelectWalletHomeOnboardingFlowVisible.mockReturnValue(false);
 
         const { UNSAFE_getByProps } = renderWithProvider(<MoneyBalanceCard />);
 
         expect(
-          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.EARN_BUTTON),
+          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.ADD_BUTTON),
         ).toBe(ButtonVariant.Primary);
       });
 
-      it('renders Earn as Secondary when the onboarding stepper is visible', () => {
+      it('renders Add as Secondary when the onboarding stepper is visible', () => {
         mockSelectWalletHomeOnboardingFlowVisible.mockReturnValue(true);
 
         const { UNSAFE_getByProps } = renderWithProvider(<MoneyBalanceCard />);
 
         expect(
-          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.EARN_BUTTON),
+          getVariant(UNSAFE_getByProps, MoneyBalanceCardTestIds.ADD_BUTTON),
         ).toBe(ButtonVariant.Secondary);
       });
     });

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
@@ -16,5 +16,4 @@ export const MoneyBalanceCardTestIds = {
   APY_TAG_SKELETON: 'money-balance-card-apy-tag-skeleton',
   ADD_BUTTON: 'money-balance-card-add-button',
   GET_STARTED_BUTTON: 'money-balance-card-get-started-button',
-  EARN_BUTTON: 'money-balance-card-earn-button',
 } as const;

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -100,27 +100,22 @@ const MoneyBalanceCard = () => {
 
   const balanceText = totalFiatFormatted ?? '';
 
+  const buttonLabelKey = 'money.balance_card.add';
+  const buttonTestId = MoneyBalanceCardTestIds.ADD_BUTTON;
+
   let buttonVariant: ButtonVariant;
-  let buttonLabelKey: string;
-  let buttonTestId: string;
   let containerTestId: string;
 
   if (!hasMoneyAccount || isError || isRetrying) {
     buttonVariant = ButtonVariant.Secondary;
-    buttonLabelKey = 'money.balance_card.add';
-    buttonTestId = MoneyBalanceCardTestIds.ADD_BUTTON;
     containerTestId = MoneyBalanceCardTestIds.ERROR_CONTAINER;
   } else if (isUnavailable) {
     buttonVariant = ButtonVariant.Secondary;
-    buttonLabelKey = 'money.balance_card.add';
-    buttonTestId = MoneyBalanceCardTestIds.ADD_BUTTON;
     containerTestId = MoneyBalanceCardTestIds.UNAVAILABLE_CONTAINER;
   } else if (isEmpty) {
     buttonVariant = hasOtherPrimaryCtaOnHome
       ? ButtonVariant.Secondary
       : ButtonVariant.Primary;
-    buttonLabelKey = 'homepage.sections.money_empty_state.earn';
-    buttonTestId = MoneyBalanceCardTestIds.EARN_BUTTON;
     containerTestId = isNewUser
       ? MoneyBalanceCardTestIds.NEW_USER_CONTAINER
       : MoneyBalanceCardTestIds.EMPTY_CONTAINER;
@@ -128,8 +123,6 @@ const MoneyBalanceCard = () => {
     buttonVariant = hasOtherPrimaryCtaOnHome
       ? ButtonVariant.Secondary
       : ButtonVariant.Primary;
-    buttonLabelKey = 'money.balance_card.add';
-    buttonTestId = MoneyBalanceCardTestIds.ADD_BUTTON;
     containerTestId = MoneyBalanceCardTestIds.FUNDED_CONTAINER;
   }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9733,15 +9733,6 @@
       "money": "Money",
       "money_empty_description": "You don't have any mUSD yet. Convert stablecoins to mUSD from the Money section on the homepage.",
       "money_empty_description_network_filter": "No mUSD on this network. Switch network to see your mUSD.",
-      "money_empty_state": {
-        "get_started": "Get started",
-        "earn": "Earn",
-        "earn_apy": "Earn {{percentage}}% APY"
-      },
-      "money_filled_state": {
-        "add": "Add",
-        "apy": "{{percentage}}% APY"
-      },
       "tokens": "Tokens",
       "perps": "Perps",
       "related_assets": "Related Assets",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money balance card on the wallet home screen used to alternate its CTA between **Earn** (when the money-account balance was 0) and **Add** (when funded). Because the balance is resolved asynchronously from cache on startup, the button visibly flipped from "Earn" to "Add" as the cached balance loaded.

Per the accepted solution in MUSD-987, this collapses the CTA to a single, stable **Add** button regardless of balance state. `buttonLabelKey`/`buttonTestId` are now constants and the state branches only decide the button variant and container testID (error/unavailable/empty/new-user/funded are unchanged). Dead code left behind by the change is removed: the `EARN_BUTTON` testID and the unreferenced `homepage.sections.money_empty_state` / `money_filled_state` locale blocks (`en.json` only — other locales flow from the localization pipeline).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Money balance card CTA flipping from "Earn" to "Add" on startup by always showing a single "Add" button.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-987

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money balance card CTA

  Scenario: user with no money balance opens the wallet home
    Given the user has a money account with a 0 balance
    When the wallet home screen loads
    Then the Money balance card shows a single "Add" button
    And the button does not change from "Earn" to "Add" as the balance resolves

  Scenario: user with a money balance opens the wallet home
    Given the user has a money account with a balance greater than 0
    When the wallet home screen loads
    Then the Money balance card shows the "Add" button
    And pressing it starts the deposit flow
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

The CTA rendered "Earn" for a 0 balance and flipped to "Add" once the cached balance resolved (see attached recording on MUSD-987).

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/2a9ee5c3-18f0-4ecd-a90d-566fd50a09cd" />


The CTA always renders "Add".

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
