### PR TITLE
refactor(perps): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/messengers/compliance/compliance-controller-messenger.ts
+++ b/app/core/Engine/messengers/compliance/compliance-controller-messenger.ts
@@ -16,14 +16,12 @@ import type { RootMessenger } from '../../types';
  * @returns The ComplianceControllerMessenger.
  */
 export function getComplianceControllerMessenger(
-  rootMessenger: RootMessenger,
-): ComplianceControllerMessenger {
-  const messenger = new Messenger<
-    'ComplianceController',
+  rootMessenger: RootMessenger<
     MessengerActions<ComplianceControllerMessenger>,
-    MessengerEvents<ComplianceControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<ComplianceControllerMessenger>
+  >,
+): ComplianceControllerMessenger {
+  const messenger: ComplianceControllerMessenger = new Messenger({
     namespace: 'ComplianceController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/compliance/compliance-service-messenger.ts
+++ b/app/core/Engine/messengers/compliance/compliance-service-messenger.ts
@@ -13,15 +13,14 @@ import type { RootMessenger } from '../../types';
  * @returns The ComplianceServiceMessenger.
  */
 export function getComplianceServiceMessenger(
-  rootMessenger: RootMessenger,
-): ComplianceServiceMessenger {
-  return new Messenger<
-    'ComplianceService',
+  rootMessenger: RootMessenger<
     MessengerActions<ComplianceServiceMessenger>,
-    MessengerEvents<ComplianceServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<ComplianceServiceMessenger>
+  >,
+): ComplianceServiceMessenger {
+  const messenger: ComplianceServiceMessenger = new Messenger({
     namespace: 'ComplianceService',
     parent: rootMessenger,
   });
+  return messenger;
 }


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the perps-owned messenger files (`compliance-controller-messenger`, `compliance-service-messenger`).

Narrows `rootMessenger` parameters to `RootMessenger<AllowedActions, AllowedEvents>`, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, and converts the inline `return new Messenger<…>(…)` pattern in `compliance-service-messenger` to a typed local variable.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.