### PR TITLE
fix(money): standardise Send to Perps and Predict toasts (MUSD-969)

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyToasts.test.tsx
+++ b/app/components/UI/Money/hooks/useMoneyToasts.test.tsx
@@ -104,6 +104,11 @@ describe('useMoneyToasts', () => {
       ).toBeDefined();
       expect(result.current.MoneyToastOptions.withdraw.success).toBeDefined();
       expect(result.current.MoneyToastOptions.withdraw.failed).toBeDefined();
+
+      expect(result.current.MoneyToastOptions.send).toBeDefined();
+      expect(result.current.MoneyToastOptions.send.inProgress).toBeDefined();
+      expect(result.current.MoneyToastOptions.send.success).toBeDefined();
+      expect(result.current.MoneyToastOptions.send.failed).toBeDefined();
     });
   });
 
@@ -286,6 +291,75 @@ describe('useMoneyToasts', () => {
     });
   });
 
+  describe('send toasts', () => {
+    it('inProgress mirrors the in-progress configuration', () => {
+      const { result } = renderHook(() => useMoneyToasts(), { wrapper });
+
+      const toast = result.current.MoneyToastOptions.send.inProgress();
+
+      expect(toast.variant).toBe(ToastVariants.Icon);
+      expect(toast.iconName).toBe(IconName.Loading);
+      expect(toast.hapticsType).toBe(NotificationMoment.Warning);
+      expect(toast.hasNoTimeout).toBe(true);
+    });
+
+    it('inProgress title/body is "Sending funds" / "This may take a few minutes."', () => {
+      const { result } = renderHook(() => useMoneyToasts(), { wrapper });
+
+      const toast = result.current.MoneyToastOptions.send.inProgress();
+
+      expect(toast.labelOptions?.[0].label).toBe('Sending funds');
+      const secondary = toast.labelOptions?.[2].label as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      expect(secondary.props.children).toBe('This may take a few minutes.');
+    });
+
+    it('success title/body interpolates the amount and destination', () => {
+      const { result } = renderHook(() => useMoneyToasts(), { wrapper });
+
+      const toast = result.current.MoneyToastOptions.send.success({
+        amountFiat: '$50.00',
+        destination: 'Perps',
+      });
+
+      expect(toast.iconName).toBe(IconName.Confirmation);
+      expect(toast.hapticsType).toBe(NotificationMoment.Success);
+      expect(toast.labelOptions?.[0].label).toBe('Funds sent');
+      const secondary = toast.labelOptions?.[2].label as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      expect(secondary.props.children).toBe('$50.00 is available in Perps.');
+    });
+
+    it('success body falls back to "Available in {{destination}}." when amount is missing', () => {
+      const { result } = renderHook(() => useMoneyToasts(), { wrapper });
+
+      const toast = result.current.MoneyToastOptions.send.success({
+        destination: 'Predict',
+      });
+
+      const secondary = toast.labelOptions?.[2].label as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      expect(secondary.props.children).toBe('Available in Predict.');
+    });
+
+    it('failed title/body is "Send failed" / "Unable to send funds. Try again."', () => {
+      const { result } = renderHook(() => useMoneyToasts(), { wrapper });
+
+      const toast = result.current.MoneyToastOptions.send.failed();
+
+      expect(toast.iconName).toBe(IconName.CircleX);
+      expect(toast.hapticsType).toBe(NotificationMoment.Error);
+      expect(toast.labelOptions?.[0].label).toBe('Send failed');
+      const secondary = toast.labelOptions?.[2].label as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      expect(secondary.props.children).toBe('Unable to send funds. Try again.');
+    });
+  });
+
   describe('closeButtonOptions', () => {
     it.each([
       ['deposit.inProgress', () => ({}), 'inProgress'],
@@ -298,10 +372,17 @@ describe('useMoneyToasts', () => {
         'success',
       ],
       ['withdraw.failed', () => ({}), 'failed'],
+      ['send.inProgress', () => ({}), 'inProgress'],
+      [
+        'send.success',
+        () => ({ amountFiat: '$1.00', destination: 'Perps' }),
+        'success',
+      ],
+      ['send.failed', () => ({}), 'failed'],
     ])('exposes a Close button on %s', (key, paramsFactory, _builder) => {
       const { result } = renderHook(() => useMoneyToasts(), { wrapper });
       const [namespace, builder] = key.split('.') as [
-        'deposit' | 'withdraw',
+        'deposit' | 'withdraw' | 'send',
         'inProgress' | 'success' | 'failed',
       ];
 

--- a/app/components/UI/Money/hooks/useMoneyToasts.tsx
+++ b/app/components/UI/Money/hooks/useMoneyToasts.tsx
@@ -56,6 +56,11 @@ export interface WithdrawSuccessParams {
   destination: string;
 }
 
+export interface SendSuccessParams {
+  amountFiat?: string;
+  destination: string;
+}
+
 export interface MoneyToastOptionsConfig {
   deposit: {
     inProgress: (params?: DepositInProgressParams) => MoneyToastOptions;
@@ -65,6 +70,11 @@ export interface MoneyToastOptionsConfig {
   withdraw: {
     inProgress: () => MoneyToastOptions;
     success: (params: WithdrawSuccessParams) => MoneyToastOptions;
+    failed: () => MoneyToastOptions;
+  };
+  send: {
+    inProgress: () => MoneyToastOptions;
+    success: (params: SendSuccessParams) => MoneyToastOptions;
     failed: () => MoneyToastOptions;
   };
 }
@@ -297,6 +307,63 @@ const useMoneyToasts = (): {
                 color={TextColor.TextAlternative}
               >
                 {strings('money.toasts.withdraw_failed_body')}
+              </Text>
+            ),
+          }),
+          closeButtonOptions,
+        }),
+      },
+      send: {
+        inProgress: () => ({
+          ...moneyBaseToastOptions.inProgress,
+          labelOptions: getMoneyToastLabels({
+            primary: strings('money.toasts.send_in_progress_title'),
+            primaryIsBold: true,
+            secondary: (
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {strings('money.toasts.in_progress_body')}
+              </Text>
+            ),
+          }),
+          closeButtonOptions,
+        }),
+        success: ({ amountFiat, destination }: SendSuccessParams) => ({
+          ...moneyBaseToastOptions.success,
+          labelOptions: getMoneyToastLabels({
+            primary: strings('money.toasts.send_success_title'),
+            primaryIsBold: true,
+            secondary: (
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {amountFiat
+                  ? strings('money.toasts.send_success_body', {
+                      amount: amountFiat,
+                      destination,
+                    })
+                  : strings('money.toasts.send_success_body_no_amount', {
+                      destination,
+                    })}
+              </Text>
+            ),
+          }),
+          closeButtonOptions,
+        }),
+        failed: () => ({
+          ...moneyBaseToastOptions.error,
+          labelOptions: getMoneyToastLabels({
+            primary: strings('money.toasts.send_failed_title'),
+            primaryIsBold: true,
+            secondary: (
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {strings('money.toasts.send_failed_body')}
               </Text>
             ),
           }),

--- a/app/components/UI/Money/hooks/useMoneyToasts.tsx
+++ b/app/components/UI/Money/hooks/useMoneyToasts.tsx
@@ -184,8 +184,27 @@ const useMoneyToasts = (): {
     [toastRef],
   );
 
-  const MoneyToastOptions: MoneyToastOptionsConfig = useMemo(
-    () => ({
+  const MoneyToastOptions: MoneyToastOptionsConfig = useMemo(() => {
+    const buildSendToast = (
+      base: MoneyToastOptions,
+      primaryKey: string,
+      secondaryKey: string,
+      secondaryParams?: Record<string, string>,
+    ): MoneyToastOptions => ({
+      ...base,
+      labelOptions: getMoneyToastLabels({
+        primary: strings(primaryKey),
+        primaryIsBold: true,
+        secondary: (
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {strings(secondaryKey, secondaryParams)}
+          </Text>
+        ),
+      }),
+      closeButtonOptions,
+    });
+
+    return {
       deposit: {
         inProgress: (params?: DepositInProgressParams) => ({
           ...moneyBaseToastOptions.inProgress,
@@ -314,70 +333,40 @@ const useMoneyToasts = (): {
         }),
       },
       send: {
-        inProgress: () => ({
-          ...moneyBaseToastOptions.inProgress,
-          labelOptions: getMoneyToastLabels({
-            primary: strings('money.toasts.send_in_progress_title'),
-            primaryIsBold: true,
-            secondary: (
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('money.toasts.in_progress_body')}
-              </Text>
-            ),
-          }),
-          closeButtonOptions,
-        }),
-        success: ({ amountFiat, destination }: SendSuccessParams) => ({
-          ...moneyBaseToastOptions.success,
-          labelOptions: getMoneyToastLabels({
-            primary: strings('money.toasts.send_success_title'),
-            primaryIsBold: true,
-            secondary: (
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {amountFiat
-                  ? strings('money.toasts.send_success_body', {
-                      amount: amountFiat,
-                      destination,
-                    })
-                  : strings('money.toasts.send_success_body_no_amount', {
-                      destination,
-                    })}
-              </Text>
-            ),
-          }),
-          closeButtonOptions,
-        }),
-        failed: () => ({
-          ...moneyBaseToastOptions.error,
-          labelOptions: getMoneyToastLabels({
-            primary: strings('money.toasts.send_failed_title'),
-            primaryIsBold: true,
-            secondary: (
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {strings('money.toasts.send_failed_body')}
-              </Text>
-            ),
-          }),
-          closeButtonOptions,
-        }),
+        inProgress: () =>
+          buildSendToast(
+            moneyBaseToastOptions.inProgress,
+            'money.toasts.send_in_progress_title',
+            'money.toasts.in_progress_body',
+          ),
+        success: ({ amountFiat, destination }: SendSuccessParams) =>
+          amountFiat
+            ? buildSendToast(
+                moneyBaseToastOptions.success,
+                'money.toasts.send_success_title',
+                'money.toasts.send_success_body',
+                { amount: amountFiat, destination },
+              )
+            : buildSendToast(
+                moneyBaseToastOptions.success,
+                'money.toasts.send_success_title',
+                'money.toasts.send_success_body_no_amount',
+                { destination },
+              ),
+        failed: () =>
+          buildSendToast(
+            moneyBaseToastOptions.error,
+            'money.toasts.send_failed_title',
+            'money.toasts.send_failed_body',
+          ),
       },
-    }),
-    [
-      closeButtonOptions,
-      moneyBaseToastOptions.error,
-      moneyBaseToastOptions.inProgress,
-      moneyBaseToastOptions.success,
-    ],
-  );
+    };
+  }, [
+    closeButtonOptions,
+    moneyBaseToastOptions.error,
+    moneyBaseToastOptions.inProgress,
+    moneyBaseToastOptions.success,
+  ]);
 
   return { showToast, MoneyToastOptions };
 };

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -1,4 +1,5 @@
 import {
+  CHAIN_IDS,
   TransactionMeta,
   TransactionStatus,
   TransactionType,
@@ -203,6 +204,18 @@ describe('useMoneyTransactionStatus', () => {
     ReturnType<MoneyToastOptionsConfig['withdraw']['failed']>,
     Parameters<MoneyToastOptionsConfig['withdraw']['failed']>
   >(() => baseFailedToast);
+  const sendInProgressFn = jest.fn<
+    ReturnType<MoneyToastOptionsConfig['send']['inProgress']>,
+    Parameters<MoneyToastOptionsConfig['send']['inProgress']>
+  >(() => baseInProgressToast);
+  const sendSuccessFn = jest.fn<
+    ReturnType<MoneyToastOptionsConfig['send']['success']>,
+    Parameters<MoneyToastOptionsConfig['send']['success']>
+  >(() => baseSuccessToast);
+  const sendFailedFn = jest.fn<
+    ReturnType<MoneyToastOptionsConfig['send']['failed']>,
+    Parameters<MoneyToastOptionsConfig['send']['failed']>
+  >(() => baseFailedToast);
 
   const moneyToastOptions: MoneyToastOptionsConfig = {
     deposit: {
@@ -214,6 +227,11 @@ describe('useMoneyTransactionStatus', () => {
       inProgress: withdrawInProgressFn,
       success: withdrawSuccessFn,
       failed: withdrawFailedFn,
+    },
+    send: {
+      inProgress: sendInProgressFn,
+      success: sendSuccessFn,
+      failed: sendFailedFn,
     },
   };
 
@@ -741,6 +759,129 @@ describe('useMoneyTransactionStatus', () => {
 
       expect(withdrawFailedFn).toHaveBeenCalledTimes(1);
       expect(depositFailedFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('perps/predict send lifecycle', () => {
+    const buildSendTxMeta = (
+      type: TransactionType,
+      overrides: Partial<TransactionMeta> = {},
+    ): TransactionMeta =>
+      buildTxMeta({
+        id: 'send-tx-1',
+        type,
+        metamaskPay: {
+          tokenAddress: MUSD_ADDRESS,
+          chainId: CHAIN_IDS.MONAD,
+          totalFiat: '100',
+        },
+        ...overrides,
+      } as unknown as Partial<TransactionMeta>);
+
+    it('approved → send in-progress toast (after deferral), not deposit/withdraw', () => {
+      const { statusUpdatedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildSendTxMeta(TransactionType.perpsDeposit, {
+          status: TransactionStatus.approved,
+        }),
+      });
+
+      expect(sendInProgressFn).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+      expect(sendInProgressFn).toHaveBeenCalledTimes(1);
+      expect(depositInProgressFn).not.toHaveBeenCalled();
+      expect(withdrawInProgressFn).not.toHaveBeenCalled();
+    });
+
+    it('confirmed → send success toast with fiat amount and "Perps" destination', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildSendTxMeta(TransactionType.perpsDeposit, {
+          status: TransactionStatus.confirmed,
+        }),
+      );
+
+      expect(sendSuccessFn).toHaveBeenCalledTimes(1);
+      const params = sendSuccessFn.mock.calls[0][0];
+      expect(params.amountFiat).toContain('100');
+      expect(params.destination).toBe('Perps');
+      expect(depositSuccessFn).not.toHaveBeenCalled();
+      expect(withdrawSuccessFn).not.toHaveBeenCalled();
+    });
+
+    it('confirmed predict deposit → "Predict" destination', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildSendTxMeta(TransactionType.predictDeposit, {
+          status: TransactionStatus.confirmed,
+        }),
+      );
+
+      expect(sendSuccessFn).toHaveBeenCalledTimes(1);
+      expect(sendSuccessFn.mock.calls[0][0].destination).toBe('Predict');
+    });
+
+    it('confirmed with missing/zero fiat → success without amount', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildSendTxMeta(TransactionType.perpsDeposit, {
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            tokenAddress: MUSD_ADDRESS,
+            chainId: CHAIN_IDS.MONAD,
+            totalFiat: '0',
+          },
+        } as unknown as Partial<TransactionMeta>),
+      );
+
+      expect(sendSuccessFn).toHaveBeenCalledTimes(1);
+      expect(sendSuccessFn.mock.calls[0][0].amountFiat).toBeUndefined();
+    });
+
+    it.each([
+      ['failed', TransactionStatus.failed],
+      ['dropped', TransactionStatus.dropped],
+      ['cancelled', TransactionStatus.cancelled],
+    ])('statusUpdated with %s → send failed toast', (_label, status) => {
+      const { statusUpdatedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildSendTxMeta(TransactionType.perpsDeposit, {
+          status,
+        }),
+      });
+
+      expect(sendFailedFn).toHaveBeenCalledTimes(1);
+      expect(depositFailedFn).not.toHaveBeenCalled();
+      expect(withdrawFailedFn).not.toHaveBeenCalled();
+      expect(clearMoneyAccountDepositIntent).not.toHaveBeenCalled();
+    });
+
+    it('ignores a perps deposit not funded with mUSD on the Money chain', () => {
+      const { statusUpdatedHandler } = renderAndGetHandlers();
+
+      statusUpdatedHandler({
+        transactionMeta: buildTxMeta({
+          id: 'send-tx-other',
+          type: TransactionType.perpsDeposit,
+          status: TransactionStatus.approved,
+          metamaskPay: {
+            tokenAddress: MUSD_ADDRESS,
+            chainId: '0x1',
+            totalFiat: '100',
+          },
+        } as unknown as Partial<TransactionMeta>),
+      });
+      jest.advanceTimersByTime(IN_PROGRESS_DELAY_MS);
+
+      expect(sendInProgressFn).not.toHaveBeenCalled();
+      expect(mockShowToast).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -34,7 +34,9 @@ import { TELLER_ABI } from '../utils/moneyAccountTransactions';
 import {
   isMoneyAccountTx,
   isMoneyDepositTx,
+  isPerpsPredictMoneyDeposit,
   nestedTxWithType,
+  perpsPredictServiceFamily,
 } from '../utils/moneyTransactionGuards';
 import useMoneyToasts from './useMoneyToasts';
 import {
@@ -189,12 +191,15 @@ export const useMoneyTransactionStatus = () => {
     };
 
     const showInProgressFor = (transactionMeta: TransactionMeta) => {
-      if (!isMoneyAccountTx(transactionMeta)) return;
+      const isSend = isPerpsPredictMoneyDeposit(transactionMeta);
+      if (!isMoneyAccountTx(transactionMeta) && !isSend) return;
       if (!reserveToastKey(transactionMeta.id, IN_PROGRESS_KEY)) return;
       if (pendingInProgress.has(transactionMeta.id)) return;
       const timeoutId = setTimeout(() => {
         pendingInProgress.delete(transactionMeta.id);
-        if (isMoneyDepositTx(transactionMeta)) {
+        if (isSend) {
+          showToast(MoneyToastOptions.send.inProgress());
+        } else if (isMoneyDepositTx(transactionMeta)) {
           const intent = getMoneyAccountDepositIntent(transactionMeta.batchId);
           showToast(MoneyToastOptions.deposit.inProgress({ intent }));
         } else {
@@ -205,10 +210,13 @@ export const useMoneyTransactionStatus = () => {
     };
 
     const showFailedFor = (transactionMeta: TransactionMeta) => {
-      if (!isMoneyAccountTx(transactionMeta)) return;
+      const isSend = isPerpsPredictMoneyDeposit(transactionMeta);
+      if (!isMoneyAccountTx(transactionMeta) && !isSend) return;
       cancelPendingInProgress(transactionMeta.id);
       if (!reserveToastKey(transactionMeta.id, FAILED_KEY)) return;
-      if (isMoneyDepositTx(transactionMeta)) {
+      if (isSend) {
+        showToast(MoneyToastOptions.send.failed());
+      } else if (isMoneyDepositTx(transactionMeta)) {
         const intent = getMoneyAccountDepositIntent(transactionMeta.batchId);
         showToast(MoneyToastOptions.deposit.failed({ intent }));
         clearMoneyAccountDepositIntent(transactionMeta.batchId);
@@ -219,9 +227,30 @@ export const useMoneyTransactionStatus = () => {
     };
 
     const showConfirmedFor = (transactionMeta: TransactionMeta) => {
-      if (!isMoneyAccountTx(transactionMeta)) return;
+      const isSend = isPerpsPredictMoneyDeposit(transactionMeta);
+      if (!isMoneyAccountTx(transactionMeta) && !isSend) return;
       cancelPendingInProgress(transactionMeta.id);
       if (!reserveToastKey(transactionMeta.id, CONFIRMED_KEY)) return;
+
+      if (isSend) {
+        const fiat = Number(transactionMeta.metamaskPay?.totalFiat);
+        const amountFiat =
+          !Number.isNaN(fiat) && fiat > 0
+            ? moneyFormatFiat(
+                new BigNumber(fiat),
+                selectCurrentCurrency(store.getState()),
+              )
+            : undefined;
+        const family = perpsPredictServiceFamily(transactionMeta);
+        const destination = strings(
+          family === 'predict'
+            ? 'money.toasts.send_destination_predict'
+            : 'money.toasts.send_destination_perps',
+        );
+        showToast(MoneyToastOptions.send.success({ amountFiat, destination }));
+        scheduleCleanup(transactionMeta.id, CONFIRMED_KEY);
+        return;
+      }
 
       const depositNested = nestedTxWithType(
         transactionMeta,
@@ -312,5 +341,10 @@ export const useMoneyTransactionStatus = () => {
       pendingCleanups.forEach((timeoutId) => clearTimeout(timeoutId));
       pendingCleanups.clear();
     };
-  }, [MoneyToastOptions.deposit, MoneyToastOptions.withdraw, showToast]);
+  }, [
+    MoneyToastOptions.deposit,
+    MoneyToastOptions.withdraw,
+    MoneyToastOptions.send,
+    showToast,
+  ]);
 };

--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.test.ts
@@ -22,10 +22,15 @@ import {
   ARBITRUM_MAINNET_CHAIN_ID_HEX,
 } from '@metamask/perps-controller';
 import { selectTransactionBridgeQuotesById } from '../../../../core/redux/slices/confirmationMetrics';
+import { isPerpsPredictMoneyDeposit } from '../../Money/utils/moneyTransactionGuards';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+}));
+
+jest.mock('../../Money/utils/moneyTransactionGuards', () => ({
+  isPerpsPredictMoneyDeposit: jest.fn(() => false),
 }));
 
 jest.mock('./stream/usePerpsLiveAccount');
@@ -66,6 +71,10 @@ const mockSelectTransactionBridgeQuotesById =
   selectTransactionBridgeQuotesById as jest.MockedFunction<
     typeof selectTransactionBridgeQuotesById
   >;
+const mockIsPerpsPredictMoneyDeposit =
+  isPerpsPredictMoneyDeposit as jest.MockedFunction<
+    typeof isPerpsPredictMoneyDeposit
+  >;
 
 describe('usePerpsDepositStatus', () => {
   let mockSubscribe: jest.Mock;
@@ -95,6 +104,8 @@ describe('usePerpsDepositStatus', () => {
 
     // Mock selectTransactionBridgeQuotesById
     mockSelectTransactionBridgeQuotesById.mockReturnValue([]);
+
+    mockIsPerpsPredictMoneyDeposit.mockReturnValue(false);
 
     // Default mock for usePerpsLiveAccount
     mockUsePerpsLiveAccount.mockReturnValue({
@@ -327,6 +338,60 @@ describe('usePerpsDepositStatus', () => {
       expect(
         mockPerpsToastOptions.accountManagement.deposit.inProgress,
       ).toHaveBeenCalledWith(60, 'test-tx-id');
+    });
+
+    it('should not show any toast when perpsDeposit is funded from the Money account', () => {
+      mockShowToast.mockClear();
+      mockIsPerpsPredictMoneyDeposit.mockReturnValue(true);
+      renderHook(() => usePerpsDepositStatus());
+      const transactionMeta: TransactionMeta = {
+        id: 'test-tx-id',
+        type: TransactionType.perpsDeposit,
+        status: TransactionStatus.approved,
+      } as TransactionMeta;
+
+      act(() => {
+        transactionHandler({ transactionMeta });
+      });
+
+      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(
+        mockPerpsToastOptions.accountManagement.deposit.inProgress,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should not set expecting state when perpsDeposit is funded from the Money account', () => {
+      mockShowToast.mockClear();
+      mockIsPerpsPredictMoneyDeposit.mockReturnValue(true);
+      const { rerender } = renderHook(() => usePerpsDepositStatus());
+
+      act(() => {
+        transactionHandler({
+          transactionMeta: {
+            id: 'test-tx-id',
+            type: TransactionType.perpsDeposit,
+            status: TransactionStatus.approved,
+          } as TransactionMeta,
+        });
+      });
+
+      mockUsePerpsLiveAccount.mockReturnValue({
+        account: {
+          spendableBalance: '1500.00',
+          withdrawableBalance: '1500.00',
+          marginUsed: '9000.00',
+          unrealizedPnl: '100.00',
+          returnOnEquity: '0.15',
+          totalBalance: '10600.00',
+        },
+        isInitialLoading: false,
+      });
+
+      rerender({});
+
+      expect(
+        mockPerpsToastOptions.accountManagement.deposit.success,
+      ).not.toHaveBeenCalled();
     });
 
     it('should not show in-progress toast when perpsDeposit transaction is submitted', () => {

--- a/app/components/UI/Perps/hooks/usePerpsDepositStatus.ts
+++ b/app/components/UI/Perps/hooks/usePerpsDepositStatus.ts
@@ -14,6 +14,7 @@ import {
 import { usePerpsLiveAccount } from './stream/usePerpsLiveAccount';
 import usePerpsToasts from './usePerpsToasts';
 import { usePerpsTrading } from './usePerpsTrading';
+import { isPerpsPredictMoneyDeposit } from '../../Money/utils/moneyTransactionGuards';
 
 /**
  * Hook to monitor deposit status and show appropriate toasts
@@ -71,6 +72,10 @@ export const usePerpsDepositStatus = () => {
         transactionMeta.type === TransactionType.perpsDeposit &&
         transactionMeta.status === TransactionStatus.approved
       ) {
+        if (isPerpsPredictMoneyDeposit(transactionMeta)) {
+          return;
+        }
+
         expectingDepositRef.current = true;
         prevSpendableBalanceRef.current =
           liveAccountRef.current?.spendableBalance || '0';

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
@@ -5,6 +5,7 @@ import Routes from '../../../../constants/navigation/Routes';
 
 import { usePredictToastRegistrations } from './usePredictToastRegistrations';
 import { selectTransactionMetadataById } from '../../../../selectors/transactionController';
+import { isPerpsPredictMoneyDeposit } from '../../Money/utils/moneyTransactionGuards';
 import { selectSingleTokenByAddressAndChainId } from '../../../../selectors/tokensController';
 import { selectTickerByChainId } from '../../../../selectors/networkController';
 
@@ -90,6 +91,10 @@ jest.mock('../../../../store', () => ({
 
 jest.mock('../../../../selectors/transactionController', () => ({
   selectTransactionMetadataById: jest.fn(() => undefined),
+}));
+
+jest.mock('../../Money/utils/moneyTransactionGuards', () => ({
+  isPerpsPredictMoneyDeposit: jest.fn(() => false),
 }));
 
 jest.mock('../../../../selectors/tokensController', () => ({
@@ -296,6 +301,60 @@ describe('usePredictToastRegistrations', () => {
 
       expect(showToast).not.toHaveBeenCalled();
       expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    });
+
+    it.each(['approved', 'confirmed', 'failed'])(
+      'does not show toast on %s status when funded from the Money account',
+      (status) => {
+        (selectTransactionMetadataById as unknown as jest.Mock).mockReturnValue(
+          { id: 'tx-money' },
+        );
+        (isPerpsPredictMoneyDeposit as unknown as jest.Mock).mockReturnValue(
+          true,
+        );
+
+        const handler = getHandler();
+
+        handler(
+          {
+            type: 'deposit',
+            status,
+            transactionId: 'tx-money',
+            senderAddress: selectedAddress,
+            amount: 100,
+          },
+          showToast,
+        );
+
+        expect(showToast).not.toHaveBeenCalled();
+      },
+    );
+
+    it('still shows pending toast for a non-money deposit', () => {
+      (selectTransactionMetadataById as unknown as jest.Mock).mockReturnValue({
+        id: 'tx-normal',
+      });
+      (isPerpsPredictMoneyDeposit as unknown as jest.Mock).mockReturnValue(
+        false,
+      );
+
+      const handler = getHandler();
+
+      handler(
+        {
+          type: 'deposit',
+          status: 'approved',
+          transactionId: 'tx-normal',
+          senderAddress: selectedAddress,
+        },
+        showToast,
+      );
+
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          iconName: 'Loading',
+        }),
+      );
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -25,6 +25,8 @@ import { usePredictClaim } from './usePredictClaim';
 import { usePredictDeposit } from './usePredictDeposit';
 import { usePredictWithdraw } from './usePredictWithdraw';
 import { store } from '../../../../store';
+import { selectTransactionMetadataById } from '../../../../selectors/transactionController';
+import { isPerpsPredictMoneyDeposit } from '../../Money/utils/moneyTransactionGuards';
 import { resolveWithdrawTokenInfo } from '../../../Views/confirmations/utils/withdraw-token-resolution';
 import { selectPredictBottomSheetEnabledFlag } from '../selectors/featureFlags';
 import { shouldSuppressLegacyOrderFailureToast } from '../contexts/PredictPreviewSheetContext';
@@ -173,6 +175,13 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
       }
 
       if (type === 'deposit') {
+        const depositMeta = transactionId
+          ? selectTransactionMetadataById(store.getState(), transactionId)
+          : undefined;
+        if (depositMeta && isPerpsPredictMoneyDeposit(depositMeta)) {
+          return;
+        }
+
         if (status === 'approved') {
           showPendingToast({
             showToast,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7155,7 +7155,15 @@
       "deposit_failed_body_convert": "Unable to convert. Try again.",
       "deposit_failed_body_add_musd": "Unable to add funds. Try again.",
       "withdraw_failed_title": "Transfer failed",
-      "withdraw_failed_body": "Unable to transfer funds. Try again."
+      "withdraw_failed_body": "Unable to transfer funds. Try again.",
+      "send_in_progress_title": "Sending funds",
+      "send_success_title": "Funds sent",
+      "send_success_body": "{{amount}} is available in {{destination}}.",
+      "send_success_body_no_amount": "Available in {{destination}}.",
+      "send_failed_title": "Send failed",
+      "send_failed_body": "Unable to send funds. Try again.",
+      "send_destination_perps": "Perps",
+      "send_destination_predict": "Predict"
     },
     "apy_tooltip": {
       "title": "Annual Percentage Yield (APY)",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Standardises the toast messages shown when a user **Sends** from the Money account into **Perps** and **Predict**.

Previously these flows showed the Perps- and Predict-specific toasts, which looked different from the rest of the Money account (different icons, colours, copy, and no close button). This routes Money-funded Perps/Predict deposits through the existing Money toast pipeline (`MoneyTransactionMonitor` / `useMoneyToasts`) so they show the standard pending → success → failed toasts, and suppresses the divergent Perps/Predict deposit toasts for these Money-funded sends. Native (non-Money) Perps/Predict deposits are unaffected.

Aligned with the Perps team (Matthieu approved).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Standardised the toast messages shown when sending from the Money account to Perps and Predict.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-969

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Standardised Money account Send toasts

  Scenario: User sends funds from the Money account to Perps
    Given the user is on the Money account home screen
    When the user taps Send and sends mUSD to Perps
    Then a "Sending funds" toast is shown while the transaction is pending
    And on confirmation a "Funds sent" toast showing the amount available in Perps is shown
    And the toast matches the standard Money account toast style (not the legacy Perps toast)

  Scenario: User sends funds from the Money account to Predict
    Given the user is on the Money account home screen
    When the user taps Send and sends mUSD to Predict
    Then a "Sending funds" toast is shown while the transaction is pending
    And on confirmation a "Funds sent" toast showing the amount available in Predict is shown
    And the toast matches the standard Money account toast style (not the legacy Predict toast)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

_To be added after manual testing._

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/b40a90b7-1993-4df8-8aa4-690beab5fa2d



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
