### PR TITLE
feat: show batch sell 7702 specific tx details

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.test.tsx
@@ -117,6 +117,12 @@ describe('BatchSell7702TransactionAssets', () => {
     expect(getByText('+8.00000 USDC')).toBeOnTheScreen();
   });
 
+  it('renders the number of source tokens swapped', () => {
+    const { getByText } = renderComponent(createBatchSellHistoryItems());
+
+    expect(getByText('2 tokens')).toBeOnTheScreen();
+  });
+
   it('renders a circular token avatar for each source and destination token', () => {
     const { getByTestId } = renderComponent(createBatchSellHistoryItems());
 

--- a/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { FeatureId, StatusTypes } from '@metamask/bridge-controller';
+import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+import { BatchSell7702TransactionAssets } from './BatchSell7702TransactionAssets';
+
+const mockTransactionTokenIcon = jest.fn(
+  ({
+    token,
+    showNetworkBadge,
+  }: {
+    token: { symbol: string };
+    showNetworkBadge?: boolean;
+  }) => (
+    <Text
+      testID={`token-icon-${token.symbol}-${showNetworkBadge ? 'badge' : 'no-badge'}`}
+    >
+      {token.symbol}
+    </Text>
+  ),
+);
+
+jest.mock('./TransactionAsset', () => ({
+  TransactionTokenIcon: (props: {
+    token: { symbol: string };
+    showNetworkBadge?: boolean;
+  }) => mockTransactionTokenIcon(props),
+}));
+
+function createBatchSellHistoryItems(): BridgeHistoryItem[] {
+  const batchId = '0xbatch123';
+
+  return [
+    {
+      txMetaId: 'batch-sell-tx-id',
+      account: '0x1234567890123456789012345678901234567890',
+      featureId: FeatureId.BATCH_SELL,
+      batchId,
+      quote: {
+        requestId: 'batch-request-id',
+        srcChainId: 42161,
+        destChainId: 42161,
+        srcAsset: {
+          chainId: 42161,
+          address: '0xf97f4df75117a78c1a5a0dbb814af92458539fb4',
+          decimals: 18,
+          symbol: 'LINK',
+          name: 'Chainlink',
+        },
+        destAsset: {
+          chainId: 42161,
+          address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          decimals: 6,
+          symbol: 'USDC',
+          name: 'USDC',
+        },
+        srcTokenAmount: '1000000000000000000',
+        destTokenAmount: '5000000',
+      },
+      status: {
+        status: StatusTypes.COMPLETE,
+        srcChain: {
+          txHash: '0xbatchsellhash',
+        },
+        destChain: {
+          txHash: '0xdest',
+        },
+      },
+      startTime: Date.now(),
+      estimatedProcessingTimeInSeconds: 0,
+    },
+    {
+      txMetaId: 'batch-sell-item-2',
+      account: '0x1234567890123456789012345678901234567890',
+      featureId: FeatureId.BATCH_SELL,
+      batchId,
+      quote: {
+        requestId: 'batch-request-id-2',
+        srcChainId: 42161,
+        destChainId: 42161,
+        srcAsset: {
+          chainId: 42161,
+          address: '0xddb46999f8891663a8f2828d25298f70416d7610',
+          decimals: 18,
+          symbol: 'ARB',
+          name: 'Arbitrum',
+        },
+        destAsset: {
+          chainId: 42161,
+          address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+          decimals: 6,
+          symbol: 'USDC',
+          name: 'USDC',
+        },
+        srcTokenAmount: '1000000000000000000',
+        destTokenAmount: '3000000',
+      },
+      status: {
+        status: StatusTypes.COMPLETE,
+        srcChain: {
+          txHash: '0xotherhash',
+        },
+        destChain: {
+          txHash: '0xdest2',
+        },
+      },
+      startTime: Date.now(),
+      estimatedProcessingTimeInSeconds: 0,
+    },
+  ] as BridgeHistoryItem[];
+}
+
+describe('BatchSell7702TransactionAssets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when batch sell history items are empty', () => {
+    const { queryByText } = render(
+      <BatchSell7702TransactionAssets batchSellHistoryItems={[]} />,
+    );
+
+    expect(queryByText('You swapped')).not.toBeOnTheScreen();
+    expect(queryByText('You received')).not.toBeOnTheScreen();
+  });
+
+  it('renders swapped and received section headers', () => {
+    const { getByText } = render(
+      <BatchSell7702TransactionAssets
+        batchSellHistoryItems={createBatchSellHistoryItems()}
+      />,
+    );
+
+    expect(getByText('You swapped')).toBeOnTheScreen();
+    expect(getByText('You received')).toBeOnTheScreen();
+  });
+
+  it('renders the summed destination amount with a plus prefix', () => {
+    const { getByText } = render(
+      <BatchSell7702TransactionAssets
+        batchSellHistoryItems={createBatchSellHistoryItems()}
+      />,
+    );
+
+    expect(getByText('+8.00000 USDC')).toBeOnTheScreen();
+  });
+
+  it('renders a source token icon for each batch sell history item', () => {
+    const { getByTestId } = render(
+      <BatchSell7702TransactionAssets
+        batchSellHistoryItems={createBatchSellHistoryItems()}
+      />,
+    );
+
+    expect(getByTestId('token-icon-LINK-no-badge')).toBeOnTheScreen();
+    expect(getByTestId('token-icon-ARB-no-badge')).toBeOnTheScreen();
+  });
+
+  it('renders the destination token icon without a network badge', () => {
+    render(
+      <BatchSell7702TransactionAssets
+        batchSellHistoryItems={createBatchSellHistoryItems()}
+      />,
+    );
+
+    expect(mockTransactionTokenIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({ symbol: 'USDC' }),
+        showNetworkBadge: false,
+      }),
+    );
+  });
+
+  it('does not show network badges on source token icons', () => {
+    render(
+      <BatchSell7702TransactionAssets
+        batchSellHistoryItems={createBatchSellHistoryItems()}
+      />,
+    );
+
+    expect(mockTransactionTokenIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({ symbol: 'LINK' }),
+        showNetworkBadge: false,
+      }),
+    );
+    expect(mockTransactionTokenIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({ symbol: 'ARB' }),
+        showNetworkBadge: false,
+      }),
+    );
+    expect(
+      mockTransactionTokenIcon.mock.calls.every(
+        ([props]) => props.showNetworkBadge === false,
+      ),
+    ).toBe(true);
+  });
+});

--- a/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.test.tsx
@@ -1,32 +1,9 @@
 import React from 'react';
-import { Text } from 'react-native';
-import { render } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { FeatureId, StatusTypes } from '@metamask/bridge-controller';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { BatchSell7702TransactionAssets } from './BatchSell7702TransactionAssets';
-
-const mockTransactionTokenIcon = jest.fn(
-  ({
-    token,
-    showNetworkBadge,
-  }: {
-    token: { symbol: string };
-    showNetworkBadge?: boolean;
-  }) => (
-    <Text
-      testID={`token-icon-${token.symbol}-${showNetworkBadge ? 'badge' : 'no-badge'}`}
-    >
-      {token.symbol}
-    </Text>
-  ),
-);
-
-jest.mock('./TransactionAsset', () => ({
-  TransactionTokenIcon: (props: {
-    token: { symbol: string };
-    showNetworkBadge?: boolean;
-  }) => mockTransactionTokenIcon(props),
-}));
+import { initialState } from '../../_mocks_/initialState';
 
 function createBatchSellHistoryItems(): BridgeHistoryItem[] {
   const batchId = '0xbatch123';
@@ -112,89 +89,39 @@ function createBatchSellHistoryItems(): BridgeHistoryItem[] {
 }
 
 describe('BatchSell7702TransactionAssets', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  const renderComponent = (batchSellHistoryItems: BridgeHistoryItem[]) =>
+    renderWithProvider(
+      <BatchSell7702TransactionAssets
+        batchSellHistoryItems={batchSellHistoryItems}
+      />,
+      { state: initialState },
+    );
 
   it('renders nothing when batch sell history items are empty', () => {
-    const { queryByText } = render(
-      <BatchSell7702TransactionAssets batchSellHistoryItems={[]} />,
-    );
+    const { queryByText } = renderComponent([]);
 
     expect(queryByText('You swapped')).not.toBeOnTheScreen();
     expect(queryByText('You received')).not.toBeOnTheScreen();
   });
 
   it('renders swapped and received section headers', () => {
-    const { getByText } = render(
-      <BatchSell7702TransactionAssets
-        batchSellHistoryItems={createBatchSellHistoryItems()}
-      />,
-    );
+    const { getByText } = renderComponent(createBatchSellHistoryItems());
 
     expect(getByText('You swapped')).toBeOnTheScreen();
     expect(getByText('You received')).toBeOnTheScreen();
   });
 
   it('renders the summed destination amount with a plus prefix', () => {
-    const { getByText } = render(
-      <BatchSell7702TransactionAssets
-        batchSellHistoryItems={createBatchSellHistoryItems()}
-      />,
-    );
+    const { getByText } = renderComponent(createBatchSellHistoryItems());
 
     expect(getByText('+8.00000 USDC')).toBeOnTheScreen();
   });
 
-  it('renders a source token icon for each batch sell history item', () => {
-    const { getByTestId } = render(
-      <BatchSell7702TransactionAssets
-        batchSellHistoryItems={createBatchSellHistoryItems()}
-      />,
-    );
+  it('renders a circular token avatar for each source and destination token', () => {
+    const { getByTestId } = renderComponent(createBatchSellHistoryItems());
 
-    expect(getByTestId('token-icon-LINK-no-badge')).toBeOnTheScreen();
-    expect(getByTestId('token-icon-ARB-no-badge')).toBeOnTheScreen();
-  });
-
-  it('renders the destination token icon without a network badge', () => {
-    render(
-      <BatchSell7702TransactionAssets
-        batchSellHistoryItems={createBatchSellHistoryItems()}
-      />,
-    );
-
-    expect(mockTransactionTokenIcon).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining({ symbol: 'USDC' }),
-        showNetworkBadge: false,
-      }),
-    );
-  });
-
-  it('does not show network badges on source token icons', () => {
-    render(
-      <BatchSell7702TransactionAssets
-        batchSellHistoryItems={createBatchSellHistoryItems()}
-      />,
-    );
-
-    expect(mockTransactionTokenIcon).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining({ symbol: 'LINK' }),
-        showNetworkBadge: false,
-      }),
-    );
-    expect(mockTransactionTokenIcon).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: expect.objectContaining({ symbol: 'ARB' }),
-        showNetworkBadge: false,
-      }),
-    );
-    expect(
-      mockTransactionTokenIcon.mock.calls.every(
-        ([props]) => props.showNetworkBadge === false,
-      ),
-    ).toBe(true);
+    expect(getByTestId('token-logo-LINK')).toBeOnTheScreen();
+    expect(getByTestId('token-logo-ARB')).toBeOnTheScreen();
+    expect(getByTestId('token-logo-USDC')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.tsx
@@ -31,6 +31,11 @@ const styles = StyleSheet.create({
   sourceIconsRow: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  swappedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
     paddingVertical: 4,
   },
   stackedSourceIcon: {
@@ -124,23 +129,34 @@ export function BatchSell7702TransactionAssets({
       <Box
         flexDirection={FlexDirection.Row}
         alignItems={AlignItems.center}
-        style={styles.sourceIconsRow}
+        style={styles.swappedRow}
       >
-        {sourceTokens.map(({ token, chainId }, index) => (
-          <Box
-            key={`${token.address}-${index}`}
-            style={[
-              index === 0 ? undefined : styles.stackedSourceIcon,
-              { zIndex: index },
-            ]}
-          >
-            <TransactionTokenIcon
-              token={token}
-              chainId={chainId}
-              showNetworkBadge={false}
-            />
-          </Box>
-        ))}
+        <Box
+          flexDirection={FlexDirection.Row}
+          alignItems={AlignItems.center}
+          style={styles.sourceIconsRow}
+        >
+          {sourceTokens.map(({ token, chainId }, index) => (
+            <Box
+              key={`${token.address}-${index}`}
+              style={[
+                index === 0 ? undefined : styles.stackedSourceIcon,
+                { zIndex: index },
+              ]}
+            >
+              <TransactionTokenIcon
+                token={token}
+                chainId={chainId}
+                showNetworkBadge={false}
+              />
+            </Box>
+          ))}
+        </Box>
+        <Text variant={TextVariant.BodyLGMedium}>
+          {strings('bridge.batch_sell_token_count', {
+            tokenCount: sourceTokens.length,
+          })}
+        </Text>
       </Box>
       <Text
         variant={TextVariant.BodyMDMedium}

--- a/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/BatchSell7702TransactionAssets.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+import {
+  formatChainIdToCaip,
+  formatChainIdToHex,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import { AlignItems, FlexDirection } from '../../../Box/box.types';
+import { Box } from '../../../Box/Box';
+import { Hex, CaipChainId } from '@metamask/utils';
+import { calcTokenAmount } from '../../../../../util/transactions';
+import { strings } from '../../../../../../locales/i18n';
+import { BridgeToken } from '../../types';
+import { TransactionTokenIcon } from './TransactionAsset';
+
+const SOURCE_TOKEN_ICON_OVERLAP = 12;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 8,
+    gap: 8,
+  },
+  sectionHeader: {
+    paddingVertical: 4,
+  },
+  sourceIconsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  stackedSourceIcon: {
+    marginLeft: -SOURCE_TOKEN_ICON_OVERLAP,
+  },
+  receivedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 4,
+  },
+});
+
+function getSourceTokenFromHistoryItem(historyItem: BridgeHistoryItem): {
+  token: BridgeToken;
+  chainId: Hex | CaipChainId;
+} {
+  const { quote } = historyItem;
+  const chainId = isNonEvmChainId(quote.srcChainId)
+    ? formatChainIdToCaip(quote.srcChainId)
+    : formatChainIdToHex(quote.srcChainId);
+
+  return {
+    chainId: chainId as Hex | CaipChainId,
+    token: {
+      address: quote.srcAsset.address,
+      symbol: quote.srcAsset.symbol,
+      decimals: quote.srcAsset.decimals,
+      name: quote.srcAsset.name,
+      image: quote.srcAsset.iconUrl || '',
+      chainId,
+    },
+  };
+}
+
+function getDestinationTokenFromHistoryItem(historyItem: BridgeHistoryItem): {
+  token: BridgeToken;
+  chainId: Hex | CaipChainId;
+} {
+  const { quote } = historyItem;
+  const chainId = isNonEvmChainId(quote.destChainId)
+    ? formatChainIdToCaip(quote.destChainId)
+    : formatChainIdToHex(quote.destChainId);
+
+  return {
+    chainId: chainId as Hex | CaipChainId,
+    token: {
+      address: quote.destAsset.address,
+      symbol: quote.destAsset.symbol,
+      decimals: quote.destAsset.decimals,
+      name: quote.destAsset.name,
+      image: quote.destAsset.iconUrl || '',
+      chainId,
+    },
+  };
+}
+
+interface BatchSell7702TransactionAssetsProps {
+  batchSellHistoryItems: BridgeHistoryItem[];
+}
+
+export function BatchSell7702TransactionAssets({
+  batchSellHistoryItems,
+}: BatchSell7702TransactionAssetsProps) {
+  if (!batchSellHistoryItems.length) {
+    return null;
+  }
+
+  const sourceTokens = batchSellHistoryItems.map(getSourceTokenFromHistoryItem);
+  const { token: destinationToken, chainId: destinationChainId } =
+    getDestinationTokenFromHistoryItem(batchSellHistoryItems[0]);
+
+  const totalDestTokenAmount = calcTokenAmount(
+    batchSellHistoryItems.reduce(
+      (acc, item) =>
+        (BigInt(acc) + BigInt(item.quote.destTokenAmount)).toString(),
+      '0',
+    ),
+    batchSellHistoryItems[0].quote.destAsset.decimals,
+  ).toFixed(5);
+
+  return (
+    <Box style={styles.container}>
+      <Text
+        variant={TextVariant.BodyMDMedium}
+        color={TextColor.Alternative}
+        style={styles.sectionHeader}
+      >
+        {strings('bridge_transaction_details.you_swapped')}
+      </Text>
+      <Box
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        style={styles.sourceIconsRow}
+      >
+        {sourceTokens.map(({ token, chainId }, index) => (
+          <Box
+            key={`${token.address}-${index}`}
+            style={[
+              index === 0 ? undefined : styles.stackedSourceIcon,
+              { zIndex: index },
+            ]}
+          >
+            <TransactionTokenIcon
+              token={token}
+              chainId={chainId}
+              showNetworkBadge={false}
+            />
+          </Box>
+        ))}
+      </Box>
+      <Text
+        variant={TextVariant.BodyMDMedium}
+        color={TextColor.Alternative}
+        style={styles.sectionHeader}
+      >
+        {strings('bridge_transaction_details.you_received')}
+      </Text>
+      <Box
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        style={styles.receivedRow}
+      >
+        <TransactionTokenIcon
+          token={destinationToken}
+          chainId={destinationChainId}
+          showNetworkBadge={false}
+        />
+        <Text variant={TextVariant.BodyLGMedium} color={TextColor.Success}>
+          +{totalDestTokenAmount} {destinationToken.symbol}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
@@ -57,6 +57,57 @@ interface TransactionAssetProps {
   txType: TransactionType;
 }
 
+export function TransactionTokenIcon({
+  token,
+  chainId,
+  showNetworkBadge = true,
+}: {
+  token: BridgeToken;
+  chainId: Hex | CaipChainId;
+  showNetworkBadge?: boolean;
+}) {
+  const networkName =
+    NETWORK_TO_SHORT_NETWORK_NAME_MAP[chainId as AllowedBridgeChainIds];
+  const networkImageSource = getNetworkImageSource({ chainId });
+  const isNative = isNativeAddress(token.address);
+
+  const tokenIcon = isNative ? (
+    <TokenIcon
+      symbol={token.symbol}
+      icon={token.image}
+      style={styles.tokenIcon}
+      big={false}
+      biggest={false}
+      testID={`network-logo-${token.symbol}`}
+    />
+  ) : (
+    <AvatarToken
+      name={token.symbol}
+      imageSource={token.image ? { uri: token.image } : undefined}
+      size={AvatarSize.Md}
+    />
+  );
+
+  if (!showNetworkBadge) {
+    return tokenIcon;
+  }
+
+  return (
+    <BadgeWrapper
+      badgePosition={BadgePosition.BottomRight}
+      badgeElement={
+        <Badge
+          variant={BadgeVariant.Network}
+          name={networkName}
+          imageSource={networkImageSource}
+        />
+      }
+    >
+      {tokenIcon}
+    </BadgeWrapper>
+  );
+}
+
 const TransactionAsset = ({
   token,
   tokenAmount,
@@ -65,11 +116,6 @@ const TransactionAsset = ({
 }: TransactionAssetProps) => {
   const networkName =
     NETWORK_TO_SHORT_NETWORK_NAME_MAP[chainId as AllowedBridgeChainIds];
-  const networkImageSource = getNetworkImageSource({ chainId });
-
-  // Solana native SOL will also be the zero address for quote data from Bridge API only!
-  // Other formats might look like solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
-  const isNative = isNativeAddress(token.address);
 
   return (
     <Box
@@ -78,33 +124,7 @@ const TransactionAsset = ({
       alignItems={AlignItems.center}
       style={styles.container}
     >
-      <BadgeWrapper
-        badgePosition={BadgePosition.BottomRight}
-        badgeElement={
-          <Badge
-            variant={BadgeVariant.Network}
-            name={networkName}
-            imageSource={networkImageSource}
-          />
-        }
-      >
-        {isNative ? (
-          <TokenIcon
-            symbol={token.symbol}
-            icon={token.image}
-            style={styles.tokenIcon}
-            big={false}
-            biggest={false}
-            testID={`network-logo-${token.symbol}`}
-          />
-        ) : (
-          <AvatarToken
-            name={token.symbol}
-            imageSource={token.image ? { uri: token.image } : undefined}
-            size={AvatarSize.Md}
-          />
-        )}
-      </BadgeWrapper>
+      <TransactionTokenIcon token={token} chainId={chainId} />
       <Box
         style={styles.tokenInfo}
         flexDirection={FlexDirection.Column}

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionAsset.tsx
@@ -21,19 +21,15 @@ import { Hex, CaipChainId } from '@metamask/utils';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
 import { StyleSheet } from 'react-native';
-import TokenIcon from '../../../../Base/TokenIcon';
 import { BridgeToken } from '../../types';
 import { TransactionType } from '@metamask/transaction-controller';
 import {
   AllowedBridgeChainIds,
   isNativeAddress,
 } from '@metamask/bridge-controller';
+import { getTokenImageSource } from '../../utils';
 
 const styles = StyleSheet.create({
-  tokenIcon: {
-    width: 40,
-    height: 40,
-  },
   tokenInfo: {
     flex: 1,
     marginLeft: 12,
@@ -71,20 +67,19 @@ export function TransactionTokenIcon({
   const networkImageSource = getNetworkImageSource({ chainId });
   const isNative = isNativeAddress(token.address);
 
-  const tokenIcon = isNative ? (
-    <TokenIcon
-      symbol={token.symbol}
-      icon={token.image}
-      style={styles.tokenIcon}
-      big={false}
-      biggest={false}
-      testID={`network-logo-${token.symbol}`}
-    />
-  ) : (
+  const tokenIcon = (
     <AvatarToken
       name={token.symbol}
-      imageSource={token.image ? { uri: token.image } : undefined}
+      imageSource={getTokenImageSource(
+        token.symbol,
+        token.image,
+        token.address,
+        token.chainId,
+      )}
       size={AvatarSize.Md}
+      testID={
+        isNative ? `network-logo-${token.symbol}` : `token-logo-${token.symbol}`
+      }
     />
   );
 

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.test.tsx
@@ -7,10 +7,11 @@ import {
 } from '@metamask/transaction-controller';
 import Routes from '../../../../../constants/navigation/Routes';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
-import { initialState } from '../../_mocks_/initialState';
+import { initialState, evmAccountAddress } from '../../_mocks_/initialState';
 import { fireEvent } from '@testing-library/react-native';
 import { Transaction } from '@metamask/keyring-api';
 import { isHardwareAccount } from '../../../../../util/address';
+import { FeatureId, StatusTypes } from '@metamask/bridge-controller';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -337,5 +338,137 @@ describe('BridgeTransactionDetails', () => {
     );
 
     expect(queryByTestId('paid-by-metamask')).not.toBeOnTheScreen();
+  });
+
+  it('displays batch sell 7702 swapped and received sections', () => {
+    const batchTxHash = '0xbatchsellhash';
+    const batchTxId = 'batch-sell-tx-id';
+    const batchId = '0xbatch123';
+    const batchSellState = {
+      ...mockState,
+      engine: {
+        ...mockState.engine,
+        backgroundState: {
+          ...mockState.engine.backgroundState,
+          BridgeStatusController: {
+            txHistory: {
+              [batchTxId]: {
+                txMetaId: batchTxId,
+                account: evmAccountAddress,
+                featureId: FeatureId.BATCH_SELL,
+                batchId,
+                quote: {
+                  requestId: 'batch-request-id',
+                  srcChainId: 42161,
+                  destChainId: 42161,
+                  srcAsset: {
+                    chainId: 42161,
+                    address: '0xf97f4df75117a78c1a5a0dbb814af92458539fb4',
+                    decimals: 18,
+                    symbol: 'LINK',
+                    name: 'Chainlink',
+                  },
+                  destAsset: {
+                    chainId: 42161,
+                    address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+                    decimals: 6,
+                    symbol: 'USDC',
+                    name: 'USDC',
+                  },
+                  srcTokenAmount: '1000000000000000000',
+                  destTokenAmount: '5000000',
+                },
+                status: {
+                  status: StatusTypes.COMPLETE,
+                  srcChain: {
+                    txHash: batchTxHash,
+                  },
+                  destChain: {
+                    txHash: '0xdest',
+                  },
+                },
+                startTime: Date.now(),
+                estimatedProcessingTimeInSeconds: 0,
+              },
+              'batch-sell-item-2': {
+                txMetaId: 'batch-sell-item-2',
+                account: evmAccountAddress,
+                featureId: FeatureId.BATCH_SELL,
+                batchId,
+                quote: {
+                  requestId: 'batch-request-id-2',
+                  srcChainId: 42161,
+                  destChainId: 42161,
+                  srcAsset: {
+                    chainId: 42161,
+                    address: '0xddb46999f8891663a8f2828d25298f70416d7610',
+                    decimals: 18,
+                    symbol: 'ARB',
+                    name: 'Arbitrum',
+                  },
+                  destAsset: {
+                    chainId: 42161,
+                    address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+                    decimals: 6,
+                    symbol: 'USDC',
+                    name: 'USDC',
+                  },
+                  srcTokenAmount: '1000000000000000000',
+                  destTokenAmount: '3000000',
+                },
+                status: {
+                  status: StatusTypes.COMPLETE,
+                  srcChain: {
+                    txHash: '0xotherhash',
+                  },
+                  destChain: {
+                    txHash: '0xdest2',
+                  },
+                },
+                startTime: Date.now(),
+                estimatedProcessingTimeInSeconds: 0,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const batchSellTx = {
+      id: batchTxId,
+      hash: batchTxHash,
+      status: TransactionStatus.confirmed,
+      chainId: '0xa4b1',
+      networkClientId: 'arbitrum',
+      time: Date.now(),
+      nestedTransactions: [
+        { type: TransactionType.swap },
+        { type: TransactionType.swapApproval },
+      ],
+      txParams: {
+        to: '0x123',
+        from: evmAccountAddress,
+        value: '0x0',
+        data: '0x',
+      },
+    } as TransactionMeta;
+
+    const { getByText } = renderScreen(
+      () => (
+        <BridgeTransactionDetails
+          route={{ params: { evmTxMeta: batchSellTx } }}
+        />
+      ),
+      {
+        name: Routes.BRIDGE.BRIDGE_TRANSACTION_DETAILS,
+      },
+      { state: batchSellState },
+    );
+
+    expect(getByText('You swapped')).toBeOnTheScreen();
+    expect(getByText('You received')).toBeOnTheScreen();
+    expect(getByText('+8.00000 USDC')).toBeOnTheScreen();
+    expect(getByText('Network')).toBeOnTheScreen();
+    expect(getByText('Arbitrum')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -4,14 +4,16 @@ import {
   HeaderStandard,
   Button,
   ButtonVariant,
-} from '@metamask/design-system-react-native';
-import Text, {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  Text,
   TextColor,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import { TextVariant as TextVariantLegacy } from '../../../../../component-library/components/Texts/Text';
 import ScreenView from '../../../../Base/ScreenView';
-import { Box } from '../../../Box/Box';
-import { FlexDirection, AlignItems } from '../../../Box/box.types';
 import { useBridgeTxHistoryData } from '../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import {
   TransactionMeta,
@@ -122,7 +124,7 @@ const PaidByMetaMask = () => (
     color={TagColor.Success}
     style={styles.paidByMetaMask}
     labelProps={{
-      variant: TextVariant.BodySM,
+      variant: TextVariantLegacy.BodySM,
       style: {
         textTransform: 'none',
         textAlign: 'center',
@@ -136,30 +138,30 @@ const PaidByMetaMask = () => (
 );
 
 const BridgeStatusToColorMap: Record<StatusTypes, TextColor> = {
-  [StatusTypes.PENDING]: TextColor.Warning,
-  [StatusTypes.COMPLETE]: TextColor.Success,
-  [StatusTypes.FAILED]: TextColor.Error,
-  [StatusTypes.UNKNOWN]: TextColor.Error,
-  [StatusTypes.SUBMITTED]: TextColor.Warning,
+  [StatusTypes.PENDING]: TextColor.WarningDefault,
+  [StatusTypes.COMPLETE]: TextColor.SuccessDefault,
+  [StatusTypes.FAILED]: TextColor.ErrorDefault,
+  [StatusTypes.UNKNOWN]: TextColor.ErrorDefault,
+  [StatusTypes.SUBMITTED]: TextColor.WarningDefault,
 };
 
 const SwapStatusToColorMap: Record<TransactionStatus, TextColor> = {
-  [TransactionStatus.submitted]: TextColor.Warning,
-  [TransactionStatus.confirmed]: TextColor.Success,
-  [TransactionStatus.failed]: TextColor.Error,
-  [TransactionStatus.unapproved]: TextColor.Warning,
-  [TransactionStatus.approved]: TextColor.Warning,
-  [TransactionStatus.signed]: TextColor.Warning,
-  [TransactionStatus.dropped]: TextColor.Error,
-  [TransactionStatus.rejected]: TextColor.Error,
-  [TransactionStatus.cancelled]: TextColor.Error,
+  [TransactionStatus.submitted]: TextColor.WarningDefault,
+  [TransactionStatus.confirmed]: TextColor.SuccessDefault,
+  [TransactionStatus.failed]: TextColor.ErrorDefault,
+  [TransactionStatus.unapproved]: TextColor.WarningDefault,
+  [TransactionStatus.approved]: TextColor.WarningDefault,
+  [TransactionStatus.signed]: TextColor.WarningDefault,
+  [TransactionStatus.dropped]: TextColor.ErrorDefault,
+  [TransactionStatus.rejected]: TextColor.ErrorDefault,
+  [TransactionStatus.cancelled]: TextColor.ErrorDefault,
 };
 
 const MultichainTxStatusToColorMap: Record<Transaction['status'], TextColor> = {
-  submitted: TextColor.Warning,
-  confirmed: TextColor.Success,
-  unconfirmed: TextColor.Warning,
-  failed: TextColor.Error,
+  submitted: TextColor.WarningDefault,
+  confirmed: TextColor.SuccessDefault,
+  unconfirmed: TextColor.WarningDefault,
+  failed: TextColor.ErrorDefault,
 };
 
 const getStatusColor = ({
@@ -185,7 +187,7 @@ const getStatusColor = ({
     return MultichainTxStatusToColorMap[multiChainTx.status];
   }
 
-  return TextColor.Error;
+  return TextColor.ErrorDefault;
 };
 
 export const BridgeTransactionDetails = (
@@ -369,16 +371,17 @@ export const BridgeTransactionDetails = (
           )}
         </Box>
         <Box style={styles.detailRow}>
-          <Text variant={TextVariant.BodyMDMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {strings('bridge_transaction_details.status')}
           </Text>
           <Box
-            flexDirection={FlexDirection.Row}
-            gap={4}
-            alignItems={AlignItems.center}
+            flexDirection={BoxFlexDirection.Row}
+            gap={1}
+            alignItems={BoxAlignItems.Center}
           >
             <Text
-              variant={TextVariant.BodyMDMedium}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
               color={getStatusColor({
                 isBridge,
                 isSwap,
@@ -396,17 +399,19 @@ export const BridgeTransactionDetails = (
           bridgeStatus.status === StatusTypes.PENDING &&
           estimatedCompletionString && (
             <Box style={styles.detailRow}>
-              <Text variant={TextVariant.BodyMDMedium}>
+              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
                 {strings(
                   'bridge_transaction_details.estimated_completion',
                 )}{' '}
               </Text>
               <Box
-                flexDirection={FlexDirection.Row}
-                gap={4}
-                alignItems={AlignItems.center}
+                flexDirection={BoxFlexDirection.Row}
+                gap={1}
+                alignItems={BoxAlignItems.Center}
               >
-                <Text>{estimatedCompletionString}</Text>
+                <Text variant={TextVariant.BodyMd}>
+                  {estimatedCompletionString}
+                </Text>
                 <TouchableOpacity
                   onPress={() => setIsStepListExpanded(!isStepListExpanded)}
                 >
@@ -430,27 +435,27 @@ export const BridgeTransactionDetails = (
           </Box>
         )}
         <Box style={styles.detailRow}>
-          <Text variant={TextVariant.BodyMDMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {strings('bridge_transaction_details.date')}
           </Text>
-          <Text>{submissionDateString}</Text>
+          <Text variant={TextVariant.BodyMd}>{submissionDateString}</Text>
         </Box>
         {is7702Batch && batchSellHistoryItems?.length && networkName ? (
           <Box style={styles.detailRow}>
-            <Text variant={TextVariant.BodyMDMedium}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {strings('bridge_transaction_details.network')}
             </Text>
             <Box
-              flexDirection={FlexDirection.Row}
-              gap={6}
-              alignItems={AlignItems.center}
+              flexDirection={BoxFlexDirection.Row}
+              gap={2}
+              alignItems={BoxAlignItems.Center}
             >
               <AvatarNetwork
                 name={networkName}
                 imageSource={networkImageSource}
                 size={AvatarSize.Xs}
               />
-              <Text>{networkName}</Text>
+              <Text variant={TextVariant.BodyMd}>{networkName}</Text>
             </Box>
           </Box>
         ) : null}
@@ -462,7 +467,7 @@ export const BridgeTransactionDetails = (
           <Text>{renderShortAddress(bridgeTxHistoryItem.account)}</Text>
         </Box> */}
         <Box style={styles.detailRow}>
-          <Text variant={TextVariant.BodyMDMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {strings('bridge_transaction_details.total_gas_fee')}
           </Text>
           {isTransactionMarkedAsGasFeeSponsored(evmTxMeta) &&
@@ -472,13 +477,13 @@ export const BridgeTransactionDetails = (
             <>
               {/* TODO get solana gas fee from multiChainTx */}
               {evmTotalGasFee && (
-                <Text>
+                <Text variant={TextVariant.BodyMd}>
                   {evmTotalGasFee}{' '}
                   {getNativeAssetForChainId(quote.srcChainId).symbol}
                 </Text>
               )}
               {multiChainTotalGasFee && (
-                <Text>
+                <Text variant={TextVariant.BodyMd}>
                   {multiChainTotalGasFee}{' '}
                   {getNativeAssetForChainId(quote.srcChainId).symbol}
                 </Text>

--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -24,6 +24,7 @@ import Icon, {
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
 import TransactionAsset from './TransactionAsset';
+import { BatchSell7702TransactionAssets } from './BatchSell7702TransactionAssets';
 import { calcTokenAmount } from '../../../../../util/transactions';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { calcHexGasTotal } from '../../utils/transactionGas';
@@ -37,6 +38,7 @@ import {
   getNativeAssetForChainId,
   isNonEvmChainId,
   StatusTypes,
+  AllowedBridgeChainIds,
 } from '@metamask/bridge-controller';
 import { Transaction } from '@metamask/keyring-api';
 import { getMultichainTxFees } from '../../../../hooks/useMultichainTransactionDisplay/useMultichainTransactionDisplay';
@@ -51,6 +53,10 @@ import { isHardwareAccount } from '../../../../../util/address';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { isTransactionMarkedAsGasFeeSponsored } from '../../../../Views/confirmations/utils/transaction';
+import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/bridge';
+import { getNetworkImageSource } from '../../../../../util/networks';
+import AvatarNetwork from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
+import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 
 const styles = StyleSheet.create({
   detailRow: {
@@ -199,10 +205,11 @@ export const BridgeTransactionDetails = (
     fromAddress && isHardwareAccount(fromAddress),
   );
 
-  const { bridgeTxHistoryItem } = useBridgeTxHistoryData({
-    evmTxMeta,
-    multiChainTx,
-  });
+  const { bridgeTxHistoryItem, batchSellHistoryItems, is7702Batch } =
+    useBridgeTxHistoryData({
+      evmTxMeta,
+      multiChainTx,
+    });
 
   // Get source chain explorer data for swaps
   const swapSrcExplorerData = useMultichainBlockExplorerTxUrl({
@@ -280,6 +287,10 @@ export const BridgeTransactionDetails = (
     quote.destAsset.decimals,
   ).toFixed(5);
 
+  const networkName =
+    NETWORK_TO_SHORT_NETWORK_NAME_MAP[sourceChainId as AllowedBridgeChainIds];
+  const networkImageSource = getNetworkImageSource({ chainId: sourceChainId });
+
   const submissionDate = startTime ? new Date(startTime) : null;
   const submissionDateString = startTime ? toDateFormat(startTime) : 'N/A';
 
@@ -329,21 +340,33 @@ export const BridgeTransactionDetails = (
       {bridgeTransactionDetailsHeader}
       <Box style={styles.transactionContainer}>
         <Box style={styles.transactionAssetsContainer}>
-          <TransactionAsset
-            token={sourceToken}
-            tokenAmount={sourceTokenAmount}
-            chainId={sourceChainId}
-            txType={isBridge ? TransactionType.bridge : TransactionType.swap}
-          />
-          <Box style={styles.arrowContainer}>
-            <Icon name={IconName.Arrow2Down} size={IconSize.Sm} />
-          </Box>
-          <TransactionAsset
-            token={destinationToken}
-            tokenAmount={destinationTokenAmount}
-            chainId={destinationChainId}
-            txType={isBridge ? TransactionType.bridge : TransactionType.swap}
-          />
+          {is7702Batch && batchSellHistoryItems?.length ? (
+            <BatchSell7702TransactionAssets
+              batchSellHistoryItems={batchSellHistoryItems}
+            />
+          ) : (
+            <>
+              <TransactionAsset
+                token={sourceToken}
+                tokenAmount={sourceTokenAmount}
+                chainId={sourceChainId}
+                txType={
+                  isBridge ? TransactionType.bridge : TransactionType.swap
+                }
+              />
+              <Box style={styles.arrowContainer}>
+                <Icon name={IconName.Arrow2Down} size={IconSize.Sm} />
+              </Box>
+              <TransactionAsset
+                token={destinationToken}
+                tokenAmount={destinationTokenAmount}
+                chainId={destinationChainId}
+                txType={
+                  isBridge ? TransactionType.bridge : TransactionType.swap
+                }
+              />
+            </>
+          )}
         </Box>
         <Box style={styles.detailRow}>
           <Text variant={TextVariant.BodyMDMedium}>
@@ -412,6 +435,25 @@ export const BridgeTransactionDetails = (
           </Text>
           <Text>{submissionDateString}</Text>
         </Box>
+        {is7702Batch && batchSellHistoryItems?.length && networkName ? (
+          <Box style={styles.detailRow}>
+            <Text variant={TextVariant.BodyMDMedium}>
+              {strings('bridge_transaction_details.network')}
+            </Text>
+            <Box
+              flexDirection={FlexDirection.Row}
+              gap={6}
+              alignItems={AlignItems.center}
+            >
+              <AvatarNetwork
+                name={networkName}
+                imageSource={networkImageSource}
+                size={AvatarSize.Xs}
+              />
+              <Text>{networkName}</Text>
+            </Box>
+          </Box>
+        ) : null}
         {/* TODO uncomment when recipient is available */}
         {/* <Box style={styles.detailRow}>
           <Text variant={TextVariant.BodyMDMedium}>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7992,6 +7992,7 @@
   "bridge_transaction_details": {
     "status": "Status",
     "date": "Date",
+    "network": "Network",
     "total_gas_fee": "Total gas fee",
     "estimated_completion": "Est. completion",
     "bridge_step_action_bridge_complete": "{{destSymbol}} received on {{destChainName}}",
@@ -8001,6 +8002,8 @@
     "view_on_block_explorer": "View on block explorer",
     "block_explorer_description": "This transaction lives on two networks. The first link shows the source; the second shows the destination once it’s confirmed.",
     "transaction_details": "Transaction details",
+    "you_swapped": "You swapped",
+    "you_received": "You received",
     "bridge_to_chain": "Bridge to {{chainName}}",
     "recipient": "Recipient"
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Batch sell EIP-7702 transactions appear as a single activity entry but contain multiple underlying swaps. Previously, transaction details only reflected one swap from the primary bridge history item, which did not match what the user actually executed.

This PR adds batch-sell-7702-specific handling across the activity list and transaction details screen:

- **Activity list**: Collapses batch sell 7702 txs into one row labeled "Batch sell", showing the summed destination token amount/fiat value via `decodeBatchSellTx` and `selectBatchSellHistoryItemsForTxHash`.
- **Transaction details**: Renders a dedicated `BatchSell7702TransactionAssets` layout when `is7702Batch` is true:
  - **You swapped** — overlapping source token icons (no network badges), stacked like batch sell quote/final review UI
  - **You received** — destination token icon + green `+{totalAmount} {symbol}` (total summed from all `batchSellHistoryItems`)
  - **Network** row below Date (7702 batch sell only) — network icon + name
- **Shared plumbing**: `useBridgeTxHistoryData` exposes `batchSellHistoryItems`, `is7702Batch`, and `batchTotalDestAmount`; `TransactionTokenIcon` extracted from `TransactionAsset` with optional `showNetworkBadge`.

Non-batch-sell and non-7702 transactions are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Improved batch sell transaction details and activity list display for EIP-7702 transactions

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [SWAPS-4630](https://consensyssoftware.atlassian.net/browse/SWAPS-4630)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Batch sell EIP-7702 transaction details

  Scenario: Activity list shows a single batch sell entry with total received amount
    Given I have completed a batch sell EIP-7702 transaction with multiple source tokens swapped to one destination token
    When I open the Activity tab
    Then I see one "Batch sell" activity row
    And the row shows the total destination token amount received across all swaps

  Scenario: Transaction details show batch sell-specific swapped/received layout
    Given I have completed a batch sell EIP-7702 transaction
    When I tap the batch sell activity row to open transaction details
    Then I see a "You swapped" section with overlapping source token icons
    And I see a "You received" section with the destination token icon and a green "+{amount} {symbol}" value
    And I do not see network badges on the batch sell token icons

  Scenario: Transaction details show network row for batch sell 7702 only
    Given I have completed a batch sell EIP-7702 transaction
    When I open transaction details for that transaction
    Then I see a "Network" row below "Date" with the network icon and chain name

  Scenario: Non-batch-sell transactions are unchanged
    Given I have a regular swap or bridge transaction (not batch sell 7702)
    When I open transaction details
    Then I see the standard source → destination vertical layout
    And I do not see "You swapped" / "You received" sections or the batch-sell-only Network row
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->


### **Before**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2026-06-17 at 3 26 13 PM" src="https://github.com/user-attachments/assets/1668ced7-7bc8-4ec7-af02-5b724c0962d1" />


### **After**

<!-- [screenshots/recordings] -->


<img width="598" height="1144" alt="Screenshot 2026-06-18 at 11 56 48 AM" src="https://github.com/user-attachments/assets/0bdfc582-a62c-499c-8b95-281eaee5a631" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4630]: https://consensyssoftware.atlassian.net/browse/SWAPS-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only bridge transaction details with a guarded branch for batch sell 7702; standard swap/bridge paths unchanged and covered by tests.
> 
> **Overview**
> **Bridge transaction details** now detect batch sell EIP-7702 txs via `useBridgeTxHistoryData` (`is7702Batch`, `batchSellHistoryItems`) and swap the usual source→arrow→destination layout for **`BatchSell7702TransactionAssets`**: “You swapped” with stacked source token icons (no network badges) and token count, “You received” with summed destination amount in green, plus a **Network** row (icon + name) below Date for these txs only.
> 
> **`TransactionTokenIcon`** is extracted from `TransactionAsset` (optional `showNetworkBadge`, `AvatarToken` + `getTokenImageSource`) and reused by both flows. **`TransactionDetails`** also migrates several labels to `@metamask/design-system-react-native` text tokens. New **i18n** keys: `you_swapped`, `you_received`, `network`. Unit tests cover the new component and an integration case on the details screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d88e92a1b050408f401cd6e055f6a1fdbb005e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->