### PR TITLE
refactor(confirmations): standardise messenger types

### DIFF
--- a/app/core/Engine/messengers/gas-fee-controller-messenger/gas-fee-controller-messenger.ts
+++ b/app/core/Engine/messengers/gas-fee-controller-messenger/gas-fee-controller-messenger.ts
@@ -9,14 +9,12 @@ import { RootMessenger } from '../../types';
 const name = 'GasFeeController';
 
 export function getGasFeeControllerMessenger(
-  rootMessenger: RootMessenger,
-): GasFeeMessenger {
-  const messenger = new Messenger<
-    typeof name,
+  rootMessenger: RootMessenger<
     MessengerActions<GasFeeMessenger>,
-    MessengerEvents<GasFeeMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<GasFeeMessenger>
+  >,
+): GasFeeMessenger {
+  const messenger: GasFeeMessenger = new Messenger({
     namespace: name,
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/signature-controller-messenger/signature-controller-messenger.ts
+++ b/app/core/Engine/messengers/signature-controller-messenger/signature-controller-messenger.ts
@@ -7,14 +7,12 @@ import { SignatureControllerMessenger } from '@metamask/signature-controller';
 import { RootMessenger } from '../../types';
 
 export function getSignatureControllerMessenger(
-  rootMessenger: RootMessenger,
-): SignatureControllerMessenger {
-  const messenger = new Messenger<
-    'SignatureController',
+  rootMessenger: RootMessenger<
     MessengerActions<SignatureControllerMessenger>,
-    MessengerEvents<SignatureControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<SignatureControllerMessenger>
+  >,
+): SignatureControllerMessenger {
+  const messenger: SignatureControllerMessenger = new Messenger({
     namespace: 'SignatureController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -66,14 +66,12 @@ import type {
 } from '../../../../components/UI/Predict/controllers/PredictController-method-action-types';
 
 export function getTransactionControllerMessenger(
-  rootMessenger: RootMessenger,
-): TransactionControllerMessenger {
-  const messenger = new Messenger<
-    'TransactionController',
+  rootMessenger: RootMessenger<
     MessengerActions<TransactionControllerMessenger>,
-    MessengerEvents<TransactionControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TransactionControllerMessenger>
+  >,
+): TransactionControllerMessenger {
+  const messenger: TransactionControllerMessenger = new Messenger({
     namespace: 'TransactionController',
     parent: rootMessenger,
   });
@@ -150,19 +148,19 @@ type InitMessengerEvents =
   | SmartTransactionsControllerSmartTransactionEvent
   | SmartTransactionsControllerSmartTransactionConfirmationDoneEvent;
 
-export type TransactionControllerInitMessenger = ReturnType<
-  typeof getTransactionControllerInitMessenger
+export type TransactionControllerInitMessenger = Messenger<
+  'TransactionControllerInit',
+  InitMessengerActions,
+  InitMessengerEvents
 >;
 
 export function getTransactionControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'TransactionControllerInit',
-    InitMessengerActions,
-    InitMessengerEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<TransactionControllerInitMessenger>,
+    MessengerEvents<TransactionControllerInitMessenger>
+  >,
+): TransactionControllerInitMessenger {
+  const messenger: TransactionControllerInitMessenger = new Messenger({
     namespace: 'TransactionControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.ts
@@ -15,14 +15,12 @@ import { TransactionControllerIsAtomicBatchSupportedAction } from '@metamask/tra
 import { NetworkControllerGetNetworkConfigurationByChainIdAction } from '@metamask/network-controller';
 
 export function getTransactionPayControllerMessenger(
-  rootMessenger: RootMessenger,
-): TransactionPayControllerMessenger {
-  const messenger = new Messenger<
-    'TransactionPayController',
+  rootMessenger: RootMessenger<
     MessengerActions<TransactionPayControllerMessenger>,
-    MessengerEvents<TransactionPayControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TransactionPayControllerMessenger>
+  >,
+): TransactionPayControllerMessenger {
+  const messenger: TransactionPayControllerMessenger = new Messenger({
     namespace: 'TransactionPayController',
     parent: rootMessenger,
   });
@@ -70,21 +68,22 @@ type InitMessengerActions =
   | KeyringControllerSignTypedMessageAction
   | NetworkControllerGetNetworkConfigurationByChainIdAction
   | TransactionControllerIsAtomicBatchSupportedAction;
+
 type InitMessengerEvents = never;
 
-export type TransactionPayControllerInitMessenger = ReturnType<
-  typeof getTransactionPayControllerInitMessenger
+export type TransactionPayControllerInitMessenger = Messenger<
+  'TransactionPayControllerInit',
+  InitMessengerActions,
+  InitMessengerEvents
 >;
 
 export function getTransactionPayControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'TransactionPayControllerInit',
-    InitMessengerActions,
-    InitMessengerEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<TransactionPayControllerInitMessenger>,
+    MessengerEvents<TransactionPayControllerInitMessenger>
+  >,
+): TransactionPayControllerInitMessenger {
+  const messenger: TransactionPayControllerInitMessenger = new Messenger({
     namespace: 'TransactionPayControllerInit',
     parent: rootMessenger,
   });


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the four confirmations-owned messenger files (`gas-fee-controller-messenger`, `signature-controller-messenger`, `transaction-controller-messenger`, `transaction-pay-controller-messenger`).

Makes messenger factory functions accept the narrowed `RootMessenger<AllowedActions, AllowedEvents>` instead of the broad `RootMessenger`, and simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to `const messenger: XMessenger = new Messenger({…})` so TypeScript infers the generic parameters from the typed variable.

Also converts `TransactionControllerInitMessenger` and `TransactionPayControllerInitMessenger` from `ReturnType<typeof getX>` aliases to explicit `Messenger<Namespace, Actions, Events>` definitions, making the types self-contained and consistent with the rest of the messenger type patterns.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure TypeScript typing changes with no runtime behavior; touches confirmations wiring types only.
> 
> **Overview**
> **Type-only refactor** across four confirmations Engine messenger modules (`gas-fee`, `signature`, `transaction`, `transaction-pay`): factory helpers now take a **narrowed** `RootMessenger<MessengerActions<…>, MessengerEvents<…>>` instead of the unconstrained `RootMessenger`, and child messengers are created as `const messenger: XMessenger = new Messenger({…})` so generics are inferred from the annotated return type rather than spelled on `new Messenger<…>`.
> 
> For **transaction** and **transaction-pay**, `TransactionControllerInitMessenger` and `TransactionPayControllerInitMessenger` are no longer `ReturnType<typeof get…>` aliases; they are explicit `Messenger<'…Init', Actions, Events>` types, with init factories typed the same way as the main messengers. `transaction-pay` also adds an explicit `InitMessengerEvents = never`.
> 
> **No runtime or delegation behavior changes**—delegate action/event lists are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e44f0cd71af7bbe6b9c9544cd0eb3571afb03d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->