### PR TITLE
fix: use the proper stx status for the source token chain cp-7.82.0

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -21,9 +21,18 @@ import {
   TextColor as ComponentLibraryTextColor,
   TextVariant as ComponentLibraryTextVariant,
 } from '../../../../../component-library/components/Texts/Text';
+import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
+import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
+import {
+  selectIsEvmNetworkSelected,
+  selectSelectedNonEvmNetworkChainId,
+} from '../../../../../selectors/multichainNetworkController';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
+const mockOnSetRpcTarget = jest.fn();
+const mockOnNonEvmNetworkChange = jest.fn();
 const mockUseTokensWithBalance = jest.fn();
 let mockDestinationStablecoins: BridgeToken[] = [];
 let mockDestinationStablecoinsByChain: Partial<
@@ -90,8 +99,8 @@ jest.mock('@metamask/design-system-react-native', () => {
 
 jest.mock('../../../../Views/NetworkSelector/useSwitchNetworks', () => ({
   useSwitchNetworks: jest.fn(() => ({
-    onSetRpcTarget: jest.fn(),
-    onNonEvmNetworkChange: jest.fn(),
+    onSetRpcTarget: mockOnSetRpcTarget,
+    onNonEvmNetworkChange: mockOnNonEvmNetworkChange,
   })),
 }));
 
@@ -361,6 +370,18 @@ describe('sortBatchSellTokens', () => {
 describe('BatchSellTokenSelect', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useNetworkInfo as jest.Mock).mockReturnValue({
+      chainId: '0x1' as Hex,
+      domainIsConnectedDapp: false,
+      networkName: 'Ethereum Mainnet',
+    });
+    (selectIsEvmNetworkSelected as unknown as jest.Mock).mockReturnValue(true);
+    (
+      selectSelectedNonEvmNetworkChainId as unknown as jest.Mock
+    ).mockReturnValue(undefined);
+    (
+      selectEvmNetworkConfigurationsByChainId as unknown as jest.Mock
+    ).mockReturnValue({});
     mockDestinationStablecoins = [];
     mockDestinationStablecoinsByChain = {};
     mockPricePercentChangesByAddress = {};
@@ -902,6 +923,109 @@ describe('BatchSellTokenSelect', () => {
       },
     });
     expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.BATCH_SELL_REVIEW);
+  });
+
+  it('switches the wallet network to the source chain on multi-token Continue when it differs', () => {
+    const bscNetworkConfig = {
+      chainId: '0x38' as Hex,
+      rpcUrl: 'https://bsc-rpc.example',
+      ticker: 'BNB',
+      label: 'BNB Smart Chain',
+    };
+    const firstToken = createToken({
+      symbol: 'BSC1',
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: '0x38' as Hex,
+      tokenFiatAmount: 20,
+    });
+    const secondToken = createToken({
+      symbol: 'BSC2',
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: '0x38' as Hex,
+      tokenFiatAmount: 10,
+    });
+
+    (
+      selectEvmNetworkConfigurationsByChainId as unknown as jest.Mock
+    ).mockReturnValue({
+      ['0x38' as Hex]: bscNetworkConfig,
+    });
+    mockWalletTokens = [firstToken, secondToken];
+
+    const { getByTestId, getByText } = render(<BatchSellTokenSelect />);
+
+    fireEvent.press(getByText('BSC1'));
+    fireEvent.press(getByText('BSC2'));
+
+    fireEvent.press(getByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON));
+
+    expect(mockOnSetRpcTarget).toHaveBeenCalledWith(bscNetworkConfig);
+    expect(mockOnNonEvmNetworkChange).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.BATCH_SELL_REVIEW);
+  });
+
+  it('does not switch the wallet network on multi-token Continue when already on the source chain', () => {
+    const firstToken = createToken({
+      symbol: 'ONE',
+      address: '0x1111111111111111111111111111111111111111',
+      chainId: '0x1' as Hex,
+    });
+    const secondToken = createToken({
+      symbol: 'TWO',
+      address: '0x2222222222222222222222222222222222222222',
+      chainId: '0x1' as Hex,
+    });
+    mockWalletTokens = [firstToken, secondToken];
+
+    const { getByTestId, getByText } = render(<BatchSellTokenSelect />);
+
+    fireEvent.press(getByText('ONE'));
+    fireEvent.press(getByText('TWO'));
+
+    fireEvent.press(getByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON));
+
+    expect(mockOnSetRpcTarget).not.toHaveBeenCalled();
+    expect(mockOnNonEvmNetworkChange).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.BATCH_SELL_REVIEW);
+  });
+
+  it('does not switch the wallet network for single-token Continue', () => {
+    const selectedToken = createToken({
+      symbol: 'BSC1',
+      chainId: '0x38' as Hex,
+      tokenFiatAmount: 20,
+    });
+    mockWalletTokens = [selectedToken];
+
+    const { getByTestId, getByText } = render(<BatchSellTokenSelect />);
+
+    fireEvent.press(getByText('BSC1'));
+    fireEvent.press(getByTestId(BatchSellTokenSelectSelectorsIDs.NEXT_BUTTON));
+
+    expect(mockOnSetRpcTarget).not.toHaveBeenCalled();
+    expect(mockOnNonEvmNetworkChange).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.HIGH_RATE_ALERT_MODAL,
+      params: expect.objectContaining({
+        sourceToken: selectedToken,
+      }),
+    });
+  });
+
+  it('passes the active wallet network into useSwitchNetworks', () => {
+    (useNetworkInfo as jest.Mock).mockReturnValue({
+      chainId: '0x1' as Hex,
+      domainIsConnectedDapp: true,
+      networkName: 'Ethereum Mainnet',
+    });
+
+    render(<BatchSellTokenSelect />);
+
+    expect(useSwitchNetworks).toHaveBeenCalledWith({
+      domainIsConnectedDapp: true,
+      selectedChainId: '0x1',
+      selectedNetworkName: 'Ethereum Mainnet',
+    });
   });
 
   it('deselects tokens removed from the committed source tokens on the review page', () => {

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx
@@ -88,6 +88,26 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
+jest.mock('../../../../Views/NetworkSelector/useSwitchNetworks', () => ({
+  useSwitchNetworks: jest.fn(() => ({
+    onSetRpcTarget: jest.fn(),
+    onNonEvmNetworkChange: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../../../selectors/selectedNetworkController', () => ({
+  useNetworkInfo: jest.fn(() => ({
+    chainId: '0x1',
+    domainIsConnectedDapp: false,
+    networkName: 'Ethereum Mainnet',
+  })),
+}));
+
+jest.mock('../../../../../selectors/multichainNetworkController', () => ({
+  selectIsEvmNetworkSelected: jest.fn(() => true),
+  selectSelectedNonEvmNetworkChainId: jest.fn(() => undefined),
+}));
+
 jest.mock('../../hooks/useTokensWithBalance', () => ({
   useTokensWithBalance: (options?: { chainIds?: CaipChainId[] }) =>
     mockUseTokensWithBalance(options),
@@ -111,6 +131,7 @@ jest.mock('../../../../../selectors/networkController', () => ({
   selectNativeCurrencyByChainId: jest.fn(
     (_state: unknown, chainId: Hex) => mockNativeCurrencyByChainId[chainId],
   ),
+  selectEvmNetworkConfigurationsByChainId: jest.fn(() => ({})),
 }));
 
 jest.mock('../../../../../core/redux/slices/bridge', () => ({

--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.tsx
@@ -29,8 +29,11 @@ import {
 import {
   formatAddressToAssetId,
   formatChainIdToCaip,
+  formatChainIdToHex,
+  isNonEvmChainId,
 } from '@metamask/bridge-controller';
-import { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
+import { NetworkConfiguration } from '@metamask/network-controller';
 
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -44,6 +47,13 @@ import {
   setBatchSellTokenSlippages,
 } from '../../../../../core/redux/slices/bridge';
 import { RootState } from '../../../../../reducers';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
+import {
+  selectIsEvmNetworkSelected,
+  selectSelectedNonEvmNetworkChainId,
+} from '../../../../../selectors/multichainNetworkController';
+import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
+import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { BridgeToken } from '../../types';
 import ButtonToggle from '../../../../../component-library/components-temp/Buttons/ButtonToggle';
 import { ButtonSize as ButtonToggleSize } from '../../../../../component-library/components/Buttons/Button';
@@ -113,6 +123,26 @@ export function BatchSellTokenSelect() {
   const navigation = useNavigation();
   const dispatch = useDispatch();
   const tw = useTailwind();
+  const evmNetworkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+  const isEvmNetworkSelected = useSelector(selectIsEvmNetworkSelected);
+  const selectedNonEvmNetworkChainId = useSelector(
+    selectSelectedNonEvmNetworkChainId,
+  );
+  const {
+    chainId: selectedEvmChainId,
+    domainIsConnectedDapp,
+    networkName: selectedEvmNetworkName,
+  } = useNetworkInfo();
+  const { onSetRpcTarget, onNonEvmNetworkChange } = useSwitchNetworks({
+    domainIsConnectedDapp,
+    selectedChainId: selectedEvmChainId,
+    selectedNetworkName: selectedEvmNetworkName,
+  });
+  const currentChainId = isEvmNetworkSelected
+    ? selectedEvmChainId
+    : selectedNonEvmNetworkChainId;
   const batchSellTokens = useBatchSellTokens();
   const [tokenSortDirection, setTokenSortDirection] =
     useState<BatchSellTokenSortDirection>('desc');
@@ -291,6 +321,26 @@ export function BatchSellTokenSelect() {
       tokenSortDirection,
     );
 
+    // Batch Sell picks a source chain in this screen without updating the wallet's
+    // active network. Switch now so STX/gas checks and submit use the source chain
+    // (same pattern as useInitialSourceToken on Swaps entry).
+    if (orderedSelectedTokens[0]?.chainId) {
+      const tokenChainId = orderedSelectedTokens[0].chainId;
+      const tokenCaipChainId = formatChainIdToCaip(tokenChainId);
+      const currentCaipChainId = formatChainIdToCaip(currentChainId);
+
+      if (tokenCaipChainId !== currentCaipChainId) {
+        if (isNonEvmChainId(tokenCaipChainId)) {
+          onNonEvmNetworkChange(tokenCaipChainId);
+        } else {
+          const hexChainId = formatChainIdToHex(tokenCaipChainId);
+          onSetRpcTarget(
+            evmNetworkConfigurations[hexChainId] as NetworkConfiguration,
+          );
+        }
+      }
+    }
+
     dispatch(setBatchSellSourceTokens(orderedSelectedTokens));
     dispatch(
       setBatchSellSourceTokenAmounts(
@@ -312,9 +362,13 @@ export function BatchSellTokenSelect() {
     );
     navigation.navigate(Routes.BRIDGE.BATCH_SELL_REVIEW);
   }, [
+    currentChainId,
     destinationStablecoins,
     dispatch,
+    evmNetworkConfigurations,
     navigation,
+    onNonEvmNetworkChange,
+    onSetRpcTarget,
     selectedTokens,
     tokenSortDirection,
   ]);

--- a/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/index.ts
+++ b/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/index.ts
@@ -7,12 +7,21 @@ import type {
 import type { BridgeStatusController } from '@metamask/bridge-status-controller';
 
 import Engine from '../../../../../core/Engine';
-import { selectBatchSellDestToken } from '../../../../../core/redux/slices/bridge';
+import {
+  selectBatchSellDestToken,
+  selectBatchSellSourceTokens,
+} from '../../../../../core/redux/slices/bridge';
+import { RootState } from '../../../../../reducers';
 import { selectBatchSellSourceWalletAddress } from '../../../../../selectors/bridge';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
+import { getMaybeHexChainId } from '../../../../../util/bridge';
 
 export function useSubmitBatchSellTx() {
-  const stxEnabled = useSelector(selectShouldUseSmartTransaction);
+  const sourceTokens = useSelector(selectBatchSellSourceTokens);
+  const batchSellChainId = getMaybeHexChainId(sourceTokens[0]?.chainId);
+  const smartTransactionsEnabled = useSelector((state: RootState) =>
+    selectShouldUseSmartTransaction(state, batchSellChainId),
+  );
   const walletAddress = useSelector(selectBatchSellSourceWalletAddress);
   const destToken = useSelector(selectBatchSellDestToken);
 
@@ -48,7 +57,7 @@ export function useSubmitBatchSellTx() {
       >[0]['quoteResponses'],
       accountAddress: walletAddress,
       location,
-      isStxEnabled: stxEnabled,
+      isStxEnabled: smartTransactionsEnabled,
       quotesReceivedContext: undefined,
       tokenSecurityTypeDestination,
     });

--- a/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/useSubmitBatchSellTx.test.tsx
+++ b/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/useSubmitBatchSellTx.test.tsx
@@ -51,6 +51,23 @@ jest.mock('../../../../../selectors/smartTransactionsController', () => ({
   selectShouldUseSmartTransaction: jest.fn(() => true),
 }));
 
+const { selectShouldUseSmartTransaction: mockSelectShouldUseSmartTransaction } =
+  jest.requireMock('../../../../../selectors/smartTransactionsController');
+
+const mockSourceTokens = [
+  {
+    address: '0x1111111111111111111111111111111111111111',
+    chainId: '0x1',
+    decimals: 18,
+    symbol: 'ETH',
+  },
+];
+
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  ...jest.requireActual('../../../../../core/redux/slices/bridge'),
+  selectBatchSellSourceTokens: jest.fn(() => mockSourceTokens),
+}));
+
 jest.mock('../../../../../selectors/bridge', () => ({
   ...jest.requireActual('../../../../../selectors/bridge'),
   selectBatchSellSourceWalletAddress: jest.fn(
@@ -152,5 +169,16 @@ describe('useSubmitBatchSellTx', () => {
         quoteResponses: [],
       }),
     ).rejects.toThrow('Batch Sell wallet address is not set');
+  });
+
+  it('passes the normalized source chain ID to selectShouldUseSmartTransaction', () => {
+    renderHook(() => useSubmitBatchSellTx(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockSelectShouldUseSmartTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      '0x1',
+    );
   });
 });


### PR DESCRIPTION
<!--
Branch: fix/batchSell-stx-submit
Copy this body into the GitHub PR description.
-->

## **Description**

Batch Sell quote request and display already resolve smart transactions (STX) against the batch sell **source chain**, but `useSubmitBatchSellTx` was calling `selectShouldUseSmartTransaction` without a chain ID. That made submit use the **globally selected network** for `isStxEnabled`, which could disagree with the chain the quotes were fetched for—especially because Batch Sell selects a source chain in UI without switching the wallet network.

This PR:

1. **Scopes STX at submit to the batch sell source chain** — same pattern as `useBatchSellQuoteRequest` / `useBatchSellQuoteData` (`getMaybeHexChainId(sourceTokens[0]?.chainId)` passed to `selectShouldUseSmartTransaction`).
2. **Switches the wallet network when committing batch sell source tokens** — on multi-token Continue in `BatchSellTokenSelect`, align the active network with the selected source chain (same inline approach as Swaps entry via `useSwitchNetworks`).

## **Changelog**

CHANGELOG entry: Fixed Batch Sell submitting with the wrong smart transaction setting when the source chain differed from the globally selected network

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31827

## **Manual testing steps**

```gherkin
Feature: Batch Sell STX at submit

  Scenario: submit uses STX for the batch sell source chain
    Given the wallet global network is Ethereum mainnet
    And STX is enabled on Arbitrum but disabled on mainnet (or vice versa)
    And Batch Sell source tokens are on Arbitrum

    When the user completes token selection and submits from final review
    Then isStxEnabled passed to submitBatchSell matches STX eligibility for Arbitrum
    And the wallet network switches to the batch sell source chain when continuing with multiple tokens

  Scenario: STX stays consistent when global network already matches source chain
    Given the wallet global network matches the batch sell source chain
    And STX is enabled on that chain

    When the user submits Batch Sell from final review
    Then isStxEnabled is true and matches the value used for quote requests
```

**Unit tests**

- `yarn jest app/components/UI/Bridge/hooks/useSubmitBatchSellTx/useSubmitBatchSellTx.test.tsx`
- `yarn jest app/components/UI/Bridge/Views/BatchSellTokenSelect/BatchSellTokenSelect.test.tsx`

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**


https://github.com/user-attachments/assets/b1f87277-974f-46c5-9225-995be6ecef24



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
