### PR TITLE
test: replace real trader names with mock names in unit tests

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
@@ -106,7 +106,7 @@ const makeNotificationPreferencesResult = (
 const followedTraders: FollowedTrader[] = [
   {
     id: 'trader-1',
-    username: 'dutchiono',
+    username: 'trader1',
     avatarUri: 'https://example.com/avatar.png',
   },
   {
@@ -325,7 +325,7 @@ describe('SocialAINotificationPreferencesContent', () => {
       Routes.SOCIAL_LEADERBOARD.PROFILE,
       {
         traderId: 'trader-1',
-        traderName: 'dutchiono',
+        traderName: 'trader1',
       },
     );
   });

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts
@@ -36,13 +36,13 @@ const fixtureFollowing = {
     {
       profileId: 'trader-1',
       address: '0x1',
-      name: 'dutchiono',
+      name: 'trader1',
       imageUrl: 'https://example.com/a1.png',
     },
     {
       profileId: 'trader-2',
       address: '0x2',
-      name: 'Kien',
+      name: 'trader2',
       imageUrl: null,
     },
   ],
@@ -99,10 +99,10 @@ describe('useFollowedTraders', () => {
       expect(result.current.traders).toEqual([
         {
           id: 'trader-1',
-          username: 'dutchiono',
+          username: 'trader1',
           avatarUri: 'https://example.com/a1.png',
         },
-        { id: 'trader-2', username: 'Kien', avatarUri: undefined },
+        { id: 'trader-2', username: 'trader2', avatarUri: undefined },
       ]);
     });
   });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -68,7 +68,7 @@ const makeDefaultPosition = (): Position => ({
 
 let mockRouteParams: MockRouteParams = {
   traderId: 'trader-1',
-  traderName: 'dutchiono',
+  traderName: 'trader1',
   traderAddress: '0xabc',
   tokenSymbol: 'PEPE',
   position: makeDefaultPosition(),
@@ -224,7 +224,7 @@ describe('TraderPositionView', () => {
     mockGetAssetImageUrl.mockReturnValue('https://example.com/token.png');
     mockRouteParams = {
       traderId: 'trader-1',
-      traderName: 'dutchiono',
+      traderName: 'trader1',
       traderAddress: '0xabc',
       tokenSymbol: 'PEPE',
       position: makeDefaultPosition(),
@@ -237,7 +237,7 @@ describe('TraderPositionView', () => {
     expect(
       screen.getByTestId(TraderPositionViewSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
-    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
+    expect(screen.getByText('trader1')).toBeOnTheScreen();
     expect(screen.getAllByText('PEPE').length).toBeGreaterThanOrEqual(1);
   });
 
@@ -271,7 +271,7 @@ describe('TraderPositionView', () => {
       Routes.SOCIAL_LEADERBOARD.PROFILE,
       {
         traderId: 'trader-1',
-        traderName: 'dutchiono',
+        traderName: 'trader1',
       },
     );
     expect(mockGoBack).not.toHaveBeenCalled();
@@ -619,7 +619,7 @@ describe('TraderPositionView', () => {
   it('refreshes profile on pull even when name and image came via nav params', async () => {
     mockRouteParams = {
       ...mockRouteParams,
-      traderName: 'dutchiono',
+      traderName: 'trader1',
       traderImageUrl: 'https://example.com/avatar.png',
     };
 
@@ -642,7 +642,7 @@ describe('TraderPositionView', () => {
   it('does not render the refresh control in the fallback state', () => {
     mockRouteParams = {
       traderId: 'trader-1',
-      traderName: 'dutchiono',
+      traderName: 'trader1',
       tokenSymbol: 'PEPE',
       position: undefined,
     };

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -162,7 +162,7 @@ let mockRouteParams: {
   traderRank?: number;
 } = {
   traderId: 'trader-1',
-  traderName: 'dutchiono',
+  traderName: 'trader1',
   traderAddress: '0xabc',
   source: 'leaderboard',
   traderRank: 1,
@@ -182,7 +182,7 @@ const fixtureProfile: TraderProfileResponse = {
     profileId: 'trader-1',
     address: '0xabc',
     allAddresses: ['0xabc'],
-    name: 'dutchiono',
+    name: 'trader1',
     imageUrl: 'https://example.com/avatar.png',
   },
   stats: {
@@ -337,7 +337,7 @@ describe('TraderProfileView', () => {
     mockIsTraderNotificationEnabled.mockReturnValue(true);
     mockRouteParams = {
       traderId: 'trader-1',
-      traderName: 'dutchiono',
+      traderName: 'trader1',
       traderAddress: '0xabc',
       source: 'leaderboard',
       traderRank: 1,
@@ -353,7 +353,7 @@ describe('TraderProfileView', () => {
 
   it('displays the trader name', () => {
     renderWithProvider(<TraderProfileView />);
-    const visibleTraderNames = screen.getAllByText('dutchiono');
+    const visibleTraderNames = screen.getAllByText('trader1');
     expect(visibleTraderNames).toHaveLength(1);
     expect(visibleTraderNames[0]).toBeOnTheScreen();
   });
@@ -408,7 +408,7 @@ describe('TraderProfileView', () => {
       Routes.SOCIAL_LEADERBOARD.POSITION,
       {
         traderId: 'trader-1',
-        traderName: 'dutchiono',
+        traderName: 'trader1',
         traderImageUrl: 'https://example.com/avatar.png',
         traderAddress: '0xabc',
         tokenSymbol: fixtureOpenPositions[0].tokenSymbol,
@@ -616,7 +616,7 @@ describe('TraderProfileView', () => {
     it('defaults source to deep_link when source param is absent', () => {
       mockRouteParams = {
         traderId: 'trader-1',
-        traderName: 'dutchiono',
+        traderName: 'trader1',
         traderAddress: '0xabc',
         traderRank: 1,
       };
@@ -632,7 +632,7 @@ describe('TraderProfileView', () => {
     it('falls back to profile address when traderAddress route param is absent', () => {
       mockRouteParams = {
         traderId: 'trader-1',
-        traderName: 'dutchiono',
+        traderName: 'trader1',
         source: 'leaderboard',
         traderRank: 1,
       };
@@ -644,7 +644,7 @@ describe('TraderProfileView', () => {
     });
 
     it('does not track tab change when traderAddress is absent and profile has no address', () => {
-      mockRouteParams = { traderId: 'trader-1', traderName: 'dutchiono' };
+      mockRouteParams = { traderId: 'trader-1', traderName: 'trader1' };
       mockProfileResult = {
         ...mockProfileResult,
         profile: {
@@ -672,7 +672,7 @@ describe('TraderProfileView', () => {
         MetaMetricsEvents.SOCIAL_TRADER_PROFILE_SCREEN_VIEWED,
         expect.objectContaining({
           trader_address: '0xabc',
-          trader_username: 'dutchiono',
+          trader_username: 'trader1',
           source: 'leaderboard',
           is_following: false,
           trader_rank: 1,
@@ -687,7 +687,7 @@ describe('TraderProfileView', () => {
         expect.objectContaining({
           source: 'trader_profile',
           traderAddress: '0xabc',
-          traderUsername: 'dutchiono',
+          traderUsername: 'trader1',
         }),
       );
     });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
@@ -18,7 +18,7 @@ const baseProfile: TraderProfile = {
   profileId: 'trader-1',
   address: '0xabc',
   allAddresses: ['0xabc'],
-  name: 'dutchiono',
+  name: 'trader1',
   imageUrl: 'https://example.com/avatar.png',
 };
 
@@ -36,7 +36,7 @@ describe('ProfileHeader', () => {
     renderWithProvider(
       <ProfileHeader profile={baseProfile} followerCount={45} />,
     );
-    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
+    expect(screen.getByText('trader1')).toBeOnTheScreen();
   });
 
   it('renders avatar image when imageUrl is present', () => {
@@ -53,7 +53,7 @@ describe('ProfileHeader', () => {
     renderWithProvider(
       <ProfileHeader profile={profileNoImage} followerCount={45} />,
     );
-    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
+    expect(screen.getByText('trader1')).toBeOnTheScreen();
   });
 
   it('renders singular follower string when count is 1', () => {
@@ -88,7 +88,7 @@ describe('ProfileHeader', () => {
     );
 
     expect(screen.queryByText('D')).toBeNull();
-    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
+    expect(screen.getByText('trader1')).toBeOnTheScreen();
   });
 
   it('renders without a fallback letter when imageUrl is empty string', () => {
@@ -102,7 +102,7 @@ describe('ProfileHeader', () => {
     );
 
     expect(screen.queryByText('D')).toBeNull();
-    expect(screen.getByText('dutchiono')).toBeOnTheScreen();
+    expect(screen.getByText('trader1')).toBeOnTheScreen();
   });
 
   describe('X (Twitter) icon', () => {
@@ -115,7 +115,7 @@ describe('ProfileHeader', () => {
         <ProfileHeader
           profile={baseProfile}
           followerCount={45}
-          twitterHandle="dutchiono"
+          twitterHandle="trader1"
         />,
       );
       expect(
@@ -150,7 +150,7 @@ describe('ProfileHeader', () => {
         <ProfileHeader
           profile={baseProfile}
           followerCount={45}
-          twitterHandle="dutchiono"
+          twitterHandle="trader1"
         />,
       );
 
@@ -159,7 +159,7 @@ describe('ProfileHeader', () => {
       );
 
       expect(Linking.openURL).toHaveBeenCalledTimes(1);
-      expect(Linking.openURL).toHaveBeenCalledWith('https://x.com/dutchiono');
+      expect(Linking.openURL).toHaveBeenCalledWith('https://x.com/trader1');
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx
@@ -123,7 +123,7 @@ interface OpenedSheetProps {
 
 const OpenedSheet: React.FC<OpenedSheetProps> = ({
   traderId = 'trader-1',
-  traderName = 'dutchiono',
+  traderName = 'trader1',
   onDismiss,
 }) => {
   const ref = useRef<TraderNotificationsBottomSheetRef>(null);
@@ -175,7 +175,7 @@ describe('TraderNotificationsBottomSheet', () => {
         <TraderNotificationsBottomSheet
           ref={ref}
           traderId="trader-1"
-          traderName="dutchiono"
+          traderName="trader1"
         />,
       );
 
@@ -197,25 +197,25 @@ describe('TraderNotificationsBottomSheet', () => {
     });
 
     it('renders the title interpolated with trader name', () => {
-      renderOpenedSheet({ traderName: 'dutchiono' });
+      renderOpenedSheet({ traderName: 'trader1' });
 
       expect(
         screen.getByText(
           strings('social_leaderboard.trader_notifications.title', {
-            traderName: 'dutchiono',
+            traderName: 'trader1',
           }),
         ),
       ).toBeOnTheScreen();
     });
 
     it('renders the notification description with trader name', () => {
-      renderOpenedSheet({ traderName: 'dutchiono' });
+      renderOpenedSheet({ traderName: 'trader1' });
 
       expect(
         screen.getByText(
           strings(
             'social_leaderboard.trader_notifications.allow_push_notifications_desc',
-            { traderName: 'dutchiono' },
+            { traderName: 'trader1' },
           ),
         ),
       ).toBeOnTheScreen();
@@ -288,7 +288,7 @@ describe('TraderNotificationsBottomSheet', () => {
             <TraderNotificationsBottomSheet
               ref={ref}
               traderId="trader-1"
-              traderName="dutchiono"
+              traderName="trader1"
             />
             <Pressable
               testID="reopen"

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts
@@ -56,7 +56,7 @@ const fixtureProfile = {
     profileId: 'trader-1',
     address: '0xabc',
     allAddresses: ['0xabc'],
-    name: 'dutchiono',
+    name: 'trader1',
     imageUrl: 'https://example.com/avatar.png',
   },
   stats: {


### PR DESCRIPTION
## **Description**

This PR replaces real trader handles used in unit test fixtures and assertions with generic mock names.

1. **What is the reason for the change?** The social leaderboard and top trader unit tests hardcoded real trader handles. Referencing real account names in the test suite is undesirable; mock data should be anonymous and self-evidently fake.
2. **What is the improvement/solution?** All occurrences were replaced with generic placeholders (`trader1` / `trader2` / `trader3`) consistently across fixtures and the assertions that depend on them.

Scope: **test-only**. No source, component, or snapshot files were changed, and there is no behavior change. The renames are purely cosmetic to the test data. ESLint/Prettier auto-formatting (via the pre-commit hook) collapsed a few now-shorter multi-line assertions, which is included in the diff.

Affected suites (11 files):

- `Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx`
- `Homepage/Sections/TopTraders/components/TraderRow.test.tsx`
- `Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts`
- `Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx`
- `SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts`
- `SocialLeaderboard/TopTradersView/TopTradersView.test.tsx`
- `SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx`
- `SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx`
- `SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx`
- `SocialLeaderboard/TraderProfileView/components/TraderNotificationsBottomSheet/TraderNotificationsBottomSheet.test.tsx`
- `SocialLeaderboard/TraderProfileView/hooks/useTraderProfile.test.ts`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Social leaderboard / top trader unit tests

  Scenario: developer runs the affected jest suites
    Given the unit test fixtures use generic mock trader names
    When the developer runs the 11 affected jest suites
    Then all suites pass with no behavior change
```

N/A — automated unit tests only; no manual app testing applies.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
