### PR TITLE
fix(ramps): use ramps-controller preview for TRAM-3539 QA

### DIFF
--- a/package.json
+++ b/package.json
@@ -554,6 +554,12 @@
     "viem": "^2.28.0",
     "vm-browserify": "1.1.2"
   },
+  "previewBuilds": {
+    "@metamask/ramps-controller": {
+      "type": "non-breaking",
+      "previewVersion": "14.2.0-preview-589a499"
+    }
+  },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9689,15 +9689,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^14.1.0, @metamask/ramps-controller@npm:^14.2.0":
-  version: 14.2.0
-  resolution: "@metamask/ramps-controller@npm:14.2.0"
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@14.2.0-preview-589a499":
+  version: 14.2.0-preview-589a499
+  resolution: "@metamask-previews/ramps-controller@npm:14.2.0-preview-589a499"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
-  checksum: 10/2060910d94a168370a7a4e03fd059137ded2de688b9b3c7167db3ad78c101cf201641f59c55eb1172e3bc4d6243143bd67f5d0ce8f0fcff682cddf67f3ef91f5
+    "@metamask/profile-sync-controller": "npm:^28.2.0"
+  checksum: 10/3d43459d4bcd9f3c688898a1c5faf373ad649057d981665e0f46a60e0347bfe898855c1dccc5a579ddb37fac4ae14c3f400ef5392dd997e332c317f1ce0cfcf4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

QA PR for [MetaMask/core#9159](https://github.com/MetaMask/core/pull/9159) — wires mobile to the `@metamask/ramps-controller` preview build that merges orders on internal order code instead of provider-native `providerOrderId`.

Fixes duplicate Moonpay Activity rows (TRAM-3539).

## Changes

- Add `previewBuilds` entry for `@metamask/ramps-controller@14.2.0-preview-589a499` (from core PR #9159 preview publish)

## Test plan

- [ ] Moonpay redirect buy: single Activity row after completion (no duplicate stub + completed row)
- [ ] Order amounts populate after polling (no `"..."` stub amount lingering)
- [ ] Smoke: ramps buy flow still navigates correctly

## Related

- Core: https://github.com/MetaMask/core/pull/9159
- Ticket: TRAM-3539

**Note:** Remove `previewBuilds` and bump to released `@metamask/ramps-controller` after core #9159 ships.
