### PR TITLE
perf: stabilize usePerpsOrderForm callbacks (TAT-3322)

### DIFF
--- a/app/components/UI/Perps/contexts/PerpsOrderContext.test.tsx
+++ b/app/components/UI/Perps/contexts/PerpsOrderContext.test.tsx
@@ -240,6 +240,42 @@ describe('PerpsOrderContext', () => {
       expect(result.current.setLeverage).toBe(initialSetLeverage);
     });
 
+    it('memoizes the whole provider value object across re-renders with unchanged form state', () => {
+      // This asserts the Provider value is memoized, not just that individual
+      // callbacks happen to be stable. The inline spread previously produced a
+      // brand-new value object on every render, re-rendering all consumers.
+      const { result, rerender } = renderHookWithProvider(() =>
+        usePerpsOrderContext(),
+      );
+
+      const firstValue = result.current;
+
+      rerender(() => usePerpsOrderContext());
+
+      expect(result.current).toBe(firstValue);
+    });
+
+    it('returns a new provider value object when the underlying form state changes', () => {
+      const { result, rerender } = renderHookWithProvider(() =>
+        usePerpsOrderContext(),
+      );
+
+      const firstValue = result.current;
+
+      mockUsePerpsOrderForm.mockReturnValue({
+        ...mockOrderFormReturn,
+        orderForm: {
+          ...mockOrderFormReturn.orderForm,
+          amount: '200',
+        },
+      });
+
+      rerender(() => usePerpsOrderContext());
+
+      expect(result.current).not.toBe(firstValue);
+      expect(result.current.orderForm.amount).toBe('200');
+    });
+
     it('works with different initial configurations', () => {
       const configs = [
         { initialAsset: 'BTC', initialDirection: 'long' as const },

--- a/app/components/UI/Perps/contexts/PerpsOrderContext.tsx
+++ b/app/components/UI/Perps/contexts/PerpsOrderContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { createContext, useContext, useMemo, ReactNode } from 'react';
 import {
   usePerpsOrderForm,
   UsePerpsOrderFormReturn,
@@ -42,13 +42,19 @@ export const PerpsOrderProvider = ({
     effectiveAvailableBalance,
   });
 
+  // orderFormState is itself memoized by usePerpsOrderForm (stable callbacks +
+  // changing primitives), so depending on it directly keeps the provider value
+  // referentially stable until the form state or existingPosition actually changes.
+  const value = useMemo<PerpsOrderContextType>(
+    () => ({
+      ...orderFormState,
+      existingPosition,
+    }),
+    [orderFormState, existingPosition],
+  );
+
   return (
-    <PerpsOrderContext.Provider
-      value={{
-        ...orderFormState,
-        existingPosition,
-      }}
-    >
+    <PerpsOrderContext.Provider value={value}>
       {children}
     </PerpsOrderContext.Provider>
   );

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { renderHook, act } from '@testing-library/react-native';
 import { usePerpsOrderForm } from './usePerpsOrderForm';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { usePerpsNetwork } from './usePerpsNetwork';
 import { usePerpsLiveAccount } from './stream/usePerpsLiveAccount';
 import { usePerpsLivePrices } from './stream/usePerpsLivePrices';
@@ -940,6 +941,93 @@ describe('usePerpsOrderForm', () => {
       });
 
       expect(result.current.orderForm.amount).toBe('0');
+    });
+  });
+
+  describe('callback referential stability', () => {
+    const STABLE_CALLBACKS = [
+      'updateOrderForm',
+      'setAmount',
+      'setLeverage',
+      'setDirection',
+      'setAsset',
+      'setTakeProfitPrice',
+      'setStopLossPrice',
+      'setLimitPrice',
+      'setOrderType',
+      'handlePercentageAmount',
+      'handleMaxAmount',
+      'handleMinAmount',
+    ] as const;
+
+    it('keeps callback identities stable across re-renders with no state changes', () => {
+      const { result, rerender } = renderHook(() => usePerpsOrderForm(), {
+        wrapper: createWrapper(),
+      });
+
+      const first = STABLE_CALLBACKS.map((key) => result.current[key]);
+
+      rerender({});
+
+      STABLE_CALLBACKS.forEach((key, index) => {
+        expect(result.current[key]).toBe(first[index]);
+      });
+    });
+
+    it('keeps state-independent setter identities stable after a state change', () => {
+      const { result } = renderHook(() => usePerpsOrderForm(), {
+        wrapper: createWrapper(),
+      });
+
+      // Setters that use functional updates only and have no reactive deps
+      const stateIndependent = [
+        'updateOrderForm',
+        'setAmount',
+        'setLeverage',
+        'setDirection',
+        'setAsset',
+        'setTakeProfitPrice',
+        'setStopLossPrice',
+        'setLimitPrice',
+        'setOrderType',
+      ] as const;
+
+      const before = stateIndependent.map((key) => result.current[key]);
+
+      act(() => {
+        result.current.setAmount('250');
+      });
+
+      expect(result.current.orderForm.amount).toBe('250');
+
+      stateIndependent.forEach((key, index) => {
+        expect(result.current[key]).toBe(before[index]);
+      });
+    });
+
+    it('preserves setStopLossPrice DevLogger side effect and clearing behavior', () => {
+      const devLoggerSpy = jest.spyOn(DevLogger, 'log').mockImplementation();
+
+      const { result } = renderHook(() => usePerpsOrderForm(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setStopLossPrice('45000');
+      });
+      expect(result.current.orderForm.stopLossPrice).toBe('45000');
+
+      act(() => {
+        result.current.setStopLossPrice('');
+      });
+      expect(result.current.orderForm.stopLossPrice).toBeUndefined();
+
+      expect(devLoggerSpy).toHaveBeenCalledWith(
+        '[Order Debug] setStopLossPrice state update:',
+        expect.objectContaining({ wasCleared: true }),
+      );
+
+      devLoggerSpy.mockRestore();
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
@@ -273,34 +273,34 @@ export function usePerpsOrderForm(
   }, [balanceForMax, maxPossibleAmount, orderForm.amount]);
 
   // Update entire form
-  const updateOrderForm = (updates: Partial<OrderFormState>) => {
+  const updateOrderForm = useCallback((updates: Partial<OrderFormState>) => {
     setOrderForm((prev) => ({ ...prev, ...updates }));
-  };
+  }, []);
 
   // Individual setters for common operations
-  const setAmount = (amount: string) => {
+  const setAmount = useCallback((amount: string) => {
     setOrderForm((prev) => ({ ...prev, amount: amount || '0' }));
-  };
+  }, []);
 
-  const setLeverage = (leverage: number) => {
+  const setLeverage = useCallback((leverage: number) => {
     setOrderForm((prev) => ({ ...prev, leverage }));
-  };
+  }, []);
 
-  const setDirection = (direction: 'long' | 'short') => {
+  const setDirection = useCallback((direction: 'long' | 'short') => {
     setOrderForm((prev) => ({ ...prev, direction }));
-  };
+  }, []);
 
-  const setAsset = (asset: string) => {
+  const setAsset = useCallback((asset: string) => {
     setOrderForm((prev) => ({ ...prev, asset }));
-  };
+  }, []);
 
-  const setTakeProfitPrice = (price?: string) => {
+  const setTakeProfitPrice = useCallback((price?: string) => {
     // Convert empty string to undefined for proper clearing
     const cleanedPrice = price === '' || price === null ? undefined : price;
     setOrderForm((prev) => ({ ...prev, takeProfitPrice: cleanedPrice }));
-  };
+  }, []);
 
-  const setStopLossPrice = (price?: string) => {
+  const setStopLossPrice = useCallback((price?: string) => {
     // Convert empty string to undefined for proper clearing
     const cleanedPrice = price === '' || price === null ? undefined : price;
     setOrderForm((prev) => {
@@ -313,18 +313,18 @@ export function usePerpsOrderForm(
       });
       return newState;
     });
-  };
+  }, []);
 
-  const setLimitPrice = (price?: string) => {
+  const setLimitPrice = useCallback((price?: string) => {
     setOrderForm((prev) => {
       const newState = { ...prev, limitPrice: price };
       return newState;
     });
-  };
+  }, []);
 
-  const setOrderType = (type: OrderType) => {
+  const setOrderType = useCallback((type: OrderType) => {
     setOrderForm((prev) => ({ ...prev, type }));
-  };
+  }, []);
 
   // Handle percentage-based amount selection (respects custom token amount when set).
   // Clamp to maxPossibleAmount so near-100% values never exceed the buffered max.
@@ -361,21 +361,40 @@ export function usePerpsOrderForm(
     }));
   }, [currentNetwork]);
 
-  return {
-    orderForm,
-    updateOrderForm,
-    setAmount,
-    setLeverage,
-    setDirection,
-    setAsset,
-    setTakeProfitPrice,
-    setStopLossPrice,
-    setLimitPrice,
-    setOrderType,
-    handlePercentageAmount,
-    handleMaxAmount,
-    handleMinAmount,
-    maxPossibleAmount,
-    balanceForValidation: balanceForMax,
-  };
+  return useMemo(
+    () => ({
+      orderForm,
+      updateOrderForm,
+      setAmount,
+      setLeverage,
+      setDirection,
+      setAsset,
+      setTakeProfitPrice,
+      setStopLossPrice,
+      setLimitPrice,
+      setOrderType,
+      handlePercentageAmount,
+      handleMaxAmount,
+      handleMinAmount,
+      maxPossibleAmount,
+      balanceForValidation: balanceForMax,
+    }),
+    [
+      orderForm,
+      updateOrderForm,
+      setAmount,
+      setLeverage,
+      setDirection,
+      setAsset,
+      setTakeProfitPrice,
+      setStopLossPrice,
+      setLimitPrice,
+      setOrderType,
+      handlePercentageAmount,
+      handleMaxAmount,
+      handleMinAmount,
+      maxPossibleAmount,
+      balanceForMax,
+    ],
+  );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

`usePerpsOrderForm` returned a fresh object literal on every render containing 9 setter/callback functions (`updateOrderForm`, `setAmount`, `setLeverage`, `setDirection`, `setAsset`, `setTakeProfitPrice`, `setStopLossPrice`, `setLimitPrice`, `setOrderType`) that were recreated inline each render. These unstable references defeated downstream memoization (e.g. the order context and memoized consumers), causing avoidable re-renders across the order form. This PR wraps each of the 9 callbacks in `useCallback` and memoizes the returned object with `useMemo`, so consumers receive stable references. Behavior is preserved exactly, including `setStopLossPrice`'s `DevLogger` side effect and the TP/SL/limit clearing logic.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31371
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3322

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps order form input stability

  Scenario: User edits the order form without regressions
    Given the user has opened a Perps market and the order form is visible

    When the user changes the amount, leverage, and direction
    And the user sets and then clears a stop-loss price
    Then each input updates correctly and reflects the entered values
    And clearing the stop-loss price resets it as before
    And the order form behaves identically to before this change (no visual or functional regression)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
