### PR TITLE
feat: add enhanced display for approved transaction for Non EVM networks cp-8.0.0

### DIFF
--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
@@ -85,6 +85,7 @@ jest.mock('../../../util/date', () => ({
 const mockDisplayData: MultichainTransactionDisplayData = {
   title: 'Send ETH',
   isRedeposit: false,
+  isUnlimitedApproval: false,
   from: {
     address: '0xabc123def456abc123def456abc123def456abc1',
     amount: '0.5',

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.test.tsx
@@ -155,6 +155,28 @@ describe('MultichainTransactionDetailsSheet', () => {
     expect(getByText('0.5 ETH')).toBeOnTheScreen();
   });
 
+  it('renders "Unlimited" in the amount row for unlimited token approvals', () => {
+    mockUseRoute.mockReturnValue({
+      params: {
+        displayData: {
+          ...mockDisplayData,
+          isUnlimitedApproval: true,
+          to: {
+            ...mockDisplayData.to,
+            amount: '115792089237316200000000000000000',
+            unit: 'USDT',
+          },
+        },
+        transaction: mockTransaction,
+      },
+    });
+
+    const { getByText, queryByText } = renderSheet();
+
+    expect(getByText('Unlimited USDT')).toBeOnTheScreen();
+    expect(queryByText('115792089237316200000000000000000 USDT')).toBeNull();
+  });
+
   it('renders the network fee row', () => {
     const { getByText } = renderSheet();
     expect(getByText('Network fee')).toBeOnTheScreen();

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsSheet.tsx
@@ -78,7 +78,8 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
   const { typography } = useTheme();
 
   const { displayData, transaction } = route.params;
-  const { title, from, to, baseFee, priorityFee } = displayData;
+  const { title, from, to, baseFee, priorityFee, isUnlimitedApproval } =
+    displayData;
   const { id, timestamp, chain, status } = transaction;
 
   const handleClose = useCallback(() => {
@@ -198,7 +199,9 @@ const MultichainTransactionDetailsSheet: React.FC = () => {
         {to &&
           renderDetailRow(
             TransactionDetailRow.Amount,
-            `${to.amount} ${to.unit}`,
+            isUnlimitedApproval
+              ? `${strings('confirm.unlimited')} ${to.unit}`
+              : `${to.amount} ${to.unit}`,
           )}
         {baseFee &&
           renderDetailRow(

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
@@ -246,6 +246,87 @@ describe('MultichainTransactionListItem', () => {
     expect(getByTestId('transaction-status-tx-123')).toBeTruthy();
   });
 
+  describe('TokenApprove transactions', () => {
+    const createApproveTransaction = (amount: string): Transaction => ({
+      ...mockTransaction,
+      type: TransactionType.TokenApprove,
+      from: [
+        {
+          address: '7RoSF9fUNf1XgRYsb7Qh4SoVkRmirHzZVELGNiNQzZNV',
+          asset: {
+            amount,
+            unit: 'USDT',
+            fungible: true,
+            type: 'solana:mainnet/token:USDT' as const,
+          },
+        },
+      ],
+      to: [
+        {
+          address: '5FHwkrdxD5AKmYrGNQYV66qPt3YxmkBzMJ8youBGNFAY',
+          asset: {
+            amount,
+            unit: 'USDT',
+            fungible: true,
+            type: 'solana:mainnet/token:USDT' as const,
+          },
+        },
+      ],
+    });
+
+    it('renders "confirm.unlimited USDT" for an unlimited token approval', () => {
+      const transaction = createApproveTransaction(
+        '115792089237316195423570985008687907853269984665640564039457584007913129.639935',
+      );
+
+      const { getByText } = renderWithProvider(
+        <MultichainTransactionListItem
+          transaction={transaction}
+          chainId={SolScope.Mainnet}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+        />,
+      );
+
+      expect(getByText('confirm.unlimited USDT')).toBeOnTheScreen();
+    });
+
+    it('renders the approve title with token unit', () => {
+      const transaction = createApproveTransaction('100');
+
+      const { getByText } = renderWithProvider(
+        <MultichainTransactionListItem
+          transaction={transaction}
+          chainId={SolScope.Mainnet}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+        />,
+      );
+
+      expect(
+        getByText('transactions.tx_review_approve USDT'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders formatted amount for a bounded token approval', () => {
+      const transaction = createApproveTransaction('100');
+
+      const { getByText } = renderWithProvider(
+        <MultichainTransactionListItem
+          transaction={transaction}
+          chainId={SolScope.Mainnet}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+        />,
+      );
+
+      expect(getByText('100 USDT')).toBeOnTheScreen();
+    });
+  });
+
   describe('analytics tracking', () => {
     it('tracks Transaction Detail List Item Clicked with default home location', () => {
       const { getByTestId } = renderWithProvider(

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
@@ -329,17 +329,7 @@ describe('MultichainTransactionListItem', () => {
     it('renders amount from from when to has no fungible movement', () => {
       const transaction: Transaction = {
         ...createApproveTransaction('200'),
-        to: [
-          {
-            address: '5FHwkrdxD5AKmYrGNQYV66qPt3YxmkBzMJ8youBGNFAY',
-            asset: {
-              amount: '0',
-              unit: '',
-              fungible: false,
-              type: 'solana:mainnet/token:USDT' as const,
-            },
-          },
-        ],
+        to: [],
       };
 
       const { getByText } = renderWithProvider(

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
@@ -325,6 +325,35 @@ describe('MultichainTransactionListItem', () => {
 
       expect(getByText('100 USDT')).toBeOnTheScreen();
     });
+
+    it('renders amount from from when to has no fungible movement', () => {
+      const transaction: Transaction = {
+        ...createApproveTransaction('200'),
+        to: [
+          {
+            address: '5FHwkrdxD5AKmYrGNQYV66qPt3YxmkBzMJ8youBGNFAY',
+            asset: {
+              amount: '0',
+              unit: '',
+              fungible: false,
+              type: 'solana:mainnet/token:USDT' as const,
+            },
+          },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <MultichainTransactionListItem
+          transaction={transaction}
+          chainId={SolScope.Mainnet}
+          navigation={
+            mockNavigation as unknown as NavigationProp<ParamListBase>
+          }
+        />,
+      );
+
+      expect(getByText('200 USDT')).toBeOnTheScreen();
+    });
   });
 
   describe('analytics tracking', () => {

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -128,7 +128,8 @@ const MultichainTransactionListItem = ({
     if (transaction.type === TransactionType.TokenApprove) {
       const unit = from?.unit || to?.unit || '';
       if (isUnlimitedApproval) {
-        return `${strings('confirm.unlimited')}${unit ? ` ${unit}` : ''}`;
+        const unitSuffix = unit ? ` ${unit}` : '';
+        return `${strings('confirm.unlimited')}${unitSuffix}`;
       }
       const amount = to?.amount || from?.amount?.replace(/^-/, '') || '';
       return `${amount} ${unit}`.trim();

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -12,6 +12,7 @@ import ListItem from '../../Base/ListItem';
 import StatusText from '../../Base/StatusText';
 import { getTransactionIcon } from '../../../util/transaction-icons';
 import { toDateFormat } from '../../../util/date';
+import { strings } from '../../../../locales/i18n';
 import { useMultichainTransactionDisplay } from '../../hooks/useMultichainTransactionDisplay';
 import styles from './MultichainTransactionListItem.styles';
 import { useSelector } from 'react-redux';
@@ -49,7 +50,15 @@ const MultichainTransactionListItem = ({
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const displayData = useMultichainTransactionDisplay(transaction, chainId);
-  const { title, to, priorityFee, baseFee, isRedeposit } = displayData;
+  const {
+    title,
+    from,
+    to,
+    priorityFee,
+    baseFee,
+    isRedeposit,
+    isUnlimitedApproval,
+  } = displayData;
 
   const handlePress = useCallback(() => {
     trackEvent(
@@ -114,6 +123,14 @@ const MultichainTransactionListItem = ({
 
     if (transaction.type === TransactionType.Unknown) {
       return `${baseFee?.amount} ${baseFee?.unit}`;
+    }
+
+    if (transaction.type === TransactionType.TokenApprove) {
+      const unit = from?.unit || to?.unit || '';
+      if (isUnlimitedApproval) {
+        return `${strings('confirm.unlimited')}${unit ? ` ${unit}` : ''}`;
+      }
+      return `${to?.amount || ''} ${unit}`.trim();
     }
 
     return `${to?.amount} ${to?.unit}`;

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -130,7 +130,8 @@ const MultichainTransactionListItem = ({
       if (isUnlimitedApproval) {
         return `${strings('confirm.unlimited')}${unit ? ` ${unit}` : ''}`;
       }
-      return `${to?.amount || ''} ${unit}`.trim();
+      const amount = to?.amount || from?.amount?.replace(/^-/, '') || '';
+      return `${amount} ${unit}`.trim();
     }
 
     return `${to?.amount} ${to?.unit}`;

--- a/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.test.ts
+++ b/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.test.ts
@@ -125,10 +125,24 @@ describe('useMultichainTransactionDisplay', () => {
       expect(result.current.title).toBe('transactions.tx_review_approve');
     });
 
-    it('returns isUnlimitedApproval false when from array is empty', () => {
+    it('returns isUnlimitedApproval true when from is empty but to carries unlimited amount', () => {
       const transaction = {
         ...createApproveTransaction('115792089237316195423570985.639935'),
         from: [],
+      } as unknown as Transaction;
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(true);
+    });
+
+    it('returns isUnlimitedApproval false when both from and to are empty', () => {
+      const transaction = {
+        ...createApproveTransaction('115792089237316195423570985.639935'),
+        from: [],
+        to: [],
       } as unknown as Transaction;
 
       const { result } = renderHook(() =>

--- a/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.test.ts
+++ b/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.test.ts
@@ -1,0 +1,169 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  TransactionType,
+  type Transaction,
+} from '@metamask/keyring-api';
+import { useMultichainTransactionDisplay } from './useMultichainTransactionDisplay';
+
+jest.mock('../../../../locales/i18n', () => ({
+  __esModule: true,
+  default: { locale: 'en' },
+  strings: (key: string) => key,
+}));
+
+jest.mock('../../../util/assets', () => ({
+  formatWithThreshold: jest.fn((amount: number) =>
+    amount !== null ? String(amount) : '',
+  ),
+}));
+
+jest.mock('@metamask/multichain-network-controller', () => ({
+  MULTICHAIN_NETWORK_DECIMAL_PLACES: {},
+}));
+
+jest.mock('../../../util/transactions', () => ({
+  isTransactionIncomplete: jest.fn(() => false),
+}));
+
+const TRON_CHAIN_ID = 'tron:728126428' as const;
+const USDT_ASSET_TYPE =
+  'tron:728126428/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' as const;
+
+const createApproveTransaction = (amount: string): Transaction =>
+  ({
+    id: 'tx-approve-123',
+    chain: TRON_CHAIN_ID,
+    account: 'account-id',
+    type: TransactionType.TokenApprove,
+    status: TransactionStatus.Confirmed,
+    timestamp: 1700000000,
+    events: [],
+    fees: [],
+    from: [
+      {
+        address: 'TOwnerAddress',
+        asset: { amount, unit: 'USDT', fungible: true, type: USDT_ASSET_TYPE },
+      },
+    ],
+    to: [
+      {
+        address: 'TSpenderAddress',
+        asset: { amount, unit: 'USDT', fungible: true, type: USDT_ASSET_TYPE },
+      },
+    ],
+  }) as unknown as Transaction;
+
+describe('useMultichainTransactionDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('TokenApprove transactions', () => {
+    it('returns isUnlimitedApproval true for amounts exceeding 1e15', () => {
+      const transaction = createApproveTransaction(
+        '115792089237316195423570985.639935',
+      );
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(true);
+    });
+
+    it('returns isUnlimitedApproval false for amounts below 1e15', () => {
+      const transaction = createApproveTransaction('1000');
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(false);
+    });
+
+    it('returns isUnlimitedApproval false for exact threshold value 1e15', () => {
+      const transaction = createApproveTransaction('1000000000000000');
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(false);
+    });
+
+    it('sets title with token unit', () => {
+      const transaction = createApproveTransaction('1000');
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.title).toBe('transactions.tx_review_approve USDT');
+    });
+
+    it('sets title without unit when from has no fungible asset', () => {
+      const transaction = {
+        ...createApproveTransaction('1000'),
+        from: [
+          {
+            address: 'TOwnerAddress',
+            asset: {
+              amount: '0',
+              unit: '',
+              fungible: false,
+              type: USDT_ASSET_TYPE,
+            },
+          },
+        ],
+      } as unknown as Transaction;
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.title).toBe('transactions.tx_review_approve');
+    });
+
+    it('returns isUnlimitedApproval false when from array is empty', () => {
+      const transaction = {
+        ...createApproveTransaction('115792089237316195423570985.639935'),
+        from: [],
+      } as unknown as Transaction;
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(false);
+    });
+  });
+
+  describe('non-TokenApprove transactions', () => {
+    it('returns isUnlimitedApproval false for Send transactions regardless of amount size', () => {
+      const transaction = {
+        ...createApproveTransaction('115792089237316195423570985.639935'),
+        type: TransactionType.Send,
+      } as unknown as Transaction;
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(false);
+    });
+
+    it('returns isUnlimitedApproval false for Receive transactions regardless of amount size', () => {
+      const transaction = {
+        ...createApproveTransaction('115792089237316195423570985.639935'),
+        type: TransactionType.Receive,
+      } as unknown as Transaction;
+
+      const { result } = renderHook(() =>
+        useMultichainTransactionDisplay(transaction, TRON_CHAIN_ID),
+      );
+
+      expect(result.current.isUnlimitedApproval).toBe(false);
+    });
+  });
+});

--- a/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
+++ b/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
@@ -80,6 +80,7 @@ export function useMultichainTransactionDisplay(
   );
 
   const isIncomplete = isTransactionIncomplete(transaction.status);
+  const approveUnitSuffix = from?.unit ? ` ${from.unit}` : '';
 
   const isUnlimitedApproval =
     transaction.type === TransactionType.TokenApprove &&
@@ -100,7 +101,7 @@ export function useMultichainTransactionDisplay(
     [TransactionType.Swap]: `${strings('transactions.swap')} ${
       from?.unit
     } ${strings('transactions.to').toLowerCase()} ${to?.unit}`,
-    [TransactionType.TokenApprove]: `${strings('transactions.tx_review_approve')}${from?.unit ? ` ${from.unit}` : ''}`,
+    [TransactionType.TokenApprove]: `${strings('transactions.tx_review_approve')}${approveUnitSuffix}`,
     [TransactionType.StakeDeposit]: strings(
       'transactions.tx_review_staking_deposit',
     ),

--- a/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
+++ b/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
@@ -83,7 +83,10 @@ export function useMultichainTransactionDisplay(
 
   const isUnlimitedApproval =
     transaction.type === TransactionType.TokenApprove &&
-    (transaction.from as Movement[]).some(
+    [
+      ...(transaction.from as Movement[]),
+      ...(transaction.to as Movement[]),
+    ].some(
       (mv) =>
         mv?.asset?.fungible === true &&
         parseFloat(mv.asset.amount) > APPROVE_AMOUNT_UNLIMITED_THRESHOLD,

--- a/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
+++ b/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
@@ -90,7 +90,7 @@ export function useMultichainTransactionDisplay(
     ].some(
       (mv) =>
         mv?.asset?.fungible === true &&
-        parseFloat(mv.asset.amount) > APPROVE_AMOUNT_UNLIMITED_THRESHOLD,
+        Number.parseFloat(mv.asset.amount) > APPROVE_AMOUNT_UNLIMITED_THRESHOLD,
     );
 
   const typeToTitle: Partial<Record<TransactionType, string>> = {
@@ -139,14 +139,14 @@ function aggregateAmount(
     const assetId = mv.asset.type;
     if (!amountByAsset[assetId]) {
       amountByAsset[assetId] = {
-        amount: parseFloat(mv.asset.amount),
+        amount: Number.parseFloat(mv.asset.amount),
         address: mv.address,
         unit: mv.asset.unit,
       };
       continue;
     }
 
-    amountByAsset[assetId].amount += parseFloat(mv.asset.amount);
+    amountByAsset[assetId].amount += Number.parseFloat(mv.asset.amount);
   }
 
   // We make an assumption that there is only one asset in the transaction.

--- a/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
+++ b/app/components/hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay.ts
@@ -39,7 +39,11 @@ export interface MultichainTransactionDisplayData {
   baseFee?: AggregatedMovementDisplayData;
   priorityFee?: AggregatedMovementDisplayData;
   isRedeposit: boolean;
+  isUnlimitedApproval: boolean;
 }
+
+// Mirrors EVM TOKEN_VALUE_UNLIMITED_THRESHOLD: amounts above 10^15 are treated as unlimited.
+const APPROVE_AMOUNT_UNLIMITED_THRESHOLD = 1e15;
 
 export function useMultichainTransactionDisplay(
   transaction: Transaction,
@@ -77,6 +81,14 @@ export function useMultichainTransactionDisplay(
 
   const isIncomplete = isTransactionIncomplete(transaction.status);
 
+  const isUnlimitedApproval =
+    transaction.type === TransactionType.TokenApprove &&
+    (transaction.from as Movement[]).some(
+      (mv) =>
+        mv?.asset?.fungible === true &&
+        parseFloat(mv.asset.amount) > APPROVE_AMOUNT_UNLIMITED_THRESHOLD,
+    );
+
   const typeToTitle: Partial<Record<TransactionType, string>> = {
     [TransactionType.Send]: isIncomplete
       ? `${strings('transactions.send')} ${from?.unit || ''}`
@@ -85,6 +97,7 @@ export function useMultichainTransactionDisplay(
     [TransactionType.Swap]: `${strings('transactions.swap')} ${
       from?.unit
     } ${strings('transactions.to').toLowerCase()} ${to?.unit}`,
+    [TransactionType.TokenApprove]: `${strings('transactions.tx_review_approve')}${from?.unit ? ` ${from.unit}` : ''}`,
     [TransactionType.StakeDeposit]: strings(
       'transactions.tx_review_staking_deposit',
     ),
@@ -103,6 +116,7 @@ export function useMultichainTransactionDisplay(
     baseFee,
     priorityFee,
     isRedeposit,
+    isUnlimitedApproval,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^68.0.1",
     "@metamask/transaction-pay-controller": "^23.9.0",
-    "@metamask/tron-wallet-snap": "^1.26.0",
+    "@metamask/tron-wallet-snap": "^1.27.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^3.0.0",
     "@myx-trade/sdk": "^0.1.265",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10387,10 +10387,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.26.0":
-  version: 1.26.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.26.0"
-  checksum: 10/ba7dc5d4bdae9f0a5c346744ea5eda311a1301a390c8ba3eedee4c99bf29d7d4937c65607198dcedda760223f07363638026e2649912123c4f89460de10906b4
+"@metamask/tron-wallet-snap@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "@metamask/tron-wallet-snap@npm:1.27.0"
+  checksum: 10/7555f647d89502aebe5f629242113203b123ab981b9a59105cc9ae9c404cfe3ee2ac10c7d246bb58c86f15b87a874ced0629bb91429f9cc01696ac22132a5da9
   languageName: node
   linkType: hard
 
@@ -35514,7 +35514,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^68.0.1"
     "@metamask/transaction-pay-controller": "npm:^23.9.0"
-    "@metamask/tron-wallet-snap": "npm:^1.26.0"
+    "@metamask/tron-wallet-snap": "npm:^1.27.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^3.0.0"
     "@myx-trade/sdk": "npm:^0.1.265"


### PR DESCRIPTION

<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This pull request enhances the handling and display of unlimited token approval transactions across the app. It introduces a new `isUnlimitedApproval` property to the transaction display data, updates the logic to detect and label unlimited approvals, and ensures that UI components and tests reflect these changes. The update also includes comprehensive unit tests for the new logic.

**Unlimited Token Approval Detection and Display:**

* Added `isUnlimitedApproval` to the `MultichainTransactionDisplayData` interface and implemented logic in `useMultichainTransactionDisplay` to set this flag for token approval transactions with amounts above 1e15. The transaction title for approvals is also updated to include the token unit if available.

**UI and Rendering Updates:**

* Updated `MultichainTransactionDetailsSheet` and `MultichainTransactionListItem` components to use the `isUnlimitedApproval` flag. When true, these components display "Unlimited <Token>" instead of the raw approval amount, ensuring clarity for the user.

**Testing Improvements:**

* Added and updated tests for both the hook (`useMultichainTransactionDisplay`) and the UI components to verify correct detection and display of unlimited approvals, including edge cases and title formatting.

**Dependency Update:**

* Bumped `@metamask/tron-wallet-snap` dependency version from `1.26.0` to `1.27.0` in `package.json`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: fixed display approved transactions for Non-EVM networks

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: Big number digit approved Non-EVM transactions break the display

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Go to a TRON explorer dApp like Tronscan.

Makes an approved transaction on a TRC20 tokens like USDT with more than 15 digits

The approved transaction displays the Unlimited USDT label

Makes an approved transaction on a TRC20 tokens like USDT with less than 15 digits

The approved transaction display the approved amount of USDT
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="400" height="700" alt="BEFORE-MOBILE-APPROVE-USDT" src="https://github.com/user-attachments/assets/f69e32f2-0be3-43ff-8c90-ce5ce310744e" />



### **After**

<img width="400" height="750" alt="AFTER-MOBILE-APPROVE-USDT" src="https://github.com/user-attachments/assets/0a678dc8-8926-43cc-a945-070d86905c59" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes to multichain transaction formatting with new unit tests; no auth, signing, or transaction execution logic is modified.
> 
> **Overview**
> Fixes broken transaction UI when non-EVM (e.g. TRON TRC20) approvals carry very large allowance values by treating fungible **TokenApprove** amounts above **10^15** as unlimited, consistent with the existing EVM threshold.
> 
> **`useMultichainTransactionDisplay`** now exposes **`isUnlimitedApproval`**, sets approve titles to **`transactions.tx_review_approve`** plus the token unit when available, and only flags unlimited for **TokenApprove** (not send/receive).
> 
> **`MultichainTransactionListItem`** and **`MultichainTransactionDetailsSheet`** use that flag to render **`confirm.unlimited`** plus the token symbol instead of the raw numeric string; bounded approvals still show the formatted amount (including when **`to`** is empty but **`from`** has the movement).
> 
> Adds unit tests for the hook and UI; bumps **`@metamask/tron-wallet-snap`** to **1.27.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42df5711c2e5b25b2cc29f35c8a6e9a8e536e82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->