### PR TITLE
refactor(earn): standardise messenger types

### DIFF
--- a/app/core/Engine/messengers/chomp-api-service-messenger.ts
+++ b/app/core/Engine/messengers/chomp-api-service-messenger.ts
@@ -15,14 +15,12 @@ import type { RootMessenger } from '../types';
  * @returns The ChompApiServiceMessenger.
  */
 export function getChompApiServiceMessenger(
-  rootMessenger: RootMessenger,
-): ChompApiServiceMessenger {
-  const messenger = new Messenger<
-    'ChompApiService',
+  rootMessenger: RootMessenger<
     MessengerActions<ChompApiServiceMessenger>,
-    MessengerEvents<ChompApiServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<ChompApiServiceMessenger>
+  >,
+): ChompApiServiceMessenger {
+  const messenger: ChompApiServiceMessenger = new Messenger({
     namespace: 'ChompApiService',
     parent: rootMessenger,
   });
@@ -36,8 +34,10 @@ export function getChompApiServiceMessenger(
 
 type AllowedInitializationActions = RemoteFeatureFlagControllerGetStateAction;
 
-export type ChompApiServiceInitMessenger = ReturnType<
-  typeof getChompApiServiceInitMessenger
+export type ChompApiServiceInitMessenger = Messenger<
+  'ChompApiServiceInitialization',
+  AllowedInitializationActions,
+  never
 >;
 
 /**
@@ -47,13 +47,13 @@ export type ChompApiServiceInitMessenger = ReturnType<
  * @param rootMessenger - The root messenger.
  * @returns The restricted init messenger.
  */
-export function getChompApiServiceInitMessenger(rootMessenger: RootMessenger) {
-  const messenger = new Messenger<
-    'ChompApiServiceInitialization',
-    AllowedInitializationActions,
-    never,
-    RootMessenger
-  >({
+export function getChompApiServiceInitMessenger(
+  rootMessenger: RootMessenger<
+    MessengerActions<ChompApiServiceInitMessenger>,
+    MessengerEvents<ChompApiServiceInitMessenger>
+  >,
+): ChompApiServiceInitMessenger {
+  const messenger: ChompApiServiceInitMessenger = new Messenger({
     namespace: 'ChompApiServiceInitialization',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/earn-controller-messenger.ts
+++ b/app/core/Engine/messengers/earn-controller-messenger.ts
@@ -14,14 +14,12 @@ import { RootMessenger } from '../types';
  * @returns The restricted controller messenger.
  */
 export function getEarnControllerMessenger(
-  rootMessenger: RootMessenger,
-): EarnControllerMessenger {
-  const messenger = new Messenger<
-    'EarnController',
+  rootMessenger: RootMessenger<
     MessengerActions<EarnControllerMessenger>,
-    MessengerEvents<EarnControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<EarnControllerMessenger>
+  >,
+): EarnControllerMessenger {
+  const messenger: EarnControllerMessenger = new Messenger({
     namespace: 'EarnController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/money-account-balance-service-messenger.ts
+++ b/app/core/Engine/messengers/money-account-balance-service-messenger.ts
@@ -14,14 +14,15 @@ import { RootMessenger } from '../types';
  * @returns The MoneyAccountBalanceServiceMessenger.
  */
 export function getMoneyAccountBalanceServiceMessenger(
-  rootMessenger: RootMessenger,
-): MoneyAccountBalanceServiceMessenger {
-  const messenger = new Messenger<
-    'MoneyAccountBalanceService',
+  rootMessenger: RootMessenger<
     MessengerActions<MoneyAccountBalanceServiceMessenger>,
-    MessengerEvents<MoneyAccountBalanceServiceMessenger>,
-    RootMessenger
-  >({ namespace: 'MoneyAccountBalanceService', parent: rootMessenger });
+    MessengerEvents<MoneyAccountBalanceServiceMessenger>
+  >,
+): MoneyAccountBalanceServiceMessenger {
+  const messenger: MoneyAccountBalanceServiceMessenger = new Messenger({
+    namespace: 'MoneyAccountBalanceService',
+    parent: rootMessenger,
+  });
 
   rootMessenger.delegate({
     messenger,

--- a/app/core/Engine/messengers/money-account-controller-messenger.ts
+++ b/app/core/Engine/messengers/money-account-controller-messenger.ts
@@ -20,14 +20,15 @@ import { RootMessenger } from '../types';
  * @returns The restricted controller messenger.
  */
 export function getMoneyAccountControllerMessenger(
-  rootMessenger: RootMessenger,
-): MoneyAccountControllerMessenger {
-  const messenger = new Messenger<
-    'MoneyAccountController',
+  rootMessenger: RootMessenger<
     MessengerActions<MoneyAccountControllerMessenger>,
-    MessengerEvents<MoneyAccountControllerMessenger>,
-    RootMessenger
-  >({ namespace: 'MoneyAccountController', parent: rootMessenger });
+    MessengerEvents<MoneyAccountControllerMessenger>
+  >,
+): MoneyAccountControllerMessenger {
+  const messenger: MoneyAccountControllerMessenger = new Messenger({
+    namespace: 'MoneyAccountController',
+    parent: rootMessenger,
+  });
 
   rootMessenger.delegate({
     messenger,
@@ -51,8 +52,10 @@ type AllowedInitializationEvents = ControllerStateChangeEvent<
   RemoteFeatureFlagControllerState
 >;
 
-export type MoneyAccountControllerInitMessenger = ReturnType<
-  typeof getMoneyAccountControllerInitMessenger
+export type MoneyAccountControllerInitMessenger = Messenger<
+  'MoneyAccountControllerInit',
+  AllowedInitializationActions,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -63,14 +66,12 @@ export type MoneyAccountControllerInitMessenger = ReturnType<
  * @returns The MoneyAccountControllerInitMessenger.
  */
 export function getMoneyAccountControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'MoneyAccountControllerInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<MoneyAccountControllerInitMessenger>,
+    MessengerEvents<MoneyAccountControllerInitMessenger>
+  >,
+): MoneyAccountControllerInitMessenger {
+  const messenger: MoneyAccountControllerInitMessenger = new Messenger({
     namespace: 'MoneyAccountControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/money-account-upgrade-controller-messenger.ts
+++ b/app/core/Engine/messengers/money-account-upgrade-controller-messenger.ts
@@ -23,14 +23,12 @@ import type { RootMessenger } from '../types';
  * @returns The restricted controller messenger.
  */
 export function getMoneyAccountUpgradeControllerMessenger(
-  rootMessenger: RootMessenger,
-): MoneyAccountUpgradeControllerMessenger {
-  const messenger = new Messenger<
-    'MoneyAccountUpgradeController',
+  rootMessenger: RootMessenger<
     MessengerActions<MoneyAccountUpgradeControllerMessenger>,
-    MessengerEvents<MoneyAccountUpgradeControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MoneyAccountUpgradeControllerMessenger>
+  >,
+): MoneyAccountUpgradeControllerMessenger {
+  const messenger: MoneyAccountUpgradeControllerMessenger = new Messenger({
     namespace: 'MoneyAccountUpgradeController',
     parent: rootMessenger,
   });
@@ -67,8 +65,10 @@ type InitEvents =
       RemoteFeatureFlagControllerState
     >;
 
-export type MoneyAccountUpgradeControllerInitMessenger = ReturnType<
-  typeof getMoneyAccountUpgradeControllerInitMessenger
+export type MoneyAccountUpgradeControllerInitMessenger = Messenger<
+  'MoneyAccountUpgradeControllerInitialization',
+  InitActions,
+  InitEvents
 >;
 
 /**
@@ -79,14 +79,12 @@ export type MoneyAccountUpgradeControllerInitMessenger = ReturnType<
  * @returns The restricted init messenger.
  */
 export function getMoneyAccountUpgradeControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'MoneyAccountUpgradeControllerInitialization',
-    InitActions,
-    InitEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<MoneyAccountUpgradeControllerInitMessenger>,
+    MessengerEvents<MoneyAccountUpgradeControllerInitMessenger>
+  >,
+): MoneyAccountUpgradeControllerInitMessenger {
+  const messenger: MoneyAccountUpgradeControllerInitMessenger = new Messenger({
     namespace: 'MoneyAccountUpgradeControllerInitialization',
     parent: rootMessenger,
   });


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the five earn-owned messenger files (`earn-controller-messenger`, `chomp-api-service-messenger`, `money-account-balance-service-messenger`, `money-account-controller-messenger`, `money-account-upgrade-controller-messenger`).

Narrows `rootMessenger` parameters to `RootMessenger<AllowedActions, AllowedEvents>`, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, and converts `ChompApiServiceInitMessenger`, `MoneyAccountControllerInitMessenger`, and `MoneyAccountUpgradeControllerInitMessenger` from `ReturnType<typeof …>` aliases to explicit `Messenger<…>` definitions.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure TypeScript typing changes with no runtime behavior; delegation lists and messenger wiring are unchanged.
> 
> **Overview**
> Applies the messenger typing pattern from #31467 across five earn-owned messenger factories (`earn-controller`, `chomp-api-service`, `money-account-balance-service`, `money-account-controller`, `money-account-upgrade-controller`).
> 
> **`rootMessenger`** parameters are now **`RootMessenger<MessengerActions<…>, MessengerEvents<…>>`** so the parent only exposes actions/events each child may delegate. **`new Messenger<…>`** no longer passes four explicit generics; instances are declared with the existing controller/service messenger type instead.
> 
> Init messenger aliases **`ChompApiServiceInitMessenger`**, **`MoneyAccountControllerInitMessenger`**, and **`MoneyAccountUpgradeControllerInitMessenger`** change from **`ReturnType<typeof …>`** to explicit **`Messenger<namespace, actions, events>`** definitions, with matching narrowed **`rootMessenger`** types on their factory functions.
> 
> No runtime or delegation behavior changes—compile-time typing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa6e6ab1b2e95defb8aa059ce7ee59f6a3990fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->