### PR TITLE
feat(predict): bug fix - Live price chart goes blank or jumps to a wrong value during live matches

### DIFF
--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { PanResponder } from 'react-native';
+import { fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictGameChartContent from './PredictGameChartContent';
 import { GameChartSeries } from './PredictGameChart.types';
@@ -8,6 +9,7 @@ import {
   CHART_WITH_TIMEFRAME_SELECTOR_HEIGHT,
   CHART_INSET_RIGHT_MIN,
 } from './PredictGameChart.constants';
+import { PREDICT_GAME_CHART_CONTENT_TEST_IDS } from './PredictGameChartContent.testIds';
 
 jest.mock('react-native-svg-charts', () => {
   const { View, Text } = jest.requireActual('react-native');
@@ -596,6 +598,124 @@ describe('PredictGameChartContent (Chart UI)', () => {
       const hundred = getPrimaryRightInset(pair('A', 100, 'B', 0));
 
       expect(hundred).toBeGreaterThan(twoDigit);
+    });
+  });
+
+  describe('Base layer always renders', () => {
+    it('mounts a line for every series by default (no tooltip interaction needed)', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChartContent data={mockDualSeriesData} testID="chart" />,
+      );
+
+      // Primary + overlay lines are mounted unconditionally (not gated behind
+      // tooltip state), so a tooltip toggle can never remount/blank them.
+      expect(getAllByTestId('line-chart').length).toBe(
+        mockDualSeriesData.length,
+      );
+    });
+
+    it('keeps the overlay lines mounted with full data when the tooltip activates', () => {
+      // Capture the PanResponder config so we can drive a scrub directly,
+      // bypassing the native responder negotiation that RNTL cannot simulate.
+      const createSpy = jest.spyOn(PanResponder, 'create');
+
+      const { getByTestId, getAllByTestId } = renderWithProvider(
+        <PredictGameChartContent data={mockDualSeriesData} testID="chart" />,
+      );
+
+      // Base layer before any interaction: primary + one overlay.
+      expect(getAllByTestId('line-chart')).toHaveLength(2);
+
+      const config = createSpy.mock.calls[0]?.[0] as NonNullable<
+        Parameters<typeof PanResponder.create>[0]
+      >;
+
+      const surface = getByTestId(PREDICT_GAME_CHART_CONTENT_TEST_IDS.SURFACE);
+
+      // Give the surface a measured width (so the touch maps to a data index)
+      // and then activate the tooltip near the right edge via a scrub grant.
+      act(() => {
+        surface.props.onLayout({
+          nativeEvent: { layout: { width: 400, height: 200 } },
+        });
+        config.onPanResponderGrant?.(
+          { nativeEvent: { locationX: 300 } } as never,
+          {} as never,
+        );
+      });
+
+      // The overlay base line still carries its full, untouched data: the
+      // tooltip toggle must not tear it down (the scroll-blank regression).
+      const renderedData = getAllByTestId('chart-data').map((node) =>
+        JSON.parse(String(node.children[0])),
+      );
+      expect(renderedData).toContainEqual([50, 45, 40, 30]);
+
+      // Extra gray "inactive" layers are added on top of the base lines.
+      expect(getAllByTestId('line-chart').length).toBeGreaterThan(2);
+
+      createSpy.mockRestore();
+    });
+  });
+
+  describe('Non-finite values', () => {
+    it('keeps a finite, [0,100]-bounded domain when a series has NaN/Infinity', () => {
+      const data: GameChartSeries[] = [
+        {
+          label: 'SEA',
+          color: TEST_HEX_COLORS.TEAM_SEA,
+          data: [
+            { timestamp: 1, value: 40 },
+            { timestamp: 2, value: NaN },
+            { timestamp: 3, value: 60 },
+          ],
+        },
+        {
+          label: 'DEN',
+          color: TEST_HEX_COLORS.TEAM_DEN,
+          data: [
+            { timestamp: 1, value: 60 },
+            { timestamp: 2, value: Infinity },
+            { timestamp: 3, value: 40 },
+          ],
+        },
+      ];
+
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChartContent data={data} />,
+      );
+
+      const lineChart = getAllByTestId('line-chart')[0];
+      expect(Number.isFinite(lineChart.props.yMin)).toBe(true);
+      expect(Number.isFinite(lineChart.props.yMax)).toBe(true);
+      expect(lineChart.props.yMin).toBeGreaterThanOrEqual(0);
+      expect(lineChart.props.yMax).toBeLessThanOrEqual(100);
+    });
+
+    it('falls back to a [0,100] domain when no finite values remain', () => {
+      const data: GameChartSeries[] = [
+        {
+          label: 'SEA',
+          color: TEST_HEX_COLORS.TEAM_SEA,
+          data: [
+            { timestamp: 1, value: NaN },
+            { timestamp: 2, value: Infinity },
+          ],
+        },
+        {
+          label: 'DEN',
+          color: TEST_HEX_COLORS.TEAM_DEN,
+          data: [{ timestamp: 1, value: NaN }],
+        },
+      ];
+
+      const { getAllByTestId } = renderWithProvider(
+        <PredictGameChartContent data={data} />,
+      );
+
+      const lineChart = getAllByTestId('line-chart')[0];
+      expect(lineChart.props.yMin).toBe(0);
+      expect(lineChart.props.yMax).toBe(100);
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx
@@ -228,9 +228,31 @@ const PredictGameChart: React.FC<PredictGameChartProps> = ({
         const existingData = [...series.data];
         const lastPoint = existingData[existingData.length - 1];
 
-        const newValue = priceUpdate
-          ? Number((priceUpdate.bestAsk * 100).toFixed(2))
-          : (lastPoint?.value ?? 50);
+        // An empty/locked/invalid order book arrives as bestAsk 0 (or a
+        // non-finite / out-of-range value). Treat that as "no update" and carry
+        // forward the last real value instead of plotting a literal 0% cliff.
+        // Never fabricate a 50% point when there is no prior value either.
+        //
+        // Note: this intentionally means a genuine bestAsk of exactly 0 (no
+        // liquidity / fully locked outcome) is also carried forward rather than
+        // drawn as 0% - for a live game that is "no tradeable price right now",
+        // which is what we want to show. Valid probabilities live in (0, 1].
+        const rawBestAsk = priceUpdate?.bestAsk;
+        const hasValidPrice =
+          typeof rawBestAsk === 'number' &&
+          Number.isFinite(rawBestAsk) &&
+          rawBestAsk > 0 &&
+          rawBestAsk <= 1;
+
+        const newValue = hasValidPrice
+          ? Number((rawBestAsk * 100).toFixed(2))
+          : lastPoint?.value;
+
+        // Nothing valid to plot and nothing to carry forward: leave this
+        // series untouched rather than injecting a 0 or a 50.
+        if (newValue === undefined) {
+          return series;
+        }
 
         const newPoint: GameChartDataPoint = {
           timestamp: now,

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx
@@ -505,6 +505,83 @@ describe('PredictGameChart Wrapper', () => {
       });
     });
 
+    it.each([
+      ['zero (empty/locked book)', 0],
+      ['NaN (invalid feed value)', NaN],
+    ])(
+      'carries forward the last real value when bestAsk is %s instead of plotting 0 or 50',
+      async (_label, invalidBestAsk) => {
+        const baseTimestamp = new Date('2024-01-15T12:00:00.000Z').getTime();
+        jest.setSystemTime(new Date(baseTimestamp + 30000)); // same minute
+
+        // Distinguishable seed values: token-a -> 60, token-b -> 40, so a
+        // carried value (60) is clearly neither a 0 cliff nor a fabricated 50.
+        const mockHistories = [
+          [{ timestamp: baseTimestamp, price: 0.6 }],
+          [{ timestamp: baseTimestamp, price: 0.4 }],
+        ];
+
+        mockUsePredictPriceHistory.mockReturnValue({
+          priceHistories: mockHistories,
+          isFetching: false,
+          errors: [null, null],
+          refetch: jest.fn(),
+        });
+
+        const pricesMap = new Map([
+          [
+            'token-a',
+            {
+              tokenId: 'token-a',
+              price: 0.54,
+              bestAsk: invalidBestAsk,
+              timestamp: Date.now(),
+            },
+          ],
+          [
+            'token-b',
+            {
+              tokenId: 'token-b',
+              price: 0.44,
+              bestAsk: 0.46,
+              timestamp: Date.now(),
+            },
+          ],
+        ]);
+
+        mockUseLiveMarketPrices.mockReturnValue({
+          prices: pricesMap,
+          getPrice: (id: string) => pricesMap.get(id),
+          isConnected: true,
+          lastUpdateTime: Date.now(),
+        });
+
+        const { getByTestId, rerender } = render(
+          <PredictGameChart market={defaultMarket} testID="chart" />,
+        );
+
+        await waitFor(() => {
+          const data = JSON.parse(
+            String(getByTestId('content-data').children[0]),
+          );
+          expect(data).toHaveLength(2);
+        });
+
+        rerender(<PredictGameChart market={defaultMarket} testID="chart" />);
+
+        await waitFor(() => {
+          const data = JSON.parse(
+            String(getByTestId('content-data').children[0]),
+          );
+
+          // Invalid bestAsk -> carry forward the seeded 60 (no 0, no 50).
+          expect(data[0].data[data[0].data.length - 1].value).toBe(60);
+          // The other token still updates normally from its valid bestAsk.
+          expect(data[1].data[data[1].data.length - 1].value).toBe(46);
+        });
+      },
+    );
+
     it('adds new data point when minute changes', async () => {
       const baseTimestamp = new Date('2024-01-15T12:00:00.000Z').getTime();
 

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.testIds.ts
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.testIds.ts
@@ -1,3 +1,4 @@
 export const PREDICT_GAME_CHART_CONTENT_TEST_IDS = {
   RETRY_BUTTON: 'retry-button',
+  SURFACE: 'predict-game-chart-surface',
 } as const;

--- a/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
+++ b/app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx
@@ -33,6 +33,13 @@ import { PREDICT_GAME_CHART_CONTENT_TEST_IDS } from './PredictGameChartContent.t
 
 const LINE_CURVE = curveStepAfter;
 
+// Replace any non-finite point with `null` so it becomes a single gap (via the
+// chart's `.defined` check) instead of injecting a NaN/Infinity coordinate that
+// would invalidate the entire SVG path and blank the whole line. Mapping to
+// null (rather than filtering) keeps indices aligned with timestamps/activeIndex.
+const toRenderable = (values: (number | null)[]): (number | null)[] =>
+  values.map((v) => (typeof v === 'number' && Number.isFinite(v) ? v : null));
+
 const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
   data,
   isLoading = false,
@@ -61,13 +68,17 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
   const hasData = nonEmptySeries.length > 0;
 
   const { chartMin, chartMax, maxValue } = useMemo(() => {
-    if (!hasData) {
+    // Filter out any non-finite values before computing the domain. A single
+    // NaN/Infinity would otherwise turn Math.min/Math.max into NaN and collapse
+    // the y-scale to [NaN, NaN], blanking every line.
+    const chartValues = nonEmptySeries
+      .flatMap((series) => series.data.map((point) => point.value))
+      .filter((value) => Number.isFinite(value));
+
+    if (!hasData || chartValues.length === 0) {
       return { chartMin: 0, chartMax: 100, maxValue: 0 };
     }
 
-    const chartValues = nonEmptySeries.flatMap((series) =>
-      series.data.map((point) => point.value),
-    );
     const minValue = Math.min(...chartValues);
     const maxChartValue = Math.max(...chartValues);
     const range = maxChartValue - minValue;
@@ -103,7 +114,7 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
   const primarySeries = nonEmptySeries[0] ?? seriesToRender[0];
   const primaryData = primarySeries?.data ?? [];
   const primaryChartData = primaryData.length
-    ? primaryData.map((point) => point.value)
+    ? toRenderable(primaryData.map((point) => point.value))
     : [50, 50];
 
   // Keep ref in sync for stable PanResponder (avoids recreation on data length changes)
@@ -250,10 +261,10 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
   const overlaySeries = nonEmptySeries.slice(1);
   const grayColor = colors.text.muted;
 
-  const getActiveData = (values: number[]) =>
-    values.map((v, i) => (i <= activeIndex ? v : null));
-
-  const getInactiveData = (values: number[]) =>
+  // The base layer below always draws each series in full color. When the
+  // tooltip is active we only need to paint the "future" (>= activeIndex)
+  // portion gray on top, so a single inactive helper is enough.
+  const getInactiveData = (values: (number | null)[]) =>
     values.map((v, i) => (i >= activeIndex ? v : null));
 
   const isTooltipActive = activeIndex >= 0;
@@ -262,56 +273,63 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
     <Box twClassName="w-full" testID={testID}>
       <View
         style={tw.style(`h-[${CHART_HEIGHT}px]`)}
+        testID={PREDICT_GAME_CHART_CONTENT_TEST_IDS.SURFACE}
         {...panResponder.panHandlers}
         onLayout={handleChartLayout}
       >
-        {!isTooltipActive ? (
-          <>
-            <LineChart
-              style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
-              data={primaryChartData}
-              svg={{
-                stroke: primarySeries?.color || colors.primary.default,
-                strokeWidth: 2,
-              }}
-              contentInset={contentInset}
-              yMin={chartMin}
-              yMax={chartMax}
-              curve={LINE_CURVE}
-            >
-              <EndpointDots
-                nonEmptySeries={nonEmptySeries}
-                primaryDataLength={primaryData.length}
-              />
-            </LineChart>
-
-            {overlaySeries.map((series, index) => (
-              <LineChart
-                key={`overlay-${index}`}
-                style={tw.style('absolute inset-0')}
-                data={series.data.map((point) => point.value)}
-                svg={{ stroke: series.color, strokeWidth: 2 }}
-                contentInset={contentInset}
-                yMin={chartMin}
-                yMax={chartMax}
-                curve={LINE_CURVE}
-              />
-            ))}
-          </>
-        ) : (
-          <>
-            <LineChart
-              style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
-              data={getActiveData(primaryChartData)}
-              svg={{
-                stroke: primarySeries?.color || colors.primary.default,
-                strokeWidth: 2,
-              }}
-              contentInset={contentInset}
-              yMin={chartMin}
-              yMax={chartMax}
-              curve={LINE_CURVE}
+        {/*
+         * Base layer: the primary and overlay lines are ALWAYS mounted in the
+         * same positions regardless of tooltip state. Activating the tooltip
+         * used to swap to a different element tree, which reordered/remounted
+         * the overlay charts; on remount `react-native-svg-charts` resets its
+         * measured size and draws nothing until the next layout pass, blanking
+         * the overlay lines for a frame on every scroll-driven toggle.
+         */}
+        <LineChart
+          style={tw.style(`h-[${CHART_HEIGHT}px] w-full`)}
+          data={primaryChartData}
+          svg={{
+            stroke: primarySeries?.color || colors.primary.default,
+            strokeWidth: 2,
+          }}
+          contentInset={contentInset}
+          yMin={chartMin}
+          yMax={chartMax}
+          curve={LINE_CURVE}
+        >
+          {!isTooltipActive && (
+            <EndpointDots
+              nonEmptySeries={nonEmptySeries}
+              primaryDataLength={primaryData.length}
             />
+          )}
+        </LineChart>
+
+        {overlaySeries.map((series, index) => (
+          <LineChart
+            key={`overlay-${index}`}
+            style={tw.style('absolute inset-0')}
+            data={toRenderable(series.data.map((point) => point.value))}
+            svg={{ stroke: series.color, strokeWidth: 2 }}
+            contentInset={contentInset}
+            yMin={chartMin}
+            yMax={chartMax}
+            curve={LINE_CURVE}
+          />
+        ))}
+
+        {/*
+         * Tooltip layer: additive only. We paint the "future" portion of each
+         * line gray on top of the always-present base lines and render the
+         * crosshair. Mounting/unmounting these extra layers never tears down
+         * the base lines, so they stay visible while scrubbing.
+         *
+         * Draw order: the gray overlay segments are rendered after the gray
+         * primary segment, so at line crossings in the grayed region the
+         * overlays stay visually on top - matching the previous split render.
+         */}
+        {isTooltipActive && (
+          <>
             <LineChart
               style={tw.style('absolute inset-0')}
               data={getInactiveData(primaryChartData)}
@@ -322,31 +340,20 @@ const PredictGameChartContent: React.FC<PredictGameChartContentProps> = ({
               curve={LINE_CURVE}
             />
 
-            {overlaySeries.map((series, index) => {
-              const seriesValues = series.data.map((point) => point.value);
-              return (
-                <React.Fragment key={`overlay-split-${index}`}>
-                  <LineChart
-                    style={tw.style('absolute inset-0')}
-                    data={getActiveData(seriesValues)}
-                    svg={{ stroke: series.color, strokeWidth: 2 }}
-                    contentInset={contentInset}
-                    yMin={chartMin}
-                    yMax={chartMax}
-                    curve={LINE_CURVE}
-                  />
-                  <LineChart
-                    style={tw.style('absolute inset-0')}
-                    data={getInactiveData(seriesValues)}
-                    svg={{ stroke: grayColor, strokeWidth: 2 }}
-                    contentInset={contentInset}
-                    yMin={chartMin}
-                    yMax={chartMax}
-                    curve={LINE_CURVE}
-                  />
-                </React.Fragment>
-              );
-            })}
+            {overlaySeries.map((series, index) => (
+              <LineChart
+                key={`overlay-inactive-${index}`}
+                style={tw.style('absolute inset-0')}
+                data={getInactiveData(
+                  toRenderable(series.data.map((point) => point.value)),
+                )}
+                svg={{ stroke: grayColor, strokeWidth: 2 }}
+                contentInset={contentInset}
+                yMin={chartMin}
+                yMax={chartMax}
+                curve={LINE_CURVE}
+              />
+            ))}
 
             <LineChart
               style={tw.style('absolute inset-0')}


### PR DESCRIPTION
## **Description**

During a live game, the Predict price chart lines would intermittently disappear (go blank) while the user scrolled the Market Details page, especially when the tooltip/crosshair was active. The favorite (primary) line tended to survive while the overlay outcome lines (e.g. DRAW, MAR) vanished, even though their endpoint dots/labels still rendered.

**Root cause (primary):** The chart renders an interactive tooltip/crosshair while you press-and-scrub. Activating the tooltip swapped the chart into a structurally different element tree that inserted an extra "inactive" primary `LineChart` ahead of the overlay charts. React reconciles fragment children by position, so the overlay `LineChart`s were unmounted/remounted on every tooltip toggle. On remount, `react-native-svg-charts` resets its measured size and renders nothing until the next layout pass (`height > 0 && width > 0` gate), blanking the overlay lines for a frame. Because a scroll that starts on the chart toggles the tooltip on→off, this manifested as "lines disappear while scrolling".

**Fix (primary):** Restructure the render so the base primary and overlay lines are always mounted in stable positions, and the tooltip's grayed "inactive" segments + crosshair are layered additively on top. Toggling the tooltip can no longer remount the base lines, so they stay visible across the toggle. Tooltip activation/dismiss behavior (press-and-hold to scrub, dismiss on release/scroll) is unchanged.

**Secondary hardening (defensive, related symptoms in the report):**

- Live updates: treat an empty/locked/invalid order book (`bestAsk` of `0`, `NaN`, or outside `(0, 1]`) as "no update" and carry forward the last real value, instead of plotting a literal `0%` cliff or a fabricated `50%`.
- Chart domain: finite-filter values before `Math.min`/`Math.max` and default to a `[0, 100]` domain so a stray non-finite value can't collapse the y-scale to `[NaN, NaN]` and blank everything.
- Per-series render arrays are sanitized (non-finite → a single gap via the chart's `.defined`) so one bad point can't invalidate an entire line path.

`WebSocketManager.ts` is intentionally left unchanged; its `|| 0` coercion also feeds spot prices and other consumers, and the `$0` spot-price issue is tracked separately (PRED-958).

## **Changelog**

CHANGELOG entry: Fixed a bug where the live game price chart lines could briefly disappear while scrolling the market details page.

## **Related issues**

Fixes: #<add-issue-number>

## **Manual testing steps**

```gherkin
Feature: Predict live game price chart

  Scenario: Lines stay visible while scrolling during a live game
    Given I am viewing an ongoing (live) game market on Market Details
    And the chart is in the "Live" timeframe showing multiple outcome lines (e.g. BRA, DRAW, MAR)
    When I press on the chart to show the tooltip and then scroll the page up and down
    Then all outcome lines remain visible and do not blank out
    And the tooltip dismisses on scroll as before (unchanged behavior)

  Scenario: Invalid live price does not draw a 0% cliff or a 50% jump
    Given a live outcome's order book becomes empty/locked (bestAsk is 0/empty/invalid)
    When the live feed delivers that update
    Then the chart carries the last real value forward
    And it does not drop to 0% or jump to 50%
```

## **Screenshots/Recordings**

### **Before**

<!-- Recording: live chart with tooltip active; overlay (DRAW/MAR) lines blank out while scrolling -->

### **After**

<!-- Recording: same flow; all lines remain visible while scrolling; tooltip still dismisses on scroll -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## Files changed

- `app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx` — stable-render restructure (base lines always mounted, tooltip layered additively); finite-filter + `[0,100]` default domain; `toRenderable` sanitization of per-series arrays.
- `app/components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx` — carry-forward last real value on invalid `bestAsk` (`0`/`NaN`/outside `(0, 1]`); no fabricated `50`.
- `app/components/UI/Predict/components/PredictGameChart/PredictGameChartContent.testIds.ts` — added `SURFACE` test id.
- `app/components/UI/Predict/components/PredictGameChart/PredictGameChart.test.tsx` — tooltip-activation regression test (overlays stay mounted), base-layer and non-finite-domain tests.
- `app/components/UI/Predict/components/PredictGameChart/PredictGameChart.wrapper.test.tsx` — `bestAsk` `0`/`NaN` carry-forward tests.

## Before opening for review

- Replace `#<add-issue-number>` with the real issue/ticket.
- Attach before/after recordings (scrolling with the tooltip up on a live game).
- Add the required `team-*` label; add `needs-qa` if QA should validate on a live game.
- Open as Draft first; change is UI-only with no Android-specific or performance-sensitive paths, so the performance checks are reasonably N/A.
