### PR TITLE
feat: show perps and predict transactions in money activity

### DIFF
--- a/app/components/UI/Money/constants/activityStyles.test.ts
+++ b/app/components/UI/Money/constants/activityStyles.test.ts
@@ -282,5 +282,21 @@ describe('activityStyles', () => {
         ),
       ).toBe(false);
     });
+
+    it('returns true for a Perps/Predict withdraw landing in the Money account', () => {
+      expect(
+        isIncomingMoneyTransactionMeta(
+          makeTx(TransactionType.batch, {
+            nestedTransactions: [
+              { type: TransactionType.predictWithdraw } as TransactionMeta,
+            ],
+            metamaskPay: {
+              tokenAddress: MUSD_TOKEN_ADDRESS,
+              chainId: MOCK_CHAIN,
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/app/components/UI/Money/constants/activityStyles.ts
+++ b/app/components/UI/Money/constants/activityStyles.ts
@@ -10,6 +10,7 @@ import {
   MUSD_DECIMALS,
   MUSD_TOKEN,
 } from '../../Earn/constants/musd';
+import { isPerpsPredictMoneyWithdraw } from '../utils/moneyTransactionGuards';
 
 function formatNumber(num: number): string {
   return getIntlNumberFormatter(I18n.locale, {
@@ -185,6 +186,10 @@ export function getMusdDisplayAmountFromTransactionMeta(
 }
 
 export function isIncomingMoneyTransactionMeta(tx: TransactionMeta): boolean {
+  if (isPerpsPredictMoneyWithdraw(tx)) {
+    return true;
+  }
+
   const t = tx.type;
   if (
     t === EvmTransactionType.incoming ||
@@ -194,6 +199,7 @@ export function isIncomingMoneyTransactionMeta(tx: TransactionMeta): boolean {
   ) {
     return true;
   }
+
   // EIP-7702 batch deposits: moneyAccountDeposit sits in nestedTransactions
   return (
     tx.nestedTransactions?.some(

--- a/app/components/UI/Money/constants/moneyActivityFilters.test.ts
+++ b/app/components/UI/Money/constants/moneyActivityFilters.test.ts
@@ -15,6 +15,8 @@ import {
 
 const MOCK_CHAIN: Hex = CHAIN_IDS.MONAD;
 const OTHER_ERC20: Hex = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+// A MetaMask Pay token of mUSD on Monad marks a Perps/Predict ↔ Money transfer.
+const MUSD_ON_MONAD = { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: MOCK_CHAIN };
 
 function tx(overrides: Partial<TransactionMeta>): TransactionMeta {
   return {
@@ -103,6 +105,31 @@ describe('moneyActivityFilters', () => {
         ),
       ).toBe(false);
     });
+
+    it('returns true for a Perps/Predict withdraw landing in the Money account (inflow)', () => {
+      expect(
+        isMoneyActivityDeposit(
+          tx({
+            type: TransactionType.batch,
+            nestedTransactions: [
+              { type: TransactionType.predictWithdraw } as TransactionMeta,
+            ],
+            metamaskPay: MUSD_ON_MONAD,
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for a Perps/Predict deposit (outflow, not a deposit into Money)', () => {
+      expect(
+        isMoneyActivityDeposit(
+          tx({
+            type: TransactionType.perpsDeposit,
+            metamaskPay: MUSD_ON_MONAD,
+          }),
+        ),
+      ).toBe(false);
+    });
   });
 
   describe('isMoneyActivityTransfer', () => {
@@ -144,6 +171,31 @@ describe('moneyActivityFilters', () => {
           tx({
             type: TransactionType.tokenMethodTransfer,
             transferInformation: transferInfo(MUSD_TOKEN_ADDRESS),
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true for a Perps/Predict deposit funded from the Money account (outflow)', () => {
+      expect(
+        isMoneyActivityTransfer(
+          tx({
+            type: TransactionType.perpsDeposit,
+            metamaskPay: MUSD_ON_MONAD,
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for a Perps/Predict withdraw (inflow, bucketed as a deposit)', () => {
+      expect(
+        isMoneyActivityTransfer(
+          tx({
+            type: TransactionType.batch,
+            nestedTransactions: [
+              { type: TransactionType.predictWithdraw } as TransactionMeta,
+            ],
+            metamaskPay: MUSD_ON_MONAD,
           }),
         ),
       ).toBe(false);

--- a/app/components/UI/Money/constants/moneyActivityFilters.ts
+++ b/app/components/UI/Money/constants/moneyActivityFilters.ts
@@ -3,6 +3,10 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { isMusdOnMoneyAccountChain } from '../../Earn/constants/musd';
+import {
+  isPerpsPredictMoneyDeposit,
+  isPerpsPredictMoneyWithdraw,
+} from '../utils/moneyTransactionGuards';
 
 const ERC20_TRANSFER_TYPES: TransactionType[] = [
   TransactionType.tokenMethodTransfer,
@@ -32,10 +36,12 @@ export function isMoneyActivityDeposit(tx: TransactionMeta): boolean {
   if (
     t === TransactionType.incoming ||
     t === TransactionType.moneyAccountDeposit ||
-    isMusdErc20Transfer(tx)
+    isMusdErc20Transfer(tx) ||
+    isPerpsPredictMoneyWithdraw(tx)
   ) {
     return true;
   }
+
   // EIP-7702 batch deposits: moneyAccountDeposit sits in nestedTransactions
   return (
     tx.nestedTransactions?.some(
@@ -48,7 +54,8 @@ export function isMoneyActivityTransfer(tx: TransactionMeta): boolean {
   const t = tx.type;
   if (
     t === TransactionType.moneyAccountWithdraw ||
-    t === TransactionType.simpleSend
+    t === TransactionType.simpleSend ||
+    isPerpsPredictMoneyDeposit(tx)
   ) {
     return true;
   }

--- a/app/components/UI/Money/hooks/useMoneyAccountTransactions.test.tsx
+++ b/app/components/UI/Money/hooks/useMoneyAccountTransactions.test.tsx
@@ -365,6 +365,54 @@ describe('useMoneyAccountTransactions', () => {
       expect(result.current.allTransactions).toHaveLength(0);
     });
 
+    const MUSD_ON_MONAD = {
+      tokenAddress: MUSD_TOKEN_ADDRESS,
+      chainId: CHAIN_IDS.MONAD,
+    };
+
+    it('includes a Perps deposit funded from the Money account as a transfer (outflow)', () => {
+      const tx = makeTx(TransactionType.perpsDeposit, {
+        metamaskPay: MUSD_ON_MONAD as TransactionMeta['metamaskPay'],
+      });
+      const { result } = renderHookWithProvider(
+        () => useMoneyAccountTransactions(),
+        { state: engineState({ moneyActivityMockDataEnabled: false }, [tx]) },
+      );
+      expect(result.current.allTransactions).toHaveLength(1);
+      expect(result.current.transfers).toHaveLength(1);
+      expect(result.current.deposits).toHaveLength(0);
+    });
+
+    it('includes a Predict withdraw landing in the Money account as a deposit (inflow)', () => {
+      const tx = makeTx(TransactionType.batch, {
+        nestedTransactions: [
+          { type: TransactionType.predictWithdraw } as TransactionMeta,
+        ],
+        metamaskPay: MUSD_ON_MONAD as TransactionMeta['metamaskPay'],
+      });
+      const { result } = renderHookWithProvider(
+        () => useMoneyAccountTransactions(),
+        { state: engineState({ moneyActivityMockDataEnabled: false }, [tx]) },
+      );
+      expect(result.current.allTransactions).toHaveLength(1);
+      expect(result.current.deposits).toHaveLength(1);
+      expect(result.current.transfers).toHaveLength(0);
+    });
+
+    it('excludes a Perps deposit not funded from the Money account', () => {
+      const tx = makeTx(TransactionType.perpsDeposit, {
+        metamaskPay: {
+          tokenAddress: OTHER_ERC20,
+          chainId: CHAIN_IDS.ARBITRUM,
+        } as TransactionMeta['metamaskPay'],
+      });
+      const { result } = renderHookWithProvider(
+        () => useMoneyAccountTransactions(),
+        { state: engineState({ moneyActivityMockDataEnabled: false }, [tx]) },
+      );
+      expect(result.current.allTransactions).toHaveLength(0);
+    });
+
     it('includes inbound mUSD landing at the money account', () => {
       const tx = makeTx(TransactionType.incoming, {
         txParams: { from: OTHER_ADDRESS, to: MONEY_ADDRESS } as never,

--- a/app/components/UI/Money/hooks/useMoneyAccountTransactions.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountTransactions.ts
@@ -23,6 +23,7 @@ import {
   ERC20_TRANSFER_FROM_CALLDATA_LENGTH,
 } from '../constants/activityStyles';
 import { getMoneyActivityStatus } from '../utils/classifyMoneyActivity';
+import { isPerpsPredictMoneyActivity } from '../utils/moneyTransactionGuards';
 
 // Statuses that should surface in money activity. `unapproved`/`approved`/
 // `signed` are mid-compose and shouldn't appear yet; `rejected`/`dropped`/
@@ -137,6 +138,7 @@ export function useMoneyAccountTransactions(): UseMoneyAccountTransactionsResult
         ) {
           return isMoneyAccountTxVisible(tx);
         }
+
         // EIP-7702 batch where a Money account call is a nested call.
         if (
           tx.nestedTransactions?.some(
@@ -147,6 +149,12 @@ export function useMoneyAccountTransactions(): UseMoneyAccountTransactionsResult
         ) {
           return isMoneyAccountTxVisible(tx);
         }
+
+        // Perps/Predict ↔ Money account transfers
+        if (isPerpsPredictMoneyActivity(tx)) {
+          return isMoneyAccountTxVisible(tx);
+        }
+
         if (moneyAddress === undefined) return false;
         // The inbound-mUSD and locally-signed mUSD branches below must skip
         // mid-compose and explicitly-aborted rows, which would otherwise

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -1033,4 +1033,41 @@ describe('useMoneyTransactionDisplayInfo — Perps/Predict ↔ Money', () => {
     expect(result.current.primaryAmount).toBe('+0.10 mUSD');
     expect(result.current.fiatAmount).toBe('+$0.10');
   });
+
+  it('shows signed-zero (not the real amount) for a failed money-funded Perps deposit', () => {
+    // Failed rows must show signed-zero like every other kind; the perps amount
+    // block must not clobber it.
+    const tx = makeTx(TransactionType.perpsDeposit, {
+      status: TransactionStatus.failed,
+      metamaskPay: payOnMonad({ totalFiat: '0.67157', targetFiat: '0.64' }),
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState({ currentCurrency: 'usd' }) },
+    );
+
+    expect(result.current.label).toBe('money.transaction.send_failed');
+    expect(result.current.isIncoming).toBe(false);
+    expect(result.current.primaryAmount).toBe('-0.00 mUSD');
+    expect(result.current.fiatAmount).toBe('-$0.00');
+  });
+
+  it('shows signed-zero for a failed Predict withdraw into the Money account', () => {
+    const tx = makeTx(TransactionType.batch, {
+      status: TransactionStatus.failed,
+      nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+      metamaskPay: payOnMonad({
+        totalFiat: '0.158879',
+        targetFiat: '0.099965',
+      }),
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState({ currentCurrency: 'usd' }) },
+    );
+
+    expect(result.current.isIncoming).toBe(true);
+    expect(result.current.primaryAmount).toBe('+0.00 mUSD');
+    expect(result.current.fiatAmount).toBe('+$0.00');
+  });
 });

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -976,3 +976,61 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
     expect(result.current.description).toBe('mUSD');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Perps/Predict ↔ Money transfers (matched via the mUSD pay token)
+// ---------------------------------------------------------------------------
+
+describe('useMoneyTransactionDisplayInfo — Perps/Predict ↔ Money', () => {
+  const MONAD: Hex = '0x8f';
+  const payOnMonad = (extra: Record<string, string>) => ({
+    tokenAddress: MUSD_TOKEN_ADDRESS,
+    chainId: MONAD,
+    ...extra,
+  });
+
+  it('renders a money-funded Perps deposit as an outflow ("Sent")', () => {
+    // Outflow → the debit from the account, including the bridge fee = totalFiat.
+    const tx = makeTx(TransactionType.perpsDeposit, {
+      metamaskPay: payOnMonad({ totalFiat: '0.67157', targetFiat: '0.64' }),
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState({ currentCurrency: 'usd' }) },
+    );
+
+    expect(result.current.label).toBe('money.transaction.sent');
+    expect(result.current.icon).toBe(IconName.Arrow2UpRight);
+    expect(result.current.description).toBe(
+      'transaction_details.label.perps_account',
+    );
+    expect(result.current.isIncoming).toBe(false);
+    expect(result.current.primaryAmount).toBe('-0.67 mUSD');
+    expect(result.current.fiatAmount).toBe('-$0.67');
+  });
+
+  it('renders a Predict withdraw into the Money account as an inflow ("Deposited")', () => {
+    // Inflow → the net amount that lands = targetFiat. Withdraw sits in the
+    // EIP-7702 batch's nested calls.
+    const tx = makeTx(TransactionType.batch, {
+      nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+      metamaskPay: payOnMonad({
+        totalFiat: '0.158879',
+        targetFiat: '0.099965',
+      }),
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState({ currentCurrency: 'usd' }) },
+    );
+
+    expect(result.current.label).toBe('money.transaction.deposited');
+    expect(result.current.icon).toBe(IconName.Add);
+    expect(result.current.description).toBe(
+      'transaction_details.label.predictions_account',
+    );
+    expect(result.current.isIncoming).toBe(true);
+    expect(result.current.primaryAmount).toBe('+0.10 mUSD');
+    expect(result.current.fiatAmount).toBe('+$0.10');
+  });
+});

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -261,8 +261,9 @@ export function useMoneyTransactionDisplayInfo(
     }
 
     // Perps/Predict ↔ Money transfers carry no `requiredAssets` and aren't token
-    // transfers, so neither amount path above resolves.
-    if (isPerpsPredictMoneyActivity(tx)) {
+    // transfers, so neither amount path above resolves. Skip when failed so the
+    // signed-zero amount set above is preserved (as for every other failed row).
+    if (status !== 'failed' && isPerpsPredictMoneyActivity(tx)) {
       const fiatStr = isPerpsPredictMoneyWithdraw(tx)
         ? tx.metamaskPay?.targetFiat
         : tx.metamaskPay?.totalFiat;

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -33,7 +33,12 @@ import {
   MUSD_TOKEN,
 } from '../../Earn/constants/musd';
 import { MONEY_WITHDRAW_TOKEN_SYMBOL } from '../constants/moneyTokens';
-import { isMoneyWithdrawTx } from '../utils/moneyTransactionGuards';
+import {
+  isMoneyWithdrawTx,
+  isPerpsPredictMoneyActivity,
+  isPerpsPredictMoneyWithdraw,
+  perpsPredictServiceFamily,
+} from '../utils/moneyTransactionGuards';
 import type { MoneyActivityTransactionMeta } from '../constants/mockActivityData';
 import {
   classifyMoneyActivity,
@@ -111,6 +116,17 @@ function deriveSubtitle(
   if (explicitSubtitle) {
     return explicitSubtitle;
   }
+
+  // Perps/Predict ↔ Money transfers (either direction) name the service account
+  // instead of a token pair / sender.
+  const serviceFamily = perpsPredictServiceFamily(tx);
+  if (serviceFamily === 'perps') {
+    return strings('transaction_details.label.perps_account');
+  }
+  if (serviceFamily === 'predict') {
+    return strings('transaction_details.label.predictions_account');
+  }
+
   switch (kind) {
     case 'converted':
       return sourceTokenSymbol
@@ -241,6 +257,25 @@ export function useMoneyTransactionDisplayInfo(
           new BigNumber(0),
           currentCurrency,
         )}`;
+      }
+    }
+
+    // Perps/Predict ↔ Money transfers carry no `requiredAssets` and aren't token
+    // transfers, so neither amount path above resolves.
+    if (isPerpsPredictMoneyActivity(tx)) {
+      const fiatStr = isPerpsPredictMoneyWithdraw(tx)
+        ? tx.metamaskPay?.targetFiat
+        : tx.metamaskPay?.totalFiat;
+      const fiat = Number(fiatStr);
+      if (!isNaN(fiat) && fiat > 0) {
+        const amount = new BigNumber(fiat);
+        primaryAmount = formatMusdAmount(amount, isIncoming);
+        if (currentCurrency) {
+          fiatAmount = `${isIncoming ? '+' : '-'}${moneyFormatFiat(
+            amount,
+            currentCurrency,
+          )}`;
+        }
       }
     }
 

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.test.ts
@@ -1,8 +1,10 @@
 import {
+  CHAIN_IDS,
   TransactionMeta,
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
 import { renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
 import Engine from '../../../../core/Engine';
@@ -177,6 +179,58 @@ describe('useRefreshMoneyBalanceOnTxConfirm', () => {
     });
 
     expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  const MUSD_ON_MONAD = {
+    tokenAddress: MUSD_TOKEN_ADDRESS,
+    chainId: CHAIN_IDS.MONAD,
+  };
+
+  it('invalidates on a confirmed Perps deposit funded from the Money account', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getConfirmedHandler();
+
+    handler({
+      ...makeTx(TransactionType.perpsDeposit),
+      metamaskPay: MUSD_ON_MONAD,
+    } as unknown as TransactionMeta);
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates on a confirmed Predict withdraw landing in the Money account', async () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getConfirmedHandler();
+
+    handler({
+      ...makeTx(TransactionType.batch, TransactionStatus.confirmed, [
+        { type: TransactionType.predictWithdraw },
+      ]),
+      metamaskPay: MUSD_ON_MONAD,
+    } as unknown as TransactionMeta);
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invalidate for a Perps deposit NOT funded from the Money account', () => {
+    renderHook(() => useRefreshMoneyBalanceOnTxConfirm());
+    const handler = getConfirmedHandler();
+
+    handler({
+      ...makeTx(TransactionType.perpsDeposit),
+      metamaskPay: {
+        tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+        chainId: CHAIN_IDS.ARBITRUM,
+      },
+    } as unknown as TransactionMeta);
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });
 
   it('does not invalidate for non-confirmed status', () => {

--- a/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
+++ b/app/components/UI/Money/hooks/useRefreshMoneyBalanceOnTxConfirm.ts
@@ -9,7 +9,10 @@ import ReactQueryService from '../../../../core/ReactQueryService';
 import { store } from '../../../../store';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { MoneyAccountBalanceServiceQueryKeys } from '../queryKeys';
-import { isMoneyAccountTx } from '../utils/moneyTransactionGuards';
+import {
+  isMoneyAccountTx,
+  isPerpsPredictMoneyActivity,
+} from '../utils/moneyTransactionGuards';
 import Logger from '../../../../util/Logger';
 import { calculateExponentialRetryDelay } from '../../../../util/exponential-retry';
 
@@ -87,10 +90,17 @@ export const useRefreshMoneyBalanceOnTxConfirm = () => {
   useEffect(() => {
     const handleTransactionConfirmed = (transactionMeta: TransactionMeta) => {
       if (transactionMeta.status !== TransactionStatus.confirmed) return;
-      if (!isMoneyAccountTx(transactionMeta)) return;
 
       const address = selectPrimaryMoneyAccount(store.getState())?.address;
       if (!address) return;
+
+      // Direct Money txs (deposit/withdraw) plus Perps/Predict transfers to or
+      // from the Money account (paid with mUSD via MetaMask Pay), which also
+      // move mUSD and so must refresh the balance.
+      const affectsMoneyBalance =
+        isMoneyAccountTx(transactionMeta) ||
+        isPerpsPredictMoneyActivity(transactionMeta);
+      if (!affectsMoneyBalance) return;
 
       refreshMoneyBalanceQueries(address).catch((error) => {
         Logger.error(error, `${LOG_PREFIX} Balance refresh failed`);

--- a/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.test.ts
@@ -1,4 +1,5 @@
 import {
+  CHAIN_IDS,
   type TransactionMeta,
   TransactionStatus,
   TransactionType,
@@ -81,6 +82,46 @@ describe('classifyMoneyActivity', () => {
       expect(classifyMoneyActivity(makeTx({ type }))).toBe('sent');
     },
   );
+
+  const MUSD_ON_MONAD = {
+    tokenAddress: MUSD_TOKEN_ADDRESS,
+    chainId: CHAIN_IDS.MONAD,
+  };
+
+  it.each([
+    TransactionType.perpsDeposit,
+    TransactionType.perpsDepositAndOrder,
+    TransactionType.predictDeposit,
+    TransactionType.predictDepositAndOrder,
+  ])(
+    'classifies a money-funded %s as sent (outflow to the service)',
+    (type) => {
+      expect(
+        classifyMoneyActivity(makeTx({ type, metamaskPay: MUSD_ON_MONAD })),
+      ).toBe('sent');
+    },
+  );
+
+  it.each([TransactionType.perpsWithdraw, TransactionType.predictWithdraw])(
+    'classifies an mUSD %s as deposited (inflow into the Money account)',
+    (type) => {
+      const tx = makeTx({
+        type: TransactionType.batch,
+        nestedTransactions: [{ type }],
+        metamaskPay: MUSD_ON_MONAD,
+      });
+      expect(classifyMoneyActivity(tx)).toBe('deposited');
+    },
+  );
+
+  it('does not treat a non-mUSD perps deposit as a Money outflow', () => {
+    const tx = makeTx({
+      type: TransactionType.perpsDeposit,
+      metamaskPay: { tokenAddress: USDC_ADDRESS, chainId: CHAIN_ID },
+    });
+    // Falls through to the default branch rather than the 'sent' early return.
+    expect(classifyMoneyActivity(tx)).toBe('received');
+  });
 
   it('resolves the nested type for an EIP-7702 batch crypto deposit', () => {
     const tx = makeTx({

--- a/app/components/UI/Money/utils/classifyMoneyActivity.ts
+++ b/app/components/UI/Money/utils/classifyMoneyActivity.ts
@@ -6,6 +6,10 @@ import {
 import { IconName } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
 import { isMusdToken } from '../../Earn/constants/musd';
+import {
+  isPerpsPredictMoneyDeposit,
+  isPerpsPredictMoneyWithdraw,
+} from './moneyTransactionGuards';
 import type {
   MoneyActivityTitleKey,
   MoneyActivityTransactionMeta,
@@ -76,6 +80,15 @@ export function classifyMoneyActivity(tx: TransactionMeta): MoneyActivityKind {
   const { moneyActivityTitleKey } = tx as MoneyActivityTransactionMeta;
   if (moneyActivityTitleKey) {
     return TITLE_KEY_TO_KIND[moneyActivityTitleKey] ?? 'received';
+  }
+
+  // Perps/Predict ↔ Money transfers (matched via the mUSD pay token). Withdraw
+  // into the Money account reads as a deposit; deposit out of it reads as sent.
+  if (isPerpsPredictMoneyWithdraw(tx)) {
+    return 'deposited';
+  }
+  if (isPerpsPredictMoneyDeposit(tx)) {
+    return 'sent';
   }
 
   const type = resolveMoneyTransactionType(tx);

--- a/app/components/UI/Money/utils/moneyTransactionGuards.test.ts
+++ b/app/components/UI/Money/utils/moneyTransactionGuards.test.ts
@@ -1,13 +1,20 @@
 import {
+  CHAIN_IDS,
   TransactionMeta,
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
 import {
   isMoneyAccountTx,
   isMoneyDepositTx,
   isMoneyWithdrawTx,
+  isPerpsPredictMoneyActivity,
+  isPerpsPredictMoneyDeposit,
+  isPerpsPredictMoneyWithdraw,
   nestedTxWithType,
+  perpsPredictServiceFamily,
   getMMPayChainIds,
 } from './moneyTransactionGuards';
 
@@ -139,6 +146,160 @@ describe('isMoneyAccountTx', () => {
     expect(isMoneyAccountTx(makeTx(TransactionType.contractInteraction))).toBe(
       false,
     );
+  });
+});
+
+// mUSD on Monad as a MetaMask Pay token = funded by / landing in the Money
+// account; any other token/chain is unrelated to it.
+const MUSD_ON_MONAD = {
+  tokenAddress: MUSD_TOKEN_ADDRESS,
+  chainId: CHAIN_IDS.MONAD as Hex,
+};
+const USDC_ON_ARBITRUM = {
+  tokenAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex,
+  chainId: CHAIN_IDS.ARBITRUM as Hex,
+};
+
+const makeServiceTx = (
+  type: TransactionType | undefined,
+  metamaskPay: Record<string, unknown> | undefined,
+  nested?: { type: TransactionType }[],
+): TransactionMeta =>
+  ({
+    ...baseTx,
+    type,
+    metamaskPay,
+    nestedTransactions: nested,
+  }) as unknown as TransactionMeta;
+
+describe('isPerpsPredictMoneyDeposit', () => {
+  it.each([
+    TransactionType.perpsDeposit,
+    TransactionType.perpsDepositAndOrder,
+    TransactionType.predictDeposit,
+    TransactionType.predictDepositAndOrder,
+  ])('returns true for %s paid with mUSD on Monad', (type) => {
+    expect(isPerpsPredictMoneyDeposit(makeServiceTx(type, MUSD_ON_MONAD))).toBe(
+      true,
+    );
+  });
+
+  it('returns false when the pay token is not mUSD on the Money chain', () => {
+    expect(
+      isPerpsPredictMoneyDeposit(
+        makeServiceTx(TransactionType.perpsDeposit, USDC_ON_ARBITRUM),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when there is no metamaskPay (not money-funded)', () => {
+    expect(
+      isPerpsPredictMoneyDeposit(
+        makeServiceTx(TransactionType.perpsDeposit, undefined),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for a withdraw type even with an mUSD pay token', () => {
+    expect(
+      isPerpsPredictMoneyDeposit(
+        makeServiceTx(TransactionType.perpsWithdraw, MUSD_ON_MONAD),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isPerpsPredictMoneyWithdraw', () => {
+  it('returns true for a top-level withdraw landing as mUSD on Monad', () => {
+    expect(
+      isPerpsPredictMoneyWithdraw(
+        makeServiceTx(TransactionType.perpsWithdraw, MUSD_ON_MONAD),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for an EIP-7702 batch with a nested predictWithdraw', () => {
+    expect(
+      isPerpsPredictMoneyWithdraw(
+        makeServiceTx(TransactionType.batch, MUSD_ON_MONAD, [
+          { type: TransactionType.predictWithdraw },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when the destination is not mUSD on the Money chain', () => {
+    expect(
+      isPerpsPredictMoneyWithdraw(
+        makeServiceTx(TransactionType.predictWithdraw, USDC_ON_ARBITRUM),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for a deposit type', () => {
+    expect(
+      isPerpsPredictMoneyWithdraw(
+        makeServiceTx(TransactionType.perpsDeposit, MUSD_ON_MONAD),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isPerpsPredictMoneyActivity', () => {
+  it('returns true for both a money-funded deposit and an mUSD withdraw', () => {
+    expect(
+      isPerpsPredictMoneyActivity(
+        makeServiceTx(TransactionType.perpsDeposit, MUSD_ON_MONAD),
+      ),
+    ).toBe(true);
+    expect(
+      isPerpsPredictMoneyActivity(
+        makeServiceTx(TransactionType.batch, MUSD_ON_MONAD, [
+          { type: TransactionType.predictWithdraw },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for an unrelated tx', () => {
+    expect(
+      isPerpsPredictMoneyActivity(
+        makeServiceTx(TransactionType.contractInteraction, MUSD_ON_MONAD),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('perpsPredictServiceFamily', () => {
+  it.each([
+    [TransactionType.perpsDeposit, 'perps'],
+    [TransactionType.perpsDepositAndOrder, 'perps'],
+    [TransactionType.perpsWithdraw, 'perps'],
+    [TransactionType.predictDeposit, 'predict'],
+    [TransactionType.predictDepositAndOrder, 'predict'],
+    [TransactionType.predictWithdraw, 'predict'],
+  ])('maps %s to %s', (type, family) => {
+    expect(perpsPredictServiceFamily(makeServiceTx(type, MUSD_ON_MONAD))).toBe(
+      family,
+    );
+  });
+
+  it('resolves the family from a nested batch call', () => {
+    expect(
+      perpsPredictServiceFamily(
+        makeServiceTx(TransactionType.batch, MUSD_ON_MONAD, [
+          { type: TransactionType.predictWithdraw },
+        ]),
+      ),
+    ).toBe('predict');
+  });
+
+  it('returns undefined for a non-service tx', () => {
+    expect(
+      perpsPredictServiceFamily(
+        makeServiceTx(TransactionType.moneyAccountWithdraw, undefined),
+      ),
+    ).toBeUndefined();
   });
 });
 

--- a/app/components/UI/Money/utils/moneyTransactionGuards.ts
+++ b/app/components/UI/Money/utils/moneyTransactionGuards.ts
@@ -3,6 +3,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { isMusdOnMoneyAccountChain } from '../../Earn/constants/musd';
 
 /**
  * Returns the first nested transaction matching a given TransactionType,
@@ -30,6 +31,124 @@ export const isMoneyWithdrawTx = (transactionMeta: TransactionMeta) =>
 
 export const isMoneyAccountTx = (transactionMeta: TransactionMeta) =>
   isMoneyDepositTx(transactionMeta) || isMoneyWithdrawTx(transactionMeta);
+
+/**
+ * Perps/Predict deposit parent types (money → service). When funded from the
+ * Money account these are paid with mUSD via MetaMask Pay; the on-chain deposit
+ * is signed from the user's EOA on the service chain (Arbitrum/Polygon)
+ **/
+export const PERPS_PREDICT_DEPOSIT_TYPES: TransactionType[] = [
+  TransactionType.perpsDeposit,
+  TransactionType.perpsDepositAndOrder,
+  TransactionType.predictDeposit,
+  TransactionType.predictDepositAndOrder,
+];
+
+/**
+ * Perps/Predict withdraw types (service → money). When the destination is the
+ * Money account these arrive as mUSD on Monad. The withdraw is wrapped in an
+ * EIP-7702 `batch`, so the type sits in `nestedTransactions`.
+ */
+export const PERPS_PREDICT_WITHDRAW_TYPES: TransactionType[] = [
+  TransactionType.perpsWithdraw,
+  TransactionType.predictWithdraw,
+];
+
+/**
+ * The Perps/Predict deposit or withdraw type for a tx, unwrapping an EIP-7702
+ * `batch` whose money-moving call sits in `nestedTransactions`.
+ */
+const effectiveServiceType = (
+  transactionMeta: TransactionMeta,
+): TransactionType | undefined => {
+  const serviceTypes = [
+    ...PERPS_PREDICT_DEPOSIT_TYPES,
+    ...PERPS_PREDICT_WITHDRAW_TYPES,
+  ];
+  if (
+    transactionMeta.type &&
+    serviceTypes.includes(transactionMeta.type as TransactionType)
+  ) {
+    return transactionMeta.type as TransactionType;
+  }
+  return transactionMeta.nestedTransactions?.find(
+    (nested) => nested.type && serviceTypes.includes(nested.type),
+  )?.type;
+};
+
+/**
+ * True when the `metamaskPay` token is mUSD on the Money account chain (Monad).
+ * For a deposit this is the source the Money account paid; for a withdraw
+ * (`isPostQuote`) it's the destination — either way it links the tx to the
+ * Money account.
+ */
+const isMusdMoneyPayToken = (transactionMeta: TransactionMeta): boolean =>
+  isMusdOnMoneyAccountChain(
+    transactionMeta.metamaskPay?.tokenAddress,
+    transactionMeta.metamaskPay?.chainId as Hex | undefined,
+  );
+
+/**
+ * Perps/Predict deposit funded from the Money account —
+ * from the perspective of the money account this a 'Send'.
+ * The tx `from` is the user's EOA, not the Money account, so it's matched via
+ * the mUSD pay token rather than the address.
+ */
+export const isPerpsPredictMoneyDeposit = (
+  transactionMeta: TransactionMeta,
+): boolean => {
+  const type = effectiveServiceType(transactionMeta);
+  return (
+    Boolean(type) &&
+    PERPS_PREDICT_DEPOSIT_TYPES.includes(type as TransactionType) &&
+    isMusdMoneyPayToken(transactionMeta)
+  );
+};
+
+/**
+ * Perps/Predict withdraw landing in the Money account — an inflow ("Deposited").
+ */
+export const isPerpsPredictMoneyWithdraw = (
+  transactionMeta: TransactionMeta,
+): boolean => {
+  const type = effectiveServiceType(transactionMeta);
+  return (
+    Boolean(type) &&
+    PERPS_PREDICT_WITHDRAW_TYPES.includes(type as TransactionType) &&
+    isMusdMoneyPayToken(transactionMeta)
+  );
+};
+
+export const isPerpsPredictMoneyActivity = (
+  transactionMeta: TransactionMeta,
+): boolean =>
+  isPerpsPredictMoneyDeposit(transactionMeta) ||
+  isPerpsPredictMoneyWithdraw(transactionMeta);
+
+/**
+ * The service family ('perps' | 'predict') for a Perps/Predict ↔ Money tx, used
+ * to label the activity row's subtitle. Returns undefined for other txs.
+ */
+export const perpsPredictServiceFamily = (
+  transactionMeta: TransactionMeta,
+): 'perps' | 'predict' | undefined => {
+  const type = effectiveServiceType(transactionMeta);
+  if (
+    type === TransactionType.perpsDeposit ||
+    type === TransactionType.perpsDepositAndOrder ||
+    type === TransactionType.perpsWithdraw
+  ) {
+    return 'perps';
+  }
+  if (
+    type === TransactionType.predictDeposit ||
+    type === TransactionType.predictDepositAndOrder ||
+    type === TransactionType.predictWithdraw
+  ) {
+    return 'predict';
+  }
+  return undefined;
+};
 
 /**
  * Resolves source and destination chain IDs for MM Pay transaction.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR show transfers between money account and perps/predict in the money activity list, and also causes the money balance to update when a perps/predict transaction occurs.

We show transfers to perps/predicts with the label `sent` and withdrawlals to the money account with the label `Deposited`

Please note that this **does not** implement the custom detail modals for perps / predict transactions.

### Notes on the implementation
The on-chain Perps/Predict transaction is signed from the user's EOA on the service chain (Arbitrum/Polygon), not the Money account. To find these transactions reliably we need to look for transactions that use mUSD on the Money account chain.

- A `perps/predict` **deposit** paid with that token is a Money **outflow**.
- A `perps/predict` **withdraw** (an EIP-7702 batch, `isPostQuote`) landing in that token is a Money **inflow**.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show money <--> perps/predict transactions in money activity

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-986

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: money activity

  Scenario: user transfers from their money account to perps/predict account
    Given user is on the money activity

    When user sends musd to their perps/predict account
    Then they see the transaction appear in the activity list

  Scenario: user transfers from perps/predict to their moneyaccount
    Given user is on the perps/predict account

    When user withdraws musd to their money account
    Then they see the transaction appear in the money activity list

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6fb7e522-e7ff-4c71-9352-fe3de8f3d867


https://github.com/user-attachments/assets/878a8416-bafb-4e87-b1cd-3c8edb6ede4b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
