### PR TITLE
perf: avoid spurious resubscription in usePerpsMarketStats

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.test.ts
@@ -174,6 +174,30 @@ describe('usePerpsMarketStats', () => {
     expect(result.current.openInterest).toBe('$99.00T'); // Decimals in formatLargeNumber for detailed view
   });
 
+  it('subscribes to prices only once when the first price tick arrives', () => {
+    // Arrange: subscribe synchronously delivers a first price tick on subscribe
+    const mockUnsubscribe = jest.fn();
+    mockSubscribeToPrices.mockImplementation(({ callback }) => {
+      callback([mockPriceData.BTC]);
+      return mockUnsubscribe;
+    });
+    mockedUsePerpsLiveCandles.mockReturnValue({
+      candleData: mockCandleData,
+      isLoading: false,
+      isLoadingMore: false,
+      hasHistoricalData: true,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
+
+    // Act: Render the hook so the subscription effect runs and the first tick arrives
+    renderHook(() => usePerpsMarketStats('BTC'));
+
+    // Assert: capturing the initial price must not re-trigger the subscription effect
+    expect(mockSubscribeToPrices).toHaveBeenCalledTimes(1);
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+  });
+
   it('formats negative funding rates with proper sign and decimals', () => {
     // Given a negative funding rate
     const negativeFundingData = {

--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import {
   CandlePeriod,
@@ -43,6 +43,11 @@ export const usePerpsMarketStats = (
 ): UsePerpsMarketStatsReturn => {
   const [marketData, setMarketData] = useState<MarketDataUpdate>({});
   const [initialPrice, setInitialPrice] = useState<number | undefined>();
+  // Track whether the initial price has been captured without making it a
+  // reactive dependency of the subscription effect. Using state here would
+  // cause the effect to re-run (unsubscribe/resubscribe) on the first tick,
+  // missing ticks during the re-subscription window.
+  const hasInitialPriceRef = useRef(false);
 
   // Get candlestick data for 24h high/low calculation via WebSocket streaming
   const { candleData } = usePerpsLiveCandles({
@@ -82,7 +87,8 @@ export const usePerpsMarketStats = (
         });
 
         // Store initial price only once for high/low calculation fallback
-        if (!initialPrice && update.price) {
+        if (!hasInitialPriceRef.current && update.price) {
+          hasInitialPriceRef.current = true;
           setInitialPrice(Number.parseFloat(update.price));
         }
       }
@@ -108,7 +114,7 @@ export const usePerpsMarketStats = (
         unsubscribe();
       }
     };
-  }, [symbol, initialPrice]);
+  }, [symbol]);
 
   // Calculate all statistics
   const stats = useMemo<MarketStats>(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

In `usePerpsMarketStats`, `initialPrice` was React state set inside the price-subscription callback and was also listed in the subscription effect's dependency array (`[symbol, initialPrice]`). When the first price tick arrived, `initialPrice` went from `undefined` to a number, re-running the effect: the cleanup unsubscribed and the effect resubscribed. This spurious unsubscribe/resubscribe cycle happens on every mount and can drop ticks during the re-subscription window. This PR captures whether the initial price has been set via a `useRef` (`hasInitialPriceRef`) so it is no longer a reactive dependency: the "set once" gate now uses the ref and the effect dependency array is reduced to `[symbol]`. The rendered `initialPrice` value is still kept in state for the returned stats but no longer re-triggers the subscription effect, aligning with the existing "Store initial price only once" comment.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31294
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3331

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market stats price subscription stability

  Scenario: User opens a market and the first price tick arrives
    Given the user opens a Perps market that shows live market stats

    When the first price tick arrives and the initial price is captured
    Then the price subscription is established exactly once (no unsubscribe/resubscribe cycle)
    And live market stats keep updating without dropped ticks
    And switching to a different symbol re-subscribes correctly for the new market
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
