### PR TITLE
refactor(ActivityListItemRow): implement pending transaction handling and improve layout structure

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.styles.ts
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.styles.ts
@@ -99,6 +99,48 @@ export const createStyles = (
       lineHeight: 16,
       textAlign: 'right',
     } as TextStyle,
+    titleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    titleSpinner: {
+      marginLeft: 6,
+    },
+    statusRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: 0,
+    },
+    subtitleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: 0,
+    },
+    subtitleLeadingIcon: {
+      marginRight: 4,
+    },
+    statusText: {
+      marginTop: 0,
+    } as TextStyle,
+    pendingActions: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      paddingTop: 4,
+      paddingBottom: 8,
+    },
+    actionContainerStyle: {
+      height: 25,
+      padding: 0,
+    },
+    speedupActionContainerStyle: {
+      marginRight: 10,
+    },
+    actionStyle: {
+      fontSize: 10,
+      padding: 0,
+      paddingHorizontal: 10,
+    },
   });
 
 export type ActivityListItemRowStyles = ReturnType<typeof createStyles>;

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -2,7 +2,7 @@
  * Tests for ActivityListItemRow content mapping.
  */
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import type { ActivityListItem, Status } from '../../../util/activity-adapters';
 import { ActivityListItemRow } from './ActivityListItemRow';
 import { strings } from '../../../../locales/i18n';
@@ -218,6 +218,56 @@ jest.mock('@metamask/design-system-react-native', () => {
 
   return { ListItem };
 });
+
+jest.mock('../StyledButton', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text: TextActual } = jest.requireActual('react-native');
+  return ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+  }) => ReactActual.createElement(TextActual, { onPress }, children);
+});
+
+jest.mock('../../Base/StatusText', () => {
+  const ReactActual = jest.requireActual('react');
+  const { Text: TextActual } = jest.requireActual('react-native');
+  const StatusText = ({
+    status,
+    testID,
+  }: {
+    status: string;
+    testID?: string;
+  }) => ReactActual.createElement(TextActual, { testID }, status);
+  return { __esModule: true, default: StatusText };
+});
+
+jest.mock('../Money/components/PendingSpinner/PendingSpinner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return ({ testID }: { testID?: string }) =>
+    ReactActual.createElement(View, { testID });
+});
+
+jest.mock('../../../component-library/components/Icons/Icon', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const Icon = ({ testID }: { testID?: string }) =>
+    ReactActual.createElement(View, { testID });
+  return {
+    __esModule: true,
+    default: Icon,
+    IconColor: { Alternative: 'alternative', Default: 'default' },
+    IconName: { Pending: 'Pending' },
+    IconSize: { Sm: '16' },
+  };
+});
+
+jest.mock('../../Views/confirmations/utils/transaction', () => ({
+  hasGasFeeTokenSelected: jest.fn(() => false),
+}));
 
 // ---------------------------------------------------------------------------
 // Helper to build minimal ActivityListItem
@@ -917,5 +967,123 @@ describe('ActivityListItemRow — title display for all ActivityKind values', ()
 
     expect(getByText('Swap ETH to USDC')).toBeOnTheScreen();
     expect(queryByText(strings('transactions.swaps_transaction'))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending rows — spinner on title, queued subtitle prefix, no inline actions
+// ---------------------------------------------------------------------------
+
+interface MakePendingLocalItemOptions {
+  txStatus?: string;
+  isEarliestNonce?: boolean;
+}
+
+const makePendingLocalItem = ({
+  txStatus = 'submitted',
+  isEarliestNonce = true,
+}: MakePendingLocalItemOptions = {}): ActivityListItem =>
+  ({
+    type: 'send',
+    chainId: 'eip155:1',
+    status: 'pending',
+    timestamp: 1_700_000_000_000,
+    hash: '0xabc',
+    isEarliestNonce,
+    raw: {
+      type: 'localTransaction',
+      data: {
+        primaryTransaction: {
+          id: 'tx-1',
+          status: txStatus,
+        },
+      },
+    },
+    data: {
+      from: '0xfrom',
+      to: '0x1234567890',
+      token: { amount: '1', symbol: 'ETH', direction: 'out' },
+    },
+  }) as unknown as ActivityListItem;
+
+const makePendingRemoteItem = (): ActivityListItem =>
+  ({
+    type: 'receive',
+    chainId: 'eip155:1',
+    status: 'pending',
+    timestamp: 1_700_000_000_000,
+    hash: '0xdef',
+    data: {
+      from: '0xfrom',
+      to: '0xto',
+      token: { amount: '1', symbol: 'ETH', direction: 'in' },
+    },
+  }) as unknown as ActivityListItem;
+
+const pendingHandlers = () => ({
+  onSpeedUpAction: jest.fn(),
+  onCancelAction: jest.fn(),
+  signQRTransaction: jest.fn(),
+  signLedgerTransaction: jest.fn(),
+  cancelUnsignedQRTransaction: jest.fn(),
+});
+
+describe('ActivityListItemRow — pending rows', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the pending title, spinner, and normal subtitle', () => {
+    const item = makePendingLocalItem({ txStatus: 'submitted' });
+    const { getByTestId } = render(
+      <ActivityListItemRow item={item} index={0} {...pendingHandlers()} />,
+    );
+
+    expect(getByTestId('activity-title-0xabc').props.children).toBe(
+      'Sending ETH',
+    );
+    expect(getByTestId('activity-pending-spinner-0xabc')).toBeOnTheScreen();
+    expect(getByTestId('activity-subtitle-0xabc').props.children).toBe(
+      'To: 0x1234...',
+    );
+  });
+
+  it('renders queued rows with an hourglass prefix and no title spinner', () => {
+    const item = makePendingLocalItem({ isEarliestNonce: false });
+    const { getByTestId, queryByTestId } = render(
+      <ActivityListItemRow item={item} index={0} {...pendingHandlers()} />,
+    );
+
+    expect(getByTestId('activity-title-0xabc').props.children).toBe(
+      'Sending ETH',
+    );
+    expect(queryByTestId('activity-pending-spinner-0xabc')).toBeNull();
+    expect(getByTestId('activity-subtitle-0xabc').props.children).toBe(
+      `${strings('transaction.queued')} • To: 0x1234...`,
+    );
+  });
+
+  it('does not render speed-up or cancel actions for pending rows', () => {
+    const item = makePendingLocalItem({ txStatus: 'submitted' });
+    const { queryByText } = render(
+      <ActivityListItemRow item={item} index={0} {...pendingHandlers()} />,
+    );
+
+    expect(queryByText(strings('transaction.speedup'))).toBeNull();
+    expect(queryByText(strings('transaction.cancel'))).toBeNull();
+  });
+
+  it('shows a spinner and normal subtitle for non-local pending rows', () => {
+    const item = makePendingRemoteItem();
+    const { getByTestId, queryByText } = render(
+      <ActivityListItemRow item={item} index={0} {...pendingHandlers()} />,
+    );
+
+    expect(getByTestId('activity-pending-spinner-0xdef')).toBeOnTheScreen();
+    expect(getByTestId('activity-subtitle-0xdef').props.children).toBe(
+      'From: 0xfrom...',
+    );
+    expect(queryByText(strings('transaction.speedup'))).toBeNull();
+    expect(queryByText(strings('transaction.cancel'))).toBeNull();
   });
 });

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -3,10 +3,17 @@
  */
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import type { ActivityListItem, Status } from '../../../util/activity-adapters';
 import { ActivityListItemRow } from './ActivityListItemRow';
+import { ActivityListItemRowPendingActions } from './ActivityListItemRowPendingActions';
 import { strings } from '../../../../locales/i18n';
 import { getNetworkImageSource } from '../../../util/networks';
+import { hasGasFeeTokenSelected } from '../../Views/confirmations/utils/transaction';
 
 const LINEA_MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
 const LINEA_MUSD_CHECKSUM_ADDRESS =
@@ -1083,6 +1090,156 @@ describe('ActivityListItemRow — pending rows', () => {
     expect(getByTestId('activity-subtitle-0xdef').props.children).toBe(
       'From: 0xfrom...',
     );
+    expect(queryByText(strings('transaction.speedup'))).toBeNull();
+    expect(queryByText(strings('transaction.cancel'))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pending row actions — speed-up/cancel and hardware signing gates
+// ---------------------------------------------------------------------------
+
+type PendingActionsProps = React.ComponentProps<
+  typeof ActivityListItemRowPendingActions
+>;
+
+const pendingActionStyles = {
+  pendingActions: {},
+  actionContainerStyle: {},
+  speedupActionContainerStyle: {},
+  actionStyle: {},
+} as PendingActionsProps['styles'];
+
+const makePendingActionTx = (
+  overrides: Partial<TransactionMeta & { isSmartTransaction?: boolean }> = {},
+) =>
+  ({
+    id: 'tx-1',
+    status: TransactionStatus.submitted,
+    type: TransactionType.simpleSend,
+    ...overrides,
+  }) as unknown as TransactionMeta;
+
+const makePendingActionProps = (
+  overrides: Partial<PendingActionsProps> = {},
+): PendingActionsProps => ({
+  tx: makePendingActionTx(),
+  styles: pendingActionStyles,
+  isQRHardwareAccount: false,
+  isLedgerAccount: false,
+  onSpeedUpAction: jest.fn(),
+  onCancelAction: jest.fn(),
+  signQRTransaction: jest.fn(),
+  signLedgerTransaction: jest.fn(),
+  cancelUnsignedQRTransaction: jest.fn(),
+  ...overrides,
+});
+
+describe('ActivityListItemRowPendingActions', () => {
+  const mockHasGasFeeTokenSelected = jest.mocked(hasGasFeeTokenSelected);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasGasFeeTokenSelected.mockReturnValue(false);
+  });
+
+  it('renders speed-up and cancel actions for submitted transactions', () => {
+    const props = makePendingActionProps();
+    const { getByText } = render(
+      <ActivityListItemRowPendingActions {...props} />,
+    );
+
+    fireEvent.press(getByText(strings('transaction.speedup')));
+    fireEvent.press(getByText(strings('transaction.cancel')));
+
+    expect(props.onSpeedUpAction).toHaveBeenCalledWith(true, props.tx);
+    expect(props.onCancelAction).toHaveBeenCalledWith(true, props.tx);
+  });
+
+  it('renders normal actions for approved software-account transactions', () => {
+    const props = makePendingActionProps({
+      tx: makePendingActionTx({ status: TransactionStatus.approved }),
+    });
+    const { getByText } = render(
+      <ActivityListItemRowPendingActions {...props} />,
+    );
+
+    expect(getByText(strings('transaction.speedup'))).toBeOnTheScreen();
+    expect(getByText(strings('transaction.cancel'))).toBeOnTheScreen();
+  });
+
+  it('renders QR signing and QR cancel actions for approved QR hardware transactions', () => {
+    const props = makePendingActionProps({
+      isQRHardwareAccount: true,
+      tx: makePendingActionTx({ status: TransactionStatus.approved }),
+    });
+    const { getByText, queryByText } = render(
+      <ActivityListItemRowPendingActions {...props} />,
+    );
+
+    expect(queryByText(strings('transaction.speedup'))).toBeNull();
+
+    fireEvent.press(getByText(strings('transaction.sign_with_keystone')));
+    fireEvent.press(getByText(strings('transaction.cancel')));
+
+    expect(props.signQRTransaction).toHaveBeenCalledWith(props.tx);
+    expect(props.cancelUnsignedQRTransaction).toHaveBeenCalledWith(props.tx);
+  });
+
+  it('renders Ledger signing action for approved Ledger transactions', () => {
+    const props = makePendingActionProps({
+      isLedgerAccount: true,
+      tx: makePendingActionTx({
+        id: 'ledger-tx',
+        status: TransactionStatus.approved,
+      }),
+    });
+    const { getByText, queryByText } = render(
+      <ActivityListItemRowPendingActions {...props} />,
+    );
+
+    expect(queryByText(strings('transaction.speedup'))).toBeNull();
+    expect(queryByText(strings('transaction.cancel'))).toBeNull();
+
+    fireEvent.press(getByText(strings('transaction.sign_with_ledger')));
+
+    expect(props.signLedgerTransaction).toHaveBeenCalledWith({
+      id: 'ledger-tx',
+    });
+  });
+
+  it.each([
+    ['smart transaction', makePendingActionTx({ isSmartTransaction: true })],
+    [
+      'bridge transaction',
+      makePendingActionTx({ type: TransactionType.bridge }),
+    ],
+    [
+      'unapproved transaction',
+      makePendingActionTx({ status: TransactionStatus.unapproved }),
+    ],
+  ])('renders nothing for %s', (_description, tx) => {
+    const { queryByText } = render(
+      <ActivityListItemRowPendingActions
+        {...makePendingActionProps({
+          tx,
+        })}
+      />,
+    );
+
+    expect(queryByText(strings('transaction.speedup'))).toBeNull();
+    expect(queryByText(strings('transaction.cancel'))).toBeNull();
+    expect(queryByText(strings('transaction.sign_with_keystone'))).toBeNull();
+    expect(queryByText(strings('transaction.sign_with_ledger'))).toBeNull();
+  });
+
+  it('renders nothing when a gas fee token is selected', () => {
+    mockHasGasFeeTokenSelected.mockReturnValue(true);
+
+    const { queryByText } = render(
+      <ActivityListItemRowPendingActions {...makePendingActionProps()} />,
+    );
+
     expect(queryByText(strings('transaction.speedup'))).toBeNull();
     expect(queryByText(strings('transaction.cancel'))).toBeNull();
   });

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -837,6 +837,27 @@ describe('ActivityListItemRow — amount display', () => {
     expect(getByText('+1 UNKNOWN')).toBeOnTheScreen();
     expect(queryByText('+$1')).toBeNull();
   });
+
+  it('does not render destination fiat as the source line for source-less swaps', () => {
+    const item = makeItem({
+      type: 'swap',
+      status: 'success',
+      destinationToken: {
+        amount: '1000000',
+        decimals: 6,
+        symbol: 'mUSD',
+        assetId: `eip155:1/erc20:${LINEA_MUSD_ADDRESS}`,
+        direction: 'in',
+      },
+    });
+
+    const { getByText, queryByText } = render(
+      <ActivityListItemRow item={item} index={0} />,
+    );
+
+    expect(getByText('+1 mUSD')).toBeOnTheScreen();
+    expect(queryByText('+$1')).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.types.ts
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.types.ts
@@ -1,10 +1,27 @@
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type {
   ActivityListItem,
   TokenAmount,
 } from '../../../util/activity-adapters';
 
-export interface ActivityListItemRowProps {
+/**
+ * Speed-up / cancel / hardware-wallet sign handlers for pending local EVM rows.
+ * Sourced from `useUnifiedTxActions` and threaded down from the list view so the
+ * shared `CancelSpeedupModal` (rendered once at the list level) stays in sync.
+ */
+export interface PendingTransactionActionHandlers {
+  isQRHardwareAccount?: boolean;
+  isLedgerAccount?: boolean;
+  onSpeedUpAction?: (open: boolean, tx?: TransactionMeta) => void;
+  onCancelAction?: (open: boolean, tx?: TransactionMeta) => void;
+  signQRTransaction?: (tx: TransactionMeta) => void;
+  signLedgerTransaction?: (tx: { id: string }) => void;
+  cancelUnsignedQRTransaction?: (tx: TransactionMeta) => void;
+}
+
+export interface ActivityListItemRowProps
+  extends PendingTransactionActionHandlers {
   item: ActivityListItem;
   index?: number;
   onPress?: (item: ActivityListItem) => void;

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRowLayout.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRowLayout.tsx
@@ -9,6 +9,7 @@ import type { ActivityListItemRowStyles } from './ActivityListItemRow.styles';
 
 export function ActivityListItemRowLayout({
   avatar,
+  footer,
   index,
   isFailed,
   item,
@@ -18,9 +19,12 @@ export function ActivityListItemRowLayout({
   secondaryAmount,
   styles,
   subtitle,
+  subtitleLeadingAccessory,
   title,
+  titleAccessory,
 }: {
   avatar: React.ReactNode;
+  footer?: React.ReactNode;
   index?: number;
   isFailed: boolean;
   item: ActivityListItem;
@@ -30,10 +34,12 @@ export function ActivityListItemRowLayout({
   secondaryAmount?: string;
   styles: ActivityListItemRowStyles;
   subtitle?: string;
+  subtitleLeadingAccessory?: React.ReactNode;
   title: string;
+  titleAccessory?: React.ReactNode;
 }) {
   const testIdSuffix = item.hash ?? index;
-  const titleNode = (
+  const titleText = (
     <Text
       numberOfLines={1}
       style={[styles.listItemTitle, isFailed && styles.listItemTitleFailed]}
@@ -42,14 +48,35 @@ export function ActivityListItemRowLayout({
       {title}
     </Text>
   );
+  const titleNode = titleAccessory ? (
+    <View style={styles.titleRow}>
+      {titleText}
+      {titleAccessory}
+    </View>
+  ) : (
+    titleText
+  );
   const subtitleNode = subtitle ? (
-    <Text
-      numberOfLines={1}
-      style={styles.subtitleText}
-      testID={`activity-subtitle-${testIdSuffix}`}
-    >
-      {subtitle}
-    </Text>
+    subtitleLeadingAccessory ? (
+      <View style={styles.subtitleRow}>
+        {subtitleLeadingAccessory}
+        <Text
+          numberOfLines={1}
+          style={styles.subtitleText}
+          testID={`activity-subtitle-${testIdSuffix}`}
+        >
+          {subtitle}
+        </Text>
+      </View>
+    ) : (
+      <Text
+        numberOfLines={1}
+        style={styles.subtitleText}
+        testID={`activity-subtitle-${testIdSuffix}`}
+      >
+        {subtitle}
+      </Text>
+    )
   ) : undefined;
   const primaryAmountNode = primaryAmount ? (
     <Text
@@ -83,15 +110,18 @@ export function ActivityListItemRowLayout({
     ) : undefined;
 
   return (
-    <ListItem
-      isInteractive
-      avatar={avatar}
-      description={subtitleNode}
-      endAccessory={amountColumn}
-      onPress={onPress}
-      style={[styles.row, styles.listItem]}
-      testID={`transaction-item-${index ?? 0}`}
-      title={titleNode}
-    />
+    <View style={styles.row}>
+      <ListItem
+        isInteractive
+        avatar={avatar}
+        description={subtitleNode}
+        endAccessory={amountColumn}
+        onPress={onPress}
+        style={styles.listItem}
+        testID={`transaction-item-${index ?? 0}`}
+        title={titleNode}
+      />
+      {footer}
+    </View>
   );
 }

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRowPendingActions.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRowPendingActions.tsx
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- intentionally reuses the legacy StyledButton to match the existing pending-row action visuals; migration to the DS Button is tracked separately */
+/**
+ * Speed-up / cancel (and hardware-wallet sign) actions for a pending local EVM
+ * activity row. Mobile equivalent of the extension's
+ * `TransactionListItemPendingActions`, with the additional QR/Ledger signing
+ * flows that only exist on Mobile (ported from the legacy `TransactionElement`).
+ */
+import React from 'react';
+import { View } from 'react-native';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { strings } from '../../../../locales/i18n';
+import StyledButton from '../StyledButton';
+import { hasGasFeeTokenSelected } from '../../Views/confirmations/utils/transaction';
+import type { ActivityListItemRowStyles } from './ActivityListItemRow.styles';
+
+type TransactionMetaWithSmartTransaction = TransactionMeta & {
+  isSmartTransaction?: boolean;
+};
+
+export interface ActivityListItemRowPendingActionsProps {
+  tx: TransactionMeta;
+  styles: ActivityListItemRowStyles;
+  isQRHardwareAccount: boolean;
+  isLedgerAccount: boolean;
+  onSpeedUpAction: (open: boolean, tx?: TransactionMeta) => void;
+  onCancelAction: (open: boolean, tx?: TransactionMeta) => void;
+  signQRTransaction: (tx: TransactionMeta) => void;
+  signLedgerTransaction: (tx: { id: string }) => void;
+  cancelUnsignedQRTransaction: (tx: TransactionMeta) => void;
+}
+
+export function ActivityListItemRowPendingActions({
+  tx,
+  styles,
+  isQRHardwareAccount,
+  isLedgerAccount,
+  onSpeedUpAction,
+  onCancelAction,
+  signQRTransaction,
+  signLedgerTransaction,
+  cancelUnsignedQRTransaction,
+}: ActivityListItemRowPendingActionsProps) {
+  const { status, type } = tx;
+  const isSmartTransaction = (tx as TransactionMetaWithSmartTransaction)
+    .isSmartTransaction;
+  const isBridgeTransaction = type === TransactionType.bridge;
+
+  // Gating mirrors TransactionElement.renderTxElement.
+  const renderNormalActions =
+    (status === 'submitted' ||
+      (status === 'approved' && !isQRHardwareAccount && !isLedgerAccount)) &&
+    !isSmartTransaction &&
+    !isBridgeTransaction &&
+    !hasGasFeeTokenSelected(tx);
+  const renderUnsignedQRActions = status === 'approved' && isQRHardwareAccount;
+  const renderLedgerActions = status === 'approved' && isLedgerAccount;
+
+  if (
+    !renderNormalActions &&
+    !renderUnsignedQRActions &&
+    !renderLedgerActions
+  ) {
+    return null;
+  }
+
+  return (
+    <View style={styles.pendingActions}>
+      {renderNormalActions && (
+        <>
+          <StyledButton
+            type="normal"
+            containerStyle={[
+              styles.actionContainerStyle,
+              styles.speedupActionContainerStyle,
+            ]}
+            style={styles.actionStyle}
+            onPress={() => onSpeedUpAction(true, tx)}
+          >
+            {strings('transaction.speedup')}
+          </StyledButton>
+          <StyledButton
+            type="cancel"
+            containerStyle={styles.actionContainerStyle}
+            style={styles.actionStyle}
+            onPress={() => onCancelAction(true, tx)}
+          >
+            {strings('transaction.cancel')}
+          </StyledButton>
+        </>
+      )}
+      {renderUnsignedQRActions && (
+        <>
+          <StyledButton
+            type="normal"
+            containerStyle={[
+              styles.actionContainerStyle,
+              styles.speedupActionContainerStyle,
+            ]}
+            style={styles.actionStyle}
+            onPress={() => signQRTransaction(tx)}
+          >
+            {strings('transaction.sign_with_keystone')}
+          </StyledButton>
+          <StyledButton
+            type="cancel"
+            containerStyle={[
+              styles.actionContainerStyle,
+              styles.speedupActionContainerStyle,
+            ]}
+            style={styles.actionStyle}
+            onPress={() => cancelUnsignedQRTransaction(tx)}
+          >
+            {strings('transaction.cancel')}
+          </StyledButton>
+        </>
+      )}
+      {renderLedgerActions && (
+        <StyledButton
+          type="normal"
+          containerStyle={[
+            styles.actionContainerStyle,
+            styles.speedupActionContainerStyle,
+          ]}
+          style={styles.actionStyle}
+          onPress={() => signLedgerTransaction({ id: tx.id })}
+        >
+          {strings('transaction.sign_with_ledger')}
+        </StyledButton>
+      )}
+    </View>
+  );
+}

--- a/app/components/UI/ActivityListItemRow/PendingActivityListItemRow.tsx
+++ b/app/components/UI/ActivityListItemRow/PendingActivityListItemRow.tsx
@@ -1,27 +1,31 @@
 /**
- * Row component that renders a single ActivityListItem from the shared adapter shape.
- * All styling and localization are Mobile-specific; data comes from the shared adapters.
+ * Pending variant of the activity row. Reuses the shared row content/layout,
+ * shows a spinner beside the title for in-flight txs, and prefixes queued txs
+ * with an hourglass indicator while keeping the normal address subtitle.
  */
 import React, { useCallback } from 'react';
-import { useColorScheme } from 'react-native';
+import { View, useColorScheme } from 'react-native';
 import { useSelector } from 'react-redux';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../component-library/components/Icons/Icon';
+import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
 import { getTransactionIcon } from '../../../util/transaction-icons';
 import { getNetworkImageSource } from '../../../util/networks';
 import { RootState } from '../../../reducers';
 import { AppThemeKey } from '../../../util/theme/models';
+import PendingSpinner from '../Money/components/PendingSpinner/PendingSpinner';
 import { createStyles } from './ActivityListItemRow.styles';
 import { ActivityListItemRowIcon } from './ActivityListItemRowIcon';
 import { ActivityListItemRowLayout } from './ActivityListItemRowLayout';
-import { PendingActivityListItemRow } from './PendingActivityListItemRow';
 import { resolveIconType } from './resolveIconType';
 import { useActivityListItemRowContent } from './useActivityListItemRowContent';
 import type { ActivityListItemRowProps } from './ActivityListItemRow.types';
 
-export { resolveActivityListItemTitle } from './useActivityListItemRowContent';
-export { resolveIconType } from './resolveIconType';
-
-function ResolvedActivityListItemRow({
+export function PendingActivityListItemRow({
   bridgeHistoryItem,
   item,
   index,
@@ -39,10 +43,9 @@ function ResolvedActivityListItemRow({
     bridgeHistoryItem,
   );
   const styles = createStyles(colors, typography);
-  const isFailed = item.status === 'failed' || item.status === 'cancelled';
   const icon = getTransactionIcon(
     resolveIconType(item.type),
-    isFailed,
+    false,
     appTheme,
     osColorScheme,
   );
@@ -53,6 +56,29 @@ function ResolvedActivityListItemRow({
   const handlePress = useCallback(() => {
     onPress?.(item);
   }, [onPress, item]);
+
+  const testIdSuffix = item.hash ?? index;
+  const isQueued = item.isEarliestNonce === false;
+  const subtitle = content.subtitle
+    ? isQueued
+      ? `${strings('transaction.queued')} • ${content.subtitle}`
+      : content.subtitle
+    : undefined;
+
+  const titleAccessory = isQueued ? undefined : (
+    <View style={styles.titleSpinner}>
+      <PendingSpinner testID={`activity-pending-spinner-${testIdSuffix}`} />
+    </View>
+  );
+
+  const subtitleLeadingAccessory = isQueued ? (
+    <Icon
+      name={IconName.Pending}
+      size={IconSize.Sm}
+      color={IconColor.Alternative}
+      style={styles.subtitleLeadingIcon}
+    />
+  ) : undefined;
 
   return (
     <ActivityListItemRowLayout
@@ -65,30 +91,19 @@ function ResolvedActivityListItemRow({
         />
       }
       index={index}
-      isFailed={isFailed}
+      isFailed={false}
       item={item}
       onPress={handlePress}
       primaryAmount={content.primaryAmount}
       primaryToken={content.primaryToken}
       secondaryAmount={content.secondaryAmount}
       styles={styles}
-      subtitle={content.subtitle}
+      subtitle={subtitle}
+      subtitleLeadingAccessory={subtitleLeadingAccessory}
       title={titleOverride ?? content.title}
+      titleAccessory={titleAccessory}
     />
   );
 }
 
-/**
- * Dispatches to the pending or resolved row variant, mirroring the extension's
- * `ActivityRow`. Holds no hooks so the branch can switch as a row transitions
- * from pending to a final status.
- */
-export function ActivityListItemRow(props: ActivityListItemRowProps) {
-  if (props.item.status === 'pending') {
-    return <PendingActivityListItemRow {...props} />;
-  }
-
-  return <ResolvedActivityListItemRow {...props} />;
-}
-
-export default ActivityListItemRow;
+export default PendingActivityListItemRow;

--- a/app/components/UI/ActivityListItemRow/resolveIconType.ts
+++ b/app/components/UI/ActivityListItemRow/resolveIconType.ts
@@ -1,0 +1,58 @@
+import type { ActivityKind } from '../../../util/activity-adapters';
+
+/**
+ * Maps an activity kind to the transaction icon family used by
+ * `getTransactionIcon`. Shared by the resolved and pending row variants.
+ */
+export function resolveIconType(type: ActivityKind): string {
+  switch (type) {
+    case 'send':
+    case 'sell':
+    case 'lendingDeposit':
+    case 'deposit':
+    case 'wrap':
+    case 'perpsAddFunds':
+    case 'predictionsAddFunds':
+      return 'send';
+    case 'receive':
+    case 'buy':
+    case 'claim':
+    case 'claimMusdBonus':
+    case 'lendingWithdrawal':
+    case 'unwrap':
+    case 'nftMint':
+    case 'perpsWithdraw':
+    case 'predictionsWithdrawFunds':
+    case 'predictionClaimWinnings':
+    case 'predictionCashedOut':
+    case 'predictionPlaced':
+    case 'perpsReceivedFundingFees':
+      return 'receive';
+    case 'swap':
+    case 'swapIncomplete':
+    case 'bridge':
+    case 'convert':
+      return 'swap';
+    case 'approveSpendingCap':
+    case 'revokeSpendingCap':
+    case 'increaseSpendingCap':
+    case 'contractInteraction':
+    case 'contractDeployment':
+    case 'smartAccountUpgrade':
+    case 'perpsOpenLong':
+    case 'perpsCloseLong':
+    case 'perpsCloseLongLiquidated':
+    case 'perpsCloseLongStopLoss':
+    case 'perpsOpenShort':
+    case 'perpsCloseShort':
+    case 'perpsCloseShortLiquidated':
+    case 'perpsCloseShortStopLoss':
+    case 'perpsPaidFundingFees':
+    case 'perpsCloseShortTakeProfit':
+    case 'perpsCloseLongTakeProfit':
+    case 'marketShort':
+    case 'stopMarketCloseShort':
+    case 'marketCloseShort':
+      return 'interaction';
+  }
+}

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -687,6 +687,17 @@ function resolveAmount(
   return isSpendingCapActivity ? amount : applyDisplaySign(amount, signPrefix);
 }
 
+function shouldUsePrimaryFiatFallback(
+  itemType: ActivityListItem['type'],
+  secondaryToken: TokenAmount | undefined,
+) {
+  if (secondaryToken) {
+    return false;
+  }
+
+  return !['swap', 'bridge', 'wrap', 'unwrap', 'convert'].includes(itemType);
+}
+
 function formatTokenQuantity(amount: string): string {
   const value = Number(amount);
   const absoluteValue = Math.abs(value);
@@ -861,17 +872,32 @@ export function useActivityListItemRowContent(
     networkChainId,
   );
   const primaryAmount = resolveAmount(primaryToken, item.type);
+  const resolvedSecondaryAmount = resolveAmount(secondaryToken, item.type);
+  const secondaryFiatAmount = resolveFiatAmount({
+    activityType: item.type,
+    contractExchangeRates,
+    conversionRate,
+    currentCurrency,
+    hexChainId,
+    token: secondaryToken,
+    usdConversionRate,
+  });
+  const primaryFiatAmount = shouldUsePrimaryFiatFallback(
+    item.type,
+    secondaryToken,
+  )
+    ? resolveFiatAmount({
+        activityType: item.type,
+        contractExchangeRates,
+        conversionRate,
+        currentCurrency,
+        hexChainId,
+        token: primaryToken,
+        usdConversionRate,
+      })
+    : undefined;
   const secondaryAmount =
-    resolveAmount(secondaryToken, item.type) ??
-    resolveFiatAmount({
-      activityType: item.type,
-      contractExchangeRates,
-      conversionRate,
-      currentCurrency,
-      hexChainId,
-      token: primaryToken,
-      usdConversionRate,
-    });
+    resolvedSecondaryAmount ?? secondaryFiatAmount ?? primaryFiatAmount;
 
   return {
     ...content,

--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -233,34 +233,24 @@ jest.mock('../../UI/ActivityListItemRow/ActivityListItemRow', () => ({
     onPress,
     title,
   }: {
-    item: { hash?: string };
+    item: {
+      hash?: string;
+      status?: string;
+      raw?: { type: string; data: { primaryTransaction: { id: string } } };
+    };
     onPress: (item: unknown) => void;
     title?: string;
   }) => {
     const { Text, TouchableOpacity } = jest.requireActual('react-native');
+    const hash = item.hash ?? 'no-hash';
     return (
-      <TouchableOpacity
-        testID={`row-${item.hash ?? 'no-hash'}`}
-        onPress={() => onPress(item)}
-      >
+      <TouchableOpacity testID={`row-${hash}`} onPress={() => onPress(item)}>
         <Text>{title ?? item.hash}</Text>
       </TouchableOpacity>
     );
   },
   resolveActivityListItemTitle: jest.fn(() => 'Activity title'),
 }));
-
-jest.mock('../../UI/TransactionElement', () => {
-  const { Text, View } = jest.requireActual('react-native');
-  return {
-    __esModule: true,
-    default: ({ tx }: { tx: { id: string } }) => (
-      <View testID={`pending-${tx.id}`}>
-        <Text>Pending tx</Text>
-      </View>
-    ),
-  };
-});
 
 jest.mock('../../UI/MultichainBridgeTransactionListItem', () => {
   const { Text, View } = jest.requireActual('react-native');
@@ -485,13 +475,15 @@ describe('ActivityList', () => {
     );
   });
 
-  it('renders local pending and confirmed transaction rows', () => {
+  it('renders local pending and confirmed transaction rows via ActivityListItemRow', () => {
     render(<ActivityList header={<></>} onScroll={mockOnScroll} />);
 
     expect(
       screen.getByTestId(ActivityListSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
-    expect(screen.getByTestId('pending-local-id')).toBeOnTheScreen();
+    // Pending local EVM rows now render through ActivityListItemRow, not the
+    // legacy TransactionElement.
+    expect(screen.getByTestId('row-0xlocal')).toBeOnTheScreen();
     expect(screen.getByTestId('row-0xconfirmed')).toBeOnTheScreen();
   });
 

--- a/app/components/Views/ActivityList/ActivityList.testIds.ts
+++ b/app/components/Views/ActivityList/ActivityList.testIds.ts
@@ -5,5 +5,11 @@ export const ActivityListSelectorsIDs = {
 export const activityListRowItemTestId = (index: number): string =>
   `transaction-item-${index}`;
 
-export const activityListRowStatusTestId = (index: number): string =>
-  `transaction-status-${index}`;
+export const activityListRowTitleTestId = (hash: string): string =>
+  `activity-title-${hash}`;
+
+export const activityListRowSubtitleTestId = (hash: string): string =>
+  `activity-subtitle-${hash}`;
+
+export const activityListRowPendingSpinnerTestId = (hash: string): string =>
+  `activity-pending-spinner-${hash}`;

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -22,7 +22,6 @@ import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import Routes from '../../../constants/navigation/Routes';
 import { RPC } from '../../../constants/network';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
-import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain/multichain';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../selectors/multichainAccounts/accountTreeController';
 import {
@@ -50,7 +49,6 @@ import {
   handleUnifiedSwapsTxHistoryItemClick,
 } from '../../UI/Bridge/utils/transaction-history';
 import MultichainBridgeTransactionListItem from '../../UI/MultichainBridgeTransactionListItem';
-import TransactionElement from '../../UI/TransactionElement';
 import TransactionsFooter from '../../UI/Transactions/TransactionsFooter';
 import ListItem from '../../Base/ListItem';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -244,11 +242,23 @@ const ActivityList = ({
     [nonEvmState?.transactions],
   );
 
-  const currentCurrency = useSelector(selectCurrentCurrency);
-
   const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
   const selectedAccountGroupInternalAccounts = useSelector(
     selectSelectedAccountGroupInternalAccounts,
+  );
+  const isQRHardwareAccount = useMemo(
+    () =>
+      isHardwareAccount(selectedInternalAccount?.address ?? '', [
+        ExtendedKeyringTypes.qr,
+      ]),
+    [selectedInternalAccount?.address],
+  );
+  const isLedgerAccount = useMemo(
+    () =>
+      isHardwareAccount(selectedInternalAccount?.address ?? '', [
+        ExtendedKeyringTypes.ledger,
+      ]),
+    [selectedInternalAccount?.address],
   );
   const selectedAccountGroupEvmAddress = useMemo(() => {
     const evmAccount = selectedAccountGroupInternalAccounts.find(
@@ -827,7 +837,7 @@ const ActivityList = ({
     if (groupedItem.type === 'pending-header') {
       return (
         <ListItem.Date style={styles.dateHeader}>
-          {strings('transactions.pending')}
+          {strings('transaction.pending')}
         </ListItem.Date>
       );
     }
@@ -842,38 +852,6 @@ const ActivityList = ({
 
     const { item } = groupedItem;
     const raw = item.raw;
-
-    // Pending local EVM transactions: route to TransactionElement for speed-up/cancel UI.
-    if (raw?.type === 'localTransaction' && item.status === 'pending') {
-      const tx = raw.data.primaryTransaction;
-      return (
-        <TransactionElement
-          tx={tx}
-          i={index}
-          navigation={navigation}
-          txChainId={tx.chainId}
-          selectedAddress={
-            selectedAccountGroupEvmAddress || selectedInternalAccount?.address
-          }
-          onSpeedUpAction={onSpeedUpAction}
-          onCancelAction={onCancelAction}
-          signQRTransaction={signQRTransaction}
-          cancelUnsignedQRTransaction={cancelUnsignedQRTransaction}
-          isQRHardwareAccount={isHardwareAccount(
-            selectedInternalAccount?.address ?? '',
-            [ExtendedKeyringTypes.qr],
-          )}
-          isLedgerAccount={isHardwareAccount(
-            selectedInternalAccount?.address ?? '',
-            [ExtendedKeyringTypes.ledger],
-          )}
-          signLedgerTransaction={signLedgerTransaction}
-          currentCurrency={currentCurrency}
-          showBottomBorder
-          location={location}
-        />
-      );
-    }
 
     // Non-EVM bridge transactions: route to MultichainBridgeTransactionListItem.
     if (raw?.type === 'keyringTransaction') {
@@ -895,12 +873,13 @@ const ActivityList = ({
       }
     }
 
-    // All other items (API EVM confirmed, completed local EVM, non-EVM non-bridge):
+    // All other items (API EVM confirmed, completed local EVM, non-EVM non-bridge,
+    // and pending local/remote rows):
     // render from the shared ActivityListItem shape.
     //
     // Preserve the legacy Activity title for swap/bridge rows (e.g.
     // "Swap ETH to USDC", "Bridge to Optimism") by deriving it from bridge
-    // history, mirroring TransactionElement. Falls back to the kind-based title.
+    // history. Falls back to the kind-based title.
     const bridgeHistoryItem = getBridgeHistoryItemByHash(item.hash);
     const title = bridgeHistoryItem
       ? getSwapBridgeTxActivityTitle(bridgeHistoryItem)
@@ -913,6 +892,13 @@ const ActivityList = ({
         index={index}
         onPress={handleActivityItemPress}
         title={title}
+        isQRHardwareAccount={isQRHardwareAccount}
+        isLedgerAccount={isLedgerAccount}
+        onSpeedUpAction={onSpeedUpAction}
+        onCancelAction={onCancelAction}
+        signQRTransaction={signQRTransaction}
+        signLedgerTransaction={signLedgerTransaction}
+        cancelUnsignedQRTransaction={cancelUnsignedQRTransaction}
       />
     );
   };

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -85,6 +85,7 @@ import {
 } from '../../UI/ActivityListItemRow/ActivityListItemRow';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
+import { getIntlDateTimeFormatter } from '../../../util/intl';
 
 const confirmedEvmOverscan = 5;
 const visibilityConfig = { itemVisiblePercentThreshold: 1 };
@@ -135,7 +136,7 @@ const formatDateHeader = (timestamp: number) => {
     return strings('perps.yesterday');
   }
 
-  return new Intl.DateTimeFormat('en-US', {
+  return getIntlDateTimeFormatter('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/app/components/Views/ActivityList/ActivityList.view.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.view.test.tsx
@@ -17,7 +17,7 @@ import {
 import { getRouteProbeTestId } from '../../../../tests/component-view/render';
 import {
   activityListRowItemTestId,
-  activityListRowStatusTestId,
+  activityListRowSubtitleTestId,
 } from './ActivityList.testIds';
 
 const transactionControllerWithIncomingSync = Engine.context
@@ -29,9 +29,10 @@ describeForPlatforms('ActivityList', () => {
   it('shows pending and confirmed local rows then opens transaction details from a confirmed row', async () => {
     const pendingRowIndex = 1;
     const confirmedRowIndex = 3;
+    const pendingTransaction = buildPendingLocalSendTransaction();
     const state = initialStateActivityWithLocalTransactions([
       buildConfirmedLocalSendTransaction(),
-      buildPendingLocalSendTransaction(),
+      pendingTransaction,
     ]).build();
 
     const { findByTestId } = renderActivityListViewWithRoutes({
@@ -39,11 +40,19 @@ describeForPlatforms('ActivityList', () => {
       extraRoutes: [{ name: Routes.MODAL.ROOT_MODAL_FLOW }],
     });
 
-    const pendingStatus = await findByTestId(
-      activityListRowStatusTestId(pendingRowIndex),
+    const pendingRow = await findByTestId(
+      activityListRowItemTestId(pendingRowIndex),
     );
+    const pendingScope = within(pendingRow);
 
-    expect(pendingStatus).toHaveTextContent(strings('transaction.submitted'));
+    expect(pendingScope.getByText('Sending ETH')).toBeOnTheScreen();
+    expect(
+      pendingScope.getByTestId(
+        activityListRowSubtitleTestId(pendingTransaction.hash as string),
+      ),
+    ).toHaveTextContent(
+      `${strings('transaction.queued')} • To: 0x80181...229cC`,
+    );
 
     const confirmedRow = await findByTestId(
       activityListRowItemTestId(confirmedRowIndex),

--- a/app/components/Views/ActivityList/ActivityList.view.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.view.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent, waitFor, within } from '@testing-library/react-native';
 import { RefreshControl } from 'react-native';
 import Engine from '../../../core/Engine';
 import Routes from '../../../constants/navigation/Routes';
-import { strings } from '../../../../locales/i18n';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import {
   buildConfirmedLocalSendTransaction,
@@ -17,6 +16,7 @@ import {
 import { getRouteProbeTestId } from '../../../../tests/component-view/render';
 import {
   activityListRowItemTestId,
+  activityListRowPendingSpinnerTestId,
   activityListRowSubtitleTestId,
 } from './ActivityList.testIds';
 
@@ -48,11 +48,15 @@ describeForPlatforms('ActivityList', () => {
     expect(pendingScope.getByText('Sending ETH')).toBeOnTheScreen();
     expect(
       pendingScope.getByTestId(
+        activityListRowPendingSpinnerTestId(pendingTransaction.hash as string),
+        { includeHiddenElements: true },
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      pendingScope.getByTestId(
         activityListRowSubtitleTestId(pendingTransaction.hash as string),
       ),
-    ).toHaveTextContent(
-      `${strings('transaction.queued')} • To: 0x80181...229cC`,
-    );
+    ).toHaveTextContent('To: 0x80181...229cC');
 
     const confirmedRow = await findByTestId(
       activityListRowItemTestId(confirmedRowIndex),

--- a/app/components/Views/ActivityList/helpers/transformations.test.ts
+++ b/app/components/Views/ActivityList/helpers/transformations.test.ts
@@ -139,6 +139,27 @@ describe('ActivityList transformations', () => {
         ),
       ).toBe(true);
     });
+
+    it('keeps direct incoming token transfers when the indexer omits contractAddress', () => {
+      const transaction = buildTransaction({
+        from: otherAddress,
+        to: address,
+        valueTransfers: [
+          {
+            amount: '1',
+            decimal: 6,
+            from: otherAddress,
+            symbol: 'USDC',
+            to: address,
+            transferType: 'ERC20',
+          },
+        ],
+      });
+
+      const result = shouldSkipTransaction(address, transaction);
+
+      expect(result).toBe(false);
+    });
   });
 
   it('matches bridge history by tx ids, original id, and source hash', () => {

--- a/app/components/Views/ActivityList/helpers/transformations.test.ts
+++ b/app/components/Views/ActivityList/helpers/transformations.test.ts
@@ -147,8 +147,10 @@ describe('ActivityList transformations', () => {
         valueTransfers: [
           {
             amount: '1',
+            contractAddress: '',
             decimal: 6,
             from: otherAddress,
+            name: 'USD Coin',
             symbol: 'USDC',
             to: address,
             transferType: 'ERC20',

--- a/app/components/Views/ActivityList/helpers/transformations.ts
+++ b/app/components/Views/ActivityList/helpers/transformations.ts
@@ -46,12 +46,27 @@ function isIncomingTokenTransfer(
   address: string,
   transaction: V1TransactionByHashResponse,
 ) {
+  const normalizedAddress = address.toLowerCase();
+
   return (
     (transaction.valueTransfers?.some(
-      (transfer) => transfer.to?.toLowerCase() === address,
+      (transfer) =>
+        Boolean(transfer.contractAddress) &&
+        transfer.to?.toLowerCase() === normalizedAddress &&
+        transfer.from?.toLowerCase() !== normalizedAddress,
     ) ??
       false) &&
-    transaction.from?.toLowerCase() !== address
+    transaction.from?.toLowerCase() !== normalizedAddress
+  );
+}
+
+function isNativeValueTransfer(
+  transfer: NonNullable<V1TransactionByHashResponse['valueTransfers']>[number],
+) {
+  const transferType = transfer.transferType?.toLowerCase();
+  return (
+    !transfer.contractAddress &&
+    (transferType === 'native' || transferType === 'normal')
   );
 }
 
@@ -74,7 +89,7 @@ function isIncomingNativeTransfer(
     if (
       !hasIncomingNativeTransfer &&
       transfer.to?.toLowerCase() === normalizedAddress &&
-      !transfer.contractAddress
+      isNativeValueTransfer(transfer)
     ) {
       hasIncomingNativeTransfer = true;
     }

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
@@ -162,6 +162,34 @@ describe('useLocalActivityItems', () => {
     });
   });
 
+  it('marks a higher-nonce pending transaction as queued when a lower nonce is signed', () => {
+    selectorState.localTransactions = [
+      makeTx({
+        id: 'signed-nonce-1',
+        hash: '0xsignednonce1',
+        status: TransactionStatus.signed,
+        time: 1,
+        txParams: { from, nonce: '0x1', to: recipient, value: '0x1' },
+      }),
+      makeTx({
+        id: 'pending-nonce-2',
+        hash: '0xpendingnonce2',
+        status: TransactionStatus.submitted,
+        time: 2,
+        txParams: { from, nonce: '0x2', to: recipient, value: '0x1' },
+      }),
+    ];
+
+    const { result } = renderHook(() => useLocalActivityItems());
+
+    expect(result.current).toHaveLength(2);
+    expect(
+      result.current.find((item) => item.hash === '0xpendingnonce2'),
+    ).toMatchObject({
+      isEarliestNonce: false,
+    });
+  });
+
   it('enriches contract-token metadata from the selected account token list', () => {
     selectorState.localTransactions = [
       makeTx({

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.test.ts
@@ -134,6 +134,34 @@ describe('useLocalActivityItems', () => {
     });
   });
 
+  it('does not mark a sole pending transaction as queued when lower nonces are confirmed', () => {
+    selectorState.localTransactions = [
+      makeTx({
+        id: 'confirmed-nonce-1',
+        hash: '0xconfirmednonce1',
+        status: TransactionStatus.confirmed,
+        time: 1,
+        txParams: { from, nonce: '0x1', to: recipient, value: '0x1' },
+      }),
+      makeTx({
+        id: 'pending-nonce-2',
+        hash: '0xpendingnonce2',
+        status: TransactionStatus.submitted,
+        time: 2,
+        txParams: { from, nonce: '0x2', to: recipient, value: '0x1' },
+      }),
+    ];
+
+    const { result } = renderHook(() => useLocalActivityItems());
+
+    expect(result.current).toHaveLength(2);
+    expect(
+      result.current.find((item) => item.hash === '0xpendingnonce2'),
+    ).toMatchObject({
+      isEarliestNonce: true,
+    });
+  });
+
   it('enriches contract-token metadata from the selected account token list', () => {
     selectorState.localTransactions = [
       makeTx({

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
@@ -30,6 +30,12 @@ const BRIDGE_FAIL_STATUSES = [
   TransactionStatus.rejected,
 ] as string[];
 
+const QUEUE_BLOCKING_STATUSES = new Set<string>([
+  TransactionStatus.submitted,
+  'approved',
+  'unapproved',
+]);
+
 /**
  * Checks whether a transaction is a TransactionMeta (vs SmartTransaction).
  * SmartTransaction objects have chainId on the object when returned from the Mobile selector.
@@ -67,6 +73,7 @@ function computeIsEarliestNonce(
 
   return !allLocalTxs.some((other) => {
     if (other.id === tx.id) return false;
+    if (!QUEUE_BLOCKING_STATUSES.has(other.status)) return false;
     const otherNonce = Number(other.txParams?.nonce);
     return (
       other.txParams?.from?.toLowerCase() === from &&

--- a/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
+++ b/app/components/Views/ActivityList/hooks/useLocalActivityItems.ts
@@ -32,6 +32,7 @@ const BRIDGE_FAIL_STATUSES = [
 
 const QUEUE_BLOCKING_STATUSES = new Set<string>([
   TransactionStatus.submitted,
+  TransactionStatus.signed,
   'approved',
   'unapproved',
 ]);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4529,6 +4529,7 @@
     "confirmed": "Confirmed",
     "pending": "Pending",
     "submitted": "Submitted",
+    "queued": "Queued",
     "failed": "Failed",
     "cancelled": "Cancelled",
     "signed": "Pending",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Implements TMCU-862 pending activity row status UI on top of `update-activity-list-item-row`.

Pending transactions no longer route through the legacy `TransactionElement`. Local and remote pending rows now render via `ActivityListItemRow`, matching the extension's pending row pattern:

- **In-flight pending** (`isEarliestNonce !== false`): title shows a `PendingSpinner` beside the action label; subtitle stays the normal address line (`To: 0x…` / `From: 0x…`)
- **Queued** (`isEarliestNonce === false`): no title spinner; subtitle is prefixed with an hourglass icon and `Queued • …`
- **No inline actions**: speed up / cancel / HW sign buttons removed from the row (list-level `CancelSpeedupModal` wiring is unchanged)

Also extracts `resolveIconType` into its own module, extends `ActivityListItemRowLayout` for title/subtitle accessories, and fixes the pending section header to use `transaction.pending`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated pending activity list items to show a loading spinner or queued status while keeping the existing address subtitle

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pending activity list item status

  Scenario: In-flight pending transaction shows spinner and address subtitle
    Given a wallet with a submitted local EVM send on the earliest nonce
    When the user opens the Activity tab
    Then the pending row shows "Sending <token>" with a spinner next to the title
    And the subtitle shows the recipient address (e.g. "To: 0x…")
    And no Speed up or Cancel buttons appear on the row

  Scenario: Queued transaction shows hourglass prefix
    Given a wallet with multiple pending local EVM sends from the same account
    When the user opens the Activity tab
    Then the non-earliest pending row shows no title spinner
    And the subtitle shows "Queued • To: 0x…" with an hourglass icon

  Scenario: Confirmed transactions are unchanged
    Given a wallet with confirmed activity history
    When the user opens the Activity tab
    Then confirmed rows render as before with no spinner or queued prefix
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6022b13a-8abf-4849-94be-a3953e24b6a4


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches activity list rendering, pending/queued nonce logic, and API transaction filtering—user-visible history and pending states can change if edge cases were wrong before.
> 
> **Overview**
> **Pending activity** now goes through `ActivityListItemRow` instead of legacy `TransactionElement`. `ActivityListItemRow` branches on `item.status === 'pending'` into `PendingActivityListItemRow`, which shows a title **spinner** for in-flight txs, a **Queued • …** subtitle with an hourglass when `isEarliestNonce === false`, and **no inline** speed-up/cancel/HW buttons (list-level modal handlers are still passed from `ActivityList`).
> 
> `ActivityListItemRowLayout` gains title/subtitle accessories and an optional footer; `resolveIconType` is extracted. `ActivityListItemRowPendingActions` is added and tested for gating (smart tx, bridge, gas-fee token, QR/Ledger) but is not mounted on the row UI in this change.
> 
> **Related fixes:** `useLocalActivityItems` only treats lower-nonce txs in blocking statuses as queue blockers; `shouldSkipTransaction` / native transfer detection are tightened so direct receives are not dropped when the indexer omits `contractAddress`; swap rows without a source token no longer show destination fiat on the source line; pending header copy uses `transaction.pending` and adds `transaction.queued`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f373ea2a1df63bde613f480744baa738c20fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->