### PR TITLE
feat(predict): add Popular Today home section

### DIFF
--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import {
+  act,
+  render,
+  fireEvent,
+  renderHook,
+  waitFor,
+} from '@testing-library/react-native';
+import type { LayoutChangeEvent, ScrollView } from 'react-native';
 import PredictChipList from './PredictChipList';
 import { calculateChipScrollX } from './calculateChipScrollX';
+import { useChipScrollList } from './useChipScrollList';
 import {
   PREDICT_CHIP_LIST_TEST_IDS,
   getPredictChipTestId,
   getPredictChipLabelTestId,
 } from './PredictChipList.testIds';
 import type { PredictChipItem } from './PredictChipList.types';
+
+const mockScrollTo = jest.fn();
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({
@@ -206,6 +216,42 @@ describe('PredictChipList', () => {
 
       expect(getByTestId(getPredictChipTestId('only'))).toBeOnTheScreen();
       expect(getByText('Only Chip')).toBeOnTheScreen();
+    });
+  });
+});
+
+describe('useChipScrollList', () => {
+  const layoutEvent = (x: number, width: number): LayoutChangeEvent =>
+    ({
+      nativeEvent: { layout: { x, y: 0, width, height: 40 } },
+    }) as LayoutChangeEvent;
+
+  beforeEach(() => {
+    mockScrollTo.mockClear();
+  });
+
+  it('scrolls the active chip into view when activeChipIndex changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ activeChipIndex }: { activeChipIndex: number }) =>
+        useChipScrollList(3, { activeChipIndex }),
+      { initialProps: { activeChipIndex: 0 } },
+    );
+
+    act(() => {
+      result.current.scrollViewRef.current = {
+        scrollTo: mockScrollTo,
+      } as unknown as ScrollView;
+      result.current.handleScrollViewLayout(layoutEvent(0, 200));
+      result.current.handleChipLayout(0, layoutEvent(16, 100));
+      result.current.handleChipLayout(1, layoutEvent(124, 100));
+      result.current.handleChipLayout(2, layoutEvent(232, 100));
+    });
+    mockScrollTo.mockClear();
+
+    rerender({ activeChipIndex: 2 });
+
+    await waitFor(() => {
+      expect(mockScrollTo).toHaveBeenCalledWith({ x: 182, animated: true });
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
@@ -254,6 +254,32 @@ describe('useChipScrollList', () => {
       expect(mockScrollTo).toHaveBeenCalledWith({ x: 182, animated: true });
     });
   });
+
+  it('does not re-scroll on incidental relayouts once the active chip is positioned', () => {
+    const { result } = renderHook(() =>
+      useChipScrollList(3, { activeChipIndex: 2 }),
+    );
+
+    act(() => {
+      result.current.scrollViewRef.current = {
+        scrollTo: mockScrollTo,
+      } as unknown as ScrollView;
+      result.current.handleScrollViewLayout(layoutEvent(0, 200));
+      result.current.handleChipLayout(0, layoutEvent(16, 100));
+      result.current.handleChipLayout(1, layoutEvent(124, 100));
+      result.current.handleChipLayout(2, layoutEvent(232, 100));
+    });
+
+    expect(mockScrollTo).toHaveBeenCalledTimes(1);
+    mockScrollTo.mockClear();
+
+    act(() => {
+      result.current.handleChipLayout(2, layoutEvent(240, 110));
+      result.current.handleScrollViewLayout(layoutEvent(0, 200));
+    });
+
+    expect(mockScrollTo).not.toHaveBeenCalled();
+  });
 });
 
 describe('calculateChipScrollX', () => {

--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { Image, Pressable, ScrollView } from 'react-native';
 import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 import {
@@ -35,12 +35,16 @@ const PredictChipList: React.FC<PredictChipListProps> = ({
   useGestureHandlerScrollView = false,
 }) => {
   const tw = useTailwind();
+  const activeChipIndex = useMemo(
+    () => chips.findIndex((chip) => chip.key === activeChipKey),
+    [chips, activeChipKey],
+  );
   const {
     scrollViewRef,
     handleScrollViewLayout,
     handleChipLayout,
     scrollToChipAtIndex,
-  } = useChipScrollList(chips.length);
+  } = useChipScrollList(chips.length, { activeChipIndex });
 
   const handlePress = useCallback(
     (key: string, index: number) => {

--- a/app/components/UI/Predict/components/PredictChipList/useChipScrollList.ts
+++ b/app/components/UI/Predict/components/PredictChipList/useChipScrollList.ts
@@ -1,28 +1,29 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { LayoutChangeEvent, ScrollView } from 'react-native';
 import { calculateChipScrollX } from './calculateChipScrollX';
 
-export function useChipScrollList(chipCount: number) {
+interface UseChipScrollListOptions {
+  activeChipIndex?: number;
+}
+
+interface ScrollToChipOptions {
+  animated?: boolean;
+}
+
+export function useChipScrollList(
+  chipCount: number,
+  options: UseChipScrollListOptions = {},
+) {
+  const { activeChipIndex } = options;
   const scrollViewRef = useRef<ScrollView>(null);
   const chipLayoutsRef = useRef<Map<number, { x: number; width: number }>>(
     new Map(),
   );
   const viewportWidthRef = useRef(0);
 
-  const handleScrollViewLayout = useCallback((event: LayoutChangeEvent) => {
-    viewportWidthRef.current = event.nativeEvent.layout.width;
-  }, []);
-
-  const handleChipLayout = useCallback(
-    (index: number, event: LayoutChangeEvent) => {
-      const { x, width } = event.nativeEvent.layout;
-      chipLayoutsRef.current.set(index, { x, width });
-    },
-    [],
-  );
-
   const scrollToChipAtIndex = useCallback(
-    (chipIndex: number) => {
+    (chipIndex: number, scrollOptions: ScrollToChipOptions = {}) => {
+      const { animated = true } = scrollOptions;
       const scrollView = scrollViewRef.current;
       const viewportWidth = viewportWidthRef.current;
       if (!scrollView || viewportWidth === 0) {
@@ -39,10 +40,46 @@ export function useChipScrollList(chipCount: number) {
         return;
       }
 
-      scrollView.scrollTo({ x: scrollX, animated: true });
+      scrollView.scrollTo({ x: scrollX, animated });
     },
     [chipCount],
   );
+
+  const scrollToActiveChip = useCallback(
+    (animated: boolean) => {
+      if (
+        activeChipIndex === undefined ||
+        activeChipIndex < 0 ||
+        activeChipIndex >= chipCount
+      ) {
+        return;
+      }
+
+      scrollToChipAtIndex(activeChipIndex, { animated });
+    },
+    [activeChipIndex, chipCount, scrollToChipAtIndex],
+  );
+
+  const handleScrollViewLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      viewportWidthRef.current = event.nativeEvent.layout.width;
+      scrollToActiveChip(false);
+    },
+    [scrollToActiveChip],
+  );
+
+  const handleChipLayout = useCallback(
+    (index: number, event: LayoutChangeEvent) => {
+      const { x, width } = event.nativeEvent.layout;
+      chipLayoutsRef.current.set(index, { x, width });
+      scrollToActiveChip(false);
+    },
+    [scrollToActiveChip],
+  );
+
+  useEffect(() => {
+    scrollToActiveChip(true);
+  }, [scrollToActiveChip]);
 
   return {
     scrollViewRef,

--- a/app/components/UI/Predict/components/PredictChipList/useChipScrollList.ts
+++ b/app/components/UI/Predict/components/PredictChipList/useChipScrollList.ts
@@ -20,6 +20,11 @@ export function useChipScrollList(
     new Map(),
   );
   const viewportWidthRef = useRef(0);
+  // Active index still owed an auto-scroll. `null` once positioned, so
+  // incidental relayouts don't snap the rail back over a user's manual scroll.
+  const pendingAutoScrollIndexRef = useRef<number | null>(
+    activeChipIndex ?? null,
+  );
 
   const scrollToChipAtIndex = useCallback(
     (chipIndex: number, scrollOptions: ScrollToChipOptions = {}) => {
@@ -27,7 +32,7 @@ export function useChipScrollList(
       const scrollView = scrollViewRef.current;
       const viewportWidth = viewportWidthRef.current;
       if (!scrollView || viewportWidth === 0) {
-        return;
+        return false;
       }
 
       const scrollX = calculateChipScrollX(
@@ -37,49 +42,66 @@ export function useChipScrollList(
         viewportWidth,
       );
       if (scrollX === null) {
-        return;
+        return false;
       }
 
       scrollView.scrollTo({ x: scrollX, animated });
+      return true;
     },
     [chipCount],
   );
 
-  const scrollToActiveChip = useCallback(
+  // Scrolls to a still-pending active chip, then clears the marker so later
+  // layout passes leave the user's scroll position alone.
+  const flushPendingAutoScroll = useCallback(
     (animated: boolean) => {
+      const pendingIndex = pendingAutoScrollIndexRef.current;
       if (
-        activeChipIndex === undefined ||
-        activeChipIndex < 0 ||
-        activeChipIndex >= chipCount
+        pendingIndex === null ||
+        pendingIndex < 0 ||
+        pendingIndex >= chipCount
       ) {
         return;
       }
 
-      scrollToChipAtIndex(activeChipIndex, { animated });
+      if (scrollToChipAtIndex(pendingIndex, { animated })) {
+        pendingAutoScrollIndexRef.current = null;
+      }
     },
-    [activeChipIndex, chipCount, scrollToChipAtIndex],
+    [chipCount, scrollToChipAtIndex],
   );
 
   const handleScrollViewLayout = useCallback(
     (event: LayoutChangeEvent) => {
       viewportWidthRef.current = event.nativeEvent.layout.width;
-      scrollToActiveChip(false);
+      flushPendingAutoScroll(false);
     },
-    [scrollToActiveChip],
+    [flushPendingAutoScroll],
   );
 
   const handleChipLayout = useCallback(
     (index: number, event: LayoutChangeEvent) => {
       const { x, width } = event.nativeEvent.layout;
       chipLayoutsRef.current.set(index, { x, width });
-      scrollToActiveChip(false);
+      flushPendingAutoScroll(false);
     },
-    [scrollToActiveChip],
+    [flushPendingAutoScroll],
   );
 
+  // Mark the new active index pending; a layout pass flushes it if not yet ready.
   useEffect(() => {
-    scrollToActiveChip(true);
-  }, [scrollToActiveChip]);
+    if (
+      activeChipIndex === undefined ||
+      activeChipIndex < 0 ||
+      activeChipIndex >= chipCount
+    ) {
+      pendingAutoScrollIndexRef.current = null;
+      return;
+    }
+
+    pendingAutoScrollIndexRef.current = activeChipIndex;
+    flushPendingAutoScroll(true);
+  }, [activeChipIndex, chipCount, flushPendingAutoScroll]);
 
   return {
     scrollViewRef,

--- a/app/components/UI/Predict/constants/feedConfig.test.ts
+++ b/app/components/UI/Predict/constants/feedConfig.test.ts
@@ -5,6 +5,7 @@ import {
   resolvePredictFeedConfig,
   resolvePredictFeedDefaultFilter,
   resolvePredictFeedDefaultTab,
+  resolvePredictFeedDynamicFilterConfig,
   type PredictDynamicFilterConfig,
   type PredictFeedFilterConfig,
 } from './feedConfig';
@@ -124,6 +125,23 @@ describe('feedConfig', () => {
     expect(baseTagSlugs).toEqual(
       new Set(['sports', 'politics', 'crypto', 'all']),
     );
+  });
+
+  it('resolves the dynamic filter config for a feed from the registry', () => {
+    expect(resolvePredictFeedDynamicFilterConfig('popular-today')).toBe(
+      PREDICT_FEED_REGISTRY['popular-today'].tabs[0].filters.dynamic,
+    );
+    expect(resolvePredictFeedDynamicFilterConfig('trending')).toBe(
+      PREDICT_FEED_REGISTRY.trending.tabs[0].filters.dynamic,
+    );
+  });
+
+  it('returns undefined dynamic config for feeds without one, unknown feeds, or unknown tabs', () => {
+    expect(resolvePredictFeedDynamicFilterConfig('live')).toBeUndefined();
+    expect(resolvePredictFeedDynamicFilterConfig('unknown')).toBeUndefined();
+    expect(
+      resolvePredictFeedDynamicFilterConfig('sports', 'unknown-tab'),
+    ).toBeUndefined();
   });
 
   it('keeps static market params category-free', () => {

--- a/app/components/UI/Predict/constants/feedConfig.ts
+++ b/app/components/UI/Predict/constants/feedConfig.ts
@@ -307,3 +307,15 @@ export const resolvePredictFeedDefaultFilter = (
     (filter) => filter.id === tab.defaultFilterId,
   );
 };
+
+export const resolvePredictFeedDynamicFilterConfig = (
+  feedId?: string | null,
+  tabId?: string | null,
+): PredictDynamicFilterConfig | undefined => {
+  const config = resolvePredictFeedConfig(feedId);
+  const tab = tabId
+    ? config?.tabs.find((candidateTab) => candidateTab.id === tabId)
+    : config?.tabs[0];
+
+  return tab?.filters.dynamic;
+};

--- a/app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx
@@ -21,7 +21,6 @@ import {
   PredictSearchSelectorsIDs,
 } from '../../Predict.testIds';
 import { PREDICT_HEADER_STACKED_TEST_IDS } from '../../components/PredictHeaderStacked';
-import { PREDICT_PORTFOLIO_TEST_IDS } from './components/PredictPortfolio';
 import { MOCK_PREDICT_MARKET } from '../../../../../../tests/component-view/fixtures/predict';
 
 const SEARCH_PLACEHOLDER = 'Search prediction markets';
@@ -53,6 +52,21 @@ describe('PredictHome', () => {
     (
       Engine.context.PredictController.listMarkets as jest.Mock
     ).mockResolvedValue({ markets: [MOCK_PREDICT_MARKET], nextCursor: null });
+    (
+      Engine.context.PredictController.listFilterOptions as jest.Mock
+    ).mockResolvedValue([
+      {
+        id: 'elections',
+        label: 'Elections',
+        source: 'related-tags',
+        params: {
+          tagSlugs: ['elections'],
+          status: 'open',
+          order: 'volume24hr',
+          limit: 12,
+        },
+      },
+    ]);
     (
       Engine.context.PredictController.searchMarkets as jest.Mock
     ).mockResolvedValue({ markets: [], totalResults: 0 });

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { fireEvent, within } from '@testing-library/react-native';
+import { backgroundState } from '../../../../../../../util/test/initial-root-state';
+import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../../../locales/i18n';
+import Routes from '../../../../../../../constants/navigation/Routes';
+import { PredictEventValues } from '../../../../constants/eventNames';
+import { usePredictFilterOptions } from '../../../../hooks/usePredictFilterOptions';
+import type { PredictFilterOption } from '../../../../types';
+import PredictPopularTodaySection, {
+  PREDICT_POPULAR_TODAY_SECTION_TEST_IDS,
+} from './PredictPopularTodaySection';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../../../../hooks/usePredictFilterOptions');
+
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: () => ({ style: jest.fn(() => ({})) }),
+}));
+
+const mockUsePredictFilterOptions = jest.mocked(usePredictFilterOptions);
+
+const createFilterOption = (
+  id: string,
+  label: string,
+): PredictFilterOption => ({
+  id,
+  label,
+  source: 'related-tags',
+  params: {
+    tagSlugs: [id],
+    status: 'open',
+    order: 'volume24hr',
+    limit: 12,
+  },
+});
+
+const setFilterOptions = (
+  overrides: Partial<ReturnType<typeof usePredictFilterOptions>> = {},
+) => {
+  mockUsePredictFilterOptions.mockReturnValue({
+    filterOptions: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    ...overrides,
+  });
+};
+
+type RenderSectionProps = React.ComponentProps<
+  typeof PredictPopularTodaySection
+>;
+
+const renderSection = (props: RenderSectionProps = {}) =>
+  renderWithProvider(<PredictPopularTodaySection {...props} />, {
+    state: { engine: { backgroundState } },
+  });
+
+describe('PredictPopularTodaySection', () => {
+  beforeEach(() => {
+    setFilterOptions();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render when there are no popular filter options', () => {
+    const { queryByTestId } = renderSection();
+
+    expect(
+      queryByTestId(PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SECTION),
+    ).toBeNull();
+  });
+
+  it('renders the Popular today header', () => {
+    setFilterOptions({
+      filterOptions: [createFilterOption('elections', 'Elections')],
+    });
+
+    const { getByTestId, getByText } = renderSection();
+
+    expect(
+      getByTestId(PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SECTION),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.HEADER),
+    ).toBeOnTheScreen();
+    expect(getByText(strings('predict.feed.popular_today'))).toBeOnTheScreen();
+  });
+
+  it('renders skeleton chips while loading', () => {
+    setFilterOptions({ isLoading: true });
+
+    const { getByTestId } = renderSection();
+
+    expect(
+      getByTestId(
+        `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SKELETON_PREFIX}-0`,
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders a chip for each popular filter option', () => {
+    setFilterOptions({
+      filterOptions: [
+        createFilterOption('elections', 'Elections'),
+        createFilterOption('crypto', 'Crypto'),
+      ],
+    });
+
+    const { getByTestId, getByText } = renderSection();
+
+    expect(
+      getByTestId(
+        `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.CHIP_PREFIX}-elections`,
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(
+        `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.CHIP_PREFIX}-crypto`,
+      ),
+    ).toBeOnTheScreen();
+    expect(getByText('Elections')).toBeOnTheScreen();
+    expect(getByText('Crypto')).toBeOnTheScreen();
+  });
+
+  it('renders popular filter chips across two rows', () => {
+    setFilterOptions({
+      filterOptions: [
+        createFilterOption('iran', 'Iran'),
+        createFilterOption('esports', 'E-Sports'),
+        createFilterOption('march-madness', 'March Madness'),
+        createFilterOption('nba', 'NBA'),
+        createFilterOption('ufc', 'UFC'),
+      ],
+    });
+
+    const { getByTestId } = renderSection();
+    const firstRow = getByTestId(
+      `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-0`,
+    );
+    const secondRow = getByTestId(
+      `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-1`,
+    );
+
+    expect(within(firstRow).getByText('Iran')).toBeOnTheScreen();
+    expect(within(firstRow).getByText('E-Sports')).toBeOnTheScreen();
+    expect(within(firstRow).getByText('March Madness')).toBeOnTheScreen();
+    expect(within(secondRow).getByText('NBA')).toBeOnTheScreen();
+    expect(within(secondRow).getByText('UFC')).toBeOnTheScreen();
+  });
+
+  it('can render popular filter chips in a single row when configured', () => {
+    setFilterOptions({
+      filterOptions: [
+        createFilterOption('iran', 'Iran'),
+        createFilterOption('esports', 'E-Sports'),
+        createFilterOption('march-madness', 'March Madness'),
+      ],
+    });
+
+    const { getByTestId, queryByTestId } = renderSection({ rowCount: 1 });
+    const firstRow = getByTestId(
+      `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-0`,
+    );
+
+    expect(within(firstRow).getByText('Iran')).toBeOnTheScreen();
+    expect(within(firstRow).getByText('E-Sports')).toBeOnTheScreen();
+    expect(within(firstRow).getByText('March Madness')).toBeOnTheScreen();
+    expect(
+      queryByTestId(`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-1`),
+    ).toBeNull();
+  });
+
+  it('navigates to the Popular Today feed when the header is pressed', () => {
+    setFilterOptions({
+      filterOptions: [createFilterOption('elections', 'Elections')],
+    });
+
+    const { getByTestId } = renderSection();
+
+    fireEvent.press(getByTestId(PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.HEADER));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.FEED,
+      params: {
+        feedId: 'popular-today',
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+      },
+    });
+  });
+
+  it('navigates to the Popular Today feed with the selected filter when a chip is pressed', () => {
+    setFilterOptions({
+      filterOptions: [createFilterOption('elections', 'Elections')],
+    });
+
+    const { getByTestId } = renderSection();
+
+    fireEvent.press(
+      getByTestId(
+        `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.CHIP_PREFIX}-elections`,
+      ),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.FEED,
+      params: {
+        feedId: 'popular-today',
+        initialFilterId: 'elections',
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+      },
+    });
+  });
+});

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -1,32 +1,229 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { Pressable, ScrollView } from 'react-native';
+import { useNavigation, type NavigationProp } from '@react-navigation/native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   Text,
   TextColor,
   TextVariant,
+  FontWeight,
+  SectionHeader,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../../locales/i18n';
+import Routes from '../../../../../../../constants/navigation/Routes';
+import { Skeleton } from '../../../../../../../component-library/components-temp/Skeleton';
+import { PredictEventValues } from '../../../../constants/eventNames';
+import { usePredictFilterOptions } from '../../../../hooks/usePredictFilterOptions';
+import type { PredictFilterOption } from '../../../../types';
+import type {
+  PredictFeedRouteParams,
+  PredictNavigationParamList,
+} from '../../../../types/navigation';
 import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
+
+const POPULAR_TODAY_FILTER_LIMIT = 10;
+const SKELETON_COUNT = 8;
+const DEFAULT_CHIP_ROW_COUNT = 2;
+
+const POPULAR_TODAY_FILTER_PARAMS = {
+  source: 'related-tags',
+  baseTagSlug: 'all',
+  baseParams: {
+    status: 'open',
+    order: 'volume24hr',
+    limit: 12,
+  },
+  limit: POPULAR_TODAY_FILTER_LIMIT,
+} as const;
+
+export const PREDICT_POPULAR_TODAY_SECTION_TEST_IDS = {
+  SECTION: PredictHomeSelectorsIDs.POPULAR_TODAY_SECTION,
+  HEADER: 'predict-home-popular-today-header',
+  CHIP_PREFIX: 'predict-home-popular-today-chip',
+  ROW_PREFIX: 'predict-home-popular-today-row',
+  SKELETON_PREFIX: 'predict-home-popular-today-skeleton',
+} as const;
+
+const normalizeRowCount = (rowCount: number) =>
+  Math.max(1, Math.floor(rowCount));
+
+const splitIntoRows = <Item,>(items: Item[], rowCount: number): Item[][] => {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const normalizedRowCount = normalizeRowCount(rowCount);
+  const rows: Item[][] = [];
+  let start = 0;
+
+  for (let rowIndex = 0; rowIndex < normalizedRowCount; rowIndex++) {
+    const remainingItems = items.length - start;
+    const remainingRows = normalizedRowCount - rowIndex;
+    const rowSize = Math.ceil(remainingItems / remainingRows);
+    const row = items.slice(start, start + rowSize);
+
+    if (row.length > 0) {
+      rows.push(row);
+    }
+
+    start += rowSize;
+  }
+
+  return rows;
+};
 
 interface PredictPopularTodaySectionProps {
   testID?: string;
+  rowCount?: number;
 }
 
 /**
- * Placeholder for the Predict home "Popular today" tags section.
- * Replaced by the real section in a later ticket; the shell composes it as-is.
+ * Predict home "Popular today" tag rail (PRED-917).
+ *
+ * Uses the same related-tag source as the full `popular-today` feed. The header
+ * opens the all-up Popular Today feed, while each chip opens that feed with the
+ * selected related-tag filter preselected.
  */
 const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
-  testID = PredictHomeSelectorsIDs.POPULAR_TODAY_SECTION,
-}) => (
-  <Box
-    testID={testID}
-    twClassName="my-2 items-center justify-center rounded-xl bg-muted py-8 px-4"
-  >
-    <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-      {strings('predict.home.popular_today_placeholder')}
-    </Text>
-  </Box>
-);
+  testID = PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SECTION,
+  rowCount = DEFAULT_CHIP_ROW_COUNT,
+}) => {
+  const tw = useTailwind();
+  const navigation =
+    useNavigation<NavigationProp<PredictNavigationParamList>>();
+  const { filterOptions, isLoading } = usePredictFilterOptions(
+    POPULAR_TODAY_FILTER_PARAMS,
+  );
+
+  const chips = useMemo(
+    () =>
+      filterOptions.map((option) => ({
+        key: option.id,
+        label: option.label,
+        option,
+      })),
+    [filterOptions],
+  );
+  const chipRows = useMemo(
+    () => splitIntoRows(chips, rowCount),
+    [chips, rowCount],
+  );
+  const skeletonRows = useMemo(
+    () =>
+      splitIntoRows(
+        Array.from({ length: SKELETON_COUNT }, (_, index) => index),
+        rowCount,
+      ),
+    [rowCount],
+  );
+
+  const navigateToPopularToday = useCallback(
+    (initialFilterId?: string) => {
+      const params: PredictFeedRouteParams = {
+        feedId: 'popular-today',
+        entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+        ...(initialFilterId ? { initialFilterId } : {}),
+      };
+
+      navigation.navigate(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.FEED,
+        params,
+      });
+    },
+    [navigation],
+  );
+
+  const handleSeeAll = useCallback(() => {
+    navigateToPopularToday();
+  }, [navigateToPopularToday]);
+
+  const handleChipPress = useCallback(
+    (option: PredictFilterOption) => {
+      navigateToPopularToday(option.id);
+    },
+    [navigateToPopularToday],
+  );
+
+  if (!isLoading && chips.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box testID={testID} twClassName="my-2">
+      <SectionHeader
+        testID={PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.HEADER}
+        title={strings('predict.feed.popular_today')}
+        isInteractive
+        onPress={handleSeeAll}
+        twClassName="px-0 pt-0 mb-2"
+      />
+
+      {isLoading ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={tw.style('pb-1')}
+        >
+          <Box twClassName="gap-2">
+            {skeletonRows.map((row, rowIndex) => (
+              <Box
+                key={`popular-today-skeleton-row-${rowIndex}`}
+                twClassName="flex-row gap-2"
+              >
+                {row.map((index) => (
+                  <Skeleton
+                    key={`popular-today-skeleton-${index}`}
+                    width={104}
+                    height={40}
+                    style={tw.style('rounded-xl')}
+                    testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
+                  />
+                ))}
+              </Box>
+            ))}
+          </Box>
+        </ScrollView>
+      ) : null}
+
+      {!isLoading && chips.length > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={tw.style('pb-1')}
+        >
+          <Box twClassName="gap-2">
+            {chipRows.map((row, rowIndex) => (
+              <Box
+                key={`popular-today-row-${rowIndex}`}
+                testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-${rowIndex}`}
+                twClassName="flex-row gap-2"
+              >
+                {row.map(({ key, label, option }) => (
+                  <Pressable
+                    key={key}
+                    testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.CHIP_PREFIX}-${key}`}
+                    onPress={() => handleChipPress(option)}
+                    accessibilityRole="button"
+                    accessibilityLabel={label}
+                    style={tw.style('rounded-xl bg-muted px-4 py-2')}
+                  >
+                    <Text
+                      variant={TextVariant.BodySm}
+                      color={TextColor.TextAlternative}
+                      fontWeight={FontWeight.Medium}
+                    >
+                      {label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </Box>
+            ))}
+          </Box>
+        </ScrollView>
+      ) : null}
+    </Box>
+  );
+};
 
 export default PredictPopularTodaySection;

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -14,28 +14,46 @@ import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { Skeleton } from '../../../../../../../component-library/components-temp/Skeleton';
 import { PredictEventValues } from '../../../../constants/eventNames';
+import { resolvePredictFeedDynamicFilterConfig } from '../../../../constants/feedConfig';
 import { usePredictFilterOptions } from '../../../../hooks/usePredictFilterOptions';
-import type { PredictFilterOption } from '../../../../types';
+import type {
+  PredictFilterOption,
+  PredictFilterOptionsParams,
+} from '../../../../types';
 import type {
   PredictFeedRouteParams,
   PredictNavigationParamList,
 } from '../../../../types/navigation';
 import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
 
+/**
+ * Max number of filter chips rendered on the home section. The full
+ * `popular-today` feed shows the complete list; the home rail shows a compact
+ * prefix of the same ordered list.
+ */
 const POPULAR_TODAY_FILTER_LIMIT = 10;
 const SKELETON_COUNT = 8;
 const DEFAULT_CHIP_ROW_COUNT = 2;
 
-const POPULAR_TODAY_FILTER_PARAMS = {
-  source: 'related-tags',
-  baseTagSlug: 'all',
-  baseParams: {
-    status: 'open',
-    order: 'volume24hr',
-    limit: 12,
-  },
-  limit: POPULAR_TODAY_FILTER_LIMIT,
-} as const;
+/**
+ * Derive the section's filter-options params from the canonical `popular-today`
+ * feed registry so there is a single source of truth. Crucially, we do NOT pass
+ * a top-level `limit` here: that keeps the React Query cache key identical to
+ * the full feed's `usePredictFilterOptions` call (which omits `limit`), so the
+ * home section and the feed share the same cached related-tags request instead
+ * of firing two. The display cap is applied client-side via
+ * `POPULAR_TODAY_FILTER_LIMIT` when slicing the returned options.
+ */
+const POPULAR_TODAY_FILTER_PARAMS: PredictFilterOptionsParams = (() => {
+  const dynamicConfig = resolvePredictFeedDynamicFilterConfig('popular-today');
+
+  return {
+    source: dynamicConfig?.source ?? 'related-tags',
+    baseTagSlug: dynamicConfig?.baseTagSlug,
+    baseParams: dynamicConfig?.baseParams,
+    limit: dynamicConfig?.limit,
+  };
+})();
 
 export const PREDICT_POPULAR_TODAY_SECTION_TEST_IDS = {
   SECTION: PredictHomeSelectorsIDs.POPULAR_TODAY_SECTION,
@@ -98,7 +116,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
 
   const chips = useMemo(
     () =>
-      filterOptions.map((option) => ({
+      filterOptions.slice(0, POPULAR_TODAY_FILTER_LIMIT).map((option) => ({
         key: option.id,
         label: option.label,
         option,

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Jetzt live",
       "categories_placeholder": "Kategorien",
-      "popular_today_placeholder": "Heute beliebt",
       "trending_placeholder": "Angesagt"
     },
     "homepage_discovery": {

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Ζωντανά τώρα",
       "categories_placeholder": "Κατηγορίες",
-      "popular_today_placeholder": "Δημοφιλή σήμερα",
       "trending_placeholder": "Δημοφιλή"
     },
     "homepage_discovery": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Live now",
       "categories_placeholder": "Categories",
-      "popular_today_placeholder": "Popular today",
       "trending_placeholder": "Trending"
     },
     "homepage_discovery": {

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "En vivo ahora",
       "categories_placeholder": "Categorías",
-      "popular_today_placeholder": "Populares hoy",
       "trending_placeholder": "Tendencias"
     },
     "homepage_discovery": {

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Disponible dès maintenant",
       "categories_placeholder": "Catégories",
-      "popular_today_placeholder": "Populaires aujourd’hui",
       "trending_placeholder": "Tendance"
     },
     "homepage_discovery": {

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "अब लाइव है",
       "categories_placeholder": "कैटेगरीज़",
-      "popular_today_placeholder": "आजकल लोकप्रिय",
       "trending_placeholder": "ट्रेंडिंग"
     },
     "homepage_discovery": {

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Sedang live",
       "categories_placeholder": "Kategori",
-      "popular_today_placeholder": "Populer saat ini",
       "trending_placeholder": "Sedang tren"
     },
     "homepage_discovery": {

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "現在進行中",
       "categories_placeholder": "Categories",
-      "popular_today_placeholder": "Popular today",
       "trending_placeholder": "人気上昇中"
     },
     "homepage_discovery": {

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "지금 진행 중",
       "categories_placeholder": "카테고리",
-      "popular_today_placeholder": "오늘 인기 항목",
       "trending_placeholder": "인기"
     },
     "homepage_discovery": {

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Ao vivo agora",
       "categories_placeholder": "Categorias",
-      "popular_today_placeholder": "Popular hoje",
       "trending_placeholder": "Tendência"
     },
     "homepage_discovery": {

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Уже активно",
       "categories_placeholder": "Категории",
-      "popular_today_placeholder": "Популярно сегодня",
       "trending_placeholder": "Популярное"
     },
     "homepage_discovery": {

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Live ngayon",
       "categories_placeholder": "Mga Kategorya",
-      "popular_today_placeholder": "Sikat ngayon",
       "trending_placeholder": "Nagte-trend"
     },
     "homepage_discovery": {

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Şimdi canlı",
       "categories_placeholder": "Kategoriler",
-      "popular_today_placeholder": "Bugün popüler",
       "trending_placeholder": "Trend"
     },
     "homepage_discovery": {

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "Đang diễn ra",
       "categories_placeholder": "Danh mục",
-      "popular_today_placeholder": "Phổ biến hôm nay",
       "trending_placeholder": "Xu hướng"
     },
     "homepage_discovery": {

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -2333,7 +2333,6 @@
     "home": {
       "live_now_title": "现已上线",
       "categories_placeholder": "类别",
-      "popular_today_placeholder": "今日热门",
       "trending_placeholder": "趋势"
     },
     "homepage_discovery": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Builds the PRED-917 Popular Today section for the redesigned Predict homepage. The section uses the same related-tag source as the full `popular-today` feed, renders a configurable two-row chip rail by default, shows loading skeletons while tags load, and hides when no tags are available.

This also fixes the feed filter pill UX after navigating from a Popular Today chip: when an `initialFilterId` is resolved by the feed config, the shared Predict chip list now scrolls the active pill into view so users can see which filter is selected.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added a Popular Today section to the Predict homepage.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: null

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict Popular Today homepage section

  Scenario: user opens Popular Today from the redesigned Predict homepage
    Given the Predict feature is available
      And the Predict homepage redesign flag is enabled
    When the user opens the Predict homepage
    Then the Popular Today section appears with related-tag chips in two rows

    When the user taps a Popular Today chip
    Then the app opens the Popular Today feed
      And the tapped filter is selected
      And the selected filter pill is scrolled into view
```

Automated verification run locally:
- `yarn jest app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx --runInBand --silent --coverage=false`
- `yarn lint:tsc`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — previous redesigned home rendered a Popular Today placeholder.

### **After**

<img width="395" height="718" alt="Screenshot 2026-06-16 at 10 42 56 AM" src="https://github.com/user-attachments/assets/00335ef2-a1b3-476d-8148-1d14c9665950" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Considered for this UI-only Predict homepage/feed chip change; no Android-specific code paths were changed.
- [x] I've tested with a power user scenario
  - Considered not applicable; this change does not touch account/token list scaling paths.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Considered not applicable; this change reuses existing Predict query/list paths and does not add new production tracing-worthy operations.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
