### PR TITLE
perf: stabilize useDepositRequests selector and move logging out of selector

### DIFF
--- a/app/components/UI/Perps/hooks/useDepositRequests.test.ts
+++ b/app/components/UI/Perps/hooks/useDepositRequests.test.ts
@@ -839,9 +839,7 @@ describe('useDepositRequests', () => {
         | undefined;
 
       mockUsePerpsSelector.mockImplementation((selector) => {
-        capturedSelector = selector as (
-          state: PerpsControllerState,
-        ) => unknown;
+        capturedSelector = selector as (state: PerpsControllerState) => unknown;
         return selector({
           depositRequests: mockPendingDeposits,
         } as Partial<PerpsControllerState> as PerpsControllerState);

--- a/app/components/UI/Perps/hooks/useDepositRequests.test.ts
+++ b/app/components/UI/Perps/hooks/useDepositRequests.test.ts
@@ -816,4 +816,49 @@ describe('useDepositRequests', () => {
       expect(result.current.depositRequests[0].depositId).toBeUndefined();
     });
   });
+
+  describe('selector stability and logging side effects', () => {
+    it('keeps a stable depositRequests reference across unrelated re-renders when contents are unchanged', () => {
+      // usePerpsSelector returns a fresh filtered array on every render, mirroring
+      // a real dispatch. The hook must stabilize it so consumers do not re-render.
+      const { result, rerender } = renderHookWithProvider(
+        () => useDepositRequests({ skipInitialFetch: true }),
+        { state: createMockState() },
+      );
+
+      const firstReference = result.current.depositRequests;
+
+      rerender({});
+
+      expect(result.current.depositRequests).toBe(firstReference);
+    });
+
+    it('does not log inside the perps selector', () => {
+      let capturedSelector:
+        | ((state: PerpsControllerState) => unknown)
+        | undefined;
+
+      mockUsePerpsSelector.mockImplementation((selector) => {
+        capturedSelector = selector as (
+          state: PerpsControllerState,
+        ) => unknown;
+        return selector({
+          depositRequests: mockPendingDeposits,
+        } as Partial<PerpsControllerState> as PerpsControllerState);
+      });
+
+      renderHookWithProvider(
+        () => useDepositRequests({ skipInitialFetch: true }),
+        { state: createMockState() },
+      );
+
+      mockDevLogger.log.mockClear();
+
+      capturedSelector?.({
+        depositRequests: mockPendingDeposits,
+      } as Partial<PerpsControllerState> as PerpsControllerState);
+
+      expect(mockDevLogger.log).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Perps/hooks/useDepositRequests.ts
+++ b/app/components/UI/Perps/hooks/useDepositRequests.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { usePerpsSelector } from './usePerpsSelector';
+import { useStableArray } from './useStableArray';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 
@@ -37,6 +38,8 @@ interface UseDepositRequestsResult {
   refetch: () => Promise<void>;
 }
 
+const EMPTY_DEPOSIT_REQUESTS: DepositRequest[] = [];
+
 /**
  * Hook to fetch deposit requests combining:
  * 1. Pending/bridging deposits from PerpsController state (real-time)
@@ -54,33 +57,51 @@ export const useDepositRequests = (
     'eip155:1',
   )?.address;
 
-  // Get pending/bridging deposits from controller state and filter by current account
-  const pendingDeposits = usePerpsSelector((state) => {
-    const allDeposits = state?.depositRequests || [];
+  // Total count of deposits across all accounts (primitive — safe to read every
+  // dispatch without triggering re-renders, used for logging context only).
+  const totalDepositCount = usePerpsSelector(
+    (state) => state?.depositRequests?.length ?? 0,
+  );
 
-    // If no selected address, return empty array (don't show potentially wrong account's data)
+  // Get pending/bridging deposits from controller state and filter by current
+  // account. The selector returns a fresh array on every dispatch, so wrap it in
+  // useStableArray to keep a stable reference when the contents are unchanged.
+  // This prevents consumers from re-rendering on unrelated PerpsController
+  // dispatches. Logging is intentionally kept out of the selector (see effect
+  // below) so it does not run on every dispatch.
+  const pendingDeposits = useStableArray(
+    usePerpsSelector((state) => {
+      const allDeposits = state?.depositRequests ?? EMPTY_DEPOSIT_REQUESTS;
+
+      // If no selected address, return empty array (don't show potentially wrong account's data)
+      if (!selectedAddress || allDeposits.length === 0) {
+        return EMPTY_DEPOSIT_REQUESTS;
+      }
+
+      // Filter by current account, normalizing addresses for comparison
+      return allDeposits.filter(
+        (req) =>
+          req.accountAddress?.toLowerCase() === selectedAddress.toLowerCase(),
+      );
+    }),
+  );
+
+  useEffect(() => {
     if (!selectedAddress) {
       DevLogger.log(
         'useDepositRequests: No selected address, returning empty array',
         {
-          totalCount: allDeposits.length,
+          totalCount: totalDepositCount,
         },
       );
-      return [];
+      return;
     }
-
-    // Filter by current account, normalizing addresses for comparison
-    const filtered = allDeposits.filter((req) => {
-      const match =
-        req.accountAddress?.toLowerCase() === selectedAddress.toLowerCase();
-      return match;
-    });
 
     DevLogger.log('useDepositRequests: Filtered deposits by account', {
       selectedAddress,
-      totalCount: allDeposits.length,
-      filteredCount: filtered.length,
-      deposits: filtered.map((d) => ({
+      totalCount: totalDepositCount,
+      filteredCount: pendingDeposits.length,
+      deposits: pendingDeposits.map((d) => ({
         id: d.id,
         timestamp: new Date(d.timestamp).toISOString(),
         amount: d.amount,
@@ -89,9 +110,7 @@ export const useDepositRequests = (
         accountAddress: d.accountAddress,
       })),
     });
-
-    return filtered;
-  });
+  }, [selectedAddress, totalDepositCount, pendingDeposits]);
 
   const [completedDeposits, setCompletedDeposits] = useState<DepositRequest[]>(
     [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

`useDepositRequests` (`app/components/UI/Perps/hooks/useDepositRequests.ts`) had two performance issues in its pending-deposit `usePerpsSelector`: the selector ran `.filter()` and returned a fresh array reference on every PerpsController dispatch (breaking react-redux's `===` equality check and re-rendering consumers on unrelated dispatches), and a `DevLogger.log` inside the selector ran a `.map()` over the filtered deposits on every dispatch. This PR wraps the filtered result in the existing `useStableArray` utility (mirroring `useWithdrawalRequests`) so the reference stays stable when contents are unchanged, and moves the `DevLogger.log` out of the selector into a `useEffect` keyed on the stabilized array. The deposit count is selected as a cheap primitive for logging context. There is no change to returned data or existing log output.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31333
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3324

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps deposit requests stability

  Scenario: User views pending deposits while unrelated Perps state updates
    Given the user has at least one pending Perps deposit in flight

    When unrelated PerpsController state updates dispatch (e.g. price ticks)
    Then the pending deposit list still displays the correct deposits
    And the deposit requests reference stays stable when its contents are unchanged (no spurious re-renders)
    And dev logging still reflects the correct deposit details without running inside the selector on every dispatch
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
