### PR TITLE
perf: memoize selectAllPopularNetworkConfigurations with deep-equal selector

### DIFF
--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -323,7 +323,7 @@ export const selectIsEIP1559Network = createSelector(
 );
 
 // Selector to get the popular network configurations, this filter also testnet networks
-export const selectAllPopularNetworkConfigurations = createSelector(
+export const selectAllPopularNetworkConfigurations = createDeepEqualSelector(
   selectEvmNetworkConfigurationsByChainId,
   (networkConfigurations) => {
     const popularNetworksChainIds = PopularList.map(


### PR DESCRIPTION
## **Description**

`selectAllPopularNetworkConfigurations` was built with `createSelector`, so reselect compared its input by reference. Whenever `selectEvmNetworkConfigurationsByChainId` produced a new object reference (even when the popular subset was structurally identical), this selector recomputed and returned a brand-new object, invalidating every downstream `useSelector` consumer.

This PR switches it to `createDeepEqualSelector` (already used throughout this file for similar shapes), so consumers receive a stable reference unless the popular network configurations actually change.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-872](https://consensyssoftware.atlassian.net/browse/TMCU-872)

## **Manual testing steps**

```gherkin
Feature: selectAllPopularNetworkConfigurations memoization

  Scenario: Popular network list remains stable across unrelated state updates
    Given the wallet is loaded with at least one popular network configured
    When unrelated Redux state updates occur (e.g. account changes, balance refreshes)
    Then consumers of selectAllPopularNetworkConfigurations do not re-render unnecessarily
    And the returned popular network configurations remain correct
```

## **Screenshots/Recordings**

### **Before**

N/A — selector-level perf change, no UI change.

### **After**

N/A — selector-level perf change, no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-872]: https://consensyssoftware.atlassian.net/browse/TMCU-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ