### PR TITLE
refactor: extract CaipAccountSelectorList row into a React.memo component

### DIFF
--- a/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
+++ b/app/components/UI/CaipAccountSelectorList/CaipAccountSelectorList.tsx
@@ -25,7 +25,8 @@ import { formatAddress, getLabelTextByAddress } from '../../../util/address';
 import { isDefaultAccountName } from '../../../util/ENSUtils';
 import { strings } from '../../../../locales/i18n';
 import { AvatarVariant } from '../../../component-library/components/Avatars/Avatar/Avatar.types';
-import { Account, Assets } from '../../hooks/useAccounts';
+import { AvatarAccountType } from '../../../component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.types';
+import { Account } from '../../hooks/useAccounts';
 import Engine from '../../../core/Engine';
 import {
   removeAccountsFromPermissions,
@@ -47,6 +48,154 @@ import {
   CaipChainId,
 } from '@metamask/utils';
 import { selectAvatarAccountType } from '../../../selectors/settings';
+
+interface CaipAccountSelectorRowProps {
+  account: Account;
+  ensName?: string;
+  accountAvatarType: AvatarAccountType;
+  isLoading: boolean;
+  isSelectionDisabled?: boolean;
+  isMultiSelect: boolean;
+  isSelectWithoutMenu: boolean;
+  isSelectedFromAddresses: boolean;
+  privacyMode: boolean;
+  styles: ReturnType<typeof styleSheet>;
+  onSelectAccount?: (caipAccountId: CaipAccountId, isSelected: boolean) => void;
+  onLongPressAccount: (params: {
+    address: string;
+    isAccountRemoveable: boolean;
+    isSelected: boolean;
+    caipAccountId: CaipAccountId;
+  }) => void;
+  onNavigateToAccountActions: (address: string) => void;
+  renderRightAccessory?: (
+    address: string,
+    accountName: string,
+  ) => React.ReactNode;
+}
+
+const CaipAccountSelectorRowBase = ({
+  account,
+  ensName,
+  accountAvatarType,
+  isLoading,
+  isSelectionDisabled,
+  isMultiSelect,
+  isSelectWithoutMenu,
+  isSelectedFromAddresses,
+  privacyMode,
+  styles,
+  onSelectAccount,
+  onLongPressAccount,
+  onNavigateToAccountActions,
+  renderRightAccessory,
+}: CaipAccountSelectorRowProps) => {
+  const {
+    name,
+    address,
+    assets,
+    type,
+    isSelected,
+    balanceError,
+    caipAccountId,
+    scopes,
+  } = account;
+
+  const partialAccount = { address, scopes };
+  const shortAddress = formatAddress(address, 'short');
+  const tagLabel = getLabelTextByAddress(address);
+  const accountName = isDefaultAccountName(name) && ensName ? ensName : name;
+  const isDisabled = !!balanceError || isLoading || isSelectionDisabled;
+
+  let cellVariant = CellVariant.SelectWithMenu;
+  if (isMultiSelect) {
+    cellVariant = CellVariant.MultiSelect;
+  }
+  if (isSelectWithoutMenu) {
+    cellVariant = CellVariant.Select;
+  }
+
+  const isSelectedAccount = isSelectedFromAddresses || isSelected;
+
+  const cellStyle: ViewStyle = {
+    opacity: isLoading ? 0.5 : 1,
+  };
+  if (!isMultiSelect) {
+    cellStyle.alignItems = 'center';
+  }
+
+  const handleLongPress = () => {
+    onLongPressAccount({
+      address,
+      isAccountRemoveable:
+        type === KeyringTypes.simple ||
+        (type === KeyringTypes.snap && !isSolanaAddress(address)),
+      isSelected: isSelectedAccount,
+      caipAccountId,
+    });
+  };
+
+  const handlePress = () => {
+    onSelectAccount?.(caipAccountId, isSelectedAccount);
+  };
+
+  const handleButtonClick = () => {
+    onNavigateToAccountActions(address);
+  };
+
+  const buttonProps = {
+    onButtonClick: handleButtonClick,
+    buttonTestId: WalletViewSelectorsIDs.ACCOUNT_ACTIONS,
+  };
+
+  const avatarProps = {
+    variant: AvatarVariant.Account as const,
+    type: accountAvatarType,
+    accountAddress: address,
+  };
+
+  const fiatBalanceAmount = assets
+    ? assets.fiatBalance.split('\n')[0] || ''
+    : '';
+
+  return (
+    <Cell
+      key={address}
+      onLongPress={handleLongPress}
+      variant={cellVariant}
+      isSelected={isSelectedAccount}
+      title={accountName}
+      secondaryText={shortAddress}
+      showSecondaryTextIcon={false}
+      tertiaryText={balanceError}
+      onPress={handlePress}
+      avatarProps={avatarProps}
+      tagLabel={tagLabel}
+      disabled={isDisabled}
+      style={cellStyle}
+      buttonProps={buttonProps}
+    >
+      {renderRightAccessory?.(address, accountName) ||
+        (assets && (
+          <View
+            style={styles.balancesContainer}
+            testID={`${AccountListBottomSheetSelectorsIDs.ACCOUNT_BALANCE_BY_ADDRESS_TEST_ID}-${partialAccount.address}`}
+          >
+            <SensitiveText
+              length={SensitiveTextLength.Long}
+              style={styles.balanceLabel}
+              isHidden={privacyMode}
+            >
+              {fiatBalanceAmount}
+            </SensitiveText>
+            <AccountNetworkIndicator partialAccount={partialAccount} />
+          </View>
+        ))}
+    </Cell>
+  );
+};
+
+const CaipAccountSelectorRow = React.memo(CaipAccountSelectorRowBase);
 
 const CaipAccountSelectorList = ({
   onSelectAccount,
@@ -73,32 +222,6 @@ const CaipAccountSelectorList = ({
 
   const accountAvatarType = useSelector(selectAvatarAccountType, shallowEqual);
   const getKeyExtractor = ({ caipAccountId }: Account) => caipAccountId;
-
-  const renderAccountBalances = useCallback(
-    (
-      { fiatBalance }: Assets,
-      partialAccount: { address: string; scopes: CaipChainId[] },
-    ) => {
-      const fiatBalanceStrSplit = fiatBalance.split('\n');
-      const fiatBalanceAmount = fiatBalanceStrSplit[0] || '';
-      return (
-        <View
-          style={styles.balancesContainer}
-          testID={`${AccountListBottomSheetSelectorsIDs.ACCOUNT_BALANCE_BY_ADDRESS_TEST_ID}-${partialAccount.address}`}
-        >
-          <SensitiveText
-            length={SensitiveTextLength.Long}
-            style={styles.balanceLabel}
-            isHidden={privacyMode}
-          >
-            {fiatBalanceAmount}
-          </SensitiveText>
-          <AccountNetworkIndicator partialAccount={partialAccount} />
-        </View>
-      );
-    },
-    [styles.balancesContainer, styles.balanceLabel, privacyMode],
-  );
 
   const onLongPress = useCallback(
     ({
@@ -193,104 +316,33 @@ const CaipAccountSelectorList = ({
   );
 
   const renderAccountItem: ListRenderItem<Account> = useCallback(
-    ({
-      item: {
-        name,
-        address,
-        assets,
-        type,
-        isSelected,
-        balanceError,
-        caipAccountId,
-        scopes,
-      },
-    }) => {
-      const partialAccount = {
-        address,
-        scopes,
-      };
-      const shortAddress = formatAddress(address, 'short');
-      const tagLabel = getLabelTextByAddress(address);
-      const ensName = ensByAccountAddress[address];
-      const accountName =
-        isDefaultAccountName(name) && ensName ? ensName : name;
-      const isDisabled = !!balanceError || isLoading || isSelectionDisabled;
-      let cellVariant = CellVariant.SelectWithMenu;
-      if (isMultiSelect) {
-        cellVariant = CellVariant.MultiSelect;
-      }
-      if (isSelectWithoutMenu) {
-        cellVariant = CellVariant.Select;
-      }
-      let isSelectedAccount = isSelected;
-      if (selectedAddresses.length > 0) {
-        isSelectedAccount = selectedAddresses.includes(caipAccountId);
-      }
-
-      const cellStyle: ViewStyle = {
-        opacity: isLoading ? 0.5 : 1,
-      };
-      if (!isMultiSelect) {
-        cellStyle.alignItems = 'center';
-      }
-
-      const handleLongPress = () => {
-        onLongPress({
-          address,
-          isAccountRemoveable:
-            type === KeyringTypes.simple ||
-            (type === KeyringTypes.snap && !isSolanaAddress(address)),
-          isSelected: isSelectedAccount,
-          caipAccountId,
-        });
-      };
-
-      const handlePress = () => {
-        onSelectAccount?.(caipAccountId, isSelectedAccount);
-      };
-
-      const handleButtonClick = () => {
-        onNavigateToAccountActions(address);
-      };
-
-      const buttonProps = {
-        onButtonClick: handleButtonClick,
-        buttonTestId: WalletViewSelectorsIDs.ACCOUNT_ACTIONS,
-      };
-
-      const avatarProps = {
-        variant: AvatarVariant.Account as const,
-        type: accountAvatarType,
-        accountAddress: address,
-      };
-
+    ({ item }) => {
+      const isSelectedFromAddresses =
+        selectedAddresses.length > 0 &&
+        selectedAddresses.includes(item.caipAccountId);
       return (
-        <Cell
-          key={address}
-          onLongPress={handleLongPress}
-          variant={cellVariant}
-          isSelected={isSelectedAccount}
-          title={accountName}
-          secondaryText={shortAddress}
-          showSecondaryTextIcon={false}
-          tertiaryText={balanceError}
-          onPress={handlePress}
-          avatarProps={avatarProps}
-          tagLabel={tagLabel}
-          disabled={isDisabled}
-          style={cellStyle}
-          buttonProps={buttonProps}
-        >
-          {renderRightAccessory?.(address, accountName) ||
-            (assets && renderAccountBalances(assets, partialAccount))}
-        </Cell>
+        <CaipAccountSelectorRow
+          account={item}
+          ensName={ensByAccountAddress[item.address]}
+          accountAvatarType={accountAvatarType}
+          isLoading={isLoading}
+          isSelectionDisabled={isSelectionDisabled}
+          isMultiSelect={isMultiSelect}
+          isSelectWithoutMenu={isSelectWithoutMenu}
+          isSelectedFromAddresses={isSelectedFromAddresses}
+          privacyMode={privacyMode}
+          styles={styles}
+          onSelectAccount={onSelectAccount}
+          onLongPressAccount={onLongPress}
+          onNavigateToAccountActions={onNavigateToAccountActions}
+          renderRightAccessory={renderRightAccessory}
+        />
       );
     },
     [
       onNavigateToAccountActions,
       accountAvatarType,
       onSelectAccount,
-      renderAccountBalances,
       ensByAccountAddress,
       isLoading,
       selectedAddresses,
@@ -299,6 +351,8 @@ const CaipAccountSelectorList = ({
       renderRightAccessory,
       isSelectionDisabled,
       onLongPress,
+      privacyMode,
+      styles,
     ],
   );
 


### PR DESCRIPTION
## **Description**

`CaipAccountSelectorList` rendered each row inline from `renderItem`, which meant every account row re-rendered whenever any of the parent's many closure deps changed (selected addresses, ENS map, privacy mode, styles, etc.) — even rows whose own data did not change.

This PR extracts the row UI into a dedicated `CaipAccountSelectorRow` component wrapped in `React.memo`, with the row receiving primitives/props it actually needs (account, ENS name, selection flag, callbacks). Rows now skip re-render when their inputs are unchanged. Behavior is preserved: same `Cell` props, same long-press / select / actions / balance-rendering paths, and existing tests pass unchanged (26/26).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-871](https://consensyssoftware.atlassian.net/browse/TMCU-871)

## **Manual testing steps**

```gherkin
Feature: CaipAccountSelectorList row memoization

  Scenario: Account list interactions remain correct after memoizing rows
    Given a wallet with multiple accounts is imported
    When the user opens the account selector
    Then accounts render with the correct name, ENS, balance, and selection state
    And tapping an account selects it
    And long-pressing a removable account shows the remove prompt
    And tapping the menu opens the account actions sheet
    And toggling privacy mode hides/shows balances correctly
```

## **Screenshots/Recordings**

### **Before**

N/A — internal refactor with no UI change.

### **After**

N/A — internal refactor with no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-871]: https://consensyssoftware.atlassian.net/browse/TMCU-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ