### PR TITLE
perf: format only tail candles on incremental chart ticks (TAT-3330)

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react-native';
 import { CandlePeriod, type CandleData } from '@metamask/perps-controller';
 import TradingViewChart from './TradingViewChart';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 
 const { mockTheme } = jest.requireActual('../../../../../util/theme');
 
@@ -203,6 +204,79 @@ describe('TradingViewChart — incremental update routing', () => {
 
     expect(typesAfterTick).toContain('UPDATE_LAST_CANDLE');
     expect(typesAfterTick).not.toContain('SET_CANDLESTICK_DATA');
+  });
+
+  // -----------------------------------------------------------------------
+  // Perf: incremental ticks must NOT re-format the full candle array
+  // -----------------------------------------------------------------------
+
+  it('does not format the full candle array on an incremental tick', () => {
+    const testID = 'incremental-no-full-format';
+    const INVALID_LOG = '🚨 Invalid candle data:';
+
+    // Dataset with an INVALID candle at the FRONT (close = 0 fails validation).
+    // formatCandleData logs an invalid-candle entry for every invalid candle it
+    // processes. If the full array were formatted on a live tick, this leading
+    // invalid candle would be logged again — which is exactly the O(N)-per-tick
+    // work the fix eliminates.
+    const dataWithInvalidHead: CandleData = {
+      symbol: 'BTC',
+      interval: CandlePeriod.FourHours,
+      candles: [
+        makeCandle(0, '0'), // INVALID: close = 0
+        makeCandle(4),
+        makeCandle(8),
+      ],
+    };
+
+    const { getByTestId, rerender } = render(
+      <TradingViewChart
+        candleData={dataWithInvalidHead}
+        symbol="BTC"
+        testID={testID}
+      />,
+    );
+    triggerChartReady(getByTestId, testID);
+
+    // Initial full load formats everything, so the invalid head candle is logged
+    // once here. Reset the spies so we only observe the live-tick behavior.
+    mockPostMessage.mockClear();
+    (DevLogger.log as jest.Mock).mockClear();
+
+    // Live tick: same symbol/interval/firstTime/count, only the last close moves.
+    const liveTick: CandleData = {
+      ...dataWithInvalidHead,
+      candles: [
+        makeCandle(0, '0'), // same invalid head
+        makeCandle(4),
+        makeCandle(8, '46000'), // only the last candle changed
+      ],
+    };
+
+    act(() => {
+      rerender(
+        <TradingViewChart
+          candleData={liveTick}
+          symbol="BTC"
+          testID={testID}
+        />,
+      );
+    });
+
+    // Routing is unchanged: a live tick still emits a single UPDATE_LAST_CANDLE
+    // carrying only the last 1-2 candles.
+    expect(mockPostMessage).toHaveBeenCalledTimes(1);
+    const msg = JSON.parse(mockPostMessage.mock.calls[0][0]);
+    expect(msg.type).toBe('UPDATE_LAST_CANDLE');
+    expect(msg.candles.length).toBeGreaterThanOrEqual(1);
+    expect(msg.candles.length).toBeLessThanOrEqual(2);
+
+    // The leading invalid candle must NOT be re-processed on the tick — proving
+    // formatCandleData ran only on the sliced tail, not the full array.
+    const invalidLogs = (DevLogger.log as jest.Mock).mock.calls.filter(
+      (call) => call[0] === INVALID_LOG,
+    );
+    expect(invalidLogs).toHaveLength(0);
   });
 
   it('sends UPDATE_LAST_CANDLE payload with only the last 1-2 candles', () => {

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.incremental.test.tsx
@@ -255,11 +255,7 @@ describe('TradingViewChart — incremental update routing', () => {
 
     act(() => {
       rerender(
-        <TradingViewChart
-          candleData={liveTick}
-          symbol="BTC"
-          testID={testID}
-        />,
+        <TradingViewChart candleData={liveTick} symbol="BTC" testID={testID} />,
       );
     });
 

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -395,8 +395,6 @@ const TradingViewChart = React.forwardRef<
       // Chart is ready - send data
       if (!webViewRef.current) return;
 
-      let dataToSend = null;
-      let dataSource = 'none';
       let dataToUse: CandleData | null = null;
 
       // Check for pending buffered data first (Android case)
@@ -430,11 +428,6 @@ const TradingViewChart = React.forwardRef<
           return;
         }
 
-        dataToSend = formatCandleData(dataToUse);
-        dataSource = 'real';
-      }
-
-      if (dataToSend && dataToUse) {
         // Compute signature for incremental-vs-full routing.
         // Times are read from the raw CandleData (milliseconds) — only used
         // for equality checks, so the unit doesn't matter as long as it's stable.
@@ -466,13 +459,19 @@ const TradingViewChart = React.forwardRef<
           (nextSignature.count === prev.count ||
             nextSignature.count === prev.count + 1);
 
+        // Route BEFORE formatting so live ticks only format the 1-2 tail candles
+        // they actually send, instead of re-formatting the entire (up to ~1000)
+        // candle array on every tick.
         if (canIncrementalUpdate) {
           // Send the last candle for same-count ticks, or the last two candles
           // for a bar-close transition (previous bar may have been finalized
           // at a different close than its last streamed value).
           const sliceSize =
             nextSignature.count === (prev?.count ?? 0) + 1 ? 2 : 1;
-          const incrementalCandles = dataToSend.slice(-sliceSize);
+          const incrementalCandles = formatCandleData({
+            ...dataToUse,
+            candles: dataToUse.candles.slice(-sliceSize),
+          });
           webViewRef.current.postMessage(
             JSON.stringify({
               type: 'UPDATE_LAST_CANDLE',
@@ -482,8 +481,8 @@ const TradingViewChart = React.forwardRef<
         } else {
           const message = {
             type: 'SET_CANDLESTICK_DATA',
-            data: dataToSend,
-            source: dataSource,
+            data: formatCandleData(dataToUse),
+            source: 'real',
             visibleCandleCount,
             interval: dataToUse.interval, // Pass interval for zoom reset on change
           };

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -33,7 +33,10 @@ export interface TPSLLines {
 }
 
 export type { TimeDuration } from '@metamask/perps-controller';
-import { PERPS_CHART_CONFIG } from '../../constants/chartConfig';
+import {
+  CANDLE_DATA_SOURCE,
+  PERPS_CHART_CONFIG,
+} from '../../constants/chartConfig';
 
 export interface OhlcData {
   open: string;
@@ -466,8 +469,7 @@ const TradingViewChart = React.forwardRef<
           // Send the last candle for same-count ticks, or the last two candles
           // for a bar-close transition (previous bar may have been finalized
           // at a different close than its last streamed value).
-          const sliceSize =
-            nextSignature.count === (prev?.count ?? 0) + 1 ? 2 : 1;
+          const sliceSize = nextSignature.count === prev.count + 1 ? 2 : 1;
           const incrementalCandles = formatCandleData({
             ...dataToUse,
             candles: dataToUse.candles.slice(-sliceSize),
@@ -482,7 +484,7 @@ const TradingViewChart = React.forwardRef<
           const message = {
             type: 'SET_CANDLESTICK_DATA',
             data: formatCandleData(dataToUse),
-            source: 'real',
+            source: CANDLE_DATA_SOURCE,
             visibleCandleCount,
             interval: dataToUse.interval, // Pass interval for zoom reset on change
           };

--- a/app/components/UI/Perps/constants/chartConfig.ts
+++ b/app/components/UI/Perps/constants/chartConfig.ts
@@ -73,6 +73,12 @@ export const TIME_DURATIONS = [
 ] as const;
 
 /**
+ * Source identifier for real (live/historical) candle data sent to the WebView.
+ * Centralised here to avoid magic strings in message-passing code.
+ */
+export const CANDLE_DATA_SOURCE = 'real' as const;
+
+/**
  * Helper function to get candlestick colors from theme
  * Prevents object creation on every render
  */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

On the Perps chart live-update path, `formatCandleData(dataToUse)` ran unconditionally on the full candle array (up to ~1000 candles) on every render, before the incremental-vs-full routing decision. So even a live tick that only sends 1-2 candles via `UPDATE_LAST_CANDLE` paid an O(N) formatting cost per tick. This PR moves the `canIncrementalUpdate` routing decision before the format call: the incremental path (live tick / single-bar append) formats only the sliced tail (`dataToUse.candles.slice(-sliceSize)`, 1 or 2 candles) then posts `UPDATE_LAST_CANDLE`, while the full path (initial load, symbol/interval change, history prepend, WebView remount) formats the whole array then posts `SET_CANDLESTICK_DATA`. Validation logic, the symbol-mismatch guard, the bar-close 2-candle `sliceSize`, the WebView-remount signature reset, and both message shapes are preserved unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31271
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3330

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps chart incremental candle formatting

  Scenario: User watches live candle updates and loads history
    Given the user has opened a Perps market chart with candles loaded

    When live ticks arrive for the current bar
    Then the latest candle updates smoothly in place without lag

    When a new bar closes
    Then a new candle is appended correctly

    When the user scrolls left to load older history
    Then earlier candles are fetched and prepended, and a full reload occurs

    When the user switches symbol or interval
    Then the chart performs a full reload and renders the correct series
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactor in Perps chart WebView messaging with existing routing preserved and a targeted regression test; no auth, data persistence, or API contract changes.
> 
> **Overview**
> **Live Perps chart updates** no longer run `formatCandleData` on the full candle series (~1000 bars) on every tick. The incremental-vs-full decision runs first: **incremental** paths (`UPDATE_LAST_CANDLE` for same-bar ticks or +1 bar) format only the last 1–2 raw candles, then post; **full** paths still format the entire dataset for `SET_CANDLESTICK_DATA`.
> 
> WebView payload semantics (signature rules, symbol guard, bar-close two-candle slice) are unchanged. The full-reload message now uses a shared **`CANDLE_DATA_SOURCE`** constant instead of an inline `'real'` string.
> 
> A new incremental test asserts that an invalid leading candle is not re-validated/logged on a live tick, guarding against accidental full-array formatting on the hot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58d27f7914b4b99616ce768eefcc1cd68cf11ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->