### PR TITLE
refactor(notifications): standardise messenger types

### DIFF
--- a/app/core/Engine/messengers/notifications/notification-services-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/notifications/notification-services-controller-messenger.test.ts
@@ -1,14 +1,28 @@
-import { RootExtendedMessenger } from '../../types';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+  MOCK_ANY_NAMESPACE,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+import type { NotificationServicesControllerMessenger } from '@metamask/notification-services-controller/notification-services';
 import { getNotificationServicesControllerMessenger } from './notification-services-controller-messenger';
-import { ExtendedMessenger } from '../../../ExtendedMessenger';
-import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<NotificationServicesControllerMessenger>,
+  MessengerEvents<NotificationServicesControllerMessenger>
+>;
 
 describe('getNotificationServicesControllerMessenger', () => {
   const arrangeMocks = () => {
-    const baseMessenger: RootExtendedMessenger =
-      new ExtendedMessenger<MockAnyNamespace>({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
+    const baseMessenger: RootMessenger = new Messenger<
+      MockAnyNamespace,
+      never,
+      never
+    >({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
     const mockDelegate = jest.spyOn(baseMessenger, 'delegate');
     return { baseMessenger, mockDelegate };
   };

--- a/app/core/Engine/messengers/notifications/notification-services-controller-messenger.ts
+++ b/app/core/Engine/messengers/notifications/notification-services-controller-messenger.ts
@@ -1,5 +1,5 @@
 import type { NotificationServicesControllerMessenger } from '@metamask/notification-services-controller/notification-services';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -7,18 +7,16 @@ import {
 } from '@metamask/messenger';
 
 export function getNotificationServicesControllerMessenger(
-  baseControllerMessenger: RootExtendedMessenger,
-): NotificationServicesControllerMessenger {
-  const messenger = new Messenger<
-    'NotificationServicesController',
+  rootMessenger: RootMessenger<
     MessengerActions<NotificationServicesControllerMessenger>,
-    MessengerEvents<NotificationServicesControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NotificationServicesControllerMessenger>
+  >,
+): NotificationServicesControllerMessenger {
+  const messenger: NotificationServicesControllerMessenger = new Messenger({
     namespace: 'NotificationServicesController',
-    parent: baseControllerMessenger,
+    parent: rootMessenger,
   });
-  baseControllerMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       // Keyring Actions
       'KeyringController:getState',

--- a/app/core/Engine/messengers/notifications/notification-services-push-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/notifications/notification-services-push-controller-messenger.test.ts
@@ -1,14 +1,28 @@
-import { RootExtendedMessenger } from '../../types';
-import { ExtendedMessenger } from '../../../ExtendedMessenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+  MOCK_ANY_NAMESPACE,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+import type { NotificationServicesPushControllerMessenger } from '@metamask/notification-services-controller/push-services';
 import { getNotificationServicesPushControllerMessenger } from './notification-services-push-controller-messenger';
-import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<NotificationServicesPushControllerMessenger>,
+  MessengerEvents<NotificationServicesPushControllerMessenger>
+>;
 
 describe('getNotificationServicesControllerMessenger', () => {
   const arrangeMocks = () => {
-    const baseMessenger: RootExtendedMessenger =
-      new ExtendedMessenger<MockAnyNamespace>({
-        namespace: MOCK_ANY_NAMESPACE,
-      });
+    const baseMessenger: RootMessenger = new Messenger<
+      MockAnyNamespace,
+      never,
+      never
+    >({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
     const mockDelegate = jest.spyOn(baseMessenger, 'delegate');
     return { baseMessenger, mockDelegate };
   };

--- a/app/core/Engine/messengers/notifications/notification-services-push-controller-messenger.ts
+++ b/app/core/Engine/messengers/notifications/notification-services-push-controller-messenger.ts
@@ -1,5 +1,5 @@
 import type { NotificationServicesPushControllerMessenger } from '@metamask/notification-services-controller/push-services';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -7,18 +7,16 @@ import {
 } from '@metamask/messenger';
 
 export function getNotificationServicesPushControllerMessenger(
-  baseControllerMessenger: RootExtendedMessenger,
-): NotificationServicesPushControllerMessenger {
-  const messenger = new Messenger<
-    'NotificationServicesPushController',
+  rootMessenger: RootMessenger<
     MessengerActions<NotificationServicesPushControllerMessenger>,
-    MessengerEvents<NotificationServicesPushControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NotificationServicesPushControllerMessenger>
+  >,
+): NotificationServicesPushControllerMessenger {
+  const messenger: NotificationServicesPushControllerMessenger = new Messenger({
     namespace: 'NotificationServicesPushController',
-    parent: baseControllerMessenger,
+    parent: rootMessenger,
   });
-  baseControllerMessenger.delegate({
+  rootMessenger.delegate({
     actions: ['AuthenticationController:getBearerToken'],
     events: [],
     messenger,


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the two engagement-owned notification messenger files (`notification-services-controller-messenger`, `notification-services-push-controller-messenger`).

Replaces the broad `RootExtendedMessenger` parameter with the narrowed `RootMessenger<AllowedActions, AllowedEvents>`, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, and renames `baseControllerMessenger` to `rootMessenger` for consistency with the rest of the codebase.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor and test harness updates; delegate actions/events and messenger parent/delegate calls are unchanged at runtime.
> 
> **Overview**
> Aligns the **notification services** and **notification push** controller messenger factories with the broader Engine messenger typing pattern from #31467.
> 
> **`getNotificationServicesControllerMessenger`** and **`getNotificationServicesPushControllerMessenger`** now take a narrowed **`RootMessenger<AllowedActions, AllowedEvents>`** instead of **`RootExtendedMessenger`**, use **`rootMessenger`** as the parameter name, and construct child messengers via a typed **`NotificationServices*ControllerMessenger`** variable rather than a long inline **`Messenger<Namespace, …>`** generic. Delegation lists and runtime wiring are unchanged.
> 
> Unit tests drop **`ExtendedMessenger`** in favor of **`@metamask/messenger`’s `Messenger`**, with local **`RootMessenger`** types scoped to each controller’s allowed actions/events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d89985a9695447dfee6508a0b6e3760bb56c7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->