### PR TITLE
fix(social-leaderboard): shorten trade date format (TSA-762)

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -13,7 +13,7 @@ jest.mock('../../utils/formatters', () => {
   const actual = jest.requireActual('../../utils/formatters');
   return {
     ...actual,
-    formatTradeDate: jest.fn().mockReturnValue('Apr 15, 2026 at 2:00 PM'),
+    formatTradeDate: jest.fn().mockReturnValue('Apr 15 at 2:00 pm'),
   };
 });
 
@@ -217,7 +217,7 @@ describe('PositionRow', () => {
     it('renders formatted closed date as subtitle instead of token amount', () => {
       renderWithProvider(<PositionRow position={closedPosition} />);
 
-      expect(screen.getByText('Apr 15, 2026 at 2:00 PM')).toBeOnTheScreen();
+      expect(screen.getByText('Apr 15 at 2:00 pm')).toBeOnTheScreen();
     });
 
     it('renders realized PnL percent as unsigned magnitude (sign comes from caret)', () => {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -167,16 +167,32 @@ describe('formatPercent', () => {
 });
 
 describe('formatTradeDate', () => {
-  it('formats a millisecond timestamp', () => {
-    const ms = 1744732800000; // a known fixed date
-    const result = formatTradeDate(ms);
-    expect(typeof result).toBe('string');
-    expect(result.length).toBeGreaterThan(0);
+  it('formats a millisecond timestamp as "MMM D at h:mm am/pm"', () => {
+    const result = formatTradeDate(1744732800000);
+    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2} at \d{1,2}:\d{2} (am|pm)$/);
   });
 
   it('converts a seconds timestamp to milliseconds before formatting', () => {
-    const seconds = 1744732800; // same date in seconds
+    const seconds = 1744732800;
     const ms = 1744732800000;
     expect(formatTradeDate(seconds)).toBe(formatTradeDate(ms));
+  });
+
+  it('renders am/pm in lowercase', () => {
+    const result = formatTradeDate(1744732800000);
+    expect(result).not.toMatch(/AM|PM/);
+    expect(result).toMatch(/am|pm/);
+  });
+
+  it('uses a short (3-letter) month abbreviation, not the full name', () => {
+    const result = formatTradeDate(1744732800000);
+    expect(result).not.toMatch(
+      /January|February|March|April|May|June|July|August|September|October|November|December/,
+    );
+  });
+
+  it('omits the year', () => {
+    const result = formatTradeDate(1744732800000);
+    expect(result).not.toMatch(/20\d{2}/);
   });
 });

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -169,7 +169,9 @@ describe('formatPercent', () => {
 describe('formatTradeDate', () => {
   it('formats a millisecond timestamp as "MMM D at h:mm am/pm"', () => {
     const result = formatTradeDate(1744732800000);
-    expect(result).toMatch(/^[A-Z][a-z]{2} \d{1,2} at \d{1,2}:\d{2} (am|pm)$/);
+    expect(result).toMatch(
+      /^[A-Z][a-z]{2,3} \d{1,2} at \d{1,2}:\d{2} (am|pm)$/,
+    );
   });
 
   it('converts a seconds timestamp to milliseconds before formatting', () => {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -6,7 +6,7 @@ import {
   formatAmountWithThreshold,
   localizeLargeNumber,
 } from '../../../../util/number';
-import { getIntlDateTimeFormatter } from '../../../../util/intl';
+import { toDateFormat } from '../../../../util/date';
 import { strings } from '../../../../../locales/i18n';
 
 const EM_DASH = '\u2014';
@@ -104,22 +104,10 @@ export function formatPercent(value: number | null | undefined): string {
 
 /**
  * Trade timestamps from the social API may be seconds or milliseconds.
- * Output matches the app-wide short transaction date convention,
- * e.g. `Jun 16 at 11:38 am`.
+ * Delegates to the shared `toDateFormat` so we render the same short
+ * convention used by the activity list (e.g. `Jun 16 at 11:38 am`).
  */
 export function formatTradeDate(timestamp: number): string {
   const ms = timestamp < 1e12 ? timestamp * 1000 : timestamp;
-  const date = new Date(ms);
-  const dateStr = getIntlDateTimeFormatter('en-US', {
-    month: 'short',
-    day: 'numeric',
-  }).format(date);
-  const timeStr = getIntlDateTimeFormatter('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  })
-    .format(date)
-    .toLowerCase();
-  return `${dateStr} at ${timeStr}`;
+  return toDateFormat(ms);
 }

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -1,12 +1,12 @@
 import {
   formatPerpsFiat,
   formatPercentage,
-  formatTransactionDate,
 } from '../../../UI/Perps/utils/formatUtils';
 import {
   formatAmountWithThreshold,
   localizeLargeNumber,
 } from '../../../../util/number';
+import { getIntlDateTimeFormatter } from '../../../../util/intl';
 import { strings } from '../../../../../locales/i18n';
 
 const EM_DASH = '\u2014';
@@ -104,8 +104,22 @@ export function formatPercent(value: number | null | undefined): string {
 
 /**
  * Trade timestamps from the social API may be seconds or milliseconds.
+ * Output matches the app-wide short transaction date convention,
+ * e.g. `Jun 16 at 11:38 am`.
  */
 export function formatTradeDate(timestamp: number): string {
   const ms = timestamp < 1e12 ? timestamp * 1000 : timestamp;
-  return formatTransactionDate(ms);
+  const date = new Date(ms);
+  const dateStr = getIntlDateTimeFormatter('en-US', {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+  const timeStr = getIntlDateTimeFormatter('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+    .format(date)
+    .toLowerCase();
+  return `${dateStr} at ${timeStr}`;
 }


### PR DESCRIPTION
## **Description**

Updates the date format used in the trader profile view (`PositionRow`) and the trader position view (`TradeRow`) to match the app-wide short transaction date convention.

Before: `July 24, 2025 at 2:30 PM` (long month, full year, uppercase AM/PM)
After: `Jun 16 at 11:38 am` (short month, no year, lowercase am/pm)

The previous implementation delegated to a Perps-specific formatter (`formatTransactionDate`) that uses the long format intentionally for that surface. `formatTradeDate` now delegates to the shared `toDateFormat` util in `app/util/date/` instead — the same function that powers the activity list rows (via `MultichainTransactionListItem`), which is the canonical convention Xavier flagged for consistency.

Bonus: `toDateFormat` is i18n-aware (month and connector come from the `strings` catalog), so when the broader i18n spike lands this surface picks up locale-aware date formatting for free.

Why this change matters: Rizvi requested a shorter date format to reduce visual noise on trader profile + position views. Xavier flagged that the app already had an established short convention; this PR adopts that convention by reusing the same util the existing surfaces use, so social-leaderboard stays in sync with the rest of the app going forward.

## **Changelog**

CHANGELOG entry: Shortened the date format used on the trader profile and trade screens (e.g. "Jun 16 at 11:38 am").

## **Related issues**

Fixes: [TSA-762](https://consensyssoftware.atlassian.net/browse/TSA-762)

## **Manual testing steps**

```gherkin
Feature: Shortened trade date format

  Scenario: User views a trader profile with positions
    Given the user is on the Social Leaderboard
    When the user taps a trader to open their profile
    Then each position row displays its last-trade timestamp as "MMM D at h:mm am/pm" (e.g. "Jun 16 at 11:38 am")

  Scenario: User views a trader's individual position
    Given the user is on a trader profile view
    When the user taps a position to open the trade screen
    Then each trade row displays its timestamp as "MMM D at h:mm am/pm" (e.g. "Jun 16 at 11:38 am")
```

## **Screenshots/Recordings**

### **Before**

### **After**


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TSA-762]: https://consensyssoftware.atlassian.net/browse/TSA-762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ