### PR TITLE
fix(ci): quote 8am cron and fix flaky test report schedule routing

### DIFF
--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -3,7 +3,7 @@ name: Flaky test report
 on:
   schedule:
     # Once every day from Monday-Friday at 08:00 UTC
-    - cron: 0 8 * * 1-5
+    - cron: '0 8 * * 1-5'
     # 10:00 UTC (Europe morning), Monday–Friday — Playwright test health report
     - cron: '0 10 * * 1-5'
     # 15:00 UTC (US morning), Monday–Friday — Playwright test health report
@@ -29,8 +29,8 @@ permissions:
 jobs:
   flaky-test-report:
     if: >-
-      (github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-5') ||
-      (github.event_name == 'workflow_dispatch' && inputs.job == 'detox')
+      (github.event_name == 'workflow_dispatch' && inputs.job == 'detox') ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-5')
     runs-on: ubuntu-latest
     steps:
       - name: Generate flaky test report
@@ -43,8 +43,8 @@ jobs:
 
   playwright-test-health-report:
     if: >-
-      (github.event_name == 'schedule' && (github.event.schedule == '0 10 * * 1-5' || github.event.schedule == '0 15 * * 1-5')) ||
-      (github.event_name == 'workflow_dispatch' && inputs.job == 'appium')
+      (github.event_name == 'workflow_dispatch' && inputs.job == 'appium') ||
+      (github.event_name == 'schedule' && (github.event.schedule == '0 10 * * 1-5' || github.event.schedule == '0 15 * * 1-5'))
     runs-on: ubuntu-latest
     steps:
       - name: Generate Playwright test health report


### PR DESCRIPTION
## Summary

- Quote the 08:00 UTC cron expression in `flaky-test-report.yml` so `github.event.schedule` matches the job `if` condition reliably
- Keep Detox flaky report on the explicit `0 8 * * 1-5` schedule; Playwright health report remains at 10:00 and 15:00 UTC
- Reorder job `if` conditions to check `workflow_dispatch` before `schedule`

## Context

After #31815 consolidated the Playwright health report into this workflow, the 08:00 UTC Detox run did not fire on schedule. The 08:00 cron was unquoted while the job condition compared against a quoted string, which can prevent the Detox job from running when the scheduler fires.

## Test plan

- [ ] Merge to `main` and confirm the next weekday 08:00 UTC scheduled run triggers the `flaky-test-report` job
- [ ] Confirm 10:00 and 15:00 UTC runs still trigger only `playwright-test-health-report`
- [ ] Manually verify `workflow_dispatch` with `job=detox` and `job=appium` both route to the correct job


Made with [Cursor](https://cursor.com)