### PR TITLE
fix: make batch sell sliders update token amount and percent live cp-7.82.0

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
 
 import {
   BatchSellPercentageSlider,
@@ -8,6 +8,12 @@ import {
 } from './BatchSellPercentageSlider';
 
 const SLIDER_TEST_ID = 'batch-sell-percentage-slider';
+const GESTURE_AREA_TEST_ID = `${SLIDER_TEST_ID}-gesture-area`;
+const SLIDER_WIDTH = 200;
+
+let tapOnEnd: ((event: { x: number }) => void) | undefined;
+let panOnUpdate: ((event: { x: number }) => void) | undefined;
+let panOnEnd: ((event: { x: number }) => void) | undefined;
 
 jest.mock('../../../../../component-library/hooks', () => ({
   useStyles: () => ({ styles: {} }),
@@ -15,23 +21,68 @@ jest.mock('../../../../../component-library/hooks', () => ({
 
 jest.mock('react-native-gesture-handler', () => {
   const { View } = jest.requireActual('react-native');
-  const gesture = {
-    onEnd: jest.fn().mockReturnThis(),
-    onUpdate: jest.fn().mockReturnThis(),
-  };
 
   return {
     GestureHandlerRootView: View,
     GestureDetector: ({ children }: { children: React.ReactNode }) => children,
     Gesture: {
-      Pan: jest.fn(() => gesture),
-      Tap: jest.fn(() => gesture),
-      Simultaneous: jest.fn((...gestures) => gestures),
+      Tap: () => ({
+        onEnd: (callback: (event: { x: number }) => void) => {
+          tapOnEnd = callback;
+          return { onEnd: jest.fn() };
+        },
+      }),
+      Pan: () => {
+        const panBuilder = {
+          onUpdate: (callback: (event: { x: number }) => void) => {
+            panOnUpdate = callback;
+            return panBuilder;
+          },
+          onEnd: (callback: (event: { x: number }) => void) => {
+            panOnEnd = callback;
+            return panBuilder;
+          },
+        };
+
+        return panBuilder;
+      },
+      Simultaneous: jest.fn(),
     },
   };
 });
 
+jest.mock('react-native-reanimated', () => {
+  const ActualReact = jest.requireActual('react') as typeof import('react');
+  const Reanimated = jest.requireActual(
+    'react-native-reanimated/mock',
+  ) as Record<string, unknown>;
+
+  return {
+    ...Reanimated,
+    runOnJS:
+      <Args extends unknown[], Ret>(fn: (...args: Args) => Ret) =>
+      (...args: Args) =>
+        fn(...args),
+    useSharedValue: (initial: number) =>
+      ActualReact.useRef({ value: initial }).current,
+    useAnimatedStyle: (fn: () => Record<string, unknown>) => fn(),
+  };
+});
+
+function triggerLayout() {
+  fireEvent(screen.getByTestId(GESTURE_AREA_TEST_ID), 'layout', {
+    nativeEvent: { layout: { width: SLIDER_WIDTH, height: 32, x: 0, y: 0 } },
+  });
+}
+
 describe('BatchSellPercentageSlider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tapOnEnd = undefined;
+    panOnUpdate = undefined;
+    panOnEnd = undefined;
+  });
+
   it.each([
     [-10, 0],
     [0, 0],
@@ -50,12 +101,75 @@ describe('BatchSellPercentageSlider', () => {
     expect(result).toBe(expectedValue);
   });
 
+  it('reports value changes while dragging', () => {
+    const onValueChange = jest.fn();
+    render(
+      <BatchSellPercentageSlider
+        value={50}
+        onValueChange={onValueChange}
+        testID={SLIDER_TEST_ID}
+      />,
+    );
+
+    triggerLayout();
+
+    act(() => {
+      panOnUpdate?.({ x: 150 });
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith(75);
+  });
+
+  it('commits the final value on drag end', () => {
+    const onDragEnd = jest.fn();
+    render(
+      <BatchSellPercentageSlider
+        value={50}
+        onValueChange={jest.fn()}
+        onDragEnd={onDragEnd}
+        testID={SLIDER_TEST_ID}
+      />,
+    );
+
+    triggerLayout();
+
+    act(() => {
+      panOnEnd?.({ x: 150 });
+    });
+
+    expect(onDragEnd).toHaveBeenCalledWith(75);
+  });
+
+  it('updates and commits on tap', () => {
+    const onValueChange = jest.fn();
+    const onDragEnd = jest.fn();
+    render(
+      <BatchSellPercentageSlider
+        value={50}
+        onValueChange={onValueChange}
+        onDragEnd={onDragEnd}
+        testID={SLIDER_TEST_ID}
+      />,
+    );
+
+    triggerLayout();
+
+    act(() => {
+      tapOnEnd?.({ x: 150 });
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith(75);
+    expect(onDragEnd).toHaveBeenCalledWith(75);
+  });
+
   it('increments accessibility value by one percentage point', () => {
     const onValueChange = jest.fn();
+    const onDragEnd = jest.fn();
     const { getByTestId } = render(
       <BatchSellPercentageSlider
         value={50}
         onValueChange={onValueChange}
+        onDragEnd={onDragEnd}
         testID={SLIDER_TEST_ID}
       />,
     );
@@ -65,6 +179,7 @@ describe('BatchSellPercentageSlider', () => {
     });
 
     expect(onValueChange).toHaveBeenCalledWith(51);
+    expect(onDragEnd).toHaveBeenCalledWith(51);
   });
 
   it('decrements accessibility value by one percentage point', () => {
@@ -98,7 +213,7 @@ describe('BatchSellPercentageSlider', () => {
       nativeEvent: { actionName: 'decrement' },
     });
 
-    expect(onValueChange).toHaveBeenCalledWith(0);
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 
   it('renders muted marker dots for each marker point', () => {

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellPercentageSlider.tsx
@@ -29,13 +29,17 @@ export function clampToPercentage(value: number): number {
 
 interface BatchSellPercentageSliderProps {
   value: number;
+  /** Called on every 1% change during drag for live display updates. */
   onValueChange: (value: number) => void;
+  /** Called when the user lifts their finger or taps the track. */
+  onDragEnd?: (value: number) => void;
   testID?: string;
 }
 
 export function BatchSellPercentageSlider({
   value,
   onValueChange,
+  onDragEnd,
   testID,
 }: BatchSellPercentageSliderProps) {
   const { styles } = useStyles(styleSheet, {});
@@ -52,7 +56,7 @@ export function BatchSellPercentageSlider({
     [translateX],
   );
 
-  const commitValueFromPosition = useCallback(
+  const updateValueFromPosition = useCallback(
     (position: number, width: number) => {
       if (width === 0) {
         return;
@@ -64,9 +68,28 @@ export function BatchSellPercentageSlider({
       );
 
       updatePosition(nextValue, width);
-      onValueChange(nextValue);
+
+      if (nextValue !== value) {
+        onValueChange(nextValue);
+      }
     },
-    [onValueChange, updatePosition],
+    [onValueChange, updatePosition, value],
+  );
+
+  const commitFromPosition = useCallback(
+    (position: number, width: number) => {
+      if (width === 0 || !onDragEnd) {
+        return;
+      }
+
+      const clampedPosition = Math.max(0, Math.min(position, width));
+      const nextValue = clampToPercentage(
+        (clampedPosition / width) * MAX_PERCENTAGE,
+      );
+
+      onDragEnd(nextValue);
+    },
+    [onDragEnd],
   );
 
   const handleLayout = useCallback(
@@ -103,23 +126,15 @@ export function BatchSellPercentageSlider({
 
   const gesture = Gesture.Simultaneous(
     Gesture.Tap().onEnd((event) => {
-      runOnJS(commitValueFromPosition)(event.x, sliderWidth.value);
+      runOnJS(updateValueFromPosition)(event.x, sliderWidth.value);
+      runOnJS(commitFromPosition)(event.x, sliderWidth.value);
     }),
     Gesture.Pan()
       .onUpdate((event) => {
-        const width = sliderWidth.value;
-
-        if (width === 0) {
-          return;
-        }
-
-        // Track finger position at 1 % granularity while dragging.
-        const rawPos = Math.max(0, Math.min(event.x, width));
-        const pct = Math.round((rawPos / width) * MAX_PERCENTAGE);
-        translateX.value = (pct / MAX_PERCENTAGE) * width;
+        runOnJS(updateValueFromPosition)(event.x, sliderWidth.value);
       })
       .onEnd((event) => {
-        runOnJS(commitValueFromPosition)(event.x, sliderWidth.value);
+        runOnJS(commitFromPosition)(event.x, sliderWidth.value);
       }),
   );
 
@@ -130,9 +145,12 @@ export function BatchSellPercentageSlider({
           ? clampToPercentage(clampedValue + 1)
           : clampToPercentage(clampedValue - 1);
 
-      onValueChange(nextValue);
+      if (nextValue !== clampedValue) {
+        onValueChange(nextValue);
+        onDragEnd?.(nextValue);
+      }
     },
-    [onValueChange, clampedValue],
+    [onDragEnd, onValueChange, clampedValue],
   );
 
   return (
@@ -151,7 +169,11 @@ export function BatchSellPercentageSlider({
     >
       <View style={styles.trackContainer}>
         <GestureDetector gesture={gesture}>
-          <Animated.View onLayout={handleLayout} style={styles.gestureArea}>
+          <Animated.View
+            onLayout={handleLayout}
+            style={styles.gestureArea}
+            testID={testID ? `${testID}-gesture-area` : undefined}
+          >
             <Animated.View style={styles.track} />
             <Animated.View style={[styles.progress, progressStyle]} />
             <Animated.View style={[styles.thumb, handleStyle]} />

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReviewTokenRow.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReviewTokenRow.test.tsx
@@ -40,16 +40,24 @@ jest.mock('./BatchSellPercentageSlider', () => {
   return {
     BatchSellPercentageSlider: ({
       onValueChange,
+      onDragEnd,
       testID,
       value,
     }: {
       onValueChange: (value: number) => void;
+      onDragEnd?: (value: number) => void;
       testID?: string;
       value: number;
     }) =>
       ReactActual.createElement(
         RNPressable,
-        { testID, onPress: () => onValueChange(75) },
+        {
+          testID,
+          onPress: () => {
+            onValueChange(75);
+            onDragEnd?.(75);
+          },
+        },
         ReactActual.createElement(RNText, null, `${value}%`),
       ),
   };
@@ -214,7 +222,7 @@ describe('BatchSellReviewTokenRow', () => {
     expect(getByText('0.74906 ETH • 50%')).toBeOnTheScreen();
   });
 
-  it('forwards slider percent changes', () => {
+  it('forwards slider percent changes on drag end', () => {
     const { getByTestId } = render(
       <BatchSellReviewTokenRow
         token={mockToken}

--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReviewTokenRow.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReviewTokenRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -66,15 +66,28 @@ export function BatchSellReviewTokenRow({
   isRemoveTokenDisabled = false,
 }: BatchSellReviewTokenRowProps) {
   const tw = useTailwind();
+  // Live slider percent for immediate subtitle updates while dragging. The parent
+  // `percent` prop is only committed on drag end (Redux + debounced quote fetch).
+  const [displayPercent, setDisplayPercent] = useState(percent);
+
+  useEffect(() => {
+    setDisplayPercent(percent);
+  }, [percent]);
+
   const balanceText = useMemo(
-    () => getTokenBalanceText(token, percent),
-    [percent, token],
+    () => getTokenBalanceText(token, displayPercent),
+    [displayPercent, token],
   );
   const shouldShowHighPriceImpactTag =
     !isLoading && !isQuoteUnavailable && isHighPriceImpact;
 
-  const handlePercentChange = useCallback(
+  const handleSliderValueChange = useCallback((nextPercent: number) => {
+    setDisplayPercent(nextPercent);
+  }, []);
+
+  const handleSliderDragEnd = useCallback(
     (nextPercent: number) => {
+      setDisplayPercent(nextPercent);
       onPercentChange(tokenKey, nextPercent);
     },
     [onPercentChange, tokenKey],
@@ -210,8 +223,9 @@ export function BatchSellReviewTokenRow({
         </Box>
       </Box>
       <BatchSellPercentageSlider
-        value={percent}
-        onValueChange={handlePercentChange}
+        value={displayPercent}
+        onValueChange={handleSliderValueChange}
+        onDragEnd={handleSliderDragEnd}
         testID={`${BatchSellReviewSelectorsIDs.TOKEN_SLIDER}-${tokenKey}`}
       />
     </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Batch Sell review sliders only updated the token amount and percentage subtitle when the user lifted their finger, so the row felt unresponsive while dragging.

This PR aligns `BatchSellPercentageSlider` with the QuickBuy slider pattern: `onValueChange` fires on every 1% step during drag (via `runOnJS(updateValueFromPosition)`), and `onDragEnd` commits the final value. `BatchSellReviewTokenRow` keeps a local `displayPercent` for immediate subtitle updates while dragging; Redux and the debounced quote request only run on drag end. Received fiat values are unchanged and still come from quotes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Batch Sell review sliders to update token amount and percentage in real time while dragging

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #31758

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch Sell review slider live token amount updates

  Scenario: user drags a token percentage slider on Batch Sell Review
    Given Batch Sell is enabled and the user has selected multiple tokens to sell
    And the user is on Batch Sell Review with quotes loaded

    When the user drags a token percentage slider
    Then the token amount and percentage subtitle update in real time at 1% steps
    And the received fiat value continues to follow existing quote behavior until a new quote loads
    And releasing the slider triggers a debounced quote refresh with the committed amount
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. --> 

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/579d2bd4-060c-4c35-bfb1-c0079fb1a3f9


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
