### PR TITLE
perf: memoize useNetworkEnablement return object and controller list arrays

### DIFF
--- a/app/components/hooks/useNetworkEnablement/useNetworkEnablement.ts
+++ b/app/components/hooks/useNetworkEnablement/useNetworkEnablement.ts
@@ -61,12 +61,18 @@ export const useNetworkEnablement = () => {
     [],
   );
 
-  const popularEvmNetworksList =
-    networkEnablementController?.listPopularEvmNetworks?.() ?? [];
-  const popularMultichainNetworksList =
-    networkEnablementController?.listPopularMultichainNetworks?.() ?? [];
-  const popularNetworksList =
-    networkEnablementController?.listPopularNetworks?.() ?? [];
+  const popularEvmNetworksList = useMemo(
+    () => networkEnablementController?.listPopularEvmNetworks?.() ?? [],
+    [networkEnablementController],
+  );
+  const popularMultichainNetworksList = useMemo(
+    () => networkEnablementController?.listPopularMultichainNetworks?.() ?? [],
+    [networkEnablementController],
+  );
+  const popularNetworksList = useMemo(
+    () => networkEnablementController?.listPopularNetworks?.() ?? [],
+    [networkEnablementController],
+  );
 
   const enabledNetworksForCurrentNamespace = useMemo(
     () => enabledNetworksByNamespace?.[namespace] || {},
@@ -141,20 +147,38 @@ export const useNetworkEnablement = () => {
     [isNetworkEnabled, enableNetwork],
   );
 
-  return {
-    namespace,
-    enabledNetworksByNamespace,
-    enabledNetworksForCurrentNamespace,
-    enabledNetworksForAllNamespaces,
-    networkEnablementController,
-    enableNetwork,
-    disableNetwork,
-    enableAllPopularNetworks,
-    popularEvmNetworks: popularEvmNetworksList,
-    popularMultichainNetworks: popularMultichainNetworksList,
-    popularNetworks: popularNetworksList,
-    isNetworkEnabled,
-    hasOneEnabledNetwork,
-    tryEnableEvmNetwork,
-  };
+  return useMemo(
+    () => ({
+      namespace,
+      enabledNetworksByNamespace,
+      enabledNetworksForCurrentNamespace,
+      enabledNetworksForAllNamespaces,
+      networkEnablementController,
+      enableNetwork,
+      disableNetwork,
+      enableAllPopularNetworks,
+      popularEvmNetworks: popularEvmNetworksList,
+      popularMultichainNetworks: popularMultichainNetworksList,
+      popularNetworks: popularNetworksList,
+      isNetworkEnabled,
+      hasOneEnabledNetwork,
+      tryEnableEvmNetwork,
+    }),
+    [
+      namespace,
+      enabledNetworksByNamespace,
+      enabledNetworksForCurrentNamespace,
+      enabledNetworksForAllNamespaces,
+      networkEnablementController,
+      enableNetwork,
+      disableNetwork,
+      enableAllPopularNetworks,
+      popularEvmNetworksList,
+      popularMultichainNetworksList,
+      popularNetworksList,
+      isNetworkEnabled,
+      hasOneEnabledNetwork,
+      tryEnableEvmNetwork,
+    ],
+  );
 };


### PR DESCRIPTION
## **Description**

The `useNetworkEnablement` hook returned a fresh object on every render, and the three controller list arrays (`popularEvmNetworks`, `popularMultichainNetworks`, `popularNetworks`) were recomputed and re-allocated each render. This produced unstable references that cascade into unnecessary re-renders and effect re-runs in every consumer that destructures from this hook.

This PR wraps the three list arrays in `useMemo` (keyed on the controller reference) and wraps the hook's return object in `useMemo` so consumers receive stable references unless an actual dependency changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-867](https://consensyssoftware.atlassian.net/browse/TMCU-867)

## **Manual testing steps**

```gherkin
Feature: useNetworkEnablement stable references

  Scenario: Consumers do not re-render unnecessarily
    Given the app is running with a wallet imported
    When navigating between Wallet, Tokens, and Network views
    Then network enablement state remains correct and no regressions appear in network switching, enable/disable, or popular network listings
```

## **Screenshots/Recordings**

### **Before**

N/A — internal hook refactor, no UI change.

### **After**

N/A — internal hook refactor, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-867]: https://consensyssoftware.atlassian.net/browse/TMCU-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ