### PR TITLE
fix: Bump `network-controller` to `33.0.0`

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -11,8 +11,6 @@ import {
 import { mockNetworkState } from '../../util/test/network';
 import { Hex, KnownCaipNamespace } from '@metamask/utils';
 import { KeyringControllerState } from '@metamask/keyring-controller';
-import { NetworkController } from '@metamask/network-controller';
-import { ClientConfigApiService } from '@metamask/remote-feature-flag-controller';
 import { backupVault } from '../BackupVault';
 import { getVersion } from 'react-native-device-info';
 import { version as migrationVersion } from '../../store/migrations';
@@ -100,8 +98,6 @@ jest.mock('./utils', () => ({
   ...jest.requireActual('./utils'),
   rejectOriginApprovals: jest.fn(),
 }));
-
-const ClientConfigApiServiceMock = jest.mocked(ClientConfigApiService);
 
 describe('Engine', () => {
   // Create a shared mock account for tests
@@ -345,130 +341,6 @@ describe('Engine', () => {
     await expect(engine.getSnapKeyring()).rejects.toThrow(
       'keyring unavailable',
     );
-  });
-
-  it('enables the RPC failover feature if the walletFrameworkRpcFailoverEnabled feature flag is already enabled', () => {
-    const state = {
-      RemoteFeatureFlagController: {
-        remoteFeatureFlags: {
-          walletFrameworkRpcFailoverEnabled: true,
-        },
-        cacheTimestamp: 0,
-      },
-    };
-    const enableRpcFailoverSpy = jest.spyOn(
-      NetworkController.prototype,
-      'enableRpcFailover',
-    );
-
-    Engine.init(TEST_ANALYTICS_ID, state);
-
-    expect(enableRpcFailoverSpy).toHaveBeenCalled();
-  });
-
-  it('disables the RPC failover feature if the walletFrameworkRpcFailoverEnabled feature flag is already disabled', () => {
-    const state = {
-      RemoteFeatureFlagController: {
-        remoteFeatureFlags: {
-          walletFrameworkRpcFailoverEnabled: false,
-        },
-        cacheTimestamp: 0,
-      },
-    };
-    const disableRpcFailoverSpy = jest.spyOn(
-      NetworkController.prototype,
-      'disableRpcFailover',
-    );
-
-    Engine.init(TEST_ANALYTICS_ID, state);
-
-    expect(disableRpcFailoverSpy).toHaveBeenCalled();
-  });
-
-  it('enables the RPC failover feature if the walletFrameworkRpcFailoverEnabled feature flag is enabled later', async () => {
-    (Date.now as jest.Mock).mockReturnValue(1000000);
-    const state = {
-      RemoteFeatureFlagController: {
-        remoteFeatureFlags: {
-          walletFrameworkRpcFailoverEnabled: false,
-        },
-        cacheTimestamp: 0,
-      },
-    };
-    const analyticsId = '24d24a09-b210-4971-9601-4603c60b23c3';
-    const enableRpcFailoverSpy = jest.spyOn(
-      NetworkController.prototype,
-      'enableRpcFailover',
-    );
-    ClientConfigApiServiceMock
-      // @ts-expect-error We aren't supplying a complete ClientConfigApiService;
-      // all we need to override is `fetchRemoteFeatureFlags`
-      .mockReturnValue({
-        async fetchRemoteFeatureFlags() {
-          return {
-            remoteFeatureFlags: {
-              walletFrameworkRpcFailoverEnabled: true,
-            },
-            cacheTimestamp: 1,
-          };
-        },
-      });
-
-    Engine.init(analyticsId, state);
-
-    // We can't await RemoteFeatureFlagController:stateChange because can't
-    // guarantee it hasn't been called already, so this is the next best option
-    while (enableRpcFailoverSpy.mock.calls.length === 0) {
-      await new Promise<void>((resolve) => {
-        setTimeout(() => {
-          resolve();
-        }, 100);
-      });
-    }
-    expect(enableRpcFailoverSpy).toHaveBeenCalled();
-  });
-
-  it('disables the RPC failover feature if the walletFrameworkRpcFailoverEnabled feature flag is disabled later', async () => {
-    (Date.now as jest.Mock).mockReturnValue(1000000);
-    const state = {
-      RemoteFeatureFlagController: {
-        remoteFeatureFlags: {
-          walletFrameworkRpcFailoverEnabled: true,
-        },
-        cacheTimestamp: 0,
-      },
-    };
-    const analyticsId = '24d24a09-b210-4971-9601-4603c60b23c3';
-    const disableRpcFailoverSpy = jest.spyOn(
-      NetworkController.prototype,
-      'disableRpcFailover',
-    );
-    ClientConfigApiServiceMock
-      // @ts-expect-error We aren't supplying a complete ClientConfigApiService;
-      // all we need to override is `fetchRemoteFeatureFlags`
-      .mockReturnValue({
-        async fetchRemoteFeatureFlags() {
-          return {
-            remoteFeatureFlags: {
-              walletFrameworkRpcFailoverEnabled: false,
-            },
-            cacheTimestamp: 1,
-          };
-        },
-      });
-
-    Engine.init(analyticsId, state);
-
-    // We can't await RemoteFeatureFlagController:stateChange because can't
-    // guarantee it hasn't been called already, so this is the next best option
-    while (disableRpcFailoverSpy.mock.calls.length === 0) {
-      await new Promise<void>((resolve) => {
-        setTimeout(() => {
-          resolve();
-        }, 100);
-      });
-    }
-    expect(disableRpcFailoverSpy).toHaveBeenCalled();
   });
 
   describe('getTotalEvmFiatAccountBalance', () => {

--- a/app/core/Engine/controllers/network-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-controller-init.test.ts
@@ -79,7 +79,6 @@ describe('networkControllerInit', () => {
     expect(controllerMock).toHaveBeenCalledWith({
       messenger: expect.any(Object),
       state: undefined,
-      getBlockTrackerOptions: expect.any(Function),
       infuraProjectId: 'NON_EMPTY',
       failoverUrls: {
         '0x1': [],

--- a/app/core/Engine/controllers/network-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-controller-init.test.ts
@@ -6,19 +6,13 @@ import {
   NetworkControllerInitMessenger,
 } from '../messengers/network-controller-messenger';
 import { MessengerClientInitRequest } from '../types';
+import { networkControllerInit } from './network-controller-init';
 import {
-  ADDITIONAL_DEFAULT_NETWORKS,
-  getInitialNetworkControllerState,
-  networkControllerInit,
-} from './network-controller-init';
-import {
-  getDefaultNetworkControllerState,
   NetworkController,
   NetworkControllerMessenger,
   NetworkControllerRpcEndpointDegradedEvent,
   NetworkControllerRpcEndpointUnavailableEvent,
 } from '@metamask/network-controller';
-import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
 import { buildAndTrackEvent } from '../utils/analytics';
 import {
@@ -73,14 +67,6 @@ describe('networkControllerInit', () => {
     jest.clearAllMocks();
   });
 
-  jest
-    .mocked(getDefaultNetworkControllerState)
-    .mockImplementation((additionalNetworks) =>
-      jest
-        .requireActual('@metamask/network-controller')
-        .getDefaultNetworkControllerState(additionalNetworks),
-    );
-
   it('initializes the controller', () => {
     const { controller } = networkControllerInit(getInitRequestMock());
     expect(controller).toBeInstanceOf(NetworkController);
@@ -92,120 +78,18 @@ describe('networkControllerInit', () => {
     const controllerMock = jest.mocked(NetworkController);
     expect(controllerMock).toHaveBeenCalledWith({
       messenger: expect.any(Object),
-      state: getInitialNetworkControllerState({}),
-      additionalDefaultNetworks: ADDITIONAL_DEFAULT_NETWORKS,
+      state: undefined,
       getBlockTrackerOptions: expect.any(Function),
-      getRpcServiceOptions: expect.any(Function),
       infuraProjectId: 'NON_EMPTY',
-    });
-  });
-
-  it('enables RPC failover when initialized with the `walletFrameworkRpcFailoverEnabled` feature flag enabled', () => {
-    const baseMessenger = new ExtendedMessenger<
-      MockAnyNamespace,
-      RemoteFeatureFlagControllerGetStateAction,
-      never
-    >({
-      namespace: MOCK_ANY_NAMESPACE,
-    });
-
-    const initRequest = getInitRequestMock(baseMessenger);
-
-    baseMessenger.unregisterActionHandler(
-      'RemoteFeatureFlagController:getState',
-    );
-    baseMessenger.registerActionHandler(
-      'RemoteFeatureFlagController:getState',
-      jest.fn().mockReturnValue({
-        remoteFeatureFlags: {
-          walletFrameworkRpcFailoverEnabled: true,
-        },
-      }),
-    );
-
-    networkControllerInit(initRequest);
-
-    const controllerMock = jest.mocked(NetworkController);
-    expect(
-      controllerMock.mock.instances[0].enableRpcFailover,
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('disables RPC failover when initialized with the `walletFrameworkRpcFailoverEnabled` feature flag disabled', () => {
-    const baseMessenger = new ExtendedMessenger<
-      MockAnyNamespace,
-      RemoteFeatureFlagControllerGetStateAction,
-      never
-    >({
-      namespace: MOCK_ANY_NAMESPACE,
-    });
-
-    const initRequest = getInitRequestMock(baseMessenger);
-
-    baseMessenger.unregisterActionHandler(
-      'RemoteFeatureFlagController:getState',
-    );
-    baseMessenger.registerActionHandler(
-      'RemoteFeatureFlagController:getState',
-      jest.fn().mockReturnValue({
-        remoteFeatureFlags: {
-          walletFrameworkRpcFailoverEnabled: false,
-        },
-      }),
-    );
-
-    networkControllerInit(initRequest);
-
-    const controllerMock = jest.mocked(NetworkController);
-    expect(
-      controllerMock.mock.instances[0].disableRpcFailover,
-    ).toHaveBeenCalledTimes(1);
-  });
-
-  it('enables RPC failover when the `walletFrameworkRpcFailoverEnabled` feature flag is enabled on state change', () => {
-    const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>(
-      {
-        namespace: MOCK_ANY_NAMESPACE,
-      },
-    );
-    const initRequest = getInitRequestMock(baseMessenger);
-    networkControllerInit(initRequest);
-
-    const controllerMock = jest.mocked(NetworkController);
-
-    // @ts-expect-error: Partial mock.
-    baseMessenger.publish('RemoteFeatureFlagController:stateChange', {
-      remoteFeatureFlags: {
-        walletFrameworkRpcFailoverEnabled: true,
+      failoverUrls: {
+        '0x1': [],
+        '0x2105': [],
+        '0x89': [],
+        '0xa': [],
+        '0xa4b1': [],
+        '0xe708': [],
       },
     });
-
-    expect(
-      controllerMock.mock.instances[0].enableRpcFailover,
-    ).toHaveBeenCalledTimes(2);
-  });
-
-  it('disables RPC failover when the `walletFrameworkRpcFailoverEnabled` feature flag is disabled on state change', () => {
-    const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never, never>(
-      {
-        namespace: MOCK_ANY_NAMESPACE,
-      },
-    );
-    const initRequest = getInitRequestMock(baseMessenger);
-    networkControllerInit(initRequest);
-
-    const controllerMock = jest.mocked(NetworkController);
-
-    // @ts-expect-error: Partial mock.
-    baseMessenger.publish('RemoteFeatureFlagController:stateChange', {
-      remoteFeatureFlags: {
-        walletFrameworkRpcFailoverEnabled: false,
-      },
-    });
-
-    expect(
-      controllerMock.mock.instances[0].disableRpcFailover,
-    ).toHaveBeenCalledTimes(1);
   });
 
   describe('buildAndTrackEvent integration', () => {

--- a/app/core/Engine/controllers/network-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-controller-init.test.ts
@@ -82,11 +82,17 @@ describe('networkControllerInit', () => {
       infuraProjectId: 'NON_EMPTY',
       failoverUrls: {
         '0x1': [],
-        '0x2105': [],
-        '0x89': [],
-        '0xa': [],
-        '0xa4b1': [],
         '0xe708': [],
+        '0xa4b1': [],
+        '0xa86a': [],
+        '0xa': [],
+        '0x89': [],
+        '0x2105': [],
+        '0x38': [],
+        '0x531': [],
+        '0x8f': [],
+        '0x3e7': [],
+        '0x13b2': [],
       },
     });
   });

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -12,7 +12,7 @@ import {
 } from './network-controller/messenger-action-handlers';
 import { Hex } from '@metamask/utils';
 import { buildAndTrackEvent } from '../utils/analytics';
-import { ChainId } from '@metamask/controller-utils';
+import { ChainId, toHex } from '@metamask/controller-utils';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -38,14 +38,23 @@ export const networkControllerInit: MessengerClientInitFunction<
       [ChainId.mainnet]: getFailoverUrlsForInfuraNetwork('ethereum-mainnet'),
       [ChainId['linea-mainnet']]:
         getFailoverUrlsForInfuraNetwork('linea-mainnet'),
-      [ChainId['base-mainnet']]:
-        getFailoverUrlsForInfuraNetwork('base-mainnet'),
       [ChainId['arbitrum-mainnet']]:
         getFailoverUrlsForInfuraNetwork('arbitrum-mainnet'),
+      [ChainId['avalanche-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('avalanche-mainnet'),
       [ChainId['optimism-mainnet']]:
         getFailoverUrlsForInfuraNetwork('optimism-mainnet'),
       [ChainId['polygon-mainnet']]:
         getFailoverUrlsForInfuraNetwork('polygon-mainnet'),
+      [ChainId['base-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('base-mainnet'),
+      [ChainId['bsc-mainnet']]: getFailoverUrlsForInfuraNetwork('bsc-mainnet'),
+      [ChainId['sei-mainnet']]: getFailoverUrlsForInfuraNetwork('sei-mainnet'),
+      [ChainId['monad-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('monad-mainnet'),
+      // HyperEVM and Arc are not part of the `ChainId` enum.
+      [toHex(999)]: getFailoverUrlsForInfuraNetwork('hyperevm-mainnet'),
+      [toHex(5042)]: getFailoverUrlsForInfuraNetwork('arc-mainnet'),
     },
   });
 

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -1,111 +1,21 @@
 import { MessengerClientInitFunction } from '../types';
 import {
-  getDefaultNetworkControllerState,
   NetworkController,
-  NetworkState,
   type NetworkControllerMessenger,
 } from '@metamask/network-controller';
 import { NetworkControllerInitMessenger } from '../messengers/network-controller-messenger';
-import { ChainId, DEFAULT_MAX_RETRIES } from '@metamask/controller-utils';
 import { getFailoverUrlsForInfuraNetwork } from '../../../util/networks/customNetworks';
 import { INFURA_PROJECT_ID } from '../../../constants/network';
 import { SECOND } from '../../../constants/time';
-import { getIsQuicknodeEndpointUrl } from './network-controller/utils';
 import {
   onRpcEndpointDegraded,
   onRpcEndpointUnavailable,
 } from './network-controller/messenger-action-handlers';
-import { Hex, Json } from '@metamask/utils';
-import Logger from '../../../util/Logger';
+import { Hex } from '@metamask/utils';
 import { buildAndTrackEvent } from '../utils/analytics';
-import { CONNECTIVITY_STATUSES } from '@metamask/connectivity-controller';
+import { ChainId } from '@metamask/controller-utils';
 
 const NON_EMPTY = 'NON_EMPTY';
-
-export const ADDITIONAL_DEFAULT_NETWORKS = [
-  ChainId['megaeth-testnet-v2'],
-  ChainId['monad-testnet'],
-];
-
-export function getInitialNetworkControllerState(persistedState: {
-  NetworkController?: Partial<NetworkState>;
-}) {
-  let initialNetworkControllerState =
-    persistedState.NetworkController as NetworkState;
-
-  if (!initialNetworkControllerState) {
-    initialNetworkControllerState = getDefaultNetworkControllerState(
-      ADDITIONAL_DEFAULT_NETWORKS,
-    );
-
-    // MegaETH Testnet v2 change back the RPC URL from timothy to carrot again
-    // TODO: Remove this once the MegaETH Testnet v2 is updated and released from the controller utils
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['megaeth-testnet-v2']
-    ].rpcEndpoints[0].url = 'https://carrot.megaeth.com/rpc';
-
-    // Add failovers for default Infura RPC endpoints
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId.mainnet
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('ethereum-mainnet');
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['linea-mainnet']
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('linea-mainnet');
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['base-mainnet']
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('base-mainnet');
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['arbitrum-mainnet']
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('arbitrum-mainnet');
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['bsc-mainnet']
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('bsc-mainnet');
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['optimism-mainnet']
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('optimism-mainnet');
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['polygon-mainnet']
-    ].rpcEndpoints[0].failoverUrls =
-      getFailoverUrlsForInfuraNetwork('polygon-mainnet');
-
-    // Update default popular network names
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId.mainnet
-    ].name = 'Ethereum';
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['linea-mainnet']
-    ].name = 'Linea';
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['base-mainnet']
-    ].name = 'Base';
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['arbitrum-mainnet']
-    ].name = 'Arbitrum';
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['bsc-mainnet']
-    ].name = 'BNB Chain';
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['optimism-mainnet']
-    ].name = 'OP';
-    initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['polygon-mainnet']
-    ].name = 'Polygon';
-
-    // Remove Sei from initial state so it appears in Additional Networks section
-    // Users can add it manually, and it will be available in FEATURED_RPCS
-    delete initialNetworkControllerState.networkConfigurationsByChainId[
-      ChainId['sei-mainnet']
-    ];
-  }
-
-  return initialNetworkControllerState;
-}
 
 /**
  * Initialize the network controller.
@@ -123,7 +33,7 @@ export const networkControllerInit: MessengerClientInitFunction<
 
   const controller = new NetworkController({
     infuraProjectId,
-    state: getInitialNetworkControllerState(persistedState),
+    state: persistedState.NetworkController,
     messenger: controllerMessenger,
     getBlockTrackerOptions: () =>
       process.env.IN_TEST
@@ -135,60 +45,19 @@ export const networkControllerInit: MessengerClientInitFunction<
             // failures quickly.
             retryTimeout: 20 * SECOND,
           },
-    getRpcServiceOptions: (rpcEndpointUrl: string) => {
-      // Note that the total number of attempts is 1 more than this
-      // (which is why we add 1 below).
-      const maxRetries = DEFAULT_MAX_RETRIES;
-      const isOffline = (): boolean => {
-        const connectivityState = controllerMessenger.call(
-          'ConnectivityController:getState',
-        );
-        return (
-          connectivityState.connectivityStatus === CONNECTIVITY_STATUSES.Offline
-        );
-      };
-      const commonOptions = {
-        fetch: globalThis.fetch.bind(globalThis),
-        btoa: globalThis.btoa.bind(globalThis),
-        isOffline,
-      };
-      const commonPolicyOptions = {
-        // Ensure that the "cooldown" period after breaking the circuit is short.
-        circuitBreakDuration: 30 * SECOND,
-        maxRetries,
-      };
-
-      if (getIsQuicknodeEndpointUrl(rpcEndpointUrl)) {
-        return {
-          ...commonOptions,
-          policyOptions: {
-            ...commonPolicyOptions,
-            // The number of rounds of retries that will break the circuit,
-            // triggering a "cooldown".
-            //
-            // When we fail over to QuickNode, we expect it to be down at first
-            // while it is being automatically activated, and we don't want to
-            // activate the "cooldown" accidentally.
-            maxConsecutiveFailures: (maxRetries + 1) * 10,
-          },
-        };
-      }
-
-      return {
-        ...commonOptions,
-        policyOptions: {
-          ...commonPolicyOptions,
-          // Ensure that if the endpoint continually responds with errors, we
-          // break the circuit relatively fast (but not prematurely).
-          //
-          // Note that the circuit will break much faster if the errors are
-          // retriable (e.g. 503) than if not (e.g. 500), so we attempt to strike
-          // a balance here.
-          maxConsecutiveFailures: (maxRetries + 1) * 3,
-        },
-      };
+    failoverUrls: {
+      [ChainId.mainnet]: getFailoverUrlsForInfuraNetwork('ethereum-mainnet'),
+      [ChainId['linea-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('linea-mainnet'),
+      [ChainId['base-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('base-mainnet'),
+      [ChainId['arbitrum-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('arbitrum-mainnet'),
+      [ChainId['optimism-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('optimism-mainnet'),
+      [ChainId['polygon-mainnet']]:
+        getFailoverUrlsForInfuraNetwork('polygon-mainnet'),
     },
-    additionalDefaultNetworks: ADDITIONAL_DEFAULT_NETWORKS,
   });
 
   initMessenger.subscribe(
@@ -245,33 +114,7 @@ export const networkControllerInit: MessengerClientInitFunction<
     },
   );
 
-  controller.initializeProvider();
-
-  // TODO: Move this to `network-controller`
-  const toggleRpcFailover = (isRpcFailoverEnabled: Json) => {
-    if (isRpcFailoverEnabled) {
-      Logger.log('Enabling RPC failover.');
-      controller.enableRpcFailover();
-    } else {
-      Logger.log('Disabling RPC failover.');
-      controller.disableRpcFailover();
-    }
-  };
-
-  initMessenger.subscribe(
-    'RemoteFeatureFlagController:stateChange',
-    toggleRpcFailover,
-    (state) => state.remoteFeatureFlags.walletFrameworkRpcFailoverEnabled,
-  );
-
-  const remoteFeatureFlagControllerState = initMessenger.call(
-    'RemoteFeatureFlagController:getState',
-  );
-
-  toggleRpcFailover(
-    remoteFeatureFlagControllerState.remoteFeatureFlags
-      .walletFrameworkRpcFailoverEnabled,
-  );
+  controller.init();
 
   return {
     controller,

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -6,7 +6,6 @@ import {
 import { NetworkControllerInitMessenger } from '../messengers/network-controller-messenger';
 import { getFailoverUrlsForInfuraNetwork } from '../../../util/networks/customNetworks';
 import { INFURA_PROJECT_ID } from '../../../constants/network';
-import { SECOND } from '../../../constants/time';
 import {
   onRpcEndpointDegraded,
   onRpcEndpointUnavailable,
@@ -35,16 +34,6 @@ export const networkControllerInit: MessengerClientInitFunction<
     infuraProjectId,
     state: persistedState.NetworkController,
     messenger: controllerMessenger,
-    getBlockTrackerOptions: () =>
-      process.env.IN_TEST
-        ? {}
-        : {
-            pollingInterval: 20 * SECOND,
-            // The retry timeout is pretty short by default, and if the endpoint is
-            // down, it will end up exhausting the max number of consecutive
-            // failures quickly.
-            retryTimeout: 20 * SECOND,
-          },
     failoverUrls: {
       [ChainId.mainnet]: getFailoverUrlsForInfuraNetwork('ethereum-mainnet'),
       [ChainId['linea-mainnet']]:

--- a/app/core/Engine/messengers/network-controller-messenger.ts
+++ b/app/core/Engine/messengers/network-controller-messenger.ts
@@ -34,8 +34,11 @@ export function getNetworkControllerMessenger(
     parent: rootMessenger,
   });
   rootMessenger.delegate({
-    actions: ['ConnectivityController:getState'],
-    events: [],
+    actions: [
+      'ConnectivityController:getState',
+      'RemoteFeatureFlagController:getState',
+    ],
+    events: ['RemoteFeatureFlagController:stateChange'],
     messenger,
   });
   return messenger;
@@ -78,14 +81,10 @@ export function getNetworkControllerInitMessenger(
     parent: rootMessenger,
   });
   rootMessenger.delegate({
-    actions: [
-      'RemoteFeatureFlagController:getState',
-      'AnalyticsController:trackEvent',
-    ],
+    actions: ['AnalyticsController:trackEvent'],
     events: [
       'NetworkController:rpcEndpointDegraded',
       'NetworkController:rpcEndpointUnavailable',
-      'RemoteFeatureFlagController:stateChange',
     ],
     messenger,
   });

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -72,7 +72,8 @@
     },
     "networkConfigurationsByChainId": {
       "0x1": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://etherscan.io"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0x1",
         "defaultRpcEndpointIndex": 0,
         "name": "Ethereum",
@@ -119,7 +120,8 @@
         ]
       },
       "0x38": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://bscscan.com"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0x38",
         "defaultRpcEndpointIndex": 0,
         "name": "BNB Chain",
@@ -134,7 +136,8 @@
         ]
       },
       "0x89": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://polygonscan.com"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0x89",
         "defaultRpcEndpointIndex": 0,
         "name": "Polygon",
@@ -149,7 +152,8 @@
         ]
       },
       "0xa": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://optimistic.etherscan.io"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0xa",
         "defaultRpcEndpointIndex": 0,
         "name": "OP",
@@ -164,7 +168,8 @@
         ]
       },
       "0xa4b1": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://arbiscan.io"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0xa4b1",
         "defaultRpcEndpointIndex": 0,
         "name": "Arbitrum",
@@ -179,7 +184,8 @@
         ]
       },
       "0xaa36a7": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://sepolia.etherscan.io"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0xaa36a7",
         "defaultRpcEndpointIndex": 0,
         "name": "Sepolia",
@@ -194,7 +200,8 @@
         ]
       },
       "0xe705": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://sepolia.lineascan.build"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0xe705",
         "defaultRpcEndpointIndex": 0,
         "name": "Linea Sepolia",
@@ -209,7 +216,8 @@
         ]
       },
       "0xe708": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://lineascan.build"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0xe708",
         "defaultRpcEndpointIndex": 0,
         "name": "Linea",
@@ -224,7 +232,8 @@
         ]
       },
       "0x2105": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://basescan.org"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0x2105",
         "defaultRpcEndpointIndex": 0,
         "name": "Base",
@@ -239,7 +248,8 @@
         ]
       },
       "0x8f": {
-        "blockExplorerUrls": [],
+        "blockExplorerUrls": ["https://monadscan.com"],
+        "defaultBlockExplorerUrlIndex": 0,
         "chainId": "0x8f",
         "defaultRpcEndpointIndex": 0,
         "name": "Monad",

--- a/package.json
+++ b/package.json
@@ -831,5 +831,11 @@
       }
     },
     "version": "v0.3.0"
+  },
+  "previewBuilds": {
+    "@metamask/network-controller": {
+      "type": "non-breaking",
+      "previewVersion": "32.0.0-preview-22ab7e3"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     ]
   },
   "resolutions": {
-    "@metamask/network-controller": "32.0.0",
+    "@metamask/network-controller": "33.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.5",
     "@appium/schema/json-schema": "^0.4.0",
@@ -215,7 +215,7 @@
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
     "@metamask/transaction-controller": "68.1.0",
     "@metamask/keyring-controller": "^26.0.0",
-    "@metamask/accounts-controller": "^39.0.0"
+    "@metamask/accounts-controller": "^39.0.2"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -235,14 +235,14 @@
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^1.0.4",
     "@metamask/account-tree-controller": "^7.5.0",
-    "@metamask/accounts-controller": "^39.0.0",
+    "@metamask/accounts-controller": "^39.0.2",
     "@metamask/address-book-controller": "^7.1.2",
     "@metamask/ai-controllers": "^0.7.0",
     "@metamask/analytics-controller": "^1.0.0",
     "@metamask/app-metadata-controller": "^2.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^9.0.1",
-    "@metamask/assets-controllers": "^109.1.0",
+    "@metamask/assets-controller": "^9.0.2",
+    "@metamask/assets-controllers": "^109.2.1",
     "@metamask/authenticated-user-storage": "^2.0.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.13.0",
@@ -254,7 +254,7 @@
     "@metamask/client-controller": "^1.0.1",
     "@metamask/compliance-controller": "2.1.0",
     "@metamask/connectivity-controller": "^0.2.0",
-    "@metamask/controller-utils": "^12.1.0",
+    "@metamask/controller-utils": "^12.3.0",
     "@metamask/core-backend": "^6.3.0",
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
@@ -305,7 +305,7 @@
     "@metamask/multichain-network-controller": "^3.1.0",
     "@metamask/multichain-transactions-controller": "^7.1.0",
     "@metamask/native-utils": "^0.8.0",
-    "@metamask/network-controller": "^32.0.0",
+    "@metamask/network-controller": "^33.0.0",
     "@metamask/network-enablement-controller": "^5.3.0",
     "@metamask/notification-services-controller": "24.1.1",
     "@metamask/permission-controller": "^13.1.1",
@@ -330,7 +330,7 @@
     "@metamask/scure-bip39": "^2.1.0",
     "@metamask/sdk-communication-layer": "0.33.1",
     "@metamask/seedless-onboarding-controller": "^10.0.1",
-    "@metamask/selected-network-controller": "^25.0.0",
+    "@metamask/selected-network-controller": "^26.1.4",
     "@metamask/signature-controller": "^39.2.0",
     "@metamask/slip44": "^4.2.0",
     "@metamask/smart-transactions-controller": "^24.2.2",
@@ -347,7 +347,7 @@
     "@metamask/storage-service": "^1.0.0",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/transaction-controller": "^68.1.0",
+    "@metamask/transaction-controller": "^68.1.1",
     "@metamask/transaction-pay-controller": "^23.13.0",
     "@metamask/tron-wallet-snap": "^1.27.0",
     "@metamask/utils": "^11.11.0",
@@ -831,11 +831,5 @@
       }
     },
     "version": "v0.3.0"
-  },
-  "previewBuilds": {
-    "@metamask/network-controller": {
-      "type": "non-breaking",
-      "previewVersion": "32.0.0-preview-22ab7e3"
-    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7825,22 +7825,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/accounts-controller@npm:^39.0.0":
-  version: 39.0.0
-  resolution: "@metamask/accounts-controller@npm:39.0.0"
+"@metamask/accounts-controller@npm:^39.0.2":
+  version: 39.0.2
+  resolution: "@metamask/accounts-controller@npm:39.0.2"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/eth-snap-keyring": "npm:^22.0.1"
     "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
     "@metamask/keyring-sdk": "npm:^2.1.1"
     "@metamask/keyring-utils": "npm:^3.2.1"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-controller": "npm:^33.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/utils": "npm:^11.11.0"
     deepmerge: "npm:^4.2.2"
     ethereum-cryptography: "npm:^2.1.2"
     immer: "npm:^9.0.6"
@@ -7849,7 +7849,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/1cdaae1818af96e1cccfb95452a54a936299f6aadc1f8f39a5651dbe409eced0379bcd959c2e944caad3fbba91a3b7c7e4a954a8a1eb9804302bfa0336ad7ac6
+  checksum: 10/1f423b6290753869f2b5177d28e65ca141ebf404607f919f518f3a0b8af7dbcdb1cf15d526749290e6bab7ddc3fbc004eeaf429fbeba1da9e61c8f2e1bc12e4c
   languageName: node
   linkType: hard
 
@@ -7955,7 +7955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^109.1.0, @metamask/assets-controllers@npm:^109.2.0, @metamask/assets-controllers@npm:^109.2.1":
+"@metamask/assets-controllers@npm:^109.2.0, @metamask/assets-controllers@npm:^109.2.1":
   version: 109.2.1
   resolution: "@metamask/assets-controllers@npm:109.2.1"
   dependencies:
@@ -9351,13 +9351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:@metamask-previews/network-controller@32.0.0-preview-22ab7e3":
-  version: 32.0.0-preview-22ab7e3
-  resolution: "@metamask-previews/network-controller@npm:32.0.0-preview-22ab7e3"
+"@metamask/network-controller@npm:33.0.0":
+  version: 33.0.0
+  resolution: "@metamask/network-controller@npm:33.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/connectivity-controller": "npm:^0.2.0"
-    "@metamask/controller-utils": "npm:^12.2.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/eth-block-tracker": "npm:^15.0.1"
     "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
     "@metamask/eth-json-rpc-middleware": "npm:^23.1.3"
@@ -9375,7 +9375,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/4cac70de3cc6ced11ed6b5fd8010078e73bc694e42c5330797daca826356e76fd67329d9182a04d53668bc9aa72fe410efc9108af0b120917019c464afd288c9
+  checksum: 10/656cc33da4afc17b76623ed286ceac72035810eae467f4389f97aaf37376adc4e6d1e31facf4d26aca469f8ee5ab6217b982f10ae8777616019ff6d9ed7c1a67
   languageName: node
   linkType: hard
 
@@ -9888,19 +9888,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/selected-network-controller@npm:^25.0.0":
-  version: 25.0.0
-  resolution: "@metamask/selected-network-controller@npm:25.0.0"
+"@metamask/selected-network-controller@npm:^26.1.4":
+  version: 26.1.4
+  resolution: "@metamask/selected-network-controller@npm:26.1.4"
   dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/json-rpc-engine": "npm:^10.1.1"
-    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^33.0.0"
+    "@metamask/permission-controller": "npm:^13.1.1"
     "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.8.1"
-  peerDependencies:
-    "@metamask/network-controller": ^25.0.0
-    "@metamask/permission-controller": ^12.0.0
-  checksum: 10/812873d81872d6cd960f7299f97e005ba998d35e444dcee6ca653bb4322dc7ec8add437f1c54a708fbca12fc8322b87e3068bd06d7188d611ad378068abbc98b
+    "@metamask/utils": "npm:^11.11.0"
+  checksum: 10/0cef6df328d36ac4634ebf2a037ec4a3acc0aa4b628e60579b15f44b3aa95edf34b67988a276438ad28ae53e18ee74216350de3657f85c65d2524500ec18f028
   languageName: node
   linkType: hard
 
@@ -35384,14 +35383,14 @@ __metadata:
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^1.0.4"
     "@metamask/account-tree-controller": "npm:^7.5.0"
-    "@metamask/accounts-controller": "npm:^39.0.0"
+    "@metamask/accounts-controller": "npm:^39.0.2"
     "@metamask/address-book-controller": "npm:^7.1.2"
     "@metamask/ai-controllers": "npm:^0.7.0"
     "@metamask/analytics-controller": "npm:^1.0.0"
     "@metamask/app-metadata-controller": "npm:^2.0.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^9.0.1"
-    "@metamask/assets-controllers": "npm:^109.1.0"
+    "@metamask/assets-controller": "npm:^9.0.2"
+    "@metamask/assets-controllers": "npm:^109.2.1"
     "@metamask/authenticated-user-storage": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^5.3.0"
     "@metamask/base-controller": "npm:^9.0.1"
@@ -35407,7 +35406,7 @@ __metadata:
     "@metamask/client-controller": "npm:^1.0.1"
     "@metamask/compliance-controller": "npm:2.1.0"
     "@metamask/connectivity-controller": "npm:^0.2.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/core-backend": "npm:^6.3.0"
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
@@ -35462,7 +35461,7 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^3.1.0"
     "@metamask/multichain-transactions-controller": "npm:^7.1.0"
     "@metamask/native-utils": "npm:^0.8.0"
-    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-controller": "npm:^33.0.0"
     "@metamask/network-enablement-controller": "npm:^5.3.0"
     "@metamask/notification-services-controller": "npm:24.1.1"
     "@metamask/object-multiplex": "npm:^1.1.0"
@@ -35489,7 +35488,7 @@ __metadata:
     "@metamask/scure-bip39": "npm:^2.1.0"
     "@metamask/sdk-communication-layer": "npm:0.33.1"
     "@metamask/seedless-onboarding-controller": "npm:^10.0.1"
-    "@metamask/selected-network-controller": "npm:^25.0.0"
+    "@metamask/selected-network-controller": "npm:^26.1.4"
     "@metamask/signature-controller": "npm:^39.2.0"
     "@metamask/skills": "npm:^0.1.0"
     "@metamask/slip44": "npm:^4.2.0"
@@ -35511,7 +35510,7 @@ __metadata:
     "@metamask/test-dapp-bitcoin": "npm:^0.2.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
-    "@metamask/transaction-controller": "npm:^68.1.0"
+    "@metamask/transaction-controller": "npm:^68.1.1"
     "@metamask/transaction-pay-controller": "npm:^23.13.0"
     "@metamask/tron-wallet-snap": "npm:^1.27.0"
     "@metamask/utils": "npm:^11.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9351,13 +9351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:32.0.0":
-  version: 32.0.0
-  resolution: "@metamask/network-controller@npm:32.0.0"
+"@metamask/network-controller@npm:@metamask-previews/network-controller@32.0.0-preview-22ab7e3":
+  version: 32.0.0-preview-22ab7e3
+  resolution: "@metamask-previews/network-controller@npm:32.0.0-preview-22ab7e3"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/connectivity-controller": "npm:^0.2.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/eth-block-tracker": "npm:^15.0.1"
     "@metamask/eth-json-rpc-infura": "npm:^10.3.0"
     "@metamask/eth-json-rpc-middleware": "npm:^23.1.3"
@@ -9365,17 +9365,17 @@ __metadata:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"
     "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/swappable-obj-proxy": "npm:^2.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
+    "@metamask/utils": "npm:^11.11.0"
     fast-deep-equal: "npm:^3.1.3"
     immer: "npm:^9.0.6"
     loglevel: "npm:^1.8.1"
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/263f6355aac3e2014f2d18c2c10b20b83e12823845cf9a12e74dea09d31d5f81be9bd396d9f3b5b7dbaa99ce5ed7f3b0ec4c537656f884f586c349965569ad07
+  checksum: 10/4cac70de3cc6ced11ed6b5fd8010078e73bc694e42c5330797daca826356e76fd67329d9182a04d53668bc9aa72fe410efc9108af0b120917019c464afd288c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bump `network-controller` to the latest version. This version includes a bunch of bug fixes and improvements that lets us delete a large amount of client-specific initialization code for the controller. 

Additionally bumps a bunch of controllers that depend on the `network-controller`, reducing overall dependency duplication.

Finally fixes some configuration issues with failover URLs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where MetaMask would not fail over to another RPC URL when Infura is down

## **Related issues**

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how default networks and RPC failover are initialized—core connectivity path—with behavior now depending on controller 33 and the new failoverUrls wiring rather than removed client-side feature-flag toggles.
> 
> **Overview**
> Upgrades **`@metamask/network-controller`** to **33.0.0** and aligns related packages (`selected-network-controller`, `accounts-controller`, `assets-controllers`, etc.) so RPC/network behavior lives in the controller instead of mobile-specific init.
> 
> **`network-controller-init`** no longer builds default network state, patches Infura failover URLs per chain, toggles RPC failover from `walletFrameworkRpcFailoverEnabled`, or supplies custom block-tracker / RPC retry options. It now passes **`persistedState.NetworkController`** directly, supplies a **`failoverUrls`** map (including Avalanche, Sei, Monad, HyperEVM, Arc), and calls **`controller.init()`** instead of **`initializeProvider()`**. **`RemoteFeatureFlagController`** getState/stateChange is delegated on the **NetworkController** messenger, not init.
> 
> Tests drop Engine/init failover flag coverage; the initial background-state fixture gains **block explorer URLs** for default networks. Changelog intent: fix failover when Infura is down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef60be9f8afffe13506505eeff8e2d3ae1efc50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->