### PR TITLE
refactor(social-ai): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/messengers/ai-digest-controller-messenger.ts
+++ b/app/core/Engine/messengers/ai-digest-controller-messenger.ts
@@ -13,15 +13,14 @@ import type { RootMessenger } from '../types';
  * @returns The AiDigestControllerMessenger.
  */
 export function getAiDigestControllerMessenger(
-  rootMessenger: RootMessenger,
-): AiDigestControllerMessenger {
-  return new Messenger<
-    'AiDigestController',
+  rootMessenger: RootMessenger<
     MessengerActions<AiDigestControllerMessenger>,
-    MessengerEvents<AiDigestControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AiDigestControllerMessenger>
+  >,
+): AiDigestControllerMessenger {
+  const messenger: AiDigestControllerMessenger = new Messenger({
     namespace: 'AiDigestController',
     parent: rootMessenger,
   });
+  return messenger;
 }

--- a/app/core/Engine/messengers/social-controller-messenger.ts
+++ b/app/core/Engine/messengers/social-controller-messenger.ts
@@ -16,14 +16,12 @@ import type { RootMessenger } from '../types';
  * @returns The SocialControllerMessenger.
  */
 export function getSocialControllerMessenger(
-  rootMessenger: RootMessenger,
-): SocialControllerMessenger {
-  const messenger = new Messenger<
-    'SocialController',
+  rootMessenger: RootMessenger<
     MessengerActions<SocialControllerMessenger>,
-    MessengerEvents<SocialControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<SocialControllerMessenger>
+  >,
+): SocialControllerMessenger {
+  const messenger: SocialControllerMessenger = new Messenger({
     namespace: 'SocialController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/social-service-messenger.ts
+++ b/app/core/Engine/messengers/social-service-messenger.ts
@@ -13,14 +13,12 @@ import type { RootMessenger } from '../types';
  * @returns The SocialServiceMessenger.
  */
 export function getSocialServiceMessenger(
-  rootMessenger: RootMessenger,
-): SocialServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'SocialService',
+  rootMessenger: RootMessenger<
     MessengerActions<SocialServiceMessenger>,
-    MessengerEvents<SocialServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<SocialServiceMessenger>
+  >,
+): SocialServiceMessenger {
+  const serviceMessenger: SocialServiceMessenger = new Messenger({
     namespace: 'SocialService',
     parent: rootMessenger,
   });


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the social-ai-owned messenger files (`social-controller-messenger`, `social-service-messenger`, `ai-digest-controller-messenger`).

Narrows `rootMessenger` parameters to `RootMessenger<AllowedActions, AllowedEvents>`, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, and converts the inline `return new Messenger<…>(…)` pattern in `ai-digest-controller-messenger` to a typed local variable.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.