### PR TITLE
fix(ci): baseline JS bundle size check on merge-base, not stale base SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,6 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
-          # Need the merge commit's first parent (main at merge target) for the bundle baseline.
           fetch-depth: 2
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -361,10 +360,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Baseline is the latest successful ci/ios-js-bundle-size status on the PR merge
-          # target: the first parent of refs/pull/N/merge (current tip of the base branch,
-          # e.g. main). github.event.pull_request.base.sha can lag behind that tip when the
-          # PR branch has not been rebased, which would charge the PR for main-only growth.
+          # Baseline is the latest successful ci/ios-js-bundle-size status on the merge-base
+          # of the checked-out ref (refs/pull/N/merge) and the PR base branch (e.g. main).
+          # github.event.pull_request.base.sha can lag behind that point when the PR branch
+          # has not been rebased, which would charge the PR for main-only growth.
           append_job_summary() {
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
               cat >> "$GITHUB_STEP_SUMMARY"
@@ -379,35 +378,36 @@ jobs:
           BASE_REF='${{ github.event.pull_request.base.ref }}'
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 
-          if ! MERGE_TARGET_SHA="$(git rev-parse HEAD^1 2>/dev/null)"; then
-            echo "::warning::Could not resolve merge target via HEAD^1; skipping iOS JS bundle delta check."
+          git fetch origin "${BASE_REF}" --depth=1
+          if ! MERGE_BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"; then
+            echo "::warning::Could not resolve merge-base between HEAD and origin/${BASE_REF}; skipping iOS JS bundle delta check."
             append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** skipped — checkout is not a merge commit with a resolvable first parent.
+          **Result:** skipped — \`git merge-base origin/${BASE_REF} HEAD\` failed.
 
           | | MiB |
           |---|--:|
           | Current bundle | ${CURRENT_MB} |
 
-          Baseline would be read from the latest successful \`ci/ios-js-bundle-size\` status on \`${BASE_REF}\` at merge target (first parent of \`refs/pull/N/merge\`).
+          Baseline would be read from the latest successful \`ci/ios-js-bundle-size\` status on the merge-base of HEAD and \`${BASE_REF}\`.
           EOF
             exit 0
           fi
 
-          echo "Merge target (${BASE_REF} at refs/pull/N/merge): ${MERGE_TARGET_SHA}"
+          echo "Merge-base (origin/${BASE_REF}, HEAD): ${MERGE_BASE_SHA}"
           if ! STATUSES_JSON="$(
             curl -fsS \
               -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${MERGE_TARGET_SHA}/status"
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${MERGE_BASE_SHA}/status"
           )"; then
-            echo "::warning::Failed to fetch commit statuses for merge target ${MERGE_TARGET_SHA}; skipping iOS JS bundle delta check."
+            echo "::warning::Failed to fetch commit statuses for merge-base ${MERGE_BASE_SHA}; skipping iOS JS bundle delta check."
             append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** skipped — could not load [combined status](${REPO_URL}/commit/${MERGE_TARGET_SHA}) for merge target \`${MERGE_TARGET_SHA}\` (\`${BASE_REF}\`).
+          **Result:** skipped — could not load [combined status](${REPO_URL}/commit/${MERGE_BASE_SHA}) for merge-base \`${MERGE_BASE_SHA}\` (\`${BASE_REF}\`).
 
           | | MiB |
           |---|--:|
@@ -430,13 +430,13 @@ jobs:
           _bundle_desc_re='^[[:space:]]*([0-9]+(\.[0-9]*)?)[[:space:]]*;?[[:space:]]*$'
           if [[ "$DESC" =~ $_bundle_desc_re ]]; then
             BASELINE_MB="${BASH_REMATCH[1]}"
-            echo "Baseline from merge target status: ${BASELINE_MB} MB"
+            echo "Baseline from merge-base status: ${BASELINE_MB} MB"
           else
-            echo "::warning::No successful ci/ios-js-bundle-size status (or unrecognized description) on merge target ${MERGE_TARGET_SHA}; skipping iOS JS bundle delta check."
+            echo "::warning::No successful ci/ios-js-bundle-size status (or unrecognized description) on merge-base ${MERGE_BASE_SHA}; skipping iOS JS bundle delta check."
             append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** skipped — no parseable \`ci/ios-js-bundle-size\` success status on merge target [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) (\`${BASE_REF}\`).
+          **Result:** skipped — no parseable \`ci/ios-js-bundle-size\` success status on merge-base [\`${MERGE_BASE_SHA}\`](${REPO_URL}/commit/${MERGE_BASE_SHA}) (\`${BASE_REF}\`).
 
           | | MiB |
           |---|--:|
@@ -470,11 +470,11 @@ jobs:
             append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** failed — delta is more than 1 MiB above the status baseline on merge target [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) (\`${BASE_REF}\`).
+          **Result:** failed — delta is more than 1 MiB above the status baseline on merge-base [\`${MERGE_BASE_SHA}\`](${REPO_URL}/commit/${MERGE_BASE_SHA}) (\`${BASE_REF}\`).
 
           | | MiB |
           |---|--:|
-          | Merge target (\`${BASE_REF}\`) | [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) |
+          | Merge-base (\`${BASE_REF}\` × HEAD) | [\`${MERGE_BASE_SHA}\`](${REPO_URL}/commit/${MERGE_BASE_SHA}) |
           | Baseline (from status) | ${BASELINE_MB} |
           | Current bundle | ${CURRENT_MB} |
           | Delta (current - baseline) | ${DELTA_MB} |
@@ -490,12 +490,12 @@ jobs:
 
           | | MiB |
           |---|--:|
-          | Merge target (\`${BASE_REF}\`) | [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) |
+          | Merge-base (\`${BASE_REF}\` × HEAD) | [\`${MERGE_BASE_SHA}\`](${REPO_URL}/commit/${MERGE_BASE_SHA}) |
           | Baseline (from \`ci/ios-js-bundle-size\` status) | ${BASELINE_MB} |
           | Current bundle | ${CURRENT_MB} |
           | Delta (current - baseline) | ${DELTA_MB} |
 
-          Fail threshold: more than 1 MiB above baseline. Baseline is the bundle size posted by CI to the merge target commit (first parent of \`refs/pull/N/merge\`), not \`github.event.pull_request.base.sha\`.
+          Fail threshold: more than 1 MiB above baseline. Baseline is the bundle size posted by CI to \`git merge-base origin/${BASE_REF} HEAD\`, not \`github.event.pull_request.base.sha\`.
 
           EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,10 +360,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Baseline is the latest successful ci/ios-js-bundle-size status on the merge-base
-          # of the checked-out ref (refs/pull/N/merge) and the PR base branch (e.g. main).
-          # github.event.pull_request.base.sha can lag behind that point when the PR branch
-          # has not been rebased, which would charge the PR for main-only growth.
+          # Baseline: ci/ios-js-bundle-size on git merge-base origin/$BASE_REF HEAD (not pull_request.base.sha).
           append_job_summary() {
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
               cat >> "$GITHUB_STEP_SUMMARY"
@@ -495,7 +492,7 @@ jobs:
           | Current bundle | ${CURRENT_MB} |
           | Delta (current - baseline) | ${DELTA_MB} |
 
-          Fail threshold: more than 1 MiB above baseline. Baseline is the bundle size posted by CI to \`git merge-base origin/${BASE_REF} HEAD\`, not \`github.event.pull_request.base.sha\`.
+          Fail threshold: more than 1 MiB above baseline.
 
           EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,21 @@ jobs:
         if: ${{ inputs.runner_provider != 'namespace' }}
         with:
           fetch-depth: 2
+      - name: Pin bundle size baseline SHA
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_REF='${{ github.event.pull_request.base.ref }}'
+          git fetch origin "${BASE_REF}" --depth=1
+          if ! MERGE_BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"; then
+            echo "::warning::Could not resolve merge-base between HEAD and origin/${BASE_REF}; bundle size delta check will be skipped."
+            echo "MERGE_BASE_SHA=" >> "$GITHUB_ENV"
+          else
+            echo "Merge-base pinned (origin/${BASE_REF}, HEAD): ${MERGE_BASE_SHA}"
+            echo "MERGE_BASE_SHA=${MERGE_BASE_SHA}" >> "$GITHUB_ENV"
+          fi
+          echo "BUNDLE_SIZE_BASE_REF=${BASE_REF}" >> "$GITHUB_ENV"
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -360,7 +375,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Baseline: ci/ios-js-bundle-size on git merge-base origin/$BASE_REF HEAD (not pull_request.base.sha).
+          # Baseline: ci/ios-js-bundle-size on merge-base pinned at checkout (before bundle build).
           append_job_summary() {
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
               cat >> "$GITHUB_STEP_SUMMARY"
@@ -372,16 +387,16 @@ jobs:
           echo "Current iOS JS bundle: ${CURRENT_MB} MB"
 
           BASELINE_MB=""
-          BASE_REF='${{ github.event.pull_request.base.ref }}'
+          BASE_REF="${BUNDLE_SIZE_BASE_REF}"
+          MERGE_BASE_SHA="${MERGE_BASE_SHA:-}"
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 
-          git fetch origin "${BASE_REF}" --depth=1
-          if ! MERGE_BASE_SHA="$(git merge-base "origin/${BASE_REF}" HEAD)"; then
-            echo "::warning::Could not resolve merge-base between HEAD and origin/${BASE_REF}; skipping iOS JS bundle delta check."
+          if [[ -z "${MERGE_BASE_SHA}" ]]; then
+            echo "::warning::Merge-base was not pinned at checkout; skipping iOS JS bundle delta check."
             append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** skipped — \`git merge-base origin/${BASE_REF} HEAD\` failed.
+          **Result:** skipped — merge-base was not available from the checkout step.
 
           | | MiB |
           |---|--:|

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,8 +319,13 @@ jobs:
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
+        with:
+          fetch-depth: 2
       - uses: actions/checkout@v6
         if: ${{ inputs.runner_provider != 'namespace' }}
+        with:
+          # Need the merge commit's first parent (main at merge target) for the bundle baseline.
+          fetch-depth: 2
       - name: Configure Namespace cache
         if: ${{ inputs.runner_provider == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
@@ -356,8 +361,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Baseline is the latest successful ci/ios-js-bundle-size status on
-          # github.event.pull_request.base.sha (GitHub's PR base commit for this run), not git merge-base(head, base).
+          # Baseline is the latest successful ci/ios-js-bundle-size status on the PR merge
+          # target: the first parent of refs/pull/N/merge (current tip of the base branch,
+          # e.g. main). github.event.pull_request.base.sha can lag behind that tip when the
+          # PR branch has not been rebased, which would charge the PR for main-only growth.
           append_job_summary() {
             if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
               cat >> "$GITHUB_STEP_SUMMARY"
@@ -369,71 +376,72 @@ jobs:
           echo "Current iOS JS bundle: ${CURRENT_MB} MB"
 
           BASELINE_MB=""
-          BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          BASE_REF='${{ github.event.pull_request.base.ref }}'
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
 
-          if [[ -n "$BASE_SHA" ]]; then
-            echo "Resolving baseline bundle size from ci/ios-js-bundle-size status on base commit ${BASE_SHA}"
-            if ! STATUSES_JSON="$(
-              curl -fsS \
-                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${BASE_SHA}/status"
-            )"; then
-              echo "::warning::Failed to fetch commit statuses for base ${BASE_SHA}; skipping iOS JS bundle delta check."
-              append_job_summary <<EOF
+          if ! MERGE_TARGET_SHA="$(git rev-parse HEAD^1 2>/dev/null)"; then
+            echo "::warning::Could not resolve merge target via HEAD^1; skipping iOS JS bundle delta check."
+            append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** skipped — could not load [combined status](${REPO_URL}/commit/${BASE_SHA}) for PR base \`${BASE_SHA}\`.
+          **Result:** skipped — checkout is not a merge commit with a resolvable first parent.
 
           | | MiB |
           |---|--:|
           | Current bundle | ${CURRENT_MB} |
 
-          Baseline would be read from the latest successful \`ci/ios-js-bundle-size\` status description on that base commit (MiB from awk, then an optional trailing semicolon, matching the main-branch post step).
+          Baseline would be read from the latest successful \`ci/ios-js-bundle-size\` status on \`${BASE_REF}\` at merge target (first parent of \`refs/pull/N/merge\`).
           EOF
-              exit 0
-            fi
-            DESC="$(
-              echo "$STATUSES_JSON" | jq -r '
-                (.statuses // [])
-                | map(select(.context == "ci/ios-js-bundle-size" and .state == "success"))
-                | sort_by(.updated_at // .created_at)
-                | if length > 0 then .[-1].description else "" end
-              '
-            )"
-            # Status description is "${FILE_SIZE_MB};" from the Post iOS JS bundle size step (awk MiB + ';').
-            # Regex in a variable: ';' in an unquoted [[ =~ ... ]] pattern is parsed as a command separator (shellcheck SC1072).
-            _bundle_desc_re='^[[:space:]]*([0-9]+(\.[0-9]*)?)[[:space:]]*;?[[:space:]]*$'
-            if [[ "$DESC" =~ $_bundle_desc_re ]]; then
-              BASELINE_MB="${BASH_REMATCH[1]}"
-              echo "Baseline from base ref status: ${BASELINE_MB} MB"
-            else
-              echo "::warning::No successful ci/ios-js-bundle-size status (or unrecognized description) on base ${BASE_SHA}; skipping iOS JS bundle delta check."
-              append_job_summary <<EOF
+            exit 0
+          fi
+
+          echo "Merge target (${BASE_REF} at refs/pull/N/merge): ${MERGE_TARGET_SHA}"
+          if ! STATUSES_JSON="$(
+            curl -fsS \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${MERGE_TARGET_SHA}/status"
+          )"; then
+            echo "::warning::Failed to fetch commit statuses for merge target ${MERGE_TARGET_SHA}; skipping iOS JS bundle delta check."
+            append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** skipped — no parseable \`ci/ios-js-bundle-size\` success status on PR base [\`${BASE_SHA}\`](${REPO_URL}/commit/${BASE_SHA}).
+          **Result:** skipped — could not load [combined status](${REPO_URL}/commit/${MERGE_TARGET_SHA}) for merge target \`${MERGE_TARGET_SHA}\` (\`${BASE_REF}\`).
+
+          | | MiB |
+          |---|--:|
+          | Current bundle | ${CURRENT_MB} |
+
+          Baseline would be read from the latest successful \`ci/ios-js-bundle-size\` status description on that commit (MiB from awk, then an optional trailing semicolon, matching the main-branch post step).
+          EOF
+            exit 0
+          fi
+          DESC="$(
+            echo "$STATUSES_JSON" | jq -r '
+              (.statuses // [])
+              | map(select(.context == "ci/ios-js-bundle-size" and .state == "success"))
+              | sort_by(.updated_at // .created_at)
+              | if length > 0 then .[-1].description else "" end
+            '
+          )"
+          # Status description is "${FILE_SIZE_MB};" from the Post iOS JS bundle size step (awk MiB + ';').
+          # Regex in a variable: ';' in an unquoted [[ =~ ... ]] pattern is parsed as a command separator (shellcheck SC1072).
+          _bundle_desc_re='^[[:space:]]*([0-9]+(\.[0-9]*)?)[[:space:]]*;?[[:space:]]*$'
+          if [[ "$DESC" =~ $_bundle_desc_re ]]; then
+            BASELINE_MB="${BASH_REMATCH[1]}"
+            echo "Baseline from merge target status: ${BASELINE_MB} MB"
+          else
+            echo "::warning::No successful ci/ios-js-bundle-size status (or unrecognized description) on merge target ${MERGE_TARGET_SHA}; skipping iOS JS bundle delta check."
+            append_job_summary <<EOF
+          ### iOS JS bundle size (PR)
+
+          **Result:** skipped — no parseable \`ci/ios-js-bundle-size\` success status on merge target [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) (\`${BASE_REF}\`).
 
           | | MiB |
           |---|--:|
           | Current bundle | ${CURRENT_MB} |
           | Raw description | \`${DESC:-<empty>}\` |
-
-          EOF
-              exit 0
-            fi
-          else
-            echo "::warning::Pull request base SHA is empty; skipping iOS JS bundle delta check."
-            append_job_summary <<EOF
-          ### iOS JS bundle size (PR)
-
-          **Result:** skipped — \`github.event.pull_request.base.sha\` was empty.
-
-          | | MiB |
-          |---|--:|
-          | Current bundle | ${CURRENT_MB} |
 
           EOF
             exit 0
@@ -462,11 +470,11 @@ jobs:
             append_job_summary <<EOF
           ### iOS JS bundle size (PR)
 
-          **Result:** failed — delta is more than 1 MiB above the status baseline on PR base [\`${BASE_SHA}\`](${REPO_URL}/commit/${BASE_SHA}).
+          **Result:** failed — delta is more than 1 MiB above the status baseline on merge target [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) (\`${BASE_REF}\`).
 
           | | MiB |
           |---|--:|
-          | PR base commit | — |
+          | Merge target (\`${BASE_REF}\`) | [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) |
           | Baseline (from status) | ${BASELINE_MB} |
           | Current bundle | ${CURRENT_MB} |
           | Delta (current - baseline) | ${DELTA_MB} |
@@ -482,12 +490,12 @@ jobs:
 
           | | MiB |
           |---|--:|
-          | PR base commit | [\`${BASE_SHA}\`](${REPO_URL}/commit/${BASE_SHA}) |
+          | Merge target (\`${BASE_REF}\`) | [\`${MERGE_TARGET_SHA}\`](${REPO_URL}/commit/${MERGE_TARGET_SHA}) |
           | Baseline (from \`ci/ios-js-bundle-size\` status) | ${BASELINE_MB} |
           | Current bundle | ${CURRENT_MB} |
           | Delta (current - baseline) | ${DELTA_MB} |
 
-          Fail threshold: more than 1 MiB above baseline. Baseline is **not** from \`git merge-base\`; it is the value posted to the PR base commit by CI.
+          Fail threshold: more than 1 MiB above baseline. Baseline is the bundle size posted by CI to the merge target commit (first parent of \`refs/pull/N/merge\`), not \`github.event.pull_request.base.sha\`.
 
           EOF
 


### PR DESCRIPTION
## **Description**

The `js-bundle-size-check` job compared the PR merge bundle against the `ci/ios-js-bundle-size` status on `github.event.pull_request.base.sha`. That SHA can lag behind current `main` when a branch is behind: CI builds `refs/pull/N/merge` (PR + latest `main`) but benchmarks against an older commit, so the delta includes **main-only bundle growth** rather than the PR's changes. Rebasing/merging `main` often "fixes" the failure because it refreshes the baseline.

This PR resolves the baseline via `git merge-base origin/${BASE_REF} HEAD` (after fetching the base branch tip), then reads `ci/ios-js-bundle-size` from that commit. `HEAD` is the checked-out merge ref; this matches how we scope PR diffs elsewhere (e.g. fitness-functions). Checkout `fetch-depth: 2` is set on both runner paths so merge-base can be computed in the shallow clone.

Example (#31573): reported delta +1.08 MiB vs stale `pull_request.base.sha`; actual PR contribution ~+0.0004 MiB vs merge-base on current `main`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-661

## **Manual testing steps**

N/A — CI workflow change only. Validation is by re-running a PR that previously failed with a false-positive bundle size delta (e.g. a branch behind `main` with negligible bundle impact) and confirming `js-bundle-size-check` passes with the merge-base commit shown in the job summary.

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — CI workflow change only.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.