### PR TITLE
perf: cache Top Traders leaderboard avatars with expo-image

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react-native';
 import React from 'react';
-import { Image } from 'react-native';
+import { Image } from 'expo-image';
 import { AvatarAccount } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { KNOWN_DEFAULT_AVATAR_URLS } from '../utils/avatarFallback';
@@ -24,6 +24,23 @@ describe('TraderAvatar', () => {
     expect(screen.getByTestId('trader-avatar')).toBeOnTheScreen();
     expect(screen.UNSAFE_queryByType(Image)).not.toBeNull();
     expect(screen.UNSAFE_queryByType(AvatarAccount)).toBeNull();
+  });
+
+  it('renders the avatar with expo-image disk caching so recycled FlatList cells reuse cached images', () => {
+    renderWithProvider(
+      <TraderAvatar
+        imageUrl={REAL_AVATAR_URL}
+        address={ADDRESS}
+        size={40}
+        recyclingKey="trader-1"
+        testID="trader-avatar"
+      />,
+    );
+
+    const image = screen.UNSAFE_getByType(Image);
+    expect(image.props.cachePolicy).toBe('memory-disk');
+    expect(image.props.recyclingKey).toBe('trader-1');
+    expect(image.props.contentFit).toBe('cover');
   });
 
   it('renders the Maskicon fallback when no image url is provided', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderAvatar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image } from 'react-native';
+import { Image } from 'expo-image';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   AvatarAccount,
@@ -27,6 +27,12 @@ export interface TraderAvatarProps {
   address?: string;
   /** Avatar diameter in pixels. */
   size: number;
+  /**
+   * Stable identity for the rendered cell. When set, expo-image reuses the
+   * decoded/cached image across FlatList cell recycling instead of re-fetching
+   * it. Pass the list item's key (e.g. `trader.id`) on recycled surfaces.
+   */
+  recyclingKey?: string;
   testID?: string;
 }
 
@@ -42,6 +48,7 @@ const TraderAvatar: React.FC<TraderAvatarProps> = ({
   imageUrl,
   address,
   size,
+  recyclingKey,
   testID,
 }) => {
   const tw = useTailwind();
@@ -50,8 +57,13 @@ const TraderAvatar: React.FC<TraderAvatarProps> = ({
     return (
       <Image
         source={{ uri: imageUrl }}
-        style={tw.style(`w-[${size}px] h-[${size}px] rounded-full bg-muted`)}
-        resizeMode="cover"
+        style={[
+          { width: size, height: size, borderRadius: size / 2 },
+          tw.style('bg-muted'),
+        ]}
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        recyclingKey={recyclingKey}
         testID={testID}
       />
     );

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
 import { StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
 import type { ReactTestInstance } from 'react-test-renderer';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import type { TopTrader } from '../types';
@@ -42,6 +43,16 @@ describe('TraderRow', () => {
       <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
     );
     expect(screen.getByTestId('trader-row-trader-1')).toBeOnTheScreen();
+  });
+
+  it('caches the avatar with expo-image and a per-row recyclingKey so fast FlatList scrolling does not re-fetch avatars on cell reuse', () => {
+    renderWithProvider(
+      <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+    );
+
+    const image = screen.UNSAFE_getByType(Image);
+    expect(image.props.cachePolicy).toBe('memory-disk');
+    expect(image.props.recyclingKey).toBe(baseTrader.id);
   });
 
   it('renders Maskicon fallback when avatarUri is absent', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -93,6 +93,7 @@ const TraderRow: React.FC<TraderRowProps> = ({
               imageUrl={trader.avatarUri}
               address={trader.address}
               size={AVATAR_SIZE}
+              recyclingKey={trader.id}
             />
           </TopRankAvatar>
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react-native';
 import React from 'react';
-import { Image } from 'react-native';
+import { Image } from 'expo-image';
 import { AvatarAccount } from '@metamask/design-system-react-native';
 import type { Trade } from '@metamask/social-controllers';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionHeader.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react-native';
 import React from 'react';
-import { Image } from 'react-native';
+import { Image } from 'expo-image';
 import { AvatarAccount } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import TraderPositionHeader from './TraderPositionHeader';


### PR DESCRIPTION
## **Description**

The Top Traders leaderboard (`TopTradersView`) renders each row via `TraderRow`, whose avatar is drawn by the shared `TraderAvatar` component using React Native `<Image source={{ uri }}>` (imported from `react-native`). RN `Image` has **no persistent disk cache**, so as the `FlatList` recycles cells during fast scrolling, each avatar is re-fetched over the network and re-decoded on every cell reuse — causing visible blank-then-pop avatars, redundant network requests, and scroll jank on a long, image-per-row list.

**What changed**

- Switched `TraderAvatar`'s real-image branch from `react-native` `Image` to **`expo-image`** `Image` with `cachePolicy="memory-disk"` (persistent disk + memory cache across sessions) and `contentFit="cover"` (replacing `resizeMode`).
- Added an optional `recyclingKey` prop to `TraderAvatar` and pass `recyclingKey={trader.id}` from `TraderRow` — matching the `FlatList` `keyExtractor` so `expo-image` reuses the cached/decoded image across cell recycling.
- Replaced the per-render template-string Tailwind width/height (`w-[${size}px] h-[${size}px]`, which allocates a fresh class string every render) with a numeric `style={{ width, height, borderRadius }}`, while keeping `tw` for the `bg-muted` background to preserve the rounded-full + muted look.

`expo-image` is the standard fix already used by `TrendingTokenLogo`. Visual output is unchanged. `TraderAvatar` is shared with the homepage `TopTraderCard` (issue #31304); that card naturally benefits from disk caching too, but **no changes were made to `TopTraderCard.tsx`** and `recyclingKey` is only supplied by the recycled leaderboard `FlatList`.

> Note: the issue references `TraderRow.tsx:94` with an inline `<Image>`, but the avatar has since been refactored into the shared `TraderAvatar` component. The fix is applied there (the actual `Image` owner) and `recyclingKey` is threaded through `TraderRow`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31305
Fixes: #31304 (same shared `TraderAvatar` component — the homepage carousel `TopTraderCard` delegates its avatar to it, so this change caches those avatars too)

## **Manual testing steps**

```gherkin
Feature: Top Traders leaderboard avatar caching

  Scenario: Avatars are fetched once and reused while scrolling
    Given I open the Top Traders leaderboard (TopTradersView)
    And the network inspector is recording requests
    When I scroll the leaderboard quickly up and down so FlatList recycles cells
    Then each trader avatar URL is requested only once
    And avatars do not blank-then-pop as rows are recycled

  Scenario: Avatars render instantly from cache on a second visit
    Given I have previously viewed the Top Traders leaderboard
    When I leave and re-open the leaderboard
    Then avatars render immediately from the disk cache without a network round-trip
```

## **Screenshots/Recordings**

N/A — no visual change intended; avatars render identically (same size, rounded-full shape, muted background, cover fit). This is an internal performance/caching change only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)
