### PR TITLE
fix: align trader position avatars with leaderboard Maskicon fallback

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -1,7 +1,4 @@
 import {
-  AvatarAccount,
-  AvatarAccountSize,
-  AvatarAccountVariant,
   Box,
   BoxAlignItems,
   Button,
@@ -12,14 +9,13 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import { Image, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { formatSignedAbbreviatedUsd } from '../../../../SocialLeaderboard/utils/formatters';
-import { hasRealAvatar } from '../utils/avatarFallback';
+import TraderAvatar from './TraderAvatar';
 
 export interface TopTraderCardProps {
   trader: TopTrader;
@@ -54,8 +50,6 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
   onTraderPress,
   testID,
 }) => {
-  const tw = useTailwind();
-
   const pnlText = formatSignedAbbreviatedUsd(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
 
@@ -76,24 +70,12 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
         testID={`top-trader-card-pressable-${trader.id}`}
       >
         <Box alignItems={BoxAlignItems.Center} twClassName="gap-1">
-          {hasRealAvatar(trader.avatarUri) ? (
-            <Image
-              source={{ uri: trader.avatarUri }}
-              style={tw.style(
-                `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-              )}
-              resizeMode="cover"
-              testID={`top-trader-avatar-${trader.id}`}
-            />
-          ) : (
-            <AvatarAccount
-              variant={AvatarAccountVariant.Maskicon}
-              address={trader.address}
-              size={AvatarAccountSize.Xl}
-              twClassName={`w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full`}
-              maskiconProps={{ size: AVATAR_SIZE }}
-            />
-          )}
+          <TraderAvatar
+            imageUrl={trader.avatarUri}
+            address={trader.address}
+            size={AVATAR_SIZE}
+            testID={`top-trader-avatar-${trader.id}`}
+          />
 
           <Box twClassName="w-full gap-0.5">
             <Text

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.test.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 import { Image } from 'react-native';
 import { AvatarAccount } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { KNOWN_DEFAULT_AVATAR_URLS } from '../utils/avatarFallback';
 import TraderAvatar from './TraderAvatar';
 
-const REAL_AVATAR_URL =
-  'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxfQ';
-const ENS_PLACEHOLDER_URL =
-  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png';
+const REAL_AVATAR_URL = 'https://example.com/avatar.png';
+const ENS_PLACEHOLDER_URL = KNOWN_DEFAULT_AVATAR_URLS[0];
 const ADDRESS = '0x0000000000000000000000000000000000000001';
 
 describe('TraderAvatar', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react-native';
+import React from 'react';
+import { Image } from 'react-native';
+import { AvatarAccount } from '@metamask/design-system-react-native';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import TraderAvatar from './TraderAvatar';
+
+const REAL_AVATAR_URL =
+  'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxfQ';
+const ENS_PLACEHOLDER_URL =
+  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png';
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+
+describe('TraderAvatar', () => {
+  it('renders the image when a real image url is provided', () => {
+    renderWithProvider(
+      <TraderAvatar
+        imageUrl={REAL_AVATAR_URL}
+        address={ADDRESS}
+        size={40}
+        testID="trader-avatar"
+      />,
+    );
+
+    expect(screen.getByTestId('trader-avatar')).toBeOnTheScreen();
+    expect(screen.UNSAFE_queryByType(Image)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback when no image url is provided', () => {
+    renderWithProvider(<TraderAvatar address={ADDRESS} size={40} />);
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback for the shared ENS placeholder url', () => {
+    renderWithProvider(
+      <TraderAvatar
+        imageUrl={ENS_PLACEHOLDER_URL}
+        address={ADDRESS}
+        size={32}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback without an address', () => {
+    renderWithProvider(<TraderAvatar size={24} />);
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+});

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
+} from '@metamask/design-system-react-native';
+import { hasRealAvatar } from '../utils/avatarFallback';
+
+/** Maps a pixel diameter to the nearest AvatarAccount size token. */
+const toAvatarAccountSize = (size: number): AvatarAccountSize => {
+  if (size <= 16) return AvatarAccountSize.Xs;
+  if (size <= 24) return AvatarAccountSize.Sm;
+  if (size <= 32) return AvatarAccountSize.Md;
+  if (size <= 40) return AvatarAccountSize.Lg;
+  return AvatarAccountSize.Xl;
+};
+
+export interface TraderAvatarProps {
+  /**
+   * Backend-provided avatar URL. Missing, empty, or known shared placeholder
+   * URLs fall through to the address-derived Maskicon.
+   */
+  imageUrl?: string | null;
+  /** Wallet address used to derive the Maskicon fallback. */
+  address?: string;
+  /** Avatar diameter in pixels. */
+  size: number;
+  testID?: string;
+}
+
+/**
+ * TraderAvatar -- renders a trader's profile image when a real one is
+ * available, otherwise falls back to the address-derived Maskicon identicon.
+ *
+ * Centralizes the `hasRealAvatar` + Maskicon-fallback pattern shared across the
+ * follow-trading surfaces (leaderboard rows/cards, profile and position
+ * headers, and trade rows) so the fallback stays consistent everywhere.
+ */
+const TraderAvatar: React.FC<TraderAvatarProps> = ({
+  imageUrl,
+  address,
+  size,
+  testID,
+}) => {
+  const tw = useTailwind();
+
+  if (hasRealAvatar(imageUrl)) {
+    return (
+      <Image
+        source={{ uri: imageUrl }}
+        style={tw.style(`w-[${size}px] h-[${size}px] rounded-full bg-muted`)}
+        resizeMode="cover"
+        testID={testID}
+      />
+    );
+  }
+
+  return (
+    <AvatarAccount
+      variant={AvatarAccountVariant.Maskicon}
+      address={address ?? ''}
+      size={toAvatarAccountSize(size)}
+      twClassName={`w-[${size}px] h-[${size}px] rounded-full`}
+      maskiconProps={{ size }}
+      testID={testID}
+    />
+  );
+};
+
+export default TraderAvatar;

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -1,7 +1,4 @@
 import {
-  AvatarAccount,
-  AvatarAccountSize,
-  AvatarAccountVariant,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -16,13 +13,13 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import { Image, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { TopRankAvatar, TopRankIndicator } from '../topRank';
 import type { TopTrader } from '../types';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { formatSignedAbbreviatedUsd } from '../../../../SocialLeaderboard/utils/formatters';
-import { hasRealAvatar } from '../utils/avatarFallback';
+import TraderAvatar from './TraderAvatar';
 
 const AVATAR_SIZE = 40;
 // Fixed row height so the skeleton placeholder can match it exactly without
@@ -92,22 +89,11 @@ const TraderRow: React.FC<TraderRowProps> = ({
           />
 
           <TopRankAvatar rank={trader.overallRank}>
-            {hasRealAvatar(trader.avatarUri) ? (
-              <Image
-                source={{ uri: trader.avatarUri }}
-                style={tw.style(
-                  `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-                )}
-                resizeMode="cover"
-              />
-            ) : (
-              <AvatarAccount
-                variant={AvatarAccountVariant.Maskicon}
-                address={trader.address}
-                size={AvatarAccountSize.Lg}
-                twClassName="rounded-full"
-              />
-            )}
+            <TraderAvatar
+              imageUrl={trader.avatarUri}
+              address={trader.address}
+              size={AVATAR_SIZE}
+            />
           </TopRankAvatar>
 
           <Box twClassName="flex-1 min-w-0">

--- a/app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/utils/avatarFallback.ts
@@ -2,7 +2,7 @@
 // has no real profile picture. We want those to fall through to the Maskicon
 // fallback rather than render the shared placeholder. Add URLs here if we
 // learn of additional defaults (Farcaster, Twitter, etc.).
-const KNOWN_DEFAULT_AVATAR_URLS: readonly string[] = [
+export const KNOWN_DEFAULT_AVATAR_URLS: readonly string[] = [
   'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png',
 ];
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -311,6 +311,7 @@ const TraderPositionView = () => {
       <TraderPositionHeader
         traderName={traderName}
         traderImageUrl={traderImageUrl}
+        traderAddress={traderAddress}
         onBack={handleBack}
         onTraderPress={handleTraderPress}
         backButtonTestID={TraderPositionViewSelectorsIDs.BACK_BUTTON}
@@ -372,6 +373,7 @@ const TraderPositionView = () => {
               trades={allTrades}
               traderName={traderName}
               traderImageUrl={traderImageUrl}
+              traderAddress={traderAddress}
             />
           </ScrollView>
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
@@ -15,10 +15,7 @@ const baseTrade: Trade = {
   transactionHash: '0xabc',
 };
 
-const REAL_AVATAR_URL =
-  'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxfQ';
-const ENS_PLACEHOLDER_URL =
-  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png';
+const REAL_AVATAR_URL = 'https://example.com/avatar.png';
 const TRADER_ADDRESS = '0x0000000000000000000000000000000000000001';
 
 describe('TradeRow', () => {
@@ -60,20 +57,6 @@ describe('TradeRow', () => {
       <TradeRow
         trade={baseTrade}
         traderName="nodestack.eth"
-        traderAddress={TRADER_ADDRESS}
-      />,
-    );
-
-    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
-    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
-  });
-
-  it('renders the Maskicon fallback when the image url is the shared ENS placeholder', () => {
-    renderWithProvider(
-      <TradeRow
-        trade={baseTrade}
-        traderName="nodestack.eth"
-        traderImageUrl={ENS_PLACEHOLDER_URL}
         traderAddress={TRADER_ADDRESS}
       />,
     );

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
@@ -1,0 +1,84 @@
+import { screen } from '@testing-library/react-native';
+import React from 'react';
+import { Image } from 'react-native';
+import { AvatarAccount } from '@metamask/design-system-react-native';
+import type { Trade } from '@metamask/social-controllers';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import TradeRow from './TradeRow';
+
+const baseTrade: Trade = {
+  intent: 'enter',
+  direction: 'buy',
+  tokenAmount: 1,
+  usdCost: 23155.92,
+  timestamp: 1_700_000_000_000,
+  transactionHash: '0xabc',
+};
+
+const REAL_AVATAR_URL =
+  'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxfQ';
+const ENS_PLACEHOLDER_URL =
+  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png';
+const TRADER_ADDRESS = '0x0000000000000000000000000000000000000001';
+
+describe('TradeRow', () => {
+  it('renders the bought label for an enter trade', () => {
+    renderWithProvider(
+      <TradeRow trade={baseTrade} traderName="nodestack.eth" />,
+    );
+
+    expect(screen.getByText('nodestack.eth bought')).toBeOnTheScreen();
+  });
+
+  it('renders the sold label for an exit trade', () => {
+    renderWithProvider(
+      <TradeRow
+        trade={{ ...baseTrade, intent: 'exit' }}
+        traderName="nodestack.eth"
+      />,
+    );
+
+    expect(screen.getByText('nodestack.eth sold')).toBeOnTheScreen();
+  });
+
+  it('renders the avatar image when a real image url is provided', () => {
+    renderWithProvider(
+      <TradeRow
+        trade={baseTrade}
+        traderName="nodestack.eth"
+        traderImageUrl={REAL_AVATAR_URL}
+        traderAddress={TRADER_ADDRESS}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(Image)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback when the image url is absent', () => {
+    renderWithProvider(
+      <TradeRow
+        trade={baseTrade}
+        traderName="nodestack.eth"
+        traderAddress={TRADER_ADDRESS}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback when the image url is the shared ENS placeholder', () => {
+    renderWithProvider(
+      <TradeRow
+        trade={baseTrade}
+        traderName="nodestack.eth"
+        traderImageUrl={ENS_PLACEHOLDER_URL}
+        traderAddress={TRADER_ADDRESS}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx
@@ -9,23 +9,28 @@ import {
   FontWeight,
   BoxFlexDirection,
   BoxAlignItems,
-  AvatarBase,
-  AvatarBaseSize,
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
 } from '@metamask/design-system-react-native';
 import type { Trade } from '@metamask/social-controllers';
 import { strings } from '../../../../../../locales/i18n';
 import { formatUsd, formatTradeDate } from '../../utils/formatters';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
 
 export interface TradeRowProps {
   trade: Trade;
   traderName: string;
   traderImageUrl?: string;
+  traderAddress?: string;
 }
 
 const TradeRow: React.FC<TradeRowProps> = ({
   trade,
   traderName,
   traderImageUrl,
+  traderAddress,
 }) => {
   const tw = useTailwind();
   const isEntry = trade.intent === 'enter';
@@ -42,16 +47,18 @@ const TradeRow: React.FC<TradeRowProps> = ({
         gap={4}
         twClassName="flex-1 min-w-0 mr-3"
       >
-        {traderImageUrl ? (
+        {hasRealAvatar(traderImageUrl) ? (
           <Image
             source={{ uri: traderImageUrl }}
             style={tw.style('w-[32px] h-[32px] rounded-full bg-muted')}
             resizeMode="cover"
           />
         ) : (
-          <AvatarBase
-            size={AvatarBaseSize.Md}
-            fallbackText={traderName.charAt(0).toUpperCase()}
+          <AvatarAccount
+            variant={AvatarAccountVariant.Maskicon}
+            address={traderAddress ?? ''}
+            size={AvatarAccountSize.Md}
+            twClassName="rounded-full"
           />
         )}
         <Box twClassName="flex-1 min-w-0">

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { Image } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   Text,
@@ -9,15 +7,14 @@ import {
   FontWeight,
   BoxFlexDirection,
   BoxAlignItems,
-  AvatarAccount,
-  AvatarAccountSize,
-  AvatarAccountVariant,
 } from '@metamask/design-system-react-native';
 import type { Trade } from '@metamask/social-controllers';
 import { strings } from '../../../../../../locales/i18n';
 import { formatUsd, formatTradeDate } from '../../utils/formatters';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
+import TraderAvatar from '../../../Homepage/Sections/TopTraders/components/TraderAvatar';
+
+const AVATAR_SIZE = 32;
 
 export interface TradeRowProps {
   trade: Trade;
@@ -32,7 +29,6 @@ const TradeRow: React.FC<TradeRowProps> = ({
   traderImageUrl,
   traderAddress,
 }) => {
-  const tw = useTailwind();
   const isEntry = trade.intent === 'enter';
   return (
     <Box
@@ -47,20 +43,11 @@ const TradeRow: React.FC<TradeRowProps> = ({
         gap={4}
         twClassName="flex-1 min-w-0 mr-3"
       >
-        {hasRealAvatar(traderImageUrl) ? (
-          <Image
-            source={{ uri: traderImageUrl }}
-            style={tw.style('w-[32px] h-[32px] rounded-full bg-muted')}
-            resizeMode="cover"
-          />
-        ) : (
-          <AvatarAccount
-            variant={AvatarAccountVariant.Maskicon}
-            address={traderAddress ?? ''}
-            size={AvatarAccountSize.Md}
-            twClassName="rounded-full"
-          />
-        )}
+        <TraderAvatar
+          imageUrl={traderImageUrl}
+          address={traderAddress}
+          size={AVATAR_SIZE}
+        />
         <Box twClassName="flex-1 min-w-0">
           <Text
             variant={TextVariant.BodyMd}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.test.tsx
@@ -5,10 +5,7 @@ import { AvatarAccount } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import TraderPositionHeader from './TraderPositionHeader';
 
-const REAL_AVATAR_URL =
-  'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxfQ';
-const ENS_PLACEHOLDER_URL =
-  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png';
+const REAL_AVATAR_URL = 'https://example.com/avatar.png';
 const TRADER_ADDRESS = '0x0000000000000000000000000000000000000001';
 
 const baseProps = {
@@ -42,19 +39,6 @@ describe('TraderPositionHeader', () => {
   it('renders the Maskicon fallback when the image url is absent', () => {
     renderWithProvider(
       <TraderPositionHeader {...baseProps} traderAddress={TRADER_ADDRESS} />,
-    );
-
-    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
-    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
-  });
-
-  it('renders the Maskicon fallback when the image url is the shared ENS placeholder', () => {
-    renderWithProvider(
-      <TraderPositionHeader
-        {...baseProps}
-        traderImageUrl={ENS_PLACEHOLDER_URL}
-        traderAddress={TRADER_ADDRESS}
-      />,
     );
 
     expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react-native';
+import React from 'react';
+import { Image } from 'react-native';
+import { AvatarAccount } from '@metamask/design-system-react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import TraderPositionHeader from './TraderPositionHeader';
+
+const REAL_AVATAR_URL =
+  'https://clicker.api.cx.metamask.io/avatar/eyJpbWFnZUlkIjoxfQ';
+const ENS_PLACEHOLDER_URL =
+  'https://daylight-images.s3.us-east-1.amazonaws.com/ens-fallback.png';
+const TRADER_ADDRESS = '0x0000000000000000000000000000000000000001';
+
+const baseProps = {
+  traderName: 'nodestack.eth',
+  onBack: jest.fn(),
+  onTraderPress: jest.fn(),
+  backButtonTestID: 'back-button',
+  traderNameTestID: 'trader-name',
+};
+
+describe('TraderPositionHeader', () => {
+  it('renders the trader name', () => {
+    renderWithProvider(<TraderPositionHeader {...baseProps} />);
+
+    expect(screen.getByText('nodestack.eth')).toBeOnTheScreen();
+  });
+
+  it('renders the avatar image when a real image url is provided', () => {
+    renderWithProvider(
+      <TraderPositionHeader
+        {...baseProps}
+        traderImageUrl={REAL_AVATAR_URL}
+        traderAddress={TRADER_ADDRESS}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(Image)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback when the image url is absent', () => {
+    renderWithProvider(
+      <TraderPositionHeader {...baseProps} traderAddress={TRADER_ADDRESS} />,
+    );
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+
+  it('renders the Maskicon fallback when the image url is the shared ENS placeholder', () => {
+    renderWithProvider(
+      <TraderPositionHeader
+        {...baseProps}
+        traderImageUrl={ENS_PLACEHOLDER_URL}
+        traderAddress={TRADER_ADDRESS}
+      />,
+    );
+
+    expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
+    expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Image, Pressable, StyleSheet } from 'react-native';
 import {
-  AvatarBase,
-  AvatarBaseSize,
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarAccountVariant,
   Box,
   Text,
   TextVariant,
@@ -15,12 +16,15 @@ import {
   BoxAlignItems,
   BoxJustifyContent,
 } from '@metamask/design-system-react-native';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
 
 const AVATAR_SIZE = 24;
 
 export interface TraderPositionHeaderProps {
   traderName: string;
   traderImageUrl?: string;
+  traderAddress?: string;
   onBack: () => void;
   onTraderPress: () => void;
   backButtonTestID: string;
@@ -46,69 +50,71 @@ const styles = StyleSheet.create({
 const TraderPositionHeader: React.FC<TraderPositionHeaderProps> = ({
   traderName,
   traderImageUrl,
+  traderAddress,
   onBack,
   onTraderPress,
   backButtonTestID,
   traderNameTestID,
-}) => {
-  const fallbackText = traderName.trim().charAt(0).toUpperCase() || '?';
-
-  return (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      justifyContent={BoxJustifyContent.Between}
-      twClassName="px-2 py-2"
-    >
-      <Box twClassName="w-10">
-        <ButtonIcon
-          iconName={IconName.ArrowLeft}
-          size={ButtonIconSize.Md}
-          onPress={onBack}
-          testID={backButtonTestID}
-        />
-      </Box>
-      <Pressable
-        onPress={onTraderPress}
-        testID={traderNameTestID}
-        accessibilityRole="button"
-        accessibilityLabel={
-          traderName ? `View ${traderName} profile` : 'View trader profile'
-        }
-        style={({ pressed }) => [
-          styles.traderNameButton,
-          pressed && styles.traderNameButtonPressed,
-        ]}
-      >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          gap={2}
-          twClassName="max-w-full"
-        >
-          {traderImageUrl ? (
-            <Image
-              source={{ uri: traderImageUrl }}
-              style={styles.avatar}
-              resizeMode="cover"
-            />
-          ) : (
-            <AvatarBase size={AvatarBaseSize.Sm} fallbackText={fallbackText} />
-          )}
-          <Text
-            variant={TextVariant.HeadingSm}
-            fontWeight={FontWeight.Bold}
-            color={TextColor.TextDefault}
-            numberOfLines={1}
-            twClassName="shrink text-center"
-          >
-            {traderName}
-          </Text>
-        </Box>
-      </Pressable>
-      <Box twClassName="w-10" />
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    justifyContent={BoxJustifyContent.Between}
+    twClassName="px-2 py-2"
+  >
+    <Box twClassName="w-10">
+      <ButtonIcon
+        iconName={IconName.ArrowLeft}
+        size={ButtonIconSize.Md}
+        onPress={onBack}
+        testID={backButtonTestID}
+      />
     </Box>
-  );
-};
+    <Pressable
+      onPress={onTraderPress}
+      testID={traderNameTestID}
+      accessibilityRole="button"
+      accessibilityLabel={
+        traderName ? `View ${traderName} profile` : 'View trader profile'
+      }
+      style={({ pressed }) => [
+        styles.traderNameButton,
+        pressed && styles.traderNameButtonPressed,
+      ]}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={2}
+        twClassName="max-w-full"
+      >
+        {hasRealAvatar(traderImageUrl) ? (
+          <Image
+            source={{ uri: traderImageUrl }}
+            style={styles.avatar}
+            resizeMode="cover"
+          />
+        ) : (
+          <AvatarAccount
+            variant={AvatarAccountVariant.Maskicon}
+            address={traderAddress ?? ''}
+            size={AvatarAccountSize.Sm}
+            twClassName="rounded-full"
+          />
+        )}
+        <Text
+          variant={TextVariant.HeadingSm}
+          fontWeight={FontWeight.Bold}
+          color={TextColor.TextDefault}
+          numberOfLines={1}
+          twClassName="shrink text-center"
+        >
+          {traderName}
+        </Text>
+      </Box>
+    </Pressable>
+    <Box twClassName="w-10" />
+  </Box>
+);
 
 export default TraderPositionHeader;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { Image, Pressable, StyleSheet } from 'react-native';
+import { Pressable, StyleSheet } from 'react-native';
 import {
-  AvatarAccount,
-  AvatarAccountSize,
-  AvatarAccountVariant,
   Box,
   Text,
   TextVariant,
@@ -17,7 +14,7 @@ import {
   BoxJustifyContent,
 } from '@metamask/design-system-react-native';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
+import TraderAvatar from '../../../Homepage/Sections/TopTraders/components/TraderAvatar';
 
 const AVATAR_SIZE = 24;
 
@@ -39,11 +36,6 @@ const styles = StyleSheet.create({
   },
   traderNameButtonPressed: {
     opacity: 0.7,
-  },
-  avatar: {
-    width: AVATAR_SIZE,
-    height: AVATAR_SIZE,
-    borderRadius: AVATAR_SIZE / 2,
   },
 });
 
@@ -88,20 +80,11 @@ const TraderPositionHeader: React.FC<TraderPositionHeaderProps> = ({
         gap={2}
         twClassName="max-w-full"
       >
-        {hasRealAvatar(traderImageUrl) ? (
-          <Image
-            source={{ uri: traderImageUrl }}
-            style={styles.avatar}
-            resizeMode="cover"
-          />
-        ) : (
-          <AvatarAccount
-            variant={AvatarAccountVariant.Maskicon}
-            address={traderAddress ?? ''}
-            size={AvatarAccountSize.Sm}
-            twClassName="rounded-full"
-          />
-        )}
+        <TraderAvatar
+          imageUrl={traderImageUrl}
+          address={traderAddress}
+          size={AVATAR_SIZE}
+        />
         <Text
           variant={TextVariant.HeadingSm}
           fontWeight={FontWeight.Bold}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx
@@ -14,12 +14,14 @@ export interface TraderTradesSectionProps {
   trades: Trade[];
   traderName: string;
   traderImageUrl?: string;
+  traderAddress?: string;
 }
 
 const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
   trades,
   traderName,
   traderImageUrl,
+  traderAddress,
 }) => (
   <>
     <Box twClassName="px-4 mt-5">
@@ -42,6 +44,7 @@ const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
           trade={trade}
           traderName={traderName}
           traderImageUrl={traderImageUrl}
+          traderAddress={traderAddress}
         />
       ))
     ) : (

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Image, Linking, Pressable } from 'react-native';
+import { Linking, Pressable } from 'react-native';
 import {
   Box,
   Text,
@@ -8,22 +8,18 @@ import {
   TextColor,
   BoxFlexDirection,
   BoxAlignItems,
-  AvatarAccount,
-  AvatarAccountSize,
-  AvatarAccountVariant,
   Icon,
   IconName,
   IconSize,
   IconColor,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import type { TraderProfile } from '@metamask/social-controllers';
 import { TraderProfileViewSelectorsIDs } from '../TraderProfileView.testIds';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { TopRankAvatar } from '../../../Homepage/Sections/TopTraders/topRank';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { hasRealAvatar } from '../../../Homepage/Sections/TopTraders/utils/avatarFallback';
+import TraderAvatar from '../../../Homepage/Sections/TopTraders/components/TraderAvatar';
 
 const AVATAR_SIZE = 40;
 
@@ -44,8 +40,6 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   twitterHandle,
   rank,
 }) => {
-  const tw = useTailwind();
-
   const handleTwitterPress = useCallback(() => {
     if (twitterHandle) {
       Linking.openURL(`https://x.com/${twitterHandle}`);
@@ -61,22 +55,11 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
       testID={TraderProfileViewSelectorsIDs.HEADER}
     >
       <TopRankAvatar rank={rank ?? 0}>
-        {hasRealAvatar(profile.imageUrl) ? (
-          <Image
-            source={{ uri: profile.imageUrl }}
-            style={tw.style(
-              `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-            )}
-            resizeMode="cover"
-          />
-        ) : (
-          <AvatarAccount
-            variant={AvatarAccountVariant.Maskicon}
-            address={profile.address}
-            size={AvatarAccountSize.Lg}
-            twClassName="rounded-full"
-          />
-        )}
+        <TraderAvatar
+          imageUrl={profile.imageUrl}
+          address={profile.address}
+          size={AVATAR_SIZE}
+        />
       </TopRankAvatar>
 
       <Box twClassName="flex-1 min-w-0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

On the Trader Position screen (the per-trader / per-token position detail page under Social Leaderboard), the trader avatar in the header and in each row of the **Trades** list rendered a plain letter monogram fallback (e.g. `"N"` for `nodestack.eth`) whenever the backend `imageUrl` was missing, empty, or a shared ENS placeholder.

This is inconsistent with the **Trader Leaderboard** (`TraderRow` / `TopTraderCard` / `ProfileHeader`), which renders an address-derived **Maskicon** identicon as its fallback and uses `hasRealAvatar()` to reject known shared placeholder URLs.

### Changes

1. **Fix** — Align the Trader Position surfaces (`TradeRow`, `TraderPositionHeader`) with the leaderboard pattern: use `hasRealAvatar()` and fall back to the address-derived Maskicon. `traderAddress` is threaded from `TraderPositionView` → `TraderTradesSection` → `TradeRow`, and to `TraderPositionHeader`.

2. **Refactor** — Extract a reusable `TraderAvatar` component that encapsulates the `hasRealAvatar` + Maskicon-fallback logic in one place, and use it across every follow-trading surface that renders a trader avatar:
   - `TraderRow` (Top Traders leaderboard row)
   - `TopTraderCard` (Top Traders homepage carousel card)
   - `ProfileHeader` (Trader profile header)
   - `TradeRow` (Trader position trades list)
   - `TraderPositionHeader` (Trader position header)

   `TraderAvatar` takes `imageUrl`, `address`, a pixel `size` (mapped to the nearest `AvatarAccountSize` with an exact `maskiconProps.size`), and an optional `testID`. The rank decoration (`TopRankAvatar`) stays as a separate wrapper around `TraderAvatar` where used, keeping each concern isolated.

   The component is co-located with the existing shared `hasRealAvatar` util and `TopRankAvatar` in the Top Traders module, following the established ADR-0020 cross-import convention already used by `ProfileHeader`.

Net result removes ~80 lines of duplicated avatar/fallback code and guarantees consistent fallback behavior everywhere.

## **Changelog**

CHANGELOG entry: Fixed trader avatars on the trader position screen falling back to a letter placeholder instead of the address-based Maskicon used on the leaderboard.

## **Related issues**

Fixes: TSA bug ticket (Trader Leaderboard epic) — see linked Jira issue.

## **Manual testing steps**

```gherkin
Feature: Trader position avatar fallback

  Scenario: trader has no real profile image
    Given I open a trader position screen for a trader without a profile image
    Then the header avatar shows the address-based Maskicon identicon
    And each Trades row avatar shows the address-based Maskicon identicon

  Scenario: trader has a real profile image
    Given I open a trader position screen for a trader with a real profile image
    Then the header and Trades rows show the real avatar image

  Scenario: leaderboard parity
    Given I browse the Top Traders leaderboard, cards, and a trader profile
    Then avatars and their Maskicon fallbacks render identically to before
```

## **Screenshots/Recordings**

### **Before**

<!-- Avatar showed letter monogram "N" fallback on the trader position screen -->

### **After**

<img width="475" height="985" alt="image" src="https://github.com/user-attachments/assets/f5fe7857-956b-4fb3-9d22-9d7f481ca02f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a3ed6a4-e17a-41ba-a128-26d15051da89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a3ed6a4-e17a-41ba-a128-26d15051da89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

