### PR TITLE
fix: render Hyperliquid leaderboard token icons via Perps logo resolution

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -420,6 +420,17 @@ describe('TraderPositionView', () => {
       expect(screen.getByText('10x')).toBeOnTheScreen();
       expect(screen.getByText('SHORT')).toBeOnTheScreen();
     });
+
+    it('does not render the copy token address button for a perp position', () => {
+      renderWithProvider(<TraderPositionView />, { state: mockState });
+
+      // Perps have no on-chain token address, so copy is not offered.
+      expect(
+        screen.queryByTestId(
+          TraderPositionViewSelectorsIDs.COPY_TOKEN_ADDRESS_BUTTON,
+        ),
+      ).not.toBeOnTheScreen();
+    });
   });
 
   it('forwards the filtered trades to the chart component', async () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTokenInfoRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTokenInfoRow.tsx
@@ -57,8 +57,11 @@ const TraderTokenIdentity: React.FC<TraderTokenIdentityProps> = ({
   copyTokenAddressTestID,
 }) => {
   const tw = useTailwind();
+  // Perps have no on-chain token address — `tokenAddress` carries the perp
+  // symbol — so copying it is meaningless. Only spot positions expose copy.
+  const isPerp = position ? isPerpPosition(position) : false;
   const canCopyTokenAddress = Boolean(
-    position?.tokenAddress && onCopyTokenAddress,
+    position?.tokenAddress && onCopyTokenAddress && !isPerp,
   );
   const perpDirection = position ? getPerpPositionDirection(position) : null;
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -366,9 +366,9 @@ describe('TraderProfileView', () => {
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
-  it('renders follower count', () => {
+  it('does not render a follower count', () => {
     renderWithProvider(<TraderProfileView />);
-    expect(screen.getByText('45 followers')).toBeOnTheScreen();
+    expect(screen.queryByText(/follower/i)).toBeNull();
   });
 
   it('renders the win rate stat', () => {
@@ -438,7 +438,9 @@ describe('TraderProfileView', () => {
     expect(
       screen.getByTestId(TraderProfileViewSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
-    expect(screen.queryByText('45 followers')).not.toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(TraderProfileViewSelectorsIDs.HEADER),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders position skeletons when positions are loading', () => {
@@ -554,7 +556,9 @@ describe('TraderProfileView', () => {
   it('renders skeleton when profile is null even if not loading', () => {
     mockProfileResult.profile = null;
     renderWithProvider(<TraderProfileView />);
-    expect(screen.queryByText('45 followers')).not.toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(TraderProfileViewSelectorsIDs.HEADER),
+    ).not.toBeOnTheScreen();
   });
 
   describe('error state', () => {
@@ -589,7 +593,9 @@ describe('TraderProfileView', () => {
 
     it('does not show skeleton when error is present', () => {
       renderWithProvider(<TraderProfileView />);
-      expect(screen.queryByText('45 followers')).not.toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(TraderProfileViewSelectorsIDs.HEADER),
+      ).not.toBeOnTheScreen();
       expect(screen.queryByText('Follow')).not.toBeOnTheScreen();
     });
 
@@ -608,7 +614,9 @@ describe('TraderProfileView', () => {
       expect(
         screen.queryByTestId(TraderProfileViewSelectorsIDs.ERROR_BANNER),
       ).not.toBeOnTheScreen();
-      expect(screen.getByText('45 followers')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.HEADER),
+      ).toBeOnTheScreen();
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -386,7 +386,6 @@ const TraderProfileView = () => {
             ) : (
               <ProfileHeader
                 profile={profile.profile}
-                followerCount={profile.followerCount}
                 twitterHandle={profile.socialHandles?.twitter}
               />
             )}

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -332,12 +332,13 @@ describe('PositionRow', () => {
       expect(screen.queryByText('SHORT')).not.toBeOnTheScreen();
     });
 
-    it('shows PnL as the value for perps instead of the current value', () => {
+    it('shows the current value (not PnL) as the top-right value for an open perp, matching spot', () => {
       renderWithProvider(<PositionRow position={perpPosition} />);
 
-      // Perps surface realized/unrealized PnL ($1,059.96), not currentValueUSD.
-      expect(screen.getByText('+$1,059.96')).toBeOnTheScreen();
-      expect(screen.queryByText('$2,259.96')).not.toBeOnTheScreen();
+      // Open perps mirror open spot: the headline figure is the current
+      // position value (neutral), not the signed PnL.
+      expect(screen.getByText('$2,259.96')).toBeOnTheScreen();
+      expect(screen.queryByText('+$1,059.96')).not.toBeOnTheScreen();
     });
 
     it('shows the trade date (not the position amount) for a closed perp', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -349,5 +349,47 @@ describe('PositionRow', () => {
       // Not the "<amount> ETH" subtitle that open positions show.
       expect(screen.queryByText('1.50B ETH')).not.toBeOnTheScreen();
     });
+
+    it('renders an up triangle with a neutral, unsigned percent for a winning closed perp (matching spot)', () => {
+      const closedPerp = {
+        ...perpPosition,
+        currentValueUSD: 0,
+        realizedPnl: 300,
+        boughtUsd: 1200,
+        pnlValueUsd: 300,
+      };
+
+      renderWithProvider(<PositionRow position={closedPerp} isClosed />);
+
+      // 300 / 1200 * 100 = 25%, rendered unsigned with the caret carrying direction.
+      expect(screen.getByText('▲')).toBeOnTheScreen();
+      expect(screen.getByText('25%')).toBeOnTheScreen();
+      expect(screen.queryByText('+25%')).toBeNull();
+    });
+
+    it('renders a down triangle with a neutral, unsigned percent for a losing closed perp', () => {
+      const closedPerp = {
+        ...perpPosition,
+        currentValueUSD: 0,
+        realizedPnl: -300,
+        boughtUsd: 1200,
+        pnlValueUsd: -300,
+      };
+
+      renderWithProvider(<PositionRow position={closedPerp} isClosed />);
+
+      expect(screen.getByText('▼')).toBeOnTheScreen();
+      expect(screen.getByText('25%')).toBeOnTheScreen();
+      expect(screen.queryByText('-25%')).toBeNull();
+    });
+
+    it('keeps the colored, signed percent (no triangle) for an open perp', () => {
+      renderWithProvider(<PositionRow position={perpPosition} />);
+
+      // Open positions keep the signed percent; the triangle is closed-only.
+      expect(screen.getByText('+182%')).toBeOnTheScreen();
+      expect(screen.queryByText('▲')).toBeNull();
+      expect(screen.queryByText('▼')).toBeNull();
+    });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { fireEvent, screen } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PositionRow from './PositionRow';
 import type { Position } from '@metamask/social-controllers';
+
+const colorOf = (node: ReturnType<typeof screen.getByText>) =>
+  (StyleSheet.flatten(node.props.style) as { color?: string } | undefined)
+    ?.color;
 
 jest.mock('../../components/PositionTokenAvatar', () => ({
   __esModule: true,
@@ -80,6 +85,14 @@ describe('PositionRow', () => {
     expect(screen.queryByText('+$1,059.96')).toBeNull();
   });
 
+  it('colors the percent to match the up triangle for a winning position', () => {
+    renderWithProvider(<PositionRow position={basePosition} />);
+    const triangleColor = colorOf(screen.getByText('▲'));
+    const percentColor = colorOf(screen.getByText('182%'));
+    expect(percentColor).toBeDefined();
+    expect(percentColor).toBe(triangleColor);
+  });
+
   it('renders a down triangle with the unsigned percent for a losing open position', () => {
     const position = {
       ...basePosition,
@@ -92,6 +105,16 @@ describe('PositionRow', () => {
     expect(screen.getByText('25%')).toBeOnTheScreen();
     expect(screen.queryByText('-25%')).toBeNull();
     expect(screen.queryByText('-$250.00 (-25%)')).toBeNull();
+  });
+
+  it('colors the percent to match the down triangle for a losing position', () => {
+    const position = { ...basePosition, pnlValueUsd: -250, pnlPercent: -25 };
+
+    renderWithProvider(<PositionRow position={position} />);
+    const triangleColor = colorOf(screen.getByText('▼'));
+    const percentColor = colorOf(screen.getByText('25%'));
+    expect(percentColor).toBeDefined();
+    expect(percentColor).toBe(triangleColor);
   });
 
   it('renders the percent even when pnlValueUsd is missing', () => {
@@ -359,7 +382,7 @@ describe('PositionRow', () => {
       expect(screen.queryByText('1.50B ETH')).not.toBeOnTheScreen();
     });
 
-    it('renders an up triangle with a neutral, unsigned percent for a winning closed perp (matching spot)', () => {
+    it('renders an up triangle with a colored, unsigned percent for a winning closed perp (matching spot)', () => {
       const closedPerp = {
         ...perpPosition,
         currentValueUSD: 0,
@@ -376,7 +399,7 @@ describe('PositionRow', () => {
       expect(screen.queryByText('+25%')).toBeNull();
     });
 
-    it('renders a down triangle with a neutral, unsigned percent for a losing closed perp', () => {
+    it('renders a down triangle with a colored, unsigned percent for a losing closed perp', () => {
       const closedPerp = {
         ...perpPosition,
         currentValueUSD: 0,

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.test.tsx
@@ -70,14 +70,17 @@ describe('PositionRow', () => {
     expect(screen.getByText('$2,259.96')).toBeOnTheScreen();
   });
 
-  it('renders only the bare percent on the bottom-right (no absolute PnL)', () => {
+  it('renders an up triangle with the unsigned percent on the bottom-right (no absolute PnL)', () => {
     renderWithProvider(<PositionRow position={basePosition} />);
-    expect(screen.getByText('+182%')).toBeOnTheScreen();
+    // Direction lives in the caret, so the percent is unsigned.
+    expect(screen.getByText('▲')).toBeOnTheScreen();
+    expect(screen.getByText('182%')).toBeOnTheScreen();
+    expect(screen.queryByText('+182%')).toBeNull();
     expect(screen.queryByText('+$1,059.96 (+182%)')).toBeNull();
     expect(screen.queryByText('+$1,059.96')).toBeNull();
   });
 
-  it('renders the negative percent without the absolute PnL', () => {
+  it('renders a down triangle with the unsigned percent for a losing open position', () => {
     const position = {
       ...basePosition,
       pnlValueUsd: -250,
@@ -85,7 +88,9 @@ describe('PositionRow', () => {
     };
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('-25%')).toBeOnTheScreen();
+    expect(screen.getByText('▼')).toBeOnTheScreen();
+    expect(screen.getByText('25%')).toBeOnTheScreen();
+    expect(screen.queryByText('-25%')).toBeNull();
     expect(screen.queryByText('-$250.00 (-25%)')).toBeNull();
   });
 
@@ -96,7 +101,7 @@ describe('PositionRow', () => {
     } as unknown as Position;
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('+182%')).toBeOnTheScreen();
+    expect(screen.getByText('182%')).toBeOnTheScreen();
   });
 
   it('renders dash when pnlPercent is null', () => {
@@ -122,7 +127,7 @@ describe('PositionRow', () => {
     expect(dashes.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders zero percent when unrealized PnL is zero', () => {
+  it('renders a neutral minus and unsigned 0% when unrealized PnL is zero', () => {
     const position = {
       ...basePosition,
       pnlValueUsd: 0,
@@ -130,7 +135,10 @@ describe('PositionRow', () => {
     };
 
     renderWithProvider(<PositionRow position={position} />);
-    expect(screen.getByText('+0%')).toBeOnTheScreen();
+    // U+2212 minus glyph (not a triangle) for break-even, then unsigned 0%.
+    expect(screen.getByText('−')).toBeOnTheScreen();
+    expect(screen.getByText('0%')).toBeOnTheScreen();
+    expect(screen.queryByText('+0%')).toBeNull();
     expect(screen.queryByText('$0.00 (+0%)')).toBeNull();
   });
 
@@ -384,13 +392,13 @@ describe('PositionRow', () => {
       expect(screen.queryByText('-25%')).toBeNull();
     });
 
-    it('keeps the colored, signed percent (no triangle) for an open perp', () => {
+    it('renders the directional triangle with an unsigned percent for an open perp', () => {
       renderWithProvider(<PositionRow position={perpPosition} />);
 
-      // Open positions keep the signed percent; the triangle is closed-only.
-      expect(screen.getByText('+182%')).toBeOnTheScreen();
-      expect(screen.queryByText('▲')).toBeNull();
-      expect(screen.queryByText('▼')).toBeNull();
+      // Open positions now match closed: caret carries direction, percent is unsigned.
+      expect(screen.getByText('▲')).toBeOnTheScreen();
+      expect(screen.getByText('182%')).toBeOnTheScreen();
+      expect(screen.queryByText('+182%')).toBeNull();
     });
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -104,9 +104,9 @@ const PositionRow: React.FC<PositionRowProps> = ({
   );
 
   // All positions — open and closed, perp and spot — render a directional
-  // triangle (▲/▼, colored by direction) alongside a neutral, unsigned
-  // percentage. A break-even position shows a neutral minus instead of a
-  // triangle. The sign lives in the caret, so the percent text is unsigned.
+  // triangle (▲/▼) alongside an unsigned percentage, both colored by direction
+  // (green up / red down). A break-even position shows a neutral minus and a
+  // neutral percentage. The sign lives in the caret, so the percent is unsigned.
   const bottomRight = (
     <Box
       flexDirection={BoxFlexDirection.Row}
@@ -122,7 +122,11 @@ const PositionRow: React.FC<PositionRowProps> = ({
           {isPnlPositive ? '▲' : '▼'}
         </Text>
       )}
-      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+      <Text
+        variant={TextVariant.BodySm}
+        twClassName={pnlColorClass}
+        color={pnlColorClass ? undefined : TextColor.TextAlternative}
+      >
         {formatPercent(displayPnlPercent).replace(/^[+-]/, '')}
       </Text>
     </Box>

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -103,12 +103,11 @@ const PositionRow: React.FC<PositionRowProps> = ({
     </Text>
   );
 
-  // Closed positions — spot and perp alike — render the directional triangle
-  // alongside a neutral-colored, unsigned percentage; open positions render a
-  // colored, signed percentage. Keyed on `isClosed` only (not `isPerp`) so a
-  // closed perp matches the spot styling rather than showing a colored percent
-  // with no triangle.
-  const bottomRight = isClosed ? (
+  // All positions — open and closed, perp and spot — render a directional
+  // triangle (▲/▼, colored by direction) alongside a neutral, unsigned
+  // percentage. A break-even position shows a neutral minus instead of a
+  // triangle. The sign lives in the caret, so the percent text is unsigned.
+  const bottomRight = (
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
@@ -127,14 +126,6 @@ const PositionRow: React.FC<PositionRowProps> = ({
         {formatPercent(displayPnlPercent).replace(/^[+-]/, '')}
       </Text>
     </Box>
-  ) : (
-    <Text
-      variant={TextVariant.BodySm}
-      twClassName={pnlColorClass}
-      color={pnlColorClass ? undefined : TextColor.TextAlternative}
-    >
-      {formatPercent(displayPnlPercent)}
-    </Text>
   );
 
   const content = (

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -71,7 +71,19 @@ const PositionRow: React.FC<PositionRowProps> = ({
 
   const perpDirection = getPerpPositionDirection(position);
 
-  const topRight = isPerp ? (
+  // Open positions — perp and spot alike — show the current position value in
+  // neutral white (matching spot). Closed positions show signed, colored
+  // realized PnL: perps via `perpPnlValue` (realized + unrealized), spot via
+  // `realizedPnl`.
+  const topRight = !isClosed ? (
+    <Text
+      variant={TextVariant.BodyMd}
+      fontWeight={FontWeight.Medium}
+      color={TextColor.TextDefault}
+    >
+      {formatUsd(position.currentValueUSD ?? null)}
+    </Text>
+  ) : isPerp ? (
     <Text
       variant={TextVariant.BodyMd}
       fontWeight={FontWeight.Medium}
@@ -80,7 +92,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
     >
       {perpPnlValue != null ? formatSignedUsd(perpPnlValue) : '—'}
     </Text>
-  ) : isClosed ? (
+  ) : (
     <Text
       variant={TextVariant.BodyMd}
       fontWeight={FontWeight.Medium}
@@ -88,14 +100,6 @@ const PositionRow: React.FC<PositionRowProps> = ({
       color={pnlColorClass ? undefined : TextColor.TextAlternative}
     >
       {formatSignedUsd(position.realizedPnl)}
-    </Text>
-  ) : (
-    <Text
-      variant={TextVariant.BodyMd}
-      fontWeight={FontWeight.Medium}
-      color={TextColor.TextDefault}
-    >
-      {formatUsd(position.currentValueUSD ?? null)}
     </Text>
   );
 

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/PositionRow.tsx
@@ -99,43 +99,39 @@ const PositionRow: React.FC<PositionRowProps> = ({
     </Text>
   );
 
-  const bottomRight =
-    !isPerp && isClosed ? (
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        gap={1}
-      >
-        {!hasPnlPercent ? null : isPnlZero ? (
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {'−'}
-          </Text>
-        ) : (
-          <Text variant={TextVariant.BodySm} twClassName={pnlColorClass}>
-            {isPnlPositive ? '▲' : '▼'}
-          </Text>
-        )}
+  // Closed positions — spot and perp alike — render the directional triangle
+  // alongside a neutral-colored, unsigned percentage; open positions render a
+  // colored, signed percentage. Keyed on `isClosed` only (not `isPerp`) so a
+  // closed perp matches the spot styling rather than showing a colored percent
+  // with no triangle.
+  const bottomRight = isClosed ? (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={1}
+    >
+      {!hasPnlPercent ? null : isPnlZero ? (
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {formatPercent(displayPnlPercent).replace(/^[+-]/, '')}
+          {'−'}
         </Text>
-      </Box>
-    ) : !isPerp ? (
-      <Text
-        variant={TextVariant.BodySm}
-        twClassName={pnlColorClass}
-        color={pnlColorClass ? undefined : TextColor.TextAlternative}
-      >
-        {formatPercent(displayPnlPercent)}
+      ) : (
+        <Text variant={TextVariant.BodySm} twClassName={pnlColorClass}>
+          {isPnlPositive ? '▲' : '▼'}
+        </Text>
+      )}
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        {formatPercent(displayPnlPercent).replace(/^[+-]/, '')}
       </Text>
-    ) : (
-      <Text
-        variant={TextVariant.BodySm}
-        twClassName={pnlColorClass}
-        color={pnlColorClass ? undefined : TextColor.TextAlternative}
-      >
-        {formatPercent(displayPnlPercent)}
-      </Text>
-    );
+    </Box>
+  ) : (
+    <Text
+      variant={TextVariant.BodySm}
+      twClassName={pnlColorClass}
+      color={pnlColorClass ? undefined : TextColor.TextAlternative}
+    >
+      {formatPercent(displayPnlPercent)}
+    </Text>
+  );
 
   const content = (
     <Box

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.test.tsx
@@ -24,34 +24,26 @@ const baseProfile: TraderProfile = {
 
 describe('ProfileHeader', () => {
   it('renders the header container', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={baseProfile} />);
     expect(
       screen.getByTestId(TraderProfileViewSelectorsIDs.HEADER),
     ).toBeOnTheScreen();
   });
 
   it('renders the trader name', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={baseProfile} />);
     expect(screen.getByText('trader1')).toBeOnTheScreen();
   });
 
   it('renders avatar image when imageUrl is present', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={baseProfile} />);
     expect(
       screen.getByTestId(TraderProfileViewSelectorsIDs.HEADER),
     ).toBeOnTheScreen();
   });
 
   it('does not render a podium medal badge on the profile avatar', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={baseProfile} />);
     expect(screen.queryByTestId('rank-medal-1')).toBeNull();
     expect(screen.queryByTestId('rank-medal-2')).toBeNull();
     expect(screen.queryByTestId('rank-medal-3')).toBeNull();
@@ -59,31 +51,13 @@ describe('ProfileHeader', () => {
 
   it('renders Maskicon fallback when imageUrl is falsy', () => {
     const profileNoImage = { ...baseProfile, imageUrl: '' };
-    renderWithProvider(
-      <ProfileHeader profile={profileNoImage} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={profileNoImage} />);
     expect(screen.getByText('trader1')).toBeOnTheScreen();
   });
 
-  it('renders singular follower string when count is 1', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={1} />,
-    );
-    expect(screen.getByText('1 follower')).toBeOnTheScreen();
-  });
-
-  it('renders plural followers string when count is greater than 1', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={45} />,
-    );
-    expect(screen.getByText('45 followers')).toBeOnTheScreen();
-  });
-
-  it('renders plural followers string when count is 0', () => {
-    renderWithProvider(
-      <ProfileHeader profile={baseProfile} followerCount={0} />,
-    );
-    expect(screen.getByText('0 followers')).toBeOnTheScreen();
+  it('does not render a follower count', () => {
+    renderWithProvider(<ProfileHeader profile={baseProfile} />);
+    expect(screen.queryByText(/follower/i)).toBeNull();
   });
 
   it('renders without a fallback letter when imageUrl is undefined', () => {
@@ -92,9 +66,7 @@ describe('ProfileHeader', () => {
       imageUrl: undefined,
     };
 
-    renderWithProvider(
-      <ProfileHeader profile={profileWithoutImage} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={profileWithoutImage} />);
 
     expect(screen.queryByText('D')).toBeNull();
     expect(screen.getByText('trader1')).toBeOnTheScreen();
@@ -106,9 +78,7 @@ describe('ProfileHeader', () => {
       imageUrl: '',
     };
 
-    renderWithProvider(
-      <ProfileHeader profile={profileWithoutImage} followerCount={45} />,
-    );
+    renderWithProvider(<ProfileHeader profile={profileWithoutImage} />);
 
     expect(screen.queryByText('D')).toBeNull();
     expect(screen.getByText('trader1')).toBeOnTheScreen();
@@ -121,11 +91,7 @@ describe('ProfileHeader', () => {
 
     it('renders the X icon link when twitterHandle is provided', () => {
       renderWithProvider(
-        <ProfileHeader
-          profile={baseProfile}
-          followerCount={45}
-          twitterHandle="trader1"
-        />,
+        <ProfileHeader profile={baseProfile} twitterHandle="trader1" />,
       );
       expect(
         screen.getByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
@@ -134,11 +100,7 @@ describe('ProfileHeader', () => {
 
     it('does not render the X icon link when twitterHandle is null', () => {
       renderWithProvider(
-        <ProfileHeader
-          profile={baseProfile}
-          followerCount={45}
-          twitterHandle={null}
-        />,
+        <ProfileHeader profile={baseProfile} twitterHandle={null} />,
       );
       expect(
         screen.queryByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
@@ -146,9 +108,7 @@ describe('ProfileHeader', () => {
     });
 
     it('does not render the X icon link when twitterHandle is undefined', () => {
-      renderWithProvider(
-        <ProfileHeader profile={baseProfile} followerCount={45} />,
-      );
+      renderWithProvider(<ProfileHeader profile={baseProfile} />);
       expect(
         screen.queryByTestId(TraderProfileViewSelectorsIDs.TWITTER_LINK),
       ).toBeNull();
@@ -156,11 +116,7 @@ describe('ProfileHeader', () => {
 
     it('calls Linking.openURL with the correct X URL when the icon is pressed', () => {
       renderWithProvider(
-        <ProfileHeader
-          profile={baseProfile}
-          followerCount={45}
-          twitterHandle="trader1"
-        />,
+        <ProfileHeader profile={baseProfile} twitterHandle="trader1" />,
       );
 
       fireEvent.press(

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/components/ProfileHeader.tsx
@@ -23,13 +23,11 @@ const AVATAR_SIZE = 40;
 
 export interface ProfileHeaderProps {
   profile: TraderProfile;
-  followerCount: number;
   twitterHandle?: string | null;
 }
 
 const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   profile,
-  followerCount,
   twitterHandle,
 }) => {
   const handleTwitterPress = useCallback(() => {
@@ -84,18 +82,6 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
             </Pressable>
           ) : null}
         </Box>
-        <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextAlternative}
-        >
-          {strings(
-            followerCount === 1
-              ? 'social_leaderboard.trader_profile.followers_count'
-              : 'social_leaderboard.trader_profile.followers_count_plural',
-            { count: followerCount },
-          )}
-        </Text>
       </Box>
     </Box>
   );

--- a/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.test.tsx
+++ b/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.test.tsx
@@ -9,10 +9,16 @@ import PositionTokenAvatar from './PositionTokenAvatar';
 import type { Position } from '@metamask/social-controllers';
 import BadgeWrapper from '../../../../component-library/components/Badges/BadgeWrapper';
 import BadgeNetwork from '../../../../component-library/components/Badges/Badge/variants/BadgeNetwork';
+import PerpsTokenLogo from '../../../UI/Perps/components/PerpsTokenLogo';
 
 jest.mock('@metamask/design-system-react-native', () => ({
   ...jest.requireActual('@metamask/design-system-react-native'),
   AvatarToken: jest.fn(() => null),
+}));
+
+jest.mock('../../../UI/Perps/components/PerpsTokenLogo', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
 }));
 
 jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
@@ -23,6 +29,7 @@ jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
 }));
 
 jest.mock('../utils/chainMapping', () => ({
+  HYPERLIQUID_CHAIN_NAME: 'hyperliquid',
   chainNameToId: jest.fn((chain: string) =>
     chain === 'base' ? 'eip155:8453' : undefined,
   ),
@@ -61,6 +68,16 @@ jest.mock('../../../../util/networks', () => ({
 const MockAvatarToken = AvatarToken as jest.Mock;
 const MockBadgeWrapper = BadgeWrapper as unknown as jest.Mock;
 const MockBadgeNetwork = BadgeNetwork as jest.Mock;
+const MockPerpsTokenLogo = PerpsTokenLogo as unknown as jest.Mock;
+
+const lastPerpsTokenLogoProps = () =>
+  MockPerpsTokenLogo.mock.calls[
+    MockPerpsTokenLogo.mock.calls.length - 1
+  ][0] as {
+    symbol: string;
+    size: number;
+    recyclingKey?: string;
+  };
 
 const lastAvatarTokenProps = () =>
   MockAvatarToken.mock.calls[MockAvatarToken.mock.calls.length - 1][0] as {
@@ -290,6 +307,68 @@ describe('PositionTokenAvatar', () => {
 
       renderWithProvider(
         <PositionTokenAvatar position={position} showChainBadge />,
+      );
+
+      expect(MockBadgeWrapper).toHaveBeenCalled();
+      const badgeElement = MockBadgeWrapper.mock.calls[0][0]
+        .badgeElement as React.ReactElement<{ name: string }>;
+      expect(badgeElement.props.name).toBe('Hyperliquid');
+    });
+  });
+
+  describe('hyperliquid positions', () => {
+    const hyperliquidPosition: Position = {
+      ...basePosition,
+      positionId: 'ondo-hl',
+      tokenSymbol: 'ONDO',
+      tokenAddress: 'ONDO',
+      chain: 'hyperliquid',
+      // Clicker serves a blank/dark placeholder here, so it must be ignored.
+      tokenImageUrl: 'https://clicker.example/ondo-blank.jpg',
+    };
+
+    it('renders PerpsTokenLogo with the token symbol instead of AvatarToken', () => {
+      renderWithProvider(
+        <PositionTokenAvatar position={hyperliquidPosition} />,
+      );
+
+      expect(MockAvatarToken).not.toHaveBeenCalled();
+      expect(MockPerpsTokenLogo).toHaveBeenCalled();
+      expect(lastPerpsTokenLogoProps().symbol).toBe('ONDO');
+    });
+
+    it('does not use the unreliable Clicker tokenImageUrl', () => {
+      renderWithProvider(
+        <PositionTokenAvatar position={hyperliquidPosition} />,
+      );
+
+      // PerpsTokenLogo resolves icons from the symbol; no Clicker URI is forwarded.
+      expect(MockPerpsTokenLogo).toHaveBeenCalled();
+      expect(MockAvatarToken).not.toHaveBeenCalled();
+    });
+
+    it('maps the AvatarToken size to the matching pixel size', () => {
+      renderWithProvider(
+        <PositionTokenAvatar
+          position={hyperliquidPosition}
+          size={AvatarTokenSize.Md}
+        />,
+      );
+
+      expect(lastPerpsTokenLogoProps().size).toBe(32);
+    });
+
+    it('defaults to the Lg pixel size', () => {
+      renderWithProvider(
+        <PositionTokenAvatar position={hyperliquidPosition} />,
+      );
+
+      expect(lastPerpsTokenLogoProps().size).toBe(40);
+    });
+
+    it('still wraps the perps logo in the Hyperliquid network badge', () => {
+      renderWithProvider(
+        <PositionTokenAvatar position={hyperliquidPosition} showChainBadge />,
       );
 
       expect(MockBadgeWrapper).toHaveBeenCalled();

--- a/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.tsx
+++ b/app/components/Views/SocialLeaderboard/components/PositionTokenAvatar.tsx
@@ -5,7 +5,12 @@ import {
 } from '@metamask/design-system-react-native';
 import type { Position } from '@metamask/social-controllers';
 import { getAssetImageUrl } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
-import { chainNameToId, getPositionNetworkBadge } from '../utils/chainMapping';
+import PerpsTokenLogo from '../../../UI/Perps/components/PerpsTokenLogo';
+import {
+  chainNameToId,
+  getPositionNetworkBadge,
+  HYPERLIQUID_CHAIN_NAME,
+} from '../utils/chainMapping';
 import BadgeWrapper, {
   BadgePosition,
 } from '../../../../component-library/components/Badges/BadgeWrapper';
@@ -19,6 +24,17 @@ export interface PositionTokenAvatarProps {
 
 type ImageSource = 'clicker' | 'metamask' | 'none';
 
+// AvatarTokenSize is a string token ('xs'..'xl'); PerpsTokenLogo takes a pixel
+// size. Mirrors the design-system AvatarBase sizing so the perps logo matches
+// the AvatarToken used for every other chain.
+const AVATAR_TOKEN_SIZE_TO_PIXELS: Record<AvatarTokenSize, number> = {
+  [AvatarTokenSize.Xs]: 16,
+  [AvatarTokenSize.Sm]: 24,
+  [AvatarTokenSize.Md]: 32,
+  [AvatarTokenSize.Lg]: 40,
+  [AvatarTokenSize.Xl]: 48,
+};
+
 /**
  * Renders the token avatar with a three-step fallback chain:
  * 1. Social API-provided URL (`position.tokenImageUrl`)
@@ -30,6 +46,14 @@ const PositionTokenAvatar: React.FC<PositionTokenAvatarProps> = ({
   size = AvatarTokenSize.Lg,
   showChainBadge = false,
 }) => {
+  // Hyperliquid perps key on a perp symbol rather than a token contract, so the
+  // EVM/Solana resolution (Clicker URL → MetaMask CDN) can't serve their icons
+  // — and the Clicker-provided `tokenImageUrl` is unreliable for them (blank or
+  // dark-on-transparent placeholders). Reuse the Perps feature's symbol-based
+  // logo resolution, which already maps these dark logos onto a contrasting
+  // background and falls back to the Hyperliquid asset CDN.
+  const isHyperliquid = position.chain.toLowerCase() === HYPERLIQUID_CHAIN_NAME;
+
   const caipChainId = useMemo(
     () => chainNameToId(position.chain),
     [position.chain],
@@ -81,7 +105,13 @@ const PositionTokenAvatar: React.FC<PositionTokenAvatarProps> = ({
     });
   };
 
-  const avatar = (
+  const avatar = isHyperliquid ? (
+    <PerpsTokenLogo
+      symbol={position.tokenSymbol}
+      size={AVATAR_TOKEN_SIZE_TO_PIXELS[size]}
+      recyclingKey={position.tokenSymbol}
+    />
+  ) : (
     <AvatarToken
       name={position.tokenSymbol}
       src={src}


### PR DESCRIPTION
## **Description**

Several related fixes to how Hyperliquid (perps) positions are displayed in the Social Leaderboard, bringing them in line with spot positions across the leaderboard, profile, and position-detail screens.

### 1. Missing/blank token icons for Hyperliquid positions

Token icons for several Hyperliquid assets (e.g. **ONDO**, **WLD**, **FARTCOIN**) rendered as blank/black circles while spot/EVM assets (e.g. ARB, TIA) rendered correctly.

**Root cause:** Hyperliquid perps key on a perp *symbol* rather than a token contract, so the existing EVM/Solana resolution (`chainNameToId('hyperliquid')` → `undefined`) can't build a MetaMask CDN URL. That leaves the Clicker-provided `tokenImageUrl` as the only source — and for these perp coins Clicker serves an unreliable placeholder: either a solid-black JPEG (ONDO, WLD) or a dark-on-transparent logo that's invisible against the dark UI (FARTCOIN). Because those images return HTTP 200, the component's `onImageError` fallback chain never fires, so no monogram fallback either.

**Fix:** For Hyperliquid positions, reuse the existing Perps feature component `PerpsTokenLogo`, which resolves icons purely from the token symbol (MetaMask perps CDN → Hyperliquid asset CDN) and already renders these dark logos on a contrasting background via `ASSETS_REQUIRING_LIGHT_BG` (a set that already lists ONDO/WLD/FARTCOIN). All other chains keep the existing Clicker → MetaMask CDN → monogram resolution unchanged, and the chain network badge still wraps the avatar.

### 2. Closed perp percentage styling didn't match spot

Closed perp rows rendered a colored, signed percentage with no direction indicator, while closed spot rows render a directional triangle (▲/▼) with a neutral, unsigned percentage (e.g. `xyz:SP500` showed `+1%` in green with no triangle).

**Root cause:** the triangle styling in `PositionRow` was gated on `!isPerp && isClosed`, so closed perps fell through to the open-style branch.

**Fix:** key the closed-position styling on `isClosed` alone so closed perps and spot match, and collapse the now-identical open-position branches.

### 3. Open perp headline value didn't match spot

Open perp rows showed a signed, colored PnL (e.g. `+$20`) as the headline figure, while open spot rows show the current position value in neutral white (e.g. `$120`).

**Fix:** open positions — perp and spot alike — now show `currentValueUSD` in neutral white. Closed positions keep the signed, colored realized PnL (perps via `perpPnlValue`, spot via `realizedPnl`).

### 4. Copy-address button shown for perps on the position detail page

The position detail page offered a copy-token-address button for perps, but perps have no on-chain token address (`tokenAddress` carries the perp symbol), so copying it is meaningless.

**Fix:** the copy-token-address affordance is now offered for spot positions only.

### 5. Removed follower count from the trader profile header

The trader profile header displayed a follower count under the trader name.

**Fix:** the follower count is no longer shown; the `followerCount` prop was removed from `ProfileHeader` and its call site.

### 6. Direction triangle now shown on open positions too

After (2), the directional triangle (▲/▼) only appeared on closed rows; open rows still showed a colored, signed percentage with no triangle.

**Fix:** unify the percentage rendering so all rows — open and closed, perp and spot — show a directional triangle alongside a neutral, unsigned percentage (break-even shows a neutral minus). The sign lives in the caret, so the percent text is unsigned everywhere.

<img width="1869" height="1962" alt="SCR-20260618-jzjt" src="https://github.com/user-attachments/assets/0f68ae0b-f76a-4348-9521-03630a82c114" />

<img width="903" height="978" alt="SCR-20260618-kdxw" src="https://github.com/user-attachments/assets/5bb953c4-f698-44db-970c-4408e7e55201" />

<img width="770" height="711" alt="image" src="https://github.com/user-attachments/assets/aa272361-41f5-46bb-ac13-f935162e763e" />




## **Changelog**

CHANGELOG entry: Fixed missing/blank token icons for Hyperliquid positions, aligned perp position display (percentage styling, headline value, and copy-address affordance) with spot, and removed the follower count from the trader profile header.

## **Related issues**

Refs: TSA-782

## **Manual testing steps**

```gherkin
Feature: Hyperliquid trader position display

  Scenario: user views a trader's Hyperliquid perp positions
    Given the user is on the Weekly Top Traders section
    And opens a trader profile holding Hyperliquid perps (e.g. retardi0x.hl)

    When the open positions list renders
    Then each Hyperliquid position (ARB, TIA, ONDO, WLD, FARTCOIN) shows a visible token logo
    And dark logos (ONDO, WLD, FARTCOIN) render on a contrasting background rather than as blank/black circles
    And each open position (perp and spot) shows its current value in neutral white
    And each open position shows a directional triangle (▲/▼) with a neutral, unsigned percentage
    And positions on other chains continue to render their icons unchanged

  Scenario: user views closed positions
    Given the user is on a trader profile's Closed tab with perp and spot positions (e.g. xyz:SP500)

    When the closed positions list renders
    Then each closed position shows a directional triangle (▲/▼) with a neutral, unsigned percentage
    And closed perps match the styling of closed spot positions in the same list

  Scenario: user opens a perp position detail page
    Given the user taps a Hyperliquid perp position

    When the position detail page renders
    Then no copy-token-address button is shown (perps have no on-chain address)
    And a spot position detail page still offers copy-token-address

  Scenario: user views a trader profile header
    Given the user opens any trader profile

    When the profile header renders
    Then no follower count is shown under the trader name
```

## **Screenshots/Recordings**

### **Before**

Hyperliquid positions ONDO, WLD, and FARTCOIN rendered as blank/black circles on the trader profile (ARB/TIA render fine); closed perps showed a colored, signed percentage with no up/down triangle while open rows had no triangle at all; open perps showed signed colored PnL instead of the current value; perp detail pages exposed a copy-address button; and the profile header showed a follower count.

### **After**

See screenshots above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Social Leaderboard presentation-only changes with broad test updates; no auth, payments, or shared infrastructure.
> 
> **Overview**
> Aligns **Hyperliquid (perp)** positions with spot across Social Leaderboard profile, position rows, and position detail.
> 
> **Hyperliquid token icons:** `PositionTokenAvatar` now uses **`PerpsTokenLogo`** (symbol-based CDN + light backgrounds) for Hyperliquid chains instead of Clicker/`AvatarToken` URLs that often render blank or invisible.
> 
> **Position row UI (`PositionRow`):** Open perp and spot rows show **neutral `currentValueUSD`** on the right; closed rows keep **signed, colored realized PnL** (perps via `perpPnlValue`). **All** rows use **▲/▼ (or − at break-even) with unsigned, direction-colored %**—replacing signed `+/-` percents on open rows and fixing closed-perp styling that previously skipped the triangle.
> 
> **Position detail:** Copy-token-address is **hidden for perps** in `TraderTokenInfoRow` (`isPerpPosition`).
> 
> **Trader profile:** **`ProfileHeader` no longer shows follower count**; `followerCount` prop removed. Tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d28391e11ea035f9338dfe57eaa66d9ffb85c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


