### PR TITLE
fix(rewards): navigation predict the pitch cp-7.82.0

### DIFF
--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -30,6 +30,7 @@ import PredictThePitchCampaignDetailsView from './Views/PredictThePitchCampaignD
 import PredictThePitchCampaignWinningView from './Views/PredictThePitchCampaignWinningView';
 import PredictThePitchCampaignLeaderboardView from './Views/PredictThePitchCampaignLeaderboardView';
 import PredictThePitchCampaignPortfolioView from './Views/PredictThePitchCampaignPortfolioView';
+import PredictThePitchCampaignStatsView from './Views/PredictThePitchCampaignStatsView';
 import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { selectIsRewardsVersionBlocked } from '../../../reducers/rewards/selectors';
@@ -275,6 +276,11 @@ const RewardsNavigator: React.FC = () => {
       <Stack.Screen
         name={Routes.REWARDS_PREDICT_THE_PITCH_CAMPAIGN_LEADERBOARD}
         component={PredictThePitchCampaignLeaderboardView}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={Routes.REWARDS_PREDICT_THE_PITCH_CAMPAIGN_STATS}
+        component={PredictThePitchCampaignStatsView}
         options={{ headerShown: false }}
       />
       <Stack.Screen

--- a/app/components/UI/Rewards/Views/PredictThePitchCampaignStatsView.test.tsx
+++ b/app/components/UI/Rewards/Views/PredictThePitchCampaignStatsView.test.tsx
@@ -285,6 +285,95 @@ describe('PredictThePitchCampaignStatsView', () => {
         PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_VOLUME,
       ),
     ).toBeDefined();
+    expect(
+      getByTestId(
+        PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_MARKETS_TRADED,
+      ),
+    ).toBeDefined();
+  });
+
+  it('shows x/y markets when below minimum', () => {
+    mockUseGetPosition.mockReturnValue({
+      position: {
+        ...basePosition,
+        marketsTraded: 2,
+        minimumMarketsTraded: 3,
+      },
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+      refetch: jest.fn(),
+    });
+
+    const { getByTestId } = render(<PredictThePitchCampaignStatsView />);
+
+    expect(
+      getByTestId(
+        PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_MARKETS_TRADED,
+      ).props.children,
+    ).toBe('2/3');
+  });
+
+  it('shows count only when markets traded meets minimum', () => {
+    mockUseGetPosition.mockReturnValue({
+      position: {
+        ...basePosition,
+        marketsTraded: 5,
+        minimumMarketsTraded: 3,
+      },
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+      refetch: jest.fn(),
+    });
+
+    const { getByTestId } = render(<PredictThePitchCampaignStatsView />);
+
+    expect(
+      getByTestId(
+        PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_MARKETS_TRADED,
+      ).props.children,
+    ).toBe('5');
+  });
+
+  it('hides the markets traded cell when marketsTraded is null', () => {
+    mockUseGetPosition.mockReturnValue({
+      position: {
+        ...basePosition,
+        marketsTraded: null,
+        minimumMarketsTraded: 3,
+      } as unknown as PredictThePitchLeaderboardPositionDto,
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+      refetch: jest.fn(),
+    });
+
+    const { queryByTestId } = render(<PredictThePitchCampaignStatsView />);
+
+    expect(
+      queryByTestId(
+        PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_MARKETS_TRADED,
+      ),
+    ).toBeNull();
+  });
+
+  it('hides the markets traded cell when position is null', () => {
+    mockUseGetPosition.mockReturnValue({
+      position: null,
+      isLoading: false,
+      hasError: false,
+      hasFetched: true,
+      refetch: jest.fn(),
+    });
+
+    const { queryByTestId } = render(<PredictThePitchCampaignStatsView />);
+
+    expect(
+      queryByTestId(
+        PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_MARKETS_TRADED,
+      ),
+    ).toBeNull();
   });
 
   it('shows fallback performance values when position numeric fields are invalid', () => {

--- a/app/components/UI/Rewards/Views/PredictThePitchCampaignStatsView.tsx
+++ b/app/components/UI/Rewards/Views/PredictThePitchCampaignStatsView.tsx
@@ -42,6 +42,8 @@ export const PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS = {
   PERFORMANCE_PNL: 'predict-the-pitch-campaign-stats-view-performance-pnl',
   PERFORMANCE_VOLUME:
     'predict-the-pitch-campaign-stats-view-performance-volume',
+  PERFORMANCE_MARKETS_TRADED:
+    'predict-the-pitch-campaign-stats-view-performance-markets-traded',
   QUALIFIED_CARD: 'predict-the-pitch-campaign-stats-view-qualified-card',
   QUALIFY_FOR_RANK_CARD:
     'predict-the-pitch-campaign-stats-view-qualify-for-rank-card',
@@ -97,6 +99,16 @@ const PredictThePitchCampaignStatsView: React.FC = () => {
   const roiDisplay = roi != null ? formatPercentChange(roi) : '-';
   const pnlDisplay = pnl != null ? formatSignedUsd(pnl) : '-';
   const volumeDisplay = volume != null ? formatUsd(volume) : '-';
+
+  const marketsTraded = position?.marketsTraded ?? null;
+  const minimumMarketsTraded = position?.minimumMarketsTraded ?? null;
+  const showMarketsTraded =
+    marketsTraded != null && minimumMarketsTraded != null;
+  const marketsDisplay = showMarketsTraded
+    ? marketsTraded < minimumMarketsTraded
+      ? `${marketsTraded}/${minimumMarketsTraded}`
+      : String(marketsTraded)
+    : '';
 
   const isPending = position != null && !position.eligible;
   const isEligible = position != null && position.eligible;
@@ -185,7 +197,20 @@ const PredictThePitchCampaignStatsView: React.FC = () => {
                   PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_VOLUME
                 }
               />
-              <Box twClassName="flex-1" />
+              {showMarketsTraded ? (
+                <StatCell
+                  label={strings(
+                    'rewards.predict_the_pitch_campaign.label_markets_traded',
+                  )}
+                  value={marketsDisplay}
+                  isLoading={showSkeleton}
+                  testID={
+                    PREDICT_THE_PITCH_CAMPAIGN_STATS_VIEW_TEST_IDS.PERFORMANCE_MARKETS_TRADED
+                  }
+                />
+              ) : (
+                <Box twClassName="flex-1" />
+              )}
             </Box>
 
             {showQualifiedCard && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes Predict the Pitch campaign stats navigation and aligns the stats page with the campaign details summary.

1. **Navigation fix:** Register `RewardsPredictThePitchCampaignStats` in `RewardsNavigator` so tapping through from campaign details no longer throws an unhandled `NAVIGATE` action.
2. **Stats page parity:** Add a **Markets traded** cell to `PredictThePitchCampaignStatsView` on the same row as **Total volume**, using the same display rules as `PredictThePitchStatsSummary` (`x/y` below minimum, count only when met).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not be labeled with `no-changelog`,
write a short User-Facing description in the past tense.
-->

CHANGELOG entry: Fixed Predict the Pitch campaign stats navigation and added markets traded to the stats performance section.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Predict the Pitch campaign stats navigation error

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict the Pitch campaign stats

  Scenario: user opens campaign stats from details
    Given the user is opted into an active Predict the Pitch campaign
    And the user is on the campaign details screen

    When the user navigates to campaign stats
    Then the stats screen opens without a navigation error
    And performance shows ROI, PnL, total volume, and markets traded on one row

  Scenario: markets traded display below minimum
    Given the user's leaderboard position has marketsTraded below minimumMarketsTraded

    When the user views campaign stats
    Then markets traded is shown as "x/y"

  Scenario: markets traded display at or above minimum
    Given the user's leaderboard position meets the minimum markets traded requirement

    When the user views campaign stats
    Then markets traded shows the count only
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Navigation to stats failed with: `The action 'NAVIGATE' with payload {"name":"RewardsPredictThePitchCampaignStats",...} was not handled by any navigator.`

### **After**
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-06-17 at 17 04 08" src="https://github.com/user-attachments/assets/41f6cdc0-bf34-4dda-97ce-b5440f33c24b" />

Stats screen loads successfully and shows markets traded beside total volume.

N/A — screenshots not attached in this update.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.