### PR TITLE
refactor(SrpInputGrid): extract seed phrase change logic into a separate utility function

### DIFF
--- a/app/components/UI/SrpInputGrid/index.tsx
+++ b/app/components/UI/SrpInputGrid/index.tsx
@@ -21,6 +21,7 @@ import {
 import SrpInput from '../../Views/SrpInput';
 import { useAppTheme } from '../../../util/theme';
 import { SrpInputGridProps } from './SrpInputGrid.types';
+import { applySeedPhraseChangeAtIndex } from './srpInputGridLogic';
 import { strings } from '../../../../locales/i18n';
 import {
   getTrimmedSeedPhraseLength,
@@ -30,9 +31,7 @@ import {
   SPACE_CHAR,
   checkValidSeedWord,
 } from '../../../util/srp/srpInputUtils';
-import { isValidMnemonic } from '../../../util/validators';
 import { formatSeedPhraseToSingleLine } from '../../../util/string';
-import Logger from '../../../util/Logger';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 export interface SrpInputGridRef {
@@ -135,85 +134,15 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
     // Handle seed phrase change at a specific index (for grid mode)
     const handleSeedPhraseChangeAtIndex = useCallback(
       (seedPhraseText: string, index: number) => {
-        try {
-          const text = formatSeedPhraseToSingleLine(seedPhraseText);
-
-          if (text.includes(SPACE_CHAR)) {
-            const isEndWithSpace = text.at(-1) === SPACE_CHAR;
-            const splitArray = text
-              .trim()
-              .split(SPACE_CHAR)
-              .filter((word) => word.trim() !== '');
-
-            if (splitArray.length === 0) {
-              onSeedPhraseChange((prev) => {
-                const newSeedPhrase = [...prev];
-                newSeedPhrase[index] = '';
-                return newSeedPhrase;
-              });
-              return;
-            }
-
-            const mergedSeedPhrase = [
-              ...seedPhrase.slice(0, index),
-              ...splitArray,
-              ...seedPhrase.slice(index + 1),
-            ];
-
-            const normalizedWords = mergedSeedPhrase
-              .map((w) => w.trim())
-              .filter((w) => w !== '');
-            const maxAllowed = Math.max(...SRP_LENGTHS);
-            const hasReachedMax = normalizedWords.length >= maxAllowed;
-            const isCompleteAndValid =
-              SRP_LENGTHS.includes(normalizedWords.length) &&
-              isValidMnemonic(normalizedWords.join(SPACE_CHAR));
-
-            let nextSeedPhraseState = normalizedWords;
-            if (
-              isEndWithSpace &&
-              index === seedPhrase.length - 1 &&
-              !isCompleteAndValid &&
-              !hasReachedMax
-            ) {
-              nextSeedPhraseState = [...normalizedWords, ''];
-            }
-
-            onSeedPhraseChange(nextSeedPhraseState);
-
-            if (isCompleteAndValid || hasReachedMax) {
-              Keyboard.dismiss();
-              setNextSeedPhraseInputFocusedIndex(null);
-              return;
-            }
-
-            const targetIndex = Math.min(
-              nextSeedPhraseState.length - 1,
-              index + splitArray.length,
-            );
-            setNextSeedPhraseInputFocusedIndex(targetIndex);
-            return;
-          }
-
-          if (seedPhrase[index] !== text) {
-            onSeedPhraseChange((prev) => {
-              const newSeedPhrase = [...prev];
-              newSeedPhrase[index] = text;
-              return newSeedPhrase;
-            });
-
-            if (text.trim() === '') {
-              setErrorWordIndexes((prev) => ({
-                ...prev,
-                [index]: false,
-              }));
-            }
-
-            onCurrentWordChange?.(!text.includes(' ') ? text : '');
-          }
-        } catch (err) {
-          Logger.error(err as Error, 'Error handling seed phrase change');
-        }
+        applySeedPhraseChangeAtIndex({
+          seedPhrase,
+          seedPhraseText,
+          index,
+          onSeedPhraseChange,
+          onCurrentWordChange,
+          setErrorWordIndexes,
+          setNextSeedPhraseInputFocusedIndex,
+        });
       },
       [seedPhrase, onSeedPhraseChange, onCurrentWordChange],
     );

--- a/app/components/UI/SrpInputGrid/srpInputGridLogic.ts
+++ b/app/components/UI/SrpInputGrid/srpInputGridLogic.ts
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Keyboard } from 'react-native';
+import { formatSeedPhraseToSingleLine } from '../../../util/string';
+import { SPACE_CHAR, SRP_LENGTHS } from '../../../util/srp/srpInputUtils';
+import { isValidMnemonic } from '../../../util/validators';
+import Logger from '../../../util/Logger';
+import { SrpInputGridProps } from './SrpInputGrid.types';
+
+export interface ApplySeedPhraseChangeAtIndexParams {
+  seedPhrase: string[];
+  seedPhraseText: string;
+  index: number;
+  onSeedPhraseChange: SrpInputGridProps['onSeedPhraseChange'];
+  onCurrentWordChange?: SrpInputGridProps['onCurrentWordChange'];
+  setErrorWordIndexes: React.Dispatch<
+    React.SetStateAction<Record<number, boolean>>
+  >;
+  setNextSeedPhraseInputFocusedIndex: React.Dispatch<
+    React.SetStateAction<number | null>
+  >;
+}
+
+// Extracted out of the component so the try/catch (with conditionals and
+// optional chaining inside) lives in a plain function. The React Compiler
+// cannot yet optimize "value blocks" within try/catch, and only optimizes
+// components/hooks, so keeping this here lets SrpInputGrid itself compile.
+export const applySeedPhraseChangeAtIndex = ({
+  seedPhrase,
+  seedPhraseText,
+  index,
+  onSeedPhraseChange,
+  onCurrentWordChange,
+  setErrorWordIndexes,
+  setNextSeedPhraseInputFocusedIndex,
+}: ApplySeedPhraseChangeAtIndexParams) => {
+  try {
+    const text = formatSeedPhraseToSingleLine(seedPhraseText);
+
+    if (text.includes(SPACE_CHAR)) {
+      const isEndWithSpace = text.at(-1) === SPACE_CHAR;
+      const splitArray = text
+        .trim()
+        .split(SPACE_CHAR)
+        .filter((word) => word.trim() !== '');
+
+      if (splitArray.length === 0) {
+        onSeedPhraseChange((prev) => {
+          const newSeedPhrase = [...prev];
+          newSeedPhrase[index] = '';
+          return newSeedPhrase;
+        });
+        return;
+      }
+
+      const mergedSeedPhrase = [
+        ...seedPhrase.slice(0, index),
+        ...splitArray,
+        ...seedPhrase.slice(index + 1),
+      ];
+
+      const normalizedWords = mergedSeedPhrase
+        .map((w) => w.trim())
+        .filter((w) => w !== '');
+      const maxAllowed = Math.max(...SRP_LENGTHS);
+      const hasReachedMax = normalizedWords.length >= maxAllowed;
+      const isCompleteAndValid =
+        SRP_LENGTHS.includes(normalizedWords.length) &&
+        isValidMnemonic(normalizedWords.join(SPACE_CHAR));
+
+      let nextSeedPhraseState = normalizedWords;
+      if (
+        isEndWithSpace &&
+        index === seedPhrase.length - 1 &&
+        !isCompleteAndValid &&
+        !hasReachedMax
+      ) {
+        nextSeedPhraseState = [...normalizedWords, ''];
+      }
+
+      onSeedPhraseChange(nextSeedPhraseState);
+
+      if (isCompleteAndValid || hasReachedMax) {
+        Keyboard.dismiss();
+        setNextSeedPhraseInputFocusedIndex(null);
+        return;
+      }
+
+      const targetIndex = Math.min(
+        nextSeedPhraseState.length - 1,
+        index + splitArray.length,
+      );
+      setNextSeedPhraseInputFocusedIndex(targetIndex);
+      return;
+    }
+
+    if (seedPhrase[index] !== text) {
+      onSeedPhraseChange((prev) => {
+        const newSeedPhrase = [...prev];
+        newSeedPhrase[index] = text;
+        return newSeedPhrase;
+      });
+
+      if (text.trim() === '') {
+        setErrorWordIndexes((prev) => ({
+          ...prev,
+          [index]: false,
+        }));
+      }
+
+      onCurrentWordChange?.(!text.includes(' ') ? text : '');
+    }
+  } catch (err) {
+    Logger.error(err as Error, 'Error handling seed phrase change');
+  }
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Extracts `handleSeedPhraseChangeAtIndex` logic from `SrpInputGrid` into a new plain-function module, `applySeedPhraseChangeAtIndex` in `srpInputGridLogic.ts`.

**Why:** The React Compiler cannot yet optimize "value blocks" inside `try/catch`, and only optimizes components and hooks. The seed-phrase change handler had a large `try/catch` with conditionals and optional chaining inline in the component, which blocked `SrpInputGrid` from compiling. Moving that logic to a standalone function preserves behavior while letting the component itself be React Compiler–eligible.

**What changed:** No user-facing behavior change — same validation, focus management, keyboard dismissal, and error handling. The component now delegates to `applySeedPhraseChangeAtIndex` via its existing `useCallback` wrapper.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: React Compiler incremental adoption for `SrpInputGrid`

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: SRP input grid seed phrase entry

  Scenario: user types words one at a time in grid mode
    Given the app is on the Secret Recovery Phrase import screen with the grid input visible
    When the user types a valid BIP-39 word into a cell and presses space
    Then focus advances to the next cell and the word is stored in the phrase

  Scenario: user pastes a multi-word phrase into a cell
    Given the app is on the Secret Recovery Phrase import screen with the grid input visible
    When the user pastes multiple space-separated words into a single cell
    Then the words are distributed across the grid cells in order

  Scenario: user completes a valid 12-word phrase
    Given the app is on the Secret Recovery Phrase import screen with the grid input visible
    When the user enters a complete valid 12-word mnemonic
    Then the keyboard dismisses and no further cell is focused

  Scenario: user clears a cell
    Given a word has been entered in a grid cell
    When the user deletes the cell contents
    Then the error state for that cell is cleared
```

Existing unit tests in `app/components/UI/SrpInputGrid/index.test.tsx` cover this behavior and should continue to pass unchanged.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — internal refactor with no visual or UX changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.