### PR TITLE
fix: stop inflating leaderboard ROI by 100× - TSA-727

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
@@ -39,7 +39,7 @@ const mockTraders = [
     name: 'alpha.eth',
     imageUrl: 'https://example.com/avatar1.png',
     pnl7d: 963146.8,
-    roiPercent7d: 0.43,
+    roiPercent7d: 43,
     pnlPerChain: { base: 963146.8 },
   },
   {
@@ -49,7 +49,7 @@ const mockTraders = [
     name: 'beta.eth',
     imageUrl: 'https://example.com/avatar2.png',
     pnl7d: 474751.45,
-    roiPercent7d: 3.59,
+    roiPercent7d: 359,
     pnlPerChain: { ethereum: 474751.45 },
   },
   {
@@ -59,7 +59,7 @@ const mockTraders = [
     name: 'gamma.eth',
     imageUrl: 'https://example.com/avatar3.png',
     pnl7d: 374735.16,
-    roiPercent7d: 6.17,
+    roiPercent7d: 617,
     pnlPerChain: { solana: 374735.16 },
   },
 ];
@@ -135,7 +135,7 @@ describe('useTopTraders', () => {
         overallRank: first.rank,
         username: first.name,
         avatarUri: first.imageUrl,
-        percentageChange: first.roiPercent7d * 100,
+        percentageChange: first.roiPercent7d,
         pnlValue: first.pnl7d,
         pnlPerChain: first.pnlPerChain ?? {},
         isFollowing: false,

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -92,7 +92,9 @@ export const useTopTraders = (
       overallRank: entry.rank,
       username: entry.name,
       avatarUri: entry.imageUrl ?? undefined,
-      percentageChange: (entry.roiPercent7d ?? 0) * 100,
+      // `roiPercent7d` is already a whole-percent value from the API
+      // (e.g. 20.98 → "20.98%"); do not multiply by 100.
+      percentageChange: entry.roiPercent7d ?? 0,
       pnlValue: entry.pnl7d ?? 0,
       pnlPerChain: entry.pnlPerChain ?? {},
       isFollowing: isFollowing(entry.profileId),


### PR DESCRIPTION
## Description

The Social Leaderboard rows (leaderboard list + homepage carousel) display ROI **100× too large** on every tab. `roiPercent7d` (formerly `roiPercent30d`) from the social API is already a whole-percent value (e.g. `20.98` → "20.98%"), but `useTopTraders` multiplied it by 100 again, so `+20.98%` rendered as `+2098.0%`.

Fixes [TSA-727](https://consensyssoftware.atlassian.net/browse/TSA-727).

## Changes

- `useTopTraders`: drop the `* 100` — map `percentageChange: entry.roiPercent7d ?? 0` directly.
- `useTopTraders.test.ts`: the previous fixtures used **fractions** (`roiPercent7d: 0.43`) which masked the bug; updated to whole-percent values and adjusted the mapping assertion.

## Why it wasn't caught

The unit test asserted `percentageChange === roiPercent7d * 100` against fractional fixtures, encoding the wrong assumption. Real Clicker/social-api data returns whole percents (confirmed against the leaderboard payload, e.g. `roiPercent7d: 20.98`).

## Test plan

- `yarn jest .../TopTraders/hooks/useTopTraders.test.ts` — 33/33 pass.
- `yarn jest .../TopTraders .../SocialLeaderboard/TopTradersView` — 143/143 pass (no ROI-display regressions; the row/card/view tests build `TopTrader` objects directly).
- `yarn lint:tsc` 0 errors · prettier clean.

## Notes

Branched from latest `main` (the 7d PR #31570 that introduced this exact line is already merged). Separate from TSA-729 (headline-vs-position-list discrepancy), which is tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TSA-727]: https://consensyssoftware.atlassian.net/browse/TSA-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ