### PR TITLE
perf: stop remounting Perps market FlashList on filter change (TAT-3329)

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
@@ -19,7 +19,10 @@ const mockRowMountCount = { value: 0 };
 // Records the `onPress` reference each row receives, keyed by symbol, so tests
 // can assert the reference is stable across re-renders (so React.memo on the
 // real row is not defeated by a new closure on every render).
-const mockRowOnPressBySymbol: Record<string, ((market: PerpsMarketData) => void)[]> = {};
+const mockRowOnPressBySymbol: Record<
+  string,
+  ((market: PerpsMarketData) => void)[]
+> = {};
 
 // Mock dependencies
 jest.mock('@shopify/flash-list', () => {

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
@@ -16,6 +16,11 @@ const mockFlashListProps: Record<string, unknown>[] = [];
 // the filter re-renders rows without tearing them down (no remount).
 const mockRowMountCount = { value: 0 };
 
+// Records the `onPress` reference each row receives, keyed by symbol, so tests
+// can assert the reference is stable across re-renders (so React.memo on the
+// real row is not defeated by a new closure on every render).
+const mockRowOnPressBySymbol: Record<string, ((market: PerpsMarketData) => void)[]> = {};
+
 // Mock dependencies
 jest.mock('@shopify/flash-list', () => {
   const ReactActual = jest.requireActual('react');
@@ -48,16 +53,19 @@ jest.mock('../PerpsMarketRowItem', () => {
     displayMetric,
   }: {
     market: PerpsMarketData;
-    onPress: () => void;
+    onPress: (market: PerpsMarketData) => void;
     iconSize?: number;
     displayMetric?: SortField;
   }) {
     ReactActual.useEffect(() => {
       mockRowMountCount.value += 1;
     }, []);
+    (mockRowOnPressBySymbol[market.symbol] ||= []).push(onPress);
     return (
       <TouchableOpacity
-        onPress={onPress}
+        // The real PerpsMarketRowItem calls `onPress?.(displayMarket)`, so the
+        // mock forwards its own market rather than the press event.
+        onPress={() => onPress(market)}
         testID={`perps-market-row-${market.symbol}`}
       >
         <Text>{market.symbol}</Text>
@@ -114,6 +122,9 @@ describe('PerpsMarketList', () => {
     jest.clearAllMocks();
     mockFlashListProps.length = 0;
     mockRowMountCount.value = 0;
+    Object.keys(mockRowOnPressBySymbol).forEach(
+      (key) => delete mockRowOnPressBySymbol[key],
+    );
   });
 
   afterEach(() => {
@@ -637,6 +648,48 @@ describe('PerpsMarketList', () => {
       // No additional mounts means rows (and their live-price subscriptions)
       // survived the filter change.
       expect(mockRowMountCount.value).toBe(mountsAfterInitialRender);
+    });
+  });
+
+  describe('Stable onPress (React.memo not defeated)', () => {
+    it('passes the same onPress reference to a row across re-renders', () => {
+      const { rerender } = render(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          sortBy="volume"
+        />,
+      );
+
+      // Force the parent to re-render without changing onMarketPress.
+      rerender(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          sortBy="priceChange"
+        />,
+      );
+
+      const btcOnPressRefs = mockRowOnPressBySymbol.BTC;
+      expect(btcOnPressRefs.length).toBeGreaterThanOrEqual(2);
+      // Every render must hand the row the exact same (stable) onPress function.
+      btcOnPressRefs.forEach((ref) => {
+        expect(ref).toBe(mockOnMarketPress);
+      });
+    });
+
+    it('still invokes onMarketPress with the correct market when pressed', () => {
+      render(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+        />,
+      );
+
+      fireEvent.press(screen.getByTestId('perps-market-row-ETH'));
+
+      expect(mockOnMarketPress).toHaveBeenCalledTimes(1);
+      expect(mockOnMarketPress).toHaveBeenCalledWith(mockMarkets[1]);
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
@@ -7,11 +7,24 @@ import {
   type SortField,
 } from '@metamask/perps-controller';
 
+// Captures props passed to FlashList so tests can assert on them. `key` is a
+// special React prop and never appears here, which is precisely why filter
+// changes must flow through `extraData` instead.
+const mockFlashListProps: Record<string, unknown>[] = [];
+
+// Tracks how many times a market row is mounted, used to prove that changing
+// the filter re-renders rows without tearing them down (no remount).
+const mockRowMountCount = { value: 0 };
+
 // Mock dependencies
 jest.mock('@shopify/flash-list', () => {
+  const ReactActual = jest.requireActual('react');
   const { FlatList } = jest.requireActual('react-native');
   return {
-    FlashList: FlatList,
+    FlashList: (props: Record<string, unknown>) => {
+      mockFlashListProps.push(props);
+      return ReactActual.createElement(FlatList, props);
+    },
   };
 });
 
@@ -26,6 +39,7 @@ jest.mock('../../../../../component-library/hooks', () => ({
 }));
 
 jest.mock('../PerpsMarketRowItem', () => {
+  const ReactActual = jest.requireActual('react');
   const { TouchableOpacity, Text } = jest.requireActual('react-native');
   return function MockPerpsMarketRowItem({
     market,
@@ -38,6 +52,9 @@ jest.mock('../PerpsMarketRowItem', () => {
     iconSize?: number;
     displayMetric?: SortField;
   }) {
+    ReactActual.useEffect(() => {
+      mockRowMountCount.value += 1;
+    }, []);
     return (
       <TouchableOpacity
         onPress={onPress}
@@ -95,6 +112,8 @@ describe('PerpsMarketList', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFlashListProps.length = 0;
+    mockRowMountCount.value = 0;
   });
 
   afterEach(() => {
@@ -576,6 +595,48 @@ describe('PerpsMarketList', () => {
         screen.queryByTestId('perps-market-list-empty'),
       ).not.toBeOnTheScreen();
       expect(screen.getByText('BTC')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Filter changes (no remount)', () => {
+    it('passes filterKey via extraData instead of keying the FlashList', () => {
+      render(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          filterKey="perps"
+        />,
+      );
+
+      const lastProps = mockFlashListProps[mockFlashListProps.length - 1];
+      expect(lastProps.extraData).toBe('perps');
+      // `key` is consumed by React and must never be forwarded as a prop here.
+      expect(lastProps.key).toBeUndefined();
+    });
+
+    it('does not remount rows when filterKey changes', () => {
+      const { rerender } = render(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          filterKey="perps"
+        />,
+      );
+
+      const mountsAfterInitialRender = mockRowMountCount.value;
+      expect(mountsAfterInitialRender).toBe(mockMarkets.length);
+
+      rerender(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          filterKey="spot"
+        />,
+      );
+
+      // No additional mounts means rows (and their live-price subscriptions)
+      // survived the filter change.
+      expect(mockRowMountCount.value).toBe(mountsAfterInitialRender);
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
@@ -80,8 +80,8 @@ const PerpsMarketList: React.FC<PerpsMarketListProps> = ({
 
   return (
     <FlashList
-      key={filterKey}
       data={markets}
+      extraData={filterKey}
       renderItem={renderItem}
       keyExtractor={(item: PerpsMarketData) => item.symbol}
       contentContainerStyle={[styles.contentContainer, contentContainerStyle]}

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
@@ -54,7 +54,10 @@ const PerpsMarketList: React.FC<PerpsMarketListProps> = ({
     ({ item }: { item: PerpsMarketData }) => (
       <PerpsMarketRowItem
         market={item}
-        onPress={() => onMarketPress(item)}
+        // Pass the stable callback directly; PerpsMarketRowItem invokes it with
+        // its own market. A per-row inline closure would change every render and
+        // defeat React.memo on the row.
+        onPress={onMarketPress}
         iconSize={iconSize}
         displayMetric={sortBy}
         showBadge={showBadge}

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.types.ts
@@ -49,8 +49,9 @@ export interface PerpsMarketListProps {
    */
   contentContainerStyle?: StyleProp<ViewStyle>;
   /**
-   * Optional key to force FlashList re-mount when filters change.
-   * This fixes rendering issues when data changes rapidly.
+   * Optional filter identifier forwarded to FlashList as `extraData` so rows
+   * re-render when the active filter changes WITHOUT remounting the list (which
+   * would tear down and recreate every row's live-price subscription).
    */
   filterKey?: string;
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Perps market list rendered `<FlashList key={filterKey} ... />`, where `filterKey` is the market-type filter (`marketTypeFilter`). Because changing the filter changed the React `key`, FlashList was forced to fully remount on every filter switch — tearing down and recreating every visible row along with each row's live-price WebSocket subscription, causing avoidable churn and dropped price updates. This PR replaces `key={filterKey}` with `extraData={filterKey}`. The `data` is already filtered upstream (`filteredMarkets` in `PerpsMarketListView`), so `extraData` is sufficient to re-render rows on filter change while keeping the list (and row subscriptions) mounted. Updates `PerpsMarketList.tsx`, the `filterKey` doc in `PerpsMarketList.types.ts`, and tests.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31361
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3329

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market list filtering without remount

  Scenario: User switches the market-type filter
    Given the user is viewing the Perps market list with live prices updating

    When the user switches the market-type filter (e.g. between filter options)
    Then the list shows the correct filtered markets for the selected filter
    And the visible rows are not remounted (live-price subscriptions are preserved, prices keep updating without flicker)
    And tapping a market row still navigates as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused UI change in the Perps market list with regression tests; no auth, security, or data-layer changes.
> 
> **Overview**
> **Stops tearing down the Perps market list when the market-type filter changes** by forwarding `filterKey` as FlashList `extraData` instead of using it as the list `key`, so rows (and their live-price subscriptions) stay mounted while filtered `data` updates upstream.
> 
> **Keeps row memoization effective** by passing the parent `onMarketPress` callback straight into each `PerpsMarketRowItem` instead of wrapping it in a new per-row closure; the row still invokes it with its own market.
> 
> Tests instrument the FlashList mock and row mock to assert `extraData` usage, no extra row mounts on `filterKey` changes, stable `onPress` references across re-renders, and correct press payloads. `filterKey` JSDoc is updated to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e6fee2583f38615fc06aa16b390c30a796f2e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->