### PR TITLE
fix(card): use push animation from Money Home except CardWelcome upsell

### DIFF
--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -2264,8 +2264,40 @@ describe('MoneyHomeView', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
         screen: Routes.CARD.HOME,
         params: { postAuthRedirect: MONEY_HOME_CARD_ORIGIN },
-        animation: 'slide_from_bottom',
       });
+    });
+
+    it('navigates to Card root with push animation when Card button is pressed in manage mode', () => {
+      mockSelectIsCardholder.mockReturnValue(true);
+      mockUseMoneyAccountCardLinkage.mockReturnValue({
+        hasMoneyAccountRequirements: false,
+        hasMoneyAccountBaseRequirements: false,
+        isCardAuthenticated: false,
+        isCardLinkedToMoneyAccount: true,
+        primaryMoneyAccount: undefined,
+        moneyAccountCardToken: null,
+        canLink: false,
+        status: 'idle',
+        isLinking: false,
+        error: null,
+        startLinkFlow: mockStartLinkFlow,
+        openLinkCardSheet: mockOpenLinkCardSheet,
+        reset: jest.fn(),
+      } as unknown as ReturnType<typeof useMoneyAccountCardLinkage>);
+
+      const { getByTestId } = renderWithProvider(<MoneyHomeView />);
+      jest.clearAllMocks();
+
+      fireEvent.press(getByTestId(MoneyActionButtonRowTestIds.CARD_BUTTON));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT, {
+        screen: Routes.CARD.HOME,
+        params: { postAuthRedirect: MONEY_HOME_CARD_ORIGIN },
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.CARD.ROOT,
+        expect.objectContaining({ animation: 'slide_from_bottom' }),
+      );
     });
   });
 

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -171,6 +171,16 @@ const MoneyHomeView = () => {
     isResidencyBlocked,
   } = useMoneyAccountCardLinkage();
 
+  const metamaskCardMode = deriveMoneyMetaMaskCardMode({
+    isCardLinkedToMoneyAccount,
+    isCardholder,
+    isCardAuthenticated,
+    isCardVerified,
+    isResidencyBlocked,
+    hasMoneyAccountBaseRequirements,
+    hasMoneyAccountRequirements,
+  });
+
   let displayState: MoneyBalanceDisplayState;
   if (!hasMoneyAccount) {
     displayState = { kind: 'noAccount' };
@@ -315,12 +325,14 @@ const MoneyHomeView = () => {
   }, [navigation, trackButtonClicked]);
 
   const navigateToCardHome = useCallback(() => {
+    const isUpsell = metamaskCardMode === 'upsell';
+
     navigation.navigate(Routes.CARD.ROOT, {
       screen: Routes.CARD.HOME,
       params: { postAuthRedirect: MONEY_HOME_CARD_ORIGIN },
-      animation: 'slide_from_bottom',
+      ...(isUpsell ? { animation: 'slide_from_bottom' } : {}),
     });
-  }, [navigation]);
+  }, [navigation, metamaskCardMode]);
 
   const handleCardHeaderPress = useCallback(() => {
     trackSurfaceClicked({
@@ -580,16 +592,6 @@ const MoneyHomeView = () => {
     },
     [navigation, trackActivitySurfaceClicked],
   );
-
-  const metamaskCardMode = deriveMoneyMetaMaskCardMode({
-    isCardLinkedToMoneyAccount,
-    isCardholder,
-    isCardAuthenticated,
-    isCardVerified,
-    isResidencyBlocked,
-    hasMoneyAccountBaseRequirements,
-    hasMoneyAccountRequirements,
-  });
 
   const { primaryToken: cardPrimaryToken } = useCardHomeData();
   const cardBalance = cardPrimaryToken?.balanceFiat ?? formattedZero;


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On Money Home, every Card-related entry point was navigating to `Routes.CARD.ROOT` with `animation: 'slide_from_bottom'`, so Card Home opened with a bottom-to-top modal transition even for cardholders and linked users. That animation should be reserved for the CardWelcome educational screen shown to brand-new users in upsell mode.

This change hoists the existing `metamaskCardMode` derivation and reuses it in `navigateToCardHome`: only when `metamaskCardMode === 'upsell'` do we pass `animation: 'slide_from_bottom'`. All other modes (`manage`, `link`, `verifying`) omit the animation param and fall back to the MainNavigator default (`slide_from_right`). Unit tests cover manage-mode navigation and guard against regressions to the modal animation.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Card navigation from Money Home to use a push animation except when opening the CardWelcome educational screen

## **Related issues**

Fixes: CARD-450

## **Manual testing steps**

```gherkin
Feature: Card navigation animation from Money Home

  Background:
    Given I am logged into MetaMask Mobile
    And I am on the Money Home screen

  Scenario: brand-new user opens Card from upsell Get now
    Given I am not a cardholder
    And the MetaMask Card section is in upsell mode

    When user taps "Get now" on the MetaMask Card section
    Then the CardWelcome screen should slide in from the bottom

  Scenario: linked cardholder opens Card from Manage
    Given I am a cardholder with my card linked to my Money account
    And the MetaMask Card section is in manage mode

    When user taps "Manage" on the MetaMask Card section
    Then Card Home should push in from the right

  Scenario: cardholder opens Card from the action row
    Given I am a cardholder with my card linked to my Money account

    When user taps the Card button in the Money Home action row
    Then Card Home should push in from the right
    And the screen should not slide in from the bottom
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — animation change; screen recordings recommended to compare bottom-to-top vs right-to-left transitions.

### **After**

N/A — screen recordings recommended showing upsell (bottom-to-top) vs manage/action-row (right-to-left) flows.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
