### PR TITLE
refactor(snaps): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/controllers/snaps/cronjob-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/cronjob-controller-init.test.ts
@@ -1,9 +1,9 @@
-import { CronjobController } from '@metamask/snaps-controllers';
-import { MessengerClientInitRequest } from '../../types';
 import {
-  CronjobControllerMessenger,
-  getCronjobControllerMessenger,
-} from '../../messengers/snaps';
+  CronjobController,
+  type CronjobControllerMessenger,
+} from '@metamask/snaps-controllers';
+import { MessengerClientInitRequest } from '../../types';
+import { getCronjobControllerMessenger } from '../../messengers/snaps';
 import { cronjobControllerInit } from './cronjob-controller-init';
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';

--- a/app/core/Engine/controllers/snaps/cronjob-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/cronjob-controller-init.ts
@@ -1,6 +1,8 @@
-import { CronjobController } from '@metamask/snaps-controllers';
+import {
+  CronjobController,
+  type CronjobControllerMessenger,
+} from '@metamask/snaps-controllers';
 import { MessengerClientInitFunction } from '../../types';
-import { CronjobControllerMessenger } from '../../messengers/snaps';
 import { CronjobControllerStorageManager } from '../../../CronjobControllerStorageManager/CronjobControllerStorageManager';
 
 /**

--- a/app/core/Engine/controllers/snaps/snap-interface-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-interface-controller-init.test.ts
@@ -1,9 +1,9 @@
-import { SnapInterfaceController } from '@metamask/snaps-controllers';
-import { MessengerClientInitRequest } from '../../types';
 import {
-  getSnapInterfaceControllerMessenger,
-  SnapInterfaceControllerMessenger,
-} from '../../messengers/snaps';
+  SnapInterfaceController,
+  type SnapInterfaceControllerMessenger,
+} from '@metamask/snaps-controllers';
+import { MessengerClientInitRequest } from '../../types';
+import { getSnapInterfaceControllerMessenger } from '../../messengers/snaps';
 import { snapInterfaceControllerInit } from './snap-interface-controller-init';
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';

--- a/app/core/Engine/controllers/snaps/snap-interface-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-interface-controller-init.ts
@@ -1,6 +1,8 @@
-import { SnapInterfaceController } from '@metamask/snaps-controllers';
+import {
+  SnapInterfaceController,
+  type SnapInterfaceControllerMessenger,
+} from '@metamask/snaps-controllers';
 import { MessengerClientInitFunction } from '../../types';
-import { SnapInterfaceControllerMessenger } from '../../messengers/snaps';
 
 /**
  * Initialize the Snap interface controller.

--- a/app/core/Engine/controllers/snaps/websocket-service-init.test.ts
+++ b/app/core/Engine/controllers/snaps/websocket-service-init.test.ts
@@ -1,10 +1,10 @@
-import { WebSocketService } from '@metamask/snaps-controllers';
+import {
+  WebSocketService,
+  type WebSocketServiceMessenger,
+} from '@metamask/snaps-controllers';
 import { MessengerClientInitRequest } from '../../types';
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
-import {
-  getWebSocketServiceMessenger,
-  WebSocketServiceMessenger,
-} from '../../messengers/snaps';
+import { getWebSocketServiceMessenger } from '../../messengers/snaps';
 import { WebSocketServiceInit } from './websocket-service-init';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';

--- a/app/core/Engine/controllers/snaps/websocket-service-init.ts
+++ b/app/core/Engine/controllers/snaps/websocket-service-init.ts
@@ -1,6 +1,8 @@
-import { WebSocketService } from '@metamask/snaps-controllers';
+import {
+  WebSocketService,
+  type WebSocketServiceMessenger,
+} from '@metamask/snaps-controllers';
 import { MessengerClientInitFunction } from '../../types';
-import { WebSocketServiceMessenger } from '../../messengers/snaps';
 
 /**
  * Initialize the WebSocket service.

--- a/app/core/Engine/messengers/snaps/cronjob-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/cronjob-controller-messenger.ts
@@ -6,8 +6,6 @@ import {
 import { CronjobControllerMessenger } from '@metamask/snaps-controllers';
 import { RootMessenger } from '../../types';
 
-export type { CronjobControllerMessenger };
-
 /**
  * Get a messenger for the cronjob controller. This is scoped to the
  * actions and events that the cronjob controller is allowed to handle.

--- a/app/core/Engine/messengers/snaps/cronjob-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/cronjob-controller-messenger.ts
@@ -16,14 +16,12 @@ export type { CronjobControllerMessenger };
  * @returns The CronjobControllerMessenger.
  */
 export function getCronjobControllerMessenger(
-  rootMessenger: RootMessenger,
-): CronjobControllerMessenger {
-  const messenger = new Messenger<
-    'CronjobController',
+  rootMessenger: RootMessenger<
     MessengerActions<CronjobControllerMessenger>,
-    MessengerEvents<CronjobControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<CronjobControllerMessenger>
+  >,
+): CronjobControllerMessenger {
+  const messenger: CronjobControllerMessenger = new Messenger({
     namespace: 'CronjobController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/snaps/execution-service-messenger.ts
+++ b/app/core/Engine/messengers/snaps/execution-service-messenger.ts
@@ -1,4 +1,8 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import { ExecutionServiceMessenger } from '@metamask/snaps-controllers';
 import { RootMessenger } from '../../types';
 
@@ -10,7 +14,10 @@ import { RootMessenger } from '../../types';
  * @returns The ExecutionServiceMessenger.
  */
 export function getExecutionServiceMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: RootMessenger<
+    MessengerActions<ExecutionServiceMessenger>,
+    MessengerEvents<ExecutionServiceMessenger>
+  >,
 ): ExecutionServiceMessenger {
   const messenger: ExecutionServiceMessenger = new Messenger({
     namespace: 'ExecutionService',

--- a/app/core/Engine/messengers/snaps/index.ts
+++ b/app/core/Engine/messengers/snaps/index.ts
@@ -1,5 +1,4 @@
 export { getCronjobControllerMessenger } from './cronjob-controller-messenger';
-export type { CronjobControllerMessenger } from './cronjob-controller-messenger';
 export { getExecutionServiceMessenger } from './execution-service-messenger';
 export {
   getSnapControllerMessenger,
@@ -7,7 +6,5 @@ export {
 } from './snap-controller-messenger';
 export type { SnapControllerInitMessenger } from './snap-controller-messenger';
 export { getSnapInterfaceControllerMessenger } from './snap-interface-controller-messenger';
-export type { SnapInterfaceControllerMessenger } from './snap-interface-controller-messenger';
 export { getSnapRegistryControllerMessenger } from './snap-registry-controller-messenger.ts';
 export { getWebSocketServiceMessenger } from './websocket-service-messenger';
-export type { WebSocketServiceMessenger } from './websocket-service-messenger';

--- a/app/core/Engine/messengers/snaps/snap-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/snaps/snap-controller-messenger.test.ts
@@ -8,13 +8,16 @@ import {
 import {
   getSnapControllerInitMessenger,
   getSnapControllerMessenger,
+  type SnapControllerInitMessenger,
 } from './snap-controller-messenger';
 import { SnapControllerMessenger } from '@metamask/snaps-controllers';
 
 type RootMessenger = Messenger<
   MockAnyNamespace,
-  MessengerActions<SnapControllerMessenger>,
-  MessengerEvents<SnapControllerMessenger>
+  | MessengerActions<SnapControllerMessenger>
+  | MessengerActions<SnapControllerInitMessenger>,
+  | MessengerEvents<SnapControllerMessenger>
+  | MessengerEvents<SnapControllerInitMessenger>
 >;
 
 const getRootMessenger = (): RootMessenger =>

--- a/app/core/Engine/messengers/snaps/snap-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-controller-messenger.ts
@@ -1,4 +1,8 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import {
   KeyringControllerLockEvent,
   KeyringControllerUnlockEvent,
@@ -19,7 +23,12 @@ import {
  * @param rootMessenger - The root messenger.
  * @returns The SnapControllerMessenger.
  */
-export function getSnapControllerMessenger(rootMessenger: RootMessenger) {
+export function getSnapControllerMessenger(
+  rootMessenger: RootMessenger<
+    MessengerActions<SnapControllerMessenger>,
+    MessengerEvents<SnapControllerMessenger>
+  >,
+): SnapControllerMessenger {
   const messenger: SnapControllerMessenger = new Messenger({
     namespace: 'SnapController',
     parent: rootMessenger,
@@ -77,8 +86,10 @@ type InitActions =
 
 type InitEvents = KeyringControllerLockEvent | KeyringControllerUnlockEvent;
 
-export type SnapControllerInitMessenger = ReturnType<
-  typeof getSnapControllerInitMessenger
+export type SnapControllerInitMessenger = Messenger<
+  'SnapControllerInit',
+  InitActions,
+  InitEvents
 >;
 
 /**
@@ -88,13 +99,13 @@ export type SnapControllerInitMessenger = ReturnType<
  * @param rootMessenger - The root messenger.
  * @returns The SnapControllerInitMessenger.
  */
-export function getSnapControllerInitMessenger(rootMessenger: RootMessenger) {
-  const messenger = new Messenger<
-    'SnapControllerInit',
-    InitActions,
-    InitEvents,
-    RootMessenger
-  >({
+export function getSnapControllerInitMessenger(
+  rootMessenger: RootMessenger<
+    MessengerActions<SnapControllerInitMessenger>,
+    MessengerEvents<SnapControllerInitMessenger>
+  >,
+): SnapControllerInitMessenger {
+  const messenger: SnapControllerInitMessenger = new Messenger({
     namespace: 'SnapControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
@@ -18,13 +18,15 @@ export type { SnapInterfaceControllerMessenger };
  * @returns The SnapInterfaceControllerMessenger.
  */
 export function getSnapInterfaceControllerMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: RootMessenger<
+    MessengerActions<SnapInterfaceControllerMessenger> | MaybeUpdateState,
+    MessengerEvents<SnapInterfaceControllerMessenger>
+  >,
 ): SnapInterfaceControllerMessenger {
   const messenger = new Messenger<
     'SnapInterfaceController',
     MessengerActions<SnapInterfaceControllerMessenger> | MaybeUpdateState,
-    MessengerEvents<SnapInterfaceControllerMessenger>,
-    RootMessenger
+    MessengerEvents<SnapInterfaceControllerMessenger>
   >({
     namespace: 'SnapInterfaceController',
     parent: rootMessenger,

--- a/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
@@ -18,15 +18,13 @@ export type { SnapInterfaceControllerMessenger };
  * @returns The SnapInterfaceControllerMessenger.
  */
 export function getSnapInterfaceControllerMessenger(
-  rootMessenger: RootMessenger<
-    MessengerActions<SnapInterfaceControllerMessenger> | MaybeUpdateState,
-    MessengerEvents<SnapInterfaceControllerMessenger>
-  >,
+  rootMessenger: RootMessenger,
 ): SnapInterfaceControllerMessenger {
   const messenger = new Messenger<
     'SnapInterfaceController',
     MessengerActions<SnapInterfaceControllerMessenger> | MaybeUpdateState,
-    MessengerEvents<SnapInterfaceControllerMessenger>
+    MessengerEvents<SnapInterfaceControllerMessenger>,
+    RootMessenger
   >({
     namespace: 'SnapInterfaceController',
     parent: rootMessenger,

--- a/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
@@ -1,10 +1,5 @@
-import {
-  Messenger,
-  MessengerActions,
-  MessengerEvents,
-} from '@metamask/messenger';
+import { Messenger } from '@metamask/messenger';
 import { SnapInterfaceControllerMessenger } from '@metamask/snaps-controllers';
-import { MaybeUpdateState } from '@metamask/phishing-controller';
 import { RootMessenger } from '../../types';
 
 /**
@@ -18,18 +13,12 @@ import { RootMessenger } from '../../types';
 export function getSnapInterfaceControllerMessenger(
   rootMessenger: RootMessenger,
 ): SnapInterfaceControllerMessenger {
-  const messenger = new Messenger<
-    'SnapInterfaceController',
-    MessengerActions<SnapInterfaceControllerMessenger> | MaybeUpdateState,
-    MessengerEvents<SnapInterfaceControllerMessenger>,
-    RootMessenger
-  >({
+  const messenger: SnapInterfaceControllerMessenger = new Messenger({
     namespace: 'SnapInterfaceController',
     parent: rootMessenger,
   });
   rootMessenger.delegate({
     actions: [
-      'PhishingController:maybeUpdateState',
       'PhishingController:testOrigin',
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',

--- a/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-interface-controller-messenger.ts
@@ -7,8 +7,6 @@ import { SnapInterfaceControllerMessenger } from '@metamask/snaps-controllers';
 import { MaybeUpdateState } from '@metamask/phishing-controller';
 import { RootMessenger } from '../../types';
 
-export type { SnapInterfaceControllerMessenger };
-
 /**
  * Get a messenger for the Snap interface controller. This is scoped
  * to the actions and events that the Snap interface controller is allowed to

--- a/app/core/Engine/messengers/snaps/snap-registry-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-registry-controller-messenger.ts
@@ -1,4 +1,8 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import { SnapRegistryControllerMessenger } from '@metamask/snaps-controllers';
 import { RootMessenger } from '../../types';
 
@@ -10,7 +14,10 @@ import { RootMessenger } from '../../types';
  * @returns The Snap registry controller messenger.
  */
 export function getSnapRegistryControllerMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: RootMessenger<
+    MessengerActions<SnapRegistryControllerMessenger>,
+    MessengerEvents<SnapRegistryControllerMessenger>
+  >,
 ): SnapRegistryControllerMessenger {
   const messenger: SnapRegistryControllerMessenger = new Messenger({
     namespace: 'SnapRegistryController',

--- a/app/core/Engine/messengers/snaps/websocket-service-messenger.ts
+++ b/app/core/Engine/messengers/snaps/websocket-service-messenger.ts
@@ -16,14 +16,12 @@ export type { WebSocketServiceMessenger };
  * @returns The WebSocketServiceMessenger.
  */
 export function getWebSocketServiceMessenger(
-  rootMessenger: RootMessenger,
-): WebSocketServiceMessenger {
-  const messenger = new Messenger<
-    'WebSocketService',
+  rootMessenger: RootMessenger<
     MessengerActions<WebSocketServiceMessenger>,
-    MessengerEvents<WebSocketServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<WebSocketServiceMessenger>
+  >,
+): WebSocketServiceMessenger {
+  const messenger: WebSocketServiceMessenger = new Messenger({
     namespace: 'WebSocketService',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/snaps/websocket-service-messenger.ts
+++ b/app/core/Engine/messengers/snaps/websocket-service-messenger.ts
@@ -6,8 +6,6 @@ import {
 import { WebSocketServiceMessenger } from '@metamask/snaps-controllers';
 import { RootMessenger } from '../../types';
 
-export type { WebSocketServiceMessenger };
-
 /**
  * Get a messenger for the WebSocket service. This is scoped to the
  * actions and events that the WebSocket service is allowed to handle.


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the six Core Platform-owned messenger files (`cronjob-controller-messenger`, `execution-service-messenger`, `snap-controller-messenger`, `snap-interface-controller-messenger`, `snap-registry-controller-messenger`, `websocket-service-messenger`).

Makes messenger factory functions accept the narrowed `RootMessenger<AllowedActions, AllowedEvents>` instead of the broad `RootMessenger`, and simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to `const messenger: XMessenger = new Messenger({…})` so TypeScript infers the generic parameters from the typed variable.

Also converts `SnapControllerInitMessenger` from a `ReturnType<typeof getSnapControllerInitMessenger>` alias to an explicit `Messenger<Namespace, Actions, Events>` definition, making the type self-contained and consistent with the rest of the messenger type patterns.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor across messenger factories and imports; the snap-interface delegate list change aligns with package types and should not alter behavior if upstream types are correct.
> 
> **Overview**
> Refactors Snap Engine messenger wiring so **controller messenger types come from `@metamask/snaps-controllers`** instead of re-exporting them from `app/core/Engine/messengers/snaps`. Init modules and tests now import those types alongside the controllers; the snaps messenger barrel only exports factories (plus `SnapControllerInitMessenger`).
> 
> Messenger factories use **narrowed `RootMessenger<AllowedActions, AllowedEvents>`** parameters and **`const messenger: XMessenger = new Messenger({…})`** instead of long explicit `Messenger<…>` generics. **`SnapControllerInitMessenger`** is defined as an explicit `Messenger<'SnapControllerInit', InitActions, InitEvents>` rather than `ReturnType<typeof getSnapControllerInitMessenger>`.
> 
> **`getSnapInterfaceControllerMessenger`** drops the local `MaybeUpdateState` union and **`PhishingController:maybeUpdateState`** from `delegate`, matching the canonical `SnapInterfaceControllerMessenger` shape from snaps-controllers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d94bacd96e4c04ba45a1c1fee25ad80f4e73b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->