### PR TITLE
perf: wrap TrendingTokenRowItem in React.memo to avoid list re-renders

### DIFF
--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.test.tsx
@@ -1815,4 +1815,15 @@ describe('TrendingTokenRowItem', () => {
       expect(queryByText('Malicious')).toBeNull();
     });
   });
+
+  describe('memoization', () => {
+    it('is wrapped in React.memo to avoid re-renders in hot lists', () => {
+      // React.memo components expose the `react.memo` symbol on `$$typeof`.
+      // This guards against accidentally dropping the memo wrapper, which
+      // would re-render every row on each parent (price feed) update.
+      expect(
+        (TrendingTokenRowItem as unknown as { $$typeof?: symbol }).$$typeof,
+      ).toBe(Symbol.for('react.memo'));
+    });
+  });
 });

--- a/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
+++ b/app/components/UI/Trending/components/TrendingTokenRowItem/TrendingTokenRowItem.tsx
@@ -264,4 +264,6 @@ const TrendingTokenRowItem = ({
   );
 };
 
-export default TrendingTokenRowItem;
+TrendingTokenRowItem.displayName = 'TrendingTokenRowItem';
+
+export default React.memo(TrendingTokenRowItem);


### PR DESCRIPTION
## **Description**

`TrendingTokenRowItem` is the row component for several growable, live-updating token lists but was exported without `React.memo`:

- It is the direct `renderItem` target in the virtualized `TrendingTokensList` FlashList (`app/components/UI/Trending/components/TrendingTokensList/TrendingTokensList.tsx`).
- It is rendered via `.map()` in the wallet Homepage tokens section (`app/components/Views/Homepage/Sections/Tokens/TokensSection.tsx`).

Because these lists are backed by trending-token feeds with live-updating prices/percent-change, the parent list re-renders frequently and FlashList recycles rows on scroll. Without `React.memo`, every `TrendingTokenRowItem` re-rendered on each parent render even when its `token` prop was unchanged — re-running a `useSelector(selectCurrentCurrency)`, three `useMemo` computations and price formatting on every render.

**Change:** wrap the default export in `React.memo` (`export default React.memo(TrendingTokenRowItem)`) and set an explicit `displayName` so debugging/tests remain readable. This is a minimal, behavior-preserving performance change — no UI/design impact. Caller `onPress`/`onCardPress` stabilization is left as a noted follow-up (out of scope here).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31324

## **Manual testing steps**

```gherkin
Feature: TrendingTokenRowItem memoization

  Scenario: Rows do not re-render on unrelated feed updates
    Given a render counter or why-did-you-render is attached to TrendingTokenRowItem
    When the user opens the Explore Crypto tab and scrolls the trending list
    And off-screen content / price feed updates arrive
    Then rows whose token prop is unchanged do not re-render

  Scenario: Existing behavior is unchanged
    Given the existing TrendingTokenRowItem.test.tsx suite
    When the test suite is run
    Then all tests pass, confirming rendering, navigation and analytics are unchanged
```

## **Screenshots/Recordings**

N/A — internal performance change, no UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)