### PR TITLE
fix: show correct decimal places when managing price alerts

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -59,7 +59,6 @@ import { trimTrailingZeros } from '../../../../Bridge/utils/trimTrailingZeros';
 const KEYPAD_EMPTY = '0';
 const MIN_KEYPAD_DECIMALS = 2;
 const MAX_KEYPAD_DECIMALS = 15;
-/** Fractional offset that yields 6 significant figures via toFixed. */
 const SIG_FIGS_FRACTIONAL_OFFSET = 5;
 
 /**
@@ -72,7 +71,6 @@ const getKeypadDecimalPlaces = (price: number): number => {
   if (!Number.isFinite(price) || price <= 0) {
     return MIN_KEYPAD_DECIMALS;
   }
-
   const exponent = Math.floor(Math.log10(price));
   const places =
     exponent >= 0
@@ -84,7 +82,7 @@ const getKeypadDecimalPlaces = (price: number): number => {
 /**
  * Converts a computed price into a plain decimal string suitable for the keypad.
  * Always preserves 6 significant figures and never produces scientific notation.
- * e.g. 0.3224 * 1.10 → "0.35464", 1.05e-14 → "0.0000000000000105".
+ * e.g. 0.3224 * 1.10 → "0.35464", 1.05e-14 → "0.000000000000011".
  */
 const toKeypadString = (price: number): string => {
   if (!Number.isFinite(price) || price <= 0) return KEYPAD_EMPTY;

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
@@ -202,6 +202,21 @@ describe('ManagePriceAlertsView', () => {
       expect(screen.getByText('Reaches $0.0₁₃105')).toBeOnTheScreen();
     });
 
+    it('preserves full precision for sub-cent thresholds', async () => {
+      mockFetchAlerts.mockResolvedValue(
+        makeFetchResponse([
+          makeAlert({ id: 'alert-a', threshold: 0.00181069 }),
+          makeAlert({ id: 'alert-b', threshold: 0.00182069 }),
+        ]),
+      );
+
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      expect(screen.getByText('Reaches $0.00181069')).toBeOnTheScreen();
+      expect(screen.getByText('Reaches $0.00182069')).toBeOnTheScreen();
+    });
+
     it('shows "Recurring" for recurring alerts and "Once" for one-shot alerts', async () => {
       const screen = renderView();
       await waitForLoaded(screen);

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
@@ -246,6 +246,7 @@ const ManagePriceAlertsView: React.FC = () => {
               threshold: formatPriceWithSubscriptNotation(
                 item.threshold,
                 currentCurrency,
+                { maximumFractionDigits: 15 },
               ),
             })}
           </Text>

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -148,8 +148,11 @@ export const formatPrice = (
  * @example formatPriceWithSubscriptNotation(1.2345, 'EUR') => "€1.23"
  * @example formatPriceWithSubscriptNotation(0.00003415, 'USD', { maxDigitsAfterSubscript: 2 }) => "$0.0₄34"
  */
-export type FormatPriceWithSubscriptNotationOptions =
-  FormatSubscriptNotationOptions;
+export interface FormatPriceWithSubscriptNotationOptions
+  extends FormatSubscriptNotationOptions {
+  /** Override the default max decimal places (2 for ≥1, 4 for <1). */
+  maximumFractionDigits?: number;
+}
 
 export const formatPriceWithSubscriptNotation = (
   price: string | number,
@@ -176,10 +179,12 @@ export const formatPriceWithSubscriptNotation = (
   const subscript = formatSubscriptNotation(num, options);
   if (subscript) return addSymbol(subscript);
 
+  const maximumFractionDigits =
+    options?.maximumFractionDigits ?? (num >= 1 ? 2 : 4);
   const formattedNumber = new Intl.NumberFormat('en-US', {
     style: 'decimal',
     minimumFractionDigits: 2,
-    maximumFractionDigits: num >= 1 ? 2 : 4,
+    maximumFractionDigits,
   }).format(num);
   return addSymbol(formattedNumber);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

`formatPriceWithSubscriptNotation` was capping decimal places at 4 for values under 1, which meant two similar thresholds like `$0.00181069` and `$0.00182069` would both display as `$0.0018`. Added a `maximumFractionDigits` override so the manage alerts list can pass `15` and preserve the stored precision.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  show correct decimal places when managing price alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3404

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c38eeb27-3ec2-421d-b442-f1c0bea475df" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/2dd73161-5c75-408b-9096-f992bfc9bc6c" />


### **After**
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/4a08f622-62b2-4882-a414-f5172209a54b" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/fc75de06-7166-45f8-9568-1464b38d73bc" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting with an opt-in override on a shared helper; no API or persistence changes.
> 
> **Overview**
> **Manage price alerts** no longer collapses similar sub-dollar thresholds to the same rounded label (e.g. both showing `$0.0018`). The list now passes **`maximumFractionDigits: 15`** into `formatPriceWithSubscriptNotation` so stored values like `$0.00181069` and `$0.00182069` stay distinguishable.
> 
> `formatPriceWithSubscriptNotation` gains an optional **`maximumFractionDigits`** override on the non-subscript path; default behavior elsewhere stays **2 decimals for ≥1** and **4 for &lt;1**. A regression test covers sub-cent threshold copy, and a small keypad doc example in create-alert was updated for extreme tiny prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36126366151c055d56e6dd018ae70d4216a462bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->