### PR TITLE
test(confirmations): cp-8.0.0 wire fiat funding source QA path

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useFiatConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatConfirm.test.ts
@@ -10,11 +10,13 @@ import { useHeadlessBuy } from '../../../../UI/Ramp/headless';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import Engine from '../../../../../core/Engine';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { getTransactionPayFiatTestOptions } from '../../../../../util/environment';
 
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('./useTransactionPayData');
 jest.mock('../../../../UI/Ramp/headless');
 jest.mock('../../context/confirmation-context');
+jest.mock('../../../../../util/environment');
 jest.mock('../../../../../core/Engine', () => ({
   context: {
     TransactionPayController: {
@@ -48,6 +50,7 @@ describe('useFiatConfirm', () => {
     } as unknown as TransactionMeta);
 
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
+    jest.mocked(getTransactionPayFiatTestOptions).mockReturnValue(undefined);
 
     jest.mocked(useTransactionPayTotals).mockReturnValue({
       total: { fiat: '55.00', usd: '55.00' },
@@ -166,6 +169,7 @@ describe('useFiatConfirm', () => {
           amount: 52,
           paymentMethodId: 'pm-123',
           currency: 'USD',
+          walletAddress: undefined,
         },
         expect.objectContaining({
           onOrderCreated: expect.any(Function),
@@ -210,6 +214,71 @@ describe('useFiatConfirm', () => {
         updateCall as { callback: (fp: typeof fiatPaymentObj) => void }
       ).callback(fiatPaymentObj);
       expect(fiatPaymentObj.orderId).toBe('order-xyz');
+    });
+
+    it('skips headless buy and sets a synthetic orderId when fiat test funding source is configured', () => {
+      jest.mocked(getTransactionPayFiatTestOptions).mockReturnValue({
+        testFundingSource: '0x1234567890123456789012345678901234567890',
+      });
+
+      jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
+        selectedPaymentMethodId: 'pm-123',
+        amountFiat: '50.00',
+        rampsQuote: { id: 'quote-1' },
+        caipAssetId: 'eip155:1/erc20:0xabc',
+      } as never);
+
+      const { result } = renderHook(() => useFiatConfirm());
+
+      act(() => {
+        result.current.onFiatConfirm();
+      });
+
+      expect(startHeadlessBuyMock).not.toHaveBeenCalled();
+      expect(setHeadlessBuyErrorMock).toHaveBeenCalledWith(undefined);
+      expect(setIsHeadlessBuyInProgressMock).toHaveBeenCalledWith(false);
+      expect(
+        Engine.context.TransactionPayController.updateFiatPayment,
+      ).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID_MOCK,
+        callback: expect.any(Function),
+      });
+
+      const updateCall = jest.mocked(
+        Engine.context.TransactionPayController.updateFiatPayment,
+      ).mock.calls[0][0];
+      const fiatPaymentObj = {} as { orderId?: string };
+      (
+        updateCall as { callback: (fp: typeof fiatPaymentObj) => void }
+      ).callback(fiatPaymentObj);
+      expect(fiatPaymentObj.orderId).toBe('fiat-test-funding-source');
+    });
+
+    it('does not set a synthetic orderId when fiat test funding source is configured without transaction metadata', () => {
+      jest.mocked(getTransactionPayFiatTestOptions).mockReturnValue({
+        testFundingSource: '0x1234567890123456789012345678901234567890',
+      });
+      jest
+        .mocked(useTransactionMetadataRequest)
+        .mockReturnValue(undefined as unknown as TransactionMeta);
+
+      jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
+        selectedPaymentMethodId: 'pm-123',
+        amountFiat: '50.00',
+        rampsQuote: { id: 'quote-1' },
+        caipAssetId: 'eip155:1/erc20:0xabc',
+      } as never);
+
+      const { result } = renderHook(() => useFiatConfirm());
+
+      act(() => {
+        result.current.onFiatConfirm();
+      });
+
+      expect(startHeadlessBuyMock).not.toHaveBeenCalled();
+      expect(
+        Engine.context.TransactionPayController.updateFiatPayment,
+      ).not.toHaveBeenCalled();
     });
 
     it('does not update fiat payment when transactionMetadata is missing', () => {

--- a/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
+++ b/app/components/Views/confirmations/hooks/pay/useFiatConfirm.ts
@@ -13,6 +13,7 @@ import {
   type RampSurface,
 } from '../../../../UI/Ramp/Deposit/types/analytics';
 import Engine from '../../../../../core/Engine';
+import { getTransactionPayFiatTestOptions } from '../../../../../util/environment';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import {
   useTransactionPayFiatPayment,
@@ -22,6 +23,7 @@ import {
 import { useConfirmationContext } from '../../context/confirmation-context';
 
 const log = createProjectLogger('fiat-confirm');
+const FIAT_TEST_FUNDING_SOURCE_ORDER_ID = 'fiat-test-funding-source';
 
 /**
  * Maps a confirmation transaction type to the headless ramps `ramp_surface`
@@ -47,6 +49,7 @@ export function useFiatConfirm() {
 
   const isFiatPaymentSelected = Boolean(fiatPayment?.selectedPaymentMethodId);
   const orderId = fiatPayment?.orderId as string | undefined;
+  const fiatTestOptions = getTransactionPayFiatTestOptions();
 
   const onFiatConfirm = useCallback(() => {
     const rampsQuote = fiatPayment?.rampsQuote as Quote | undefined;
@@ -62,8 +65,27 @@ export function useFiatConfirm() {
       return;
     }
 
-    setIsHeadlessBuyInProgress(true);
     setHeadlessBuyError(undefined);
+
+    if (fiatTestOptions?.testFundingSource) {
+      setIsHeadlessBuyInProgress(false);
+
+      if (!transactionMetadata?.id) {
+        log('Fiat test funding source missing transaction metadata');
+        return;
+      }
+
+      Engine.context.TransactionPayController.updateFiatPayment({
+        transactionId: transactionMetadata.id,
+        callback: (fp) => {
+          fp.orderId = FIAT_TEST_FUNDING_SOURCE_ORDER_ID;
+        },
+      });
+
+      return;
+    }
+
+    setIsHeadlessBuyInProgress(true);
 
     // Subtract the on-ramp provider fee from the total so the Ramps order
     // amount covers exactly the Relay leg of the intent (fees + deposit).
@@ -111,6 +133,7 @@ export function useFiatConfirm() {
       },
     );
   }, [
+    fiatTestOptions?.testFundingSource,
     fiatPayment,
     totals,
     setHeadlessBuyError,

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
@@ -10,9 +10,11 @@ import {
 import { TransactionPayControllerInit } from './transaction-pay-controller-init';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { createPolymarketCallbacks } from './polymarket-callbacks';
+import { getTransactionPayFiatTestOptions } from '../../../../util/environment';
 
 jest.mock('@metamask/transaction-pay-controller');
 jest.mock('./polymarket-callbacks');
+jest.mock('../../../../util/environment');
 
 function buildInitRequestMock(
   initRequestProperties: Record<string, unknown> = {},
@@ -116,5 +118,17 @@ describe('Transaction Pay Controller Init', () => {
 
     expect(createPolymarketCallbacks).toHaveBeenCalledTimes(1);
     expect(polymarket).toBe(polymarketCallbacksMock);
+  });
+
+  it('wires fiat test options through a controller messenger action callback', () => {
+    const fiatOptions = {
+      testAmountOverride: '0.1',
+      testFundingSource: '0x123' as const,
+    };
+    jest.mocked(getTransactionPayFiatTestOptions).mockReturnValue(fiatOptions);
+
+    const getFiatOptions = testConstructorOption('getFiatOptions');
+
+    expect(getFiatOptions?.()).toBe(fiatOptions);
   });
 });

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.test.ts
@@ -120,15 +120,15 @@ describe('Transaction Pay Controller Init', () => {
     expect(polymarket).toBe(polymarketCallbacksMock);
   });
 
-  it('wires fiat test options through a controller messenger action callback', () => {
+  it('wires fiat test options through controller options', () => {
     const fiatOptions = {
       testAmountOverride: '0.1',
       testFundingSource: '0x123' as const,
     };
     jest.mocked(getTransactionPayFiatTestOptions).mockReturnValue(fiatOptions);
 
-    const getFiatOptions = testConstructorOption('getFiatOptions');
+    const result = testConstructorOption('fiatOptions');
 
-    expect(getFiatOptions?.()).toBe(fiatOptions);
+    expect(result).toBe(fiatOptions);
   });
 });

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -3,12 +3,14 @@ import Logger from '../../../../util/Logger';
 import {
   TransactionPayController,
   TransactionPayControllerMessenger,
+  type TransactionPayControllerOptions,
 } from '@metamask/transaction-pay-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { getAmountData } from './amount-data-callback';
 import { getDelegationTransaction } from '../../../../util/transactions/delegation';
 import { getPaymentOverrideData } from './paymentoverride-callback';
 import { createPolymarketCallbacks } from './polymarket-callbacks';
+import { getTransactionPayFiatTestOptions } from '../../../../util/environment';
 
 export const TransactionPayControllerInit: MessengerClientInitFunction<
   TransactionPayController,
@@ -18,16 +20,21 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
   const { controllerMessenger, initMessenger, persistedState } = request;
 
   try {
-    const transactionPayController = new TransactionPayController({
+    const controllerOptions: TransactionPayControllerOptions = {
       getAmountData,
       getDelegationTransaction: ({ transaction }) =>
         getDelegationTransaction(initMessenger, transaction),
-      getPaymentOverrideData: (request) =>
-        getPaymentOverrideData(request, initMessenger),
+      getFiatOptions: getTransactionPayFiatTestOptions,
+      getPaymentOverrideData: (paymentOverrideRequest) =>
+        getPaymentOverrideData(paymentOverrideRequest, initMessenger),
       messenger: controllerMessenger,
       polymarket: createPolymarketCallbacks(initMessenger),
       state: persistedState.TransactionPayController,
-    });
+    };
+
+    const transactionPayController = new TransactionPayController(
+      controllerOptions,
+    );
 
     return { controller: transactionPayController };
   } catch (error) {

--- a/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/transaction-pay-controller-init.ts
@@ -3,7 +3,6 @@ import Logger from '../../../../util/Logger';
 import {
   TransactionPayController,
   TransactionPayControllerMessenger,
-  type TransactionPayControllerOptions,
 } from '@metamask/transaction-pay-controller';
 import { TransactionPayControllerInitMessenger } from '../../messengers/transaction-pay-controller-messenger';
 import { getAmountData } from './amount-data-callback';
@@ -20,21 +19,17 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
   const { controllerMessenger, initMessenger, persistedState } = request;
 
   try {
-    const controllerOptions: TransactionPayControllerOptions = {
+    const transactionPayController = new TransactionPayController({
       getAmountData,
       getDelegationTransaction: ({ transaction }) =>
         getDelegationTransaction(initMessenger, transaction),
-      getFiatOptions: getTransactionPayFiatTestOptions,
+      fiatOptions: getTransactionPayFiatTestOptions(),
       getPaymentOverrideData: (paymentOverrideRequest) =>
         getPaymentOverrideData(paymentOverrideRequest, initMessenger),
       messenger: controllerMessenger,
       polymarket: createPolymarketCallbacks(initMessenger),
       state: persistedState.TransactionPayController,
-    };
-
-    const transactionPayController = new TransactionPayController(
-      controllerOptions,
-    );
+    });
 
     return { controller: transactionPayController };
   } catch (error) {

--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -199,6 +199,7 @@ export function getTransactionControllerInitMessenger(
       'TransactionController:updateTransaction',
       'TransactionPayController:getAmountData',
       'TransactionPayController:getDelegationTransaction',
+      'TransactionPayController:getFiatOptions',
       'TransactionPayController:getPaymentOverrideData',
       'TransactionPayController:getState',
       'TransactionPayController:getStrategy',

--- a/app/util/environment.test.ts
+++ b/app/util/environment.test.ts
@@ -1,6 +1,11 @@
-import { getDevAutoUnlockPassword, isProduction } from './environment';
+import {
+  getDevAutoUnlockPassword,
+  getTransactionPayFiatTestOptions,
+  isProduction,
+} from './environment';
 
 const originalMetamaskEnvironment = process.env.METAMASK_ENVIRONMENT;
+const originalMetamaskBuildType = process.env.METAMASK_BUILD_TYPE;
 
 describe('isProduction', () => {
   afterAll(() => {
@@ -110,5 +115,173 @@ describe('getDevAutoUnlockPassword', () => {
     });
 
     expect(getDevAutoUnlockPassword()).toBeUndefined();
+  });
+});
+
+describe('getTransactionPayFiatTestOptions', () => {
+  const originalFundingSource =
+    process.env.TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE;
+  const originalAmountOverride =
+    process.env.TRANSACTION_PAY_FIAT_TEST_AMOUNT_OVERRIDE;
+
+  afterEach(() => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: originalMetamaskEnvironment,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'METAMASK_BUILD_TYPE', {
+      value: originalMetamaskBuildType,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE',
+      {
+        value: originalFundingSource,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_AMOUNT_OVERRIDE',
+      {
+        value: originalAmountOverride,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+  });
+
+  it('returns the funding source in dev', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'dev',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE',
+      {
+        value: '0x1234567890123456789012345678901234567890',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+
+    expect(getTransactionPayFiatTestOptions()).toStrictEqual({
+      testAmountOverride: undefined,
+      testFundingSource: '0x1234567890123456789012345678901234567890',
+    });
+  });
+
+  it('returns the funding source in flask builds', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'production',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'METAMASK_BUILD_TYPE', {
+      value: 'flask',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE',
+      {
+        value: '0x1234567890123456789012345678901234567890',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+
+    expect(getTransactionPayFiatTestOptions()).toStrictEqual({
+      testAmountOverride: undefined,
+      testFundingSource: '0x1234567890123456789012345678901234567890',
+    });
+  });
+
+  it('returns the amount override in enabled builds', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'dev',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_AMOUNT_OVERRIDE',
+      {
+        value: '0.1',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+
+    expect(getTransactionPayFiatTestOptions()).toStrictEqual({
+      testAmountOverride: '0.1',
+      testFundingSource: undefined,
+    });
+  });
+
+  it('returns undefined outside enabled builds', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'production',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, 'METAMASK_BUILD_TYPE', {
+      value: 'main',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE',
+      {
+        value: '0x1234567890123456789012345678901234567890',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+
+    expect(getTransactionPayFiatTestOptions()).toBeUndefined();
+  });
+
+  it('returns undefined when the funding source is empty', () => {
+    Object.defineProperty(process.env, 'METAMASK_ENVIRONMENT', {
+      value: 'dev',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    Object.defineProperty(
+      process.env,
+      'TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE',
+      {
+        value: '',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    );
+
+    expect(getTransactionPayFiatTestOptions()).toBeUndefined();
   });
 });

--- a/app/util/environment.ts
+++ b/app/util/environment.ts
@@ -1,4 +1,10 @@
 /* eslint-disable import-x/prefer-default-export */
+import type { TransactionPayFiatOptions } from '@metamask/transaction-pay-controller';
+import type { Hex } from '@metamask/utils';
+
+const DEV_ENVIRONMENT = 'dev';
+const RC_ENVIRONMENT = 'rc';
+const FLASK_BUILD_TYPE = 'flask';
 
 // TODO: This should be consolidated into app/util/test/utils.js
 // This needs to be updated to check for the METAMASK_ENVIRONMENT environment variable instead of NODE_ENV
@@ -21,11 +27,42 @@ export const getE2EMockOAuthEmailForQaMock = (): string | undefined => {
 
 export const getDevAutoUnlockPassword = (): string | undefined => {
   const password = process.env.DEV_AUTO_UNLOCK_PASSWORD;
-  if (process.env.METAMASK_ENVIRONMENT !== 'dev') {
+
+  if (process.env.METAMASK_ENVIRONMENT !== DEV_ENVIRONMENT) {
     return undefined;
   }
 
   return typeof password === 'string' && password.length > 0
     ? password
+    : undefined;
+};
+
+export const getTransactionPayFiatTestOptions = ():
+  | TransactionPayFiatOptions
+  | undefined => {
+  const fundingSource = process.env.TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE;
+  const amountOverride = process.env.TRANSACTION_PAY_FIAT_TEST_AMOUNT_OVERRIDE;
+
+  const isEnabledBuild =
+    process.env.METAMASK_ENVIRONMENT === DEV_ENVIRONMENT ||
+    process.env.METAMASK_ENVIRONMENT === RC_ENVIRONMENT ||
+    process.env.METAMASK_BUILD_TYPE === FLASK_BUILD_TYPE;
+
+  if (!isEnabledBuild) {
+    return undefined;
+  }
+
+  const testFundingSource =
+    typeof fundingSource === 'string' && fundingSource.length > 0
+      ? (fundingSource as Hex)
+      : undefined;
+
+  const testAmountOverride =
+    typeof amountOverride === 'string' && amountOverride.length > 0
+      ? amountOverride
+      : undefined;
+
+  return testFundingSource || testAmountOverride
+    ? { testAmountOverride, testFundingSource }
     : undefined;
 };

--- a/app/util/transactions/hooks/index.test.ts
+++ b/app/util/transactions/hooks/index.test.ts
@@ -1,4 +1,3 @@
-import { Hex } from '@metamask/utils';
 import { TransactionPayPublishHook } from '@metamask/transaction-pay-controller';
 import {
   type PublishBatchHookTransaction,
@@ -193,6 +192,18 @@ describe('getTransactionControllerHooks', () => {
 
     expect(result).toStrictEqual({ transactionHash: '0xpay' });
     expect(submitSmartTransactionHook).not.toHaveBeenCalled();
+  });
+
+  it('does not pass static fiat test options to TransactionPayPublishHook', async () => {
+    const hooks = getTransactionControllerHooks(buildRequest());
+
+    await hooks.publish?.(MOCK_TRANSACTION_META);
+
+    expect(TransactionPayPublishHook).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        fiat: expect.anything(),
+      }),
+    );
   });
 
   it('records sentinel_stx metrics when smart transaction hook publishes', async () => {

--- a/app/util/transactions/hooks/index.test.ts
+++ b/app/util/transactions/hooks/index.test.ts
@@ -1,3 +1,4 @@
+import { Hex } from '@metamask/utils';
 import { TransactionPayPublishHook } from '@metamask/transaction-pay-controller';
 import {
   type PublishBatchHookTransaction,
@@ -192,18 +193,6 @@ describe('getTransactionControllerHooks', () => {
 
     expect(result).toStrictEqual({ transactionHash: '0xpay' });
     expect(submitSmartTransactionHook).not.toHaveBeenCalled();
-  });
-
-  it('does not pass static fiat test options to TransactionPayPublishHook', async () => {
-    const hooks = getTransactionControllerHooks(buildRequest());
-
-    await hooks.publish?.(MOCK_TRANSACTION_META);
-
-    expect(TransactionPayPublishHook).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        fiat: expect.anything(),
-      }),
-    );
   });
 
   it('records sentinel_stx metrics when smart transaction hook publishes', async () => {


### PR DESCRIPTION
## **Description**

Adds development-gated fiat QA options for the MetaMask Pay fiat submit path.

### New environment variables

Both variables are no-ops on production builds (`METAMASK_ENVIRONMENT=production`). They are only read in dev, RC, or Flask builds.

| Variable | Type | Purpose |
|---|---|---|
| `TRANSACTION_PAY_FIAT_TEST_FUNDING_SOURCE` | `Hex` address | When set, skips the real Ramps headless-buy flow on fiat confirm. Instead, writes a synthetic `orderId` directly so the existing `TransactionPayController` fiat submit path runs without a real on-ramp order. |
| `TRANSACTION_PAY_FIAT_TEST_AMOUNT_OVERRIDE` | numeric string (e.g. `"0.1"`) | Overrides the fiat amount used by the core fiat test-funding helper when building the synthetic funding transfer. Quote totals are still derived from the normal Ramps quote. |

Both are passed as `fiatOptions` on `TransactionPayController` during controller init and retrieved at publish time via `TransactionPayController:getFiatOptions`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.