### PR TITLE
feat(money): add education gate selector for US non-cardholders

### DIFF
--- a/app/components/UI/Money/selectors/eligibility.test.ts
+++ b/app/components/UI/Money/selectors/eligibility.test.ts
@@ -1,5 +1,23 @@
-import { selectIsMoneyAccountGeoEligible } from './eligibility';
+import {
+  selectIsMoneyAccountGeoEligible,
+  selectIsUserInUS,
+  selectShouldShowMoneyEducation,
+} from './eligibility';
+import {
+  selectIsCardAuthenticated,
+  selectIsCardholder,
+} from '../../../../selectors/cardController';
 import type { RootState } from '../../../../reducers';
+
+jest.mock('../../../../selectors/cardController', () => ({
+  selectIsCardAuthenticated: jest.fn(),
+  selectIsCardholder: jest.fn(),
+}));
+
+const mockSelectIsCardAuthenticated =
+  selectIsCardAuthenticated as unknown as jest.MockedFunction<() => boolean>;
+const mockSelectIsCardholder =
+  selectIsCardholder as unknown as jest.MockedFunction<() => boolean>;
 
 describe('selectIsMoneyAccountGeoEligible', () => {
   const createStateWithGeolocation = (
@@ -151,5 +169,87 @@ describe('selectIsMoneyAccountGeoEligible', () => {
     if (originalEnv !== undefined) {
       process.env.MM_MONEY_ACCOUNT_GEO_BLOCKED_COUNTRIES = originalEnv;
     }
+  });
+});
+
+describe('selectIsUserInUS', () => {
+  const createStateWithGeolocation = (geolocation: string | null | undefined) =>
+    ({
+      engine: {
+        backgroundState: {
+          GeolocationController: {
+            location: geolocation,
+          },
+        },
+      },
+    }) as unknown as RootState;
+
+  it('returns true for a plain US country code', () => {
+    expect(selectIsUserInUS(createStateWithGeolocation('US'))).toBe(true);
+  });
+
+  it('returns true for a US country-region code', () => {
+    expect(selectIsUserInUS(createStateWithGeolocation('US-CA'))).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(selectIsUserInUS(createStateWithGeolocation('us'))).toBe(true);
+  });
+
+  it('returns false for a non-US country', () => {
+    expect(selectIsUserInUS(createStateWithGeolocation('GB'))).toBe(false);
+  });
+
+  it('returns false when geolocation is unknown', () => {
+    expect(selectIsUserInUS(createStateWithGeolocation('UNKNOWN'))).toBe(false);
+  });
+
+  it('returns false when geolocation is undefined', () => {
+    expect(selectIsUserInUS(createStateWithGeolocation(undefined))).toBe(false);
+  });
+});
+
+describe('selectShouldShowMoneyEducation', () => {
+  const createState = (geolocation: string | null | undefined) =>
+    ({
+      engine: {
+        backgroundState: {
+          GeolocationController: {
+            location: geolocation,
+          },
+        },
+      },
+    }) as unknown as RootState;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true for a US user who is not authenticated and not a cardholder', () => {
+    mockSelectIsCardAuthenticated.mockReturnValue(false);
+    mockSelectIsCardholder.mockReturnValue(false);
+
+    expect(selectShouldShowMoneyEducation(createState('US'))).toBe(true);
+  });
+
+  it('returns false when the user is not in the US', () => {
+    mockSelectIsCardAuthenticated.mockReturnValue(false);
+    mockSelectIsCardholder.mockReturnValue(false);
+
+    expect(selectShouldShowMoneyEducation(createState('GB'))).toBe(false);
+  });
+
+  it('returns false when the US user is authenticated', () => {
+    mockSelectIsCardAuthenticated.mockReturnValue(true);
+    mockSelectIsCardholder.mockReturnValue(false);
+
+    expect(selectShouldShowMoneyEducation(createState('US'))).toBe(false);
+  });
+
+  it('returns false when the US user is a cardholder', () => {
+    mockSelectIsCardAuthenticated.mockReturnValue(false);
+    mockSelectIsCardholder.mockReturnValue(true);
+
+    expect(selectShouldShowMoneyEducation(createState('US'))).toBe(false);
   });
 });

--- a/app/components/UI/Money/selectors/eligibility.test.ts
+++ b/app/components/UI/Money/selectors/eligibility.test.ts
@@ -1,7 +1,7 @@
 import {
   selectIsMoneyAccountGeoEligible,
   selectIsUserInUS,
-  selectShouldShowMoneyEducation,
+  selectIsUsUnauthenticatedNonCardholder,
 } from './eligibility';
 import {
   selectIsCardAuthenticated,
@@ -209,7 +209,7 @@ describe('selectIsUserInUS', () => {
   });
 });
 
-describe('selectShouldShowMoneyEducation', () => {
+describe('selectIsUsUnauthenticatedNonCardholder', () => {
   const createState = (geolocation: string | null | undefined) =>
     ({
       engine: {
@@ -229,27 +229,35 @@ describe('selectShouldShowMoneyEducation', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(false);
     mockSelectHasCardholderAccounts.mockReturnValue(false);
 
-    expect(selectShouldShowMoneyEducation(createState('US'))).toBe(true);
+    expect(selectIsUsUnauthenticatedNonCardholder(createState('US'))).toBe(
+      true,
+    );
   });
 
   it('returns false when the user is not in the US', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(false);
     mockSelectHasCardholderAccounts.mockReturnValue(false);
 
-    expect(selectShouldShowMoneyEducation(createState('GB'))).toBe(false);
+    expect(selectIsUsUnauthenticatedNonCardholder(createState('GB'))).toBe(
+      false,
+    );
   });
 
   it('returns false when the US user is authenticated', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(true);
     mockSelectHasCardholderAccounts.mockReturnValue(false);
 
-    expect(selectShouldShowMoneyEducation(createState('US'))).toBe(false);
+    expect(selectIsUsUnauthenticatedNonCardholder(createState('US'))).toBe(
+      false,
+    );
   });
 
   it('returns false when any wallet account is a cardholder', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(false);
     mockSelectHasCardholderAccounts.mockReturnValue(true);
 
-    expect(selectShouldShowMoneyEducation(createState('US'))).toBe(false);
+    expect(selectIsUsUnauthenticatedNonCardholder(createState('US'))).toBe(
+      false,
+    );
   });
 });

--- a/app/components/UI/Money/selectors/eligibility.test.ts
+++ b/app/components/UI/Money/selectors/eligibility.test.ts
@@ -5,19 +5,19 @@ import {
 } from './eligibility';
 import {
   selectIsCardAuthenticated,
-  selectIsCardholder,
+  selectHasCardholderAccounts,
 } from '../../../../selectors/cardController';
 import type { RootState } from '../../../../reducers';
 
 jest.mock('../../../../selectors/cardController', () => ({
   selectIsCardAuthenticated: jest.fn(),
-  selectIsCardholder: jest.fn(),
+  selectHasCardholderAccounts: jest.fn(),
 }));
 
 const mockSelectIsCardAuthenticated =
   selectIsCardAuthenticated as unknown as jest.MockedFunction<() => boolean>;
-const mockSelectIsCardholder =
-  selectIsCardholder as unknown as jest.MockedFunction<() => boolean>;
+const mockSelectHasCardholderAccounts =
+  selectHasCardholderAccounts as unknown as jest.MockedFunction<() => boolean>;
 
 describe('selectIsMoneyAccountGeoEligible', () => {
   const createStateWithGeolocation = (
@@ -227,28 +227,28 @@ describe('selectShouldShowMoneyEducation', () => {
 
   it('returns true for a US user who is not authenticated and not a cardholder', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(false);
-    mockSelectIsCardholder.mockReturnValue(false);
+    mockSelectHasCardholderAccounts.mockReturnValue(false);
 
     expect(selectShouldShowMoneyEducation(createState('US'))).toBe(true);
   });
 
   it('returns false when the user is not in the US', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(false);
-    mockSelectIsCardholder.mockReturnValue(false);
+    mockSelectHasCardholderAccounts.mockReturnValue(false);
 
     expect(selectShouldShowMoneyEducation(createState('GB'))).toBe(false);
   });
 
   it('returns false when the US user is authenticated', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(true);
-    mockSelectIsCardholder.mockReturnValue(false);
+    mockSelectHasCardholderAccounts.mockReturnValue(false);
 
     expect(selectShouldShowMoneyEducation(createState('US'))).toBe(false);
   });
 
-  it('returns false when the US user is a cardholder', () => {
+  it('returns false when any wallet account is a cardholder', () => {
     mockSelectIsCardAuthenticated.mockReturnValue(false);
-    mockSelectIsCardholder.mockReturnValue(true);
+    mockSelectHasCardholderAccounts.mockReturnValue(true);
 
     expect(selectShouldShowMoneyEducation(createState('US'))).toBe(false);
   });

--- a/app/components/UI/Money/selectors/eligibility.ts
+++ b/app/components/UI/Money/selectors/eligibility.ts
@@ -45,16 +45,14 @@ export const selectIsUserInUS = createSelector(
 );
 
 /**
- * Gate for the Money account education / warning screen.
- *
- * Shown when a US user has neither authenticated with the card service nor
- * become a cardholder, so they see the explainer before proceeding.
+ * Whether the user is in the US, not authenticated with the card service, and
+ * not a cardholder.
  *
  * Cardholder status is evaluated wallet-wide (any account) rather than for the
- * currently selected account, so an existing card customer never sees the
- * first-time education screen after switching accounts.
+ * currently selected account, so an existing card customer never matches this
+ * condition after switching accounts.
  */
-export const selectShouldShowMoneyEducation = createSelector(
+export const selectIsUsUnauthenticatedNonCardholder = createSelector(
   selectIsUserInUS,
   selectIsCardAuthenticated,
   selectHasCardholderAccounts,

--- a/app/components/UI/Money/selectors/eligibility.ts
+++ b/app/components/UI/Money/selectors/eligibility.ts
@@ -9,6 +9,12 @@
 import { createSelector } from 'reselect';
 import { selectMoneyAccountGeoBlockedCountries } from './featureFlags';
 import { getDetectedGeolocation } from '../../../../reducers/fiatOrders';
+import {
+  selectIsCardAuthenticated,
+  selectIsCardholder,
+} from '../../../../selectors/cardController';
+
+const US_COUNTRY_CODE = 'US';
 
 export const selectIsMoneyAccountGeoEligible = createSelector(
   selectMoneyAccountGeoBlockedCountries,
@@ -23,4 +29,31 @@ export const selectIsMoneyAccountGeoEligible = createSelector(
       (blocked) => !userCountry.startsWith(blocked.toUpperCase()),
     );
   },
+);
+
+/**
+ * Whether the user's detected geolocation resolves to the United States.
+ *
+ * The Ramps geolocation API returns codes like "US" or "US-CA"
+ * (country-region), so only the leading country segment is compared.
+ * Defaults to `false` when geolocation is unknown or still loading.
+ */
+export const selectIsUserInUS = createSelector(
+  getDetectedGeolocation,
+  (geolocation): boolean =>
+    (geolocation?.toUpperCase().split('-')[0] ?? null) === US_COUNTRY_CODE,
+);
+
+/**
+ * Gate for the Money account education / warning screen.
+ *
+ * Shown when a US user has neither authenticated with the card service nor
+ * become a cardholder, so they see the explainer before proceeding.
+ */
+export const selectShouldShowMoneyEducation = createSelector(
+  selectIsUserInUS,
+  selectIsCardAuthenticated,
+  selectIsCardholder,
+  (isInUS, isCardAuthenticated, isCardholder): boolean =>
+    isInUS && !isCardAuthenticated && !isCardholder,
 );

--- a/app/components/UI/Money/selectors/eligibility.ts
+++ b/app/components/UI/Money/selectors/eligibility.ts
@@ -11,7 +11,7 @@ import { selectMoneyAccountGeoBlockedCountries } from './featureFlags';
 import { getDetectedGeolocation } from '../../../../reducers/fiatOrders';
 import {
   selectIsCardAuthenticated,
-  selectIsCardholder,
+  selectHasCardholderAccounts,
 } from '../../../../selectors/cardController';
 
 const US_COUNTRY_CODE = 'US';
@@ -49,11 +49,15 @@ export const selectIsUserInUS = createSelector(
  *
  * Shown when a US user has neither authenticated with the card service nor
  * become a cardholder, so they see the explainer before proceeding.
+ *
+ * Cardholder status is evaluated wallet-wide (any account) rather than for the
+ * currently selected account, so an existing card customer never sees the
+ * first-time education screen after switching accounts.
  */
 export const selectShouldShowMoneyEducation = createSelector(
   selectIsUserInUS,
   selectIsCardAuthenticated,
-  selectIsCardholder,
-  (isInUS, isCardAuthenticated, isCardholder): boolean =>
-    isInUS && !isCardAuthenticated && !isCardholder,
+  selectHasCardholderAccounts,
+  (isInUS, isCardAuthenticated, hasCardholderAccounts): boolean =>
+    isInUS && !isCardAuthenticated && !hasCardholderAccounts,
 );


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a new memoized selector, `selectShouldShowMoneyEducation`, that gates the Money account education/warning screen. It returns `true` only when the user is in the US **and** is not authenticated with the card service **and** is not a cardholder.

To support it, this PR also adds `selectIsUserInUS`, which derives US residency from the detected geolocation (`getDetectedGeolocation`). It handles both `US` and `US-CA` (country-region) formats, is case-insensitive, and defaults to `false` when geolocation is unknown or still loading — consistent with the existing `selectIsMoneyAccountGeoEligible` pattern in this file.

The "authenticated" and "cardholder" signals reuse the existing `selectIsCardAuthenticated` and `selectIsCardholder` selectors from `app/selectors/cardController`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: null

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — selector-only change covered by unit tests (`eligibility.test.ts`). The selector is not yet wired into a UI surface, so there is no user-facing flow to exercise manually.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
