### PR TITLE
fix: Telegram OAuth login on Android 16 cp-7.82.0

### DIFF
--- a/app/core/OAuthService/OAuthLoginHandlers/constants.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/constants.ts
@@ -97,9 +97,7 @@ export const AppleWebClientId = CURRENT_OAUTH_CONFIG.ANDROID_APPLE_CLIENT_ID;
 // Use universal link for OAuth redirect
 export const GoogleRedirectUri = `${PROTOCOLS.HTTPS}://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/${ACTIONS.OAUTH_REDIRECT}`;
 export const AppRedirectUri = GoogleRedirectUri;
-export const TelegramRedirectUri = Device.isAndroid()
-  ? `${PROTOCOLS.METAMASK}://${ACTIONS.OAUTH_REDIRECT}`
-  : AppRedirectUri;
+export const TelegramRedirectUri = AppRedirectUri;
 export const AppleServerRedirectUri = `${CURRENT_OAUTH_CONFIG.AUTH_SERVER_URL}/api/v1/oauth/callback`;
 
 export const shouldUseLegacyIosGoogleConfig = () => {

--- a/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
@@ -235,9 +235,10 @@ export class TelegramLoginHandler extends BaseLoginHandler {
         return initialUrl;
       }
 
-      // Temporary workaround for Android 16 Safer Intents
-      // Telegram do no need return data from oauth login
-      // Login is done in kratos
+      // Temporary workaround for Android 16 Safer Intents which prevents Chrome from handling custom scheme URLs directly
+      // by force to return https url with universal link which is allowed and let the app handle the redirect as usual
+      // Currently Telegram login flow is not using params in the redirect url, so it should not cause any issue
+      // TODO: a proper solution would be to make the callback URL return a webpage with a deeplink to open the app
       if (Device.isAndroid()) {
         return this.redirectUri;
       }

--- a/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
@@ -236,9 +236,7 @@ export class TelegramLoginHandler extends BaseLoginHandler {
       }
 
       // Temporary workaround for Android 16 Safer Intents which prevents Chrome from handling custom scheme URLs directly
-      // by force to return https url with universal link which is allowed and let the app handle the redirect as usual
-      // Currently Telegram login flow is not using params in the redirect url, so it should not cause any issue
-      // TODO: a proper solution would be to make the callback URL return a webpage with a deeplink to open the app
+      // Currently Telegram login flow is not using params in the redirect url
       if (Device.isAndroid()) {
         return this.redirectUri;
       }

--- a/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
@@ -1,5 +1,5 @@
-import { openAuthSessionAsync, openBrowserAsync } from 'expo-web-browser';
-import { AppState, Linking, Platform } from 'react-native';
+import { openAuthSessionAsync } from 'expo-web-browser';
+import { AppState, Linking } from 'react-native';
 import {
   Env as ProfileSyncEnv,
   getEnvUrls,
@@ -27,7 +27,6 @@ const TELEGRAM_AUTH_SERVER_INITIATE_PATH = '/api/v2/telegram/login/initiate';
 const TELEGRAM_AUTH_SERVER_VERIFY_PATH = '/api/v2/telegram/login/verify';
 const TELEGRAM_MINT_PATH = 'api/v1/oauth/mint';
 const REDIRECT_LINKING_FALLBACK_TIMEOUT_MS = 1500;
-const ANDROID_LOGIN_REDIRECT_TIMEOUT_MS = 120000;
 const VERIFY_APP_ACTIVE_TIMEOUT_MS = 5000;
 const VERIFY_AFTER_APP_ACTIVE_DELAY_MS = 500;
 const VERIFY_NETWORK_RETRY_DELAY_MS = 500;

--- a/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
@@ -57,14 +57,6 @@ const wait = (timeoutMs: number) =>
 const isNetworkRequestError = (error: unknown) =>
   error instanceof Error && error.message.includes('Network request failed');
 
-const redirectUrlHasExpectedState = (url: string, expectedState: string) => {
-  try {
-    return new URL(url).searchParams.get('state') === expectedState;
-  } catch {
-    return false;
-  }
-};
-
 const waitForActiveAppState = async () => {
   if (AppState.currentState === 'active') {
     return;
@@ -191,17 +183,15 @@ export class TelegramLoginHandler extends BaseLoginHandler {
     initiateUrl.searchParams.set('app_redirect_uri', this.redirectUri);
     initiateUrl.searchParams.set('code_challenge', challenge);
 
-    const buildLoginResult = (): LoginHandlerCodeResult => ({
+    await this.loginWithAuthSession(initiateUrl.toString());
+
+    return {
       authConnection: this.authConnection,
       code: challenge,
       clientId: this.clientId,
       redirectUri: this.redirectUri,
       codeVerifier,
-    });
-
-    await this.loginWithAuthSession(initiateUrl.toString());
-
-    return buildLoginResult();
+    };
   }
 
   async loginWithAuthSession(authorizationUrl: string): Promise<string> {

--- a/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
@@ -21,6 +21,7 @@ import {
 } from '../baseHandler';
 import { isRetryableError, retryWithDelay } from '../utils';
 import { OAuthError, OAuthErrorType } from '../../error';
+import Device from '../../../../util/device';
 
 const TELEGRAM_AUTH_SERVER_INITIATE_PATH = '/api/v2/telegram/login/initiate';
 const TELEGRAM_AUTH_SERVER_VERIFY_PATH = '/api/v2/telegram/login/verify';
@@ -63,58 +64,6 @@ const redirectUrlHasExpectedState = (url: string, expectedState: string) => {
     return false;
   }
 };
-
-const waitForAndroidRedirectOrResume = (
-  expectedRedirectUri: string,
-  expectedState: string,
-  timeoutMs: number,
-) =>
-  new Promise<boolean>((resolve) => {
-    let sawBrowserAppState = AppState.currentState !== 'active';
-    let didResolve = false;
-    const subscriptionRef: {
-      appState?: ReturnType<typeof AppState.addEventListener>;
-      linking?: ReturnType<typeof Linking.addEventListener>;
-    } = {};
-
-    const finish = (didRedirectOrResume: boolean) => {
-      if (didResolve) {
-        return;
-      }
-
-      didResolve = true;
-      subscriptionRef.appState?.remove();
-      subscriptionRef.linking?.remove();
-      resolve(didRedirectOrResume);
-    };
-
-    const timeout = setTimeout(() => finish(false), timeoutMs);
-
-    subscriptionRef.linking = Linking.addEventListener('url', ({ url }) => {
-      if (
-        url.startsWith(expectedRedirectUri) &&
-        redirectUrlHasExpectedState(url, expectedState)
-      ) {
-        clearTimeout(timeout);
-        finish(true);
-      }
-    });
-
-    subscriptionRef.appState = AppState.addEventListener(
-      'change',
-      (nextState) => {
-        if (nextState !== 'active') {
-          sawBrowserAppState = true;
-          return;
-        }
-
-        if (sawBrowserAppState) {
-          clearTimeout(timeout);
-          finish(true);
-        }
-      },
-    );
-  });
 
 const waitForActiveAppState = async () => {
   if (AppState.currentState === 'active') {
@@ -250,29 +199,6 @@ export class TelegramLoginHandler extends BaseLoginHandler {
       codeVerifier,
     });
 
-    if (Platform.OS === 'android') {
-      const redirectOrResumePromise = waitForAndroidRedirectOrResume(
-        this.redirectUri,
-        this.nonce,
-        ANDROID_LOGIN_REDIRECT_TIMEOUT_MS,
-      );
-
-      await openBrowserAsync(initiateUrl.toString(), {
-        createTask: false,
-      });
-
-      const didRedirectOrResume = await redirectOrResumePromise;
-
-      if (didRedirectOrResume) {
-        return buildLoginResult();
-      }
-
-      throw new OAuthError(
-        'TelegramLoginHandler: No OAuth redirect received',
-        OAuthErrorType.TelegramLoginError,
-      );
-    }
-
     await this.loginWithAuthSession(initiateUrl.toString());
 
     return buildLoginResult();
@@ -318,6 +244,13 @@ export class TelegramLoginHandler extends BaseLoginHandler {
 
       if (initialUrl?.startsWith(this.redirectUri)) {
         return initialUrl;
+      }
+
+      // Temporary workaround for Android 16 Safer Intents
+      // Telegram do no need return data from oauth login
+      // Login is done in kratos
+      if (Device.isAndroid()) {
+        return this.redirectUri;
       }
 
       if (result.type === 'cancel') {

--- a/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/shared/TelegramLoginHandler.ts
@@ -1,5 +1,5 @@
-import { openAuthSessionAsync } from 'expo-web-browser';
-import { AppState, Linking } from 'react-native';
+import { openAuthSessionAsync, openBrowserAsync } from 'expo-web-browser';
+import { AppState, Linking, Platform } from 'react-native';
 import {
   Env as ProfileSyncEnv,
   getEnvUrls,
@@ -26,6 +26,7 @@ const TELEGRAM_AUTH_SERVER_INITIATE_PATH = '/api/v2/telegram/login/initiate';
 const TELEGRAM_AUTH_SERVER_VERIFY_PATH = '/api/v2/telegram/login/verify';
 const TELEGRAM_MINT_PATH = 'api/v1/oauth/mint';
 const REDIRECT_LINKING_FALLBACK_TIMEOUT_MS = 1500;
+const ANDROID_LOGIN_REDIRECT_TIMEOUT_MS = 120000;
 const VERIFY_APP_ACTIVE_TIMEOUT_MS = 5000;
 const VERIFY_AFTER_APP_ACTIVE_DELAY_MS = 500;
 const VERIFY_NETWORK_RETRY_DELAY_MS = 500;
@@ -54,6 +55,66 @@ const wait = (timeoutMs: number) =>
 
 const isNetworkRequestError = (error: unknown) =>
   error instanceof Error && error.message.includes('Network request failed');
+
+const redirectUrlHasExpectedState = (url: string, expectedState: string) => {
+  try {
+    return new URL(url).searchParams.get('state') === expectedState;
+  } catch {
+    return false;
+  }
+};
+
+const waitForAndroidRedirectOrResume = (
+  expectedRedirectUri: string,
+  expectedState: string,
+  timeoutMs: number,
+) =>
+  new Promise<boolean>((resolve) => {
+    let sawBrowserAppState = AppState.currentState !== 'active';
+    let didResolve = false;
+    const subscriptionRef: {
+      appState?: ReturnType<typeof AppState.addEventListener>;
+      linking?: ReturnType<typeof Linking.addEventListener>;
+    } = {};
+
+    const finish = (didRedirectOrResume: boolean) => {
+      if (didResolve) {
+        return;
+      }
+
+      didResolve = true;
+      subscriptionRef.appState?.remove();
+      subscriptionRef.linking?.remove();
+      resolve(didRedirectOrResume);
+    };
+
+    const timeout = setTimeout(() => finish(false), timeoutMs);
+
+    subscriptionRef.linking = Linking.addEventListener('url', ({ url }) => {
+      if (
+        url.startsWith(expectedRedirectUri) &&
+        redirectUrlHasExpectedState(url, expectedState)
+      ) {
+        clearTimeout(timeout);
+        finish(true);
+      }
+    });
+
+    subscriptionRef.appState = AppState.addEventListener(
+      'change',
+      (nextState) => {
+        if (nextState !== 'active') {
+          sawBrowserAppState = true;
+          return;
+        }
+
+        if (sawBrowserAppState) {
+          clearTimeout(timeout);
+          finish(true);
+        }
+      },
+    );
+  });
 
 const waitForActiveAppState = async () => {
   if (AppState.currentState === 'active') {
@@ -181,15 +242,40 @@ export class TelegramLoginHandler extends BaseLoginHandler {
     initiateUrl.searchParams.set('app_redirect_uri', this.redirectUri);
     initiateUrl.searchParams.set('code_challenge', challenge);
 
-    await this.loginWithAuthSession(initiateUrl.toString());
-
-    return {
+    const buildLoginResult = (): LoginHandlerCodeResult => ({
       authConnection: this.authConnection,
       code: challenge,
       clientId: this.clientId,
       redirectUri: this.redirectUri,
       codeVerifier,
-    };
+    });
+
+    if (Platform.OS === 'android') {
+      const redirectOrResumePromise = waitForAndroidRedirectOrResume(
+        this.redirectUri,
+        this.nonce,
+        ANDROID_LOGIN_REDIRECT_TIMEOUT_MS,
+      );
+
+      await openBrowserAsync(initiateUrl.toString(), {
+        createTask: false,
+      });
+
+      const didRedirectOrResume = await redirectOrResumePromise;
+
+      if (didRedirectOrResume) {
+        return buildLoginResult();
+      }
+
+      throw new OAuthError(
+        'TelegramLoginHandler: No OAuth redirect received',
+        OAuthErrorType.TelegramLoginError,
+      );
+    }
+
+    await this.loginWithAuthSession(initiateUrl.toString());
+
+    return buildLoginResult();
   }
 
   async loginWithAuthSession(authorizationUrl: string): Promise<string> {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Android 16's Safer Intents changes prevent Chrome Custom Tabs from returning the OAuth redirect URL to the app when Telegram login completes. The Telegram flow uses a backend-mediated PKCE exchange (`code_challenge` on initiate, verify on the server) and does not require redirect payload data in the callback URL.

This PR makes two targeted changes:

1. **`constants.ts`** — Use the universal-link redirect URI (`https://link.metamask.io/oauth/redirect`) for Telegram on Android instead of the `metamask://` custom scheme, aligning Android with iOS.
2. **`TelegramLoginHandler.ts`** — After `openAuthSessionAsync` and the existing linking fallbacks, treat Android sessions as successful when no redirect URL is received. The handler still passes `code_challenge` to the initiate endpoint; verification continues server-side in Kratos.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Telegram login failing on Android 16 devices

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Android 16 Safer Intents breaking Telegram OAuth redirect handling

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Telegram OAuth login on Android 16

  Scenario: User signs in with Telegram on Android 16
    Given MetaMask is installed on an Android 16 device or emulator
    And the user is on the seedless onboarding / social login screen

    When the user taps "Continue with Telegram"
    And completes authentication in the browser / Custom Tab
    Then the app returns to MetaMask without an OAuth redirect error
    And the Telegram login flow completes successfully
```

Also verify iOS Telegram login is unaffected (same universal-link redirect URI as before).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — backend-mediated OAuth flow; success is verified by completing login without error rather than a visible UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.