### PR TITLE
perf: memoize PerpsOrderContext value (TAT-3321)

### DIFF
--- a/app/components/UI/Perps/contexts/PerpsOrderContext.test.tsx
+++ b/app/components/UI/Perps/contexts/PerpsOrderContext.test.tsx
@@ -240,6 +240,42 @@ describe('PerpsOrderContext', () => {
       expect(result.current.setLeverage).toBe(initialSetLeverage);
     });
 
+    it('memoizes the whole provider value object across re-renders with unchanged form state', () => {
+      // This asserts the Provider value is memoized, not just that individual
+      // callbacks happen to be stable. The inline spread previously produced a
+      // brand-new value object on every render, re-rendering all consumers.
+      const { result, rerender } = renderHookWithProvider(() =>
+        usePerpsOrderContext(),
+      );
+
+      const firstValue = result.current;
+
+      rerender(() => usePerpsOrderContext());
+
+      expect(result.current).toBe(firstValue);
+    });
+
+    it('returns a new provider value object when the underlying form state changes', () => {
+      const { result, rerender } = renderHookWithProvider(() =>
+        usePerpsOrderContext(),
+      );
+
+      const firstValue = result.current;
+
+      mockUsePerpsOrderForm.mockReturnValue({
+        ...mockOrderFormReturn,
+        orderForm: {
+          ...mockOrderFormReturn.orderForm,
+          amount: '200',
+        },
+      });
+
+      rerender(() => usePerpsOrderContext());
+
+      expect(result.current).not.toBe(firstValue);
+      expect(result.current.orderForm.amount).toBe('200');
+    });
+
     it('works with different initial configurations', () => {
       const configs = [
         { initialAsset: 'BTC', initialDirection: 'long' as const },

--- a/app/components/UI/Perps/contexts/PerpsOrderContext.tsx
+++ b/app/components/UI/Perps/contexts/PerpsOrderContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { createContext, useContext, useMemo, ReactNode } from 'react';
 import {
   usePerpsOrderForm,
   UsePerpsOrderFormReturn,
@@ -42,13 +42,19 @@ export const PerpsOrderProvider = ({
     effectiveAvailableBalance,
   });
 
+  // orderFormState is itself memoized by usePerpsOrderForm (stable callbacks +
+  // changing primitives), so depending on it directly keeps the provider value
+  // referentially stable until the form state or existingPosition actually changes.
+  const value = useMemo<PerpsOrderContextType>(
+    () => ({
+      ...orderFormState,
+      existingPosition,
+    }),
+    [orderFormState, existingPosition],
+  );
+
   return (
-    <PerpsOrderContext.Provider
-      value={{
-        ...orderFormState,
-        existingPosition,
-      }}
-    >
+    <PerpsOrderContext.Provider value={value}>
       {children}
     </PerpsOrderContext.Provider>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

`PerpsOrderProvider` built its context value via an inline spread (`value={{ ...orderFormState, existingPosition }}`) with no memoization, producing a brand-new object on every provider render and re-rendering all context consumers. This PR wraps the provider value in `useMemo` keyed on the (now stable) `orderFormState` object and `existingPosition`, so consumers only re-render when the underlying state actually changes.

Stacked on #31891 (base branch is the parent's branch `perf/tat-3322-stabilize-order-form-callbacks`, not main). The memoization here is only effective because TAT-3322 stabilized `usePerpsOrderForm`'s returned callbacks/object; review and merge #31891 first.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/31284
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3321

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps order context stability

  Scenario: User interacts with the order form backed by the order context
    Given the user has opened a Perps market with the order form rendered

    When the user changes the order amount and leverage
    Then the order form and all order-context consumers update correctly with the new values
    And consumers do not re-render on unrelated provider renders (value is referentially stable when state is unchanged)
    And there is no functional regression in placing or editing an order
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
