### PR TITLE
fix(ci): skip setup-node yarn cache when ci-js-deps artifact is used

### DIFF
--- a/.github/actions/setup-ci-js-deps/action.yml
+++ b/.github/actions/setup-ci-js-deps/action.yml
@@ -25,14 +25,10 @@ runs:
           node_modules
           .yarn/cache
 
-    - uses: actions/setup-node@v6
-      with:
-        node-version-file: '.nvmrc'
-        cache: ${{ inputs.runner_provider != 'namespace' && 'yarn' || '' }}
-
-    # Namespace: always run install so the shared volume stays in sync with yarn.lock.
-    # Non-Namespace: skip install when node_modules was extracted from a same-run
-    # artifact; run install when starting from a clean workspace.
+    # Run before setup-node so yarn cache is only enabled when this job installs deps.
+    # When node_modules comes from the ci-js-deps artifact, skipping cache avoids a
+    # post-job "Path Validation Error" from actions/setup-node trying to save a
+    # cache path that was never populated.
     - name: Determine if install is needed
       id: check-deps
       shell: bash
@@ -45,6 +41,14 @@ runs:
           echo "needs-install=true" >> "$GITHUB_OUTPUT"
         fi
 
+    - uses: actions/setup-node@v6
+      with:
+        node-version-file: '.nvmrc'
+        cache: ${{ inputs.runner_provider != 'namespace' && steps.check-deps.outputs.needs-install == 'true' && 'yarn' || '' }}
+
+    # Namespace: always run install so the shared volume stays in sync with yarn.lock.
+    # Non-Namespace: skip install when node_modules was extracted from a same-run
+    # artifact; run install when starting from a clean workspace.
     - name: Install Yarn dependencies with retry
       if: ${{ steps.check-deps.outputs.needs-install == 'true' }}
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2


### PR DESCRIPTION
## **Description**

Fixes false-red **Unit tests** and **Component view tests** CI jobs on non-Namespace runners when `node_modules` is restored from the `prepare-ci-js-deps` artifact.

**Reason for the change:** Shard jobs download and extract `ci-js-deps`, skip `yarn install`, but `setup-ci-js-deps` still configured `actions/setup-node` with `cache: yarn`. On post-job cleanup, `setup-node` attempts to save a yarn cache path that was never populated, failing the job even when all tests passed.

**Observed failure** (example from [ci run 27626966241](https://github.com/MetaMask/metamask-mobile/actions/runs/27626966241), `Unit tests (1)`):

```
Test Suites: 380 passed, 380 total
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

**Solution:**
- Run **Determine if install is needed** before `setup-node`
- Enable `cache: yarn` only when `needs-install=true` (and not on Namespace runners)

Changed file: `.github/actions/setup-ci-js-deps/action.yml`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/31818 (flaky E2E PR validation surfaced the failure pattern)

## **Manual testing steps**

```gherkin
Feature: CI setup-node yarn cache guard

  Scenario: Shard job reuses ci-js-deps artifact without false cache failure
    Given a unit-test or component-view shard job on a non-Namespace runner
    And node_modules is extracted from the ci-js-deps artifact
    When setup-ci-js-deps runs with needs-install=false
    Then setup-node does not enable yarn cache
    And the job post-step does not fail with a Path Validation Error

  Scenario: prepare-ci-js-deps still caches yarn on full install
    Given prepare-ci-js-deps runs a full yarn install
    When needs-install=true
    Then setup-node yarn cache remains enabled
```

Validation: merge and confirm unit/component-view shards complete without post-step cache errors on CI.

## **Screenshots/Recordings**

### **Before**

N/A — CI log excerpt above shows tests passing while the job fails on cache post-step.

### **After**

N/A — to be confirmed by green unit/component-view shards on this PR's CI run.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.