### PR TITLE
feat(money): make Earn on Crypto a full-page screen (MUSD-994)

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -126,6 +126,7 @@ import {
   MoneyTabScreenStack,
 } from '../../UI/Money/routes';
 import MoneyOnboardingView from '../../UI/Money/Views/MoneyOnboardingView';
+import MoneyPotentialEarningsView from '../../UI/Money/Views/MoneyPotentialEarningsView';
 import { selectMoneyEnableMoneyAccountFlag } from '../../UI/Money/selectors/featureFlags';
 import { BridgeTransactionDetails } from '../../UI/Bridge/components/TransactionDetails/TransactionDetails';
 import { BridgeModalStack, BridgeScreenStack } from '../../UI/Bridge/routes';
@@ -1213,6 +1214,11 @@ const MainNavigator = () => {
             name={Routes.MONEY.ONBOARDING}
             component={MoneyOnboardingView}
             options={{ headerShown: false, ...fadeNativeOptions }}
+          />
+          <NativeStack.Screen
+            name={Routes.MONEY.POTENTIAL_EARNINGS}
+            component={MoneyPotentialEarningsView}
+            options={{ headerShown: false, ...slideFromRightNativeOptions }}
           />
           <NativeStack.Screen
             name={Routes.MONEY.MODALS.ROOT}

--- a/app/components/UI/Money/routes/index.test.tsx
+++ b/app/components/UI/Money/routes/index.test.tsx
@@ -112,7 +112,7 @@ describe('MoneyTabScreenStack', () => {
     jest.clearAllMocks();
   });
 
-  it('registers Money home, activity, how-it-works, and potential-earnings screens', () => {
+  it('registers Money home, activity, and how-it-works screens', () => {
     const { getByTestId } = renderWithProvider(<MoneyTabScreenStack />, {
       theme: themeWithCustomBackground,
     });
@@ -120,9 +120,6 @@ describe('MoneyTabScreenStack', () => {
     expect(getByTestId('money-screen-MoneyHome')).toBeOnTheScreen();
     expect(getByTestId('money-screen-MoneyActivity')).toBeOnTheScreen();
     expect(getByTestId('money-screen-MoneyHowItWorks')).toBeOnTheScreen();
-    expect(
-      getByTestId('money-screen-MoneyPotentialEarnings'),
-    ).toBeOnTheScreen();
   });
 
   it('sets stack content background from theme to avoid flash during inner navigation', () => {

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -9,7 +9,6 @@ import { useTheme } from '../../../../util/theme';
 import MoneyHomeView from '../Views/MoneyHomeView';
 import MoneyActivityView from '../Views/MoneyActivityView';
 import MoneyHowItWorksView from '../Views/MoneyHowItWorksView';
-import MoneyPotentialEarningsView from '../Views/MoneyPotentialEarningsView';
 import MoneyAddMoneySheet from '../components/MoneyAddMoneySheet';
 import MoneyMoreSheet from '../components/MoneyMoreSheet';
 import MoneyTransferSheet from '../components/MoneyTransferSheet';
@@ -48,10 +47,6 @@ const MoneyTabScreenStack = () => {
       <Stack.Screen
         name={Routes.MONEY.HOW_IT_WORKS}
         component={MoneyHowItWorksView}
-      />
-      <Stack.Screen
-        name={Routes.MONEY.POTENTIAL_EARNINGS}
-        component={MoneyPotentialEarningsView}
       />
     </Stack.Navigator>
   );


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Earn on your crypto" screen (`MoneyPotentialEarningsView`) was registered inside the Money tab stack, so it rendered with the bottom tab navigation bar still visible and the CTA sitting above it — it was not a true full-page screen as per the design.

This PR promotes `MoneyPotentialEarningsView` from the Money tab stack (`MoneyTabScreenStack`) to a top-level native stack route in `MainNavigator`, mirroring the existing Money confirmations/onboarding pattern. As a result the bottom tab navigation bar is no longer rendered on this screen and the "Convert your crypto" CTA sits at the true bottom edge of the screen with safe-area padding. No changes were needed to the view itself or to the navigation calls (the route name resolves to the new top-level registration).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed the "Earn on your crypto" screen to a full-page layout, removing the bottom navigation bar.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-994

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Earn on your crypto full-page screen

  Scenario: user opens Earn on your crypto from the Money home screen
    Given the user is on the Money home screen
    And the "Earn on your crypto" section shows eligible tokens

    When the user taps the section header or "View all"
    Then the "Earn on your crypto" screen opens as a full page
    And the bottom tab navigation bar is not visible
    And the "Convert your crypto" CTA is pinned to the bottom of the screen with padding
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/0dbe0051-1d6c-4c4e-b875-dfa38dd1e8cf


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
