### PR TITLE
perf: stabilize PerpsProgressBar withdrawalProgress selector fallback

### DIFF
--- a/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.test.tsx
+++ b/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.test.tsx
@@ -1212,4 +1212,44 @@ describe('PerpsProgressBar', () => {
       }).not.toThrow();
     });
   });
+
+  describe('withdrawal progress selector stability (TAT-3328)', () => {
+    it('returns a stable fallback reference when withdrawalProgress is null/undefined', () => {
+      renderWithProvider(<PerpsProgressBar {...defaultProps} />);
+
+      // Capture the selector function passed to usePerpsSelector
+      const selector = mockUsePerpsSelector.mock.calls[0][0] as (
+        state: { withdrawalProgress?: unknown } | undefined,
+      ) => unknown;
+
+      // Simulate Redux evaluating the selector across unrelated dispatches
+      const firstResult = selector({ withdrawalProgress: undefined });
+      const secondResult = selector({ withdrawalProgress: undefined });
+      const thirdResult = selector(undefined);
+
+      // A new object literal on each call would break referential stability and
+      // cause spurious re-renders. The fallback must be the same reference.
+      expect(firstResult).toBe(secondResult);
+      expect(secondResult).toBe(thirdResult);
+    });
+
+    it('returns the actual withdrawalProgress when present, even with progress 0', () => {
+      renderWithProvider(<PerpsProgressBar {...defaultProps} />);
+
+      const selector = mockUsePerpsSelector.mock.calls[0][0] as (
+        state: { withdrawalProgress?: unknown } | undefined,
+      ) => unknown;
+
+      const validProgress = {
+        progress: 0,
+        lastUpdated: 123,
+        activeWithdrawalId: 'withdrawal1',
+      };
+
+      // A valid object with progress 0 must NOT be replaced by the fallback.
+      expect(selector({ withdrawalProgress: validProgress })).toBe(
+        validProgress,
+      );
+    });
+  });
 });

--- a/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx
+++ b/app/components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx
@@ -26,6 +26,12 @@ import {
 } from '@metamask/perps-controller';
 import { HYPERLIQUID_WITHDRAWAL_PROGRESS_INTERVAL_MS } from '../../constants/perpsUIConfig';
 
+// Hoisted to module scope so the selector returns a stable reference when
+// withdrawalProgress is null/undefined. An inline object literal would create a
+// new reference on every Redux evaluation, breaking selector referential
+// stability and causing spurious re-renders on unrelated dispatches.
+const EMPTY_WITHDRAWAL_PROGRESS = { progress: 0, lastUpdated: 0 } as const;
+
 interface PerpsProgressBarProps {
   /**
    * Progress amount as a number between 0 and 100
@@ -107,7 +113,7 @@ export const PerpsProgressBar: React.FC<PerpsProgressBarProps> = ({
 
   // Get persistent withdrawal progress from controller
   const persistentWithdrawalProgress = usePerpsSelector(
-    (state) => state?.withdrawalProgress || { progress: 0, lastUpdated: 0 },
+    (state) => state?.withdrawalProgress ?? EMPTY_WITHDRAWAL_PROGRESS,
   );
 
   // Track transaction progress


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

`PerpsProgressBar` selected `withdrawalProgress` with an inline fallback `(state) => state?.withdrawalProgress || { progress: 0, lastUpdated: 0 }`. The `|| { ... }` allocated a brand-new object literal on every Redux evaluation whenever `withdrawalProgress` was null/undefined, breaking selector referential stability and triggering spurious re-renders of the component on unrelated dispatches. This PR hoists a module-scope constant `EMPTY_WITHDRAWAL_PROGRESS = { progress: 0, lastUpdated: 0 } as const` so the fallback is a stable reference, and switches `||` to `??` so a valid object with `progress: 0` is not incorrectly replaced by the fallback.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31332
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3328

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps withdrawal progress bar stability

  Scenario: User watches the withdrawal progress bar during unrelated updates
    Given the user is on a Perps screen showing the withdrawal progress bar with no active withdrawal

    When unrelated PerpsController state updates dispatch (e.g. price ticks)
    Then the progress bar still renders correctly (empty/zero progress)
    And the component does not re-render spuriously while withdrawalProgress is null/undefined
    And when a withdrawal with progress 0 is present it is shown unchanged (not replaced by the fallback)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
