### PR TITLE
fix: stx always being disabled for non ethereum networks cp-7.82.0

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -55,6 +55,10 @@ jest.mock('react-redux', () => ({
   useSelector: (selector: (state: unknown) => unknown) => selector({}),
 }));
 
+jest.mock('../../../../hooks/useRefreshSmartTransactionsLiveness', () => ({
+  useRefreshSmartTransactionsLiveness: jest.fn(),
+}));
+
 jest.mock('@metamask/design-system-react-native', () => {
   const DesignSystem = jest.requireActual(
     '@metamask/design-system-react-native',

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -61,6 +61,7 @@ import { BatchSellEmptyState } from './BatchSellEmptyState';
 import { DEFAULT_BATCH_SELL_SLIPPAGE } from '../../components/SlippageModal/utils';
 import { normalizeTokenAddress } from '../../utils/tokenUtils';
 import { useBatchSellTokens } from './useBatchSellTokens';
+import { useRefreshSmartTransactionsLiveness } from '../../../../hooks/useRefreshSmartTransactionsLiveness';
 
 const getTokenKey = (token: BridgeToken) =>
   `${formatChainIdToCaip(token.chainId)}:${normalizeTokenAddress(
@@ -175,6 +176,10 @@ export function BatchSellTokenSelect() {
   }, [selectedChainId, sortedEligibleChains]);
 
   const activeChainId = selectedChainId ?? sortedEligibleChains[0]?.chainId;
+
+  // Fetch STX liveness for the active batch sell source chain
+  useRefreshSmartTransactionsLiveness(activeChainId);
+
   const destinationStablecoins = useSelector((state: RootState) =>
     selectBatchSellDestStablecoins(state, activeChainId),
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Batch sell was reporting smart transactions (STX) as disabled on all networks except Ethereum mainnet and Sepolia, even when STX was enabled for the user and the Sentinel liveness API returned `smartTransactions: true` for chains like BSC, Base, and Polygon.

Unified Swap/Bridge already refreshes STX liveness on entry via `useRefreshSmartTransactionsLiveness`, which calls `SmartTransactionsController.fetchLiveness` and populates `livenessByChainId` in Redux. Batch sell never triggered that fetch, so only the controller defaults (mainnet + sepolia) were present and `selectSmartTransactionsEnabled` returned false for every other chain.

This change adds the same liveness refresh to the first batch sell screen (`BatchSellTokenSelect`), keyed off the active source chain (`activeChainId`), matching the BridgeView pattern. When the user switches chain pills, liveness is refetched for the newly selected chain.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31821

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch sell smart transaction liveness

  Scenario: STX is enabled on a non-Ethereum batch sell network
    Given smart transactions are opted in in Settings > Advanced
    Given the wallet has tokens on BSC (or Base / Polygon / Arbitrum / Linea)
    When the user opens Batch sell token select
    And selects the non-Ethereum network pill
    And proceeds through review to fetch quotes
    Then quote requests include stx_enabled true (when other STX gates pass)
    And batch sell submission passes isStxEnabled true

  Scenario: STX liveness refreshes when switching batch sell networks
    Given the user is on Batch sell token select with multiple eligible networks
    When the user switches between network pills
    Then liveness is fetched for each selected chain (verify via Redux livenessByChainId or network inspector)
```

Additional verification:
- Confirm Ethereum mainnet and Sepolia batch sell behavior is unchanged.
- Confirm batch sell still respects STX opt-out (Settings toggle off → STX false).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="1047" height="418" alt="Screenshot 2026-06-16 at 11 27 20 AM" src="https://github.com/user-attachments/assets/97164095-a6e6-464c-abac-4c486f4202b0" />


### **After**

<!-- [screenshots/recordings] -->
<img width="1641" height="574" alt="Screenshot 2026-06-16 at 11 22 41 AM" src="https://github.com/user-attachments/assets/d8d54a76-160d-443b-aef0-1ca7024ecdf7" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
