### PR TITLE
refactor(assets): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/messengers/defi-positions-controller-messenger/defi-positions-controller-messenger.ts
+++ b/app/core/Engine/messengers/defi-positions-controller-messenger/defi-positions-controller-messenger.ts
@@ -15,14 +15,12 @@ import { AnalyticsControllerActions } from '@metamask/analytics-controller';
  * @returns The restricted messenger.
  */
 export function getDeFiPositionsControllerMessenger(
-  rootMessenger: RootMessenger,
-): DeFiPositionsControllerMessenger {
-  const messenger = new Messenger<
-    'DeFiPositionsController',
+  rootMessenger: RootMessenger<
     MessengerActions<DeFiPositionsControllerMessenger>,
-    MessengerEvents<DeFiPositionsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<DeFiPositionsControllerMessenger>
+  >,
+): DeFiPositionsControllerMessenger {
+  const messenger: DeFiPositionsControllerMessenger = new Messenger({
     namespace: 'DeFiPositionsController',
     parent: rootMessenger,
   });
@@ -38,19 +36,19 @@ export function getDeFiPositionsControllerMessenger(
   return messenger;
 }
 
-export type DeFiPositionsControllerInitMessenger = ReturnType<
-  typeof getDeFiPositionsControllerInitMessenger
+export type DeFiPositionsControllerInitMessenger = Messenger<
+  'DeFiPositionsControllerInit',
+  RemoteFeatureFlagControllerGetStateAction | AnalyticsControllerActions,
+  never
 >;
 
 export function getDeFiPositionsControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'DeFiPositionsControllerInit',
-    RemoteFeatureFlagControllerGetStateAction | AnalyticsControllerActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<DeFiPositionsControllerInitMessenger>,
+    MessengerEvents<DeFiPositionsControllerInitMessenger>
+  >,
+): DeFiPositionsControllerInitMessenger {
+  const messenger: DeFiPositionsControllerInitMessenger = new Messenger({
     namespace: 'DeFiPositionsControllerInit',
     parent: rootMessenger,
   });


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the assets-owned messenger files (`defi-positions-controller-messenger`).

Narrows `rootMessenger` parameters to `RootMessenger<AllowedActions, AllowedEvents>`, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, and converts `DeFiPositionsControllerInitMessenger` from a `ReturnType<typeof …>` alias to an explicit `Messenger<…>` definition.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.