### PR TITLE
perf: pass stable onPress to PerpsMarketRowItem (TAT-3327)

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
@@ -19,7 +19,10 @@ const mockRowMountCount = { value: 0 };
 // Records the `onPress` reference each row receives, keyed by symbol, so tests
 // can assert the reference is stable across re-renders (so React.memo on the
 // real row is not defeated by a new closure on every render).
-const mockRowOnPressBySymbol: Record<string, ((market: PerpsMarketData) => void)[]> = {};
+const mockRowOnPressBySymbol: Record<
+  string,
+  ((market: PerpsMarketData) => void)[]
+> = {};
 
 // Mock dependencies
 jest.mock('@shopify/flash-list', () => {

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.test.tsx
@@ -16,6 +16,11 @@ const mockFlashListProps: Record<string, unknown>[] = [];
 // the filter re-renders rows without tearing them down (no remount).
 const mockRowMountCount = { value: 0 };
 
+// Records the `onPress` reference each row receives, keyed by symbol, so tests
+// can assert the reference is stable across re-renders (so React.memo on the
+// real row is not defeated by a new closure on every render).
+const mockRowOnPressBySymbol: Record<string, ((market: PerpsMarketData) => void)[]> = {};
+
 // Mock dependencies
 jest.mock('@shopify/flash-list', () => {
   const ReactActual = jest.requireActual('react');
@@ -48,16 +53,19 @@ jest.mock('../PerpsMarketRowItem', () => {
     displayMetric,
   }: {
     market: PerpsMarketData;
-    onPress: () => void;
+    onPress: (market: PerpsMarketData) => void;
     iconSize?: number;
     displayMetric?: SortField;
   }) {
     ReactActual.useEffect(() => {
       mockRowMountCount.value += 1;
     }, []);
+    (mockRowOnPressBySymbol[market.symbol] ||= []).push(onPress);
     return (
       <TouchableOpacity
-        onPress={onPress}
+        // The real PerpsMarketRowItem calls `onPress?.(displayMarket)`, so the
+        // mock forwards its own market rather than the press event.
+        onPress={() => onPress(market)}
         testID={`perps-market-row-${market.symbol}`}
       >
         <Text>{market.symbol}</Text>
@@ -114,6 +122,9 @@ describe('PerpsMarketList', () => {
     jest.clearAllMocks();
     mockFlashListProps.length = 0;
     mockRowMountCount.value = 0;
+    Object.keys(mockRowOnPressBySymbol).forEach(
+      (key) => delete mockRowOnPressBySymbol[key],
+    );
   });
 
   afterEach(() => {
@@ -637,6 +648,48 @@ describe('PerpsMarketList', () => {
       // No additional mounts means rows (and their live-price subscriptions)
       // survived the filter change.
       expect(mockRowMountCount.value).toBe(mountsAfterInitialRender);
+    });
+  });
+
+  describe('Stable onPress (React.memo not defeated)', () => {
+    it('passes the same onPress reference to a row across re-renders', () => {
+      const { rerender } = render(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          sortBy="volume"
+        />,
+      );
+
+      // Force the parent to re-render without changing onMarketPress.
+      rerender(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+          sortBy="priceChange"
+        />,
+      );
+
+      const btcOnPressRefs = mockRowOnPressBySymbol.BTC;
+      expect(btcOnPressRefs.length).toBeGreaterThanOrEqual(2);
+      // Every render must hand the row the exact same (stable) onPress function.
+      btcOnPressRefs.forEach((ref) => {
+        expect(ref).toBe(mockOnMarketPress);
+      });
+    });
+
+    it('still invokes onMarketPress with the correct market when pressed', () => {
+      render(
+        <PerpsMarketList
+          markets={mockMarkets}
+          onMarketPress={mockOnMarketPress}
+        />,
+      );
+
+      fireEvent.press(screen.getByTestId('perps-market-row-ETH'));
+
+      expect(mockOnMarketPress).toHaveBeenCalledTimes(1);
+      expect(mockOnMarketPress).toHaveBeenCalledWith(mockMarkets[1]);
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketList/PerpsMarketList.tsx
@@ -54,7 +54,10 @@ const PerpsMarketList: React.FC<PerpsMarketListProps> = ({
     ({ item }: { item: PerpsMarketData }) => (
       <PerpsMarketRowItem
         market={item}
-        onPress={() => onMarketPress(item)}
+        // Pass the stable callback directly; PerpsMarketRowItem invokes it with
+        // its own market. A per-row inline closure would change every render and
+        // defeat React.memo on the row.
+        onPress={onMarketPress}
         iconSize={iconSize}
         displayMetric={sortBy}
         showBadge={showBadge}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

`PerpsMarketList.renderItem` (already `useCallback`-wrapped) passed each `PerpsMarketRowItem` an inline `onPress={() => onMarketPress(item)}`, creating a brand-new function for every row on every render and defeating the `React.memo` on `PerpsMarketRowItem` — so rows re-rendered even when their data was unchanged. This PR passes the stable `onMarketPress` reference directly; `PerpsMarketRowItem` already calls `onPress?.(displayMarket)` with its own market, so press behavior is identical but the `onPress` prop is now referentially stable and memoization holds. `renderItem` deps are unchanged (`onMarketPress` was already a dependency).

Stacked on #31895 (base branch is the parent's branch `perf/tat-3329-flashlist-no-remount`, not main). Review and merge #31895 first.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31321

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3327

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market list stable row press handler

  Scenario: User scrolls and taps markets in the list
    Given the user is viewing the Perps market list with live prices updating

    When the list re-renders due to live price ticks
    Then unchanged rows are not re-rendered (memoization holds with a stable onPress)

    When the user taps a market row
    Then navigation opens the correct market that was tapped
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
