### PR TITLE
feat(charts): add currentPriceLineColorOverride prop to AdvancedChart

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -97,6 +97,7 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       lineColorOverride,
       successColorOverride,
       errorColorOverride,
+      currentPriceLineColorOverride,
     },
     ref,
   ) => {
@@ -146,10 +147,14 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
           lineColorOverride: initialLineColorRef.current,
           successColorOverride: initialSuccessColorRef.current,
           errorColorOverride: initialErrorColorRef.current,
+          currentPriceLineColorOverride,
         }),
-      // Color overrides intentionally excluded — hot-swapped via SET_THEME_COLORS.
+      // lineColorOverride/successColorOverride/errorColorOverride intentionally excluded —
+      // hot-swapped via SET_THEME_COLORS. currentPriceLineColorOverride is a direct dep:
+      // it is theme-derived and changes only with theme, so no extra rebuilds occur and
+      // the initial-ref indirection would introduce a stale-color race on theme change.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [theme, enableDrawingTools, disabledFeatures, lineChrome],
+      [theme, enableDrawingTools, disabledFeatures, lineChrome, currentPriceLineColorOverride],
     );
 
     // Reset all chart state when the WebView reloads due to htmlContent changes

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.tsx
@@ -131,33 +131,50 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
     const tradingViewOpenInterceptRef = useRef(0);
     const skeletonHiddenReportedRef = useRef(false);
 
-    // Capture the color overrides baked into the HTML template so the
+    // Track the color overrides baked into the current HTML template so the
     // SET_THEME_COLORS effect can skip sending when colors haven't diverged.
+    // Refs are updated synchronously inside the useMemo below (not in a post-render
+    // effect) so the snapshot is always in sync with what was actually baked, even
+    // when multiple deps change in the same render cycle.
     const initialLineColorRef = useRef(lineColorOverride);
     const initialSuccessColorRef = useRef(successColorOverride);
     const initialErrorColorRef = useRef(errorColorOverride);
     const themeColorsSentRef = useRef(false);
 
-    const htmlContent = useMemo(
-      () =>
-        createAdvancedChartTemplate(theme, {
-          enableDrawingTools,
-          disabledFeatures,
-          lineChrome,
-          lineColorOverride: initialLineColorRef.current,
-          successColorOverride: initialSuccessColorRef.current,
-          errorColorOverride: initialErrorColorRef.current,
-          currentPriceLineColorOverride,
-        }),
+    const htmlContent = useMemo(() => {
+      // Snapshot current prop values at the moment the template is created.
+      // This must happen inside useMemo (not in a separate effect) so the refs
+      // reflect what is actually baked, preventing a stale-color race where a
+      // simultaneous non-color dep change causes the SET_THEME_COLORS effect to
+      // see "colors already match" and skip a needed hot-swap.
+      initialLineColorRef.current = lineColorOverride;
+      initialSuccessColorRef.current = successColorOverride;
+      initialErrorColorRef.current = errorColorOverride;
+      return createAdvancedChartTemplate(theme, {
+        enableDrawingTools,
+        disabledFeatures,
+        lineChrome,
+        lineColorOverride,
+        successColorOverride,
+        errorColorOverride,
+        currentPriceLineColorOverride,
+      });
       // lineColorOverride/successColorOverride/errorColorOverride intentionally excluded —
-      // hot-swapped via SET_THEME_COLORS. currentPriceLineColorOverride is a direct dep:
-      // it is theme-derived and changes only with theme, so no extra rebuilds occur and
-      // the initial-ref indirection would introduce a stale-color race on theme change.
+      // color changes hot-swap via SET_THEME_COLORS without rebuilding the WebView.
+      // currentPriceLineColorOverride is a direct dep: it is theme-derived and changes
+      // only with theme, so the initial-ref indirection would introduce a stale-color race.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [theme, enableDrawingTools, disabledFeatures, lineChrome, currentPriceLineColorOverride],
-    );
+    }, [
+      theme,
+      enableDrawingTools,
+      disabledFeatures,
+      lineChrome,
+      currentPriceLineColorOverride,
+    ]);
 
-    // Reset all chart state when the WebView reloads due to htmlContent changes
+    // Reset all chart state when the WebView reloads due to htmlContent changes.
+    // Color refs are intentionally omitted here — they are snapshotted synchronously
+    // inside the useMemo above.
     useEffect(() => {
       skeletonHiddenReportedRef.current = false;
       setChartReadyCount(0);
@@ -171,9 +188,6 @@ const AdvancedChart = forwardRef<AdvancedChartRef, AdvancedChartProps>(
       prevOhlcvSeriesKeyRef.current = undefined;
       ohlcvSeriesStaleSnapshotRef.current = null;
       themeColorsSentRef.current = false;
-      initialLineColorRef.current = lineColorOverride;
-      initialSuccessColorRef.current = successColorOverride;
-      initialErrorColorRef.current = errorColorOverride;
     }, [htmlContent]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // ---- Helpers ----

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChart.types.ts
@@ -507,6 +507,8 @@ export interface AdvancedChartProps {
   successColorOverride?: string;
   /** Override the candlestick down/error color baked into the HTML template (A/B test). */
   errorColorOverride?: string;
+  /** Override the current-price horizontal line color. Does not affect candle or volume colors. */
+  currentPriceLineColorOverride?: string;
 }
 
 /**

--- a/app/components/UI/Charts/AdvancedChart/AdvancedChartTemplate.ts
+++ b/app/components/UI/Charts/AdvancedChart/AdvancedChartTemplate.ts
@@ -56,6 +56,7 @@ interface ChartFeatures {
   lineColorOverride?: string;
   successColorOverride?: string;
   errorColorOverride?: string;
+  currentPriceLineColorOverride?: string;
 }
 
 const createConfigScript = (
@@ -78,7 +79,8 @@ window.CONFIG = {
     successColor: '${successColor}',
     lineColor: '${lineColor}',
     errorColor: '${errorColor}',
-    primaryColor: '${theme.colors.primary.default}'
+    primaryColor: '${theme.colors.primary.default}',
+    currentPriceColor: '${features.currentPriceLineColorOverride ?? ''}'
   },
   features: {
     enableDrawingTools: ${features.enableDrawingTools ? 'true' : 'false'},

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -766,6 +766,7 @@ function handleSetThemeColors(payload) {
 
   var chart = window.chartWidget.activeChart();
   var lineColor = theme.lineColor || theme.successColor;
+  var currentPriceColor = theme.currentPriceColor || lineColor;
 
   // Update volume study colors if present
   if (window.volumeStudyId) {
@@ -796,7 +797,7 @@ function handleSetThemeColors(payload) {
   if (window.lastPriceShapeId) {
     try {
       chart.getShapeById(window.lastPriceShapeId).setProperties({
-        linecolor: theme.successColor,
+        linecolor: theme.currentPriceColor || theme.successColor,
       });
     } catch (e) {}
   }
@@ -804,7 +805,7 @@ function handleSetThemeColors(payload) {
   if (window.lineLastPriceShapeId) {
     try {
       chart.getShapeById(window.lineLastPriceShapeId).setProperties({
-        linecolor: lineColor,
+        linecolor: currentPriceColor,
       });
     } catch (e) {}
   }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -2243,7 +2243,8 @@ function createLastPriceLine() {
 
   var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   var chart = window.chartWidget.activeChart();
-  var color = window.CONFIG.theme.successColor;
+  var color =
+    window.CONFIG.theme.currentPriceColor || window.CONFIG.theme.successColor;
   var candlePt = getLineEndDotTimeAndPriceFromSeries(chart);
   var candlePrice =
     candlePt && isFinite(candlePt.price) ? candlePt.price : lastBar.close;
@@ -2329,7 +2330,9 @@ function createLineLastPriceLine() {
   var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   var chart = window.chartWidget.activeChart();
   const color =
-    window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+    window.CONFIG.theme.currentPriceColor ||
+    window.CONFIG.theme.lineColor ||
+    window.CONFIG.theme.successColor;
   var seriesPt = resolveLineEndOverlayPoint(chart);
   var linePrice =
     seriesPt && isFinite(seriesPt.price) ? seriesPt.price : lastBar.close;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -2252,7 +2252,8 @@ function createLastPriceLine() {
 
   var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   var chart = window.chartWidget.activeChart();
-  var color = window.CONFIG.theme.successColor;
+  var color =
+    window.CONFIG.theme.currentPriceColor || window.CONFIG.theme.successColor;
   var candlePt = getLineEndDotTimeAndPriceFromSeries(chart);
   var candlePrice =
     candlePt && isFinite(candlePt.price) ? candlePt.price : lastBar.close;
@@ -2338,7 +2339,9 @@ function createLineLastPriceLine() {
   var lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   var chart = window.chartWidget.activeChart();
   const color =
-    window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+    window.CONFIG.theme.currentPriceColor ||
+    window.CONFIG.theme.lineColor ||
+    window.CONFIG.theme.successColor;
   var seriesPt = resolveLineEndOverlayPoint(chart);
   var linePrice =
     seriesPt && isFinite(seriesPt.price) ? seriesPt.price : lastBar.close;

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -775,6 +775,7 @@ function handleSetThemeColors(payload) {
 
   var chart = window.chartWidget.activeChart();
   var lineColor = theme.lineColor || theme.successColor;
+  var currentPriceColor = theme.currentPriceColor || lineColor;
 
   // Update volume study colors if present
   if (window.volumeStudyId) {
@@ -805,7 +806,7 @@ function handleSetThemeColors(payload) {
   if (window.lastPriceShapeId) {
     try {
       chart.getShapeById(window.lastPriceShapeId).setProperties({
-        linecolor: theme.successColor,
+        linecolor: theme.currentPriceColor || theme.successColor,
       });
     } catch (e) {}
   }
@@ -813,7 +814,7 @@ function handleSetThemeColors(payload) {
   if (window.lineLastPriceShapeId) {
     try {
       chart.getShapeById(window.lineLastPriceShapeId).setProperties({
-        linecolor: lineColor,
+        linecolor: currentPriceColor,
       });
     } catch (e) {}
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds currentPriceLineColorOverride prop to AdvancedChart

- Adds currentPriceLineColorOverride?: string to AdvancedChartProps and the ChartFeatures template interface, baking it into window.CONFIG.theme.currentPriceColor at HTML creation time
- Updates createLastPriceLine (candle chart) and createLineLastPriceLine (line chart) in chartLogic.js to read currentPriceColor || successColor so the override applies without touching candle up-colors, volume, or line-chart series color
- Consumers that don't pass the prop get an empty string → falsy → existing successColor fallback; no visual change to the token detail chart
- Fixes a race condition in the initial*ColorRef hot-swap pattern: the three color-override refs (initialLineColorRef, initialSuccessColorRef, initialErrorColorRef) are now snapshotted synchronously inside useMemo rather
than in a post-render useEffect. This prevents SET_THEME_COLORS from seeing "colors already match" and skipping a needed hot-swap when a theme change and a color override change land in the same render cycle.

Motivation

The current-price horizontal line currently uses successColor (green), which is
also used for candle up-colors and volume. A per-consumer override is needed so
Perps can render a white price line without changing candle colors globally.

Test plan

- [ ] All existing AdvancedChart unit tests pass (yarn jest app/components/UI/Charts/AdvancedChart/)
- [ ] Token detail chart: current-price line unchanged (still green/successColor) — no currentPriceLineColorOverride passed
- [ ] After this merges, the Perps migration PR adds currentPriceLineColorOverride={colors.text.default} to PerpsAdvancedChart and verifies the price line renders white (dark mode) / near-black (light mode) without affecting candle colors

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3152

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Advanced chart current price color

  Scenario: chart colors update after live price direction changes
    Given the token details chart is loaded with a custom current price line color

    When live price data changes the token chart direction from positive to negative
    Then the chart updates its line and candle colors without rebuilding the WebView
    And the current price horizontal line keeps the custom current price line color
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
