### PR TITLE
perf: scope live PnL price subscription to position symbols (TAT-3323)

### DIFF
--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -709,6 +709,92 @@ describe('usePerpsLivePositions', () => {
       });
     });
 
+    it('resets stale prices when an empty {} payload is received (cache-clear / reconnect)', async () => {
+      // Arrange: PriceStreamChannel.clearCache() notifies subscribers with {}
+      // on reconnect, provider change, or account switch. Without a reset, the
+      // previous mark prices linger and enrichPositionsWithLivePnL produces
+      // stale PnL values until every subscribed symbol receives a fresh tick.
+      let positionsCallback: (positions: Position[]) => void = jest.fn();
+      let pricesCallback: (prices: Record<string, PriceUpdate>) => void =
+        jest.fn();
+
+      mockPositionsSubscribe.mockImplementation((params) => {
+        positionsCallback = params.callback;
+        return jest.fn();
+      });
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
+        pricesCallback = params.callback;
+        return jest.fn();
+      });
+
+      const { result } = renderHook(() =>
+        usePerpsLivePositions({ useLivePnl: true }),
+      );
+
+      const position: Position = {
+        ...mockPosition,
+        symbol: 'BTC-PERP',
+        entryPrice: '50000',
+        size: '1.0',
+        marginUsed: '5000',
+        unrealizedPnl: '1000',
+        returnOnEquity: '0.2',
+      };
+
+      // Step 1: receive positions and an initial price tick
+      act(() => {
+        positionsCallback([position]);
+      });
+
+      act(() => {
+        pricesCallback({
+          'BTC-PERP': {
+            symbol: 'BTC-PERP',
+            price: '51000',
+            markPrice: '51000',
+            timestamp: Date.now(),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        // Live PnL calculated: (51000 - 50000) * 1 = 1000... wait, entry is 50000
+        // (51000 - 50000) * 1.0 = 1000, original was also 1000, so check returnOnEquity
+        expect(result.current.positions[0].unrealizedPnl).toBe('1000');
+      });
+
+      // Step 2: cache-clear fires — channel emits {} to signal stale data
+      act(() => {
+        pricesCallback({});
+      });
+
+      // Step 3: after the reset, enrichPositionsWithLivePnL receives empty priceData
+      // and falls back to the original position PnL from the WS positions feed.
+      await waitFor(() => {
+        const pos = result.current.positions[0];
+        // Original unrealizedPnl from the position WS (not the old mark-price calc)
+        expect(pos.unrealizedPnl).toBe('1000');
+        expect(pos.returnOnEquity).toBe('0.2');
+      });
+
+      // Step 4: a fresh tick arrives after reconnect — enrichment resumes correctly
+      act(() => {
+        pricesCallback({
+          'BTC-PERP': {
+            symbol: 'BTC-PERP',
+            price: '52000',
+            markPrice: '52000',
+            timestamp: Date.now(),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        // (52000 - 50000) * 1 = 2000
+        expect(result.current.positions[0].unrealizedPnl).toBe('2000');
+      });
+    });
+
     it('merges partial price ticks so a tick for one symbol does not wipe another (multi-position portfolio)', async () => {
       // Arrange
       let positionsCallback: (positions: Position[]) => void = jest.fn();

--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -25,6 +25,7 @@ jest.mock('../../../../../core/Engine', () => ({
 // Mock the stream provider
 const mockPositionsSubscribe = jest.fn();
 const mockPricesSubscribe = jest.fn();
+const mockPricesSubscribeToSymbols = jest.fn();
 
 jest.mock('../../providers/PerpsStreamManager', () => ({
   usePerpsStream: jest.fn(() => ({
@@ -34,6 +35,7 @@ jest.mock('../../providers/PerpsStreamManager', () => ({
     },
     prices: {
       subscribe: mockPricesSubscribe,
+      subscribeToSymbols: mockPricesSubscribeToSymbols,
     },
   })),
   PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
@@ -93,30 +95,55 @@ describe('usePerpsLivePositions', () => {
     });
 
     it('does NOT subscribe to prices by default (useLivePnl: false)', () => {
-      // Arrange
+      // Arrange - even with positions present, no price subscription by default
+      mockChannelPositionsSnapshot = [{ ...mockPosition, symbol: 'BTC-PERP' }];
       mockPositionsSubscribe.mockReturnValue(jest.fn());
       mockPricesSubscribe.mockReturnValue(jest.fn());
+      mockPricesSubscribeToSymbols.mockReturnValue(jest.fn());
 
       // Act
       renderHook(() => usePerpsLivePositions());
 
-      // Assert - prices should NOT be subscribed
+      // Assert - prices should NOT be subscribed via either API
+      expect(mockPricesSubscribe).not.toHaveBeenCalled();
+      expect(mockPricesSubscribeToSymbols).not.toHaveBeenCalled();
+    });
+
+    it('subscribes to prices (scoped to position symbols) only when useLivePnl: true', () => {
+      // Arrange - seed positions so symbols can be derived for the scoped subscription
+      mockChannelPositionsSnapshot = [
+        { ...mockPosition, symbol: 'BTC-PERP' },
+        { ...mockPosition, symbol: 'ETH-PERP' },
+      ];
+      mockPositionsSubscribe.mockReturnValue(jest.fn());
+      mockPricesSubscribe.mockReturnValue(jest.fn());
+      mockPricesSubscribeToSymbols.mockReturnValue(jest.fn());
+
+      // Act
+      renderHook(() => usePerpsLivePositions({ useLivePnl: true }));
+
+      // Assert - subscribes via the symbol-scoped API, NOT the full price channel
+      expect(mockPricesSubscribeToSymbols).toHaveBeenCalledWith({
+        symbols: ['BTC-PERP', 'ETH-PERP'],
+        callback: expect.any(Function),
+        throttleMs: 0,
+      });
       expect(mockPricesSubscribe).not.toHaveBeenCalled();
     });
 
-    it('subscribes to prices only when useLivePnl: true', () => {
-      // Arrange
+    it('does NOT subscribe to prices when useLivePnl: true but there are no positions', () => {
+      // Arrange - no positions means there is nothing to price-scope to
+      mockChannelPositionsSnapshot = undefined;
       mockPositionsSubscribe.mockReturnValue(jest.fn());
       mockPricesSubscribe.mockReturnValue(jest.fn());
+      mockPricesSubscribeToSymbols.mockReturnValue(jest.fn());
 
       // Act
       renderHook(() => usePerpsLivePositions({ useLivePnl: true }));
 
       // Assert
-      expect(mockPricesSubscribe).toHaveBeenCalledWith({
-        callback: expect.any(Function),
-        throttleMs: 0,
-      });
+      expect(mockPricesSubscribeToSymbols).not.toHaveBeenCalled();
+      expect(mockPricesSubscribe).not.toHaveBeenCalled();
     });
 
     it('unsubscribes from positions on unmount', () => {
@@ -133,11 +160,12 @@ describe('usePerpsLivePositions', () => {
     });
 
     it('unsubscribes from positions and prices on unmount when useLivePnl: true', () => {
-      // Arrange
+      // Arrange - seed positions so the scoped price subscription is created
+      mockChannelPositionsSnapshot = [{ ...mockPosition, symbol: 'BTC-PERP' }];
       const mockPositionsUnsubscribe = jest.fn();
       const mockPricesUnsubscribe = jest.fn();
       mockPositionsSubscribe.mockReturnValue(mockPositionsUnsubscribe);
-      mockPricesSubscribe.mockReturnValue(mockPricesUnsubscribe);
+      mockPricesSubscribeToSymbols.mockReturnValue(mockPricesUnsubscribe);
 
       // Act
       const { unmount } = renderHook(() =>
@@ -405,7 +433,7 @@ describe('usePerpsLivePositions', () => {
         return jest.fn();
       });
 
-      mockPricesSubscribe.mockImplementation((params) => {
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
         pricesCallback = params.callback;
         return jest.fn();
       });
@@ -455,7 +483,7 @@ describe('usePerpsLivePositions', () => {
         return jest.fn();
       });
 
-      mockPricesSubscribe.mockImplementation((params) => {
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
         pricesCallback = params.callback;
         return jest.fn();
       });
@@ -504,7 +532,7 @@ describe('usePerpsLivePositions', () => {
         return jest.fn();
       });
 
-      mockPricesSubscribe.mockImplementation((params) => {
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
         pricesCallback = params.callback;
         return jest.fn();
       });
@@ -552,7 +580,7 @@ describe('usePerpsLivePositions', () => {
         return jest.fn();
       });
 
-      mockPricesSubscribe.mockImplementation((params) => {
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
         pricesCallback = params.callback;
         return jest.fn();
       });
@@ -602,7 +630,7 @@ describe('usePerpsLivePositions', () => {
         return jest.fn();
       });
 
-      mockPricesSubscribe.mockImplementation((params) => {
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
         pricesCallback = params.callback;
         return jest.fn();
       });
@@ -651,7 +679,7 @@ describe('usePerpsLivePositions', () => {
         return jest.fn();
       });
 
-      mockPricesSubscribe.mockImplementation((params) => {
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
         pricesCallback = params.callback;
         return jest.fn();
       });
@@ -678,6 +706,86 @@ describe('usePerpsLivePositions', () => {
         const updatedPosition = result.current.positions[0];
         expect(updatedPosition.unrealizedPnl).toBe('1000');
         expect(updatedPosition.returnOnEquity).toBe('0.2');
+      });
+    });
+
+    it('merges partial price ticks so a tick for one symbol does not wipe another (multi-position portfolio)', async () => {
+      // Arrange
+      let positionsCallback: (positions: Position[]) => void = jest.fn();
+      let pricesCallback: (prices: Record<string, PriceUpdate>) => void =
+        jest.fn();
+
+      mockPositionsSubscribe.mockImplementation((params) => {
+        positionsCallback = params.callback;
+        return jest.fn();
+      });
+      mockPricesSubscribeToSymbols.mockImplementation((params) => {
+        pricesCallback = params.callback;
+        return jest.fn();
+      });
+
+      const { result } = renderHook(() =>
+        usePerpsLivePositions({ useLivePnl: true }),
+      );
+
+      const btc: Position = {
+        ...mockPosition,
+        symbol: 'BTC-PERP',
+        entryPrice: '50000',
+        size: '1.0',
+        marginUsed: '5000',
+      };
+      const eth: Position = {
+        ...mockPosition,
+        symbol: 'ETH-PERP',
+        entryPrice: '2000',
+        size: '10.0',
+        marginUsed: '2000',
+      };
+
+      act(() => {
+        positionsCallback([btc, eth]);
+      });
+
+      // First tick: full batch with prices for BOTH symbols
+      act(() => {
+        pricesCallback({
+          'BTC-PERP': {
+            symbol: 'BTC-PERP',
+            price: '52000',
+            markPrice: '52000',
+            timestamp: Date.now(),
+          },
+          'ETH-PERP': {
+            symbol: 'ETH-PERP',
+            price: '2200',
+            markPrice: '2200',
+            timestamp: Date.now(),
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.positions[0].unrealizedPnl).toBe('2000'); // BTC: (52000-50000)*1
+        expect(result.current.positions[1].unrealizedPnl).toBe('2000'); // ETH: (2200-2000)*10
+      });
+
+      // Second tick: PARTIAL batch with only BTC updated
+      act(() => {
+        pricesCallback({
+          'BTC-PERP': {
+            symbol: 'BTC-PERP',
+            price: '53000',
+            markPrice: '53000',
+            timestamp: Date.now(),
+          },
+        });
+      });
+
+      // Assert - BTC reflects new price, ETH retains its merged price (NOT wiped)
+      await waitFor(() => {
+        expect(result.current.positions[0].unrealizedPnl).toBe('3000'); // BTC: (53000-50000)*1
+        expect(result.current.positions[1].unrealizedPnl).toBe('2000'); // ETH: unchanged, still (2200-2000)*10
       });
     });
   });

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -162,15 +162,32 @@ export function usePerpsLivePositions(
     };
   }, [stream, throttleMs]);
 
+  // Derive the unique set of symbols from the current positions so we only
+  // subscribe to the prices we actually need (instead of the full price channel).
+  // Sorted + memoized so the subscription effect only re-runs when the set of
+  // symbols actually changes, not on every positions tick (which creates a new array).
+  const symbols = useMemo(
+    () => Array.from(new Set(rawPositions.map((p) => p.symbol))).sort(),
+    [rawPositions],
+  );
+  const symbolsKey = useMemo(() => symbols.join(','), [symbols]);
+
   // Subscribe to price updates for real-time PnL recalculation (only if useLivePnl is true)
   useEffect(() => {
-    if (!useLivePnl) {
+    if (!useLivePnl || symbols.length === 0) {
       return undefined;
     }
 
-    const unsubscribe = stream.prices.subscribe({
+    const unsubscribe = stream.prices.subscribeToSymbols({
+      symbols,
       callback: (newPriceData) => {
-        setPriceData(newPriceData);
+        if (!newPriceData) {
+          return;
+        }
+        // Merge incoming price batches into existing state instead of replacing.
+        // Live WebSocket ticks deliver only the symbols that changed, so replacing
+        // would wipe other positions' prices when a partial batch arrives.
+        setPriceData((prev) => ({ ...prev, ...newPriceData }));
       },
       throttleMs,
     });
@@ -178,7 +195,11 @@ export function usePerpsLivePositions(
     return () => {
       unsubscribe();
     };
-  }, [stream, throttleMs, useLivePnl]);
+    // symbolsKey captures symbols content changes via memoization, so symbols is
+    // intentionally omitted to avoid re-subscribing when the array reference
+    // changes but its contents are the same.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stream, symbolsKey, throttleMs, useLivePnl]);
 
   return {
     positions,

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -167,7 +167,10 @@ export function usePerpsLivePositions(
   // Sorted + memoized so the subscription effect only re-runs when the set of
   // symbols actually changes, not on every positions tick (which creates a new array).
   const symbols = useMemo(
-    () => Array.from(new Set(rawPositions.map((p) => p.symbol))).sort(),
+    () =>
+      Array.from(new Set(rawPositions.map((p) => p.symbol))).sort((a, b) =>
+        a.localeCompare(b),
+      ),
     [rawPositions],
   );
   const symbolsKey = useMemo(() => symbols.join(','), [symbols]);

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -187,6 +187,13 @@ export function usePerpsLivePositions(
         if (!newPriceData) {
           return;
         }
+        // An empty payload signals a cache clear emitted by PriceStreamChannel
+        // on reconnect, provider change, or account switch. Treat it as a full
+        // reset so stale mark prices are not used for PnL until fresh ticks arrive.
+        if (Object.keys(newPriceData).length === 0) {
+          setPriceData({});
+          return;
+        }
         // Merge incoming price batches into existing state instead of replacing.
         // Live WebSocket ticks deliver only the symbols that changed, so replacing
         // would wipe other positions' prices when a partial batch arrives.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

On the live PnL critical path, `usePerpsLivePositions` (with `useLivePnl: true`) subscribed to the full price channel via `stream.prices.subscribe` (not symbol-scoped), receiving a tick for every market, and on every tick replaced `priceData` then re-`.map()`ed over all positions — producing a new array each tick and re-rendering all consumers even when only one unrelated market moved. This PR derives the unique set of symbols from `rawPositions` (memoized + sorted) and subscribes only to those via `stream.prices.subscribeToSymbols` (mirroring `usePerpsLivePrices`), and merges incoming partial price batches into `priceData` (`{ ...prev, ...newPriceData }`) instead of replacing, so multi-position portfolios don't get other symbols' prices wiped by a partial delta. PnL math (`enrichPositionsWithLivePnL`) is untouched and the hook's public shape (`{ positions, isInitialLoading }`) is unchanged. Affected `useLivePnl: true` consumers: `PerpsPositionsView.tsx` and `PerpsMarketTabs.tsx`. Note: this is high-risk live-PnL code — re-subscription is keyed off a sorted `symbolsKey`, merge never prunes closed-symbol prices (harmless, bounded), and empty-positions no longer subscribes at all.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31360
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3323

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps live PnL scoped to position symbols

  Scenario: User watches live PnL across a multi-position portfolio
    Given the user holds 3+ open Perps positions across different markets

    When live prices update for one market
    Then that position's PnL/RoE updates live and independently
    And the other positions' PnL values are preserved (not blanked or frozen)

    When the user closes one of several positions
    Then the remaining positions keep updating live
    And closing the last position cleanly unsubscribes with no errors or leaked ticks

    When the user switches accounts
    Then positions and live PnL re-initialize correctly for the new account
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live unrealized PnL display and stream subscription lifecycle; behavior changes around reconnect and multi-position partial ticks could show wrong PnL if edge cases are missed, though the hook’s public API is unchanged.
> 
> **Overview**
> **Live PnL path in `usePerpsLivePositions`** is refactored for performance and correctness when `useLivePnl: true`. Instead of subscribing to the **full** price channel via `stream.prices.subscribe`, the hook derives a **sorted, memoized** symbol list from `rawPositions` and uses **`subscribeToSymbols`**, skipping price subscription entirely when there are no positions. Re-subscription is keyed off `symbolsKey` so position ticks that don’t change the symbol set don’t churn subscriptions.
> 
> **Price state handling** changes from **replace-on-every-tick** to **merge** (`{ ...prev, ...newPriceData }`) so partial WebSocket batches don’t wipe other markets’ marks in multi-position portfolios. An **empty `{}` payload** (cache clear on reconnect / account switch) now **resets** `priceData` so stale marks aren’t used until fresh ticks arrive.
> 
> **Tests** in `useLivePositions.test.ts` mock `subscribeToSymbols`, assert scoped subscription behavior (including no subscription with zero positions), and add cases for cache-clear reset and partial-tick merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153f34aaa4de1f2838e7940f6448fe73d058efe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->