### PR TITLE
chore: hide Sell pill when nothing to sell and improve CTA quote loading state

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.test.tsx
@@ -21,9 +21,11 @@ describe('QuickBuyConfirmButton', () => {
     expect(screen.getByText('Confirm')).toBeOnTheScreen();
   });
 
-  it('does not render the label in loading state', () => {
+  it('marks the button as busy in loading state', () => {
     render(<QuickBuyConfirmButton {...defaultProps} state="loading" />);
-    expect(screen.queryByText('Confirm')).not.toBeOnTheScreen();
+    expect(
+      screen.getByTestId('confirm-button').props.accessibilityState,
+    ).toEqual(expect.objectContaining({ busy: true, disabled: true }));
   });
 
   it('does not render the label in success state', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyConfirmButton.tsx
@@ -1,17 +1,17 @@
 import React, { useEffect } from 'react';
-import {
-  ActivityIndicator,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, {
   useSharedValue,
   withTiming,
   useAnimatedStyle,
 } from 'react-native-reanimated';
+import {
+  Box,
+  Button,
+  ButtonBaseSize,
+  ButtonVariant,
+} from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { useTheme } from '../../../../../../util/theme';
 import Icon, {
   IconName,
   IconSize,
@@ -20,20 +20,13 @@ import Icon, {
 export type ConfirmButtonState = 'idle' | 'loading' | 'success';
 
 const styles = StyleSheet.create({
-  container: {
+  successContainer: {
     height: 48,
     width: '100%',
     borderRadius: 12,
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'hidden',
-  },
-  inactive: {
-    opacity: 0.5,
-  },
-  label: {
-    fontSize: 16,
-    fontWeight: '500',
   },
 });
 
@@ -49,13 +42,11 @@ interface QuickBuyConfirmButtonProps {
 const QuickBuyConfirmButton: React.FC<QuickBuyConfirmButtonProps> = ({
   state,
   label,
-  hasValidAmount,
   isDisabled,
   onPress,
   testID,
 }) => {
   const tw = useTailwind();
-  const { colors } = useTheme();
   const checkScale = useSharedValue(0);
 
   useEffect(() => {
@@ -67,46 +58,35 @@ const QuickBuyConfirmButton: React.FC<QuickBuyConfirmButtonProps> = ({
     transform: [{ scale: checkScale.value }],
   }));
 
-  // Use design-system ButtonPrimary token equivalents:
-  const activeContainerStyle = tw.style('bg-icon-default');
-  const activeLabelStyle = tw.style('text-primary-inverse');
-
-  const labelColor = hasValidAmount
-    ? (activeLabelStyle.color as string)
-    : colors.text.alternative;
-
-  const showInactiveStyle = isDisabled && state === 'idle';
-
-  return (
-    <TouchableOpacity
-      style={[
-        styles.container,
-        hasValidAmount
-          ? activeContainerStyle
-          : { backgroundColor: colors.background.muted },
-        showInactiveStyle && styles.inactive,
-      ]}
-      onPress={onPress}
-      disabled={state !== 'idle' || isDisabled}
-      testID={testID}
-      activeOpacity={0.8}
-    >
-      {state === 'loading' && (
-        <ActivityIndicator size="small" color={labelColor} />
-      )}
-      {state === 'success' && (
+  if (state === 'success') {
+    return (
+      <Box
+        style={[styles.successContainer, tw.style('bg-icon-default')]}
+        testID={testID}
+      >
         <Animated.View style={checkmarkStyle}>
           <Icon
             name={IconName.CheckBold}
             size={IconSize.Lg}
-            color={labelColor}
+            color={tw.style('text-primary-inverse').color as string}
           />
         </Animated.View>
-      )}
-      {state === 'idle' && (
-        <Text style={[styles.label, { color: labelColor }]}>{label}</Text>
-      )}
-    </TouchableOpacity>
+      </Box>
+    );
+  }
+
+  return (
+    <Button
+      variant={ButtonVariant.Primary}
+      size={ButtonBaseSize.Lg}
+      isLoading={state === 'loading'}
+      onPress={onPress}
+      isFullWidth
+      testID={testID}
+      isDisabled={state !== 'idle' || isDisabled}
+    >
+      {label}
+    </Button>
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import QuickBuyActionFooter from './QuickBuyActionFooter';
+import { useQuickBuyContext } from '../useQuickBuyContext';
+
+jest.mock('../useQuickBuyContext', () => ({
+  useQuickBuyContext: jest.fn(),
+}));
+
+jest.mock('../../../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('./QuickBuyPercentageSlider', () => ({
+  QuickBuyPercentageSlider: () => null,
+}));
+
+jest.mock('./QuickBuyTokenIcon', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../QuickBuyBanners', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../QuickBuyConfirmButton', () => {
+  const ReactMock = jest.requireActual('react');
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ testID, state }: { testID?: string; state: string }) =>
+      ReactMock.createElement(Text, { testID }, `confirm-button:${state}`),
+  };
+});
+
+const baseContext = {
+  sliderPercent: 0,
+  isSliderDisabled: false,
+  handleSliderChange: jest.fn(),
+  handleSliderDragEnd: jest.fn(),
+  confirmButtonState: 'idle' as const,
+  getButtonLabel: () => 'Buy',
+  hasValidAmount: false,
+  isConfirmDisabled: true,
+  handleBuy: jest.fn(),
+  metamaskFeePercent: 0,
+  isHardwareSolanaBlocked: false,
+  tradeMode: 'buy' as const,
+  sourceToken: undefined,
+  sourceBalanceFiat: undefined,
+  destBalanceFiat: undefined,
+  destToken: undefined,
+  selectedDestStable: undefined,
+  features: { payWithSheet: true },
+  setActiveScreen: jest.fn(),
+};
+
+describe('QuickBuyActionFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useQuickBuyContext as jest.Mock).mockReturnValue(baseContext);
+  });
+
+  it('renders the confirm button in idle state when not loading', () => {
+    render(<QuickBuyActionFooter />);
+    expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
+    expect(screen.getByText('confirm-button:idle')).toBeOnTheScreen();
+  });
+
+  it('renders the confirm button in loading state while quotes are fetched', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      confirmButtonState: 'loading',
+      isConfirmDisabled: true,
+    });
+    render(<QuickBuyActionFooter />);
+    expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
+    expect(screen.getByText('confirm-button:loading')).toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.test.tsx
@@ -70,11 +70,14 @@ describe('QuickBuyAmountSection', () => {
     expect(screen.getByText('123.45 ETH')).toBeOnTheScreen();
   });
 
-  it('replaces the secondary label with an ActivityIndicator when isQuoteLoading', () => {
+  it('replaces the secondary label with a spinner when isQuoteLoading', () => {
     render(
       <QuickBuyAmountSection {...defaultProps} isQuoteLoading usdAmount="20" />,
     );
     expect(screen.getByTestId('quick-buy-amount-area')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('quick-buy-amount-loading-spinner'),
+    ).toBeOnTheScreen();
     // Secondary label is replaced by spinner — crypto label should NOT be present
     expect(screen.queryByText('0 ETH')).not.toBeOnTheScreen();
   });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, TextInput, ActivityIndicator } from 'react-native';
+import { StyleSheet, TextInput } from 'react-native';
 import {
   Box,
   Text,
@@ -8,6 +8,9 @@ import {
   FontWeight,
   BoxAlignItems,
   BoxJustifyContent,
+  IconColor,
+  IconSize,
+  Spinner,
 } from '@metamask/design-system-react-native';
 import type { QuickBuyAmountDisplayMode } from '../types';
 import { formatTokenAmount } from '../../../../utils/formatters';
@@ -91,7 +94,11 @@ const QuickBuyAmountSection: React.FC<QuickBuyAmountSectionProps> = ({
       </Text>
 
       {isQuoteLoading ? (
-        <ActivityIndicator size="small" />
+        <Spinner
+          color={IconColor.IconDefault}
+          spinnerIconProps={{ size: IconSize.Sm }}
+          testID="quick-buy-amount-loading-spinner"
+        />
       ) : (
         <Text
           variant={TextVariant.BodyMd}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
@@ -33,13 +33,17 @@ describe('QuickBuyToolbar', () => {
     });
   });
 
-  it('renders the static buy mode pill when only buy mode is enabled', () => {
+  it('renders buy-only toggle styling when only buy mode is enabled', () => {
     render(<QuickBuyToolbar />);
+    expect(screen.getByTestId('quick-buy-trade-mode-toggle')).toBeOnTheScreen();
     expect(
-      screen.getByText('social_leaderboard.quick_buy.buy_mode'),
+      screen.getByText('social_leaderboard.quick_buy.buy_label'),
     ).toBeOnTheScreen();
     expect(
-      screen.queryByTestId('quick-buy-trade-mode-toggle'),
+      screen.queryByTestId('quick-buy-trade-mode-sell'),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.queryByText('social_leaderboard.quick_buy.buy_mode'),
     ).not.toBeOnTheScreen();
   });
 
@@ -57,7 +61,7 @@ describe('QuickBuyToolbar', () => {
     ).not.toBeOnTheScreen();
   });
 
-  it('renders the static buy mode pill when sell is enabled but there is no sellable balance', () => {
+  it('renders buy-only toggle when sell is enabled but there is no sellable balance', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       ...baseContext,
       setActiveScreen,
@@ -65,11 +69,12 @@ describe('QuickBuyToolbar', () => {
       hasSellableBalance: false,
     });
     render(<QuickBuyToolbar />);
+    expect(screen.getByTestId('quick-buy-trade-mode-toggle')).toBeOnTheScreen();
     expect(
-      screen.getByText('social_leaderboard.quick_buy.buy_mode'),
+      screen.getByText('social_leaderboard.quick_buy.buy_label'),
     ).toBeOnTheScreen();
     expect(
-      screen.queryByTestId('quick-buy-trade-mode-toggle'),
+      screen.queryByTestId('quick-buy-trade-mode-sell'),
     ).not.toBeOnTheScreen();
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
@@ -48,11 +48,28 @@ describe('QuickBuyToolbar', () => {
       ...baseContext,
       setActiveScreen,
       features: { tradeModes: ['buy', 'sell'] },
+      hasSellableBalance: true,
     });
     render(<QuickBuyToolbar />);
     expect(screen.getByTestId('quick-buy-trade-mode-toggle')).toBeOnTheScreen();
     expect(
       screen.queryByText('social_leaderboard.quick_buy.buy_mode'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('renders the static buy mode pill when sell is enabled but there is no sellable balance', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      setActiveScreen,
+      features: { tradeModes: ['buy', 'sell'] },
+      hasSellableBalance: false,
+    });
+    render(<QuickBuyToolbar />);
+    expect(
+      screen.getByText('social_leaderboard.quick_buy.buy_mode'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId('quick-buy-trade-mode-toggle'),
     ).not.toBeOnTheScreen();
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.tsx
@@ -20,12 +20,13 @@ const QuickBuyToolbar: React.FC = () => {
     setActiveScreen,
     features,
     isPriceImpactError,
+    hasSellableBalance,
   } = useQuickBuyContext();
 
   // Prefer the quote-derived rate (available once a quote is fetched),
   // fall back to the price-metadata rate for the pre-quote state.
   const rateLabel = formattedRate ?? formattedExchangeRate;
-  const showToggle = features.tradeModes.length > 1;
+  const showToggle = features.tradeModes.length > 1 && hasSellableBalance;
 
   return (
     <Box

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.tsx
@@ -4,11 +4,7 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
-  Text,
-  TextColor,
-  TextVariant,
 } from '@metamask/design-system-react-native';
-import { strings } from '../../../../../../../../locales/i18n';
 import QuickBuyRateTag from './QuickBuyRateTag';
 import QuickBuyTradeModeToggle from './QuickBuyTradeModeToggle';
 import { useQuickBuyContext } from '../useQuickBuyContext';
@@ -26,7 +22,7 @@ const QuickBuyToolbar: React.FC = () => {
   // Prefer the quote-derived rate (available once a quote is fetched),
   // fall back to the price-metadata rate for the pre-quote state.
   const rateLabel = formattedRate ?? formattedExchangeRate;
-  const showToggle = features.tradeModes.length > 1 && hasSellableBalance;
+  const showFullToggle = features.tradeModes.length > 1 && hasSellableBalance;
 
   return (
     <Box
@@ -35,18 +31,7 @@ const QuickBuyToolbar: React.FC = () => {
       alignItems={BoxAlignItems.Center}
       justifyContent={BoxJustifyContent.Between}
     >
-      {showToggle ? (
-        <QuickBuyTradeModeToggle />
-      ) : (
-        <Box
-          twClassName="rounded-full bg-muted px-3 py-1"
-          flexDirection={BoxFlexDirection.Row}
-        >
-          <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
-            {strings('social_leaderboard.quick_buy.buy_mode')}
-          </Text>
-        </Box>
-      )}
+      <QuickBuyTradeModeToggle buyOnly={!showFullToggle} />
 
       <QuickBuyRateTag
         label={rateLabel}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.test.tsx
@@ -74,4 +74,23 @@ describe('QuickBuyTradeModeToggle', () => {
     renderToggle('buy');
     expect(screen.getByTestId('quick-buy-trade-mode-toggle')).toBeOnTheScreen();
   });
+
+  it('renders only Buy with selected styling in buy-only mode', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      tradeMode: 'buy',
+      setTradeMode,
+      hasSellableBalance: false,
+    });
+    render(<QuickBuyTradeModeToggle buyOnly />);
+    expect(screen.getByTestId('quick-buy-trade-mode-toggle')).toBeOnTheScreen();
+    expect(
+      screen.getByText('social_leaderboard.quick_buy.buy_label'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId('quick-buy-trade-mode-sell'),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.queryByTestId('quick-buy-trade-mode-buy'),
+    ).not.toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyTradeModeToggle.tsx
@@ -38,10 +38,12 @@ const styles = StyleSheet.create({
 
 interface QuickBuyTradeModeToggleProps {
   testID?: string;
+  buyOnly?: boolean;
 }
 
 const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
   testID = 'quick-buy-trade-mode-toggle',
+  buyOnly = false,
 }) => {
   const { tradeMode, setTradeMode, hasSellableBalance } = useQuickBuyContext();
   const { colors } = useTheme();
@@ -57,7 +59,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
   };
 
   useEffect(() => {
-    if (!buyLayout) return;
+    if (buyOnly || !buyLayout) return;
     Animated.spring(slideAnim, {
       toValue: tradeMode === 'buy' ? 0 : buyLayout.width,
       // Color interpolation (backgroundColor below) is not supported by the
@@ -66,7 +68,7 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
       tension: 180,
       friction: 20,
     }).start();
-  }, [tradeMode, buyLayout, slideAnim]);
+  }, [tradeMode, buyLayout, slideAnim, buyOnly]);
 
   const sliderWidth = tradeMode === 'buy' ? (buyLayout?.width ?? 0) : sellWidth;
 
@@ -79,6 +81,29 @@ const QuickBuyTradeModeToggle: React.FC<QuickBuyTradeModeToggleProps> = ({
           outputRange: [colors.success.default, colors.error.default],
         })
       : colors.success.default;
+
+  if (buyOnly) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        twClassName="border border-muted rounded-xl p-1"
+        testID={testID}
+      >
+        <Box
+          twClassName="rounded-lg px-4 py-1"
+          style={{ backgroundColor: colors.success.default }}
+        >
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.PrimaryInverse}
+          >
+            {strings('social_leaderboard.quick_buy.buy_label')}
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -401,6 +401,14 @@ export function useQuickBuyController(
   // ─── Sell mode: position token (what the user is selling) ──────────────
   const positionToken = usePositionTokenBalance(target, positionTokenFromSetup);
 
+  // If the position balance drops to zero while sell mode is active, fall back
+  // to buy so the user is not stranded in a mode they can no longer use.
+  useEffect(() => {
+    if (positionToken === undefined && tradeMode === 'sell') {
+      setTradeMode('buy');
+    }
+  }, [positionToken, tradeMode]);
+
   // ─── Sell "Receive" options (stablecoins) ──────────────────────────────
   const receiveTokenOptions = useReceiveTokens(
     destChainId as string | undefined,
@@ -1417,7 +1425,7 @@ export function useQuickBuyController(
   }
 
   let confirmButtonState: 'idle' | 'loading' | 'success' = 'idle';
-  if (isConfirmLoading) {
+  if (isConfirmLoading || isBlockingQuoteLoad) {
     confirmButtonState = 'loading';
   }
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -1023,6 +1023,7 @@ describe('useQuickBuyController', () => {
 
       expect(result.current.isBlockingQuoteLoad).toBe(true);
       expect(result.current.isConfirmDisabled).toBe(true);
+      expect(result.current.confirmButtonState).toBe('loading');
 
       // A single render with the matching quote both clears the loader and
       // enables the CTA — no extra render needed (regression: the button used to
@@ -1757,6 +1758,54 @@ describe('useQuickBuyController', () => {
         // Assert — degrade to the snapshot's fiat rather than blanking out.
         expect(result.current.destBalanceFiat).toBe('$100.00');
       });
+    });
+  });
+
+  describe('sell mode availability', () => {
+    const createPositionToken = () =>
+      createSourceToken({
+        address: '0xDEST',
+        chainId: '0x1',
+        symbol: 'TARGET',
+      });
+
+    it('resets tradeMode to buy when the position token balance becomes zero', () => {
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(
+        createPositionToken(),
+      );
+      const { result, rerender } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.setTradeMode('sell');
+      });
+      expect(result.current.tradeMode).toBe('sell');
+
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
+      rerender(undefined);
+
+      expect(result.current.tradeMode).toBe('buy');
+    });
+
+    it('exposes hasSellableBalance false when there is no position token', () => {
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.hasSellableBalance).toBe(false);
+    });
+
+    it('exposes hasSellableBalance true when a position token exists', () => {
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(
+        createPositionToken(),
+      );
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      expect(result.current.hasSellableBalance).toBe(true);
     });
   });
 


### PR DESCRIPTION
…ide when there's nothing to sell

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Improves QuickBuy Buy/Sell pill and buttons CTA loading state.

- Hides the Sell toggle when the user has no sellable balance; shows the static Buy pill instead
- Resets to buy mode if the position balance drops to zero while in sell mode
- Uses the Design System Button loading state for the confirm CTA (same as Swaps) instead of a disabled button 
- Uses the Design System Spinner below the amount while quotes load

<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-16 at 16 57 09" src="https://github.com/user-attachments/assets/cce7d3fa-b6ce-4b81-a7a0-c62f32cdd90a" />
<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-16 at 17 16 28" src="https://github.com/user-attachments/assets/3c45c795-1466-4bce-ba7d-bc6d29474367" />

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
https://consensyssoftware.atlassian.net/browse/TSA-717
https://consensyssoftware.atlassian.net/browse/TSA-718

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
