### PR TITLE
fix: decouple activity list from network enablement controller

### DIFF
--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -49,11 +49,11 @@ jest.mock(
 jest.mock('../../../selectors/networkController', () => ({
   selectEvmNetworkConfigurationsByChainId: jest.fn((state) => state.evmConfigs),
   selectProviderType: jest.fn((state) => state.providerType),
+  selectAllConfiguredEvmChainIds: jest.fn((state) => state.enabledEvm),
 }));
 
-jest.mock('../../../selectors/networkEnablementController', () => ({
-  selectEVMEnabledNetworks: jest.fn((state) => state.enabledEvm),
-  selectNonEVMEnabledNetworks: jest.fn((state) => state.enabledNonEvm),
+jest.mock('../../../selectors/multichainNetworkController', () => ({
+  selectAllConfiguredNonEvmChainIds: jest.fn((state) => state.enabledNonEvm),
 }));
 
 jest.mock('../../../selectors/transactionController', () => ({

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -26,13 +26,11 @@ import { selectCurrentCurrency } from '../../../selectors/currencyRateController
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain/multichain';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../selectors/multichainAccounts/accountTreeController';
 import {
+  selectAllConfiguredEvmChainIds,
   selectEvmNetworkConfigurationsByChainId,
   selectProviderType,
 } from '../../../selectors/networkController';
-import {
-  selectEVMEnabledNetworks,
-  selectNonEVMEnabledNetworks,
-} from '../../../selectors/networkEnablementController';
+import { selectAllConfiguredNonEvmChainIds } from '../../../selectors/multichainNetworkController';
 import { selectRelatedChainIdsByTransactionId } from '../../../selectors/transactionController';
 import { baseStyles } from '../../../styles/common';
 import { isHardwareAccount } from '../../../util/address';
@@ -267,15 +265,13 @@ const ActivityList = ({
     return solanaAccount?.address ?? '';
   }, [selectedAccountGroupInternalAccounts]);
 
-  const enabledEVMNetworks = useSelector(selectEVMEnabledNetworks);
-  const enabledEVMChainIds = useMemo(
-    () => enabledEVMNetworks ?? [],
-    [enabledEVMNetworks],
-  );
-  const enabledNonEVMNetworks = useSelector(selectNonEVMEnabledNetworks);
-  const enabledNonEVMChainIds = useMemo(
-    () => enabledNonEVMNetworks ?? [],
-    [enabledNonEVMNetworks],
+  // All configured networks (not "enabled"): the Activity feed shows every
+  // network the account has, decoupled from NetworkEnablementController so a
+  // single-network enable/disable (e.g. Predict enabling Polygon) can't
+  // collapse the list to one network.
+  const configuredEVMChainIds = useSelector(selectAllConfiguredEvmChainIds);
+  const configuredNonEVMChainIds = useSelector(
+    selectAllConfiguredNonEvmChainIds,
   );
 
   const relatedChainIdsByTransactionId = useSelector(
@@ -284,9 +280,9 @@ const ActivityList = ({
 
   const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
 
-  /** Drop confirmed EVM rows not on currently enabled chains (guards stale query pages). */
-  const allConfirmedForEnabledChains = useMemo<ActivityListItem[]>(() => {
-    const chains = enabledEVMChainIds ?? [];
+  /** Drop confirmed EVM rows not on a configured chain (guards stale query pages / removed networks). */
+  const allConfirmedForConfiguredChains = useMemo<ActivityListItem[]>(() => {
+    const chains = configuredEVMChainIds ?? [];
     if (chains.length === 0) return [];
     const allowed = new Set(chains.map((c) => c.toLowerCase()));
     return allConfirmedFiltered.filter((item) => {
@@ -296,7 +292,7 @@ const ActivityList = ({
       const hexFormatted = `0x${parseInt(hexChainId, 10).toString(16)}`;
       return allowed.has(hexFormatted.toLowerCase());
     });
-  }, [allConfirmedFiltered, enabledEVMChainIds]);
+  }, [allConfirmedFiltered, configuredEVMChainIds]);
 
   const { maliciousTokenKeys } =
     useMultichainActivityMaliciousTokenKeys(nonEvmTransactions);
@@ -312,13 +308,13 @@ const ActivityList = ({
     nonEvmItems: ActivityListItem[];
   }>(() => {
     const bridgeHistoryValues = Object.values(bridgeHistory ?? {});
-    const enabledEvmSet = new Set(
-      (enabledEVMChainIds ?? []).map((id) => id.toLowerCase()),
+    const configuredEvmSet = new Set(
+      (configuredEVMChainIds ?? []).map((id) => id.toLowerCase()),
     );
 
-    // Filter local items to enabled EVM chains only, also deduplicate against confirmed
+    // Filter local items to configured EVM chains only, also deduplicate against confirmed
     const confirmedHashes = new Set(
-      allConfirmedForEnabledChains
+      allConfirmedForConfiguredChains
         .map((item) => item.hash?.toLowerCase())
         .filter(Boolean) as string[],
     );
@@ -335,7 +331,7 @@ const ActivityList = ({
         txChainId,
       ];
 
-      if (!relatedChainIds.some((id) => enabledEvmSet.has(id))) {
+      if (!relatedChainIds.some((id) => configuredEvmSet.has(id))) {
         return false;
       }
 
@@ -353,7 +349,7 @@ const ActivityList = ({
         const nonce = tx.txParams?.nonce;
         const from = tx.txParams?.from?.toLowerCase();
         if (nonce !== undefined && nonce !== null && from) {
-          const matchedByNonce = allConfirmedForEnabledChains.some(
+          const matchedByNonce = allConfirmedForConfiguredChains.some(
             (confirmed) => {
               // parse nonce from confirmed item if available
               const confirmedRaw = confirmed.raw;
@@ -377,7 +373,7 @@ const ActivityList = ({
       return true;
     });
 
-    // Non-EVM: filter by enabled chains, include bridge txns whose dest chain is enabled
+    // Non-EVM: filter to configured chains, include bridge txns whose dest chain is configured
     const seenNonEvmTransactionIds = new Set<string>();
     const filteredNonEvmTransactions = nonEvmTransactions.reduce<
       typeof nonEvmTransactions
@@ -387,13 +383,13 @@ const ActivityList = ({
       }
 
       const includeTransaction = (() => {
-        if (enabledNonEVMChainIds.includes(tx.chain)) return true;
+        if (configuredNonEVMChainIds.includes(tx.chain)) return true;
         const bridge = Object.values(bridgeHistory ?? {}).find(
           (item) => item.status?.srcChain?.txHash === tx.id,
         );
         return (
           bridge?.quote?.destChainId !== undefined &&
-          enabledEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
+          configuredEVMChainIds.includes(numberToHex(bridge.quote.destChainId))
         );
       })();
 
@@ -415,15 +411,15 @@ const ActivityList = ({
 
     return {
       localItems: filteredLocalItems,
-      confirmedEvmItems: allConfirmedForEnabledChains,
+      confirmedEvmItems: allConfirmedForConfiguredChains,
       nonEvmItems,
     };
   }, [
-    allConfirmedForEnabledChains,
+    allConfirmedForConfiguredChains,
     localActivityItems,
     nonEvmTransactions,
-    enabledEVMChainIds,
-    enabledNonEVMChainIds,
+    configuredEVMChainIds,
+    configuredNonEVMChainIds,
     bridgeHistory,
     relatedChainIdsByTransactionId,
     maliciousTokenKeys,
@@ -436,27 +432,27 @@ const ActivityList = ({
   }, [unifiedTransactionSource]);
   const groupedData = useMemo(() => groupActivityListItems(data), [data]);
 
-  const hasEvmChainsEnabled = enabledEVMChainIds.length > 0;
+  const hasConfiguredEvmChains = configuredEVMChainIds.length > 0;
   const popularListBlockExplorer = useBlockExplorer(
-    hasEvmChainsEnabled ? enabledEVMChainIds[0] : undefined,
+    hasConfiguredEvmChains ? configuredEVMChainIds[0] : undefined,
   );
 
   const configBlockExplorerUrl = useMemo(() => {
-    if (!enabledEVMChainIds?.length || enabledEVMChainIds.length !== 1) {
+    if (!configuredEVMChainIds?.length || configuredEVMChainIds.length !== 1) {
       return undefined;
     }
-    const selectedChainId = enabledEVMChainIds[0];
+    const selectedChainId = configuredEVMChainIds[0];
     const config = evmNetworkConfigurationsByChainId?.[selectedChainId];
     if (!config) return undefined;
     const index = config.defaultBlockExplorerUrlIndex ?? 0;
     return config.blockExplorerUrls?.[index];
-  }, [enabledEVMChainIds, evmNetworkConfigurationsByChainId]);
+  }, [configuredEVMChainIds, evmNetworkConfigurationsByChainId]);
 
   const blockExplorerUrl = useMemo(() => {
     if (configBlockExplorerUrl) {
       return configBlockExplorerUrl;
     }
-    return hasEvmChainsEnabled
+    return hasConfiguredEvmChains
       ? popularListBlockExplorer.getBlockExplorerUrl(
           selectedAccountGroupEvmAddress,
         ) || undefined
@@ -465,13 +461,13 @@ const ActivityList = ({
     configBlockExplorerUrl,
     popularListBlockExplorer,
     selectedAccountGroupEvmAddress,
-    hasEvmChainsEnabled,
+    hasConfiguredEvmChains,
   ]);
 
-  const hasNonEvmChainsEnabled = enabledNonEVMChainIds.length > 0;
+  const hasConfiguredNonEvmChains = configuredNonEVMChainIds.length > 0;
 
-  const showEvmFooter = hasEvmChainsEnabled && !hasNonEvmChainsEnabled;
-  const showNonEvmFooter = hasNonEvmChainsEnabled && !hasEvmChainsEnabled;
+  const showEvmFooter = hasConfiguredEvmChains && !hasConfiguredNonEvmChains;
+  const showNonEvmFooter = hasConfiguredNonEvmChains && !hasConfiguredEvmChains;
 
   const onViewBlockExplorer = useCallback(() => {
     if (!selectedAccountGroupEvmAddress) {
@@ -491,8 +487,10 @@ const ActivityList = ({
       if (!url) return;
     } else {
       url = blockExplorerUrl;
-      title = hasEvmChainsEnabled
-        ? popularListBlockExplorer.getBlockExplorerName(enabledEVMChainIds[0])
+      title = hasConfiguredEvmChains
+        ? popularListBlockExplorer.getBlockExplorerName(
+            configuredEVMChainIds[0],
+          )
         : undefined;
     }
 
@@ -515,26 +513,26 @@ const ActivityList = ({
     blockExplorerUrl,
     selectedAccountGroupEvmAddress,
     popularListBlockExplorer,
-    enabledEVMChainIds,
+    configuredEVMChainIds,
     configBlockExplorerUrl,
-    hasEvmChainsEnabled,
+    hasConfiguredEvmChains,
     trackEvent,
     createEventBuilder,
   ]);
 
   const allNonEvmChainsAreSolana = useMemo(
     () =>
-      enabledNonEVMChainIds.every((chain) =>
+      configuredNonEVMChainIds.every((chain) =>
         chain.toLowerCase().startsWith('solana:'),
       ),
-    [enabledNonEVMChainIds],
+    [configuredNonEVMChainIds],
   );
 
   const nonEvmExplorerChainId = useMemo(() => {
-    if (enabledNonEVMChainIds.length) return enabledNonEVMChainIds[0];
+    if (configuredNonEVMChainIds.length) return configuredNonEVMChainIds[0];
     if (chainId?.includes(':')) return chainId;
     return undefined;
-  }, [enabledNonEVMChainIds, chainId]);
+  }, [configuredNonEVMChainIds, chainId]);
 
   const nonEvmExplorerUrl = useMemo(() => {
     if (!selectedAccountGroupSolanaAddress || !nonEvmExplorerChainId) return '';
@@ -572,7 +570,7 @@ const ActivityList = ({
     if (showEvmFooter) {
       return (
         <TransactionsFooter
-          chainId={enabledEVMChainIds[0]}
+          chainId={configuredEVMChainIds[0]}
           providerType={configBlockExplorerUrl ? providerType : undefined}
           rpcBlockExplorer={blockExplorerUrl}
           onViewBlockExplorer={onViewBlockExplorer}
@@ -596,7 +594,7 @@ const ActivityList = ({
 
     return null;
   }, [
-    enabledEVMChainIds,
+    configuredEVMChainIds,
     unifiedTransactionSource.nonEvmItems?.length,
     onViewBlockExplorer,
     onViewNonEvmExplorer,
@@ -890,7 +888,7 @@ const ActivityList = ({
             index={index}
             location={location}
             showDestinationPerspective={
-              !enabledNonEVMChainIds.includes(raw.data.chain)
+              !configuredNonEVMChainIds.includes(raw.data.chain)
             }
           />
         );

--- a/app/components/Views/ActivityList/useTransactionsQuery.test.ts
+++ b/app/components/Views/ActivityList/useTransactionsQuery.test.ts
@@ -34,7 +34,7 @@ describe('useTransactionsQuery', () => {
     jest.clearAllMocks();
   });
 
-  it('uses the selected account-group EVM address and enabled networks', () => {
+  it('uses the selected account-group EVM address and configured networks', () => {
     const excludedTxHashes = new Set(['0xskip']);
     mockUseSelector
       .mockReturnValueOnce({ address: '0xGroupAddress' })

--- a/app/components/Views/ActivityList/useTransactionsQuery.ts
+++ b/app/components/Views/ActivityList/useTransactionsQuery.ts
@@ -5,7 +5,7 @@ import { KnownCaipNamespace, toCaipAccountId } from '@metamask/utils';
 import { apiClient } from '../../../core/apiClient';
 import { selectEvmAddress } from '../../../selectors/accountsController';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../selectors/multichainAccounts/accountTreeController';
-import { selectEvmEnabledCaipNetworks } from '../../../selectors/networkEnablementController';
+import { selectAllConfiguredEvmCaipNetworks } from '../../../selectors/networkController';
 import { selectApiEvmTransactions } from './helpers/transformations';
 import { MINUTE } from '../../../constants/time';
 import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
@@ -17,7 +17,10 @@ export const useTransactionsQuery = () => {
   const globalEvmAddress = useSelector(selectEvmAddress);
   /** Activity must load EVM history for the group's EVM account when e.g. Bitcoin is selected. */
   const evmAddress = (groupEvmAccount?.address ?? globalEvmAddress ?? '') || '';
-  const networks = useSelector(selectEvmEnabledCaipNetworks);
+  // Fetch history for every configured network — decoupled from
+  // NetworkEnablementController so enabling/disabling a single network (e.g.
+  // Predict enabling Polygon) never collapses the Activity feed to one network.
+  const networks = useSelector(selectAllConfiguredEvmCaipNetworks);
   const excludedTxHashes = useSelector(selectRequiredTransactionHashes);
   const accountAddresses = evmAddress
     ? [toCaipAccountId(KnownCaipNamespace.Eip155, '0', evmAddress)]

--- a/app/selectors/multichainNetworkController/index.ts
+++ b/app/selectors/multichainNetworkController/index.ts
@@ -191,6 +191,16 @@ export const selectNonEvmNetworkConfigurationsByChainId = createSelector(
   },
 );
 
+/**
+ * All configured non-EVM networks, in CAIP-2 form — independent of which are
+ * "enabled". Use for surfaces that must show all networks (e.g. the Activity
+ * feed) so enabling a single network doesn't collapse the view.
+ */
+export const selectAllConfiguredNonEvmChainIds = createDeepEqualSelector(
+  selectNonEvmNetworkConfigurationsByChainId,
+  (configsByChainId): string[] => Object.keys(configsByChainId ?? {}),
+);
+
 export const selectSelectedNonEvmNetworkDecimals = createSelector(
   selectNonEvmNetworkConfigurationsByChainId,
   selectSelectedNonEvmNetworkChainId,

--- a/app/selectors/networkController.ts
+++ b/app/selectors/networkController.ts
@@ -197,6 +197,29 @@ export const selectEvmNetworkConfigurationsByChainId = createSelector(
     networkControllerState?.networkConfigurationsByChainId,
 );
 
+/**
+ * All configured EVM networks, as hex chain IDs — independent of which are
+ * "enabled". Use for surfaces that must show all networks (e.g. the Activity
+ * feed) so enabling/disabling a single network doesn't collapse the view.
+ */
+export const selectAllConfiguredEvmChainIds = createDeepEqualSelector(
+  selectEvmNetworkConfigurationsByChainId,
+  (configsByChainId): Hex[] => Object.keys(configsByChainId ?? {}) as Hex[],
+);
+
+/**
+ * Same as {@link selectAllConfiguredEvmChainIds} but in CAIP-2 form
+ * (e.g. `eip155:1`), matching the shape the accounts transactions API expects.
+ */
+export const selectAllConfiguredEvmCaipNetworks = createDeepEqualSelector(
+  selectAllConfiguredEvmChainIds,
+  (chainIds): string[] =>
+    chainIds.map(
+      (chainId) =>
+        `${KnownCaipNamespace.Eip155}:${Number.parseInt(chainId, 16)}`,
+    ),
+);
+
 export const selectNetworkConfigurations = createDeepEqualSelector(
   selectEvmNetworkConfigurationsByChainId,
   selectNonEvmNetworkConfigurationsByChainId,


### PR DESCRIPTION
## **Description**

The redesigned Activity feed derived its network set from `NetworkEnablementController`, so enabling/disabling a single network (e.g. Predict enabling Polygon, or any network switch) collapsed the feed to that one network. This decouples the feed from enablement: both the fetch and the EVM/non-EVM filtering now read **all configured networks**, so the feed shows every network the account has and the in-screen network chip stays the only network filter.

- Adds `selectAllConfiguredEvmChainIds` / `selectAllConfiguredEvmCaipNetworks` (`networkController`) and `selectAllConfiguredNonEvmChainIds` (`multichainNetworkController`).
- `ActivityList` and `useTransactionsQuery` consume the configured-network selectors; no remaining dependency on `NetworkEnablementController`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Activity feed network coverage

  Scenario: A single-network enablement change no longer collapses the feed
    Given I have multiple networks configured
    And I am on the Activity screen with "All networks" selected
    When a feature enables one network (e.g. opening Predict enables Polygon)
    Then the feed still shows activity across all my configured networks
    And it does not collapse to only the newly enabled network
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
