### PR TITLE
refactor(OAuthRehydration, SocialLoginIosUser): streamline biometric choice and screen tracking

### DIFF
--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -260,11 +260,6 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     }
   }, [getAuthType]);
 
-  // default biometric choice to true
-  useEffect(() => {
-    setBiometryChoice(true);
-  }, [setBiometryChoice]);
-
   const tooManyAttemptsError = useCallback(
     async (initialRemainingTime: number) => {
       const lockEnd = Date.now() + initialRemainingTime * 1000;
@@ -672,17 +667,23 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     };
   }, []);
 
-  const handleBackPress = () => {
-    navigation.goBack();
-    return false;
-  };
-
+  const hasTrackedScreenView = useRef(false);
   useEffect(() => {
+    if (hasTrackedScreenView.current) return;
+    hasTrackedScreenView.current = true;
     trace({
       name: TraceName.LoginUserInteraction,
       op: TraceOperation.Login,
     });
     track(MetaMetricsEvents.LOGIN_SCREEN_VIEWED, {});
+  }, [track]);
+
+  const handleBackPress = useCallback(() => {
+    navigation.goBack();
+    return false;
+  }, [navigation]);
+
+  useEffect(() => {
     const backHandlerSubscription = BackHandler.addEventListener(
       'hardwareBackPress',
       handleBackPress,
@@ -691,8 +692,7 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
     return () => {
       backHandlerSubscription.remove();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [handleBackPress]);
 
   useEffect(() => {
     const onboardingTraceCtxFromRoute = route.params?.onboardingTraceCtx;

--- a/app/components/Views/SocialLoginIosUser/index.tsx
+++ b/app/components/Views/SocialLoginIosUser/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   useNavigation,
@@ -51,7 +51,10 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
   const isUserTypeNew = type === 'new';
   const accountType = getSocialAccountType(provider ?? '', !isUserTypeNew);
 
+  const hasTrackedView = useRef(false);
   useEffect(() => {
+    if (hasTrackedView.current) return;
+    hasTrackedView.current = true;
     trackEvent(
       createEventBuilder(MetaMetricsEvents.SOCIAL_LOGIN_IOS_SUCCESS_VIEWED)
         .addProperties({
@@ -60,8 +63,7 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
         })
         .build(),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [trackEvent, createEventBuilder, isUserTypeNew, accountType]);
 
   const handleSetMetaMaskPin = () => {
     trackEvent(


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Prepares OAuth onboarding screens for the React Compiler by replacing `eslint-disable-next-line react-hooks/exhaustive-deps` suppressions with correct hook dependency arrays and one-time analytics guards.

**OAuthRehydration**
- Removed a redundant `useEffect` that called `setBiometryChoice(true)` on mount; biometrics already default to enabled via `useState(true)`.
- Split screen-view tracing/metrics and Android back-handler setup into separate effects.
- Guarded `LOGIN_SCREEN_VIEWED` / login trace with a `useRef` so events fire once per mount even when the effect re-runs.
- Wrapped `handleBackPress` in `useCallback` and listed it in the back-handler effect deps.

**SocialLoginIosUser**
- Guarded `SOCIAL_LOGIN_IOS_SUCCESS_VIEWED` with a `useRef` for the same one-time tracking semantics.
- Replaced the empty-deps eslint suppression with a full dependency array (`trackEvent`, `createEventBuilder`, `isUserTypeNew`, `accountType`).

No user-facing behavior change is intended beyond removing duplicate analytics if an effect were to re-run.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: React Compiler onboarding compatibility work

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: OAuth onboarding React Compiler hook compliance

  Scenario: OAuth rehydration login screen analytics and back navigation
    Given a user on the OAuth rehydration / password login screen
    When the screen mounts
    Then login screen viewed metrics and trace fire once
    When the user presses the Android hardware back button
    Then navigation goes back without duplicate tracking events

  Scenario: iOS social login success screen analytics
    Given a user completes social login on iOS and lands on SocialLoginIosUser
    When the success screen mounts
    Then SOCIAL_LOGIN_IOS_SUCCESS_VIEWED fires once with correct is_new_user and account_type properties
    When the user taps "Set MetaMask PIN" or continues onboarding
    Then subsequent navigation works as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — internal hook/refactor change with no visual UI difference.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.