### PR TITLE
refactor(money-movement): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
+++ b/app/core/Engine/messengers/ramps-controller-messenger/ramps-controller-messenger.ts
@@ -24,14 +24,9 @@ type AllowedEvents = MessengerEvents<RampsControllerMessenger>;
  * @returns The RampsControllerMessenger.
  */
 export function getRampsControllerMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: RootMessenger<AllowedActions, AllowedEvents>,
 ): RampsControllerMessenger {
-  const messenger = new Messenger<
-    'RampsController',
-    AllowedActions,
-    AllowedEvents,
-    typeof rootMessenger
-  >({
+  const messenger: RampsControllerMessenger = new Messenger({
     namespace: 'RampsController',
     parent: rootMessenger,
   });
@@ -79,8 +74,11 @@ export function getRampsControllerMessenger(
   return messenger;
 }
 
-export type RampsControllerInitMessenger = ReturnType<
-  typeof getRampsControllerInitMessenger
+export type RampsControllerInitMessenger = Messenger<
+  'RampsControllerInit',
+  RemoteFeatureFlagControllerGetStateAction,
+  | RampsControllerOrderStatusChangedEvent
+  | RemoteFeatureFlagControllerStateChangeEvent
 >;
 
 /**
@@ -90,14 +88,13 @@ export type RampsControllerInitMessenger = ReturnType<
  * @param rootMessenger - The root messenger.
  * @returns The RampsControllerInitMessenger.
  */
-export function getRampsControllerInitMessenger(rootMessenger: RootMessenger) {
-  const messenger = new Messenger<
-    'RampsControllerInit',
-    RemoteFeatureFlagControllerGetStateAction,
-    | RampsControllerOrderStatusChangedEvent
-    | RemoteFeatureFlagControllerStateChangeEvent,
-    RootMessenger
-  >({
+export function getRampsControllerInitMessenger(
+  rootMessenger: RootMessenger<
+    MessengerActions<RampsControllerInitMessenger>,
+    MessengerEvents<RampsControllerInitMessenger>
+  >,
+): RampsControllerInitMessenger {
+  const messenger: RampsControllerInitMessenger = new Messenger({
     namespace: 'RampsControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/ramps-service-messenger/ramps-service-messenger.ts
+++ b/app/core/Engine/messengers/ramps-service-messenger/ramps-service-messenger.ts
@@ -17,14 +17,9 @@ type AllowedEvents = MessengerEvents<RampsServiceMessenger>;
  * @returns The RampsServiceMessenger.
  */
 export function getRampsServiceMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: RootMessenger<AllowedActions, AllowedEvents>,
 ): RampsServiceMessenger {
-  const messenger = new Messenger<
-    'RampsService',
-    AllowedActions,
-    AllowedEvents,
-    typeof rootMessenger
-  >({
+  const messenger: RampsServiceMessenger = new Messenger({
     namespace: 'RampsService',
     parent: rootMessenger,
   });


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the money-movement-owned messenger files (`ramps-controller-messenger`, `ramps-service-messenger`).

Narrows `rootMessenger` parameters to `RootMessenger<AllowedActions, AllowedEvents>` using the existing local type aliases, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, and converts `RampsControllerInitMessenger` from a `ReturnType<typeof …>` alias to an explicit `Messenger<…>` definition.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.