### PR TITLE
fix(predict): odds prices stale on feed cards and event page during live markets cp-7.81.2

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.test.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../types';
 import FeaturedCarouselSportCard from './FeaturedCarouselSportCard';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => ({
@@ -83,6 +84,14 @@ jest.mock('../../hooks/useLiveGameUpdates', () => ({
   useLiveGameUpdates: () => ({ gameUpdate: null }),
 }));
 
+const mockGetLivePrice = jest.fn();
+jest.mock('../../hooks/useLiveMarketPrices', () => ({
+  useLiveMarketPrices: jest.fn(() => ({
+    getPrice: mockGetLivePrice,
+  })),
+}));
+const mockUseLiveMarketPrices = jest.mocked(useLiveMarketPrices);
+
 jest.mock('../../constants/sportLeagueConfigs', () => ({
   getLeagueConfig: () => ({}),
 }));
@@ -106,6 +115,24 @@ const initialState = {
     backgroundState,
   },
 };
+
+const stateWithSportCardLivePricesEnabled = (enabled: boolean) => ({
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      RemoteFeatureFlagController: {
+        ...backgroundState.RemoteFeatureFlagController,
+        remoteFeatureFlags: {
+          ...backgroundState.RemoteFeatureFlagController?.remoteFeatureFlags,
+          predictSportCardLivePrices: {
+            enabled,
+            minimumVersion: '0.0.0',
+          },
+        },
+      },
+    },
+  },
+});
 
 const createMockOutcome = (
   tokens: PredictOutcomeToken[],
@@ -184,6 +211,7 @@ const createMockSportMarket = (
 describe('FeaturedCarouselSportCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetLivePrice.mockReturnValue(undefined);
   });
 
   it('renders league name and live indicator for ongoing games', () => {
@@ -257,7 +285,9 @@ describe('FeaturedCarouselSportCard', () => {
       { state: initialState },
     );
 
-    expect(getByText(strings('predict.outcome_draw'))).toBeOnTheScreen();
+    expect(
+      getByText(`${strings('predict.outcome_draw')} 20%`),
+    ).toBeOnTheScreen();
   });
 
   it.each(['nba', 'nfl'] as const)(
@@ -412,6 +442,62 @@ describe('FeaturedCarouselSportCard', () => {
       expect.objectContaining({
         outcomeToken: expect.objectContaining({ title: 'Celtics' }),
       }),
+    );
+  });
+
+  it('renders live best ask prices when available', () => {
+    mockGetLivePrice.mockImplementation((tokenId: string) => ({
+      tokenId,
+      price: 0,
+      bestBid: 0,
+      bestAsk:
+        tokenId === 'home-token'
+          ? 0.75
+          : tokenId === 'draw-token'
+            ? 0.18
+            : 0.25,
+    }));
+    const market = createMockSportMarket();
+
+    const { getByText } = renderWithProvider(
+      <FeaturedCarouselSportCard market={market} index={0} />,
+      { state: initialState },
+    );
+
+    expect(getByText('$133.33')).toBeOnTheScreen();
+    expect(getByText('$400.00')).toBeOnTheScreen();
+    expect(getByText('75%')).toBeOnTheScreen();
+    expect(
+      getByText(`${strings('predict.outcome_draw')} 18%`),
+    ).toBeOnTheScreen();
+    expect(getByText('25%')).toBeOnTheScreen();
+  });
+
+  it('renders static prices and disables live subscriptions when the flag is off', () => {
+    mockGetLivePrice.mockImplementation((tokenId: string) => ({
+      tokenId,
+      price: 0,
+      bestBid: 0,
+      bestAsk: 0.99,
+    }));
+    const market = createMockSportMarket();
+
+    const { getByText, queryByText } = renderWithProvider(
+      <FeaturedCarouselSportCard market={market} index={0} />,
+      { state: stateWithSportCardLivePricesEnabled(false) },
+    );
+
+    expect(getByText('$166.67')).toBeOnTheScreen();
+    expect(getByText('$250.00')).toBeOnTheScreen();
+    expect(getByText('60%')).toBeOnTheScreen();
+    expect(
+      getByText(`${strings('predict.outcome_draw')} 20%`),
+    ).toBeOnTheScreen();
+    expect(getByText('40%')).toBeOnTheScreen();
+    expect(queryByText('99%')).not.toBeOnTheScreen();
+    expect(mockUseLiveMarketPrices).toHaveBeenLastCalledWith(
+      ['home-token', 'draw-token', 'away-token'],
+      { enabled: false },
     );
   });
 });

--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -19,6 +20,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import {
   PredictMarket,
   PredictMarketGame,
+  PredictMarketStatus,
   PredictOutcomeToken,
 } from '../../types';
 import {
@@ -30,10 +32,13 @@ import { PredictEventValues } from '../../constants/eventNames';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { usePredictPreviewSheet } from '../../contexts';
 import { useLiveGameUpdates } from '../../hooks/useLiveGameUpdates';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 import { isDrawCapableLeague } from '../../constants/sports';
+import { selectPredictSportCardLivePricesEnabledFlag } from '../../selectors/featureFlags';
 import PredictSportTeamLogo from '../PredictSportTeamLogo/PredictSportTeamLogo';
 import { getLeagueConfig } from '../../constants/sportLeagueConfigs';
 import { parseScore } from '../../utils/gameParser';
+import { isValidPrice } from '../../utils/prices';
 import FeaturedCarouselCardFooter from './FeaturedCarouselCardFooter';
 import FeaturedCarouselPayoutRow from './FeaturedCarouselPayoutRow';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
@@ -62,6 +67,9 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { openBuySheet } = usePredictPreviewSheet();
   const { executeGuardedAction } = usePredictActionGuard({ navigation });
+  const livePricesEnabled = useSelector(
+    selectPredictSportCardLivePricesEnabledFlag,
+  );
 
   const game = market.game as PredictMarketGame;
   const config = getLeagueConfig(game.league);
@@ -117,6 +125,31 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
   const drawToken = showDraw
     ? outcome?.tokens?.find((t) => t.title?.toLowerCase() === 'draw')
     : undefined;
+  const tokenIds = useMemo(
+    () =>
+      [homeToken, drawToken, awayToken]
+        .map((token) => token?.id)
+        .filter((id): id is string => Boolean(id)),
+    [awayToken, drawToken, homeToken],
+  );
+  const { getPrice } = useLiveMarketPrices(tokenIds, {
+    enabled:
+      livePricesEnabled &&
+      market.status === PredictMarketStatus.OPEN &&
+      tokenIds.length > 0,
+  });
+
+  const getDisplayPrice = useCallback(
+    (token: PredictOutcomeToken): number => {
+      if (!livePricesEnabled) {
+        return token.price;
+      }
+
+      const liveBestAsk = getPrice(token.id)?.bestAsk;
+      return isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
+    },
+    [getPrice, livePricesEnabled],
+  );
 
   const handleCardPress = useCallback(() => {
     navigation.navigate(Routes.PREDICT.ROOT, {
@@ -265,7 +298,7 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                 {game.homeTeam.name}
               </Text>
               {homeToken && (
-                <FeaturedCarouselPayoutRow price={homeToken.price} />
+                <FeaturedCarouselPayoutRow price={getDisplayPrice(homeToken)} />
               )}
             </Box>
 
@@ -279,7 +312,7 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                 {game.awayTeam.name}
               </Text>
               {awayToken && (
-                <FeaturedCarouselPayoutRow price={awayToken.price} />
+                <FeaturedCarouselPayoutRow price={getDisplayPrice(awayToken)} />
               )}
             </Box>
           </Box>
@@ -298,7 +331,9 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                     style={tw.style('font-medium')}
                     color={TextColor.SuccessDefault}
                   >
-                    {formatPercentage(Math.round(homeToken.price * 100))}
+                    {formatPercentage(
+                      Math.round(getDisplayPrice(homeToken) * 100),
+                    )}
                   </Text>
                 </Button>
               </Box>
@@ -315,7 +350,10 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                     style={tw.style('font-medium')}
                     color={TextColor.TextDefault}
                   >
-                    {strings('predict.outcome_draw')}
+                    {strings('predict.outcome_draw')}{' '}
+                    {formatPercentage(
+                      Math.round(getDisplayPrice(drawToken) * 100),
+                    )}
                   </Text>
                 </Button>
               </Box>
@@ -333,7 +371,9 @@ const FeaturedCarouselSportCard: React.FC<FeaturedCarouselSportCardProps> = ({
                     style={tw.style('font-medium')}
                     color={TextColor.SuccessDefault}
                   >
-                    {formatPercentage(Math.round(awayToken.price * 100))}
+                    {formatPercentage(
+                      Math.round(getDisplayPrice(awayToken) * 100),
+                    )}
                   </Text>
                 </Button>
               </Box>

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -51,6 +51,13 @@ jest.mock('../../hooks/useLiveGameUpdates', () => ({
   useLiveGameUpdates: () => ({ gameUpdate: mockGameUpdate }),
 }));
 
+const mockGetLivePrice = jest.fn();
+jest.mock('../../hooks/useLiveMarketPrices', () => ({
+  useLiveMarketPrices: jest.fn(() => ({
+    getPrice: mockGetLivePrice,
+  })),
+}));
+
 jest.mock('../../constants/sportLeagueConfigs', () => ({
   getLeagueConfig: () => ({}),
 }));
@@ -130,6 +137,7 @@ describe('PredictMarketSportCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsFromTrending.mockReturnValue(false);
+    mockGetLivePrice.mockReturnValue(undefined);
     mockGameUpdate = null;
   });
 
@@ -156,6 +164,29 @@ describe('PredictMarketSportCard', () => {
     expect(getByText('SPA 60¢')).toBeOnTheScreen();
     expect(getByText('DRAW 15¢')).toBeOnTheScreen();
     expect(getByText('ENG 62¢')).toBeOnTheScreen();
+  });
+
+  it('renders live Moneyline best ask prices when available', () => {
+    mockGetLivePrice.mockImplementation((tokenId: string) => ({
+      tokenId,
+      price: 0,
+      bestBid: 0,
+      bestAsk:
+        tokenId === 'token-home'
+          ? 0.71
+          : tokenId === 'token-draw'
+            ? 0.12
+            : 0.29,
+    }));
+
+    const { getByText } = renderWithProvider(
+      <PredictMarketSportCard market={mockMarket} />,
+      { state: initialState },
+    );
+
+    expect(getByText('SPA 71¢')).toBeOnTheScreen();
+    expect(getByText('DRAW 12¢')).toBeOnTheScreen();
+    expect(getByText('ENG 29¢')).toBeOnTheScreen();
   });
 
   it('uses the main moneyline outcome when extended sports markets are present', () => {

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx
@@ -11,6 +11,7 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import PredictMarketSportCard from './';
 import Routes from '../../../../../constants/navigation/Routes';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -57,6 +58,7 @@ jest.mock('../../hooks/useLiveMarketPrices', () => ({
     getPrice: mockGetLivePrice,
   })),
 }));
+const mockUseLiveMarketPrices = jest.mocked(useLiveMarketPrices);
 
 jest.mock('../../constants/sportLeagueConfigs', () => ({
   getLeagueConfig: () => ({}),
@@ -133,6 +135,24 @@ const initialState = {
   },
 };
 
+const stateWithSportCardLivePricesEnabled = (enabled: boolean) => ({
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      RemoteFeatureFlagController: {
+        ...backgroundState.RemoteFeatureFlagController,
+        remoteFeatureFlags: {
+          ...backgroundState.RemoteFeatureFlagController?.remoteFeatureFlags,
+          predictSportCardLivePrices: {
+            enabled,
+            minimumVersion: '0.0.0',
+          },
+        },
+      },
+    },
+  },
+});
+
 describe('PredictMarketSportCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -187,6 +207,29 @@ describe('PredictMarketSportCard', () => {
     expect(getByText('SPA 71¢')).toBeOnTheScreen();
     expect(getByText('DRAW 12¢')).toBeOnTheScreen();
     expect(getByText('ENG 29¢')).toBeOnTheScreen();
+  });
+
+  it('renders static prices and disables live subscriptions when the flag is off', () => {
+    mockGetLivePrice.mockImplementation((tokenId: string) => ({
+      tokenId,
+      price: 0,
+      bestBid: 0,
+      bestAsk: 0.99,
+    }));
+
+    const { getByText, queryByText } = renderWithProvider(
+      <PredictMarketSportCard market={mockMarket} />,
+      { state: stateWithSportCardLivePricesEnabled(false) },
+    );
+
+    expect(getByText('SPA 60¢')).toBeOnTheScreen();
+    expect(getByText('DRAW 15¢')).toBeOnTheScreen();
+    expect(getByText('ENG 62¢')).toBeOnTheScreen();
+    expect(queryByText('SPA 99¢')).not.toBeOnTheScreen();
+    expect(mockUseLiveMarketPrices).toHaveBeenLastCalledWith(
+      ['token-home', 'token-draw', 'token-away'],
+      { enabled: false },
+    );
   });
 
   it('uses the main moneyline outcome when extended sports markets are present', () => {

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -16,6 +16,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
 import {
@@ -44,6 +45,7 @@ import type { TransactionActiveAbTestEntry } from '../../../../../util/transacti
 import PredictSportScoreboard from '../PredictSportScoreboard';
 import { isGameEnded } from '../../utils/scoreboard';
 import { isValidPrice } from '../../utils/prices';
+import { selectPredictSportCardLivePricesEnabledFlag } from '../../selectors/featureFlags';
 
 interface PredictMarketSportCardProps {
   market: PredictMarketType;
@@ -212,6 +214,9 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { openBuySheet } = usePredictPreviewSheet();
   const { executeGuardedAction } = usePredictActionGuard({ navigation });
+  const livePricesEnabled = useSelector(
+    selectPredictSportCardLivePricesEnabledFlag,
+  );
 
   const game = market.game as PredictMarketGame | undefined;
   const { gameUpdate } = useLiveGameUpdates(game?.id ?? null);
@@ -301,15 +306,19 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
     [buttonItems],
   );
   const { getPrice } = useLiveMarketPrices(tokenIds, {
-    enabled: showBuyButtons,
+    enabled: showBuyButtons && livePricesEnabled,
   });
 
   const getDisplayPrice = useCallback(
     (token: PredictOutcomeToken): number => {
+      if (!livePricesEnabled) {
+        return token.price;
+      }
+
       const liveBestAsk = getPrice(token.id)?.bestAsk;
       return isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
     },
-    [getPrice],
+    [getPrice, livePricesEnabled],
   );
 
   const getButtonTextColorClass = (item: SportOutcomeButtonItem): string => {

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -25,6 +25,7 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { useLiveGameUpdates } from '../../hooks/useLiveGameUpdates';
+import { useLiveMarketPrices } from '../../hooks/useLiveMarketPrices';
 import { usePredictPreviewSheet } from '../../contexts';
 import { useResolvedPredictEntryPoint } from '../../hooks/useResolvedPredictEntryPoint';
 import {
@@ -42,6 +43,7 @@ import {
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import PredictSportScoreboard from '../PredictSportScoreboard';
 import { isGameEnded } from '../../utils/scoreboard';
+import { isValidPrice } from '../../utils/prices';
 
 interface PredictMarketSportCardProps {
   market: PredictMarketType;
@@ -294,6 +296,21 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
     market.status === PredictMarketStatus.OPEN &&
     !gameEnded &&
     buttonItems.length > 0;
+  const tokenIds = useMemo(
+    () => buttonItems.map((item) => item.token.id),
+    [buttonItems],
+  );
+  const { getPrice } = useLiveMarketPrices(tokenIds, {
+    enabled: showBuyButtons,
+  });
+
+  const getDisplayPrice = useCallback(
+    (token: PredictOutcomeToken): number => {
+      const liveBestAsk = getPrice(token.id)?.bestAsk;
+      return isValidPrice(liveBestAsk) ? liveBestAsk : token.price;
+    },
+    [getPrice],
+  );
 
   const getButtonTextColorClass = (item: SportOutcomeButtonItem): string => {
     if (item.teamColor) return 'text-white';
@@ -381,7 +398,8 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
                         getButtonTextColorClass(item),
                       )}
                     >
-                      {item.label.toUpperCase()} {formatCents(item.token.price)}
+                      {item.label.toUpperCase()}{' '}
+                      {formatCents(getDisplayPrice(item.token))}
                     </Text>
                   </Button>
                 </Box>

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -47,6 +47,12 @@ jest.mock('../../hooks/useLiveGameUpdates', () => ({
   useLiveGameUpdates: () => ({ gameUpdate: null }),
 }));
 
+jest.mock('../../hooks/useLiveMarketPrices', () => ({
+  useLiveMarketPrices: jest.fn(() => ({
+    getPrice: jest.fn(() => undefined),
+  })),
+}));
+
 jest.mock('../../constants/sportLeagueConfigs', () => ({
   getLeagueConfig: () => ({}),
 }));

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCardWrapper.test.tsx
@@ -47,9 +47,10 @@ jest.mock('../../hooks/useLiveGameUpdates', () => ({
   useLiveGameUpdates: () => ({ gameUpdate: null }),
 }));
 
+const mockGetLivePrice = jest.fn();
 jest.mock('../../hooks/useLiveMarketPrices', () => ({
   useLiveMarketPrices: jest.fn(() => ({
-    getPrice: jest.fn(() => undefined),
+    getPrice: mockGetLivePrice,
   })),
 }));
 
@@ -127,16 +128,13 @@ const initialState = {
 describe('PredictMarketSportCardWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetLivePrice.mockReturnValue(undefined);
     mockUsePredictMarket.mockReturnValue({
       data: null,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
     } as unknown as ReturnType<typeof usePredictMarket>);
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
   });
 
   describe('loading state', () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -363,6 +363,7 @@ const defaultFeatureFlags: PredictFeatureFlags = {
   predictUpDownEnabled: false,
   predictPortfolioEnabled: false,
   predictHomeRedesignEnabled: false,
+  predictSportCardLivePricesEnabled: true,
   predictWorldCup: DEFAULT_PREDICT_WORLD_CUP_FLAG,
 };
 

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -11,6 +11,7 @@ import {
   selectPredictHomeRedesignEnabledFlag,
   selectPredictHotTabFlag,
   selectPredictPortfolioEnabledFlag,
+  selectPredictSportCardLivePricesEnabledFlag,
   selectPredictUpDownEnabledFlag,
   selectPredictWithAnyTokenEnabledFlag,
   selectPredictWorldCupConfig,
@@ -1779,6 +1780,35 @@ describe('Predict Feature Flag Selectors', () => {
       const result = selectPredictHomeRedesignEnabledFlag(state);
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('selectPredictSportCardLivePricesEnabledFlag', () => {
+    it('defaults to true when the remote flag is missing', () => {
+      expect(
+        selectPredictSportCardLivePricesEnabledFlag(mockedEmptyFlagsState),
+      ).toBe(true);
+    });
+
+    it('returns false when the remote flag is disabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                predictSportCardLivePrices: {
+                  enabled: false,
+                  minimumVersion: '1.0.0',
+                },
+              },
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      expect(selectPredictSportCardLivePricesEnabledFlag(state)).toBe(false);
     });
   });
 

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -182,6 +182,11 @@ export const selectPredictHomeRedesignEnabledFlag = createSelector(
   (flags) => flags.predictHomeRedesignEnabled,
 );
 
+export const selectPredictSportCardLivePricesEnabledFlag = createSelector(
+  selectPredictFeatureFlags,
+  (flags) => flags.predictSportCardLivePricesEnabled,
+);
+
 export const selectPredictFeaturedCarouselEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) =>

--- a/app/components/UI/Predict/types/flags.ts
+++ b/app/components/UI/Predict/types/flags.ts
@@ -58,6 +58,7 @@ export interface PredictFeatureFlags {
   predictWorldCup: PredictWorldCupConfig;
   predictPortfolioEnabled: boolean;
   predictHomeRedesignEnabled: boolean;
+  predictSportCardLivePricesEnabled: boolean;
 }
 
 export interface PredictHotTabFlag extends VersionGatedFeatureFlag {

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts
@@ -35,6 +35,7 @@ describe('resolvePredictFeatureFlags', () => {
       predictUpDownEnabled: false,
       predictPortfolioEnabled: false,
       predictHomeRedesignEnabled: false,
+      predictSportCardLivePricesEnabled: true,
       predictWorldCup: DEFAULT_PREDICT_WORLD_CUP_FLAG,
     });
   });
@@ -215,6 +216,39 @@ describe('resolvePredictFeatureFlags', () => {
 
     expect(result.fakOrdersEnabled).toBe(true);
     expect(result.predictWithAnyTokenEnabled).toBe(false);
+  });
+
+  describe('predictSportCardLivePricesEnabled', () => {
+    it('defaults to true so sport cards fetch live prices by default', () => {
+      const result = resolvePredictFeatureFlags({});
+
+      expect(result.predictSportCardLivePricesEnabled).toBe(true);
+    });
+
+    it('returns false when the remote flag is disabled and version gate passes', () => {
+      mockValidatedVersionGatedFeatureFlag.mockImplementation((flag) => {
+        if (
+          flag &&
+          typeof flag === 'object' &&
+          'enabled' in flag &&
+          'minimumVersion' in flag
+        ) {
+          return (flag as { enabled: boolean }).enabled;
+        }
+        return undefined;
+      });
+
+      const result = resolvePredictFeatureFlags({
+        remoteFeatureFlags: {
+          predictSportCardLivePrices: {
+            enabled: false,
+            minimumVersion: '1.0.0',
+          },
+        },
+      });
+
+      expect(result.predictSportCardLivePricesEnabled).toBe(false);
+    });
   });
 
   describe('predictWorldCup', () => {

--- a/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
+++ b/app/components/UI/Predict/utils/resolvePredictFeatureFlags.ts
@@ -111,6 +111,10 @@ export function resolvePredictFeatureFlags(
   const predictHomeRedesignEnabled = resolveVersionGatedBooleanFlag(
     flags.predictHomeRedesign,
   );
+  const predictSportCardLivePricesEnabled = resolveVersionGatedBooleanFlag(
+    flags.predictSportCardLivePrices,
+    true,
+  );
   const parsedPredictWorldCup = parse(
     unwrapRemoteFeatureFlag<PredictFeatureFlags['predictWorldCup']>(
       flags.predictWorldCup,
@@ -135,6 +139,7 @@ export function resolvePredictFeatureFlags(
     predictUpDownEnabled,
     predictPortfolioEnabled,
     predictHomeRedesignEnabled,
+    predictSportCardLivePricesEnabled,
     predictWorldCup,
   };
 }

--- a/app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.view.test.tsx
@@ -21,7 +21,7 @@ import {
   PredictSearchSelectorsIDs,
 } from '../../Predict.testIds';
 import { PREDICT_HEADER_STACKED_TEST_IDS } from '../../components/PredictHeaderStacked';
-import { MOCK_PREDICT_MARKET } from '../../../../../../tests/component-view/fixtures/predict';
+import { MOCK_PREDICT_LIVE_SPORT_MARKET } from '../../../../../../tests/component-view/fixtures/predict';
 
 const SEARCH_PLACEHOLDER = 'Search prediction markets';
 const PREDICTIONS_TITLE = 'Predictions';
@@ -47,11 +47,15 @@ describe('PredictHome', () => {
     (
       Engine.context.PredictController.getMarkets as jest.Mock
     ).mockResolvedValue({ markets: [], nextCursor: null });
-    // The Live Now section hides itself when there is no data, so it needs at
-    // least one live market to render for the composition/order assertion.
+    // Live Now hides when empty after load and only keeps scoreboard-capable
+    // markets (`game` present). The sport card also needs full team/league data
+    // once the carousel renders loaded cards (see MOCK_PREDICT_LIVE_SPORT_MARKET).
     (
       Engine.context.PredictController.listMarkets as jest.Mock
-    ).mockResolvedValue({ markets: [MOCK_PREDICT_MARKET], nextCursor: null });
+    ).mockResolvedValue({
+      markets: [MOCK_PREDICT_LIVE_SPORT_MARKET],
+      nextCursor: null,
+    });
     (
       Engine.context.PredictController.listFilterOptions as jest.Mock
     ).mockResolvedValue([
@@ -111,26 +115,15 @@ describe('PredictHome', () => {
     });
 
     it('composes the section placeholders in Figma order', async () => {
-      const { findByTestId, getByTestId } = renderPredictHomeView();
+      const { findByTestId } = renderPredictHomeView();
 
-      // Wait for the shell to mount.
+      // Wait for the shell and async sections (Live Now loads via React Query).
       await findByTestId(PredictHomeSelectorsIDs.CONTAINER);
-
-      expect(
-        getByTestId(PredictHomeSelectorsIDs.PORTFOLIO_MODULE),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(PredictHomeSelectorsIDs.LIVE_NOW_SECTION),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(PredictHomeSelectorsIDs.CATEGORIES_SECTION),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(PredictHomeSelectorsIDs.POPULAR_TODAY_SECTION),
-      ).toBeOnTheScreen();
-      expect(
-        getByTestId(PredictHomeSelectorsIDs.TRENDING_SECTION),
-      ).toBeOnTheScreen();
+      await findByTestId(PredictHomeSelectorsIDs.PORTFOLIO_MODULE);
+      await findByTestId(PredictHomeSelectorsIDs.LIVE_NOW_SECTION);
+      await findByTestId(PredictHomeSelectorsIDs.CATEGORIES_SECTION);
+      await findByTestId(PredictHomeSelectorsIDs.POPULAR_TODAY_SECTION);
+      await findByTestId(PredictHomeSelectorsIDs.TRENDING_SECTION);
     });
   });
 

--- a/tests/component-view/fixtures/predict.ts
+++ b/tests/component-view/fixtures/predict.ts
@@ -70,11 +70,11 @@ export const MOCK_PREDICT_LIVE_SPORT_MARKET: PredictMarket = {
   game: {
     id: 'game-live-1',
     startTime: '2026-06-08T21:30:00Z',
-    status: 'live',
+    status: 'ongoing',
     league: 'fifwc',
     elapsed: "45'",
     period: '1H',
-    score: { home: 1, away: 0 },
+    score: { home: 1, away: 0, raw: '0-1' },
     awayTeam: {
       id: 'england',
       name: 'England',

--- a/tests/component-view/fixtures/predict.ts
+++ b/tests/component-view/fixtures/predict.ts
@@ -34,3 +34,62 @@ export const MOCK_PREDICT_MARKET: PredictMarket = {
   liquidity: 500_000,
   volume: 1_000_000,
 };
+
+/** Scoreboard-capable live sports market for Live Now / sport-card view tests. */
+export const MOCK_PREDICT_LIVE_SPORT_MARKET: PredictMarket = {
+  id: 'market-live-sport-1',
+  providerId: 'polymarket',
+  slug: 'spain-vs-england-live',
+  title: 'Spain vs England',
+  description: 'Live World Cup matchup between Spain and England',
+  image: '',
+  status: 'open',
+  recurrence: Recurrence.NONE,
+  category: 'sports',
+  tags: ['World Cup'],
+  outcomes: [
+    {
+      id: 'outcome-game-winner',
+      providerId: 'polymarket',
+      marketId: 'market-live-sport-1',
+      title: 'Game Winner',
+      description: 'Who will win the game',
+      image: '',
+      status: 'open',
+      tokens: [
+        { id: 'token-home', title: 'Spain', price: 0.6 },
+        { id: 'token-draw', title: 'Draw', price: 0.15 },
+        { id: 'token-away', title: 'England', price: 0.62 },
+      ],
+      volume: 1_000_000,
+      groupItemTitle: '',
+    },
+  ],
+  liquidity: 500_000,
+  volume: 1_000_000,
+  game: {
+    id: 'game-live-1',
+    startTime: '2026-06-08T21:30:00Z',
+    status: 'live',
+    league: 'fifwc',
+    elapsed: "45'",
+    period: '1H',
+    score: { home: 1, away: 0 },
+    awayTeam: {
+      id: 'england',
+      name: 'England',
+      logo: 'https://example.com/england.png',
+      abbreviation: 'ENG',
+      color: '#FF0000',
+      alias: 'England',
+    },
+    homeTeam: {
+      id: 'spain',
+      name: 'Spain',
+      logo: 'https://example.com/spain.png',
+      abbreviation: 'SPA',
+      color: '#FF8800',
+      alias: 'Spain',
+    },
+  },
+};

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -356,7 +356,11 @@ jest.mock('../../app/core/Engine', () => {
         getCryptoTargetPrice: jest.fn().mockResolvedValue(69000),
         subscribeToMarketPrices: jest.fn(() => () => undefined),
         subscribeToCryptoPrices: jest.fn(() => () => undefined),
-        getConnectionStatus: jest.fn(() => ({ marketConnected: false })),
+        subscribeToGameUpdates: jest.fn(() => () => undefined),
+        getConnectionStatus: jest.fn(() => ({
+          marketConnected: false,
+          sportsConnected: false,
+        })),
         trackFeedViewed: jest.fn(),
         trackTabChanged: jest.fn(),
         trackBannerAction: jest.fn(),

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5406,6 +5406,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  predictSportCardLivePrices: {
+    name: 'predictSportCardLivePrices',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      minimumVersion: '7.81.0',
+      enabled: true,
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   smartTransactionsAllowedRpcHosts: {
     name: 'smartTransactionsAllowedRpcHosts',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
## **Description**

This PR updates Predict sport game market cards so Moneyline odds can update from live WebSocket market prices.

The main sport market card now subscribes to live prices for the visible Moneyline tokens and displays live `bestAsk` values when available, falling back to static token prices when live data is missing or disabled. The featured carousel sport card uses the same live-price fallback for payout rows and buy button odds.

The live sport-card price behavior is controlled by a default-on remote feature flag, `predictSportCardLivePrices`, so the WebSocket subscriptions can be disabled remotely while preserving the existing static price display. Diagnostic console logs were also added around live market price subscribe/unsubscribe events to make subscription behavior visible during validation.

## **Changelog**

CHANGELOG entry: Updated Predict sport game market cards to show live Moneyline prices.

## **Related issues**

Fixes: PRED-958 / PRED-1028

## **Manual testing steps**

```gherkin
Feature: Predict sport game card live prices

  Scenario: sport game cards show live Moneyline odds
    Given Predict sport game markets are visible on the feed or featured carousel
    And the predictSportCardLivePrices remote feature flag is enabled or missing

    When live market price WebSocket updates are received for the visible Moneyline tokens
    Then the sport game card odds update from the live best ask price
    And the card falls back to the static token price when live prices are unavailable

  Scenario: live sport card prices are disabled remotely
    Given the predictSportCardLivePrices remote feature flag is disabled

    When Predict sport game cards render
    Then the cards do not enable live market price subscriptions
    And the cards continue showing static token prices
```

Focused automated tests run:

```bash
npx jest --runTestsByPath app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts --coverage=false
npx jest --runTestsByPath app/components/UI/Predict/selectors/featureFlags/index.test.ts --coverage=false
npx jest --runTestsByPath app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.test.tsx --coverage=false
npx jest --runTestsByPath app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarouselSportCard.test.tsx --coverage=false
```

## **Screenshots/Recordings**

N/A - this change updates live odds data plumbing and feature flag behavior. Visual output is covered by component tests for the rendered odds text.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] N/A - targeted Predict card price display and feature flag gating change; Android-specific performance validation was not required.
- [x] N/A - no expected impact on power-user account/token scenarios.
- [x] N/A - no new production performance trace was needed for this UI price-display change.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
## **Description**

Extended sports game-details tabs (moneyline, spreads, totals, and future market types) were not grouping or pricing outcomes reliably compared to Polymarket.

This PR:

1. **Adds `enabledSportsMarketTypes`** to the `predictExtendedSportsMarkets` remote flag so outcome grouping respects an allowlist of supported market types (defaults to moneyline, spreads, and totals when the field is omitted on an enabled flag).
2. **Fixes spread line ordering** to match Polymarket’s ascending/descending display based on the first spread’s displayed sign.
3. **Polls REST ask prices** (`entry.sell`) for non-moneyline grouped outcomes while keeping moneyline on live WebSocket best-ask prices; polling pauses while the buy sheet is open.
4. **Refactors game-details outcome UI** into `outcomeGrouping.ts`, `PredictGameOutcomeCards.tsx`, `usePricedOutcomeGroup.ts`, and `utils.ts`, with unit tests colocated by module.

**Why:** PRED-957 — corners, team totals, and first-half team totals (and related extended markets) were not showing up or behaving correctly in game details.

**How:** Filter groupable outcomes at parse time, sort line markets consistently, price cards through the correct source per market type, and slim `PredictGameOutcomesTab` to routing + composition only.

## **Changelog**

CHANGELOG entry: Fixed extended sports game-details outcome tabs to group enabled market types correctly, order spread lines like Polymarket, and show current buy prices for non-moneyline markets.

## **Related issues**

Fixes: PRED-957

## **Manual testing steps**

```gherkin
Feature: Extended sports game details outcomes

  Scenario: User views grouped game lines with live prices
    Given extended sports markets are enabled for the game league
    And enabledSportsMarketTypes includes moneyline, spreads, and totals
    When the user opens a live or upcoming game details screen
    And selects the Game Lines chip
    Then moneyline, spreads, and totals subgroups render
    And spread lines appear in the same order as on Polymarket
    And non-moneyline buy button prices reflect REST ask prices
    And moneyline buy button prices reflect live WebSocket best ask

  Scenario: Price polling pauses while buy sheet is open
    Given the user is on a game details spreads or totals card
    When the user opens the buy preview sheet
    Then REST price polling stops until the sheet is dismissed

  Scenario: Enabled market types flag limits grouped tabs
    Given enabledSportsMarketTypes is set to ["moneyline"] only
    When the user opens game details for an extended-league game
    Then only moneyline appears in outcome groups
    And the full outcomes list remains available on the market object
```

**Automated tests run locally:**

```bash
npx jest --runTestsByPath \
  app/components/UI/Predict/components/PredictGameDetailsContent/utils.test.ts \
  app/components/UI/Predict/components/PredictGameDetailsContent/usePricedOutcomeGroup.test.tsx \
  app/components/UI/Predict/components/PredictGameDetailsContent/PredictGameOutcomesTab.test.tsx \
  app/components/UI/Predict/providers/polymarket/outcomeGrouping.test.ts \
  app/components/UI/Predict/providers/polymarket/utils.test.ts \
  app/components/UI/Predict/utils/resolvePredictFeatureFlags.test.ts \
  --coverage=false
```

## **Screenshots/Recordings**

N/A — manual QA pending on device/simulator. Will attach before/after recordings of game-details Game Lines (spreads order + buy prices) before marking Ready for review.

### **Before**

<!-- Add recording: spread lines out of order / stale buy prices -->

### **After**

<!-- Add recording: spread lines match Polymarket / REST prices on spreads & totals -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
