### PR TITLE
fix(confirmations): remove gas fee token feature flag

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -23,8 +23,8 @@ export function useTransactionPayAvailableTokens() {
 
   // For post-quote transactions, tokens are always available
   // (the supported destination tokens from the bridge API).
-  // Disabled tokens (e.g. required tokens with no gas) are excluded
-  // so the UI can correctly fall back to fiat payment or BuySection.
+  // Disabled tokens are excluded so the UI can correctly fall back to fiat
+  // payment or BuySection when every token is blocked.
   const hasTokens = isPostQuote || availableTokens.some((t) => !t.disabled);
 
   return { availableTokens, hasTokens };

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -27,23 +27,11 @@ import {
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
-import { store } from '../../../../store';
-import {
-  selectGasFeeTokenFlags,
+import type {
   BlockedTokensListConfig,
   BlockedTokensConfig,
 } from '../../../../selectors/featureFlagController/confirmations';
 import { strings } from '../../../../../locales/i18n';
-
-jest.mock('../../../../store', () => ({
-  store: {
-    getState: jest.fn(),
-  },
-}));
-
-jest.mock('../../../../selectors/featureFlagController/confirmations', () => ({
-  selectGasFeeTokenFlags: jest.fn(),
-}));
 
 jest.mock('../../../../util/transaction-controller', () => ({
   updateAtomicBatchData: jest.fn(),
@@ -81,12 +69,8 @@ const ERC20_TOKEN_MOCK = {
 } as AssetType;
 
 describe('Transaction Pay Utils', () => {
-  const selectGasFeeTokenFlagsMock = jest.mocked(selectGasFeeTokenFlags);
-
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(store.getState).mockReturnValue({} as never);
-    selectGasFeeTokenFlagsMock.mockReturnValue({ gasFeeTokens: {} });
   });
 
   describe('getRequiredBalance', () => {
@@ -335,7 +319,7 @@ describe('Transaction Pay Utils', () => {
     });
 
     describe('disabled', () => {
-      it('marks token as disabled when no native balance and no gas station support', () => {
+      it('keeps token enabled when native balance is zero', () => {
         const result = getAvailableTokens({
           tokens: [
             ERC20_TOKEN_MOCK,
@@ -344,10 +328,8 @@ describe('Transaction Pay Utils', () => {
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].disabled).toBe(true);
-        expect(result[0].disabledMessage).toBe(
-          strings('pay_with_modal.no_gas'),
-        );
+        expect(result[0].disabled).toBe(false);
+        expect(result[0].disabledMessage).toBeUndefined();
       });
 
       it('marks token as enabled when native balance exists', () => {
@@ -360,43 +342,14 @@ describe('Transaction Pay Utils', () => {
         expect(result[0].disabledMessage).toBeUndefined();
       });
 
-      it('marks token as enabled when no native balance but gas station supports token', () => {
-        selectGasFeeTokenFlagsMock.mockReturnValue({
-          gasFeeTokens: {
-            [CHAIN_ID_MOCK]: {
-              name: 'Ethereum',
-              tokens: [
-                {
-                  name: 'Test Token',
-                  address: ERC20_TOKEN_MOCK.address as Hex,
-                },
-              ],
-            },
-          },
-        });
-
-        const result = getAvailableTokens({
-          tokens: [
-            ERC20_TOKEN_MOCK,
-            { ...TOKEN_MOCK, balance: '0' } as AssetType,
-          ],
-        });
-
-        expect(result).toHaveLength(1);
-        expect(result[0].disabled).toBe(false);
-        expect(result[0].disabledMessage).toBeUndefined();
-      });
-
-      it('marks token as disabled when native token is not found in tokens list', () => {
+      it('keeps token enabled when native token is not found in tokens list', () => {
         const result = getAvailableTokens({
           tokens: [ERC20_TOKEN_MOCK],
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].disabled).toBe(true);
-        expect(result[0].disabledMessage).toBe(
-          strings('pay_with_modal.no_gas'),
-        );
+        expect(result[0].disabled).toBe(false);
+        expect(result[0].disabledMessage).toBeUndefined();
       });
     });
 
@@ -516,7 +469,7 @@ describe('Transaction Pay Utils', () => {
         expect(result[1].disabled).toBe(false);
       });
 
-      it('keeps no-gas disabled message when token is disabled for no gas but not blocked', () => {
+      it('keeps token enabled when token is not blocked and native balance is zero', () => {
         const blockedTokens: BlockedTokensListConfig = {
           chainIds: [],
           tokens: [],
@@ -531,10 +484,8 @@ describe('Transaction Pay Utils', () => {
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].disabled).toBe(true);
-        expect(result[0].disabledMessage).toBe(
-          strings('pay_with_modal.no_gas'),
-        );
+        expect(result[0].disabled).toBe(false);
+        expect(result[0].disabledMessage).toBeUndefined();
       });
     });
   });

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -16,27 +16,20 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { BigNumber } from 'bignumber.js';
 import { isTestNet } from '../../../../util/networks';
-import { store } from '../../../../store';
-import {
-  selectGasFeeTokenFlags,
+import type {
   BlockedTokensListConfig,
   BlockedTokensConfig,
 } from '../../../../selectors/featureFlagController/confirmations';
 import { strings } from '../../../../../locales/i18n';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import Logger from '../../../../util/Logger';
 import { updateAtomicBatchData } from '../../../../util/transaction-controller';
 import { MUSD_TOKEN_ADDRESS } from '../../../UI/Earn/constants/musd';
 
+const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+
 interface ResolvedPayTokenRequest {
   address: Hex;
   chainId: Hex;
-}
-
-const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
-
-function toAddressWord(address: string): string {
-  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
 }
 
 /**
@@ -102,6 +95,10 @@ export function getRequiredBalance(
   }
 
   return undefined;
+}
+
+function toAddressWord(address: string): string {
+  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
 }
 
 export function getTokenTransferData(
@@ -172,7 +169,6 @@ export function getAvailableTokens({
   fiatPayment?: TransactionFiatPayment;
 }): AssetType[] {
   const hasFiatPayment = Boolean(fiatPayment?.selectedPaymentMethodId);
-  const supportedGasFeeTokens = getSupportedGasFeeTokens();
 
   return tokens
     .filter((token) => {
@@ -206,31 +202,13 @@ export function getAvailableTokens({
       return new BigNumber(token.balance).gt(0);
     })
     .map((token) => {
-      const chainId = (token.chainId as Hex) ?? '0x0';
-
-      const nativeToken = tokens.find(
-        (t) =>
-          t.chainId === chainId && t.address === getNativeTokenAddress(chainId),
-      );
-
-      const noNativeBalance =
-        !nativeToken || new BigNumber(nativeToken.balance).isZero();
-
-      const isGasStationSupported = supportedGasFeeTokens[chainId]?.includes(
-        token.address?.toLowerCase() as Hex,
-      );
-
-      const noGasDisabled = noNativeBalance && !isGasStationSupported;
-
       const blocked = isTokenBlocked(token, blockedTokens);
 
-      const disabled = noGasDisabled || blocked;
+      const disabled = blocked;
 
       const disabledMessage = blocked
         ? strings('pay_with_modal.not_supported')
-        : noGasDisabled
-          ? strings('pay_with_modal.no_gas')
-          : undefined;
+        : undefined;
 
       const isSelected = hasFiatPayment
         ? false
@@ -283,21 +261,6 @@ export function isTokenBlocked(
     (blocked) =>
       blocked.address.toLowerCase() === token.address.toLowerCase() &&
       blocked.chainId.toLowerCase() === token.chainId?.toLowerCase(),
-  );
-}
-
-function getSupportedGasFeeTokens(): Record<Hex, Hex[]> {
-  const state = store.getState();
-  const { gasFeeTokens } = selectGasFeeTokenFlags(state);
-
-  return Object.keys(gasFeeTokens).reduce(
-    (acc, chainId) => ({
-      ...acc,
-      [chainId]: gasFeeTokens[chainId as Hex].tokens.map(
-        (token) => token.address.toLowerCase() as Hex,
-      ),
-    }),
-    {},
   );
 }
 

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -97,10 +97,6 @@ export function getRequiredBalance(
   return undefined;
 }
 
-function toAddressWord(address: string): string {
-  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
-}
-
 export function getTokenTransferData(
   transactionMeta: TransactionMeta | undefined,
 ):
@@ -136,6 +132,10 @@ export function getTokenTransferData(
   }
 
   return undefined;
+}
+
+function toAddressWord(address: string): string {
+  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
 }
 
 export function getTokenAddress(

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -16,7 +16,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { BigNumber } from 'bignumber.js';
 import { isTestNet } from '../../../../util/networks';
-import type {
+import {
   BlockedTokensListConfig,
   BlockedTokensConfig,
 } from '../../../../selectors/featureFlagController/confirmations';
@@ -25,11 +25,15 @@ import Logger from '../../../../util/Logger';
 import { updateAtomicBatchData } from '../../../../util/transaction-controller';
 import { MUSD_TOKEN_ADDRESS } from '../../../UI/Earn/constants/musd';
 
-const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
-
 interface ResolvedPayTokenRequest {
   address: Hex;
   chainId: Hex;
+}
+
+const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+
+function toAddressWord(address: string): string {
+  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
 }
 
 /**
@@ -132,10 +136,6 @@ export function getTokenTransferData(
   }
 
   return undefined;
-}
-
-function toAddressWord(address: string): string {
-  return address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
 }
 
 export function getTokenAddress(

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -9,8 +9,6 @@ import {
   BUFFER_SUBSEQUENT_DEFAULT,
   STX_DISABLED_DEFAULT,
   selectNonZeroUnusedApprovalsAllowList,
-  selectGasFeeTokenFlags,
-  GasFeeTokenFlags,
   selectPayQuoteConfig,
   selectMetaMaskPayFiatFlags,
   PAY_FIAT_ENABLED_TRANSACTION_TYPES,
@@ -26,7 +24,6 @@ import {
 } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
-import { Hex } from '@metamask/utils';
 import { RootState } from '../../../reducers';
 
 jest.mock('../../../core/Engine', () => ({
@@ -209,84 +206,6 @@ describe('Non-Zero Unused Approvals Allow List', () => {
       undefinedFeatureFlagState,
     );
     expect(result).toEqual([]);
-  });
-});
-
-describe('Gas Fee Token Flags', () => {
-  const chainIdMock = '0x1' as Hex;
-
-  const mockedGasFeeTokenFlags: GasFeeTokenFlags = {
-    gasFeeTokens: {
-      [chainIdMock]: {
-        name: 'Ethereum',
-        tokens: [
-          {
-            name: 'USDC',
-            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Hex,
-          },
-          {
-            name: 'DAI',
-            address: '0x6b175474e89094c44da98b954eedeac495271d0f' as Hex,
-          },
-        ],
-      },
-      '0x89': {
-        name: 'Polygon',
-        tokens: [{ name: 'USDC.e', address: '0xusdce' as Hex }],
-      },
-    },
-  };
-
-  const mockedStateWithGasFeeTokenFlags = {
-    engine: {
-      backgroundState: {
-        RemoteFeatureFlagController: {
-          remoteFeatureFlags: {
-            confirmations_gas_fee_tokens: mockedGasFeeTokenFlags,
-          },
-          cacheTimestamp: 0,
-        },
-      },
-    },
-  };
-
-  it('returns empty gasFeeTokens when empty feature flag state', () => {
-    const result = selectGasFeeTokenFlags(mockedEmptyFlagsState);
-
-    expect(result).toEqual({ gasFeeTokens: {} });
-  });
-
-  it('returns empty gasFeeTokens when undefined RemoteFeatureFlagController state', () => {
-    const result = selectGasFeeTokenFlags(mockedUndefinedFlagsState);
-
-    expect(result).toEqual({ gasFeeTokens: {} });
-  });
-
-  it('returns gas fee tokens from feature flag', () => {
-    const result = selectGasFeeTokenFlags(
-      mockedStateWithGasFeeTokenFlags as never,
-    );
-
-    expect(result).toEqual(mockedGasFeeTokenFlags);
-  });
-
-  it('returns empty gasFeeTokens when confirmations_gas_fee_tokens exists but gasFeeTokens is undefined', () => {
-    const stateWithUndefinedGasFeeTokens = {
-      engine: {
-        backgroundState: {
-          RemoteFeatureFlagController: {
-            remoteFeatureFlags: {
-              confirmations_gas_fee_tokens: {},
-            },
-            cacheTimestamp: 0,
-          },
-        },
-      },
-    };
-
-    const result = selectGasFeeTokenFlags(stateWithUndefinedGasFeeTokens);
-
-    expect(result).toEqual({ gasFeeTokens: {} });
   });
 });
 

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -82,18 +82,6 @@ export interface PayPostQuoteFlags {
   overrides?: Record<string, PayPostQuoteConfig>;
 }
 
-export interface GasFeeTokenFlags {
-  gasFeeTokens: {
-    [chainId: Hex]: {
-      name: string;
-      tokens: {
-        name: string;
-        address: Hex;
-      }[];
-    };
-  };
-}
-
 export interface MetaMaskPayFiatFlags {
   enabledTransactionTypes: TransactionType[];
   maxDelayMinutesForPaymentMethods: number;
@@ -264,25 +252,6 @@ export const selectNonZeroUnusedApprovalsAllowList = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags: ReturnType<typeof selectRemoteFeatureFlags>) =>
     remoteFeatureFlags?.nonZeroUnusedApprovals ?? [],
-);
-
-export const selectGasFeeTokenFlags = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags): GasFeeTokenFlags => {
-    const gasFeeTokenFlags =
-      remoteFeatureFlags?.confirmations_gas_fee_tokens as
-        | Record<string, Json>
-        | undefined;
-
-    const gasFeeTokens =
-      (gasFeeTokenFlags?.gasFeeTokens as
-        | GasFeeTokenFlags['gasFeeTokens']
-        | undefined) ?? {};
-
-    return {
-      gasFeeTokens,
-    };
-  },
 );
 
 export const selectMetaMaskPayFiatFlags = createSelector(


### PR DESCRIPTION
## **Description**

MetaMask Pay's picker previously disabled otherwise eligible ERC-20 payment tokens when the account had no native gas balance and the token was not listed in the gas-fee-token feature flag. That made token availability depend on the gas-fee-token allowlist even when the token itself was a valid Pay candidate.

This PR removes that native-gas gate from Pay token availability. The picker still excludes unsupported token classes and still disables blocklisted tokens, but it now shows eligible payment tokens regardless of native gas balance. Because the picker was the only consumer of the gas-fee-token selector, this also removes `selectGasFeeTokenFlags` and its selector tests.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pay payment-token eligibility UX and removes a remote feature-flag path; users may see tokens that were previously hidden for "no gas," with downstream Pay/gas handling still responsible at execution time.
> 
> **Overview**
> **MetaMask Pay** no longer disables ERC-20 payment tokens when the wallet has no native gas or when the token is absent from the gas-fee-token remote flag. In `getAvailableTokens`, **disabled** state now comes only from the Pay blocklist (`not_supported`), not from a native-balance + gas-station allowlist check or the `no_gas` message.
> 
> Because the Pay picker was the only caller, this PR **removes** `selectGasFeeTokenFlags`, the `GasFeeTokenFlags` type, `getSupportedGasFeeTokens`, and related store/feature-flag wiring. Unit tests are updated to expect eligible tokens to stay enabled with zero native balance and when the native token is missing from the token list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0ef9be1c3341601feb2ee68c2be803e75d9f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->