### PR TITLE
fix: fix Snap E2E tests flakiness

### DIFF
--- a/tests/smoke/snaps/test-snap-management.spec.ts
+++ b/tests/smoke/snaps/test-snap-management.spec.ts
@@ -10,6 +10,28 @@ import SnapSettingsView from '../../page-objects/Settings/SnapSettingsView';
 import { Assertions } from '../../framework';
 import BrowserView from '../../page-objects/Browser/BrowserView';
 import AccountMenu from '../../page-objects/AccountMenu/AccountMenu';
+import WalletView from '../../page-objects/wallet/WalletView';
+
+/**
+ * Navigate from the browser to Snap Settings.
+ * With disableSynchronization the tab bar may not be immediately available
+ * after closing the browser, so we navigate step-by-step with explicit waits.
+ */
+async function navigateFromBrowserToSnapSettings() {
+  await BrowserView.tapCloseBrowserButton();
+  await TabBarComponent.tapWallet();
+  await WalletView.tapHamburgerMenu();
+  await Assertions.expectElementToBeVisible(AccountMenu.container, {
+    timeout: 10000,
+    description: 'Account menu should be visible',
+  });
+  await AccountMenu.tapSettings();
+  await Assertions.expectElementToBeVisible(SettingsView.title, {
+    timeout: 10000,
+    description: 'Settings view title should be visible',
+  });
+  await SettingsView.tapSnaps();
+}
 
 jest.setTimeout(150_000);
 
@@ -40,9 +62,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         disableSynchronization: true,
       },
       async () => {
-        await BrowserView.tapCloseBrowserButton();
-        await TabBarComponent.tapSettings();
-        await SettingsView.tapSnaps();
+        await navigateFromBrowserToSnapSettings();
 
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.toggleEnable();
@@ -73,9 +93,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         disableSynchronization: true,
       },
       async () => {
-        await BrowserView.tapCloseBrowserButton();
-        await TabBarComponent.tapSettings();
-        await SettingsView.tapSnaps();
+        await navigateFromBrowserToSnapSettings();
 
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.toggleEnable();
@@ -107,9 +125,7 @@ describe(SmokeSnaps('Snap Management Tests'), () => {
         disableSynchronization: true,
       },
       async () => {
-        await BrowserView.tapCloseBrowserButton();
-        await TabBarComponent.tapSettings();
-        await SettingsView.tapSnaps();
+        await navigateFromBrowserToSnapSettings();
 
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.removeSnap();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

The snap management tests (disable, enable, remove) were failing at times in the pipeline because `tapSettings()` has a nested retry loop that fights itself under `disableSynchronization: true`— once the account menu overlay opens, the tab bar is hidden, and retries can never recover.      
                                                           
Replaced with a step-by-step navigation helper that uses explicit waits between each tap. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
