### PR TITLE
chore: make minor fixes to price alerts

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -404,8 +404,8 @@ describe('CreatePriceAlertView — tiny price token', () => {
       getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
     );
 
-    // 0.00000000000001 * 1.05 = 1.05e-14 → must render as plain decimal
-    expect(getByText('$0.0000000000000105')).toBeOnTheScreen();
+    // 0.00000000000001 * 1.05 = 1.05e-14 → capped at 15 decimal places → rounded to "0.000000000000011"
+    expect(getByText('$0.000000000000011')).toBeOnTheScreen();
   });
 
   it('quick-percentage pill produces a non-zero value and reveals the Set button', () => {
@@ -448,5 +448,28 @@ describe('CreatePriceAlertView — tiny price token', () => {
     expect(
       getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
     ).toBeOnTheScreen();
+  });
+
+  it('enforces the 15-decimal cap — typing a 16th decimal digit is blocked', () => {
+    // currentPrice ~1e-10 → dynamic decimal calc would exceed 15 without the cap
+    setRoute({
+      symbol: 'SHIB',
+      ticker: 'SHIB',
+      currentPrice: 0.0000000001,
+      currentCurrency: 'USD',
+      assetId: 'eip155:1/erc20:0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE',
+    });
+
+    const { getByTestId, getByText } = render(<CreatePriceAlertView />);
+
+    // Enter "0." then 15 digits
+    fireEvent.press(getByTestId('keypad-key-dot'));
+    for (let i = 0; i < 15; i++) {
+      fireEvent.press(getByTestId('keypad-key-1'));
+    }
+    // The 16th digit must be blocked
+    fireEvent.press(getByTestId('keypad-key-2'));
+
+    expect(getByText('$0.111111111111111')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -58,6 +58,7 @@ import { trimTrailingZeros } from '../../../../Bridge/utils/trimTrailingZeros';
 
 const KEYPAD_EMPTY = '0';
 const MIN_KEYPAD_DECIMALS = 2;
+const MAX_KEYPAD_DECIMALS = 15;
 /** Fractional offset that yields 6 significant figures via toFixed. */
 const SIG_FIGS_FRACTIONAL_OFFSET = 5;
 
@@ -65,6 +66,7 @@ const SIG_FIGS_FRACTIONAL_OFFSET = 5;
  * Max fractional digits the keypad should allow for a given USD price.
  * Mirrors the precision used by {@link toKeypadString} so manual entry and
  * quick-percentage pills stay consistent (e.g. sub-cent SHIB prices).
+ * Capped at {@link MAX_KEYPAD_DECIMALS} to prevent excessively long inputs.
  */
 const getKeypadDecimalPlaces = (price: number): number => {
   if (!Number.isFinite(price) || price <= 0) {
@@ -72,9 +74,11 @@ const getKeypadDecimalPlaces = (price: number): number => {
   }
 
   const exponent = Math.floor(Math.log10(price));
-  return exponent >= 0
-    ? Math.max(MIN_KEYPAD_DECIMALS, SIG_FIGS_FRACTIONAL_OFFSET - exponent)
-    : Math.abs(exponent) + SIG_FIGS_FRACTIONAL_OFFSET;
+  const places =
+    exponent >= 0
+      ? Math.max(MIN_KEYPAD_DECIMALS, SIG_FIGS_FRACTIONAL_OFFSET - exponent)
+      : Math.abs(exponent) + SIG_FIGS_FRACTIONAL_OFFSET;
+  return Math.min(places, MAX_KEYPAD_DECIMALS);
 };
 
 /**
@@ -104,7 +108,7 @@ const viewStyles = StyleSheet.create({
 
 const CreatePriceAlertView: React.FC = () => {
   const tw = useTailwind();
-  const { colors } = useTheme();
+  const { colors, brandColors } = useTheme();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<StackNavigationProp<any>>();
   const route =
@@ -386,7 +390,7 @@ const CreatePriceAlertView: React.FC = () => {
                     true: colors.primary.default,
                     false: colors.border.muted,
                   }}
-                  thumbColor={colors.background.default}
+                  thumbColor={brandColors.white}
                   ios_backgroundColor={colors.border.muted}
                   testID={CreatePriceAlertTestIds.RECURRING_TOGGLE}
                 />
@@ -427,10 +431,13 @@ const CreatePriceAlertView: React.FC = () => {
                 </Box>
               )}
 
+              {/* "price_alert" is intentionally not in the Keypad CURRENCIES map —
+                  unknown codes fall through to the decimals-aware branch in useCurrency,
+                  which is the only path that actually enforces the decimals cap. */}
               <KeypadComponent
                 value={targetAmount}
                 onChange={handleKeypadChange}
-                currency="native"
+                currency="price_alert"
                 decimals={keypadDecimals}
               />
             </View>

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
@@ -283,7 +283,40 @@ describe('ManagePriceAlertsView', () => {
       );
     });
 
-    it('removes the row optimistically when delete is pressed', async () => {
+    it('shows a spinner in place of the delete button while the request is in-flight', async () => {
+      let resolveDelete!: (value: unknown) => void;
+      mockDeleteAlert.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveDelete = r;
+        }),
+      );
+
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      );
+
+      expect(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_SPINNER_PREFIX}-alert-1`,
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      ).toBeNull();
+
+      await act(async () => {
+        resolveDelete(makeOkResponse(204));
+      });
+    });
+
+    it('removes the row after a successful delete', async () => {
       const screen = renderView();
       await waitForLoaded(screen);
 
@@ -369,7 +402,7 @@ describe('ManagePriceAlertsView', () => {
       expect(mockReplace).not.toHaveBeenCalled();
     });
 
-    it('restores the row when deleteAlert returns a non-ok response', async () => {
+    it('restores the row and delete button when deleteAlert returns a non-ok response', async () => {
       mockDeleteAlert.mockResolvedValueOnce(makeErrorResponse(500));
       mockFetchAlerts
         .mockResolvedValueOnce(
@@ -401,6 +434,46 @@ describe('ManagePriceAlertsView', () => {
           ),
         ).toBeOnTheScreen();
       });
+
+      // Spinner should be gone and delete button restored after failure
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+          ),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('ignores a second press on the delete button while the first request is in-flight', async () => {
+      let resolveDelete!: (value: unknown) => void;
+      mockDeleteAlert.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveDelete = r;
+        }),
+      );
+
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      );
+
+      // Button is replaced by spinner — a second press is impossible
+      expect(
+        screen.queryByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      ).toBeNull();
+
+      expect(mockDeleteAlert).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveDelete(makeOkResponse(204));
+      });
     });
   });
 
@@ -427,6 +500,66 @@ describe('ManagePriceAlertsView', () => {
         expect(mockUpdateAlert).toHaveBeenCalledWith('alert-1', {
           active: false,
         });
+      });
+    });
+
+    it('disables the switch while the update request is in-flight', async () => {
+      let resolveUpdate!: (value: unknown) => void;
+      mockUpdateAlert.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveUpdate = r;
+        }),
+      );
+
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+        ),
+        'valueChange',
+        false,
+      );
+
+      expect(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+        ),
+      ).toHaveProp('disabled', true);
+
+      await act(async () => {
+        resolveUpdate(makeOkResponse(200));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+          ),
+        ).toHaveProp('disabled', false);
+      });
+    });
+
+    it('re-enables the switch after a failed update', async () => {
+      mockUpdateAlert.mockResolvedValueOnce(makeErrorResponse(500));
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+        ),
+        'valueChange',
+        false,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(
+            `${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-alert-1`,
+          ),
+        ).toHaveProp('disabled', false);
       });
     });
 

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
@@ -1,6 +1,18 @@
-import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ActivityIndicator, FlatList, Switch, View } from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Switch,
+  View,
+} from 'react-native';
 import {
   useNavigation,
   useRoute,
@@ -41,9 +53,13 @@ import { fetchAlerts, deleteAlert, updateAlert } from '../../api';
 
 const priceAlertsQueryKey = (assetId: string) => ['priceAlerts', assetId];
 
+const styles = StyleSheet.create({
+  switchDisabled: { opacity: 0.5 },
+});
+
 const ManagePriceAlertsView: React.FC = () => {
   const tw = useTailwind();
-  const { colors } = useTheme();
+  const { colors, brandColors } = useTheme();
   const queryClient = useQueryClient();
   const { toastRef } = useContext(ToastContext);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,6 +75,14 @@ const ManagePriceAlertsView: React.FC = () => {
     route.params;
 
   const hasResolvedInitialFetch = useRef(false);
+  const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const [togglingIds, setTogglingIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const inFlightDeletes = useRef(new Set<string>());
+  const inFlightToggles = useRef(new Set<string>());
 
   const {
     data: alerts = [],
@@ -128,15 +152,19 @@ const ManagePriceAlertsView: React.FC = () => {
 
   const handleDeleteAlert = useCallback(
     async (id: string) => {
+      if (inFlightDeletes.current.has(id)) return;
+      inFlightDeletes.current.add(id);
+      setDeletingIds((prev) => new Set(prev).add(id));
+
       const queryKey = priceAlertsQueryKey(assetId);
       const previous = queryClient.getQueryData<PriceAlert[]>(queryKey) ?? [];
-      const next = previous.filter((a) => a.id !== id);
-      const isEmpty = next.length === 0;
-      queryClient.setQueryData(queryKey, next);
 
       try {
         const response = await deleteAlert(id);
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+        const next = previous.filter((a) => a.id !== id);
+        queryClient.setQueryData(queryKey, next);
         toastRef?.current?.showToast({
           variant: ToastVariants.Icon,
           iconName: IconName.Trash,
@@ -144,7 +172,7 @@ const ManagePriceAlertsView: React.FC = () => {
           labelOptions: [{ label: strings('price_alerts.delete_success') }],
           hasNoTimeout: false,
         });
-        if (isEmpty) {
+        if (next.length === 0) {
           navigation.goBack();
         }
       } catch {
@@ -155,6 +183,13 @@ const ManagePriceAlertsView: React.FC = () => {
         } else {
           queryClient.setQueryData(queryKey, previous);
         }
+      } finally {
+        inFlightDeletes.current.delete(id);
+        setDeletingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
       }
     },
     [navigation, assetId, queryClient, toastRef, colors],
@@ -162,6 +197,10 @@ const ManagePriceAlertsView: React.FC = () => {
 
   const handleToggleAlert = useCallback(
     async (id: string, newValue: boolean) => {
+      if (inFlightToggles.current.has(id)) return;
+      inFlightToggles.current.add(id);
+      setTogglingIds((prev) => new Set(prev).add(id));
+
       const queryKey = priceAlertsQueryKey(assetId);
       const previous = queryClient.getQueryData<PriceAlert[]>(queryKey) ?? [];
       queryClient.setQueryData(
@@ -177,58 +216,83 @@ const ManagePriceAlertsView: React.FC = () => {
           queryKey,
           previous.map((a) => (a.id === id ? { ...a, active: !newValue } : a)),
         );
+      } finally {
+        inFlightToggles.current.delete(id);
+        setTogglingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
       }
     },
     [assetId, queryClient],
   );
 
-  const renderItem = ({ item }: { item: PriceAlert }) => (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      justifyContent={BoxJustifyContent.Between}
-      twClassName="px-4 py-3 border-b border-muted"
-      testID={`${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${item.id}`}
-    >
-      <Box twClassName="flex-1 mr-3">
-        <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
-          {strings('price_alerts.reaches_threshold', {
-            threshold: formatPriceWithSubscriptNotation(
-              item.threshold,
-              currentCurrency,
-            ),
-          })}
-        </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {item.recurring
-            ? strings('price_alerts.recurring')
-            : strings('price_alerts.once_label')}
-        </Text>
+  const renderItem = ({ item }: { item: PriceAlert }) => {
+    const isDeleting = deletingIds.has(item.id);
+    const isToggling = togglingIds.has(item.id);
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="px-4 py-3 border-b border-muted"
+        testID={`${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${item.id}`}
+      >
+        <Box twClassName="flex-1 mr-3">
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+            {strings('price_alerts.reaches_threshold', {
+              threshold: formatPriceWithSubscriptNotation(
+                item.threshold,
+                currentCurrency,
+              ),
+            })}
+          </Text>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {item.recurring
+              ? strings('price_alerts.recurring')
+              : strings('price_alerts.once_label')}
+          </Text>
+        </Box>
+
+        {isDeleting ? (
+          <ActivityIndicator
+            size="small"
+            color={colors.primary.default}
+            testID={`${ManagePriceAlertsTestIds.ALERT_DELETE_SPINNER_PREFIX}-${item.id}`}
+            style={tw.style('self-center')}
+          />
+        ) : (
+          <ButtonIcon
+            onPress={() => handleDeleteAlert(item.id)}
+            size={ButtonIconSize.Md}
+            iconName={IconName.Trash}
+            testID={`${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-${item.id}`}
+            accessibilityLabel="Delete alert"
+            style={tw.style('self-center')}
+          />
+        )}
+
+        <Switch
+          value={item.active}
+          onValueChange={(v) => handleToggleAlert(item.id, v)}
+          disabled={isToggling}
+          trackColor={{
+            true: colors.primary.default,
+            false: colors.border.muted,
+          }}
+          thumbColor={brandColors.white}
+          ios_backgroundColor={colors.border.muted}
+          testID={`${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-${item.id}`}
+          style={[
+            tw.style('ml-3 self-center'),
+            isToggling && styles.switchDisabled,
+          ]}
+        />
       </Box>
-
-      <ButtonIcon
-        onPress={() => handleDeleteAlert(item.id)}
-        size={ButtonIconSize.Md}
-        iconName={IconName.Trash}
-        testID={`${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-${item.id}`}
-        accessibilityLabel="Delete alert"
-        style={tw.style('self-center')}
-      />
-
-      <Switch
-        value={item.active}
-        onValueChange={(v) => handleToggleAlert(item.id, v)}
-        trackColor={{
-          true: colors.primary.default,
-          false: colors.border.muted,
-        }}
-        thumbColor={colors.background.default}
-        ios_backgroundColor={colors.border.muted}
-        testID={`${ManagePriceAlertsTestIds.ALERT_TOGGLE_PREFIX}-${item.id}`}
-        style={tw.style('ml-3 self-center')}
-      />
-    </Box>
-  );
+    );
+  };
 
   return (
     <SafeAreaView

--- a/app/components/UI/Assets/PriceAlerts/constants.ts
+++ b/app/components/UI/Assets/PriceAlerts/constants.ts
@@ -78,6 +78,7 @@ export const ManagePriceAlertsTestIds = {
   ALERT_ITEM_PREFIX: 'manage-price-alerts-item',
   ALERT_TOGGLE_PREFIX: 'manage-price-alerts-toggle',
   ALERT_DELETE_PREFIX: 'manage-price-alerts-delete',
+  ALERT_DELETE_SPINNER_PREFIX: 'manage-price-alerts-delete-spinner',
   ADD_ALERT_BUTTON: 'manage-price-alerts-add-button',
   EMPTY_STATE: 'manage-price-alerts-empty',
 } as const;


### PR DESCRIPTION


## **Description**

Fixes three bugs in the price alerts UI:

- **Decimal cap**: keypad now blocks input past 15 decimal places. The limit is dynamic based on token price but hard-capped at 15. Required passing `currency="price_alert"` (an unknown code) to the keypad so the `decimals` prop is actually honoured — `"native"` was silently ignoring it.
- **Toggle thumb colour**: both toggles were using `colors.background.default` as the thumb, which is near-black on Android dark mode. Fixed to `brandColors.white` to match the rest of the app.
- **In-flight feedback on manage screen**: delete button swaps to a spinner while the request is pending; active/inactive toggle is disabled and dimmed at 50% opacity. Prevents double-taps when the API is slow.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: make minor fixes to price alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3382

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
