### PR TITLE
feat: cp-8.0.0 add error prefixes to sentinel, relay, and gas station 7702

### DIFF
--- a/app/util/transactions/error-prefix.ts
+++ b/app/util/transactions/error-prefix.ts
@@ -1,0 +1,13 @@
+export function prefixError(error: unknown, prefix: string): Error {
+  if (error instanceof Error) {
+    const prefixedError = error;
+
+    if (!prefixedError.message.startsWith(prefix)) {
+      prefixedError.message = `${prefix}${prefixedError.message}`;
+    }
+
+    return prefixedError;
+  }
+
+  return new Error(`${prefix}${String(error)}`);
+}

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -680,6 +680,33 @@ describe('Delegation 7702 Publish Hook', () => {
     ).rejects.toThrow('Gas Station 7702: Transaction relay error - TEST_STATUS');
   });
 
+  it('prefixes relay submit errors', async () => {
+    submitRelayTransactionMock.mockRejectedValueOnce(
+      new Error('Sentinel: Relay: submission failed'),
+    );
+    isAtomicBatchSupportedMock.mockResolvedValueOnce([
+      {
+        chainId: TRANSACTION_META_MOCK.chainId,
+        delegationAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        isSupported: true,
+        upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+      },
+    ]);
+
+    await expect(
+      hookClass.getHook()(
+        {
+          ...TRANSACTION_META_MOCK,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        },
+        SIGNED_TX_MOCK,
+      ),
+    ).rejects.toThrow(
+      'Gas Station 7702: Sentinel: Relay: submission failed',
+    );
+  });
+
   it('submits request to relay for gasless 7702 swap without gas fee tokens', async () => {
     isAtomicBatchSupportedMock.mockResolvedValueOnce([
       {

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -293,7 +293,7 @@ describe('Delegation 7702 Publish Hook', () => {
           },
           SIGNED_TX_MOCK,
         ),
-      ).rejects.toThrow('Selected gas fee token not found');
+      ).rejects.toThrow('Gas Station 7702: Selected gas fee token not found');
     });
 
     it('throws error when upgrade contract address not found for non-upgraded accounts', async () => {
@@ -314,7 +314,7 @@ describe('Delegation 7702 Publish Hook', () => {
           },
           SIGNED_TX_MOCK,
         ),
-      ).rejects.toThrow('Upgrade contract address not found');
+      ).rejects.toThrow('Gas Station 7702: Upgrade contract address not found');
     });
 
     it('throws error when gas fee token is undefined in buildExecutions for includeTransfer', async () => {
@@ -343,7 +343,7 @@ describe('Delegation 7702 Publish Hook', () => {
           },
           SIGNED_TX_MOCK,
         ),
-      ).rejects.toThrow('Selected gas fee token not found');
+      ).rejects.toThrow('Gas Station 7702: Selected gas fee token not found');
     });
   });
 
@@ -677,7 +677,7 @@ describe('Delegation 7702 Publish Hook', () => {
         },
         SIGNED_TX_MOCK,
       ),
-    ).rejects.toThrow('Transaction relay error - TEST_STATUS');
+    ).rejects.toThrow('Gas Station 7702: Transaction relay error - TEST_STATUS');
   });
 
   it('submits request to relay for gasless 7702 swap without gas fee tokens', async () => {

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -677,7 +677,9 @@ describe('Delegation 7702 Publish Hook', () => {
         },
         SIGNED_TX_MOCK,
       ),
-    ).rejects.toThrow('Gas Station 7702: Transaction relay error - TEST_STATUS');
+    ).rejects.toThrow(
+      'Gas Station 7702: Transaction relay error - TEST_STATUS',
+    );
   });
 
   it('prefixes relay submit errors', async () => {
@@ -702,9 +704,7 @@ describe('Delegation 7702 Publish Hook', () => {
         },
         SIGNED_TX_MOCK,
       ),
-    ).rejects.toThrow(
-      'Gas Station 7702: Sentinel: Relay: submission failed',
-    );
+    ).rejects.toThrow('Gas Station 7702: Sentinel: Relay: submission failed');
   });
 
   it('submits request to relay for gasless 7702 swap without gas fee tokens', async () => {

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -46,11 +46,13 @@ import {
   getClientVersionForTransactionMetadata,
   sanitizeOrigin,
 } from '../../../constants/smartTransactions';
+import { prefixError } from '../error-prefix';
 
 // Test chain ID (Sepolia) used in E2E tests to match the delegation package's test contract configuration
 const SEPOLIA_CHAIN_ID = '0xaa36a7';
 const EMPTY_HEX = '0x';
 const POLLING_INTERVAL_MS = 1000; // 1 Second
+const ERROR_PREFIX = 'Gas Station 7702: ';
 
 const EMPTY_RESULT = {
   transactionHash: undefined,
@@ -101,10 +103,7 @@ export class Delegation7702PublishHook {
       return await this.#hook(transactionMeta, _signedTx);
     } catch (error) {
       log('Error', error);
-      if (error instanceof Error) {
-        error.message = `Gas Station 7702: ${error.message}`;
-      }
-      throw error;
+      throw prefixError(error, ERROR_PREFIX);
     }
   }
 

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -101,6 +101,9 @@ export class Delegation7702PublishHook {
       return await this.#hook(transactionMeta, _signedTx);
     } catch (error) {
       log('Error', error);
+      if (error instanceof Error) {
+        error.message = `Gas Station 7702: ${error.message}`;
+      }
       throw error;
     }
   }

--- a/app/util/transactions/sentinel-api.test.ts
+++ b/app/util/transactions/sentinel-api.test.ts
@@ -282,7 +282,7 @@ describe('sentinel-api', () => {
 
       // First call throws error
       await expect(getSentinelNetworkFlags('0x1' as Hex)).rejects.toThrow(
-        'Failed to fetch sentinel network flags: 503 - Service Unavailable',
+        'Sentinel: Failed to fetch network flags: 503 - Service Unavailable',
       );
 
       // Second call retries and succeeds (error was not cached)
@@ -309,19 +309,19 @@ describe('sentinel-api', () => {
       expect(results[0]).toEqual({
         status: 'rejected',
         reason: new Error(
-          'Failed to fetch sentinel network flags: 500 - Internal Server Error',
+          'Sentinel: Failed to fetch network flags: 500 - Internal Server Error',
         ),
       });
       expect(results[1]).toEqual({
         status: 'rejected',
         reason: new Error(
-          'Failed to fetch sentinel network flags: 500 - Internal Server Error',
+          'Sentinel: Failed to fetch network flags: 500 - Internal Server Error',
         ),
       });
       expect(results[2]).toEqual({
         status: 'rejected',
         reason: new Error(
-          'Failed to fetch sentinel network flags: 500 - Internal Server Error',
+          'Sentinel: Failed to fetch network flags: 500 - Internal Server Error',
         ),
       });
 

--- a/app/util/transactions/sentinel-api.test.ts
+++ b/app/util/transactions/sentinel-api.test.ts
@@ -308,21 +308,15 @@ describe('sentinel-api', () => {
 
       expect(results[0]).toEqual({
         status: 'rejected',
-        reason: new Error(
-          'Sentinel: Failed to fetch network flags: 500',
-        ),
+        reason: new Error('Sentinel: Failed to fetch network flags: 500'),
       });
       expect(results[1]).toEqual({
         status: 'rejected',
-        reason: new Error(
-          'Sentinel: Failed to fetch network flags: 500',
-        ),
+        reason: new Error('Sentinel: Failed to fetch network flags: 500'),
       });
       expect(results[2]).toEqual({
         status: 'rejected',
-        reason: new Error(
-          'Sentinel: Failed to fetch network flags: 500',
-        ),
+        reason: new Error('Sentinel: Failed to fetch network flags: 500'),
       });
 
       // Only one fetch was made (concurrent deduplication worked)

--- a/app/util/transactions/sentinel-api.test.ts
+++ b/app/util/transactions/sentinel-api.test.ts
@@ -155,10 +155,10 @@ describe('sentinel-api', () => {
       expect(result).toBeUndefined();
     });
 
-    it('throws if getNetworkData throws', async () => {
+    it('prefixes errors if getNetworkData throws', async () => {
       fetchMock.mockRejectedValueOnce(new Error('API connection error'));
       await expect(getSentinelNetworkFlags('0x1' as Hex)).rejects.toThrow(
-        'API connection error',
+        'Sentinel: API connection error',
       );
     });
   });
@@ -282,7 +282,7 @@ describe('sentinel-api', () => {
 
       // First call throws error
       await expect(getSentinelNetworkFlags('0x1' as Hex)).rejects.toThrow(
-        'Sentinel: Failed to fetch network flags: 503 - Service Unavailable',
+        'Sentinel: Failed to fetch network flags: 503',
       );
 
       // Second call retries and succeeds (error was not cached)
@@ -309,19 +309,19 @@ describe('sentinel-api', () => {
       expect(results[0]).toEqual({
         status: 'rejected',
         reason: new Error(
-          'Sentinel: Failed to fetch network flags: 500 - Internal Server Error',
+          'Sentinel: Failed to fetch network flags: 500',
         ),
       });
       expect(results[1]).toEqual({
         status: 'rejected',
         reason: new Error(
-          'Sentinel: Failed to fetch network flags: 500 - Internal Server Error',
+          'Sentinel: Failed to fetch network flags: 500',
         ),
       });
       expect(results[2]).toEqual({
         status: 'rejected',
         reason: new Error(
-          'Sentinel: Failed to fetch network flags: 500 - Internal Server Error',
+          'Sentinel: Failed to fetch network flags: 500',
         ),
       });
 

--- a/app/util/transactions/sentinel-api.ts
+++ b/app/util/transactions/sentinel-api.ts
@@ -141,7 +141,7 @@ async function fetchNetworkFlags(): Promise<SentinelNetworkMap> {
     if (!response.ok) {
       const errorBody = await response.text();
       throw new Error(
-        `Failed to fetch sentinel network flags: ${response.status} - ${errorBody}`,
+        `Sentinel: Failed to fetch network flags: ${response.status} - ${errorBody}`,
       );
     }
 

--- a/app/util/transactions/sentinel-api.ts
+++ b/app/util/transactions/sentinel-api.ts
@@ -1,9 +1,11 @@
 import { convertHexToDecimal } from '@metamask/controller-utils';
 import { Hex } from '@metamask/utils';
+import { prefixError } from './error-prefix';
 
 // TODO: Make it configurable via environment variable
 const BASE_URL = 'https://tx-sentinel-{0}.api.cx.metamask.io/';
 const ENDPOINT_NETWORKS = 'networks';
+const ERROR_PREFIX = 'Sentinel: ';
 
 /**
  * Optional bearer token getter, set at Engine init to authenticate
@@ -139,10 +141,7 @@ async function fetchNetworkFlags(): Promise<SentinelNetworkMap> {
     const response = await fetch(url, { headers });
 
     if (!response.ok) {
-      const errorBody = await response.text();
-      throw new Error(
-        `Sentinel: Failed to fetch network flags: ${response.status} - ${errorBody}`,
-      );
+      throw new Error(`Failed to fetch network flags: ${response.status}`);
     }
 
     const data: SentinelNetworkMap = await response.json();
@@ -152,6 +151,8 @@ async function fetchNetworkFlags(): Promise<SentinelNetworkMap> {
     cache.timestamp = Date.now();
 
     return data;
+  } catch (error) {
+    throw prefixError(error, ERROR_PREFIX);
   } finally {
     // Clear pending promise after completion (success or failure)
     // This allows cache expiry to trigger a new fetch after TTL

--- a/app/util/transactions/transaction-relay.test.ts
+++ b/app/util/transactions/transaction-relay.test.ts
@@ -100,7 +100,7 @@ describe('Transaction Relay (mobile)', () => {
     it('throws when chain is not supported by relay', async () => {
       mockRelayUnsupported();
       await expect(submitRelayTransaction(SUBMIT_REQUEST_MOCK)).rejects.toThrow(
-        `Chain not supported by transaction relay - ${SUBMIT_REQUEST_MOCK.chainId}`,
+        `Sentinel: Relay: Chain not supported - ${SUBMIT_REQUEST_MOCK.chainId}`,
       );
     });
 
@@ -128,7 +128,7 @@ describe('Transaction Relay (mobile)', () => {
     it('throws when chain is not supported by relay', async () => {
       mockRelayUnsupported();
       await expect(waitForRelayResult(WAIT_REQUEST_MOCK)).rejects.toThrow(
-        `Chain not supported by transaction relay - ${WAIT_REQUEST_MOCK.chainId}`,
+        `Sentinel: Relay: Chain not supported - ${WAIT_REQUEST_MOCK.chainId}`,
       );
     });
 
@@ -178,7 +178,7 @@ describe('Transaction Relay (mobile)', () => {
 
       // eslint-disable-next-line jest/valid-expect
       expect(resultPromise).rejects.toThrow(
-        'Failed to fetch relay transaction status: 502 - test error',
+        'Sentinel: Relay: Failed to fetch transaction status: 502 - test error',
       );
       await jest.advanceTimersByTimeAsync(INTERVAL_MS);
     });

--- a/app/util/transactions/transaction-relay.test.ts
+++ b/app/util/transactions/transaction-relay.test.ts
@@ -104,6 +104,24 @@ describe('Transaction Relay (mobile)', () => {
       );
     });
 
+    it('prefixes JSON-RPC relay submission errors', async () => {
+      const error = new Error('submission failed');
+      jsonRpcRequestMock.mockRejectedValueOnce(error);
+
+      await expect(submitRelayTransaction(SUBMIT_REQUEST_MOCK)).rejects.toThrow(
+        'Sentinel: Relay: submission failed',
+      );
+      expect(error.message).toBe('Sentinel: Relay: submission failed');
+    });
+
+    it('converts non-Error JSON-RPC relay submission rejections', async () => {
+      jsonRpcRequestMock.mockRejectedValueOnce('submission failed');
+
+      await expect(submitRelayTransaction(SUBMIT_REQUEST_MOCK)).rejects.toThrow(
+        'Sentinel: Relay: submission failed',
+      );
+    });
+
     it('submit JSON-RPC relay request when chain is supported', async () => {
       await submitRelayTransaction(SUBMIT_REQUEST_MOCK);
 
@@ -174,13 +192,33 @@ describe('Transaction Relay (mobile)', () => {
 
     it('rejects when polling responds with non-ok status', async () => {
       mockFetchError(ERROR_BODY_MOCK, 502);
-      const resultPromise = waitForRelayResult(WAIT_REQUEST_MOCK);
 
-      // eslint-disable-next-line jest/valid-expect
-      expect(resultPromise).rejects.toThrow(
-        'Sentinel: Relay: Failed to fetch transaction status: 502 - test error',
+      const errorPromise = waitForRelayResult(WAIT_REQUEST_MOCK).catch(
+        (error) => error,
       );
+
       await jest.advanceTimersByTimeAsync(INTERVAL_MS);
+
+      await expect(errorPromise).resolves.toMatchObject({
+        message:
+          'Sentinel: Relay: Failed to fetch transaction status: 502 - test error',
+      });
+    });
+
+    it('prefixes polling transport errors', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error('poll failed'),
+      );
+
+      const errorPromise = waitForRelayResult(WAIT_REQUEST_MOCK).catch(
+        (error) => error,
+      );
+
+      await jest.advanceTimersByTimeAsync(INTERVAL_MS);
+
+      await expect(errorPromise).resolves.toMatchObject({
+        message: 'Sentinel: Relay: poll failed',
+      });
     });
 
     it('polls repeatedly on interval until a non-pending status is returned', async () => {

--- a/app/util/transactions/transaction-relay.ts
+++ b/app/util/transactions/transaction-relay.ts
@@ -85,21 +85,23 @@ export async function waitForRelayResult(
 
     const url = `${baseUrl}smart-transactions/${uuid}`;
 
-    const waitResult = await new Promise<RelayWaitResponse>((resolve, reject) => {
-      const intervalId = setInterval(async () => {
-        try {
-          const headers = await getSentinelApiHeadersAsync();
-          const relayResult = await pollResult(url, headers);
-          if (relayResult.status !== RelayStatus.Pending) {
+    const waitResult = await new Promise<RelayWaitResponse>(
+      (resolve, reject) => {
+        const intervalId = setInterval(async () => {
+          try {
+            const headers = await getSentinelApiHeadersAsync();
+            const relayResult = await pollResult(url, headers);
+            if (relayResult.status !== RelayStatus.Pending) {
+              clearInterval(intervalId);
+              resolve(relayResult);
+            }
+          } catch (error) {
             clearInterval(intervalId);
-            resolve(relayResult);
+            reject(error);
           }
-        } catch (error) {
-          clearInterval(intervalId);
-          reject(error);
-        }
-      }, interval);
-    });
+        }, interval);
+      },
+    );
 
     return waitResult;
   } catch (error) {

--- a/app/util/transactions/transaction-relay.ts
+++ b/app/util/transactions/transaction-relay.ts
@@ -7,8 +7,10 @@ import {
   getSentinelApiHeadersAsync,
   getSentinelNetworkFlags,
 } from './sentinel-api';
+import { prefixError } from './error-prefix';
 
 const log = createProjectLogger('transaction-relay');
+const ERROR_PREFIX = 'Sentinel: Relay: ';
 
 export interface RelaySubmitRequest {
   authorizationList?: AuthorizationList;
@@ -44,57 +46,65 @@ export async function submitRelayTransaction(
   request: RelaySubmitRequest,
 ): Promise<RelaySubmitResponse> {
   const { chainId } = request;
-
   const url = await getRelayUrl(chainId);
 
-  if (!url) {
-    throw new Error(`Sentinel: Relay: Chain not supported - ${chainId}`);
+  try {
+    if (!url) {
+      throw new Error(`Chain not supported - ${chainId}`);
+    }
+
+    log('Request', url, request);
+
+    const headers = await getSentinelApiHeadersAsync();
+
+    const response = (await jsonRpcRequest(
+      url,
+      RELAY_RPC_METHOD,
+      [request as unknown as Json],
+      { headers },
+    )) as RelaySubmitResponse;
+
+    log('Response', response);
+
+    return response;
+  } catch (error) {
+    throw prefixError(error, ERROR_PREFIX);
   }
-
-  log('Request', url, request);
-
-  const headers = await getSentinelApiHeadersAsync();
-
-  const response = (await jsonRpcRequest(
-    url,
-    RELAY_RPC_METHOD,
-    [request as unknown as Json],
-    { headers },
-  )) as RelaySubmitResponse;
-
-  log('Response', response);
-
-  return response;
 }
 
 export async function waitForRelayResult(
   request: RelayWaitRequest,
 ): Promise<RelayWaitResponse> {
   const { chainId, interval, uuid } = request;
-
   const baseUrl = await getRelayUrl(chainId);
 
-  if (!baseUrl) {
-    throw new Error(`Sentinel: Relay: Chain not supported - ${chainId}`);
-  }
+  try {
+    if (!baseUrl) {
+      throw new Error(`Chain not supported - ${chainId}`);
+    }
 
-  const url = `${baseUrl}smart-transactions/${uuid}`;
+    const url = `${baseUrl}smart-transactions/${uuid}`;
 
-  return new Promise<RelayWaitResponse>((resolve, reject) => {
-    const intervalId = setInterval(async () => {
-      try {
-        const headers = await getSentinelApiHeadersAsync();
-        const result = await pollResult(url, headers);
-        if (result.status !== RelayStatus.Pending) {
+    const waitResult = await new Promise<RelayWaitResponse>((resolve, reject) => {
+      const intervalId = setInterval(async () => {
+        try {
+          const headers = await getSentinelApiHeadersAsync();
+          const relayResult = await pollResult(url, headers);
+          if (relayResult.status !== RelayStatus.Pending) {
+            clearInterval(intervalId);
+            resolve(relayResult);
+          }
+        } catch (error) {
           clearInterval(intervalId);
-          resolve(result);
+          reject(error);
         }
-      } catch (error) {
-        clearInterval(intervalId);
-        reject(error);
-      }
-    }, interval);
-  });
+      }, interval);
+    });
+
+    return waitResult;
+  } catch (error) {
+    throw prefixError(error, ERROR_PREFIX);
+  }
 }
 
 export async function isRelaySupported(chainId: Hex): Promise<boolean> {
@@ -115,7 +125,7 @@ async function pollResult(
     const errorBody = await response.text();
 
     throw new Error(
-      `Sentinel: Relay: Failed to fetch transaction status: ${response.status} - ${errorBody}`,
+      `Failed to fetch transaction status: ${response.status} - ${errorBody}`,
     );
   }
 

--- a/app/util/transactions/transaction-relay.ts
+++ b/app/util/transactions/transaction-relay.ts
@@ -48,7 +48,7 @@ export async function submitRelayTransaction(
   const url = await getRelayUrl(chainId);
 
   if (!url) {
-    throw new Error(`Chain not supported by transaction relay - ${chainId}`);
+    throw new Error(`Sentinel: Relay: Chain not supported - ${chainId}`);
   }
 
   log('Request', url, request);
@@ -75,7 +75,7 @@ export async function waitForRelayResult(
   const baseUrl = await getRelayUrl(chainId);
 
   if (!baseUrl) {
-    throw new Error(`Chain not supported by transaction relay - ${chainId}`);
+    throw new Error(`Sentinel: Relay: Chain not supported - ${chainId}`);
   }
 
   const url = `${baseUrl}smart-transactions/${uuid}`;
@@ -115,7 +115,7 @@ async function pollResult(
     const errorBody = await response.text();
 
     throw new Error(
-      `Failed to fetch relay transaction status: ${response.status} - ${errorBody}`,
+      `Sentinel: Relay: Failed to fetch transaction status: ${response.status} - ${errorBody}`,
     );
   }
 


### PR DESCRIPTION
## **Description**

Adds consistent source prefixes to errors thrown by the Sentinel network flags utility, transaction relay utility, and 7702 delegation publish hook. Relay submission and polling failures are now prefixed at their exported boundaries, so downstream errors retain their source context when they bubble through the 7702 publish hook.

Prefix scheme:

| Layer | Prefix |
|---|---|
| Sentinel network flags fetch | `Sentinel:` |
| Relay submit / chain support / status polling | `Sentinel: Relay:` |
| 7702 delegation publish hook | `Gas Station 7702:` |

Example stacked error:

```
Gas Station 7702: Sentinel: Relay: Chain not supported - 0x1
```

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only error message formatting and wrapping on failure paths; transaction success behavior is unchanged aside from slightly less detail in Sentinel HTTP error text.
> 
> **Overview**
> Introduces shared **`prefixError`** and applies source-specific prefixes wherever Sentinel network flags, transaction relay, and the 7702 delegation publish hook fail.
> 
> **Sentinel** (`fetchNetworkFlags`) now throws errors prefixed with `Sentinel:`; HTTP failures use a shorter message (`Failed to fetch network flags: {status}`) instead of including the response body. **Relay** (`submitRelayTransaction`, `waitForRelayResult`) wraps failures with `Sentinel: Relay:` at the public API boundary, including unsupported chains and polling/JSON-RPC errors. **Gas Station 7702** prefixes any error from the publish hook wrapper with `Gas Station 7702:`, so nested failures can read like `Gas Station 7702: Sentinel: Relay: …`.
> 
> Unit tests are updated and extended to assert the new message shapes and stacked prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e175f9c361472c531766c2a2bc0061094a17d70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->