### PR TITLE
feat: read notification_subtype from deeplink and relay to analytics

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -72,6 +72,7 @@ const TraderPositionView = () => {
     position: positionParam,
     positionId,
     source: sourceParam,
+    notificationSubtype,
   } = route.params;
   const { track } = useSocialLeaderboardAnalytics();
 
@@ -217,8 +218,17 @@ const TraderPositionView = () => {
     track(MetaMetricsEvents.SOCIAL_FOLLOW_TRADING_TOKEN_SCREEN_VIEWED, {
       ...followTradingTokenContext,
       [SocialLeaderboardEventProperties.SOURCE]: followTradingTokenSource,
+      ...(notificationSubtype !== undefined && {
+        [SocialLeaderboardEventProperties.NOTIFICATION_SUBTYPE]:
+          notificationSubtype,
+      }),
     });
-  }, [followTradingTokenContext, followTradingTokenSource, track]);
+  }, [
+    followTradingTokenContext,
+    followTradingTokenSource,
+    notificationSubtype,
+    track,
+  ]);
 
   // Keep a stable ref to the latest context so the dismissed-cleanup effect
   // can read the current value without listing it as a dependency.

--- a/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
+++ b/app/components/Views/SocialLeaderboard/analytics/socialLeaderboardEvents.ts
@@ -23,6 +23,7 @@ export const SocialLeaderboardEventProperties = {
   LATENCY_MS: 'latency_ms',
   MARKET_CAP: 'market_cap',
   NOTIFICATION_TYPE: 'notification_type',
+  NOTIFICATION_SUBTYPE: 'notification_subtype',
   PAY_WITH_TOKEN: 'pay_with_token',
   RECEIVE_TOKEN: 'receive_token',
   PRESET_VALUE: 'preset_value',

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleSocialTraderPositionUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleSocialTraderPositionUrl.test.ts
@@ -33,10 +33,10 @@ describe('handleSocialTraderPositionUrl', () => {
     jest.clearAllMocks();
   });
 
-  it('navigates to TraderPositionView with positionId', () => {
+  it('navigates to TraderPositionView with positionId and forwards notificationSubtype', () => {
     handleSocialTraderPositionUrl({
       actionPath:
-        '?positionId=92d9001b-8b64-4b13-9c1b-ba9292a6099a&traderId=trader-1&deduplication_id=dedup-1&notification_event=follow_newtrade_buy',
+        '?positionId=92d9001b-8b64-4b13-9c1b-ba9292a6099a&traderId=trader-1&deduplication_id=dedup-1&notification_subtype=follow_newtrade_buy',
     });
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
@@ -46,11 +46,12 @@ describe('handleSocialTraderPositionUrl', () => {
         positionId: '92d9001b-8b64-4b13-9c1b-ba9292a6099a',
         traderId: 'trader-1',
         source: 'notification',
+        notificationSubtype: 'follow_newtrade_buy',
       },
     );
   });
 
-  it('navigates with only positionId and traderId route params', () => {
+  it('navigates with only positionId and traderId when no subtype is present', () => {
     handleSocialTraderPositionUrl({
       actionPath: '?positionId=position-1&traderId=trader-1',
     });
@@ -62,14 +63,15 @@ describe('handleSocialTraderPositionUrl', () => {
         positionId: 'position-1',
         traderId: 'trader-1',
         source: 'notification',
+        notificationSubtype: undefined,
       },
     );
   });
 
-  it('decodes encoded positionId and traderId values', () => {
+  it('decodes encoded positionId, traderId, and subtype values', () => {
     handleSocialTraderPositionUrl({
       actionPath:
-        '?positionId=position%20id%2Fwith%20reserved%3Fchars&traderId=trader%20id%2Fwith%20reserved%3Fchars&deduplication_id=dedup%20id%2Fwith%20reserved%3Fchars&notification_event=follow%20newtrade%2Fbuy',
+        '?positionId=position%20id%2Fwith%20reserved%3Fchars&traderId=trader%20id%2Fwith%20reserved%3Fchars&deduplication_id=dedup%20id%2Fwith%20reserved%3Fchars&notification_subtype=follow%20newtrade%2Fbuy',
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -78,6 +80,7 @@ describe('handleSocialTraderPositionUrl', () => {
         positionId: 'position id/with reserved?chars',
         traderId: 'trader id/with reserved?chars',
         source: 'notification',
+        notificationSubtype: 'follow newtrade/buy',
       },
     );
     expect(DevLogger.log).toHaveBeenCalledWith(
@@ -86,8 +89,24 @@ describe('handleSocialTraderPositionUrl', () => {
         positionId: 'position id/with reserved?chars',
         traderId: 'trader id/with reserved?chars',
         deduplicationId: 'dedup id/with reserved?chars',
-        notificationEvent: 'follow newtrade/buy',
+        notificationSubtype: 'follow newtrade/buy',
       },
+    );
+  });
+
+  it.each([
+    'follow_newtrade_buy',
+    'follow_newtrade_sell',
+    'follow_newtrade_perp_long',
+    'follow_newtrade_perp_short',
+  ])('forwards subtype %s through to the destination screen', (subtype) => {
+    handleSocialTraderPositionUrl({
+      actionPath: `?positionId=position-1&traderId=trader-1&notification_subtype=${subtype}`,
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.SOCIAL_LEADERBOARD.POSITION,
+      expect.objectContaining({ notificationSubtype: subtype }),
     );
   });
 
@@ -174,6 +193,7 @@ describe('handleSocialTraderPositionUrl', () => {
         positionId: 'position-1',
         traderId: 'trader-1',
         source: 'notification',
+        notificationSubtype: undefined,
       },
     );
     expect(DevLogger.log).toHaveBeenCalledWith(

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleUniversalLink.test.ts
@@ -1258,14 +1258,14 @@ describe('handleUniversalLink', () => {
 
   describe('ACTIONS.SOCIAL_TRADER_POSITION', () => {
     it('calls _handleSocialTraderPosition when action is SOCIAL_TRADER_POSITION', async () => {
-      const positionUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.SOCIAL_TRADER_POSITION}?positionId=position-1&traderId=trader-1&deduplication_id=dedup-1&notification_event=follow_newtrade_buy`;
+      const positionUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.SOCIAL_TRADER_POSITION}?positionId=position-1&traderId=trader-1&deduplication_id=dedup-1&notification_subtype=follow_newtrade_buy`;
       const positionUrlObj = {
         ...urlObj,
         hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
         href: positionUrl,
         pathname: `/${ACTIONS.SOCIAL_TRADER_POSITION}`,
         search:
-          '?positionId=position-1&traderId=trader-1&deduplication_id=dedup-1&notification_event=follow_newtrade_buy',
+          '?positionId=position-1&traderId=trader-1&deduplication_id=dedup-1&notification_subtype=follow_newtrade_buy',
       };
 
       await handleUniversalLink({
@@ -1280,7 +1280,7 @@ describe('handleUniversalLink', () => {
       expect(mockHandleDeepLinkModalDisplay).not.toHaveBeenCalled();
       expect(handleSocialTraderPositionUrl).toHaveBeenCalledWith({
         actionPath:
-          '?positionId=position-1&traderId=trader-1&deduplication_id=dedup-1&notification_event=follow_newtrade_buy',
+          '?positionId=position-1&traderId=trader-1&deduplication_id=dedup-1&notification_subtype=follow_newtrade_buy',
       });
       expect(handled).toHaveBeenCalled();
     });

--- a/app/core/DeeplinkManager/handlers/legacy/handleSocialTraderPositionUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleSocialTraderPositionUrl.ts
@@ -15,7 +15,7 @@ interface SocialTraderPositionNavigationParams {
   positionId?: string;
   traderId?: string;
   deduplicationId?: string;
-  notificationEvent?: string;
+  notificationSubtype?: string;
 }
 
 const parseSocialTraderPositionNavigationParams = (
@@ -29,7 +29,8 @@ const parseSocialTraderPositionNavigationParams = (
     positionId: urlParams.get('positionId')?.trim() || undefined,
     traderId: urlParams.get('traderId')?.trim() || undefined,
     deduplicationId: urlParams.get('deduplication_id')?.trim() || undefined,
-    notificationEvent: urlParams.get('notification_event')?.trim() || undefined,
+    notificationSubtype:
+      urlParams.get('notification_subtype')?.trim() || undefined,
   };
 };
 
@@ -41,7 +42,7 @@ const navigateToFallback = () => {
  * Handles notification-approved TraderPosition deeplinks.
  *
  * Supported URL format:
- * - https://link.metamask.io/social-trader-position?positionId=<positionId>&traderId=<traderId>&deduplication_id=<deduplicationId>&notification_event=<notificationEvent>
+ * - https://link.metamask.io/social-trader-position?positionId=<positionId>&traderId=<traderId>&deduplication_id=<deduplicationId>&notification_subtype=<notificationSubtype>
  */
 export const handleSocialTraderPositionUrl = ({
   actionPath,
@@ -52,11 +53,11 @@ export const handleSocialTraderPositionUrl = ({
   );
 
   try {
-    const { positionId, traderId, deduplicationId, notificationEvent } =
+    const { positionId, traderId, deduplicationId, notificationSubtype } =
       parseSocialTraderPositionNavigationParams(actionPath);
     DevLogger.log(
       '[handleSocialTraderPositionUrl] Parsed navigation parameters:',
-      { positionId, traderId, deduplicationId, notificationEvent },
+      { positionId, traderId, deduplicationId, notificationSubtype },
     );
 
     if (!positionId || !traderId) {
@@ -85,13 +86,13 @@ export const handleSocialTraderPositionUrl = ({
       );
     }
 
-    if (notificationEvent !== undefined) {
+    if (notificationSubtype !== undefined) {
       const event = AnalyticsEventBuilder.createEventBuilder(
         MetaMetricsEvents.SOCIAL_FOLLOW_TRADING_NOTIFICATION_CLICKED,
       )
         .addProperties({
-          [SocialLeaderboardEventProperties.NOTIFICATION_TYPE]:
-            notificationEvent,
+          [SocialLeaderboardEventProperties.NOTIFICATION_SUBTYPE]:
+            notificationSubtype,
         })
         .build();
       analytics.trackEvent(event);
@@ -101,6 +102,7 @@ export const handleSocialTraderPositionUrl = ({
       positionId,
       traderId,
       source: 'notification',
+      notificationSubtype,
     });
   } catch (error) {
     DevLogger.log(

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -246,6 +246,10 @@ type TraderPositionViewParams =
       /** Analytics entry-point that opened the position view. Narrowed at the
        * receiver into the QuickBuy / FollowTradingToken source enums. */
       source?: string;
+      /** Notification subtype forwarded from the social-trader-position
+       * deeplink (e.g. `follow_newtrade_perp_long`). Attached to the
+       * destination screen's analytics event for click attribution. */
+      notificationSubtype?: string;
     }
   | {
       /** Deep-link path: triggers useTraderPosition to fetch by UUID. */
@@ -260,6 +264,10 @@ type TraderPositionViewParams =
       /** Analytics entry-point that opened the position view. Narrowed at the
        * receiver into the QuickBuy / FollowTradingToken source enums. */
       source?: string;
+      /** Notification subtype forwarded from the social-trader-position
+       * deeplink (e.g. `follow_newtrade_perp_long`). Attached to the
+       * destination screen's analytics event for click attribution. */
+      notificationSubtype?: string;
     };
 
 /**


### PR DESCRIPTION
  ## **Description**

  Mobile half of TSA-702. The deeplink contract change (see paired social-api PR) renames the `notification_event` query param on `social-trader-position` URLs to `notification_subtype` for parity with NAAP. This PR updates the mobile deeplink
   handler to parse the new name, forwards the value through navigation to `TraderPositionView`, and includes it on the `SOCIAL_FOLLOW_TRADING_TOKEN_SCREEN_VIEWED` analytics event so click-attribution can distinguish spot vs perp opens in
  analytics.

  **What changed**

  - `handleSocialTraderPositionUrl.ts` — parses `notification_subtype` (was `notification_event`), fires the existing `SOCIAL_FOLLOW_TRADING_NOTIFICATION_CLICKED` event with the new property key, and forwards `notificationSubtype` as a
  navigation param to `TraderPositionView`.
  - `TraderPositionView.tsx` — reads `notificationSubtype` from route params and includes it on the `SOCIAL_FOLLOW_TRADING_TOKEN_SCREEN_VIEWED` event when present.
  - `socialLeaderboardEvents.ts` — adds `NOTIFICATION_SUBTYPE: 'notification_subtype'` as an analytics property key.
  - `NavigationService/types.ts` — adds optional `notificationSubtype` to both `TraderPositionViewParams` union branches.

  **Backwards compatibility**

  Missing `notification_subtype` does not break navigation — the analytics property is omitted via a spread guard when absent. Routes that don't originate from a notification tap (in-app row taps, deeplinks without a subtype) work unchanged.

  **Paired PR**

  This depends on the social-api rename ([PR #89](https://github.com/consensys-vertical-apps/va-mmcx-social-api/pull/89)) landing for the new param name to appear on real deeplinks. Until both ship, notification-tap analytics will be missing the subtype property — but routing/destination behavior is unchanged.

  ## **Changelog**

  CHANGELOG entry: null

  ## **Related issues**

  Fixes: https://consensyssoftware.atlassian.net/browse/TSA-702

  ## **Manual testing steps**

  ```gherkin
  Feature: Notification deeplink forwards subtype through to analytics

    Scenario: Tap a notification with a spot subtype
      Given the user taps a social-trader-position deeplink with notification_subtype=follow_newtrade_buy
      When the deeplink handler runs
      Then the user lands on TraderPositionView for the given position
      And the SOCIAL_FOLLOW_TRADING_NOTIFICATION_CLICKED event fires with notification_subtype=follow_newtrade_buy
      And once the screen renders, SOCIAL_FOLLOW_TRADING_TOKEN_SCREEN_VIEWED fires with notification_subtype=follow_newtrade_buy

    Scenario: Tap a notification with a perp subtype
      Given the user taps a social-trader-position deeplink with notification_subtype=follow_newtrade_perp_long
      When the deeplink handler runs
      Then navigation and analytics propagate notification_subtype=follow_newtrade_perp_long end-to-end

    Scenario: Legacy deeplinks without a subtype still work
      Given the user taps a social-trader-position deeplink with no notification_subtype query param
      When the deeplink handler runs
      Then navigation completes normally
      And the SOCIAL_FOLLOW_TRADING_TOKEN_SCREEN_VIEWED event fires WITHOUT a notification_subtype property
  ```

  ## **Screenshots/Recordings**

  N/A — analytics-only change, no visible UI.

  ### **Before**

  N/A

  ### **After**

  N/A

  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.