### PR TITLE
fix(predict): exclude child markets from World Cup feed cp-7.82.0

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictWorldCup.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.test.ts
@@ -141,6 +141,32 @@ describe('usePredictWorldCupMarkets', () => {
     expect(result.current.hasMore).toBe(true);
   });
 
+  it('filters child more-market cards', async () => {
+    const { Wrapper } = createWrapper();
+    const parentMarket = createMarket({ id: 'parent-market' });
+    const childMarket = createMarket({
+      id: 'child-market',
+      parentMarketId: 'parent-market',
+    });
+    mockGetMarkets.mockResolvedValue({
+      markets: [parentMarket, childMarket],
+      nextCursor: null,
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePredictWorldCupMarkets({
+          tabKey: 'all',
+          config: DEFAULT_PREDICT_WORLD_CUP_FLAG,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.marketData).toEqual([parentMarket]),
+    );
+  });
+
   it('requests Props markets with a cached paginated query', async () => {
     const { Wrapper } = createWrapper();
     const propsMarket = createMarket({ id: 'props-market' });

--- a/app/components/UI/Predict/hooks/usePredictWorldCup.ts
+++ b/app/components/UI/Predict/hooks/usePredictWorldCup.ts
@@ -27,6 +27,7 @@ import {
 import { strings } from '../../../../../locales/i18n';
 import type { PredictMarket } from '../types';
 import type { PredictWorldCupConfig } from '../types/flags';
+import { filterStandaloneMarkets } from '../utils/feed';
 import { getVisiblePredictMarkets } from '../utils/marketStaleness';
 import type { UsePredictMarketDataResult } from './usePredictMarketData';
 
@@ -237,11 +238,12 @@ export const usePredictWorldCupMarkets = ({
     [infiniteQuery.data],
   );
   const visibleInfiniteMarketData = useMemo(
-    () => getVisiblePredictMarkets(infiniteMarketData),
+    () => getVisiblePredictMarkets(filterStandaloneMarkets(infiniteMarketData)),
     [infiniteMarketData],
   );
   const visibleSingleMarketData = useMemo(
-    () => getVisiblePredictMarkets(singleQuery.data ?? []),
+    () =>
+      getVisiblePredictMarkets(filterStandaloneMarkets(singleQuery.data ?? [])),
     [singleQuery.data],
   );
 


### PR DESCRIPTION
## **Description**

World Cup Predict tabs were not applying the shared feed hygiene used elsewhere in Predict. Child markets linked to a parent event (`parentMarketId`) could appear alongside their parent in the World Cup list.

This change applies `filterStandaloneMarkets` in `usePredictWorldCupMarkets` before `getVisiblePredictMarkets`, matching `usePredictMarketData`, `usePredictMarketList`, and `useFeaturedCarouselData`. A unit test verifies child markets are excluded from the returned `marketData`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/PRED-1032

## **Manual testing steps**

```gherkin
Feature: World Cup Predict feed excludes child markets

  Scenario: World Cup All tab shows only standalone markets
    Given the Predict World Cup feature flag is enabled
    And the World Cup All tab returns a parent market and a child market with parentMarketId set

    When the user opens the World Cup Predict surface and selects the All tab
    Then only the standalone parent market is shown in the feed
    And the child more-market card is not listed
```

Additional verification:
- Ran `npx jest app/components/UI/Predict/hooks/usePredictWorldCup.test.ts --coverage=false` — all 9 tests pass.

## **Screenshots/Recordings**

N/A — non-visual data-filtering change; behavior covered by unit test.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
