### PR TITLE
fix: Readded spacing between top movers segment control and pills cp-7.82.0

### DIFF
--- a/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.tsx
+++ b/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.tsx
@@ -125,7 +125,7 @@ const PerpsTopMoversSectionInner: React.FC<PerpsTopMoversSectionProps> = ({
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
-        twClassName="px-4 gap-2"
+        twClassName="px-4 gap-2 mb-3"
       >
         <TogglePill
           label={strings('perps.home.gainers')}


### PR DESCRIPTION
## **Description**

During the Perps homepage section layout refactor (#31243), the bottom margin on the Gainers/Losers toggle was removed along with the top margin on the pill carousel below it. That left the Top Movers segment control visually cramped against the market pill list.

This PR restores **12px** of vertical spacing between the Gainers/Losers buttons and the pill carousel by adding `mb-3` to the toggle container in `PerpsTopMoversSection`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/DSYS-880

## **Manual testing steps**

```gherkin
Feature: Perps Top Movers section spacing

  Scenario: Gainers/Losers toggle has spacing above the pill list
    Given Perps is enabled and the Top Movers feature flag is on
    When the user opens the Perps home screen and scrolls to the Top Movers section
    Then the Gainers/Losers toggle is visibly separated from the market pill list below
    And the gap between the toggle and the first row of pills matches the 12px design spec

  Scenario: Spacing is consistent when switching between Gainers and Losers
    Given the user is viewing the Top Movers section on Perps home
    When the user taps between the Gainers and Losers toggles
    Then the spacing between the toggle and the pill list remains unchanged
    And the pill list updates to show the selected direction as before
```

## **Screenshots/Recordings**

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-15 at 15 08 16" src="https://github.com/user-attachments/assets/3f3ba8b9-b81c-45ab-bf91-f509e51fe42e" />

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-15 at 15 07 59" src="https://github.com/user-attachments/assets/cc1f1bb3-c70b-4afa-ad0a-859a8310476a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.