### PR TITLE
fix(rewards): apply bottom safe-area inset on VIP dashboard views (Android)

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
@@ -114,7 +114,7 @@ const RewardsVipRefereeViewContent: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="RewardsVipRefereeView">
       <SafeAreaView
-        edges={{ top: 'additive' }}
+        edges={{ top: 'additive', bottom: 'additive' }}
         style={tw.style('flex-1 bg-default')}
         testID={REWARDS_VIP_REFEREE_VIEW_TEST_IDS.VIEW}
       >

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.tsx
@@ -71,7 +71,7 @@ const RewardsVipTiersViewContent: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="RewardsVipTiersView">
       <SafeAreaView
-        edges={{ top: 'additive' }}
+        edges={{ top: 'additive', bottom: 'additive' }}
         style={tw.style('flex-1 bg-default')}
         testID={REWARDS_VIP_TIERS_VIEW_TEST_IDS.ROOT}
       >

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -146,7 +146,7 @@ const RewardsVipViewContent: React.FC = () => {
   return (
     <ErrorBoundary navigation={navigation} view="RewardsVipView">
       <SafeAreaView
-        edges={{ top: 'additive' }}
+        edges={{ top: 'additive', bottom: 'additive' }}
         style={tw.style('flex-1 bg-default')}
         testID={REWARDS_VIEW_SELECTORS.VIP_VIEW}
       >


### PR DESCRIPTION
## **Description**

On Android (gesture navigation), the bottom of the VIP dashboard is clipped when scrolled all the way down — the "Total points / Progress to equity" section sits under the system gesture bar with no padding. The same latent issue affects the VIP tiers screen and the VIP referral/invite screen.

**Root cause:** each screen's root `SafeAreaView` declared only `edges={{ top: 'additive' }}`, so the Android **bottom** safe-area inset was never applied; the inner `ScrollView`'s fixed `pb-8` (32px) isn't enough to clear the gesture bar.

**Fix:** add `bottom: 'additive'` to the root `SafeAreaView` on the three affected VIP views, matching the convention already used by ~18 sibling scrollable Rewards views.

Files changed:
- `app/components/UI/Rewards/Views/RewardsVipView.tsx`
- `app/components/UI/Rewards/Views/RewardsVipTiersView.tsx`
- `app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx`

## **Changelog**

CHANGELOG entry: Fix the VIP dashboard, tiers, and referral screens being cut off at the bottom on Android by applying the bottom safe-area inset.

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. On an Android device/emulator using gesture navigation, open MetaMask → Rewards → VIP dashboard.
2. Scroll to the very bottom.
3. Verify the "Total points / Progress to equity" section is fully visible above the gesture bar (not clipped).
4. Repeat for the VIP tiers screen and the VIP referral/invite screen.

## **Screenshots/Recordings**

Captured on the real VIP dashboard (Gold Fox VIP 1, live UAT data) on a local Android emulator with the 3-button navigation bar (real bottom inset).

### **Before**

The bottom "Progress to equity / 2 / 100M" section is clipped against the system navigation bar.

<img src="https://raw.githubusercontent.com/VGR-GIT/vip-dashboard-pr-assets/main/vip_before_3btn.png" width="320" />

### **After**

The same bottom section now clears the navigation bar with the correct safe-area inset applied.

<img src="https://raw.githubusercontent.com/VGR-GIT/vip-dashboard-pr-assets/main/vip_after_3btn.png" width="320" />

Before / After side-by-side (zoomed on the bottom section below it for clarity):

<img src="https://raw.githubusercontent.com/VGR-GIT/vip-dashboard-pr-assets/main/vip_3btn_sidebyside.png" width="640" />

<img src="https://raw.githubusercontent.com/VGR-GIT/vip-dashboard-pr-assets/main/vip_3btn_bottom_zoom.png" width="480" />

Scroll-to-bottom recording of the fixed dashboard:

<img src="https://raw.githubusercontent.com/VGR-GIT/vip-dashboard-pr-assets/main/vip_dashboard_scroll.gif" width="320" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket and includes the necessary testing evidence such as recordings and or screenshots.

