### PR TITLE
fix(perps): hide non-tradable markets in What's Happening

### DIFF
--- a/app/components/UI/WhatsHappening/components/WhatsHappeningAssetSlider.test.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningAssetSlider.test.tsx
@@ -50,6 +50,12 @@ jest.mock('@metamask/perps-controller', () => ({
   getPerpsDisplaySymbol: (symbol: string) => symbol,
 }));
 
+const mockUseTradablePerpsMarketSymbols = jest.fn();
+
+jest.mock('../hooks', () => ({
+  useTradablePerpsMarketSymbols: () => mockUseTradablePerpsMarketSymbols(),
+}));
+
 const btcAsset = {
   sourceAssetId: 'a1',
   symbol: 'BTC',
@@ -64,6 +70,14 @@ const ethAsset = {
   name: 'Ethereum',
   caip19: [],
   hlPerpsMarket: ['ETH'],
+};
+
+const dxyAsset = {
+  sourceAssetId: 'dxy',
+  symbol: 'DXY',
+  name: 'Dollar Index',
+  caip19: [],
+  hlPerpsMarket: ['xyz:DXY'],
 };
 
 const noPerpsAsset = {
@@ -94,6 +108,10 @@ describe('WhatsHappeningAssetSlider', () => {
     jest.clearAllMocks();
     mockUseWhatsHappeningAssetPrices.mockReturnValue({
       perpsPriceBySymbol: {},
+    });
+    mockUseTradablePerpsMarketSymbols.mockReturnValue({
+      tradableSymbols: new Set(['BTC', 'ETH', 'SOL']),
+      isLoading: false,
     });
   });
 
@@ -180,5 +198,34 @@ describe('WhatsHappeningAssetSlider', () => {
     );
     expect(screen.getByText('-2.50%')).toBeOnTheScreen();
     expect(screen.queryByText('undefined')).toBeNull();
+  });
+
+  it('hides a perps asset whose market is not in the tradable set (e.g. xyz:DXY)', () => {
+    renderWithProvider(
+      <WhatsHappeningAssetSlider
+        {...sharedProps}
+        assets={[btcAsset, dxyAsset]}
+      />,
+    );
+    expect(screen.getByText('BTC')).toBeOnTheScreen();
+    expect(screen.queryByText('DXY')).toBeNull();
+  });
+
+  it('returns null when all perps assets are non-tradable', () => {
+    const { toJSON } = renderWithProvider(
+      <WhatsHappeningAssetSlider {...sharedProps} assets={[dxyAsset]} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null while the tradable set is still loading (prevents flash of non-tradable markets)', () => {
+    mockUseTradablePerpsMarketSymbols.mockReturnValue({
+      tradableSymbols: new Set(),
+      isLoading: true,
+    });
+    const { toJSON } = renderWithProvider(
+      <WhatsHappeningAssetSlider {...sharedProps} assets={[btcAsset]} />,
+    );
+    expect(toJSON()).toBeNull();
   });
 });

--- a/app/components/UI/WhatsHappening/components/WhatsHappeningAssetSlider.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningAssetSlider.tsx
@@ -6,6 +6,8 @@ import { useWhatsHappeningAssetPrices } from '../../../Views/WhatsHappeningDetai
 import type { WhatsHappeningItem } from '../types';
 import type { WhatsHappeningSourceValue } from '../constants';
 import WhatsHappeningAssetPill from './WhatsHappeningAssetPill';
+import { useTradablePerpsMarketSymbols } from '../hooks';
+import { isRelatedAssetTradable } from '../util/tradableAssets';
 
 export interface WhatsHappeningAssetSliderProps {
   assets: RelatedAsset[];
@@ -22,9 +24,15 @@ const WhatsHappeningAssetSlider: React.FC<WhatsHappeningAssetSliderProps> = ({
 }) => {
   const tw = useTailwind();
 
+  const { tradableSymbols } = useTradablePerpsMarketSymbols();
+
   const perpsAssets = useMemo(
-    () => assets.filter((a) => a.hlPerpsMarket?.[0]),
-    [assets],
+    () =>
+      assets.filter(
+        (a) =>
+          a.hlPerpsMarket?.[0] && isRelatedAssetTradable(a, tradableSymbols),
+      ),
+    [assets, tradableSymbols],
   );
 
   const { perpsPriceBySymbol } = useWhatsHappeningAssetPrices(perpsAssets);

--- a/app/components/UI/WhatsHappening/components/WhatsHappeningCard.test.tsx
+++ b/app/components/UI/WhatsHappening/components/WhatsHappeningCard.test.tsx
@@ -70,6 +70,13 @@ jest.mock('@metamask/perps-controller', () => ({
   }),
 }));
 
+jest.mock('../hooks', () => ({
+  useTradablePerpsMarketSymbols: () => ({
+    tradableSymbols: new Set(['BTC', 'ETH', 'SOL', 'xyz:BRENT', 'xyz:WTI']),
+    isLoading: false,
+  }),
+}));
+
 const mockRelatedAsset = {
   sourceAssetId: 'btc-mainnet',
   symbol: 'BTC',

--- a/app/components/UI/WhatsHappening/hooks/index.ts
+++ b/app/components/UI/WhatsHappening/hooks/index.ts
@@ -6,3 +6,5 @@ export type {
   UseWhatsHappeningResult,
   UseWhatsHappeningOptions,
 } from './useWhatsHappening';
+export { useTradablePerpsMarketSymbols } from './useTradablePerpsMarketSymbols';
+export type { UseTradablePerpsMarketSymbolsResult } from './useTradablePerpsMarketSymbols';

--- a/app/components/UI/WhatsHappening/hooks/useTradablePerpsMarketSymbols.test.ts
+++ b/app/components/UI/WhatsHappening/hooks/useTradablePerpsMarketSymbols.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react-native';
+import { useTradablePerpsMarketSymbols } from './useTradablePerpsMarketSymbols';
+
+const mockUsePerpsMarkets = jest.fn();
+
+jest.mock('../../Perps/hooks/usePerpsMarkets', () => ({
+  usePerpsMarkets: (...args: unknown[]) => mockUsePerpsMarkets(...args),
+}));
+
+const makeMarket = (symbol: string) => ({
+  symbol,
+  name: symbol,
+  maxLeverage: '10x',
+  price: '$1.00',
+  change24h: '+1%',
+  change24hPercent: '1',
+  volume: '$1M',
+  openInterest: '$500K',
+  volumeNumber: 1_000_000,
+});
+
+describe('useTradablePerpsMarketSymbols', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty set and isLoading true while markets are loading', () => {
+    mockUsePerpsMarkets.mockReturnValue({ markets: [], isLoading: true });
+
+    const { result } = renderHook(() => useTradablePerpsMarketSymbols());
+
+    expect(result.current.tradableSymbols.size).toBe(0);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns a set of symbol strings from the guardrail-filtered market list', () => {
+    mockUsePerpsMarkets.mockReturnValue({
+      markets: [makeMarket('BTC'), makeMarket('ETH'), makeMarket('xyz:TSLA')],
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useTradablePerpsMarketSymbols());
+
+    expect(result.current.tradableSymbols).toEqual(
+      new Set(['BTC', 'ETH', 'xyz:TSLA']),
+    );
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('returns an empty set when the market list is empty (no tradable markets)', () => {
+    mockUsePerpsMarkets.mockReturnValue({ markets: [], isLoading: false });
+
+    const { result } = renderHook(() => useTradablePerpsMarketSymbols());
+
+    expect(result.current.tradableSymbols.size).toBe(0);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('passes no arguments to usePerpsMarkets (relies on its showZeroVolume default)', () => {
+    mockUsePerpsMarkets.mockReturnValue({ markets: [], isLoading: false });
+
+    renderHook(() => useTradablePerpsMarketSymbols());
+
+    expect(mockUsePerpsMarkets).toHaveBeenCalledWith();
+  });
+});

--- a/app/components/UI/WhatsHappening/hooks/useTradablePerpsMarketSymbols.ts
+++ b/app/components/UI/WhatsHappening/hooks/useTradablePerpsMarketSymbols.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { usePerpsMarkets } from '../../Perps/hooks/usePerpsMarkets';
+
+export interface UseTradablePerpsMarketSymbolsResult {
+  /**
+   * Set of perps market symbols that pass the tradability guardrail
+   * (non-zero volume and open interest). Matches the same filtering applied
+   * everywhere in the Perps UI via usePerpsMarkets → filterAndSortMarkets.
+   *
+   * An empty Set during initial load means the list has not arrived yet — do
+   * not treat it as "no tradable markets exist".
+   */
+  tradableSymbols: Set<string>;
+  isLoading: boolean;
+}
+
+/**
+ * Returns a Set of tradable perps market symbols derived from the canonical
+ * perps market list. Markets are already filtered by the existing guardrail
+ * (filterAndSortMarkets via usePerpsMarkets) — this hook only projects those
+ * results to a symbol Set for O(1) membership checks.
+ *
+ * No volume/open-interest logic is re-implemented here. The single source of
+ * truth remains filterAndSortMarkets (invoked inside usePerpsMarkets).
+ */
+export function useTradablePerpsMarketSymbols(): UseTradablePerpsMarketSymbolsResult {
+  const { markets, isLoading } = usePerpsMarkets();
+
+  const tradableSymbols = useMemo(
+    () => new Set(markets.map((m) => m.symbol)),
+    [markets],
+  );
+
+  return { tradableSymbols, isLoading };
+}

--- a/app/components/UI/WhatsHappening/util/tradableAssets.test.ts
+++ b/app/components/UI/WhatsHappening/util/tradableAssets.test.ts
@@ -1,0 +1,65 @@
+import { isRelatedAssetTradable } from './tradableAssets';
+
+const tradableSymbols = new Set(['BTC', 'ETH', 'xyz:TSLA', 'xyz:EUR']);
+
+const btcAsset = {
+  sourceAssetId: 'btc',
+  symbol: 'BTC',
+  name: 'Bitcoin',
+  caip19: [],
+  hlPerpsMarket: ['BTC'],
+};
+
+const dxyAsset = {
+  sourceAssetId: 'dxy',
+  symbol: 'DXY',
+  name: 'Dollar Index',
+  caip19: [],
+  hlPerpsMarket: ['xyz:DXY'],
+};
+
+const eurAsset = {
+  sourceAssetId: 'eur',
+  symbol: 'EUR',
+  name: 'Euro',
+  caip19: [],
+  hlPerpsMarket: ['xyz:EUR'],
+};
+
+const nonPerpsAsset = {
+  sourceAssetId: 'usdc',
+  symbol: 'USDC',
+  name: 'USD Coin',
+  caip19: ['eip155:1/erc20:0xusdc'],
+};
+
+describe('isRelatedAssetTradable', () => {
+  it('returns true for a tradable perps asset', () => {
+    expect(isRelatedAssetTradable(btcAsset, tradableSymbols)).toBe(true);
+  });
+
+  it('returns false for a perps asset whose market is not tradable (e.g. xyz:DXY)', () => {
+    expect(isRelatedAssetTradable(dxyAsset, tradableSymbols)).toBe(false);
+  });
+
+  it('returns true for a tradable HIP-3 perps asset', () => {
+    expect(isRelatedAssetTradable(eurAsset, tradableSymbols)).toBe(true);
+  });
+
+  it('returns true for a non-perps asset regardless of tradable set', () => {
+    expect(isRelatedAssetTradable(nonPerpsAsset, tradableSymbols)).toBe(true);
+  });
+
+  it('returns true for a non-perps asset even with an empty tradable set', () => {
+    expect(isRelatedAssetTradable(nonPerpsAsset, new Set())).toBe(true);
+  });
+
+  it('returns false for a perps asset when tradable set is empty (markets still loading)', () => {
+    expect(isRelatedAssetTradable(btcAsset, new Set())).toBe(false);
+  });
+
+  it('returns false for a perps asset with an empty hlPerpsMarket array (edge case)', () => {
+    const assetNoMarket = { ...btcAsset, hlPerpsMarket: [] };
+    expect(isRelatedAssetTradable(assetNoMarket, tradableSymbols)).toBe(true);
+  });
+});

--- a/app/components/UI/WhatsHappening/util/tradableAssets.ts
+++ b/app/components/UI/WhatsHappening/util/tradableAssets.ts
@@ -1,0 +1,24 @@
+import type { RelatedAsset } from '@metamask/ai-controllers';
+
+/**
+ * Returns true when the asset should be displayed as a tradable perps asset.
+ *
+ * Assets without an `hlPerpsMarket` mapping are NOT perps assets and are
+ * always considered displayable (this predicate does not gate them).
+ * Assets that DO have an `hlPerpsMarket` mapping are only shown when their
+ * first market symbol is present in `tradableSymbols`, which is derived from
+ * the canonical perps guardrail (filterAndSortMarkets via usePerpsMarkets).
+ *
+ * This intentionally performs NO volume/open-interest logic — tradability is
+ * determined entirely by membership in the already-filtered market set.
+ */
+export function isRelatedAssetTradable(
+  asset: RelatedAsset,
+  tradableSymbols: Set<string>,
+): boolean {
+  const perpsSymbol = asset.hlPerpsMarket?.[0];
+  if (!perpsSymbol) {
+    return true;
+  }
+  return tradableSymbols.has(perpsSymbol);
+}

--- a/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.test.tsx
@@ -47,6 +47,13 @@ jest.mock('../hooks/useWhatsHappeningAssetPrices', () => ({
   })),
 }));
 
+const mockUseTradablePerpsMarketSymbols = jest.fn();
+
+jest.mock('../../../UI/WhatsHappening/hooks', () => ({
+  ...jest.requireActual('../../../UI/WhatsHappening/hooks'),
+  useTradablePerpsMarketSymbols: () => mockUseTradablePerpsMarketSymbols(),
+}));
+
 jest.mock(
   '../../../UI/Tokens/components/TokenListSecurityBadge/TokenListSecurityBadge',
   () => 'TokenListSecurityBadge',
@@ -84,9 +91,21 @@ const baseItem: WhatsHappeningItem = {
   articles: [],
 };
 
+const dxyAsset = {
+  sourceAssetId: 'dxy',
+  symbol: 'DXY',
+  name: 'Dollar Index',
+  caip19: [],
+  hlPerpsMarket: ['xyz:DXY'],
+};
+
 describe('WhatsHappeningExpandedCard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseTradablePerpsMarketSymbols.mockReturnValue({
+      tradableSymbols: new Set(['xyz:TSLA', 'BTC']),
+      isLoading: false,
+    });
   });
 
   it('renders the title and description', () => {
@@ -320,5 +339,35 @@ describe('WhatsHappeningExpandedCard', () => {
       />,
     );
     expect(screen.getByText('$172.50')).toBeOnTheScreen();
+  });
+
+  it('hides a perps asset whose market is not tradable (e.g. xyz:DXY)', () => {
+    const item = { ...baseItem, relatedAssets: [perpsOnlyAsset, dxyAsset] };
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={item}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="homepage"
+      />,
+    );
+    expect(screen.getByText('Tesla')).toBeOnTheScreen();
+    expect(screen.queryByText('Dollar Index')).toBeNull();
+  });
+
+  it('hides the Related Assets section entirely when all perps assets are non-tradable', () => {
+    const item = { ...baseItem, relatedAssets: [dxyAsset] };
+    renderWithProvider(
+      <WhatsHappeningExpandedCard
+        item={item}
+        cardIndex={0}
+        cardWidth={CARD_WIDTH}
+        cardHeight={CARD_HEIGHT}
+        source="homepage"
+      />,
+    );
+    expect(screen.queryByText('Related Assets')).toBeNull();
+    expect(screen.queryByText('Dollar Index')).toBeNull();
   });
 });

--- a/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/WhatsHappeningExpandedCard.tsx
@@ -18,6 +18,8 @@ import {
 import type { Article, MarketInsightsSource } from '@metamask/ai-controllers';
 import type { WhatsHappeningItem } from '../../../UI/WhatsHappening/types';
 import type { WhatsHappeningSourceValue } from '../../../UI/WhatsHappening/constants';
+import { useTradablePerpsMarketSymbols } from '../../../UI/WhatsHappening/hooks';
+import { isRelatedAssetTradable } from '../../../UI/WhatsHappening/util/tradableAssets';
 import { strings } from '../../../../../locales/i18n';
 import {
   getImpactLabel,
@@ -88,8 +90,18 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
     [item.date],
   );
 
+  const { tradableSymbols } = useTradablePerpsMarketSymbols();
+
+  const tradableRelatedAssets = useMemo(
+    () =>
+      item.relatedAssets.filter((a) =>
+        isRelatedAssetTradable(a, tradableSymbols),
+      ),
+    [item.relatedAssets, tradableSymbols],
+  );
+
   const { perpsPriceBySymbol } = useWhatsHappeningAssetPrices(
-    item.relatedAssets,
+    tradableRelatedAssets,
   );
 
   const scrollBottomFadeColors = useMemo((): string[] => {
@@ -252,7 +264,7 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
             )}
 
             {/* Related assets section */}
-            {item.relatedAssets.length > 0 && (
+            {tradableRelatedAssets.length > 0 && (
               <Box gap={1}>
                 <Text
                   variant={TextVariant.HeadingSm}
@@ -262,7 +274,7 @@ const WhatsHappeningExpandedCard: React.FC<WhatsHappeningExpandedCardProps> = ({
                   {strings('homepage.sections.related_assets')}
                 </Text>
 
-                {item.relatedAssets.map((asset, index) => (
+                {tradableRelatedAssets.map((asset, index) => (
                   <PerpsRow
                     key={`${asset.symbol}-${index}`}
                     asset={asset}


### PR DESCRIPTION

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "What's Happening" UI was promoting perps markets that exist on-chain but are not yet tradable (no price, no volume, no open interest) — for example the `xyz:DXY` dollar-index market. trade.xyz "creates" these markets days/weeks before they become tradable, and the rest of the Perps UX already hides them via the `filterAndSortMarkets` guardrail (`showZeroVolume: false`). The "What's Happening" carousel and detail view bypassed that guardrail: they rendered a perps asset whenever the related asset merely had an `hlPerpsMarket` symbol mapping.

This PR routes both "What's Happening" surfaces through the existing guardrail instead of reimplementing any volume/open-interest logic:

- New `useTradablePerpsMarketSymbols` hook — a thin WhatsHappening-side adapter that reads the already-filtered market list from `usePerpsMarkets` (which internally applies `filterAndSortMarkets`) and projects it to a `Set<string>` of tradable symbols for O(1) membership checks. No tradability rules are duplicated; `filterAndSortMarkets` remains the single source of truth.
- New `isRelatedAssetTradable` predicate — returns `true` for non-perps related assets, and for perps assets only when their `hlPerpsMarket` symbol is in the tradable set.
- `WhatsHappeningAssetSlider` (carousel pills) now requires the symbol to be tradable; while the set is still loading, perps pills stay hidden to avoid a flash-then-remove of non-tradable markets.
- `WhatsHappeningExpandedCard` (detail view) filters related assets before rendering `PerpsRow` and hides the "Related Assets" section entirely when nothing tradable remains.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the "What's Happening" section showing perps markets that are not yet tradable (e.g. DXY).

## **Related issues**

Fixes: TSA-781

## **Manual testing steps**

```gherkin
Feature: What's Happening hides non-tradable perps markets

  Scenario: Carousel does not show a non-tradable perps market
    Given a "What's Happening" trend references a perps market with no trading activity (e.g. xyz:DXY)
    And the same trend references a tradable market (e.g. BTC)
    When the user views the "What's Happening" carousel
    Then the non-tradable market pill is not displayed
    And the tradable market pill is displayed

  Scenario: Detail view hides non-tradable related assets
    Given a "What's Happening" card whose related assets include a non-tradable perps market
    When the user opens the expanded detail view
    Then the non-tradable perps asset row is not displayed
    And non-perps related assets remain displayed

  Scenario: Related Assets section is hidden when nothing is tradable
    Given a "What's Happening" card whose only related asset is a non-tradable perps market
    When the user opens the expanded detail view
    Then the "Related Assets" section is not displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="664" height="801" alt="image" src="https://github.com/user-attachments/assets/88a6f6c9-d878-4f49-b30e-abbe21152247" />

### **After**

<img width="622" height="788" alt="image" src="https://github.com/user-attachments/assets/4aa3b0eb-04e0-4af9-9861-a1f22ff7537f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering aligned with existing Perps market guardrails; no auth, payments, or duplicated tradability logic.
> 
> **Overview**
> What's Happening no longer surfaces perps-related assets just because they have an `hlPerpsMarket` mapping. **Carousel pills** and the **detail Related Assets** section now only include perps assets whose market symbol appears in the same guardrail-filtered list the rest of Perps uses (`usePerpsMarkets` → `filterAndSortMarkets`), via new `useTradablePerpsMarketSymbols` and `isRelatedAssetTradable`. Non-perps related assets are unchanged.
> 
> The asset slider returns nothing when every perps asset is filtered out (including while tradable symbols are still loading, which avoids briefly showing markets like `xyz:DXY`). The expanded card hides the whole Related Assets block when nothing tradable remains and only fetches prices for tradable assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c656bdddd991d08ae15d935760ccc45ffb25568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->