### PR TITLE
ci: update sonarcloud org id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1395,7 +1395,7 @@ jobs:
           if [[ "$LABEL" == "skip-sonar-cloud" ]]; then
             echo "skip-sonar-cloud label found. Skipping SonarCloud Quality Gate check."
           else
-            PROJECT_KEY="metamask-mobile"
+            PROJECT_KEY="MetaMask_metamask-mobile"
             PR_NUMBER="${{ github.event.pull_request.number }}"
             SONAR_TOKEN="${{ secrets.SONAR_TOKEN }}"
 

--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -48,7 +48,7 @@ jest.mock('../selectors/featureFlagController', () => ({
   selectRawFeatureFlags: jest.fn(),
 }));
 
-// Mock whenEngineReady to prevent Engine access after Jest teardown
+// Mock whenEngineReady to prevent Engine access after Jest teardownn
 jest.mock('../util/analytics/whenEngineReady', () => ({
   whenEngineReady: jest.fn().mockResolvedValue(undefined),
 }));

--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -48,7 +48,7 @@ jest.mock('../selectors/featureFlagController', () => ({
   selectRawFeatureFlags: jest.fn(),
 }));
 
-// Mock whenEngineReady to prevent Engine access after Jest teardownn
+// Mock whenEngineReady to prevent Engine access after Jest teardown
 jest.mock('../util/analytics/whenEngineReady', () => ({
   whenEngineReady: jest.fn().mockResolvedValue(undefined),
 }));

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=metamask-mobile
-sonar.organization=consensys
+sonar.projectKey=MetaMask-metamask-mobile
+sonar.organization=metamask
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=MetaMask Mobile Project

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=MetaMask-metamask-mobile
+sonar.projectKey=MetaMask_metamask-mobile
 sonar.organization=metamask
 
 # This is the name and version displayed in the SonarCloud UI.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,6 @@
 sonar.projectKey=MetaMask_metamask-mobile
 sonar.organization=metamask
 
-# This is the name and version displayed in the SonarCloud UI.
-sonar.projectName=MetaMask Mobile Project
-#sonar.projectVersion=1.0
 
 # Root for sonar analysis.
 sonar.sources=app/


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Since 3 weeks we are not receiving PRs decoration anymore with Sonar analysis findings. It seems that now is required the project to be bound to the same github org that is attached to the sonarcloud instance, but MetaMask project was configured under `consensys` org instead of `metamask` org.

[https://docs.sonarsource.com/sonarqube-cloud/administering-sonarcloud/about-sonarqube-cloud-solution/resources-structure/binding](https://docs.sonarsource.com/sonarqube-cloud/administering-sonarcloud/about-sonarqube-cloud-solution/resources-structure/binding-with-dop?_gl=1*18fevs1*_gcl_au*MTQxNDYyODA2Ni4xNzgxNTk2NDMx*_ga*MjA0MzEzNDQ5OS4xNzgxNTk2MzY1*_ga_9JZ0GZ5TC6*czE3ODE2ODcxNjIkbzQkZzEkdDE3ODE2ODg5MDQkajYwJGwwJGgw)

This PR changes the sonar config so the analysis is pushed to the `metamask` org configured in our sonarcloud instance. PR decoration is now working as we can see in this PR:
<img width="967" height="411" alt="Screenshot 2026-06-18 at 15 57 53" src="https://github.com/user-attachments/assets/f9b62516-8b21-4af3-86fa-fb4beac0e95d" />


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only CI and Sonar metadata; no application or security logic. Wrong keys would break quality gate or decoration until fixed in SonarCloud.
> 
> **Overview**
> **Repoints SonarCloud** from the old `consensys` / `metamask-mobile` setup to the `metamask` organization and project key `MetaMask_metamask-mobile`, so analysis and GitHub PR decoration match Sonar’s requirement that the repo be bound to the same GitHub org as the SonarCloud instance.
> 
> In `sonar-project.properties`, `sonar.organization` becomes `metamask` and `sonar.projectKey` becomes `MetaMask_metamask-mobile`; the explicit `sonar.projectName` (and related commented version line) is removed. The **SonarCloud quality gate** job in CI uses the same `PROJECT_KEY` when polling `project_status` for the PR, keeping the gate in sync with where scans are uploaded.
> 
> No changes to analysis scope, exclusions, or coverage paths—only identity/org configuration and the matching CI constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf41e72311e4731c432bf8c28be5a7d374217c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->