### PR TITLE
test(e2e): retry transient anvil fork startup failures

### DIFF
--- a/tests/framework/fixtures/FixtureUtils.ts
+++ b/tests/framework/fixtures/FixtureUtils.ts
@@ -256,6 +256,16 @@ export async function startResourceWithRetry(
   resource: Resource,
   maxRetries: number = 3,
 ): Promise<number> {
+  const isRetryableAnvilForkError = (errorMessage: string): boolean =>
+    resourceType === ResourceType.ANVIL &&
+    [
+      'failed to create genesis',
+      'failed to get account for',
+      'failed to get fork block number',
+      'http error 401',
+      'error code -32603',
+    ].some((signature) => errorMessage.includes(signature));
+
   let attempt = 0;
   let lastError: Error | undefined;
 
@@ -298,6 +308,18 @@ export async function startResourceWithRetry(
         logger.debug(
           `Port ${failedPort} conflict for ${resourceType}, retrying with new random port (${attempt}/${maxRetries})`,
         );
+        continue;
+      }
+
+      // Anvil forks can fail transiently when upstream RPC returns temporary
+      // errors during genesis/account fetch. Retrying usually recovers.
+      if (attempt < maxRetries && isRetryableAnvilForkError(errorMessage)) {
+        attempt++;
+        const retryDelayMs = 2000;
+        logger.debug(
+          `Transient fork startup error for ${resourceType}, retrying (${attempt}/${maxRetries}) after ${retryDelayMs}ms: ${errorMessage}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
         continue;
       }
 


### PR DESCRIPTION
## **Description**

Stake smoke tests intermittently fail during Anvil mainnet-fork startup in CI. The flaky report and failing job show transient provider errors that were not retried:

- `Anvil exited: Error: failed to create genesis`
- `failed to get account for ...`
- `error code -32603`

**Evidence**

- Slack flaky report: https://consensys.slack.com/archives/C02U025CVU4/p1781602966392039
- Thread context: https://consensys.slack.com/archives/C02U025CVU4/p1781607181796609
- Failing job: https://github.com/MetaMask/metamask-mobile/actions/runs/27603760495/job/81612424974
- Artifact (video + screenshot): https://github.com/MetaMask/metamask-mobile/actions/runs/27603760495/artifacts/7661452060
  - `✗ SmokeStake_ Lending Withdrawal from Wallet withdraws USDC from Aave lending position/test.mp4`
  - `✗ SmokeStake_ Lending Withdrawal from Wallet withdraws USDC from Aave lending position/testFnFailure.png`

**Root cause**

`startResourceWithRetry()` only retried port conflicts. Transient Anvil fork-provider startup failures during genesis/account fetch were treated as fatal.

**Fix**

Extend `startResourceWithRetry()` in `tests/framework/fixtures/FixtureUtils.ts` to retry known transient Anvil fork startup error signatures (genesis creation, account fetch, fork block number, HTTP 401, RPC `-32603`) with a 2s delay, up to the existing max retry count.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensys.slack.com/archives/C02U025CVU4/p1781602966392039

## **Manual testing steps**

```gherkin
Feature: E2E Anvil fork startup resiliency

  Scenario: Stake smoke startup retries on transient fork errors
    Given stake smoke tests use an Anvil mainnet fork via startResourceWithRetry()
    When transient provider errors occur during fork startup (genesis, account fetch, RPC -32603)
    Then startup retries up to maxRetries instead of failing immediately

  Scenario: Non-transient Anvil errors still fail fast
    Given an Anvil startup error that does not match retryable signatures
    When startResourceWithRetry() is invoked
    Then the error is thrown without retry
```

## **Screenshots/Recordings**

### **Before**

CI failure artifact from flaky SmokeStake run:
https://github.com/MetaMask/metamask-mobile/actions/runs/27603760495/artifacts/7661452060

- `✗ SmokeStake_ Lending Withdrawal from Wallet withdraws USDC from Aave lending position/test.mp4`
- `✗ SmokeStake_ Lending Withdrawal from Wallet withdraws USDC from Aave lending position/testFnFailure.png`

### **After**

N/A — test infrastructure change only; no user-facing UI change. Validation is via CI re-run of affected stake smoke tests.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.