### PR TITLE
perf: scope perps price dispatch with symbol->subscriber index (TAT-3325)

### DIFF
--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -1588,6 +1588,225 @@ describe('PerpsStreamManager', () => {
     });
   });
 
+  describe('PriceStreamChannel symbol-scoped dispatch', () => {
+    let priceCallback: (data: PriceUpdate[]) => void;
+
+    beforeEach(() => {
+      priceCallback = jest.fn();
+      mockSubscribeToPrices.mockImplementation((params) => {
+        priceCallback = params.callback;
+        return jest.fn();
+      });
+    });
+
+    const makePrice = (symbol: string, price: string): PriceUpdate => ({
+      symbol,
+      price,
+      timestamp: Date.now(),
+    });
+
+    it('dispatches a single-symbol tick only to subscribers registered for that symbol', () => {
+      const btcCb = jest.fn();
+      const ethCb = jest.fn();
+
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC-PERP'],
+        callback: btcCb,
+        throttleMs: 0,
+      });
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['ETH-PERP'],
+        callback: ethCb,
+        throttleMs: 0,
+      });
+
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '50000')]);
+      });
+
+      expect(btcCb).toHaveBeenCalledTimes(1);
+      expect(btcCb).toHaveBeenCalledWith({
+        'BTC-PERP': expect.objectContaining({
+          symbol: 'BTC-PERP',
+          price: '50000',
+        }),
+      });
+      // ETH subscriber must NOT be touched by a BTC-only tick
+      expect(ethCb).not.toHaveBeenCalled();
+
+      act(() => {
+        priceCallback([makePrice('ETH-PERP', '3000')]);
+      });
+
+      expect(ethCb).toHaveBeenCalledTimes(1);
+      expect(ethCb).toHaveBeenCalledWith({
+        'ETH-PERP': expect.objectContaining({
+          symbol: 'ETH-PERP',
+          price: '3000',
+        }),
+      });
+      // BTC subscriber unaffected by the ETH tick
+      expect(btcCb).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves first-update and throttle semantics for scoped dispatch', () => {
+      const cb = jest.fn();
+
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC-PERP'],
+        callback: cb,
+        throttleMs: 100,
+      });
+
+      // First update is delivered immediately (first-update semantics)
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '100')]);
+      });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      // Rapid subsequent updates are throttled (not delivered immediately)
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '101')]);
+        priceCallback([makePrice('BTC-PERP', '102')]);
+      });
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      // After the throttle window the latest pending update is delivered once
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb.mock.calls[1][0]['BTC-PERP']).toMatchObject({ price: '102' });
+    });
+
+    it('delivers correct filtered slices to overlapping multi-symbol subscribers', () => {
+      const aCb = jest.fn(); // subscribes to BTC + ETH
+      const bCb = jest.fn(); // subscribes to ETH only
+
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC-PERP', 'ETH-PERP'],
+        callback: aCb,
+        throttleMs: 0,
+      });
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['ETH-PERP'],
+        callback: bCb,
+        throttleMs: 0,
+      });
+
+      // A tick for the shared symbol notifies both with their ETH slice
+      act(() => {
+        priceCallback([makePrice('ETH-PERP', '3000')]);
+      });
+      expect(aCb).toHaveBeenCalledWith({
+        'ETH-PERP': expect.objectContaining({ price: '3000' }),
+      });
+      expect(bCb).toHaveBeenCalledWith({
+        'ETH-PERP': expect.objectContaining({ price: '3000' }),
+      });
+
+      // A BTC-only tick reaches A (registered for BTC) but not B
+      aCb.mockClear();
+      bCb.mockClear();
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '50000')]);
+      });
+      expect(aCb).toHaveBeenCalledWith({
+        'BTC-PERP': expect.objectContaining({ price: '50000' }),
+      });
+      expect(bCb).not.toHaveBeenCalled();
+
+      // A tick carrying both symbols yields the full slice for A and ETH for B
+      aCb.mockClear();
+      bCb.mockClear();
+      act(() => {
+        priceCallback([
+          makePrice('BTC-PERP', '51000'),
+          makePrice('ETH-PERP', '3100'),
+        ]);
+      });
+      expect(aCb).toHaveBeenCalledTimes(1);
+      expect(aCb).toHaveBeenCalledWith({
+        'BTC-PERP': expect.objectContaining({ price: '51000' }),
+        'ETH-PERP': expect.objectContaining({ price: '3100' }),
+      });
+      expect(bCb).toHaveBeenCalledTimes(1);
+      expect(bCb).toHaveBeenCalledWith({
+        'ETH-PERP': expect.objectContaining({ price: '3100' }),
+      });
+    });
+
+    it('stops dispatching to a subscriber after it unsubscribes (index cleanup)', () => {
+      const btcCb = jest.fn();
+      const ethCb = jest.fn();
+
+      const unsubBtc = testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC-PERP'],
+        callback: btcCb,
+        throttleMs: 0,
+      });
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['ETH-PERP'],
+        callback: ethCb,
+        throttleMs: 0,
+      });
+
+      unsubBtc();
+
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '50000')]);
+      });
+
+      expect(btcCb).not.toHaveBeenCalled();
+      expect(ethCb).not.toHaveBeenCalled();
+    });
+
+    it('keeps symbol-scoped dispatch and clearCache semantics after an account switch', () => {
+      const btcCb = jest.fn();
+      const ethCb = jest.fn();
+
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['BTC-PERP'],
+        callback: btcCb,
+        throttleMs: 0,
+      });
+      testStreamManager.prices.subscribeToSymbols({
+        symbols: ['ETH-PERP'],
+        callback: ethCb,
+        throttleMs: 0,
+      });
+
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '50000')]);
+      });
+      expect(btcCb).toHaveBeenCalledWith({
+        'BTC-PERP': expect.objectContaining({ price: '50000' }),
+      });
+
+      btcCb.mockClear();
+      ethCb.mockClear();
+
+      // Account switch clears caches and notifies every subscriber with cleared data
+      act(() => {
+        testStreamManager.prices.clearCache();
+      });
+      expect(btcCb).toHaveBeenCalledWith({});
+      expect(ethCb).toHaveBeenCalledWith({});
+
+      btcCb.mockClear();
+      ethCb.mockClear();
+
+      // After the switch, the symbol index still scopes dispatch correctly
+      act(() => {
+        priceCallback([makePrice('BTC-PERP', '60000')]);
+      });
+      expect(btcCb).toHaveBeenCalledWith({
+        'BTC-PERP': expect.objectContaining({ price: '60000' }),
+      });
+      expect(ethCb).not.toHaveBeenCalled();
+    });
+  });
+
   it('cleans up all subscriptions on provider unmount', async () => {
     const mockUnsubscribe = jest.fn();
     mockSubscribeToPrices.mockReturnValue(mockUnsubscribe);

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -63,12 +63,21 @@ interface StreamSubscription<T> {
   timer?: NodeJS.Timeout;
   pendingUpdate?: T;
   hasReceivedFirstUpdate?: boolean; // Track if subscriber has received first update
+  // Symbols this subscriber cares about. When present, the channel can dispatch
+  // an update only to subscribers registered for the symbols that changed,
+  // instead of iterating every subscriber on every tick. Used by the price channel.
+  symbols?: string[];
 }
 
 // Base class for any stream type
 abstract class StreamChannel<T> {
   protected cache = new Map<string, T>();
   protected subscribers = new Map<string, StreamSubscription<T>>();
+  // Reverse index: symbol -> set of subscriber ids registered for that symbol.
+  // Populated only for subscriptions that declare `symbols` (the price channel),
+  // so symbol-scoped channels can dispatch a tick to just the relevant
+  // subscribers. Channels without symbol subscriptions never touch this map.
+  protected readonly symbolSubscribers = new Map<string, Set<string>>();
   protected wsSubscription: (() => void) | null = null;
   readonly #onDataPersist?: () => void;
 
@@ -100,40 +109,130 @@ abstract class StreamChannel<T> {
     }
 
     this.subscribers.forEach((subscriber) => {
-      // Check if this is the first update for this subscriber
-      if (!subscriber.hasReceivedFirstUpdate) {
-        subscriber.callback(updates);
-        subscriber.hasReceivedFirstUpdate = true;
-        return; // Don't set up throttle for the first update
-      }
+      this.deliverToSubscriber(subscriber, updates);
+    });
+  }
 
-      // If no throttling (throttleMs is 0 or undefined), notify immediately
-      if (!subscriber.throttleMs) {
-        subscriber.callback(updates);
+  /**
+   * Symbol-scoped variant of {@link notifySubscribers}. Only subscribers that
+   * registered for at least one of `changedSymbols` are notified, so a tick that
+   * carries a subset of symbols does not iterate (or allocate filtered payloads
+   * for) subscribers that don't care about it. Each notified subscriber receives
+   * the exact same `updates` payload it would via notifySubscribers, so its own
+   * filtering wrapper still produces the correct slice. First-update and throttle
+   * semantics are identical because delivery goes through the shared
+   * {@link deliverToSubscriber}.
+   */
+  protected notifySubscribersForSymbols(
+    updates: T,
+    changedSymbols: Iterable<string>,
+  ) {
+    // Block emission while any pause is held (WebSocket continues receiving updates)
+    if (this.pauseCount > 0) {
+      return;
+    }
+
+    // A subscriber registered for multiple changed symbols must be delivered to
+    // exactly once per tick (not once per matching symbol).
+    const notifiedIds = new Set<string>();
+    for (const symbol of changedSymbols) {
+      const ids = this.symbolSubscribers.get(symbol);
+      if (!ids) {
+        continue;
+      }
+      ids.forEach((id) => {
+        if (notifiedIds.has(id)) {
+          return;
+        }
+        const subscriber = this.subscribers.get(id);
+        if (!subscriber) {
+          return;
+        }
+        notifiedIds.add(id);
+        this.deliverToSubscriber(subscriber, updates);
+      });
+    }
+  }
+
+  /**
+   * Deliver a single update to one subscriber, applying first-update and throttle
+   * semantics. Shared by {@link notifySubscribers} and
+   * {@link notifySubscribersForSymbols} so both dispatch paths behave identically.
+   */
+  private deliverToSubscriber(subscriber: StreamSubscription<T>, updates: T) {
+    // Check if this is the first update for this subscriber
+    if (!subscriber.hasReceivedFirstUpdate) {
+      subscriber.callback(updates);
+      subscriber.hasReceivedFirstUpdate = true;
+      return; // Don't set up throttle for the first update
+    }
+
+    // If no throttling (throttleMs is 0 or undefined), notify immediately
+    if (!subscriber.throttleMs) {
+      subscriber.callback(updates);
+      return;
+    }
+
+    // For subsequent updates with throttling, use throttle logic
+    // Store pending update
+    subscriber.pendingUpdate = updates;
+
+    // Throttle pattern: Only set timer if one isn't already running
+    // This ensures callbacks fire at most once per throttleMs interval
+    // WITHOUT resetting the countdown on every update (which would be debouncing)
+    // The conditional check prevents timer accumulation - no memory leaks
+    subscriber.timer ??= setTimeout(() => {
+      if (subscriber.pendingUpdate) {
+        subscriber.callback(subscriber.pendingUpdate);
+        subscriber.pendingUpdate = undefined;
+      }
+      subscriber.timer = undefined;
+    }, subscriber.throttleMs);
+  }
+
+  /**
+   * Register a subscription's symbols into the reverse index so symbol-scoped
+   * dispatch can find it. No-op for subscriptions without symbols.
+   */
+  private indexSubscriptionSymbols(subscription: StreamSubscription<T>) {
+    const { symbols } = subscription;
+    if (!symbols) {
+      return;
+    }
+    symbols.forEach((symbol) => {
+      let ids = this.symbolSubscribers.get(symbol);
+      if (!ids) {
+        ids = new Set<string>();
+        this.symbolSubscribers.set(symbol, ids);
+      }
+      ids.add(subscription.id);
+    });
+  }
+
+  /**
+   * Remove a subscription's symbols from the reverse index, pruning empty sets.
+   */
+  private deindexSubscriptionSymbols(subscription?: StreamSubscription<T>) {
+    const symbols = subscription?.symbols;
+    if (!subscription || !symbols) {
+      return;
+    }
+    symbols.forEach((symbol) => {
+      const ids = this.symbolSubscribers.get(symbol);
+      if (!ids) {
         return;
       }
-
-      // For subsequent updates with throttling, use throttle logic
-      // Store pending update
-      subscriber.pendingUpdate = updates;
-
-      // Throttle pattern: Only set timer if one isn't already running
-      // This ensures callbacks fire at most once per throttleMs interval
-      // WITHOUT resetting the countdown on every update (which would be debouncing)
-      // The conditional check prevents timer accumulation - no memory leaks
-      subscriber.timer ??= setTimeout(() => {
-        if (subscriber.pendingUpdate) {
-          subscriber.callback(subscriber.pendingUpdate);
-          subscriber.pendingUpdate = undefined;
-        }
-        subscriber.timer = undefined;
-      }, subscriber.throttleMs);
+      ids.delete(subscription.id);
+      if (ids.size === 0) {
+        this.symbolSubscribers.delete(symbol);
+      }
     });
   }
 
   subscribe(params: {
     callback: (data: T) => void;
     throttleMs?: number;
+    symbols?: string[];
   }): () => void {
     const id = Math.random().toString(36);
 
@@ -143,6 +242,7 @@ abstract class StreamChannel<T> {
       hasReceivedFirstUpdate: false, // Initialize as false
     };
     this.subscribers.set(id, subscription);
+    this.indexSubscriptionSymbols(subscription);
 
     // Give immediate cached data if available
     const cached = this.getCachedData();
@@ -162,6 +262,7 @@ abstract class StreamChannel<T> {
         clearTimeout(sub.timer);
         sub.timer = undefined;
       }
+      this.deindexSubscriptionSymbols(sub);
       this.subscribers.delete(id);
 
       // Disconnect if no subscribers
@@ -439,7 +540,8 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
           priceMap[update.symbol] = priceUpdate;
         });
 
-        this.notifySubscribers(priceMap);
+        // Scope dispatch to subscribers registered for the symbols in this tick.
+        this.notifySubscribersForSymbols(priceMap, Object.keys(priceMap));
       },
     });
   }
@@ -488,6 +590,9 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
     }
 
     return this.subscribe({
+      // Registering symbols lets the channel scope dispatch to only the
+      // subscribers interested in the symbols present in a given tick.
+      symbols: params.symbols,
       callback: (allPrices) => {
         // Filter to only requested symbols
         const filtered: Record<string, PriceUpdate> = {};
@@ -580,7 +685,8 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
             });
 
             if (this.subscribers.size > 0) {
-              this.notifySubscribers(priceMap);
+              // Scope dispatch to subscribers registered for the symbols in this tick.
+              this.notifySubscribersForSymbols(priceMap, Object.keys(priceMap));
             }
           },
         });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

This optimizes the central perps price streaming path in `PerpsStreamManager`. It adds a `symbol -> Set<subscriberId>` reverse index to the base `StreamChannel` so a price tick for a given symbol is dispatched only to subscribers registered for that symbol, instead of iterating every price subscriber on every tick. A new `notifySubscribersForSymbols(updates, changedSymbols)` dispatches scoped to the symbols present in a tick; both `PriceStreamChannel` WebSocket callbacks (live `connect()` and `prewarm()`) call it with `Object.keys(priceMap)`. Per-subscriber first-update and throttle semantics are factored into a shared `deliverToSubscriber()` used by both the broadcast and scoped paths so behavior is identical. The index is only populated for subscriptions that declare `symbols` (the price channel via `subscribeToSymbols`); all other channels (orders, positions, account, fills, OI caps, top-of-book, market data, candles) keep the original broadcast path, and the public `subscribe`/`subscribeToSymbols` API is unchanged. Intentional behavior change: a subscriber whose symbols are absent from a tick is simply not notified, rather than receiving an empty `{}` (consumers replace state with the filtered slice, so observable state is equivalent). Note: this is high-risk, central streaming code on the price hot path.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->
Fixes: https://github.com/MetaMask/metamask-mobile/issues/31362
Refs: https://consensyssoftware.atlassian.net/browse/TAT-3325

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps symbol-scoped price dispatch

  Scenario: User browses live perps prices across multiple surfaces
    Given the user is on the Perps markets list with live prices streaming

    When prices update for individual markets
    Then each visible market row updates with its own live price without flicker
    And opening a market detail chart shows that market's live price updating

    When the user switches accounts
    Then all price subscribers are cleared and re-initialize, and live prices resume correctly afterward
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — no visual change (performance-only refactor).

### **After**

N/A — no visual change (performance-only refactor).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
