### PR TITLE
chore: QuickBuy rate tag flip and amount skeleton loading

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.test.tsx
@@ -1,116 +1,40 @@
-import React, { createRef } from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react-native';
-import { TextInput } from 'react-native';
 import QuickBuyAmountSection from './QuickBuyAmountSection';
 
-const defaultProps = {
-  amountDisplayMode: 'fiat' as const,
-  fiatAmountLabel: '$0',
-  destSymbol: 'ETH',
-  estimatedReceiveAmount: undefined,
-  isQuoteLoading: false,
-  hiddenInputRef: createRef<TextInput | null>(),
-  onAmountAreaPress: jest.fn(),
-  onAmountChange: jest.fn(),
-};
-
 describe('QuickBuyAmountSection', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  const baseProps = {
+    amountDisplayMode: 'fiat' as const,
+    fiatAmountLabel: '$2.55',
+    destSymbol: 'GIGA',
+    estimatedReceiveAmount: '56.52037',
+    isQuoteLoading: false,
+  };
 
-  it('renders the fiat amount as primary in fiat mode', () => {
-    render(
-      <QuickBuyAmountSection
-        {...defaultProps}
-        amountDisplayMode="fiat"
-        fiatAmountLabel="$50"
-      />,
-    );
-    expect(screen.getByText('$50')).toBeOnTheScreen();
-  });
+  it('renders the secondary amount label when not loading', () => {
+    render(<QuickBuyAmountSection {...baseProps} />);
 
-  it('renders a non-USD preformatted fiat label as primary in fiat mode', () => {
-    render(
-      <QuickBuyAmountSection
-        {...defaultProps}
-        amountDisplayMode="fiat"
-        fiatAmountLabel="50 €"
-      />,
-    );
-    expect(screen.getByText('50 €')).toBeOnTheScreen();
-  });
-
-  it('shows the zero placeholder label when no amount is entered', () => {
-    render(<QuickBuyAmountSection {...defaultProps} fiatAmountLabel="$0" />);
-    expect(screen.getByText('$0')).toBeOnTheScreen();
-  });
-
-  it('renders the crypto amount as primary in crypto mode', () => {
-    render(
-      <QuickBuyAmountSection
-        {...defaultProps}
-        amountDisplayMode="crypto"
-        estimatedReceiveAmount="0.025"
-        destSymbol="ETH"
-      />,
-    );
-    expect(screen.getByText('0.025 ETH')).toBeOnTheScreen();
-  });
-
-  it('shows 0 crypto placeholder when estimatedCryptoAmount is undefined', () => {
-    render(
-      <QuickBuyAmountSection
-        {...defaultProps}
-        amountDisplayMode="crypto"
-        estimatedReceiveAmount={undefined}
-        destSymbol="ETH"
-      />,
-    );
-    expect(screen.getByText('0 ETH')).toBeOnTheScreen();
-  });
-
-  it('shows the estimated crypto amount with destSymbol as the secondary label', () => {
-    render(
-      <QuickBuyAmountSection
-        {...defaultProps}
-        estimatedReceiveAmount="123.45"
-        destSymbol="ETH"
-      />,
-    );
-    expect(screen.getByText('123.45 ETH')).toBeOnTheScreen();
-  });
-
-  it('replaces the secondary label with a spinner when isQuoteLoading', () => {
-    render(
-      <QuickBuyAmountSection
-        {...defaultProps}
-        isQuoteLoading
-        fiatAmountLabel="$20"
-      />,
-    );
-    expect(screen.getByTestId('quick-buy-amount-area')).toBeOnTheScreen();
+    expect(screen.getByText('$2.55')).toBeOnTheScreen();
+    expect(screen.getByText('56.52037 GIGA')).toBeOnTheScreen();
     expect(
-      screen.getByTestId('quick-buy-amount-loading-spinner'),
-    ).toBeOnTheScreen();
-    // Secondary label is replaced by spinner — crypto label should NOT be present
-    expect(screen.queryByText('0 ETH')).not.toBeOnTheScreen();
-  });
-
-  it('shows the secondary label when NOT loading', () => {
-    render(<QuickBuyAmountSection {...defaultProps} isQuoteLoading={false} />);
-    expect(screen.getByText('0 ETH')).toBeOnTheScreen();
-  });
-
-  it('does not render a toggle button', () => {
-    render(<QuickBuyAmountSection {...defaultProps} />);
-    expect(
-      screen.queryByTestId('quick-buy-toggle-amount-display'),
+      screen.queryByTestId('quick-buy-amount-loading'),
     ).not.toBeOnTheScreen();
   });
 
-  it('does not render available balance text', () => {
-    render(<QuickBuyAmountSection {...defaultProps} />);
-    expect(screen.queryByText(/available/)).not.toBeOnTheScreen();
+  it('shows skeleton and token symbol while quote is loading', () => {
+    render(<QuickBuyAmountSection {...baseProps} isQuoteLoading />);
+
+    expect(screen.getByText('$2.55')).toBeOnTheScreen();
+    expect(screen.getByTestId('quick-buy-amount-loading')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('quick-buy-amount-loading-skeleton'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('quick-buy-amount-loading-symbol'),
+    ).toHaveTextContent('GIGA');
+    expect(
+      screen.queryByTestId('quick-buy-amount-loading-icon'),
+    ).not.toBeOnTheScreen();
+    expect(screen.queryByText('56.52037 GIGA')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyAmountSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TextInput } from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   Text,
@@ -7,11 +8,10 @@ import {
   TextColor,
   FontWeight,
   BoxAlignItems,
+  BoxFlexDirection,
   BoxJustifyContent,
-  IconColor,
-  IconSize,
-  Spinner,
 } from '@metamask/design-system-react-native';
+import { Skeleton } from '../../../../../../../component-library/components-temp/Skeleton';
 import type { QuickBuyAmountDisplayMode } from '../types';
 import { formatTokenAmount } from '../../../../utils/formatters';
 
@@ -52,6 +52,8 @@ const QuickBuyAmountSection: React.FC<QuickBuyAmountSectionProps> = ({
   sourceCryptoAmount,
   sourceSymbol,
 }) => {
+  const tw = useTailwind();
+
   const cryptoAmountLabel = estimatedReceiveAmount
     ? `${formatTokenAmount(parseFloat(estimatedReceiveAmount))} ${destSymbol}`
     : `0 ${destSymbol}`;
@@ -90,11 +92,26 @@ const QuickBuyAmountSection: React.FC<QuickBuyAmountSectionProps> = ({
       </Text>
 
       {isQuoteLoading ? (
-        <Spinner
-          color={IconColor.IconDefault}
-          spinnerIconProps={{ size: IconSize.Sm }}
-          testID="quick-buy-amount-loading-spinner"
-        />
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
+          testID="quick-buy-amount-loading"
+        >
+          <Skeleton
+            width={88}
+            height={16}
+            style={tw.style('rounded-md')}
+            testID="quick-buy-amount-loading-skeleton"
+          />
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            testID="quick-buy-amount-loading-symbol"
+          >
+            {destSymbol}
+          </Text>
+        </Box>
       ) : (
         <Text
           variant={TextVariant.BodySm}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyToolbar.test.tsx
@@ -87,14 +87,14 @@ describe('QuickBuyToolbar', () => {
   it('prefers formattedRate (quote-based) over formattedExchangeRate when a quote is available', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       ...baseContext,
-      formattedRate: '1 ETH = 4381.23 REPPO',
-      formattedExchangeRate: '1 ETH = 1000 USDC',
+      formattedRate: '1 SOL = 25,738.44 GIGA',
+      formattedExchangeRate: '1 SOL = 23,529 GIGA',
       setActiveScreen,
     });
 
     render(<QuickBuyToolbar />);
-    expect(screen.getByText('1 ETH = 4381.23 REPPO')).toBeOnTheScreen();
-    expect(screen.queryByText('1 ETH = 1000 USDC')).not.toBeOnTheScreen();
+    expect(screen.getByText('1 SOL = 25,738.44 GIGA')).toBeOnTheScreen();
+    expect(screen.queryByText('1 SOL = 23,529 GIGA')).not.toBeOnTheScreen();
   });
 
   it('shows formattedRate even when formattedExchangeRate is undefined', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -879,7 +879,7 @@ export function useQuickBuyController(
     () =>
       tradeMode === 'sell'
         ? formatExchangeRate(sourceToken, destToken)
-        : formatExchangeRate(destTokenForRate, sourceToken),
+        : formatExchangeRate(sourceToken, destTokenForRate),
     [destToken, destTokenForRate, sourceToken, tradeMode],
   );
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -1471,6 +1471,41 @@ describe('useQuickBuyController', () => {
     });
   });
 
+  describe('formattedExchangeRate', () => {
+    it('shows pay-with token on the left in buy mode pre-quote', () => {
+      const solToken = createSourceToken({
+        symbol: 'SOL',
+        currencyExchangeRate: 150,
+      });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [solToken],
+        isLoading: false,
+      });
+      (useQuickBuySetup as jest.Mock).mockReturnValue({
+        chainId: '0x1',
+        destToken: {
+          address: '0xDEST',
+          chainId: '0x1',
+          decimals: 18,
+          symbol: 'GIGA',
+          name: 'Gigachad',
+        },
+        isLoading: false,
+        isUnsupportedChain: false,
+      });
+      (usePositionTokenBalance as jest.Mock).mockReturnValue({
+        currencyExchangeRate: 0.006375,
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget({ tokenSymbol: 'GIGA' }), jest.fn()),
+      );
+
+      expect(result.current.formattedExchangeRate).toMatch(/^1 SOL = /);
+      expect(result.current.formattedExchangeRate).not.toMatch(/^1 GIGA = /);
+    });
+  });
+
   describe('source token auto-selection', () => {
     it('auto-selects the first option when options load (legacy — native on dest chain matches priority 1)', () => {
       const firstToken = createSourceToken({ symbol: 'ETH' });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes two QuickBuy UX issues on the trader position sheet:

- Rate tag flip: Pre-quote metadata showed 1 [dest] = X [source] while the quote pill showed 1 [source] = X [dest], so the tag swapped sides when a quote landed. Buy-mode pre-quote now uses the same source-first orientation as the quote-derived rate.
- Amount loading state: Replaced the secondary-line spinner with a skeleton + token symbol so the fiat headline and token context stay visible during blocking quote loads. Buy/Sell button spinner behavior is unchanged.

<img height="790" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 15 44 37" src="https://github.com/user-attachments/assets/93e3af49-edaf-46f1-a0ca-a163b35738da" />

https://github.com/user-attachments/assets/9735648c-51b4-495c-9344-0563ad59b15e


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
https://consensyssoftware.atlassian.net/browse/TSA-608
https://consensyssoftware.atlassian.net/browse/TSA-716

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
