### PR TITLE
feat(rewards): add priority support entry point to VIP referee page

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -47,12 +47,11 @@ import { navigateToRewardsRoute } from '../utils';
 import CampaignsPreview from '../components/Campaigns/CampaignsPreview';
 import EarnRewardsPreview from '../components/EarnRewards/EarnRewardsPreview';
 import BenefitsPreview from '../components/Benefits/BenefitsPreview.tsx';
-import { Image, Pressable, ScrollView } from 'react-native';
+import { Pressable, ScrollView } from 'react-native';
 import { useOndoOutcomeToast } from '../hooks/useOndoOutcomeToast';
 import { usePerpsTradingCampaignEndedOutcomeToast } from '../hooks/usePerpsTradingCampaignEndedOutcomeToast';
 import { useGetPredictThePitchOutcomeToast } from '../hooks/useGetPredictThePitchOutcomeToast';
 import VipIcon from '../../../../images/rewards/vip.svg';
-import VipRefereeFoxIcon from '../../../../images/rewards/vip_splash.png';
 import Engine from '../../../../core/Engine';
 
 const VIP_UNLOCK_TAP_COUNT = 5;
@@ -379,12 +378,7 @@ const RewardsDashboard: React.FC = () => {
                   style={tw.style('h-8 w-8 items-center justify-center')}
                   testID={REWARDS_VIEW_SELECTORS.VIP_REFEREE_BUTTON}
                 >
-                  <Image
-                    source={VipRefereeFoxIcon}
-                    style={tw.style('h-6 w-6')}
-                    width={24}
-                    height={24}
-                  />
+                  <VipIcon width={24} height={24} name="VipIcon" />
                 </Pressable>
               )}
               {isVipProgramEnabled && isVipEnabled && (

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
@@ -8,6 +8,7 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipRefereeDashboard } from '../hooks/useVipRefereeDashboard';
@@ -196,9 +197,6 @@ const mockUseTrack = useTrackRewardsPageView as jest.MockedFunction<
 >;
 const mockUseVipRefereeDashboard =
   useVipRefereeDashboard as jest.MockedFunction<typeof useVipRefereeDashboard>;
-const mockUseAnalytics = useAnalytics as jest.MockedFunction<
-  typeof useAnalytics
->;
 const mockFetch = jest.fn();
 
 const defaultDashboard: VipRefereeMeState = {
@@ -227,10 +225,12 @@ describe('RewardsVipRefereeView', () => {
     mockIsVipProgramEnabled = true;
     mockVipRefereeSplashAccepted = {};
     mockUseDispatch.mockReturnValue(mockReduxDispatch);
-    mockUseAnalytics.mockReturnValue({
-      trackEvent: mockTrackEvent,
-      createEventBuilder: mockCreateEventBuilder,
-    } as ReturnType<typeof useAnalytics>);
+    jest.mocked(useAnalytics).mockReturnValue(
+      createMockUseAnalyticsHook({
+        trackEvent: mockTrackEvent,
+        createEventBuilder: mockCreateEventBuilder,
+      }),
+    );
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
       if (selector === selectSelectedInternalAccountFormattedAddress)

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import { StackActions } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
 import { acceptVipRefereeInvite } from '../../../../reducers/rewards';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipRefereeDashboard } from '../hooks/useVipRefereeDashboard';
@@ -16,8 +17,10 @@ import RewardsVipRefereeView, {
 const mockNavDispatch = jest.fn();
 const mockReduxDispatch = jest.fn();
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 // Obviously-synthetic fixtures — never real VIP codes/figures.
 const mockSubscriptionId = 'test-subscription-id';
+const mockAccountAddress = '0xAbC0000000000000000000000000000000000123';
 let mockIsVipReferee = true;
 let mockIsVipProgramEnabled = true;
 let mockVipRefereeSplashAccepted: Record<string, boolean> = {};
@@ -34,6 +37,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       dispatch: mockNavDispatch,
       goBack: mockGoBack,
+      navigate: mockNavigate,
     }),
   };
 });
@@ -60,10 +64,29 @@ jest.mock('@metamask/design-system-react-native', () => {
   }) =>
     ReactActual.createElement(View, { testID: props.testID }, props.children);
 
+  const Button = ({
+    children,
+    onPress,
+    testID,
+  }: {
+    children?: React.ReactNode;
+    onPress?: () => void;
+    testID?: string;
+  }) =>
+    ReactActual.createElement(
+      Pressable,
+      { onPress, testID },
+      ReactActual.createElement(Text, null, children),
+    );
+
   return {
     HeaderStandard,
     Box: passthrough,
     BoxFlexDirection: { Row: 'row', Column: 'column' },
+    Button,
+    ButtonVariant: { Primary: 'primary', Secondary: 'secondary' },
+    ButtonSize: { Lg: 'lg' },
+    IconName: { MessageQuestion: 'MessageQuestion', Export: 'Export' },
     Text: ({ children, ...rest }: { children?: React.ReactNode }) =>
       ReactActual.createElement(Text, rest, children),
     TextColor: { TextDefault: 'default', TextAlternative: 'alt' },
@@ -111,6 +134,9 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.vip.referee_perps_volume_label': 'Perps volume',
       'rewards.vip.referee_error_title': 'Error title',
       'rewards.vip.referee_error_description': 'Error description',
+      'rewards.vip.referee_contact_support': 'Contact priority support',
+      'rewards.vip.referee_priority_support_disclaimer':
+        'By contacting priority support you will connect your wallet.',
       'rewards.vip.retry_button': 'Retry',
     };
     return translations[key] ?? key;
@@ -119,6 +145,10 @@ jest.mock('../../../../../locales/i18n', () => ({
 
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/accountsController', () => ({
+  selectSelectedInternalAccountFormattedAddress: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/featureFlagController/vipProgram', () => ({
@@ -187,6 +217,8 @@ describe('RewardsVipRefereeView', () => {
     mockUseDispatch.mockReturnValue(mockReduxDispatch);
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
+      if (selector === selectSelectedInternalAccountFormattedAddress)
+        return mockAccountAddress;
       if (selector === selectVipProgramEnabled) return mockIsVipProgramEnabled;
       return (
         selector as (
@@ -266,6 +298,39 @@ describe('RewardsVipRefereeView', () => {
     expect(
       queryByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.LAST_UPDATED),
     ).toBeNull();
+  });
+
+  it('renders the contact priority support button and disclaimer', () => {
+    const { getByTestId, getByText } = render(<RewardsVipRefereeView />);
+
+    expect(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SUPPORT_DISCLAIMER),
+    ).toBeOnTheScreen();
+    expect(getByText('Contact priority support')).toBeOnTheScreen();
+    expect(
+      getByText('By contacting priority support you will connect your wallet.'),
+    ).toBeOnTheScreen();
+  });
+
+  it('opens the priority support webview tagged as VIP with the account address on press', () => {
+    const { getByTestId } = render(<RewardsVipRefereeView />);
+
+    fireEvent.press(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: {
+        url: expect.stringContaining(
+          `priority=vip&account=${mockAccountAddress}`,
+        ),
+        title: 'Contact priority support',
+      },
+    });
   });
 
   it('renders the error banner when the fetch errors with no data', () => {

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
@@ -8,7 +8,10 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
-import { createMockUseAnalyticsHook } from '../../../../util/test/analyticsMock';
+import {
+  createMockEventBuilder,
+  createMockUseAnalyticsHook,
+} from '../../../../util/test/analyticsMock';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipRefereeDashboard } from '../hooks/useVipRefereeDashboard';
@@ -22,7 +25,7 @@ const mockReduxDispatch = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 const mockTrackEvent = jest.fn();
-const mockCreateEventBuilder = jest.fn(() => ({ build: jest.fn(() => ({})) }));
+const mockCreateEventBuilder = jest.fn(() => createMockEventBuilder());
 // Obviously-synthetic fixtures — never real VIP codes/figures.
 const mockSubscriptionId = 'test-subscription-id';
 const mockAccountAddress = '0xAbC0000000000000000000000000000000000123';

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
@@ -7,6 +7,8 @@ import { acceptVipRefereeInvite } from '../../../../reducers/rewards';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipRefereeDashboard } from '../hooks/useVipRefereeDashboard';
 import type { VipRefereeMeState } from '../../../../core/Engine/controllers/rewards-controller/types';
@@ -18,6 +20,8 @@ const mockNavDispatch = jest.fn();
 const mockReduxDispatch = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn(() => ({ build: jest.fn(() => ({})) }));
 // Obviously-synthetic fixtures — never real VIP codes/figures.
 const mockSubscriptionId = 'test-subscription-id';
 const mockAccountAddress = '0xAbC0000000000000000000000000000000000123';
@@ -68,14 +72,16 @@ jest.mock('@metamask/design-system-react-native', () => {
     children,
     onPress,
     testID,
+    disabled,
   }: {
     children?: React.ReactNode;
     onPress?: () => void;
     testID?: string;
+    disabled?: boolean;
   }) =>
     ReactActual.createElement(
       Pressable,
-      { onPress, testID },
+      { onPress: disabled ? undefined : onPress, testID, disabled },
       ReactActual.createElement(Text, null, children),
     );
 
@@ -116,7 +122,7 @@ jest.mock('@metamask/design-system-twrnc-preset', () => {
   };
 });
 
-jest.mock('../../../../images/rewards/vip_splash.png', () => 1);
+jest.mock('../../../../images/rewards/vip.svg', () => 'VipIcon');
 
 jest.mock('../../../../../locales/i18n', () => ({
   __esModule: true,
@@ -134,9 +140,8 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.vip.referee_perps_volume_label': 'Perps volume',
       'rewards.vip.referee_error_title': 'Error title',
       'rewards.vip.referee_error_description': 'Error description',
-      'rewards.vip.referee_contact_support': 'Contact priority support',
-      'rewards.vip.referee_priority_support_disclaimer':
-        'By contacting priority support you will connect your wallet.',
+      'rewards.vip.referee_contact_support': 'Contact support',
+      'app_settings.contact_support': 'Contact support',
       'rewards.vip.retry_button': 'Retry',
     };
     return translations[key] ?? key;
@@ -176,6 +181,10 @@ jest.mock('../components/RewardsErrorBanner', () => {
 
 jest.mock('../hooks/useTrackRewardsPageView', () => jest.fn());
 
+jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: jest.fn(),
+}));
+
 jest.mock('../hooks/useVipRefereeDashboard', () => ({
   useVipRefereeDashboard: jest.fn(),
 }));
@@ -187,6 +196,9 @@ const mockUseTrack = useTrackRewardsPageView as jest.MockedFunction<
 >;
 const mockUseVipRefereeDashboard =
   useVipRefereeDashboard as jest.MockedFunction<typeof useVipRefereeDashboard>;
+const mockUseAnalytics = useAnalytics as jest.MockedFunction<
+  typeof useAnalytics
+>;
 const mockFetch = jest.fn();
 
 const defaultDashboard: VipRefereeMeState = {
@@ -215,6 +227,10 @@ describe('RewardsVipRefereeView', () => {
     mockIsVipProgramEnabled = true;
     mockVipRefereeSplashAccepted = {};
     mockUseDispatch.mockReturnValue(mockReduxDispatch);
+    mockUseAnalytics.mockReturnValue({
+      trackEvent: mockTrackEvent,
+      createEventBuilder: mockCreateEventBuilder,
+    } as ReturnType<typeof useAnalytics>);
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
       if (selector === selectSelectedInternalAccountFormattedAddress)
@@ -300,19 +316,13 @@ describe('RewardsVipRefereeView', () => {
     ).toBeNull();
   });
 
-  it('renders the contact priority support button and disclaimer', () => {
+  it('renders the contact support button', () => {
     const { getByTestId, getByText } = render(<RewardsVipRefereeView />);
 
     expect(
       getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
     ).toBeOnTheScreen();
-    expect(
-      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SUPPORT_DISCLAIMER),
-    ).toBeOnTheScreen();
-    expect(getByText('Contact priority support')).toBeOnTheScreen();
-    expect(
-      getByText('By contacting priority support you will connect your wallet.'),
-    ).toBeOnTheScreen();
+    expect(getByText('Contact support')).toBeOnTheScreen();
   });
 
   it('opens the priority support webview tagged as VIP with the account address on press', () => {
@@ -328,9 +338,36 @@ describe('RewardsVipRefereeView', () => {
         url: expect.stringContaining(
           `priority=vip&account=${mockAccountAddress}`,
         ),
-        title: 'Contact priority support',
+        title: 'Contact support',
       },
     });
+    expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+      MetaMetricsEvents.NAVIGATION_TAPS_GET_HELP,
+    );
+    expect(mockTrackEvent).toHaveBeenCalled();
+  });
+
+  it('does not open support when the selected account address is missing', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
+      if (selector === selectSelectedInternalAccountFormattedAddress)
+        return undefined;
+      if (selector === selectVipProgramEnabled) return mockIsVipProgramEnabled;
+      return (
+        selector as (
+          state: ReturnType<typeof getRewardsSelectorState>,
+        ) => unknown
+      )(getRewardsSelectorState());
+    });
+
+    const { getByTestId } = render(<RewardsVipRefereeView />);
+
+    fireEvent.press(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 
   it('renders the error banner when the fetch errors with no data', () => {

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
@@ -319,6 +319,52 @@ describe('RewardsVipRefereeView', () => {
     ).toBeNull();
   });
 
+  it('renders the referred-by card when dashboard data is present', () => {
+    const { getByTestId } = render(<RewardsVipRefereeView />);
+
+    expect(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.REFERRED_BY_CARD),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the loading skeleton without the contact support button', () => {
+    mockUseVipRefereeDashboard.mockReturnValue({
+      dashboard: null,
+      isLoading: true,
+      hasError: false,
+      hasAttemptedFetch: false,
+      fetchVipRefereeDashboard: mockFetch,
+    });
+
+    const { getByTestId, queryByTestId } = render(<RewardsVipRefereeView />);
+
+    expect(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SKELETON),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
+    ).toBeNull();
+  });
+
+  it('does not render the contact support button when the fetch errors with no data', () => {
+    mockUseVipRefereeDashboard.mockReturnValue({
+      dashboard: null,
+      isLoading: false,
+      hasError: true,
+      hasAttemptedFetch: true,
+      fetchVipRefereeDashboard: mockFetch,
+    });
+
+    const { getByTestId, queryByTestId } = render(<RewardsVipRefereeView />);
+
+    expect(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.ERROR),
+    ).toBeOnTheScreen();
+    expect(
+      queryByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
+    ).toBeNull();
+  });
+
   it('renders the contact support button', () => {
     const { getByTestId, getByText } = render(<RewardsVipRefereeView />);
 
@@ -326,6 +372,26 @@ describe('RewardsVipRefereeView', () => {
       getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
     ).toBeOnTheScreen();
     expect(getByText('Contact support')).toBeOnTheScreen();
+  });
+
+  it('disables the contact support button when the selected account address is missing', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectRewardsSubscriptionId) return mockSubscriptionId;
+      if (selector === selectSelectedInternalAccountFormattedAddress)
+        return undefined;
+      if (selector === selectVipProgramEnabled) return mockIsVipProgramEnabled;
+      return (
+        selector as (
+          state: ReturnType<typeof getRewardsSelectorState>,
+        ) => unknown
+      )(getRewardsSelectorState());
+    });
+
+    const { getByTestId } = render(<RewardsVipRefereeView />);
+
+    expect(
+      getByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON),
+    ).toBeDisabled();
   });
 
   it('opens the priority support webview tagged as VIP with the account address on press', () => {
@@ -339,7 +405,7 @@ describe('RewardsVipRefereeView', () => {
       screen: Routes.WEBVIEW.SIMPLE,
       params: {
         url: expect.stringContaining(
-          `priority=vip&account=${mockAccountAddress}`,
+          `priority=vip&account=${encodeURIComponent(mockAccountAddress)}`,
         ),
         title: 'Contact support',
       },

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
@@ -1,11 +1,15 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Image, ScrollView } from 'react-native';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import {
   Box,
   BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
   FontWeight,
   HeaderStandard,
+  IconName,
   Skeleton,
   Text,
   TextColor,
@@ -16,6 +20,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
+import { buildVipPrioritySupportUrl } from '../../../../constants/urls';
 import VipSplashFox from '../../../../images/rewards/vip_splash.png';
 import { acceptVipRefereeInvite } from '../../../../reducers/rewards';
 import {
@@ -23,6 +28,7 @@ import {
   selectIsVipReferee,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
@@ -50,6 +56,8 @@ export const REWARDS_VIP_REFEREE_VIEW_TEST_IDS = {
   SWAPS_VOLUME: 'rewards-vip-referee-view-swaps-volume',
   PERPS_VOLUME: 'rewards-vip-referee-view-perps-volume',
   LAST_UPDATED: 'rewards-vip-referee-view-last-updated',
+  CONTACT_SUPPORT_BUTTON: 'rewards-vip-referee-view-contact-support-button',
+  SUPPORT_DISCLAIMER: 'rewards-vip-referee-view-support-disclaimer',
 } as const;
 
 const referredByCardStyle = {
@@ -63,6 +71,9 @@ const RewardsVipRefereeViewContent: React.FC = () => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const accountAddress = useSelector(
+    selectSelectedInternalAccountFormattedAddress,
+  );
   const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const isVipReferee = useSelector(selectIsVipReferee);
   const canViewReferee = Boolean(
@@ -100,6 +111,23 @@ const RewardsVipRefereeViewContent: React.FC = () => {
 
     dispatch(acceptVipRefereeInvite({ subscriptionId }));
   }, [canViewReferee, dispatch, hasAcceptedVipRefereeInvite, subscriptionId]);
+
+  // Opens the help center in the in-app WebView, tagging the request as VIP priority
+  // and passing the user's account address so the support-side automation can verify
+  // enrollment (via the existing GET /support/subscriptions/check?account= endpoint).
+  const handleContactPrioritySupport = useCallback(() => {
+    if (!accountAddress) {
+      return;
+    }
+
+    navigation.navigate(Routes.WEBVIEW.MAIN, {
+      screen: Routes.WEBVIEW.SIMPLE,
+      params: {
+        url: buildVipPrioritySupportUrl(accountAddress),
+        title: strings('rewards.vip.referee_contact_support'),
+      },
+    });
+  }, [navigation, accountAddress]);
 
   if (!canViewReferee) {
     return null;
@@ -259,6 +287,29 @@ const RewardsVipRefereeViewContent: React.FC = () => {
                   })}
                 </Text>
               ) : null}
+
+              <Box twClassName="gap-2 mt-2">
+                <Button
+                  variant={ButtonVariant.Secondary}
+                  size={ButtonSize.Lg}
+                  onPress={handleContactPrioritySupport}
+                  startIconName={IconName.MessageQuestion}
+                  endIconName={IconName.Export}
+                  twClassName="w-full"
+                  testID={
+                    REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON
+                  }
+                >
+                  {strings('rewards.vip.referee_contact_support')}
+                </Button>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SUPPORT_DISCLAIMER}
+                >
+                  {strings('rewards.vip.referee_priority_support_disclaimer')}
+                </Text>
+              </Box>
             </>
           ) : null}
         </ScrollView>

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Image, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import {
   Box,
@@ -9,7 +9,6 @@ import {
   ButtonVariant,
   FontWeight,
   HeaderStandard,
-  IconName,
   Skeleton,
   Text,
   TextColor,
@@ -20,8 +19,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
-import { buildVipPrioritySupportUrl } from '../../../../constants/urls';
-import VipSplashFox from '../../../../images/rewards/vip_splash.png';
+import {
+  buildVipPrioritySupportUrl,
+  METAMASK_SUPPORT_URL,
+} from '../../../../constants/urls';
+import { MetaMetricsEvents } from '../../../../core/Analytics';
+import VipIcon from '../../../../images/rewards/vip.svg';
 import { acceptVipRefereeInvite } from '../../../../reducers/rewards';
 import {
   selectHasAcceptedVipRefereeInvite,
@@ -31,6 +34,7 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { useVipRefereeDashboard } from '../hooks/useVipRefereeDashboard';
 import RewardsErrorBanner from '../components/RewardsErrorBanner';
@@ -57,7 +61,6 @@ export const REWARDS_VIP_REFEREE_VIEW_TEST_IDS = {
   PERPS_VOLUME: 'rewards-vip-referee-view-perps-volume',
   LAST_UPDATED: 'rewards-vip-referee-view-last-updated',
   CONTACT_SUPPORT_BUTTON: 'rewards-vip-referee-view-contact-support-button',
-  SUPPORT_DISCLAIMER: 'rewards-vip-referee-view-support-disclaimer',
 } as const;
 
 const referredByCardStyle = {
@@ -70,6 +73,7 @@ const RewardsVipRefereeViewContent: React.FC = () => {
   const tw = useTailwind();
   const dispatch = useDispatch();
   const navigation = useNavigation();
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const accountAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
@@ -120,14 +124,25 @@ const RewardsVipRefereeViewContent: React.FC = () => {
       return;
     }
 
+    let supportBaseUrl;
+
+    ///: BEGIN:ONLY_INCLUDE_IF(beta)
+    supportBaseUrl = 'https://intercom.help/internal-beta-testing/en/';
+    ///: END:ONLY_INCLUDE_IF
+
+    supportBaseUrl = supportBaseUrl || METAMASK_SUPPORT_URL;
+
     navigation.navigate(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
       params: {
-        url: buildVipPrioritySupportUrl(accountAddress),
-        title: strings('rewards.vip.referee_contact_support'),
+        url: buildVipPrioritySupportUrl(accountAddress, supportBaseUrl),
+        title: strings('app_settings.contact_support'),
       },
     });
-  }, [navigation, accountAddress]);
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.NAVIGATION_TAPS_GET_HELP).build(),
+    );
+  }, [accountAddress, createEventBuilder, navigation, trackEvent]);
 
   if (!canViewReferee) {
     return null;
@@ -151,168 +166,199 @@ const RewardsVipRefereeViewContent: React.FC = () => {
           onBack={() => navigation.goBack()}
           backButtonProps={{ testID: 'header-back-button' }}
         />
+        <Box twClassName="flex-1">
+          <ScrollView
+            style={tw.style('flex-1')}
+            contentContainerStyle={tw.style('py-4 gap-4')}
+            testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SCROLL}
+          >
+            {showSkeleton ? (
+              <Box
+                twClassName="gap-4 px-4"
+                testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SKELETON}
+              >
+                <Skeleton style={tw.style('h-10 w-36 rounded-lg')} />
 
-        <ScrollView
-          contentContainerStyle={tw.style('py-4 pb-8 gap-6 px-4')}
-          testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SCROLL}
-        >
-          <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Bold}>
-            {strings('rewards.vip.referee_page_title')}
-          </Text>
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  twClassName="items-center justify-between rounded-2xl border px-4 py-3"
+                  style={referredByCardStyle}
+                >
+                  <Skeleton style={tw.style('h-9 w-9 rounded-lg')} />
+                  <Skeleton style={tw.style('h-5 w-40 rounded-lg')} />
+                </Box>
+
+                <Box twClassName="mt-4 -mx-4 border-b border-border-muted" />
+
+                <Box twClassName="gap-1">
+                  <Skeleton style={tw.style('h-8 w-32 rounded-lg')} />
+                  <Skeleton style={tw.style('h-4 w-44 rounded-lg')} />
+                </Box>
+
+                <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-6">
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-20 rounded-lg')} />
+                    <Skeleton style={tw.style('h-6 w-16 rounded-lg')} />
+                  </Box>
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-24 rounded-lg')} />
+                    <Skeleton style={tw.style('h-6 w-20 rounded-lg')} />
+                  </Box>
+                </Box>
+
+                <Box twClassName="gap-1">
+                  <Skeleton style={tw.style('h-4 w-24 rounded-lg')} />
+                  <Skeleton style={tw.style('h-6 w-20 rounded-lg')} />
+                </Box>
+
+                <Skeleton style={tw.style('h-4 w-36 rounded-lg')} />
+              </Box>
+            ) : showError ? (
+              <Box twClassName="px-4">
+                <RewardsErrorBanner
+                  title={strings('rewards.vip.referee_error_title')}
+                  description={strings('rewards.vip.referee_error_description')}
+                  onConfirm={fetchVipRefereeDashboard}
+                  confirmButtonLabel={strings('rewards.vip.retry_button')}
+                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.ERROR}
+                />
+              </Box>
+            ) : dashboard ? (
+              <Box twClassName="px-4 gap-4">
+                <Text
+                  variant={TextVariant.HeadingLg}
+                  fontWeight={FontWeight.Bold}
+                >
+                  {strings('rewards.vip.referee_page_title')}
+                </Text>
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  twClassName="items-center justify-between rounded-2xl border px-4 py-3"
+                  style={referredByCardStyle}
+                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.REFERRED_BY_CARD}
+                >
+                  <VipIcon width={36} height={36} name="VipIcon" />
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                    style={referredByTextStyle}
+                  >
+                    {strings('rewards.vip.referee_referred_by', {
+                      code: dashboard.referredByCode ?? '',
+                    })}
+                  </Text>
+                </Box>
+                {/* Divider */}
+                <Box twClassName="mt-4 -mx-4 border-b border-border-muted" />
+
+                <Box twClassName="gap-1">
+                  <Text
+                    variant={TextVariant.HeadingMd}
+                    fontWeight={FontWeight.Bold}
+                  >
+                    {strings('rewards.vip.referee_stats_title')}
+                  </Text>
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                  >
+                    {strings('rewards.vip.referee_period_last_30d')}
+                  </Text>
+                </Box>
+
+                <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-6">
+                  <Box
+                    twClassName="flex-1"
+                    testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.POINTS}
+                  >
+                    <Text
+                      variant={TextVariant.BodySm}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('rewards.vip.referee_points_label')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.HeadingSm}
+                      fontWeight={FontWeight.Bold}
+                    >
+                      {formatNumber(dashboard.points)}
+                    </Text>
+                  </Box>
+                  <Box
+                    twClassName="flex-1"
+                    testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SWAPS_VOLUME}
+                  >
+                    <Text
+                      variant={TextVariant.BodySm}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('rewards.vip.referee_swaps_volume_label')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.HeadingSm}
+                      fontWeight={FontWeight.Bold}
+                    >
+                      {formatUsd(dashboard.swapsVolume)}
+                    </Text>
+                  </Box>
+                </Box>
+
+                <Box
+                  twClassName="flex-1"
+                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.PERPS_VOLUME}
+                >
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                  >
+                    {strings('rewards.vip.referee_perps_volume_label')}
+                  </Text>
+                  <Text
+                    variant={TextVariant.HeadingSm}
+                    fontWeight={FontWeight.Bold}
+                  >
+                    {formatUsd(dashboard.perpsVolume)}
+                  </Text>
+                </Box>
+
+                {dashboard.computedAt ? (
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                    testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.LAST_UPDATED}
+                  >
+                    {strings('rewards.vip.last_updated', {
+                      time: formatRewardsTimeOnly(
+                        new Date(dashboard.computedAt),
+                      ),
+                    })}
+                  </Text>
+                ) : null}
+              </Box>
+            ) : null}
+          </ScrollView>
 
           {showSkeleton ? (
-            <Box
-              twClassName="gap-6"
-              testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SKELETON}
-            >
-              <Skeleton style={tw.style('h-16 rounded-2xl')} />
-              <Skeleton style={tw.style('h-8 w-44 rounded-lg')} />
-              <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-6">
-                <Skeleton style={tw.style('h-12 flex-1 rounded-lg')} />
-                <Skeleton style={tw.style('h-12 flex-1 rounded-lg')} />
-              </Box>
+            <Box twClassName="px-4 pb-4">
+              <Skeleton style={tw.style('h-12 w-full rounded-lg')} />
             </Box>
-          ) : showError ? (
-            <RewardsErrorBanner
-              title={strings('rewards.vip.referee_error_title')}
-              description={strings('rewards.vip.referee_error_description')}
-              onConfirm={fetchVipRefereeDashboard}
-              confirmButtonLabel={strings('rewards.vip.retry_button')}
-              testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.ERROR}
-            />
           ) : dashboard ? (
-            <>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                twClassName="items-center justify-between rounded-2xl border px-4 py-3"
-                style={referredByCardStyle}
-                testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.REFERRED_BY_CARD}
+            <Box twClassName="px-4 pb-4">
+              <Button
+                variant={ButtonVariant.Secondary}
+                size={ButtonSize.Lg}
+                disabled={!accountAddress}
+                onPress={handleContactPrioritySupport}
+                twClassName="w-full"
+                testID={
+                  REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON
+                }
               >
-                <Image
-                  source={VipSplashFox}
-                  style={tw.style('h-9 w-9')}
-                  width={36}
-                  height={36}
-                />
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  style={referredByTextStyle}
-                >
-                  {strings('rewards.vip.referee_referred_by', {
-                    code: dashboard.referredByCode ?? '',
-                  })}
-                </Text>
-              </Box>
-
-              <Box twClassName="gap-1">
-                <Text
-                  variant={TextVariant.HeadingMd}
-                  fontWeight={FontWeight.Bold}
-                >
-                  {strings('rewards.vip.referee_stats_title')}
-                </Text>
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('rewards.vip.referee_period_last_30d')}
-                </Text>
-              </Box>
-
-              <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-6">
-                <Box
-                  twClassName="flex-1"
-                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.POINTS}
-                >
-                  <Text
-                    variant={TextVariant.BodySm}
-                    color={TextColor.TextAlternative}
-                  >
-                    {strings('rewards.vip.referee_points_label')}
-                  </Text>
-                  <Text
-                    variant={TextVariant.HeadingSm}
-                    fontWeight={FontWeight.Bold}
-                  >
-                    {formatNumber(dashboard.points)}
-                  </Text>
-                </Box>
-                <Box
-                  twClassName="flex-1"
-                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SWAPS_VOLUME}
-                >
-                  <Text
-                    variant={TextVariant.BodySm}
-                    color={TextColor.TextAlternative}
-                  >
-                    {strings('rewards.vip.referee_swaps_volume_label')}
-                  </Text>
-                  <Text
-                    variant={TextVariant.HeadingSm}
-                    fontWeight={FontWeight.Bold}
-                  >
-                    {formatUsd(dashboard.swapsVolume)}
-                  </Text>
-                </Box>
-              </Box>
-
-              <Box
-                twClassName="flex-1"
-                testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.PERPS_VOLUME}
-              >
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.TextAlternative}
-                >
-                  {strings('rewards.vip.referee_perps_volume_label')}
-                </Text>
-                <Text
-                  variant={TextVariant.HeadingSm}
-                  fontWeight={FontWeight.Bold}
-                >
-                  {formatUsd(dashboard.perpsVolume)}
-                </Text>
-              </Box>
-
-              {dashboard.computedAt ? (
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.TextAlternative}
-                  twClassName="text-right"
-                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.LAST_UPDATED}
-                >
-                  {strings('rewards.vip.last_updated', {
-                    time: formatRewardsTimeOnly(new Date(dashboard.computedAt)),
-                  })}
-                </Text>
-              ) : null}
-
-              <Box twClassName="gap-2 mt-2">
-                <Button
-                  variant={ButtonVariant.Secondary}
-                  size={ButtonSize.Lg}
-                  onPress={handleContactPrioritySupport}
-                  startIconName={IconName.MessageQuestion}
-                  endIconName={IconName.Export}
-                  twClassName="w-full"
-                  testID={
-                    REWARDS_VIP_REFEREE_VIEW_TEST_IDS.CONTACT_SUPPORT_BUTTON
-                  }
-                >
-                  {strings('rewards.vip.referee_contact_support')}
-                </Button>
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={TextColor.TextAlternative}
-                  testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.SUPPORT_DISCLAIMER}
-                >
-                  {strings('rewards.vip.referee_priority_support_disclaimer')}
-                </Text>
-              </Box>
-            </>
+                {strings('rewards.vip.referee_contact_support')}
+              </Button>
+            </Box>
           ) : null}
-        </ScrollView>
+        </Box>
       </SafeAreaView>
     </ErrorBoundary>
   );

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -38,6 +38,10 @@ import VipFeeTile, {
 import VipPointsSection from '../components/Vip/VipPointsSection';
 import VipTierProgressCard from '../components/Vip/VipTierProgressCard';
 import VipVolumeSection from '../components/Vip/VipVolumeSection';
+import {
+  VIP_GOLD_BACKGROUND_MUTED,
+  VIP_GOLD_BORDER_DEFAULT,
+} from '../components/Vip/Vip.constants';
 import { REWARDS_VIEW_SELECTORS } from './RewardsView.constants';
 import {
   selectHasAcceptedVipInvite,
@@ -66,6 +70,11 @@ export const REWARDS_VIP_VIEW_TEST_IDS = {
 
 const BENEFIT_TILE_GAP = 12;
 const BENEFIT_TILE_SNAP_INTERVAL = VIP_FEE_TILE_WIDTH + BENEFIT_TILE_GAP;
+
+const vipTierCardSkeletonStyle = {
+  borderColor: VIP_GOLD_BORDER_DEFAULT,
+  backgroundColor: VIP_GOLD_BACKGROUND_MUTED,
+};
 
 const RewardsVipViewContent: React.FC = () => {
   const tw = useTailwind();
@@ -170,13 +179,49 @@ const RewardsVipViewContent: React.FC = () => {
         >
           {showSkeleton ? (
             <Box
-              twClassName="gap-4 px-4"
+              twClassName="gap-4"
               testID={REWARDS_VIP_VIEW_TEST_IDS.SKELETON}
             >
-              <Skeleton style={tw.style('h-10 w-36 rounded-lg')} />
-              <Skeleton style={tw.style('h-44 rounded-2xl')} />
-              <Skeleton style={tw.style('h-8 w-44 rounded-lg')} />
-              <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
+              <Box twClassName="px-4 gap-4">
+                <Skeleton style={tw.style('h-8 w-36 rounded-lg')} />
+
+                <Box
+                  twClassName="gap-4 rounded-2xl border p-4"
+                  style={vipTierCardSkeletonStyle}
+                >
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    twClassName="items-start justify-between"
+                  >
+                    <Skeleton style={tw.style('h-8 w-8 rounded-lg')} />
+                    <Box twClassName="items-end gap-1">
+                      <Skeleton style={tw.style('h-4 w-16 rounded-lg')} />
+                      <Skeleton style={tw.style('h-4 w-20 rounded-lg')} />
+                    </Box>
+                  </Box>
+                  <Box twClassName="gap-1">
+                    <Skeleton style={tw.style('h-6 w-24 rounded-lg')} />
+                    <Skeleton style={tw.style('h-4 w-32 rounded-lg')} />
+                  </Box>
+                  <Box twClassName="gap-1">
+                    <Skeleton style={tw.style('h-3 w-full rounded-full')} />
+                    <Skeleton style={tw.style('h-4 w-40 rounded-lg')} />
+                  </Box>
+                </Box>
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                twClassName="items-center gap-2 px-4 my-3"
+              >
+                <Skeleton style={tw.style('h-8 w-36 rounded-lg')} />
+                <Skeleton style={tw.style('h-5 w-5 rounded-full')} />
+              </Box>
+
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                twClassName="gap-3 px-4"
+              >
                 {[0, 1, 2, 3].map((index) => (
                   <Skeleton
                     key={index}
@@ -187,8 +232,63 @@ const RewardsVipViewContent: React.FC = () => {
                   />
                 ))}
               </Box>
-              <Skeleton style={tw.style('h-36 rounded-2xl')} />
-              <Skeleton style={tw.style('h-36 rounded-2xl')} />
+
+              <Box twClassName="mt-4 border-b border-border-muted" />
+
+              <Box twClassName="gap-3 px-4">
+                <Box twClassName="gap-1">
+                  <Skeleton style={tw.style('h-8 w-32 rounded-lg')} />
+                  <Skeleton style={tw.style('h-4 w-44 rounded-lg')} />
+                </Box>
+
+                <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-6">
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-20 rounded-lg')} />
+                    <Skeleton style={tw.style('h-6 w-16 rounded-lg')} />
+                  </Box>
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-24 rounded-lg')} />
+                    <Skeleton style={tw.style('h-6 w-20 rounded-lg')} />
+                  </Box>
+                </Box>
+
+                <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-6">
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-28 rounded-lg')} />
+                    <Skeleton style={tw.style('h-6 w-16 rounded-lg')} />
+                  </Box>
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-24 rounded-lg')} />
+                    <Skeleton style={tw.style('h-6 w-20 rounded-lg')} />
+                  </Box>
+                </Box>
+
+                <Box twClassName="gap-1">
+                  <Skeleton style={tw.style('h-4 w-24 rounded-lg')} />
+                  <Skeleton style={tw.style('h-6 w-16 rounded-lg')} />
+                </Box>
+              </Box>
+
+              <Box twClassName="px-4 items-end">
+                <Skeleton style={tw.style('h-4 w-36 rounded-lg')} />
+              </Box>
+
+              <Box twClassName="mt-4 border-b border-border-muted" />
+
+              <Box twClassName="gap-3 px-4">
+                <Skeleton style={tw.style('h-8 w-40 rounded-lg')} />
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  twClassName="items-center gap-3"
+                >
+                  <Box twClassName="flex-1 gap-1">
+                    <Skeleton style={tw.style('h-4 w-full rounded-lg')} />
+                    <Skeleton style={tw.style('h-4 w-4/5 rounded-lg')} />
+                    <Skeleton style={tw.style('h-4 w-3/4 rounded-lg')} />
+                  </Box>
+                  <Skeleton style={tw.style('h-24 w-24 rounded-full')} />
+                </Box>
+              </Box>
             </Box>
           ) : showError ? (
             <Box twClassName="px-4">

--- a/app/components/UI/Rewards/components/Vip/VipRefereeSplashScreen.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipRefereeSplashScreen.tsx
@@ -133,7 +133,7 @@ const VipRefereeSplashScreen: React.FC<VipRefereeSplashScreenProps> = ({
         <Box twClassName="gap-[18px] px-4 pb-[18px]">
           {referredByCode ? (
             <Text
-              variant={TextVariant.BodySm}
+              variant={TextVariant.BodyMd}
               fontWeight={FontWeight.Medium}
               style={tw.style('text-center', referredByColorStyle)}
               testID={VIP_REFEREE_SPLASH_SCREEN_TEST_IDS.REFERRED_BY}

--- a/app/constants/urls.test.ts
+++ b/app/constants/urls.test.ts
@@ -1,0 +1,37 @@
+import { buildVipPrioritySupportUrl, METAMASK_SUPPORT_URL } from './urls';
+
+describe('buildVipPrioritySupportUrl', () => {
+  it('appends VIP priority and account query params to the default support URL', () => {
+    const account = '0xAbC0000000000000000000000000000000000123';
+
+    expect(buildVipPrioritySupportUrl(account)).toBe(
+      `${METAMASK_SUPPORT_URL}&priority=vip&account=${encodeURIComponent(account)}`,
+    );
+  });
+
+  it('uses ? as the separator when the base URL has no query string', () => {
+    const baseUrl = 'https://support.metamask.io/';
+
+    expect(buildVipPrioritySupportUrl('0xabc', baseUrl)).toBe(
+      `${baseUrl}?priority=vip&account=0xabc`,
+    );
+  });
+
+  it('uses & as the separator when the base URL already has query params', () => {
+    const baseUrl = 'https://support.metamask.io/?utm_source=mobile_app';
+
+    expect(buildVipPrioritySupportUrl('0xabc', baseUrl)).toBe(
+      `${baseUrl}&priority=vip&account=0xabc`,
+    );
+  });
+
+  it('URL-encodes the account address', () => {
+    const account = '0xabc&foo=bar?baz';
+
+    expect(
+      buildVipPrioritySupportUrl(account, 'https://support.example.com'),
+    ).toBe(
+      `https://support.example.com?priority=vip&account=${encodeURIComponent(account)}`,
+    );
+  });
+});

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -64,8 +64,13 @@ export const REWARDS_LEARN_MORE_URL = `https://support.metamask.io/manage-crypto
 // the account address and returns tier/subscription status).
 // NOTE: `priority=vip` is a placeholder value pending support/Intercom confirmation;
 // `account` matches the support endpoint's query-param name.
-export const buildVipPrioritySupportUrl = (account: string) =>
-  `${METAMASK_SUPPORT_URL}&priority=vip&account=${encodeURIComponent(account)}`;
+export const buildVipPrioritySupportUrl = (
+  account: string,
+  baseUrl: string = METAMASK_SUPPORT_URL,
+) => {
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}priority=vip&account=${encodeURIComponent(account)}`;
+};
 
 // Perps
 export const PERPS_LEARN_MORE_URL = `https://support.metamask.io/manage-crypto/trade/perps/${MOBILE_UTM}`;

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -57,6 +57,16 @@ export const LENDING_FAQ_URL = `https://support.metamask.io/manage-crypto/earn/l
 // Rewards
 export const REWARDS_LEARN_MORE_URL = `https://support.metamask.io/manage-crypto/metamask-rewards/${MOBILE_UTM}`;
 
+// Builds the priority-support help-center URL for VIP users. Includes a fixed
+// `priority=vip` tag so the support-side automation can fast-path the request to a
+// human, plus the user's account address so that automation can verify enrollment via
+// the existing support API (GET /support/subscriptions/check?account=, which keys off
+// the account address and returns tier/subscription status).
+// NOTE: `priority=vip` is a placeholder value pending support/Intercom confirmation;
+// `account` matches the support endpoint's query-param name.
+export const buildVipPrioritySupportUrl = (account: string) =>
+  `${METAMASK_SUPPORT_URL}&priority=vip&account=${encodeURIComponent(account)}`;
+
 // Perps
 export const PERPS_LEARN_MORE_URL = `https://support.metamask.io/manage-crypto/trade/perps/${MOBILE_UTM}`;
 export const PERPS_ADL_URL = `https://support.metamask.io/manage-crypto/trade/perps/leverage-and-liquidation/${MOBILE_UTM}#what-is-auto-deleveraging-adl`;

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -221,6 +221,7 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getDefaultRewardsEnvUrl',
       'RewardsDataService:getBenefits',
       'RewardsDataService:getVIPDashboard',
+      'RewardsDataService:getVipRefereeDashboard',
       'RewardsDataService:getVipFees',
       'RewardsDataService:postBenefitImpression',
       'RewardsDataService:getClientVersionRequirements',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8942,7 +8942,7 @@
       "referee_perps_volume_label": "Perps volume",
       "referee_error_title": "We couldn’t load your VIP referee details",
       "referee_error_description": "Check your connection and try again.",
-      "referee_contact_support": "Contact priority support",
+      "referee_contact_support": "Contact support",
       "referee_priority_support_disclaimer": "By contacting priority support you will connect your wallet.",
       "referral_tag_label": "VIP",
       "last_updated": "Last updated: {{time}}"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8942,6 +8942,8 @@
       "referee_perps_volume_label": "Perps volume",
       "referee_error_title": "We couldn’t load your VIP referee details",
       "referee_error_description": "Check your connection and try again.",
+      "referee_contact_support": "Contact priority support",
+      "referee_priority_support_disclaimer": "By contacting priority support you will connect your wallet.",
       "referral_tag_label": "VIP",
       "last_updated": "Last updated: {{time}}"
     },


### PR DESCRIPTION
## **Description**

Marketing/customer support asked for an entry point on the VIP pilot **referee** page so VIP referees can reach **priority support**. This adds a "Contact priority support" CTA (plus a short wallet-connect disclaimer) to the bottom of the VIP referee dashboard (`RewardsVipRefereeView`).

Tapping it opens the existing in-app support WebView (`support.metamask.io`) with two extra query params:

- `priority=vip` — a fixed tag so the support-side automation can fast-path the request to a human;
- `account=<address>` — the user's account address, so that automation can verify enrollment via the **existing** support API (`GET /support/subscriptions/check?account=`, an `x-api-key` server-to-server endpoint added in Season 1 / RWDS-157 that returns the account's subscription status + tier).

This intentionally reuses the Season-1 support-verification flow (which keys off the **account address**, not a subscription id), rather than inventing a new lookup.

> [!NOTE]
> Pending confirmation from the support/Intercom side: the `priority=vip` tag **value**, and whether the support automation already reads these inbound params / calls `/support/subscriptions/check`. The tag is isolated in a single URL builder (`buildVipPrioritySupportUrl`) so it's a one-line change. The `account` param name matches the existing support endpoint's query key. The disclaimer copy is also placeholder wording.

## **Changelog**

CHANGELOG entry: Added a "Contact priority support" link to the VIP referee dashboard that routes VIP users to priority support.

## **Related issues**

https://consensyssoftware.atlassian.net/browse/RWDS-1394

## **Manual testing steps**

1. Open the app as a VIP **referee** (VIP program flag on, user is a VIP referee with a subscription id).
2. Navigate to the VIP referee page ("VIP Pilot").
3. Scroll to the bottom — confirm the "Contact priority support" button and the disclaimer text render below the stats / "Last updated" row.
4. Tap the button — confirm the in-app WebView opens `support.metamask.io` with `&priority=vip&account=<your account address>` appended to the URL.

## **Screenshots/Recordings**

### **Before**

N/A — new entry point; nothing rendered here previously.

### **After**


<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-16 at 15 53 20" src="https://github.com/user-attachments/assets/659101c4-2ca1-42b6-9b1d-023ece8998f7" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-16 at 15 53 25" src="https://github.com/user-attachments/assets/76899d30-bfaf-403a-9dfa-badc5d1e03bd" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-16 at 16 09 35" src="https://github.com/user-attachments/assets/388a4e82-cf88-4fa1-84f9-ac3caf1fa1cb" />
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-16 at 16 10 45" src="https://github.com/user-attachments/assets/701f7794-7b3d-47ba-b229-1a49155a7c81" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pulled and built the branch, run the app, tested code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
