### PR TITLE
fix(money): show Send flow instead of stuck pending tx for Between accounts (MUSD-975)

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -12,9 +12,7 @@ import BigNumber from 'bignumber.js';
 import {
   TransactionStatus,
   TransactionType,
-  type TransactionMeta,
 } from '@metamask/transaction-controller';
-import { providerErrors } from '@metamask/rpc-errors';
 import { createProjectLogger, Hex } from '@metamask/utils';
 import {
   BottomSheet,
@@ -31,7 +29,6 @@ import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
 } from '../../../Earn/constants/musd';
-import Engine from '../../../../../core/Engine';
 import {
   useMoneyAccountDeposit,
   type InitiateDepositOptions,
@@ -48,6 +45,7 @@ import styleSheet from './MoneyAddMoneySheet.styles';
 import { MoneyAddMoneySheetTestIds } from './MoneyAddMoneySheet.testIds';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import useMountEffect from '../../hooks/useMountEffect';
+import { rejectPendingTransactions } from '../../utils/rejectPendingTransactions';
 import {
   BOTTOM_SHEET_NAMES,
   COMPONENT_NAMES,
@@ -261,24 +259,5 @@ const MoneyAddMoneySheet: React.FC = () => {
     </BottomSheet>
   );
 };
-
-function rejectPendingTransactions(transactions: TransactionMeta[]) {
-  const { ApprovalController } = Engine.context;
-
-  for (const tx of transactions) {
-    if (tx.status !== TransactionStatus.unapproved) {
-      continue;
-    }
-    try {
-      ApprovalController.rejectRequest(
-        tx.id,
-        providerErrors.userRejectedRequest(),
-      );
-      log('Rejected transaction', tx.type, tx.id);
-    } catch {
-      log('Failed to reject transaction', tx.type, tx.id);
-    }
-  }
-}
 
 export default MoneyAddMoneySheet;

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useState } from 'react';
+import { act, fireEvent } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import MoneyTransferSheet from './MoneyTransferSheet';
+import { MoneyTransferSheetTestIds } from './MoneyTransferSheet.testIds';
+import Routes from '../../../../../constants/navigation/Routes';
+import Engine from '../../../../../core/Engine';
+import { updateBgState } from '../../../../../core/redux/slices/engine';
+import { addTransactionBatch } from '../../../../../util/transaction-controller';
+import { useMoneyPerpsDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPerpsDeposit';
+import { useMoneyPredictDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit';
+import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+
+const PENDING_TX_ID = 'pending-tx-from-elsewhere';
+
+const mockNavigate = jest.fn();
+let unmountSheet: () => void = () => undefined;
+const mockGoBack = jest.fn(() => unmountSheet());
+
+const mockVaultConfig = {
+  chainId: '0x8f',
+  boringVault: '0xb4563bcD3B7764CCBf497f515585f70B6C3EA5Ae',
+  tellerAddress: '0x2D49EA58A4C70b62c8B56DE971310d9e999c8117',
+  accountantAddress: '0x7382c5b8B51B8C4f127B3123C1039581BAA5A06B',
+  lensAddress: '0xA816ECd922de94c6879AD23B9A884dB257F20947',
+};
+
+// Stable references so react-redux's useSelector doesn't warn on every render.
+const mockPrimaryMoneyAccount = {
+  address: '0x1111111111111111111111111111111111111111',
+};
+const mockRecipient = '0x2222222222222222222222222222222222222222';
+
+// Mutable mock of Engine.state.TransactionController so the test can simulate
+// the TransactionController removing a transaction after it is rejected.
+const mockEngineState: {
+  TransactionController: { transactions: TransactionMeta[] };
+} = {
+  TransactionController: { transactions: [] },
+};
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const MockBottomSheet = forwardRef(
+    (
+      {
+        children,
+        testID,
+        goBack,
+      }: {
+        children: React.ReactNode;
+        testID?: string;
+        goBack?: () => void;
+      },
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      useImperativeHandle(
+        ref,
+        () => ({
+          onCloseBottomSheet: (cb?: () => void) => {
+            goBack?.();
+            cb?.();
+          },
+          onOpenBottomSheet: jest.fn(),
+        }),
+        [goBack],
+      );
+      return <View testID={testID}>{children}</View>;
+    },
+  );
+  const MockBottomSheetHeader = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <View>{children}</View>;
+  return {
+    ...actual,
+    BottomSheet: MockBottomSheet,
+    BottomSheetHeader: MockBottomSheetHeader,
+  };
+});
+
+// Keep the real `useMoneyAccountWithdrawal` + `useConfirmNavigation`; stub only
+// the heavy withdrawal-building internals so `initiateWithdrawal` reaches
+// navigation.
+jest.mock('../../utils/moneyAccountTransactions', () => ({
+  buildMoneyAccountWithdrawBatch: jest.fn().mockResolvedValue({
+    withdrawTx: { to: '0xwithdraw', data: '0x', value: '0x0' },
+    transferTx: { to: '0xtransfer', data: '0x', value: '0x0' },
+  }),
+  getMoneyAccountDepositAssetAddress: jest.fn(() => '0xasset'),
+}));
+
+jest.mock('../../../../../util/notifications/methods/common', () => ({
+  getProviderByChainId: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../../../util/transaction-controller', () => ({
+  addTransactionBatch: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    NetworkController: {
+      findNetworkClientIdByChainId: jest.fn(() => 'network-client-1'),
+    },
+    ApprovalController: { rejectRequest: jest.fn() },
+  },
+
+  get state() {
+    return mockEngineState;
+  },
+}));
+
+jest.mock(
+  '../../../../../selectors/featureFlagController/moneyAccount',
+  () => ({
+    ...jest.requireActual(
+      '../../../../../selectors/featureFlagController/moneyAccount',
+    ),
+    selectMoneyAccountVaultConfig: jest.fn(() => mockVaultConfig),
+  }),
+);
+
+jest.mock('../../../../../selectors/moneyAccountController', () => ({
+  ...jest.requireActual('../../../../../selectors/moneyAccountController'),
+  selectPrimaryMoneyAccount: jest.fn(() => mockPrimaryMoneyAccount),
+}));
+
+jest.mock('../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../selectors/accountsController'),
+  selectEvmAddress: jest.fn(() => mockRecipient),
+}));
+
+// Other transfer options are out of scope here; disable them.
+jest.mock(
+  '../../../../Views/confirmations/hooks/pay/useMoneyPerpsDeposit',
+  () => ({ useMoneyPerpsDeposit: jest.fn() }),
+);
+jest.mock(
+  '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit',
+  () => ({ useMoneyPredictDeposit: jest.fn() }),
+);
+jest.mock('../../hooks/useMoneyAnalytics', () => ({
+  useMoneyAnalytics: jest.fn(),
+}));
+
+// Wrapper that unmounts the sheet when `goBack` runs — modelling the modal
+// being popped on close, which is what tears the hook down in production.
+const SheetHarness = () => {
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    unmountSheet = () => setOpen(false);
+    return () => {
+      unmountSheet = () => undefined;
+    };
+  }, []);
+  return open ? <MoneyTransferSheet /> : null;
+};
+
+function renderHarness(pendingTransactions: TransactionMeta[]) {
+  return renderWithProvider(<SheetHarness />, {
+    state: {
+      engine: {
+        backgroundState: {
+          TransactionController: { transactions: pendingTransactions },
+        },
+      },
+    },
+  });
+}
+
+const flushAsync = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+/**
+ * Regression test for MUSD-975: tapping "Another account" (Between accounts)
+ * while a stale unapproved transaction was pending created a second stuck
+ * pending transaction and never showed the Send flow, because closing the sheet
+ * unmounted the component before the deferred navigation could run.
+ */
+describe('MoneyTransferSheet — Between accounts with a pending transaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEngineState.TransactionController = { transactions: [] };
+    (useMoneyPerpsDeposit as jest.Mock).mockReturnValue({
+      isEnabled: false,
+      initiatePerpsDeposit: jest.fn(),
+    });
+    (useMoneyPredictDeposit as jest.Mock).mockReturnValue({
+      isEnabled: false,
+      initiatePredictDeposit: jest.fn(),
+    });
+    (useMoneyAnalytics as jest.Mock).mockReturnValue({
+      trackBottomSheetViewed: jest.fn(),
+      trackSurfaceClicked: jest.fn(),
+    });
+  });
+
+  it('navigates to the Send flow even when an unconfirmed transaction is already pending', async () => {
+    const pendingTx = {
+      id: PENDING_TX_ID,
+      status: TransactionStatus.unapproved,
+    } as TransactionMeta;
+
+    const { getByTestId, store } = renderHarness([pendingTx]);
+
+    fireEvent.press(
+      getByTestId(MoneyTransferSheetTestIds.BETWEEN_ACCOUNTS_OPTION),
+    );
+    await flushAsync();
+
+    // The pre-existing pending transaction is rejected straight away.
+    expect(
+      jest.mocked(Engine.context.ApprovalController.rejectRequest),
+    ).toHaveBeenCalledWith(PENDING_TX_ID, expect.anything());
+
+    // Closing + navigating is deferred until the rejection clears from state,
+    // so the sheet stays mounted: it has not been closed and nothing has
+    // navigated yet. This is what keeps the navigation alive.
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(addTransactionBatch).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    // Simulate the TransactionController removing the rejected transaction.
+    mockEngineState.TransactionController = { transactions: [] };
+    await act(async () => {
+      store.dispatch(updateBgState({ key: 'TransactionController' }));
+    });
+    await flushAsync();
+
+    // Now that nothing is pending, the sheet closes (modal popped) and the
+    // withdrawal flow runs in one step — the user reaches the Send
+    // confirmation instead of being stranded with a stuck pending transaction.
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(addTransactionBatch).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.MONEY.CONFIRMATIONS_ROOT,
+      expect.objectContaining({
+        screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+      }),
+    );
+  });
+
+  it('navigates to the Send flow when no transaction is pending (control)', async () => {
+    const { getByTestId } = renderHarness([]);
+
+    fireEvent.press(
+      getByTestId(MoneyTransferSheetTestIds.BETWEEN_ACCOUNTS_OPTION),
+    );
+    await flushAsync();
+
+    // Nothing to reject, so the sheet closes and navigates immediately.
+    expect(
+      jest.mocked(Engine.context.ApprovalController.rejectRequest),
+    ).not.toHaveBeenCalled();
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(addTransactionBatch).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.MONEY.CONFIRMATIONS_ROOT,
+      expect.objectContaining({
+        screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+      }),
+    );
+  });
+});

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
@@ -21,6 +21,11 @@ jest.mock('../../hooks/useMoneyAnalytics', () => ({
   useMoneyAnalytics: jest.fn(),
 }));
 
+jest.mock('../../../../../selectors/transactionController', () => ({
+  ...jest.requireActual('../../../../../selectors/transactionController'),
+  selectTransactions: jest.fn(() => []),
+}));
+
 const mockInitiateWithdrawal = jest.fn().mockResolvedValue(undefined);
 const mockInitiatePerpsDeposit = jest.fn().mockResolvedValue(undefined);
 const mockInitiatePredictDeposit = jest.fn().mockResolvedValue(undefined);

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
@@ -1,6 +1,18 @@
-import React, { useCallback, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { providerErrors } from '@metamask/rpc-errors';
 import {
   BottomSheet,
   BottomSheetHeader,
@@ -11,6 +23,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
+import Engine from '../../../../../core/Engine';
+import { selectTransactions } from '../../../../../selectors/transactionController';
 import { useMoneyAccountWithdrawal } from '../../hooks/useMoneyAccount';
 import { useMoneyPerpsDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPerpsDeposit';
 import { useMoneyPredictDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit';
@@ -29,6 +43,8 @@ import {
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import useMountEffect from '../../hooks/useMountEffect';
 
+type TransferAction = 'withdraw' | 'perps' | 'predict';
+
 const MoneyTransferSheet = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
@@ -46,6 +62,71 @@ const MoneyTransferSheet = () => {
 
   useMountEffect(trackBottomSheetViewed);
 
+  const transactions = useSelector(selectTransactions);
+
+  const hasPendingTransaction = useMemo(
+    () =>
+      (transactions ?? []).some(
+        (tx) => tx.status === TransactionStatus.unapproved,
+      ),
+    [transactions],
+  );
+
+  const [deferredAction, setDeferredAction] = useState<TransferAction | null>(
+    null,
+  );
+
+  // Close the sheet (which pops the modal) and kick off the transfer in one
+  // atomic step, so the confirmation slides straight over the sheet rather than
+  // flashing back to Money home in between. We resolve the initiator here rather
+  // than capturing it earlier so a deferred run uses the up-to-date navigation
+  // closure (which no longer sees the just-rejected transaction), not a stale
+  // snapshot.
+  const closeAndStart = useCallback(
+    (action: TransferAction) => {
+      let initiate = initiateWithdrawal;
+      if (action === 'perps') {
+        initiate = initiatePerpsDeposit;
+      } else if (action === 'predict') {
+        initiate = initiatePredictDeposit;
+      }
+      sheetRef.current?.onCloseBottomSheet(() => {
+        initiate().catch((error: Error) => {
+          Logger.error(
+            error,
+            '[MoneyTransferSheet] Transfer initiation failed',
+          );
+        });
+      });
+    },
+    [initiateWithdrawal, initiatePerpsDeposit, initiatePredictDeposit],
+  );
+
+  // A leftover unapproved transaction would be picked up by the confirmation
+  // screen, so we reject it before opening a fresh one. Rejection clears from
+  // state asynchronously and closing the sheet unmounts us, so when something is
+  // pending we stay mounted and defer the close+navigate (see effect) instead of
+  // letting it race the unmount.
+  const startAction = useCallback(
+    (action: TransferAction) => {
+      if (hasPendingTransaction) {
+        rejectPendingTransactions(transactions ?? []);
+        setDeferredAction(action);
+        return;
+      }
+      closeAndStart(action);
+    },
+    [hasPendingTransaction, transactions, closeAndStart],
+  );
+
+  useEffect(() => {
+    if (!deferredAction || hasPendingTransaction) {
+      return;
+    }
+    closeAndStart(deferredAction);
+    setDeferredAction(null);
+  }, [deferredAction, hasPendingTransaction, closeAndStart]);
+
   const handleGoBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
@@ -57,15 +138,8 @@ const MoneyTransferSheet = () => {
       redirect_target: SCREEN_NAMES.MONEY_TRANSFER,
     });
 
-    sheetRef.current?.onCloseBottomSheet(() => {
-      initiateWithdrawal().catch((error: Error) => {
-        Logger.error(
-          error,
-          '[MoneyTransferSheet] Withdrawal initiation failed',
-        );
-      });
-    });
-  }, [initiateWithdrawal, trackSurfaceClicked]);
+    startAction('withdraw');
+  }, [startAction, trackSurfaceClicked]);
 
   const handlePerpsAccount = useCallback(() => {
     trackSurfaceClicked({
@@ -73,10 +147,8 @@ const MoneyTransferSheet = () => {
       redirect_target: SCREEN_NAMES.MONEY_TRANSFER,
     });
 
-    sheetRef.current?.onCloseBottomSheet(() => {
-      initiatePerpsDeposit();
-    });
-  }, [initiatePerpsDeposit, trackSurfaceClicked]);
+    startAction('perps');
+  }, [startAction, trackSurfaceClicked]);
 
   const handlePredictionsAccount = useCallback(() => {
     trackSurfaceClicked({
@@ -85,10 +157,8 @@ const MoneyTransferSheet = () => {
       redirect_target: SCREEN_NAMES.MONEY_TRANSFER,
     });
 
-    sheetRef.current?.onCloseBottomSheet(() => {
-      initiatePredictDeposit();
-    });
-  }, [initiatePredictDeposit, trackSurfaceClicked]);
+    startAction('predict');
+  }, [startAction, trackSurfaceClicked]);
 
   const options: MoneySheetOption[] = [
     {
@@ -146,5 +216,26 @@ const MoneyTransferSheet = () => {
     </BottomSheet>
   );
 };
+
+function rejectPendingTransactions(transactions: TransactionMeta[]) {
+  const { ApprovalController } = Engine.context;
+
+  for (const tx of transactions) {
+    if (tx.status !== TransactionStatus.unapproved) {
+      continue;
+    }
+    try {
+      ApprovalController.rejectRequest(
+        tx.id,
+        providerErrors.userRejectedRequest(),
+      );
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        '[MoneyTransferSheet] Failed to reject pending transaction',
+      );
+    }
+  }
+}
 
 export default MoneyTransferSheet;

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
@@ -8,11 +8,7 @@ import React, {
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
-import {
-  TransactionStatus,
-  type TransactionMeta,
-} from '@metamask/transaction-controller';
-import { providerErrors } from '@metamask/rpc-errors';
+import { TransactionStatus } from '@metamask/transaction-controller';
 import {
   BottomSheet,
   BottomSheetHeader,
@@ -23,8 +19,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
-import Engine from '../../../../../core/Engine';
 import { selectTransactions } from '../../../../../selectors/transactionController';
+import { rejectPendingTransactions } from '../../utils/rejectPendingTransactions';
 import { useMoneyAccountWithdrawal } from '../../hooks/useMoneyAccount';
 import { useMoneyPerpsDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPerpsDeposit';
 import { useMoneyPredictDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit';
@@ -216,26 +212,5 @@ const MoneyTransferSheet = () => {
     </BottomSheet>
   );
 };
-
-function rejectPendingTransactions(transactions: TransactionMeta[]) {
-  const { ApprovalController } = Engine.context;
-
-  for (const tx of transactions) {
-    if (tx.status !== TransactionStatus.unapproved) {
-      continue;
-    }
-    try {
-      ApprovalController.rejectRequest(
-        tx.id,
-        providerErrors.userRejectedRequest(),
-      );
-    } catch (error) {
-      Logger.error(
-        error as Error,
-        '[MoneyTransferSheet] Failed to reject pending transaction',
-      );
-    }
-  }
-}
 
 export default MoneyTransferSheet;

--- a/app/components/UI/Money/utils/rejectPendingTransactions.test.ts
+++ b/app/components/UI/Money/utils/rejectPendingTransactions.test.ts
@@ -1,0 +1,76 @@
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { providerErrors } from '@metamask/rpc-errors';
+import { rejectPendingTransactions } from './rejectPendingTransactions';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    ApprovalController: { rejectRequest: jest.fn() },
+  },
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+const mockRejectRequest = jest.mocked(
+  Engine.context.ApprovalController.rejectRequest,
+);
+
+const tx = (id: string, status: TransactionStatus): TransactionMeta =>
+  ({ id, status }) as TransactionMeta;
+
+describe('rejectPendingTransactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects only unapproved transactions', () => {
+    rejectPendingTransactions([
+      tx('a', TransactionStatus.unapproved),
+      tx('b', TransactionStatus.confirmed),
+      tx('c', TransactionStatus.submitted),
+      tx('d', TransactionStatus.unapproved),
+    ]);
+
+    expect(mockRejectRequest).toHaveBeenCalledTimes(2);
+    expect(mockRejectRequest).toHaveBeenCalledWith(
+      'a',
+      providerErrors.userRejectedRequest(),
+    );
+    expect(mockRejectRequest).toHaveBeenCalledWith(
+      'd',
+      providerErrors.userRejectedRequest(),
+    );
+  });
+
+  it('does nothing when there are no unapproved transactions', () => {
+    rejectPendingTransactions([tx('a', TransactionStatus.confirmed)]);
+
+    expect(mockRejectRequest).not.toHaveBeenCalled();
+    expect(Logger.error).not.toHaveBeenCalled();
+  });
+
+  it('logs and continues when a rejection throws', () => {
+    const error = new Error('boom');
+    mockRejectRequest.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    rejectPendingTransactions([
+      tx('a', TransactionStatus.unapproved),
+      tx('b', TransactionStatus.unapproved),
+    ]);
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      error,
+      'Failed to reject pending transaction',
+    );
+    // The throw on the first tx does not stop the second from being rejected.
+    expect(mockRejectRequest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/UI/Money/utils/rejectPendingTransactions.ts
+++ b/app/components/UI/Money/utils/rejectPendingTransactions.ts
@@ -1,0 +1,31 @@
+import { providerErrors } from '@metamask/rpc-errors';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
+
+/**
+ * Reject every unapproved transaction so a stale one is not picked up by the
+ * next confirmation screen. Best-effort: failures are logged, not thrown.
+ *
+ * @param transactions - Transactions to scan; only `unapproved` ones are rejected.
+ */
+export function rejectPendingTransactions(transactions: TransactionMeta[]) {
+  const { ApprovalController } = Engine.context;
+
+  for (const tx of transactions) {
+    if (tx.status !== TransactionStatus.unapproved) {
+      continue;
+    }
+    try {
+      ApprovalController.rejectRequest(
+        tx.id,
+        providerErrors.userRejectedRequest(),
+      );
+    } catch (error) {
+      Logger.error(error as Error, 'Failed to reject pending transaction');
+    }
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Money account page, tapping **Send → "Another account"** (Between accounts) created a transaction that landed in Activity stuck in a pending state, and no Send flow (amount entry / account selection) was ever shown.

The transfer initiator runs from the bottom sheet's *post-close* callback. The design-system `BottomSheet` calls `goBack()` — which pops and unmounts the sheet — **before** invoking that callback. When an `unapproved` transaction already existed in state, `useConfirmNavigation` took its deferred-navigation branch, whose `useEffect` lives in the now-unmounted sheet and therefore never fires. Navigation silently died while `addTransactionBatch` (a plain promise, unbound from the React lifecycle) still ran and created a transaction that got stuck pending. Each failed attempt left another `unapproved` transaction, so the bug was self-perpetuating.

This mirrors the fix already shipped for the deposit sheet (`MoneyAddMoneySheet`): reject any pending transaction while the sheet is still mounted, then defer the close+navigate until state clears, so `navigateToConfirmation` always takes its reliable immediate-navigate path. The initiator is resolved at run-time via a key so a deferred run uses the up-to-date navigation closure rather than a stale snapshot. The guard is applied to the withdrawal, perps, and predictions options on the sheet.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where starting a Money transfer while another transaction was pending left a stuck pending transaction without opening the Send flow.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-975

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account transfer ("Between accounts")

  Scenario: starting a transfer while a transaction is already pending
    Given the user is on the Money account page
    And an unapproved transaction is already pending

    When user taps "Send"
    And user selects "Another account"
    Then the pending transaction is cleared
    And the Send flow opens for amount entry and account selection
    And no extra transaction is left stuck in the Activity list
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
