### PR TITLE
fix: rebase before push in OTA release PR workflow to avoid push race

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -171,6 +171,10 @@ jobs:
           else
             git add app/constants/ota.ts
             git commit -m "chore: set OTA_VERSION to v${SEMVER} for OTA hotfix (${BRANCH})"
+            # Runway may push commits to this branch concurrently (it cherry-picks on OTA
+            # trigger), so rebase our commit onto the latest remote tip before pushing to
+            # avoid a non-fast-forward rejection.
+            git pull --rebase origin "$BRANCH"
             git push origin "$BRANCH"
           fi
 
@@ -202,6 +206,9 @@ jobs:
           set -euo pipefail
           git config user.name metamaskbot
           git config user.email metamaskbot@users.noreply.github.com
+          # Re-sync with the remote tip before the changelog tooling commits and pushes,
+          # since Runway may have pushed to this branch concurrently.
+          git pull --rebase origin "release/${{ inputs.semver-version }}-ota"
           corepack enable
           yarn install --immutable
           bash .github/scripts/run-update-release-changelog-mobile.sh \


### PR DESCRIPTION
## Summary

The `Auto Create Release PR` workflow ([auto-create-release-pr.yml](.github/workflows/auto-create-release-pr.yml) → [create-release-pr.yml](.github/workflows/create-release-pr.yml)) fails for OTA hotfixes because of a push race with Runway.

When Runway creates a `release/X.Y.Z-ota` branch it cherry-picks commits onto it immediately. The `create-release-pr` job checks out the branch at create-time HEAD, commits the `OTA_VERSION` bump, and does a plain `git push`. By push time the remote has advanced, so the push is rejected as non-fast-forward and the whole job aborts before the OTA release PR is created.

Example failure: [run 27546445975](https://github.com/MetaMask/metamask-mobile/actions/runs/27546445975/job/81477792040)

```
! [rejected]  release/7.81.1-ota -> release/7.81.1-ota (fetch first)
error: failed to push some refs ...
##[error]Process completed with exit code 1.
```

## Changes

- "Bump OTA_VERSION and push (OTA hotfix)": run `git pull --rebase origin "$BRANCH"` after committing and before pushing, so the OTA_VERSION commit replays on top of whatever Runway pushed and the push becomes a fast-forward.
- "Update release changelog (OTA hotfix)": run the same `git pull --rebase` before the changelog tooling commits/pushes, since it pushes to the same branch.

`--rebase` is required: once we have committed locally and Runway has pushed, the branches have diverged and modern git refuses a bare `git pull`. Rebase also keeps a clean linear history (no merge commit) and we never force-push.

## Test plan

- [ ] Trigger an OTA hotfix (Runway creates `release/X.Y.Z-ota`) and confirm the `create-release-pr` job completes and the OTA release PR to `stable` is created even when Runway pushes concurrently.
- [ ] Confirm a native (non-OTA) `release/X.Y.0` run is unaffected (these steps are gated on `is_ota == 'true'`).

Made with [Cursor](https://cursor.com)