### PR TITLE
perf: memoize TopTradersView FlatList renderItem with useCallback

### DIFF
--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, screen } from '@testing-library/react-native';
 import React from 'react';
+import { FlatList } from 'react-native';
 import Logger from '../../../../util/Logger';
 import Routes from '../../../../constants/navigation/Routes';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
@@ -23,9 +24,18 @@ const mockHasNotificationPreferences = jest.fn(() => true);
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
+  // Real React Navigation returns a stable `navigation` reference across
+  // renders. Mirror that here (lazily, to respect const TDZ at mock-init time)
+  // so hooks depending on `navigation` stay referentially stable.
+  let navigation: { goBack: jest.Mock; navigate: jest.Mock } | undefined;
   return {
     ...actual,
-    useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+    useNavigation: () => {
+      if (!navigation) {
+        navigation = { goBack: mockGoBack, navigate: mockNavigate };
+      }
+      return navigation;
+    },
     useRoute: () => ({ params: {} }),
   };
 });
@@ -405,6 +415,45 @@ describe('TopTradersView', () => {
       screen.queryByTestId(TopTradersViewSelectorsIDs.CHAIN_FILTER_ALL),
     ).toBeOnTheScreen();
     expect(screen.queryByText('alpha.eth')).not.toBeOnTheScreen();
+  });
+
+  describe('performance', () => {
+    it('keeps a stable renderItem reference across a parent re-render with unchanged trader props', async () => {
+      // An inline `renderItem` closure would be re-created on every render,
+      // defeating the `React.memo` on `TraderRow`. The memoized `renderTraderRow`
+      // must keep a stable identity when nothing it depends on changes.
+      //
+      // Pull-to-refresh sets `refreshing` to true, forcing a parent re-render
+      // while the trader data (and every renderItem dependency) stays unchanged.
+      // Fake timers hold the view in that refreshing state so the re-render's
+      // renderItem can be compared against the initial one.
+      jest.useFakeTimers();
+      mockRefresh.mockResolvedValue(undefined);
+      const { UNSAFE_getByType } = renderWithProvider(<TopTradersView />);
+
+      const renderItemBefore = UNSAFE_getByType(FlatList).props.renderItem;
+
+      let refreshPromise: Promise<void> | undefined;
+      act(() => {
+        refreshPromise = screen
+          .getByTestId(TopTradersViewSelectorsIDs.TRADER_LIST)
+          .props.refreshControl.props.onRefresh();
+      });
+
+      const renderItemDuringRefresh =
+        UNSAFE_getByType(FlatList).props.renderItem;
+
+      expect(typeof renderItemBefore).toBe('function');
+      expect(renderItemDuringRefresh).toBe(renderItemBefore);
+
+      // Drain the artificial min-duration timer and let refresh settle so no
+      // state update leaks outside `act`.
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+        await refreshPromise;
+      });
+      jest.useRealTimers();
+    });
   });
 
   describe('analytics', () => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -65,6 +65,8 @@ import { TRADER_ROW_HEIGHT } from '../../Homepage/Sections/TopTraders/components
 import { useTopTraders } from '../../Homepage/Sections/TopTraders/hooks';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { SPOT_CHAINS } from '../../Homepage/Sections/TopTraders/constants';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import type { TopTrader } from '../../Homepage/Sections/TopTraders/types';
 import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
 
 type ChainFilter = 'all' | 'base' | 'solana' | 'ethereum' | 'hyperliquid';
@@ -346,6 +348,17 @@ const TopTradersView = () => {
     [navigation, traders, selectedChain, track],
   );
 
+  const renderTraderRow = useCallback(
+    ({ item }: { item: TopTrader }) => (
+      <TraderRow
+        trader={item}
+        onFollowPress={handleFollowPress}
+        onTraderPress={handleTraderPress}
+      />
+    ),
+    [handleFollowPress, handleTraderPress],
+  );
+
   return (
     <SafeAreaView
       style={tw.style('flex-1 bg-default')}
@@ -421,13 +434,7 @@ const TopTradersView = () => {
         <FlatList
           data={traders}
           keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <TraderRow
-              trader={item}
-              onFollowPress={handleFollowPress}
-              onTraderPress={handleTraderPress}
-            />
-          )}
+          renderItem={renderTraderRow}
           showsVerticalScrollIndicator={false}
           contentContainerStyle={tw.style('pb-6')}
           testID={TopTradersViewSelectorsIDs.TRADER_LIST}


### PR DESCRIPTION
## **Description**

The leaderboard `FlatList` in `TopTradersView` defined `renderItem` as an inline arrow function (`renderItem={({ item }) => <TraderRow ... />}`), which was re-created on every render of `TopTradersView`. Because the function identity changed each render, `FlatList` could not rely on a stable `renderItem` reference, and `TraderRow` — although wrapped in `React.memo` — was forced to re-render its visible rows on every parent re-render (e.g. `refreshing` toggles, chain-filter changes). The list holds up to 50 traders, each rendering an avatar, PnL text, and a follow button, so this wasted work on every refresh/filter toggle was real.

**What changed / why**
- Extracted the inline `renderItem` into a `useCallback`-memoized `renderTraderRow` (deps: `handleFollowPress`, `handleTraderPress`, both already `useCallback`-stable) and passed it to the `FlatList`. The param is typed as `{ item: TopTrader }`. This keeps the `renderItem` identity stable across parent re-renders that don't change its dependencies, so memoized `TraderRow`s no longer re-render when their props are unchanged.
- Behavior is preserved; this is a performance-only change.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #31317

## **Manual testing steps**

```gherkin
Feature: Top Traders leaderboard list performance

  Scenario: Pull-to-refresh does not re-render unchanged rows
    Given the user is on the Top Traders leaderboard with rows visible
    When the user pulls to refresh
    Then the visible TraderRow components are not re-rendered while their props are unchanged
    And the leaderboard data and ordering are unchanged

  Scenario: Switching chain filters keeps the list correct
    Given the user is on the Top Traders leaderboard
    When the user taps a different chain filter pill
    Then the list updates to that chain's traders without visual regressions
```

Profiling note: profile a pull-to-refresh / chain-filter toggle with the React DevTools profiler and confirm visible `TraderRow`s no longer re-render when their props are unchanged.

## **Screenshots/Recordings**

N/A — internal performance change, no UI/design impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Made with [Cursor](https://cursor.com)