### PR TITLE
perf: stop eagerly rendering all account rows in CaipAccountSelectorList

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -346,22 +346,13 @@ runs:
         NODE_OPTIONS: --max-old-space-size=4096
         YARN_ENABLE_GLOBAL_CACHE: 'true'
 
-    - name: Install Foundry with retry
-      if: ${{ inputs.install-foundry == 'true' }}
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
-      with:
-        timeout_minutes: ${{ fromJSON(inputs.js-retry-timeout-minutes) }}
-        max_attempts: 3
-        retry_wait_seconds: 30
-        on_retry_command: echo "⚠️ yarn install:foundryup failed — likely a transient network issue on the self-hosted runner. Retrying..."
-        command: |
-          echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
-          yarn install:foundryup
-
-    - name: Add Foundry binary path
+    - name: Install Foundry
       if: ${{ inputs.install-foundry == 'true' }}
       shell: bash
-      run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
+      run: |
+        echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
+        yarn install:foundryup
+        echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
 
     ## iOS Setup ##
 

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -346,13 +346,22 @@ runs:
         NODE_OPTIONS: --max-old-space-size=4096
         YARN_ENABLE_GLOBAL_CACHE: 'true'
 
-    - name: Install Foundry
+    - name: Install Foundry with retry
+      if: ${{ inputs.install-foundry == 'true' }}
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      with:
+        timeout_minutes: ${{ fromJSON(inputs.js-retry-timeout-minutes) }}
+        max_attempts: 3
+        retry_wait_seconds: 30
+        on_retry_command: echo "⚠️ yarn install:foundryup failed — likely a transient network issue on the self-hosted runner. Retrying..."
+        command: |
+          echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
+          yarn install:foundryup
+
+    - name: Add Foundry binary path
       if: ${{ inputs.install-foundry == 'true' }}
       shell: bash
-      run: |
-        echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
-        yarn install:foundryup
-        echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
+      run: echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
 
     ## iOS Setup ##
 

--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -335,8 +335,10 @@ const CaipAccountSelectorList = ({
       data={accounts}
       keyExtractor={getKeyExtractor}
       renderItem={renderAccountItem}
-      // Increasing number of items at initial render fixes scroll issue.
-      initialNumToRender={999}
+      initialNumToRender={20}
+      maxToRenderPerBatch={20}
+      windowSize={11}
+      removeClippedSubviews
       testID={ACCOUNT_SELECTOR_LIST_TESTID}
       {...props}
     />


### PR DESCRIPTION
## **Description**

`CaipAccountSelectorList` set `initialNumToRender={999}` on its `FlatList`, which forced React Native to mount every account row up-front to work around an auto-scroll issue. For users with many accounts this caused noticeable jank on open of the account selector and wasted memory on rows that are off-screen.

The original auto-scroll uses `scrollToOffset` with a precomputed `yOffset` from the data, which works correctly with FlatList virtualization — the list will mount rows around the target offset as it scrolls. This PR restores normal virtualization with sensible window sizes (`initialNumToRender=20`, `maxToRenderPerBatch=20`, `windowSize=11`, `removeClippedSubviews`) so only on-screen and near-screen rows mount initially.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-869](https://consensyssoftware.atlassian.net/browse/TMCU-869)

## **Manual testing steps**

```gherkin
Feature: CaipAccountSelectorList virtualization

  Scenario: Opening the account selector with many accounts
    Given a wallet with 30+ accounts is imported
    When the user opens the account selector
    Then the list opens smoothly without jank
    And the currently selected account is scrolled into view
    And scrolling the list renders additional rows on demand
```

## **Screenshots/Recordings**

### **Before**

N/A — internal performance change, no UI change.

### **After**

N/A — internal performance change, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-869]: https://consensyssoftware.atlassian.net/browse/TMCU-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ