### PR TITLE
feat(activity-list): add ActivityListAccountImportTimeRow component a…

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.styles.ts
+++ b/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.styles.ts
@@ -12,6 +12,11 @@ export const createStyles = (colors: Theme['colors']) =>
       alignItems: 'center',
       paddingTop: 10,
     },
+    importTextContainer: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: 4,
+    },
     importText: {
       color: colors.text.alternative,
       fontSize: 14,

--- a/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.styles.ts
+++ b/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.styles.ts
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '@metamask/design-tokens';
+import { fontStyles } from '../../../styles/common';
+
+export const createStyles = (colors: Theme['colors']) =>
+  StyleSheet.create({
+    row: {
+      backgroundColor: colors.background.default,
+      flex: 1,
+    },
+    rowBody: {
+      alignItems: 'center',
+      paddingTop: 10,
+    },
+    importText: {
+      color: colors.text.alternative,
+      fontSize: 14,
+      ...fontStyles.bold,
+      alignContent: 'center',
+    },
+  });
+
+export type ActivityListAccountImportTimeRowStyles = ReturnType<
+  typeof createStyles
+>;

--- a/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.tsx
@@ -7,8 +7,6 @@ import {
   IconSize,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
-import Routes from '../../../constants/navigation/Routes';
-import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import ListItem from '../../Base/ListItem';
 import { toDateFormat } from '../../../util/date';
 import { useTheme } from '../../../util/theme';
@@ -16,26 +14,20 @@ import { createStyles } from './ActivityListAccountImportTimeRow.styles';
 
 interface ActivityListAccountImportTimeRowProps {
   importTime: number;
-  navigation: AppNavigationProp;
+  onPress: () => void;
 }
 
 export const ActivityListAccountImportTimeRow = ({
   importTime,
-  navigation,
+  onPress,
 }: ActivityListAccountImportTimeRowProps) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
-  const handlePress = () => {
-    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.IMPORT_WALLET_TIP,
-    });
-  };
-
   return (
     <View style={styles.row}>
       <TouchableOpacity
-        onPress={handlePress}
+        onPress={onPress}
         style={styles.rowBody}
         testID="activity-list-account-import-time-row"
       >

--- a/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import FAIcon from 'react-native-vector-icons/FontAwesome';
+import { strings } from '../../../../locales/i18n';
+import Routes from '../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+import ListItem from '../../Base/ListItem';
+import { toDateFormat } from '../../../util/date';
+import { useTheme } from '../../../util/theme';
+import { createStyles } from './ActivityListAccountImportTimeRow.styles';
+
+interface ActivityListAccountImportTimeRowProps {
+  importTime: number;
+  navigation: AppNavigationProp;
+}
+
+export const ActivityListAccountImportTimeRow = ({
+  importTime,
+  navigation,
+}: ActivityListAccountImportTimeRowProps) => {
+  const { colors } = useTheme();
+  const styles = createStyles(colors);
+
+  const handlePress = () => {
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.IMPORT_WALLET_TIP,
+    });
+  };
+
+  return (
+    <View style={styles.row}>
+      <TouchableOpacity
+        onPress={handlePress}
+        style={styles.rowBody}
+        testID="activity-list-account-import-time-row"
+      >
+        <Text style={styles.importText}>
+          {`${strings('transactions.import_wallet_row')} `}
+          <FAIcon name="info-circle" />
+        </Text>
+        <ListItem.Date>{toDateFormat(importTime)}</ListItem.Date>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default ActivityListAccountImportTimeRow;

--- a/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListAccountImportTimeRow.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-import FAIcon from 'react-native-vector-icons/FontAwesome';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
@@ -34,10 +39,16 @@ export const ActivityListAccountImportTimeRow = ({
         style={styles.rowBody}
         testID="activity-list-account-import-time-row"
       >
-        <Text style={styles.importText}>
-          {`${strings('transactions.import_wallet_row')} `}
-          <FAIcon name="info-circle" />
-        </Text>
+        <View style={styles.importTextContainer}>
+          <Text style={styles.importText}>
+            {strings('transactions.import_wallet_row')}
+          </Text>
+          <Icon
+            name={IconName.Info}
+            size={IconSize.Sm}
+            color={IconColor.IconAlternative}
+          />
+        </View>
         <ListItem.Date>{toDateFormat(importTime)}</ListItem.Date>
       </TouchableOpacity>
     </View>

--- a/app/components/UI/ActivityListItemRow/ActivityListDateHeader.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListDateHeader.test.tsx
@@ -24,11 +24,11 @@ describe('ActivityListDateHeader', () => {
 
   it('renders provided label without formatting timestamp', () => {
     const { getByTestId } = render(
-      <ActivityListDateHeader label="transactions.pending" timestamp={0} />,
+      <ActivityListDateHeader label="transaction.pending" timestamp={0} />,
     );
 
     expect(getByTestId('activity-list-date-header')).toHaveTextContent(
-      'transactions.pending',
+      'transaction.pending',
     );
   });
 

--- a/app/components/UI/ActivityListItemRow/ActivityListDateHeader.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListDateHeader.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ActivityListDateHeader from './ActivityListDateHeader';
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: {
+        alternative: 'text-alternative',
+        default: 'text-default',
+      },
+    },
+  }),
+}));
+
+describe('ActivityListDateHeader', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders provided label without formatting timestamp', () => {
+    const { getByTestId } = render(
+      <ActivityListDateHeader label="transactions.pending" timestamp={0} />,
+    );
+
+    expect(getByTestId('activity-list-date-header')).toHaveTextContent(
+      'transactions.pending',
+    );
+  });
+
+  it('renders formatted date label from timestamp', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 5, 19, 12));
+
+    const { getByTestId } = render(
+      <ActivityListDateHeader timestamp={new Date(2026, 5, 19, 1).getTime()} />,
+    );
+
+    expect(getByTestId('activity-list-date-header')).toHaveTextContent(
+      'perps.today',
+    );
+  });
+});

--- a/app/components/UI/ActivityListItemRow/ActivityListDateHeader.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListDateHeader.tsx
@@ -1,35 +1,9 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { Box } from '@metamask/design-system-react-native';
-import { strings } from '../../../../locales/i18n';
 import ListItem from '../../Base/ListItem';
 import { useTheme } from '../../../util/theme';
-
-const isSameLocalDay = (date: Date, otherDate: Date) =>
-  date.getFullYear() === otherDate.getFullYear() &&
-  date.getMonth() === otherDate.getMonth() &&
-  date.getDate() === otherDate.getDate();
-
-export const formatActivityListDateHeader = (timestamp: number) => {
-  const date = new Date(timestamp);
-  const today = new Date();
-  const yesterday = new Date(today);
-  yesterday.setDate(today.getDate() - 1);
-
-  if (isSameLocalDay(date, today)) {
-    return strings('perps.today');
-  }
-
-  if (isSameLocalDay(date, yesterday)) {
-    return strings('perps.yesterday');
-  }
-
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-};
+import { formatActivityListDateHeader } from '../../../util/activity-adapters';
 
 export const ActivityListDateHeader = ({
   timestamp,

--- a/app/components/UI/ActivityListItemRow/ActivityListDateHeader.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListDateHeader.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Box } from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
+import ListItem from '../../Base/ListItem';
+import { useTheme } from '../../../util/theme';
+
+const isSameLocalDay = (date: Date, otherDate: Date) =>
+  date.getFullYear() === otherDate.getFullYear() &&
+  date.getMonth() === otherDate.getMonth() &&
+  date.getDate() === otherDate.getDate();
+
+export const formatActivityListDateHeader = (timestamp: number) => {
+  const date = new Date(timestamp);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  if (isSameLocalDay(date, today)) {
+    return strings('perps.today');
+  }
+
+  if (isSameLocalDay(date, yesterday)) {
+    return strings('perps.yesterday');
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+};
+
+export const ActivityListDateHeader = ({
+  timestamp,
+  label,
+}: {
+  timestamp?: number;
+  label?: string;
+}) => {
+  const { colors } = useTheme();
+  const styles = StyleSheet.create({
+    dateHeader: {
+      color: colors.text.alternative,
+      fontSize: 14,
+      marginBottom: 0,
+      paddingHorizontal: 0,
+      paddingTop: 16,
+      paddingBottom: 4,
+    },
+  });
+
+  const text = label ?? formatActivityListDateHeader(timestamp ?? 0);
+
+  return (
+    <Box twClassName="px-4">
+      <ListItem.Date
+        style={styles.dateHeader}
+        testID="activity-list-date-header"
+      >
+        {text}
+      </ListItem.Date>
+    </Box>
+  );
+};
+
+export default ActivityListDateHeader;

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.styles.ts
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.styles.ts
@@ -104,7 +104,10 @@ export const createStyles = (
       alignItems: 'center',
     },
     titleSpinner: {
+      height: 18,
+      justifyContent: 'center',
       marginLeft: 6,
+      transform: [{ translateY: -2 }],
     },
     statusRow: {
       flexDirection: 'row',
@@ -117,7 +120,10 @@ export const createStyles = (
       marginTop: 0,
     },
     subtitleLeadingIcon: {
+      height: 16,
+      justifyContent: 'center',
       marginRight: 4,
+      transform: [{ translateY: -1 }],
     },
     statusText: {
       marginTop: 0,

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -543,6 +543,28 @@ describe('ActivityListItemRow — row content', () => {
     );
   });
 
+  it('renders unlimited spending cap amount without compacting the raw allowance', () => {
+    const item = makeItem({
+      type: 'approveSpendingCap',
+      status: 'success',
+      token: {
+        amount: '115792089237316195423570985.639935',
+        isUnlimitedApproval: true,
+        symbol: 'USDT',
+        direction: 'out',
+      },
+    });
+
+    const { getByTestId, queryByText } = render(
+      <ActivityListItemRow item={item} index={0} />,
+    );
+
+    expect(getByTestId('activity-primary-amount-0xabc').props.children).toBe(
+      `${strings('confirm.unlimited')} USDT`,
+    );
+    expect(queryByText('115792089237316195423570985.639935 USDT')).toBeNull();
+  });
+
   it('renders cross-token bridge as swapped with token pair subtitle', () => {
     const item = makeItem({
       type: 'bridge',

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -223,7 +223,16 @@ jest.mock('@metamask/design-system-react-native', () => {
     );
   };
 
-  return { ListItem };
+  const Icon = ({ testID }: { testID?: string }) =>
+    ReactActual.createElement(View, { testID });
+
+  return {
+    Icon,
+    IconColor: { IconAlternative: 'icon-alternative' },
+    IconName: { Clock: 'Clock' },
+    IconSize: { Sm: '16' },
+    ListItem,
+  };
 });
 
 jest.mock('../StyledButton', () => {
@@ -256,20 +265,6 @@ jest.mock('../Money/components/PendingSpinner/PendingSpinner', () => {
   const { View } = jest.requireActual('react-native');
   return ({ testID }: { testID?: string }) =>
     ReactActual.createElement(View, { testID });
-});
-
-jest.mock('../../../component-library/components/Icons/Icon', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
-  const Icon = ({ testID }: { testID?: string }) =>
-    ReactActual.createElement(View, { testID });
-  return {
-    __esModule: true,
-    default: Icon,
-    IconColor: { Alternative: 'alternative', Default: 'default' },
-    IconName: { Pending: 'Pending' },
-    IconSize: { Sm: '16' },
-  };
 });
 
 jest.mock('../../Views/confirmations/utils/transaction', () => ({

--- a/app/components/UI/ActivityListItemRow/PendingActivityListItemRow.tsx
+++ b/app/components/UI/ActivityListItemRow/PendingActivityListItemRow.tsx
@@ -6,11 +6,12 @@
 import React, { useCallback } from 'react';
 import { View, useColorScheme } from 'react-native';
 import { useSelector } from 'react-redux';
-import Icon, {
+import {
+  Icon,
   IconColor,
   IconName,
   IconSize,
-} from '../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import { useTheme } from '../../../util/theme';
 import { getTransactionIcon } from '../../../util/transaction-icons';
@@ -72,12 +73,13 @@ export function PendingActivityListItemRow({
   );
 
   const subtitleLeadingAccessory = isQueued ? (
-    <Icon
-      name={IconName.Pending}
-      size={IconSize.Sm}
-      color={IconColor.Alternative}
-      style={styles.subtitleLeadingIcon}
-    />
+    <View style={styles.subtitleLeadingIcon}>
+      <Icon
+        name={IconName.Clock}
+        size={IconSize.Xs}
+        color={IconColor.IconAlternative}
+      />
+    </View>
   ) : undefined;
 
   return (

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -669,13 +669,18 @@ function resolveAmount(
 ): string | undefined {
   if (!token) return undefined;
 
-  const humanAmount = getHumanReadableTokenAmount(token);
-  if (humanAmount === undefined) return undefined;
-
-  const displayAmount = formatTokenQuantity(humanAmount);
+  const displayAmount = token.isUnlimitedApproval
+    ? strings('confirm.unlimited')
+    : getHumanReadableTokenAmount(token);
+  if (displayAmount === undefined) {
+    return undefined;
+  }
+  const formattedAmount = token.isUnlimitedApproval
+    ? displayAmount
+    : formatTokenQuantity(displayAmount);
   const amount = token.symbol
-    ? `${displayAmount} ${token.symbol}`
-    : displayAmount;
+    ? `${formattedAmount} ${token.symbol}`
+    : formattedAmount;
   const isSpendingCapActivity =
     activityType === 'approveSpendingCap' ||
     activityType === 'increaseSpendingCap' ||
@@ -801,6 +806,7 @@ function resolveFiatAmount({
   usdConversionRate: number | null | undefined;
 }): string | undefined {
   if (!token || !currentCurrency || !hexChainId) return undefined;
+  if (token.isUnlimitedApproval) return undefined;
 
   const humanAmount = getHumanReadableTokenAmount(token);
   if (humanAmount === undefined) return undefined;

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -103,6 +103,33 @@ describe('AssetDetailsActivityListItem', () => {
     );
   });
 
+  it('does not render account import marker when import time is null', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectSelectedInternalAccount) {
+        return { metadata: { importTime: null } };
+      }
+      return undefined;
+    });
+    const navigation = createNavigation();
+    const transaction = createTransaction({ insertImportTime: true });
+
+    const { queryByTestId } = render(
+      <AssetDetailsActivityListItem
+        transaction={transaction}
+        index={0}
+        assetSymbol="ETH"
+        chainId="0x1"
+        navigation={navigation}
+        onSpeedUpAction={jest.fn()}
+        onCancelAction={jest.fn()}
+      />,
+    );
+
+    expect(
+      queryByTestId('activity-list-account-import-time-row'),
+    ).not.toBeOnTheScreen();
+  });
+
   it('opens transaction details when activity row is pressed', () => {
     const navigation = createNavigation();
     const onSpeedUpAction = jest.fn();

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
+import Routes from '../../../constants/navigation/Routes';
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: { alternative: 'text-alternative' },
+    },
+  }),
+}));
+
+jest.mock('../ActivityListItemRow/ActivityListItemRow', () => ({
+  ActivityListItemRow: jest.fn(({ onPress, item }) => {
+    const { TouchableOpacity } = jest.requireActual('react-native');
+    return (
+      <TouchableOpacity
+        testID="activity-list-item-row"
+        onPress={() => onPress?.(item)}
+      />
+    );
+  }),
+  resolveActivityListItemTitle: jest.fn(() => 'Send ETH'),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+
+const createNavigation = () => ({
+  navigate: jest.fn(),
+});
+
+const createTransaction = (overrides = {}) => ({
+  id: 'tx-1',
+  chainId: '0x1',
+  hash: '0xabc',
+  status: TransactionStatus.confirmed,
+  time: 1000,
+  type: TransactionType.simpleSend,
+  txParams: {
+    from: '0x123',
+    to: '0x456',
+    value: '0x1',
+  },
+  ...overrides,
+});
+
+describe('AssetDetailsActivityListItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectSelectedInternalAccount) {
+        return { metadata: { importTime: 2000 } };
+      }
+      return undefined;
+    });
+  });
+
+  it('renders account import marker for transaction import insertion point', () => {
+    const navigation = createNavigation();
+    const transaction = createTransaction({ insertImportTime: true });
+
+    const { getByTestId } = render(
+      <AssetDetailsActivityListItem
+        transaction={transaction}
+        index={0}
+        assetSymbol="ETH"
+        chainId="0x1"
+        navigation={navigation}
+        onSpeedUpAction={jest.fn()}
+        onCancelAction={jest.fn()}
+      />,
+    );
+
+    const importRow = getByTestId('activity-list-account-import-time-row');
+    fireEvent.press(importRow);
+
+    expect(importRow).toBeTruthy();
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      { screen: Routes.SHEET.IMPORT_WALLET_TIP },
+    );
+  });
+});

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -10,6 +10,7 @@ import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 import Routes from '../../../constants/navigation/Routes';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 import type { TransactionWithImportTime } from './AssetDetailsActivityListItem.utils';
+import { resolveActivityListItemTitle } from '../ActivityListItemRow/ActivityListItemRow';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -99,6 +100,46 @@ describe('AssetDetailsActivityListItem', () => {
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.MODAL.ROOT_MODAL_FLOW,
       { screen: Routes.SHEET.IMPORT_WALLET_TIP },
+    );
+  });
+
+  it('opens transaction details when activity row is pressed', () => {
+    const navigation = createNavigation();
+    const onSpeedUpAction = jest.fn();
+    const onCancelAction = jest.fn();
+    const transaction = createTransaction();
+
+    const { getByTestId, queryByTestId } = render(
+      <AssetDetailsActivityListItem
+        transaction={transaction}
+        index={0}
+        assetSymbol="ETH"
+        chainId="0x1"
+        navigation={navigation}
+        onSpeedUpAction={onSpeedUpAction}
+        onCancelAction={onCancelAction}
+      />,
+    );
+
+    fireEvent.press(getByTestId('activity-list-item-row'));
+
+    expect(
+      queryByTestId('activity-list-account-import-time-row'),
+    ).not.toBeOnTheScreen();
+    expect(resolveActivityListItemTitle).toHaveBeenCalled();
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      expect.objectContaining({
+        screen: Routes.SHEET.TRANSACTION_DETAILS,
+        params: expect.objectContaining({
+          tx: expect.objectContaining({ id: 'tx-1' }),
+          transactionElement: expect.objectContaining({
+            actionKey: 'Send ETH',
+          }),
+          showSpeedUpModal: expect.any(Function),
+          showCancelModal: expect.any(Function),
+        }),
+      }),
     );
   });
 });

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.test.tsx
@@ -5,9 +5,11 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 import Routes from '../../../constants/navigation/Routes';
 import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
+import type { TransactionWithImportTime } from './AssetDetailsActivityListItem.utils';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -40,14 +42,18 @@ jest.mock('../ActivityListItemRow/ActivityListItemRow', () => ({
 
 const mockUseSelector = jest.mocked(useSelector);
 
-const createNavigation = () => ({
-  navigate: jest.fn(),
-});
+const createNavigation = () =>
+  ({
+    navigate: jest.fn(),
+  }) as unknown as AppNavigationProp & { navigate: jest.Mock };
 
-const createTransaction = (overrides = {}) => ({
+const createTransaction = (
+  overrides: Partial<TransactionWithImportTime> = {},
+): TransactionWithImportTime => ({
   id: 'tx-1',
   chainId: '0x1',
   hash: '0xabc',
+  networkClientId: 'mainnet',
   status: TransactionStatus.confirmed,
   time: 1000,
   type: TransactionType.simpleSend,

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
@@ -86,7 +86,9 @@ export const AssetDetailsActivityListItem = ({
   );
 
   const shouldRenderImportTime =
-    Boolean(tx.insertImportTime) && accountImportTime !== undefined;
+    Boolean(tx.insertImportTime) &&
+    typeof accountImportTime === 'number' &&
+    Number.isFinite(accountImportTime);
   const importTimeRow = shouldRenderImportTime ? (
     <ActivityListAccountImportTimeRow
       importTime={accountImportTime}

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
@@ -85,6 +85,12 @@ export const AssetDetailsActivityListItem = ({
     [currentChainId, navigation, onCancelAction, onSpeedUpAction, tokenChainId],
   );
 
+  const handleImportTimePress = useCallback(() => {
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.IMPORT_WALLET_TIP,
+    });
+  }, [navigation]);
+
   const shouldRenderImportTime =
     Boolean(tx.insertImportTime) &&
     typeof accountImportTime === 'number' &&
@@ -92,7 +98,7 @@ export const AssetDetailsActivityListItem = ({
   const importTimeRow = shouldRenderImportTime ? (
     <ActivityListAccountImportTimeRow
       importTime={accountImportTime}
-      navigation={navigation}
+      onPress={handleImportTimePress}
     />
   ) : null;
 

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useMemo } from 'react';
+import { Box } from '@metamask/design-system-react-native';
+import { useSelector } from 'react-redux';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import Routes from '../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+import {
+  ActivityListItemRow,
+  resolveActivityListItemTitle,
+} from '../ActivityListItemRow/ActivityListItemRow';
+import { type ActivityListItem } from '../../../util/activity-adapters';
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
+import ActivityListAccountImportTimeRow from '../ActivityListItemRow/ActivityListAccountImportTimeRow';
+import {
+  getActivityFromTo,
+  getActivityValue,
+  getTransactionDetailsParams,
+  mapTransactionToActivityItem,
+  type TransactionWithImportTime,
+} from './AssetDetailsActivityListItem.utils';
+
+interface AssetDetailsActivityListItemProps {
+  transaction: TransactionWithImportTime;
+  index: number;
+  assetSymbol?: string;
+  chainId?: Hex;
+  tokenChainId?: Hex;
+  navigation: AppNavigationProp;
+  onSpeedUpAction: (open: boolean, tx?: TransactionMeta) => void;
+  onCancelAction: (open: boolean, tx?: TransactionMeta) => void;
+}
+
+export const AssetDetailsActivityListItem = ({
+  transaction: tx,
+  index,
+  assetSymbol,
+  chainId: currentChainId,
+  tokenChainId,
+  navigation,
+  onSpeedUpAction,
+  onCancelAction,
+}: AssetDetailsActivityListItemProps) => {
+  const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
+  const accountImportTime = selectedInternalAccount?.metadata.importTime;
+  const activityItem = useMemo(
+    () =>
+      mapTransactionToActivityItem({
+        transaction: tx,
+        assetSymbol,
+        currentChainId,
+        tokenChainId,
+      }),
+    [assetSymbol, currentChainId, tokenChainId, tx],
+  );
+
+  const handlePress = useCallback(
+    (item: ActivityListItem) => {
+      const selectedTx =
+        item.raw?.type === 'localTransaction'
+          ? item.raw.data.primaryTransaction
+          : undefined;
+      if (!selectedTx) return;
+
+      const { from, to } = getActivityFromTo(item);
+      const value = getActivityValue(item);
+      const actionKey = resolveActivityListItemTitle(item);
+
+      navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+        screen: Routes.SHEET.TRANSACTION_DETAILS,
+        params: getTransactionDetailsParams({
+          item,
+          selectedTx,
+          actionKey,
+          value,
+          from,
+          to,
+          currentChainId,
+          tokenChainId,
+          showSpeedUpModal: () => onSpeedUpAction(true, selectedTx),
+          showCancelModal: () => onCancelAction(true, selectedTx),
+        }),
+      });
+    },
+    [currentChainId, navigation, onCancelAction, onSpeedUpAction, tokenChainId],
+  );
+
+  const shouldRenderImportTime =
+    Boolean(tx.insertImportTime) && accountImportTime !== undefined;
+  const importTimeRow = shouldRenderImportTime ? (
+    <ActivityListAccountImportTimeRow
+      importTime={accountImportTime}
+      navigation={navigation}
+    />
+  ) : null;
+
+  const shouldShowImportTimeBeforeRow =
+    shouldRenderImportTime && accountImportTime > activityItem.timestamp;
+
+  return (
+    <Box twClassName="px-4">
+      {shouldShowImportTimeBeforeRow && importTimeRow}
+      <ActivityListItemRow
+        item={activityItem}
+        index={index}
+        onPress={handlePress}
+      />
+      {!shouldShowImportTimeBeforeRow && importTimeRow}
+    </Box>
+  );
+};
+
+export default AssetDetailsActivityListItem;

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.test.ts
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.test.ts
@@ -1,0 +1,98 @@
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import {
+  getTransactionDetailsParams,
+  mapTransactionToActivityItem,
+  type TransactionWithImportTime,
+} from './AssetDetailsActivityListItem.utils';
+
+const createTransaction = (
+  overrides: Partial<TransactionWithImportTime> = {},
+): TransactionWithImportTime => ({
+  id: 'tx-1',
+  chainId: '0x1',
+  hash: '0xabc',
+  networkClientId: 'mainnet',
+  status: TransactionStatus.confirmed,
+  time: 1000,
+  type: TransactionType.simpleSend,
+  txParams: {
+    from: '0x123',
+    to: '0x456',
+    value: '0x1',
+  },
+  ...overrides,
+});
+
+describe('AssetDetailsActivityListItem utils', () => {
+  it('maps transaction metadata to activity item with asset details chain context', () => {
+    const transaction = createTransaction({
+      chainId: undefined,
+      txParams: {
+        from: '0x123',
+        to: '0x456',
+        value: '0x1',
+      },
+    });
+
+    const item = mapTransactionToActivityItem({
+      transaction,
+      assetSymbol: 'ETH',
+      currentChainId: '0x1',
+      tokenChainId: '0x89',
+    });
+
+    expect(item.raw?.type).toBe('localTransaction');
+    if (item.raw?.type !== 'localTransaction') {
+      throw new Error('Expected local transaction activity item');
+    }
+    expect(item.chainId).toBe('eip155:137');
+    expect(item.raw?.data.primaryTransaction.chainId).toBe('0x89');
+    expect(item.raw?.data.primaryTransaction.txParams.chainId).toBe('0x89');
+    expect(item.raw?.data.nativeAssetSymbol).toBe('ETH');
+  });
+
+  it('creates transaction details params for redesigned asset detail rows', () => {
+    const selectedTx = createTransaction();
+    const item = mapTransactionToActivityItem({
+      transaction: selectedTx,
+      assetSymbol: 'ETH',
+      currentChainId: '0x1',
+    });
+    const showSpeedUpModal = jest.fn();
+    const showCancelModal = jest.fn();
+
+    const params = getTransactionDetailsParams({
+      item,
+      selectedTx,
+      actionKey: 'Send ETH',
+      value: '1 ETH',
+      from: '0x123',
+      to: '0x456',
+      currentChainId: '0x1',
+      tokenChainId: '0x89',
+      showSpeedUpModal,
+      showCancelModal,
+    });
+
+    expect(params).toStrictEqual({
+      tx: selectedTx,
+      transactionElement: {
+        actionKey: 'Send ETH',
+        value: '1 ETH',
+      },
+      transactionDetails: {
+        hash: item.hash,
+        renderFrom: '0x123',
+        renderTo: '0x456',
+        renderValue: '1 ETH',
+        transactionType: item.type,
+        txChainId: '0x1',
+      },
+      showSpeedUpModal,
+      showCancelModal,
+    });
+  });
+});

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.ts
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.ts
@@ -1,0 +1,108 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import {
+  mapLocalTransaction,
+  type ActivityListItem,
+  type TransactionGroup,
+} from '../../../util/activity-adapters';
+
+export type TransactionWithImportTime = TransactionMeta & {
+  insertImportTime?: boolean;
+};
+
+export const getActivityValue = (item: ActivityListItem) => {
+  const { data } = item;
+
+  if ('token' in data && data.token?.symbol) {
+    return `${data.token.amount ?? ''} ${data.token.symbol}`.trim();
+  }
+
+  if ('destinationToken' in data && data.destinationToken?.symbol) {
+    return `${data.destinationToken.amount ?? ''} ${
+      data.destinationToken.symbol
+    }`.trim();
+  }
+
+  if ('sourceToken' in data && data.sourceToken?.symbol) {
+    return `${data.sourceToken.amount ?? ''} ${data.sourceToken.symbol}`.trim();
+  }
+
+  return undefined;
+};
+
+export const getActivityFromTo = (item: ActivityListItem) => {
+  const { data } = item;
+  if ('from' in data || 'to' in data) {
+    return { from: data.from, to: data.to };
+  }
+  return {};
+};
+
+export const mapTransactionToActivityItem = ({
+  transaction: tx,
+  assetSymbol,
+  currentChainId,
+  tokenChainId,
+}: {
+  transaction: TransactionWithImportTime;
+  assetSymbol?: string;
+  currentChainId?: Hex;
+  tokenChainId?: Hex;
+}) => {
+  const chainId = tx.chainId ?? tokenChainId ?? currentChainId;
+  const transaction = {
+    ...tx,
+    chainId,
+    txParams: {
+      ...tx.txParams,
+      chainId: tx.txParams?.chainId ?? chainId,
+    },
+  };
+  const transactionGroup: TransactionGroup = {
+    initialTransaction: transaction,
+    primaryTransaction: transaction,
+    nativeAssetSymbol: assetSymbol,
+  };
+
+  return mapLocalTransaction(transactionGroup);
+};
+
+export const getTransactionDetailsParams = ({
+  item,
+  selectedTx,
+  actionKey,
+  value,
+  from,
+  to,
+  currentChainId,
+  tokenChainId,
+  showSpeedUpModal,
+  showCancelModal,
+}: {
+  item: ActivityListItem;
+  selectedTx: TransactionMeta;
+  actionKey: string;
+  value?: string;
+  from?: string;
+  to?: string;
+  currentChainId?: Hex;
+  tokenChainId?: Hex;
+  showSpeedUpModal: () => void;
+  showCancelModal: () => void;
+}) => ({
+  tx: selectedTx,
+  transactionElement: {
+    actionKey,
+    value,
+  },
+  transactionDetails: {
+    hash: item.hash,
+    renderFrom: from,
+    renderTo: to,
+    renderValue: value,
+    transactionType: item.type,
+    txChainId: selectedTx.chainId ?? tokenChainId ?? currentChainId,
+  },
+  showSpeedUpModal,
+  showCancelModal,
+});

--- a/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.ts
+++ b/app/components/UI/Transactions/AssetDetailsActivityListItem.utils.ts
@@ -1,6 +1,8 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import {
+  getActivityFromTo,
+  getActivityValue,
   mapLocalTransaction,
   type ActivityListItem,
   type TransactionGroup,
@@ -10,33 +12,7 @@ export type TransactionWithImportTime = TransactionMeta & {
   insertImportTime?: boolean;
 };
 
-export const getActivityValue = (item: ActivityListItem) => {
-  const { data } = item;
-
-  if ('token' in data && data.token?.symbol) {
-    return `${data.token.amount ?? ''} ${data.token.symbol}`.trim();
-  }
-
-  if ('destinationToken' in data && data.destinationToken?.symbol) {
-    return `${data.destinationToken.amount ?? ''} ${
-      data.destinationToken.symbol
-    }`.trim();
-  }
-
-  if ('sourceToken' in data && data.sourceToken?.symbol) {
-    return `${data.sourceToken.amount ?? ''} ${data.sourceToken.symbol}`.trim();
-  }
-
-  return undefined;
-};
-
-export const getActivityFromTo = (item: ActivityListItem) => {
-  const { data } = item;
-  if ('from' in data || 'to' in data) {
-    return { from: data.from, to: data.to };
-  }
-  return {};
-};
+export { getActivityFromTo, getActivityValue };
 
 export const mapTransactionToActivityItem = ({
   transaction: tx,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -845,7 +845,7 @@ class Transactions extends PureComponent {
 
   renderGroupedActivityItem = ({ item, index }) => {
     if (item.type === 'pending-header') {
-      return <ActivityListDateHeader label={strings('transactions.pending')} />;
+      return <ActivityListDateHeader label={strings('transaction.pending')} />;
     }
 
     if (item.type === 'date-header') {

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -83,6 +83,9 @@ import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmatio
 import { LedgerReplacementTxTypes } from '../LedgerModals/LedgerTransactionModal';
 import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
 import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
+import ActivityListDateHeader from '../ActivityListItemRow/ActivityListDateHeader';
+import { groupActivityListItems } from '../../../util/activity-adapters';
+import { mapTransactionToActivityItem } from './AssetDetailsActivityListItem.utils';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -517,6 +520,18 @@ class Transactions extends PureComponent {
 
   keyExtractor = (item) => item.id.toString();
 
+  groupedActivityKeyExtractor = (item, index) => {
+    if (item.type === 'pending-header') {
+      return 'pending-header';
+    }
+
+    if (item.type === 'date-header') {
+      return `date-header-${item.date}`;
+    }
+
+    return item.item.id ?? item.item.hash ?? `${item.item.timestamp}-${index}`;
+  };
+
   onSpeedUpAction = (speedUpAction, tx) => {
     if (!speedUpAction) {
       this.setState({ speedUpIsOpen: false, cancelIsOpen: false });
@@ -857,6 +872,38 @@ class Transactions extends PureComponent {
     );
   };
 
+  renderGroupedActivityItem = ({ item, index }) => {
+    if (item.type === 'pending-header') {
+      return <ActivityListDateHeader label={strings('transactions.pending')} />;
+    }
+
+    if (item.type === 'date-header') {
+      return <ActivityListDateHeader timestamp={item.date} />;
+    }
+
+    const tx =
+      item.item.raw?.type === 'localTransaction'
+        ? item.item.raw.data.primaryTransaction
+        : undefined;
+
+    if (!tx) {
+      return null;
+    }
+
+    return (
+      <AssetDetailsActivityListItem
+        transaction={tx}
+        index={index}
+        assetSymbol={this.props.assetSymbol}
+        chainId={this.props.chainId}
+        tokenChainId={this.props.tokenChainId}
+        navigation={this.props.navigation}
+        onSpeedUpAction={this.onSpeedUpAction}
+        onCancelAction={this.onCancelAction}
+      />
+    );
+  };
+
   get footer() {
     const {
       chainId,
@@ -905,6 +952,21 @@ class Transactions extends PureComponent {
 
     const filteredTransactions =
       filterDuplicateOutgoingTransactions(transactions);
+    const shouldUseActivityRedesign =
+      this.props.isActivityRedesignEnabled &&
+      this.props.location === TransactionDetailLocation.AssetDetails;
+    const activityListData = shouldUseActivityRedesign
+      ? groupActivityListItems(
+          filteredTransactions.map((transaction) =>
+            mapTransactionToActivityItem({
+              transaction,
+              assetSymbol: this.props.assetSymbol,
+              currentChainId: this.props.chainId,
+              tokenChainId: this.props.tokenChainId,
+            }),
+          ),
+        )
+      : filteredTransactions;
 
     return (
       <View style={styles.wrapper}>
@@ -913,10 +975,16 @@ class Transactions extends PureComponent {
             <FlatList
               testID={ActivitiesViewSelectorsIDs.CONTAINER}
               ref={this.flatList}
-              getItemLayout={this.getItemLayout}
-              data={filteredTransactions}
+              getItemLayout={
+                shouldUseActivityRedesign ? undefined : this.getItemLayout
+              }
+              data={activityListData}
               extraData={this.state}
-              keyExtractor={this.keyExtractor}
+              keyExtractor={
+                shouldUseActivityRedesign
+                  ? this.groupedActivityKeyExtractor
+                  : this.keyExtractor
+              }
               refreshControl={
                 <RefreshControl
                   colors={[colors.primary.default]}
@@ -925,7 +993,11 @@ class Transactions extends PureComponent {
                   onRefresh={this.onRefresh}
                 />
               }
-              renderItem={this.renderItem}
+              renderItem={
+                shouldUseActivityRedesign
+                  ? this.renderGroupedActivityItem
+                  : this.renderItem
+              }
               initialNumToRender={10}
               maxToRenderPerBatch={2}
               onEndReachedThreshold={0.5}

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -529,7 +529,24 @@ class Transactions extends PureComponent {
       return `date-header-${item.date}`;
     }
 
-    return item.item.id ?? item.item.hash ?? `${item.item.timestamp}-${index}`;
+    const raw = item.item.raw;
+    if (raw?.type === 'localTransaction') {
+      const txId =
+        raw.data.primaryTransaction?.id ?? raw.data.initialTransaction?.id;
+      if (txId) {
+        return `local-transaction-${txId}`;
+      }
+    }
+
+    if (raw?.type === 'keyringTransaction' && raw.data.id) {
+      return `keyring-transaction-${raw.data.id}`;
+    }
+
+    if (raw?.type === 'apiEvmTransaction' && item.item.hash) {
+      return `api-evm-transaction-${item.item.hash}`;
+    }
+
+    return `${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
   };
 
   onSpeedUpAction = (speedUpAction, tx) => {
@@ -829,48 +846,28 @@ class Transactions extends PureComponent {
     }
   };
 
-  renderItem = ({ item, index }) => {
-    if (
-      this.props.isActivityRedesignEnabled &&
-      this.props.location === TransactionDetailLocation.AssetDetails
-    ) {
-      return (
-        <AssetDetailsActivityListItem
-          transaction={item}
-          index={index}
-          assetSymbol={this.props.assetSymbol}
-          chainId={this.props.chainId}
-          tokenChainId={this.props.tokenChainId}
-          navigation={this.props.navigation}
-          onSpeedUpAction={this.onSpeedUpAction}
-          onCancelAction={this.onCancelAction}
-        />
-      );
-    }
-
-    return (
-      <TransactionElement
-        tx={item}
-        i={index}
-        assetSymbol={this.props.assetSymbol}
-        onSpeedUpAction={this.onSpeedUpAction}
-        isQRHardwareAccount={this.state.isQRHardwareAccount}
-        isLedgerAccount={this.state.isLedgerAccount}
-        signQRTransaction={this.signQRTransaction}
-        signLedgerTransaction={this.signLedgerTransaction}
-        cancelUnsignedQRTransaction={this.cancelUnsignedQRTransaction}
-        onCancelAction={this.onCancelAction}
-        onPressItem={this.toggleDetailsView}
-        selectedAddress={this.props.selectedAddress}
-        collectibleContracts={this.props.collectibleContracts}
-        exchangeRate={this.props.exchangeRate}
-        currentCurrency={this.props.currentCurrency}
-        navigation={this.props.navigation}
-        txChainId={item.chainId}
-        location={this.props.location}
-      />
-    );
-  };
+  renderItem = ({ item, index }) => (
+    <TransactionElement
+      tx={item}
+      i={index}
+      assetSymbol={this.props.assetSymbol}
+      onSpeedUpAction={this.onSpeedUpAction}
+      isQRHardwareAccount={this.state.isQRHardwareAccount}
+      isLedgerAccount={this.state.isLedgerAccount}
+      signQRTransaction={this.signQRTransaction}
+      signLedgerTransaction={this.signLedgerTransaction}
+      cancelUnsignedQRTransaction={this.cancelUnsignedQRTransaction}
+      onCancelAction={this.onCancelAction}
+      onPressItem={this.toggleDetailsView}
+      selectedAddress={this.props.selectedAddress}
+      collectibleContracts={this.props.collectibleContracts}
+      exchangeRate={this.props.exchangeRate}
+      currentCurrency={this.props.currentCurrency}
+      navigation={this.props.navigation}
+      txChainId={item.chainId}
+      location={this.props.location}
+    />
+  );
 
   renderGroupedActivityItem = ({ item, index }) => {
     if (item.type === 'pending-header') {

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -84,7 +84,10 @@ import { LedgerReplacementTxTypes } from '../LedgerModals/LedgerTransactionModal
 import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
 import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 import ActivityListDateHeader from '../ActivityListItemRow/ActivityListDateHeader';
-import { groupActivityListItems } from '../../../util/activity-adapters';
+import {
+  getGroupedActivityListItemKey,
+  groupActivityListItems,
+} from '../../../util/activity-adapters';
 import { mapTransactionToActivityItem } from './AssetDetailsActivityListItem.utils';
 
 const createStyles = (colors) =>
@@ -520,35 +523,6 @@ class Transactions extends PureComponent {
 
   keyExtractor = (item) => item.id.toString();
 
-  groupedActivityKeyExtractor = (item, index) => {
-    if (item.type === 'pending-header') {
-      return 'pending-header';
-    }
-
-    if (item.type === 'date-header') {
-      return `date-header-${item.date}`;
-    }
-
-    const raw = item.item.raw;
-    if (raw?.type === 'localTransaction') {
-      const txId =
-        raw.data.primaryTransaction?.id ?? raw.data.initialTransaction?.id;
-      if (txId) {
-        return `local-transaction-${txId}`;
-      }
-    }
-
-    if (raw?.type === 'keyringTransaction' && raw.data.id) {
-      return `keyring-transaction-${raw.data.id}`;
-    }
-
-    if (raw?.type === 'apiEvmTransaction' && item.item.hash) {
-      return `api-evm-transaction-${item.item.hash}`;
-    }
-
-    return `${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
-  };
-
   onSpeedUpAction = (speedUpAction, tx) => {
     if (!speedUpAction) {
       this.setState({ speedUpIsOpen: false, cancelIsOpen: false });
@@ -979,7 +953,7 @@ class Transactions extends PureComponent {
               extraData={this.state}
               keyExtractor={
                 shouldUseActivityRedesign
-                  ? this.groupedActivityKeyExtractor
+                  ? getGroupedActivityListItemKey
                   : this.keyExtractor
               }
               refreshControl={

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -81,6 +81,8 @@ import {
 } from '../../../core/HardwareWallet';
 import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 import { LedgerReplacementTxTypes } from '../LedgerModals/LedgerTransactionModal';
+import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
+import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 
 const createStyles = (colors) =>
   StyleSheet.create({
@@ -219,6 +221,7 @@ class Transactions extends PureComponent {
       hideAwaitingConfirmation: PropTypes.func,
       showHardwareWalletError: PropTypes.func,
     }),
+    isActivityRedesignEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -811,28 +814,48 @@ class Transactions extends PureComponent {
     }
   };
 
-  renderItem = ({ item, index }) => (
-    <TransactionElement
-      tx={item}
-      i={index}
-      assetSymbol={this.props.assetSymbol}
-      onSpeedUpAction={this.onSpeedUpAction}
-      isQRHardwareAccount={this.state.isQRHardwareAccount}
-      isLedgerAccount={this.state.isLedgerAccount}
-      signQRTransaction={this.signQRTransaction}
-      signLedgerTransaction={this.signLedgerTransaction}
-      cancelUnsignedQRTransaction={this.cancelUnsignedQRTransaction}
-      onCancelAction={this.onCancelAction}
-      onPressItem={this.toggleDetailsView}
-      selectedAddress={this.props.selectedAddress}
-      collectibleContracts={this.props.collectibleContracts}
-      exchangeRate={this.props.exchangeRate}
-      currentCurrency={this.props.currentCurrency}
-      navigation={this.props.navigation}
-      txChainId={item.chainId}
-      location={this.props.location}
-    />
-  );
+  renderItem = ({ item, index }) => {
+    if (
+      this.props.isActivityRedesignEnabled &&
+      this.props.location === TransactionDetailLocation.AssetDetails
+    ) {
+      return (
+        <AssetDetailsActivityListItem
+          transaction={item}
+          index={index}
+          assetSymbol={this.props.assetSymbol}
+          chainId={this.props.chainId}
+          tokenChainId={this.props.tokenChainId}
+          navigation={this.props.navigation}
+          onSpeedUpAction={this.onSpeedUpAction}
+          onCancelAction={this.onCancelAction}
+        />
+      );
+    }
+
+    return (
+      <TransactionElement
+        tx={item}
+        i={index}
+        assetSymbol={this.props.assetSymbol}
+        onSpeedUpAction={this.onSpeedUpAction}
+        isQRHardwareAccount={this.state.isQRHardwareAccount}
+        isLedgerAccount={this.state.isLedgerAccount}
+        signQRTransaction={this.signQRTransaction}
+        signLedgerTransaction={this.signLedgerTransaction}
+        cancelUnsignedQRTransaction={this.cancelUnsignedQRTransaction}
+        onCancelAction={this.onCancelAction}
+        onPressItem={this.toggleDetailsView}
+        selectedAddress={this.props.selectedAddress}
+        collectibleContracts={this.props.collectibleContracts}
+        exchangeRate={this.props.exchangeRate}
+        currentCurrency={this.props.currentCurrency}
+        navigation={this.props.navigation}
+        txChainId={item.chainId}
+        location={this.props.location}
+      />
+    );
+  };
 
   get footer() {
     const {
@@ -981,6 +1004,7 @@ const mapStateToProps = (state) => ({
   primaryCurrency: selectPrimaryCurrency(state),
   gasEstimateType: selectGasFeeControllerEstimateType(state),
   networkType: selectProviderType(state),
+  isActivityRedesignEnabled: selectIsActivityRedesignEnabled(state),
 });
 
 Transactions.contextType = ThemeContext;

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -2802,51 +2802,6 @@ describe('UnconnectedTransactions Component Direct Method Testing', () => {
       expect(mockFindBlockExplorerUrlForChain).not.toHaveBeenCalled();
     });
 
-    it('uses raw transaction id for grouped activity item keys', () => {
-      instance = new UnconnectedTransactions({
-        ...defaultTestProps,
-        isActivityRedesignEnabled: true,
-        location: TransactionDetailLocation.AssetDetails,
-      });
-
-      const transaction = {
-        id: 'tx-1',
-        chainId: '0x1',
-        hash: '0xabc',
-        status: 'confirmed',
-        time: 1000000,
-        type: 'simpleSend',
-        txParams: {
-          from: '0x123',
-          to: '0x456',
-          value: '1000000000000000000',
-        },
-      };
-
-      const key = instance.groupedActivityKeyExtractor(
-        {
-          type: 'item',
-          item: {
-            type: 'send',
-            chainId: '0x1',
-            status: 'success',
-            timestamp: 1000000,
-            raw: {
-              type: 'localTransaction',
-              data: {
-                primaryTransaction: transaction,
-                initialTransaction: transaction,
-              },
-            },
-            data: {},
-          },
-        },
-        0,
-      );
-
-      expect(key).toBe('local-transaction-tx-1');
-    });
-
     it('keeps legacy transaction element when renderItem receives asset details props', () => {
       instance = new UnconnectedTransactions({
         ...defaultTestProps,

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { default as Transactions, UnconnectedTransactions } from '.';
 import TransactionElement from '../TransactionElement';
 import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
+import ActivityListDateHeader from '../ActivityListItemRow/ActivityListDateHeader';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { render, cleanup, act } from '@testing-library/react-native';
@@ -2833,6 +2834,80 @@ describe('UnconnectedTransactions Component Direct Method Testing', () => {
           chainId: '0x1',
           index: 0,
           navigation: mockNavigation,
+        }),
+      );
+    });
+
+    it('renders date headers for grouped redesigned asset details activity', () => {
+      instance = new UnconnectedTransactions({
+        ...defaultTestProps,
+        isActivityRedesignEnabled: true,
+        location: TransactionDetailLocation.AssetDetails,
+      });
+
+      const element = instance.renderGroupedActivityItem({
+        item: { type: 'date-header', date: 1000000 },
+        index: 0,
+      });
+
+      expect(element.type).toBe(ActivityListDateHeader);
+      expect(element.props).toEqual(
+        expect.objectContaining({
+          timestamp: 1000000,
+        }),
+      );
+    });
+
+    it('renders redesigned rows for grouped asset details activity items', () => {
+      instance = new UnconnectedTransactions({
+        ...defaultTestProps,
+        assetSymbol: 'ETH',
+        isActivityRedesignEnabled: true,
+        location: TransactionDetailLocation.AssetDetails,
+      });
+
+      const transaction = {
+        id: 'tx-1',
+        chainId: '0x1',
+        hash: '0xabc',
+        status: 'confirmed',
+        time: 1000000,
+        type: 'simpleSend',
+        txParams: {
+          from: '0x123',
+          to: '0x456',
+          value: '100',
+        },
+      };
+
+      const element = instance.renderGroupedActivityItem({
+        item: {
+          type: 'item',
+          item: {
+            id: 'activity-1',
+            type: 'send',
+            chainId: '0x1',
+            status: 'success',
+            timestamp: 1000000,
+            raw: {
+              type: 'localTransaction',
+              data: {
+                primaryTransaction: transaction,
+                initialTransaction: transaction,
+              },
+            },
+            data: {},
+          },
+        },
+        index: 1,
+      });
+
+      expect(element.type).toBe(AssetDetailsActivityListItem);
+      expect(element.props).toEqual(
+        expect.objectContaining({
+          transaction,
+          index: 1,
+          assetSymbol: 'ETH',
         }),
       );
     });

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { default as Transactions, UnconnectedTransactions } from '.';
+import TransactionElement from '../TransactionElement';
+import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { render, cleanup, act } from '@testing-library/react-native';
@@ -135,6 +137,15 @@ jest.mock('../../../util/Logger', () => ({
 jest.mock('../TransactionElement', () => ({
   __esModule: true,
   default: () => null,
+}));
+
+jest.mock('../ActivityListItemRow/ActivityListItemRow', () => ({
+  ActivityListItemRow: jest.fn(() => null),
+  resolveActivityListItemTitle: jest.fn(() => 'Activity title'),
+}));
+
+jest.mock('../../../selectors/featureFlagController/activityRedesign', () => ({
+  selectIsActivityRedesignEnabled: jest.fn(() => false),
 }));
 
 // Mock other connected components
@@ -282,6 +293,7 @@ const defaultTestProps = {
   gasFeeEstimates: {
     medium: { suggestedMaxFeePerGas: '20' },
   },
+  isActivityRedesignEnabled: false,
 };
 
 describe('Transactions', () => {
@@ -2787,6 +2799,67 @@ describe('UnconnectedTransactions Component Direct Method Testing', () => {
         'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       );
       expect(mockFindBlockExplorerUrlForChain).not.toHaveBeenCalled();
+    });
+
+    it('renders new activity row for asset details when activity redesign is enabled', () => {
+      instance = new UnconnectedTransactions({
+        ...defaultTestProps,
+        assetSymbol: 'ETH',
+        isActivityRedesignEnabled: true,
+        location: TransactionDetailLocation.AssetDetails,
+      });
+
+      const element = instance.renderItem({
+        item: {
+          id: 'tx-1',
+          chainId: '0x1',
+          hash: '0xabc',
+          status: 'confirmed',
+          time: 1000000,
+          type: 'simpleSend',
+          txParams: {
+            from: '0x123',
+            to: '0x456',
+            value: '1000000000000000000',
+          },
+        },
+        index: 0,
+      });
+
+      expect(element.type).toBe(AssetDetailsActivityListItem);
+      expect(element.props).toEqual(
+        expect.objectContaining({
+          assetSymbol: 'ETH',
+          chainId: '0x1',
+          index: 0,
+          navigation: mockNavigation,
+        }),
+      );
+    });
+
+    it('keeps legacy transaction element when activity redesign is disabled', () => {
+      instance = new UnconnectedTransactions({
+        ...defaultTestProps,
+        isActivityRedesignEnabled: false,
+        location: TransactionDetailLocation.AssetDetails,
+      });
+
+      const element = instance.renderItem({
+        item: {
+          id: 'tx-1',
+          chainId: '0x1',
+          status: 'confirmed',
+          time: 1000000,
+          txParams: {
+            from: '0x123',
+            to: '0x456',
+            value: '100',
+          },
+        },
+        index: 0,
+      });
+
+      expect(element.type).toBe(TransactionElement);
     });
 
     it('viewOnBlockExplore uses asset rpcBlockExplorer when tokenChainId is set', () => {

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -2802,10 +2802,54 @@ describe('UnconnectedTransactions Component Direct Method Testing', () => {
       expect(mockFindBlockExplorerUrlForChain).not.toHaveBeenCalled();
     });
 
-    it('renders new activity row for asset details when activity redesign is enabled', () => {
+    it('uses raw transaction id for grouped activity item keys', () => {
       instance = new UnconnectedTransactions({
         ...defaultTestProps,
-        assetSymbol: 'ETH',
+        isActivityRedesignEnabled: true,
+        location: TransactionDetailLocation.AssetDetails,
+      });
+
+      const transaction = {
+        id: 'tx-1',
+        chainId: '0x1',
+        hash: '0xabc',
+        status: 'confirmed',
+        time: 1000000,
+        type: 'simpleSend',
+        txParams: {
+          from: '0x123',
+          to: '0x456',
+          value: '1000000000000000000',
+        },
+      };
+
+      const key = instance.groupedActivityKeyExtractor(
+        {
+          type: 'item',
+          item: {
+            type: 'send',
+            chainId: '0x1',
+            status: 'success',
+            timestamp: 1000000,
+            raw: {
+              type: 'localTransaction',
+              data: {
+                primaryTransaction: transaction,
+                initialTransaction: transaction,
+              },
+            },
+            data: {},
+          },
+        },
+        0,
+      );
+
+      expect(key).toBe('local-transaction-tx-1');
+    });
+
+    it('keeps legacy transaction element when renderItem receives asset details props', () => {
+      instance = new UnconnectedTransactions({
+        ...defaultTestProps,
         isActivityRedesignEnabled: true,
         location: TransactionDetailLocation.AssetDetails,
       });
@@ -2827,15 +2871,7 @@ describe('UnconnectedTransactions Component Direct Method Testing', () => {
         index: 0,
       });
 
-      expect(element.type).toBe(AssetDetailsActivityListItem);
-      expect(element.props).toEqual(
-        expect.objectContaining({
-          assetSymbol: 'ETH',
-          chainId: '0x1',
-          index: 0,
-          navigation: mockNavigation,
-        }),
-      );
+      expect(element.type).toBe(TransactionElement);
     });
 
     it('renders date headers for grouped redesigned asset details activity', () => {

--- a/app/components/Views/ActivityList/ActivityList.test.tsx
+++ b/app/components/Views/ActivityList/ActivityList.test.tsx
@@ -87,7 +87,7 @@ jest.mock('@shopify/flash-list', () => {
           testID,
         }: {
           data: unknown[];
-          keyExtractor: (item: unknown) => string;
+          keyExtractor: (item: unknown, index: number) => string;
           ListEmptyComponent?: React.ReactElement | (() => React.ReactElement);
           ListFooterComponent?: React.ReactElement | null;
           ListHeaderComponent?: React.ReactElement;
@@ -116,7 +116,10 @@ jest.mock('@shopify/flash-list', () => {
             {ListHeaderComponent}
             {data.length
               ? data.map((item, index) => (
-                  <View key={keyExtractor(item)}>
+                  <View
+                    key={keyExtractor(item, index)}
+                    testID={`mock-key-${keyExtractor(item, index)}`}
+                  >
                     {renderItem({ item, index })}
                   </View>
                 ))
@@ -545,6 +548,49 @@ describe('ActivityList', () => {
         screen: expect.any(String),
       }),
     );
+  });
+
+  it('uses unique chain-aware fallback keys for rows without hashes', () => {
+    (useTransactionsQuery as jest.Mock).mockReturnValue({
+      data: {
+        pages: [
+          {
+            data: [
+              {
+                ...confirmedItem,
+                chainId: 'eip155:1',
+                hash: undefined,
+                raw: undefined,
+                timestamp: 123,
+              },
+              {
+                ...confirmedItem,
+                chainId: 'eip155:137',
+                hash: undefined,
+                raw: undefined,
+                timestamp: 123,
+              },
+            ],
+          },
+        ],
+      },
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isInitialLoading: false,
+      refetch: mockRefetch,
+    });
+    (useLocalActivityItems as jest.Mock).mockReturnValue([]);
+    selectorValues.enabledEvm = ['0x1', '0x89'];
+
+    render(<ActivityList header={<></>} onScroll={mockOnScroll} />);
+
+    expect(
+      screen.getByTestId('mock-key-eip155:1-contractInteraction-123-1'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('mock-key-eip155:137-contractInteraction-123-2'),
+    ).toBeOnTheScreen();
   });
 
   it('renders non-EVM bridge rows and footer when only non-EVM chains are enabled', () => {

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -69,6 +69,10 @@ import { filterMultichainTransactionsExcludingMaliciousTokenActivity } from '../
 import { useTransactionsQuery } from './useTransactionsQuery';
 import { type ActivityListItem } from './types';
 import {
+  formatActivityListDateHeader,
+  getActivityFromTo,
+  getActivityValue,
+  getGroupedActivityListItemKey,
   groupActivityListItems,
   type GroupedActivityListItem,
 } from '../../../util/activity-adapters';
@@ -85,7 +89,6 @@ import {
 } from '../../UI/ActivityListItemRow/ActivityListItemRow';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../util/analytics/externalLinkTracking';
-import { getIntlDateTimeFormatter } from '../../../util/intl';
 
 const confirmedEvmOverscan = 5;
 const visibilityConfig = { itemVisiblePercentThreshold: 1 };
@@ -97,51 +100,10 @@ const updateIncomingTransactions = () =>
     }
   ).updateIncomingTransactions();
 
-const generateKey = (item: ActivityListItem): string => {
-  const hash = item.hash;
-  if (hash) {
-    return `${item.chainId}:${hash}`;
-  }
-  return `${item.chainId}:${item.timestamp}:${item.type}`;
-};
-
-const generateGroupedKey = (item: GroupedActivityListItem): string => {
-  if (item.type === 'pending-header') {
-    return 'pending-header';
-  }
-
-  if (item.type === 'date-header') {
-    return `date-header-${item.date}`;
-  }
-
-  return generateKey(item.item);
-};
-
-const isSameLocalDay = (date: Date, otherDate: Date) =>
-  date.getFullYear() === otherDate.getFullYear() &&
-  date.getMonth() === otherDate.getMonth() &&
-  date.getDate() === otherDate.getDate();
-
-const formatDateHeader = (timestamp: number) => {
-  const date = new Date(timestamp);
-  const today = new Date();
-  const yesterday = new Date(today);
-  yesterday.setDate(today.getDate() - 1);
-
-  if (isSameLocalDay(date, today)) {
-    return strings('perps.today');
-  }
-
-  if (isSameLocalDay(date, yesterday)) {
-    return strings('perps.yesterday');
-  }
-
-  return getIntlDateTimeFormatter('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-};
+const generateGroupedKey = (
+  item: GroupedActivityListItem,
+  index = 0,
+): string => getGroupedActivityListItemKey(item, index);
 
 const noop = () => undefined;
 
@@ -150,34 +112,6 @@ const getBlockExplorerTrackingText = (url: string, fallbackName?: string) => {
   const prefix = strings('transactions.view_full_history_on');
 
   return blockExplorerName ? `${prefix} ${blockExplorerName}` : prefix;
-};
-
-const getActivityValue = (item: ActivityListItem) => {
-  const { data } = item;
-
-  if ('token' in data && data.token?.symbol) {
-    return `${data.token.amount ?? ''} ${data.token.symbol}`.trim();
-  }
-
-  if ('destinationToken' in data && data.destinationToken?.symbol) {
-    return `${data.destinationToken.amount ?? ''} ${
-      data.destinationToken.symbol
-    }`.trim();
-  }
-
-  if ('sourceToken' in data && data.sourceToken?.symbol) {
-    return `${data.sourceToken.amount ?? ''} ${data.sourceToken.symbol}`.trim();
-  }
-
-  return undefined;
-};
-
-const getActivityFromTo = (item: ActivityListItem) => {
-  const { data } = item;
-  return {
-    from: 'from' in data && typeof data.from === 'string' ? data.from : '',
-    to: 'to' in data && typeof data.to === 'string' ? data.to : '',
-  };
 };
 
 interface ActivityListProps {
@@ -846,7 +780,7 @@ const ActivityList = ({
     if (groupedItem.type === 'date-header') {
       return (
         <ListItem.Date style={styles.dateHeader}>
-          {formatDateHeader(groupedItem.date)}
+          {formatActivityListDateHeader(groupedItem.date)}
         </ListItem.Date>
       );
     }

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -102,7 +102,7 @@ const updateIncomingTransactions = () =>
 
 const generateGroupedKey = (
   item: GroupedActivityListItem,
-  index = 0,
+  index: number = 0,
 ): string => getGroupedActivityListItemKey(item, index);
 
 const noop = () => undefined;

--- a/app/components/Views/ActivityView/selectors/featureFlags/index.ts
+++ b/app/components/Views/ActivityView/selectors/featureFlags/index.ts
@@ -1,8 +1,1 @@
-import { createSelector } from 'reselect';
-import { selectRemoteFeatureFlags } from '../../../../../selectors/featureFlagController';
-
-export const selectIsActivityRedesignEnabled = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean =>
-    remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
-);
+export { selectIsActivityRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import {
+  SolScope,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/keyring-api';
+import MultichainAssetDetailsActivityListItem from './MultichainAssetDetailsActivityListItem';
+import Routes from '../../../constants/navigation/Routes';
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+jest.mock('../../../util/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      text: { alternative: 'text-alternative' },
+    },
+  }),
+}));
+
+jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: jest.fn(),
+    createEventBuilder: jest.fn(() => ({
+      addProperties: jest.fn().mockReturnThis(),
+      build: jest.fn(() => ({})),
+    })),
+  }),
+}));
+
+jest.mock('../../hooks/useMultichainTransactionDisplay', () => ({
+  useMultichainTransactionDisplay: jest.fn(() => ({
+    title: 'Send SOL',
+    to: { amount: '1', unit: 'SOL' },
+    isRedeposit: false,
+  })),
+}));
+
+jest.mock('../../UI/ActivityListItemRow/ActivityListItemRow', () => ({
+  ActivityListItemRow: jest.fn(({ onPress, item }) => {
+    const { TouchableOpacity } = jest.requireActual('react-native');
+    return (
+      <TouchableOpacity
+        testID="activity-list-item-row"
+        onPress={() => onPress?.(item)}
+      />
+    );
+  }),
+}));
+
+const createNavigation = () => ({
+  navigate: jest.fn(),
+});
+
+const createTransaction = (overrides = {}) => ({
+  id: 'tx-1',
+  chain: SolScope.Mainnet,
+  status: TransactionStatus.Confirmed,
+  timestamp: 1,
+  type: TransactionType.Send,
+  from: [
+    {
+      address: 'from',
+      asset: {
+        fungible: true,
+        amount: '1',
+        unit: 'SOL',
+        type: `${SolScope.Mainnet}/slip44:501`,
+      },
+    },
+  ],
+  to: [{ address: 'to' }],
+  ...overrides,
+});
+
+describe('MultichainAssetDetailsActivityListItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens multichain details when transaction has import insertion point', () => {
+    const navigation = createNavigation();
+    const transaction = createTransaction({ insertImportTime: true });
+
+    const { getByTestId, queryByTestId } = render(
+      <MultichainAssetDetailsActivityListItem
+        transaction={transaction}
+        index={0}
+        chainId={SolScope.Mainnet}
+        navigation={navigation}
+      />,
+    );
+
+    fireEvent.press(getByTestId('activity-list-item-row'));
+
+    expect(
+      queryByTestId('activity-list-account-import-time-row'),
+    ).not.toBeOnTheScreen();
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      expect.objectContaining({
+        screen: Routes.SHEET.MULTICHAIN_TRANSACTION_DETAILS,
+      }),
+    );
+  });
+});

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import {
   SolScope,
+  type Transaction,
   TransactionStatus,
   TransactionType,
 } from '@metamask/keyring-api';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import MultichainAssetDetailsActivityListItem from './MultichainAssetDetailsActivityListItem';
 import Routes from '../../../constants/navigation/Routes';
 
@@ -50,13 +52,23 @@ jest.mock('../../UI/ActivityListItemRow/ActivityListItemRow', () => ({
   }),
 }));
 
-const createNavigation = () => ({
-  navigate: jest.fn(),
-});
+const createNavigation = () =>
+  ({
+    navigate: jest.fn(),
+  }) as unknown as AppNavigationProp & { navigate: jest.Mock };
 
-const createTransaction = (overrides = {}) => ({
+type TransactionWithImportTime = Transaction & {
+  insertImportTime?: boolean;
+};
+
+const createTransaction = (
+  overrides: Partial<TransactionWithImportTime> = {},
+): TransactionWithImportTime => ({
   id: 'tx-1',
   chain: SolScope.Mainnet,
+  account: 'from',
+  events: [],
+  fees: [],
   status: TransactionStatus.Confirmed,
   timestamp: 1,
   type: TransactionType.Send,
@@ -71,7 +83,7 @@ const createTransaction = (overrides = {}) => ({
       },
     },
   ],
-  to: [{ address: 'to' }],
+  to: [{ address: 'to', asset: null }],
   ...overrides,
 });
 

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Box } from '@metamask/design-system-react-native';
+import type { Transaction } from '@metamask/keyring-api';
+import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
+import Routes from '../../../constants/navigation/Routes';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
+import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
+import { useMultichainTransactionDisplay } from '../../hooks/useMultichainTransactionDisplay';
+import { ActivityListItemRow } from '../../UI/ActivityListItemRow/ActivityListItemRow';
+import {
+  getMultichainTransactionDetailEventProperties,
+  mapMultichainTransactionToActivityItem,
+  TRANSACTION_DETAIL_EVENTS,
+} from './MultichainAssetDetailsActivityListItem.utils';
+
+interface MultichainAssetDetailsActivityListItemProps {
+  transaction: Transaction;
+  chainId: SupportedCaipChainId;
+  navigation: AppNavigationProp;
+  index: number;
+  location?: TransactionDetailLocation;
+}
+
+export const MultichainAssetDetailsActivityListItem = ({
+  transaction,
+  chainId,
+  navigation,
+  index,
+  location,
+}: MultichainAssetDetailsActivityListItemProps) => {
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const displayData = useMultichainTransactionDisplay(transaction, chainId);
+  const activityItem = mapMultichainTransactionToActivityItem({
+    transaction,
+    chainId,
+  });
+
+  const handlePress = () => {
+    trackEvent(
+      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+        .addProperties(
+          getMultichainTransactionDetailEventProperties({
+            transaction,
+            chainId,
+            location,
+          }),
+        )
+        .build(),
+    );
+
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.MULTICHAIN_TRANSACTION_DETAILS,
+      params: { displayData, transaction },
+    });
+  };
+
+  return (
+    <Box twClassName="px-4">
+      <ActivityListItemRow
+        item={activityItem}
+        index={index}
+        onPress={handlePress}
+        title={displayData.title}
+      />
+    </Box>
+  );
+};
+
+export default MultichainAssetDetailsActivityListItem;

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Box } from '@metamask/design-system-react-native';
 import type { Transaction } from '@metamask/keyring-api';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
@@ -36,7 +36,7 @@ export const MultichainAssetDetailsActivityListItem = ({
     chainId,
   });
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     trackEvent(
       createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
         .addProperties(
@@ -53,7 +53,15 @@ export const MultichainAssetDetailsActivityListItem = ({
       screen: Routes.SHEET.MULTICHAIN_TRANSACTION_DETAILS,
       params: { displayData, transaction },
     });
-  };
+  }, [
+    chainId,
+    createEventBuilder,
+    displayData,
+    location,
+    navigation,
+    trackEvent,
+    transaction,
+  ]);
 
   return (
     <Box twClassName="px-4">

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.utils.test.ts
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.utils.test.ts
@@ -1,0 +1,92 @@
+import {
+  SolScope,
+  type Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/keyring-api';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
+import {
+  getMultichainTransactionDetailEventProperties,
+  mapMultichainTransactionToActivityItem,
+} from './MultichainAssetDetailsActivityListItem.utils';
+
+const createTransaction = (overrides: Partial<Transaction> = {}): Transaction =>
+  ({
+    id: 'tx-1',
+    account: 'from',
+    chain: SolScope.Mainnet,
+    events: [],
+    fees: [],
+    status: TransactionStatus.Confirmed,
+    timestamp: 1,
+    type: TransactionType.Send,
+    from: [
+      {
+        address: 'from',
+        asset: {
+          fungible: true,
+          amount: '1',
+          unit: 'SOL',
+          type: `${SolScope.Mainnet}/slip44:501`,
+        },
+      },
+    ],
+    to: [{ address: 'to', asset: null }],
+    ...overrides,
+  }) as Transaction;
+
+describe('MultichainAssetDetailsActivityListItem utils', () => {
+  it('maps keyring transaction to activity item with fallback chain id', () => {
+    const transaction = createTransaction({ chain: undefined });
+
+    const item = mapMultichainTransactionToActivityItem({
+      transaction,
+      chainId: SolScope.Mainnet,
+    });
+
+    expect(item).toEqual(
+      expect.objectContaining({
+        chainId: SolScope.Mainnet,
+        hash: 'tx-1',
+        raw: expect.objectContaining({
+          type: 'keyringTransaction',
+        }),
+        type: 'send',
+      }),
+    );
+  });
+
+  it('builds transaction detail event properties with asset details location', () => {
+    const transaction = createTransaction();
+
+    expect(
+      getMultichainTransactionDetailEventProperties({
+        transaction,
+        chainId: SolScope.Mainnet,
+        location: TransactionDetailLocation.AssetDetails,
+      }),
+    ).toStrictEqual({
+      transaction_type: TransactionType.Send,
+      transaction_status: TransactionStatus.Confirmed,
+      location: TransactionDetailLocation.AssetDetails,
+      chain_id_source: SolScope.Mainnet,
+      chain_id_destination: SolScope.Mainnet,
+    });
+  });
+
+  it('defaults transaction detail event location to home', () => {
+    const transaction = createTransaction({ status: undefined });
+
+    expect(
+      getMultichainTransactionDetailEventProperties({
+        transaction,
+        chainId: SolScope.Mainnet,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        location: TransactionDetailLocation.Home,
+        transaction_status: 'unknown',
+      }),
+    );
+  });
+});

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.utils.ts
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.utils.ts
@@ -1,0 +1,39 @@
+import type { Transaction } from '@metamask/keyring-api';
+import type { SupportedCaipChainId } from '@metamask/multichain-network-controller';
+import {
+  TRANSACTION_DETAIL_EVENTS,
+  TransactionDetailLocation,
+} from '../../../core/Analytics/events/transactions';
+import { mapKeyringTransaction } from '../../../util/activity-adapters';
+
+export const mapMultichainTransactionToActivityItem = ({
+  transaction,
+  chainId,
+}: {
+  transaction: Transaction;
+  chainId: SupportedCaipChainId;
+}) =>
+  mapKeyringTransaction({
+    transaction: {
+      ...transaction,
+      chain: transaction.chain ?? chainId,
+    },
+  });
+
+export const getMultichainTransactionDetailEventProperties = ({
+  transaction,
+  chainId,
+  location,
+}: {
+  transaction: Transaction;
+  chainId: SupportedCaipChainId;
+  location?: TransactionDetailLocation;
+}) => ({
+  transaction_type: transaction.type?.toLowerCase() ?? 'unknown',
+  transaction_status: transaction.status ?? 'unknown',
+  location: location ?? TransactionDetailLocation.Home,
+  chain_id_source: String(chainId),
+  chain_id_destination: String(chainId),
+});
+
+export { TRANSACTION_DETAIL_EVENTS };

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -9,6 +9,9 @@ import { selectSelectedInternalAccountFormattedAddress } from '../../../selector
 import { ButtonProps } from '../../../component-library/components/Buttons/Button/Button.types';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { configureUseAnalyticsExternalLinkMock } from '../../../util/test/analyticsMock';
+import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
+import { ActivityListItemRow } from '../../UI/ActivityListItemRow/ActivityListItemRow';
+import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 jest.useFakeTimers();
 
 jest.mock('../../../util/analytics/externalLinkTracking', () => ({
@@ -33,6 +36,19 @@ jest.mock(
   '../../UI/MultichainTransactionListItem',
   () => 'MockTransactionListItem',
 );
+jest.mock('../../UI/ActivityListItemRow/ActivityListItemRow', () => ({
+  ActivityListItemRow: jest.fn(() => null),
+}));
+jest.mock('../../../selectors/featureFlagController/activityRedesign', () => ({
+  selectIsActivityRedesignEnabled: jest.fn(() => false),
+}));
+jest.mock('../../hooks/useMultichainTransactionDisplay', () => ({
+  useMultichainTransactionDisplay: jest.fn(() => ({
+    title: 'Send TRX',
+    to: { amount: '1', unit: 'TRX' },
+    isRedeposit: false,
+  })),
+}));
 jest.mock('../../../component-library/components/Buttons/Button', () => {
   const ButtonVariants = { Link: 'Link', Primary: 'Primary' };
   const ButtonSize = { Lg: 'Lg', Md: 'Md' };
@@ -133,6 +149,9 @@ describe('MultichainTransactionsView', () => {
       if (selector === selectNonEvmTransactions) {
         return mockTransactionsData;
       }
+      if (selector === selectIsActivityRedesignEnabled) {
+        return false;
+      }
       return null;
     });
   });
@@ -168,6 +187,40 @@ describe('MultichainTransactionsView', () => {
 
     const transactionItems = queryAllByTestId('transaction-item');
     expect(transactionItems.length).toBe(2);
+  });
+
+  it('renders redesigned activity rows for asset details when activity redesign is enabled', async () => {
+    (useSelector as jest.Mock).mockImplementation((selector) => {
+      if (selector === selectSelectedInternalAccountFormattedAddress) {
+        return mockSelectedAddress;
+      }
+      if (selector === selectNonEvmTransactions) {
+        return { transactions: mockTransactions };
+      }
+      if (selector === selectIsActivityRedesignEnabled) {
+        return true;
+      }
+      return null;
+    });
+
+    customRender(
+      <MultichainTransactionsView
+        selectedAddress={mockSelectedAddress}
+        chainId={SolScope.Mainnet}
+        location={TransactionDetailLocation.AssetDetails}
+      />,
+    );
+
+    expect(ActivityListItemRow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 0,
+        title: 'Send TRX',
+        item: expect.objectContaining({
+          type: 'send',
+        }),
+      }),
+      undefined,
+    );
   });
 
   it('does not render view more link for bitcoin activity', async () => {

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.test.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react-native';
-import { BtcScope, SolScope, TransactionType } from '@metamask/keyring-api';
+import {
+  BtcScope,
+  SolScope,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/keyring-api';
 import MultichainTransactionsView from './MultichainTransactionsView';
 import { selectNonEvmTransactions } from '../../../selectors/multichain';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
@@ -105,7 +110,8 @@ describe('MultichainTransactionsView', () => {
       to: [{ address: '5FHwkrdxD5AKmYrGNQYV66qPt3YxmkBzMJ8youBGNFAY' }],
       value: '1500000000',
       type: TransactionType.Send,
-      timestamp: 1742313600000,
+      status: TransactionStatus.Confirmed,
+      timestamp: 1742313600,
     },
     {
       id: 'tx-456',
@@ -114,7 +120,8 @@ describe('MultichainTransactionsView', () => {
       to: [{ address: '7RoSF9fUNf1XgRYsb7Qh4SoVkRmirHzZVELGNiNQzZNV' }],
       value: '2000000000',
       type: TransactionType.Receive,
-      timestamp: 1742400000000,
+      status: TransactionStatus.Confirmed,
+      timestamp: 1742400000,
     },
   ];
 
@@ -137,6 +144,22 @@ describe('MultichainTransactionsView', () => {
     jest.clearAllTimers();
 
     configureUseAnalyticsExternalLinkMock();
+    mockUseTheme.mockReturnValue({
+      colors: {
+        background: {
+          alternative: 'background-alternative',
+          default: 'background-default',
+        },
+        border: { muted: 'border-muted' },
+        icon: { default: 'icon-default' },
+        primary: { default: 'primary-default' },
+        text: {
+          alternative: 'text-alternative',
+          default: 'text-default',
+        },
+      },
+      typography: {},
+    });
 
     // Ensure selector returns a static instance
     const mockTransactionsData = { transactions: mockTransactions };
@@ -203,7 +226,7 @@ describe('MultichainTransactionsView', () => {
       return null;
     });
 
-    customRender(
+    const { queryAllByTestId } = customRender(
       <MultichainTransactionsView
         selectedAddress={mockSelectedAddress}
         chainId={SolScope.Mainnet}
@@ -213,7 +236,7 @@ describe('MultichainTransactionsView', () => {
 
     expect(ActivityListItemRow).toHaveBeenCalledWith(
       expect.objectContaining({
-        index: 0,
+        index: 1,
         title: 'Send TRX',
         item: expect.objectContaining({
           type: 'send',
@@ -221,6 +244,7 @@ describe('MultichainTransactionsView', () => {
       }),
       undefined,
     );
+    expect(queryAllByTestId('activity-list-date-header')).toHaveLength(2);
   });
 
   it('does not render view more link for bitcoin activity', async () => {

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -33,6 +33,8 @@ import { TabEmptyState } from '../../../component-library/components-temp/TabEmp
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
 import { useMultichainActivityMaliciousTokenKeys } from '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys';
 import { filterMultichainTransactionsExcludingMaliciousTokenActivity } from '../../../util/multichain/multichainTransactionTokenScan';
+import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
+import MultichainAssetDetailsActivityListItem from './MultichainAssetDetailsActivityListItem';
 
 interface MultichainTransactionsViewProps {
   /**
@@ -123,6 +125,9 @@ const MultichainTransactionsView = ({
   );
 
   const { bridgeHistoryItemsBySrcTxHash } = useBridgeHistoryItemBySrcTxHash();
+  const isActivityRedesignEnabled = useSelector(
+    selectIsActivityRedesignEnabled,
+  );
 
   const [refreshing, setRefreshing] = React.useState(false);
 
@@ -175,15 +180,34 @@ const MultichainTransactionsView = ({
     const srcTxHash = item.id;
     const bridgeHistoryItem = bridgeHistoryItemsBySrcTxHash[srcTxHash];
 
-    return bridgeHistoryItem ? (
-      <MultichainBridgeTransactionListItem
-        transaction={item}
-        bridgeHistoryItem={bridgeHistoryItem}
-        navigation={nav}
-        index={index}
-        location={location}
-      />
-    ) : (
+    if (bridgeHistoryItem) {
+      return (
+        <MultichainBridgeTransactionListItem
+          transaction={item}
+          bridgeHistoryItem={bridgeHistoryItem}
+          navigation={nav}
+          index={index}
+          location={location}
+        />
+      );
+    }
+
+    if (
+      isActivityRedesignEnabled &&
+      location === TransactionDetailLocation.AssetDetails
+    ) {
+      return (
+        <MultichainAssetDetailsActivityListItem
+          transaction={item}
+          navigation={nav}
+          index={index}
+          chainId={chainId}
+          location={location}
+        />
+      );
+    }
+
+    return (
       <MultichainTransactionListItem
         transaction={item}
         navigation={nav}

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -295,7 +295,24 @@ const MultichainTransactionsView = ({
     }
 
     if ('type' in item && item.type === 'item') {
-      return item.item.hash ?? `${item.item.timestamp}-${index}`;
+      const raw = item.item.raw;
+      if (raw?.type === 'keyringTransaction' && raw.data.id) {
+        return `keyring-transaction-${raw.data.id}`;
+      }
+
+      if (raw?.type === 'localTransaction') {
+        const txId =
+          raw.data.primaryTransaction?.id ?? raw.data.initialTransaction?.id;
+        if (txId) {
+          return `local-transaction-${txId}`;
+        }
+      }
+
+      if (raw?.type === 'apiEvmTransaction' && item.item.hash) {
+        return `api-evm-transaction-${item.item.hash}`;
+      }
+
+      return `${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
     }
 
     return item.id;

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -35,6 +35,7 @@ import { useMultichainActivityMaliciousTokenKeys } from '../../hooks/useMulticha
 import { filterMultichainTransactionsExcludingMaliciousTokenActivity } from '../../../util/multichain/multichainTransactionTokenScan';
 import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
 import {
+  getGroupedActivityListItemKey,
   groupActivityListItems,
   type GroupedActivityListItem,
 } from '../../../util/activity-adapters';
@@ -295,24 +296,7 @@ const MultichainTransactionsView = ({
     }
 
     if ('type' in item && item.type === 'item') {
-      const raw = item.item.raw;
-      if (raw?.type === 'keyringTransaction' && raw.data.id) {
-        return `keyring-transaction-${raw.data.id}`;
-      }
-
-      if (raw?.type === 'localTransaction') {
-        const txId =
-          raw.data.primaryTransaction?.id ?? raw.data.initialTransaction?.id;
-        if (txId) {
-          return `local-transaction-${txId}`;
-        }
-      }
-
-      if (raw?.type === 'apiEvmTransaction' && item.item.hash) {
-        return `api-evm-transaction-${item.item.hash}`;
-      }
-
-      return `${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
+      return getGroupedActivityListItemKey(item, index);
     }
 
     return item.id;

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -250,7 +250,7 @@ const MultichainTransactionsView = ({
     index: number;
   }) => {
     if (item.type === 'pending-header') {
-      return <ActivityListDateHeader label={strings('transactions.pending')} />;
+      return <ActivityListDateHeader label={strings('transaction.pending')} />;
     }
 
     if (item.type === 'date-header') {

--- a/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainTransactionsView.tsx
@@ -34,7 +34,13 @@ import { TransactionDetailLocation } from '../../../core/Analytics/events/transa
 import { useMultichainActivityMaliciousTokenKeys } from '../../hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys';
 import { filterMultichainTransactionsExcludingMaliciousTokenActivity } from '../../../util/multichain/multichainTransactionTokenScan';
 import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
+import {
+  groupActivityListItems,
+  type GroupedActivityListItem,
+} from '../../../util/activity-adapters';
+import ActivityListDateHeader from '../../UI/ActivityListItemRow/ActivityListDateHeader';
 import MultichainAssetDetailsActivityListItem from './MultichainAssetDetailsActivityListItem';
+import { mapMultichainTransactionToActivityItem } from './MultichainAssetDetailsActivityListItem.utils';
 
 interface MultichainTransactionsViewProps {
   /**
@@ -128,6 +134,23 @@ const MultichainTransactionsView = ({
   const isActivityRedesignEnabled = useSelector(
     selectIsActivityRedesignEnabled,
   );
+  const shouldUseActivityRedesign =
+    isActivityRedesignEnabled &&
+    location === TransactionDetailLocation.AssetDetails;
+  const activityListData = useMemo(
+    () =>
+      shouldUseActivityRedesign
+        ? groupActivityListItems(
+            visibleMultichainTransactions.map((transaction) =>
+              mapMultichainTransactionToActivityItem({
+                transaction,
+                chainId,
+              }),
+            ),
+          )
+        : visibleMultichainTransactions,
+    [chainId, shouldUseActivityRedesign, visibleMultichainTransactions],
+  );
 
   const [refreshing, setRefreshing] = React.useState(false);
 
@@ -218,15 +241,75 @@ const MultichainTransactionsView = ({
     );
   };
 
+  const renderGroupedActivityItem = ({
+    item,
+    index,
+  }: {
+    item: GroupedActivityListItem;
+    index: number;
+  }) => {
+    if (item.type === 'pending-header') {
+      return <ActivityListDateHeader label={strings('transactions.pending')} />;
+    }
+
+    if (item.type === 'date-header') {
+      return <ActivityListDateHeader timestamp={item.date} />;
+    }
+
+    const transaction =
+      item.item.raw?.type === 'keyringTransaction'
+        ? item.item.raw.data
+        : undefined;
+
+    if (!transaction) {
+      return null;
+    }
+
+    return renderTransactionItem({ item: transaction, index });
+  };
+
+  const renderListItem = ({
+    item,
+    index,
+  }: {
+    item: Transaction | GroupedActivityListItem;
+    index: number;
+  }) =>
+    shouldUseActivityRedesign
+      ? renderGroupedActivityItem({
+          item: item as GroupedActivityListItem,
+          index,
+        })
+      : renderTransactionItem({ item: item as Transaction, index });
+
+  const keyExtractor = (
+    item: Transaction | GroupedActivityListItem,
+    index: number,
+  ) => {
+    if ('type' in item && item.type === 'pending-header') {
+      return 'pending-header';
+    }
+
+    if ('type' in item && item.type === 'date-header') {
+      return `date-header-${item.date}`;
+    }
+
+    if ('type' in item && item.type === 'item') {
+      return item.item.hash ?? `${item.item.timestamp}-${index}`;
+    }
+
+    return item.id;
+  };
+
   return (
     <PriceChartProvider>
       <View style={style.wrapper}>
         <PriceChartContext.Consumer>
           {({ isChartBeingTouched }) => (
             <FlashList
-              data={visibleMultichainTransactions}
-              renderItem={renderTransactionItem}
-              keyExtractor={(item) => item.id}
+              data={activityListData}
+              renderItem={renderListItem}
+              keyExtractor={keyExtractor}
               ListHeaderComponent={header}
               ListEmptyComponent={renderEmptyList}
               ListFooterComponent={footer}

--- a/app/selectors/featureFlagController/activityRedesign/index.ts
+++ b/app/selectors/featureFlagController/activityRedesign/index.ts
@@ -3,6 +3,6 @@ import { selectRemoteFeatureFlags } from '..';
 
 export const selectIsActivityRedesignEnabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean =>
-    remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
+  (remoteFeatureFlags): boolean => true,
+  // remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
 );

--- a/app/selectors/featureFlagController/activityRedesign/index.ts
+++ b/app/selectors/featureFlagController/activityRedesign/index.ts
@@ -3,6 +3,6 @@ import { selectRemoteFeatureFlags } from '..';
 
 export const selectIsActivityRedesignEnabled = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean => true,
-  // remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
+  (remoteFeatureFlags): boolean =>
+    remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
 );

--- a/app/selectors/featureFlagController/activityRedesign/index.ts
+++ b/app/selectors/featureFlagController/activityRedesign/index.ts
@@ -1,0 +1,8 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+
+export const selectIsActivityRedesignEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean =>
+    remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
+);

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -1,9 +1,17 @@
 import type { ActivityListItem } from './types';
 import {
   activityMatchesAssetId,
+  formatActivityListDateHeader,
+  getActivityFromTo,
+  getActivityValue,
+  getGroupedActivityListItemKey,
   groupActivityListItems,
   shouldShowPlusSign,
 } from './activity-list-helpers';
+
+jest.mock('../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
 
 function makeItem(overrides: Partial<ActivityListItem> = {}): ActivityListItem {
   return {
@@ -32,6 +40,10 @@ function localDay(timestamp: number) {
 }
 
 describe('activity list helpers', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('hides plus signs for spending-cap activity types', () => {
     expect(shouldShowPlusSign('approveSpendingCap')).toBe(false);
     expect(shouldShowPlusSign('increaseSpendingCap')).toBe(false);
@@ -92,5 +104,133 @@ describe('activity list helpers', () => {
       { type: 'date-header', date: localDay(secondHistorical.timestamp) },
       { type: 'item', item: secondHistorical },
     ]);
+  });
+
+  it('formats date headers for today, yesterday, and older dates', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2026, 5, 19, 12));
+
+    expect(
+      formatActivityListDateHeader(new Date(2026, 5, 19, 1).getTime()),
+    ).toBe('perps.today');
+    expect(
+      formatActivityListDateHeader(new Date(2026, 5, 18, 1).getTime()),
+    ).toBe('perps.yesterday');
+    expect(
+      formatActivityListDateHeader(new Date(2026, 5, 17, 1).getTime()),
+    ).toBe('Jun 17, 2026');
+  });
+
+  it('extracts display value from supported token fields', () => {
+    const tokenItem = makeItem({
+      data: {
+        token: {
+          amount: '1',
+          direction: 'out',
+          symbol: 'ETH',
+        },
+      },
+    });
+    const destinationTokenItem = makeItem({
+      data: {
+        destinationToken: {
+          amount: '2',
+          direction: 'in',
+          symbol: 'USDC',
+        },
+      },
+      type: 'swap',
+    });
+    const sourceTokenItem = makeItem({
+      data: {
+        sourceToken: {
+          amount: '3',
+          direction: 'out',
+          symbol: 'DAI',
+        },
+      },
+      type: 'swapIncomplete',
+    });
+
+    expect(getActivityValue(tokenItem)).toBe('1 ETH');
+    expect(getActivityValue(destinationTokenItem)).toBe('2 USDC');
+    expect(getActivityValue(sourceTokenItem)).toBe('3 DAI');
+    expect(getActivityValue(makeItem({ data: {} }))).toBeUndefined();
+  });
+
+  it('extracts from and to addresses when present', () => {
+    expect(
+      getActivityFromTo(
+        makeItem({
+          data: {
+            from: '0xfrom',
+            to: '0xto',
+          },
+        }),
+      ),
+    ).toStrictEqual({ from: '0xfrom', to: '0xto' });
+    expect(getActivityFromTo(makeItem({ data: {} }))).toStrictEqual({
+      from: '',
+      to: '',
+    });
+  });
+
+  it('generates stable keys for grouped activity rows', () => {
+    const localTransactionItem = makeItem({
+      raw: {
+        type: 'localTransaction',
+        data: {
+          primaryTransaction: { id: 'local-tx-id' },
+          initialTransaction: { id: 'initial-tx-id' },
+        },
+      },
+    } as Partial<ActivityListItem>);
+    const keyringTransactionItem = makeItem({
+      hash: 'keyring-hash',
+      raw: {
+        type: 'keyringTransaction',
+        data: { id: 'keyring-tx-id' },
+      },
+    } as Partial<ActivityListItem>);
+    const apiTransactionItem = makeItem({
+      hash: '0xapi',
+      raw: {
+        type: 'apiEvmTransaction',
+        data: {},
+      },
+    } as Partial<ActivityListItem>);
+    const fallbackItem = makeItem({
+      hash: undefined,
+      timestamp: 123,
+      type: 'contractInteraction',
+    });
+
+    expect(getGroupedActivityListItemKey({ type: 'pending-header' }, 0)).toBe(
+      'pending-header',
+    );
+    expect(
+      getGroupedActivityListItemKey({ type: 'date-header', date: 456 }, 0),
+    ).toBe('date-header-456');
+    expect(
+      getGroupedActivityListItemKey(
+        { type: 'item', item: localTransactionItem },
+        0,
+      ),
+    ).toBe('local-transaction-local-tx-id');
+    expect(
+      getGroupedActivityListItemKey(
+        { type: 'item', item: keyringTransactionItem },
+        0,
+      ),
+    ).toBe('keyring-transaction-keyring-tx-id');
+    expect(
+      getGroupedActivityListItemKey(
+        { type: 'item', item: apiTransactionItem },
+        0,
+      ),
+    ).toBe('api-evm-transaction-0xapi');
+    expect(
+      getGroupedActivityListItemKey({ type: 'item', item: fallbackItem }, 7),
+    ).toBe('contractInteraction-123-7');
   });
 });

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -216,21 +216,46 @@ describe('activity list helpers', () => {
         { type: 'item', item: localTransactionItem },
         0,
       ),
-    ).toBe('local-transaction-local-tx-id');
+    ).toBe('local-transaction-eip155:1-local-tx-id');
     expect(
       getGroupedActivityListItemKey(
         { type: 'item', item: keyringTransactionItem },
         0,
       ),
-    ).toBe('keyring-transaction-keyring-tx-id');
+    ).toBe('keyring-transaction-eip155:1-keyring-tx-id');
     expect(
       getGroupedActivityListItemKey(
         { type: 'item', item: apiTransactionItem },
         0,
       ),
-    ).toBe('api-evm-transaction-0xapi');
+    ).toBe('api-evm-transaction-eip155:1-0xapi');
     expect(
       getGroupedActivityListItemKey({ type: 'item', item: fallbackItem }, 7),
-    ).toBe('contractInteraction-123-7');
+    ).toBe('eip155:1-contractInteraction-123-7');
+  });
+
+  it('uses chain id and row index in fallback keys', () => {
+    const firstItem = makeItem({
+      chainId: 'eip155:1',
+      hash: undefined,
+      timestamp: 123,
+      type: 'contractInteraction',
+    });
+    const secondItem = makeItem({
+      chainId: 'eip155:137',
+      hash: undefined,
+      timestamp: 123,
+      type: 'contractInteraction',
+    });
+
+    expect(
+      getGroupedActivityListItemKey({ type: 'item', item: firstItem }, 0),
+    ).toBe('eip155:1-contractInteraction-123-0');
+    expect(
+      getGroupedActivityListItemKey({ type: 'item', item: firstItem }, 1),
+    ).toBe('eip155:1-contractInteraction-123-1');
+    expect(
+      getGroupedActivityListItemKey({ type: 'item', item: secondItem }, 0),
+    ).toBe('eip155:137-contractInteraction-123-0');
   });
 });

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -158,6 +158,22 @@ describe('activity list helpers', () => {
     expect(getActivityValue(makeItem({ data: {} }))).toBeUndefined();
   });
 
+  it('extracts unlimited approval display value from token metadata', () => {
+    const item = makeItem({
+      data: {
+        token: {
+          amount: '115792089237316195423570985.639935',
+          direction: 'out',
+          isUnlimitedApproval: true,
+          symbol: 'USDT',
+        },
+      },
+      type: 'approveSpendingCap',
+    });
+
+    expect(getActivityValue(item)).toBe('confirm.unlimited USDT');
+  });
+
   it('extracts from and to addresses when present', () => {
     expect(
       getActivityFromTo(

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -93,23 +93,24 @@ export const getGroupedActivityListItemKey = (
   }
 
   const raw = item.item.raw;
+  const { chainId } = item.item;
   if (raw?.type === 'localTransaction') {
     const txId =
       raw.data.primaryTransaction?.id ?? raw.data.initialTransaction?.id;
     if (txId) {
-      return `local-transaction-${txId}`;
+      return `local-transaction-${chainId}-${txId}`;
     }
   }
 
   if (raw?.type === 'keyringTransaction' && raw.data.id) {
-    return `keyring-transaction-${raw.data.id}`;
+    return `keyring-transaction-${chainId}-${raw.data.id}`;
   }
 
   if (raw?.type === 'apiEvmTransaction' && item.item.hash) {
-    return `api-evm-transaction-${item.item.hash}`;
+    return `api-evm-transaction-${chainId}-${item.item.hash}`;
   }
 
-  return `${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
+  return `${chainId}-${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
 };
 
 export function activityMatchesAssetId(

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -1,4 +1,5 @@
 import type { CaipAssetType } from '@metamask/utils';
+import { strings } from '../../../locales/i18n';
 import {
   mobileActivityAdapterEnvironment,
   type ActivityAdapterEnvironment,
@@ -23,6 +24,93 @@ export type GroupedActivityListItem =
 export function shouldShowPlusSign(activityType: ActivityListItem['type']) {
   return !hidePlusSignActivityTypes.has(activityType);
 }
+
+export const isSameLocalDay = (date: Date, otherDate: Date) =>
+  date.getFullYear() === otherDate.getFullYear() &&
+  date.getMonth() === otherDate.getMonth() &&
+  date.getDate() === otherDate.getDate();
+
+export const formatActivityListDateHeader = (timestamp: number) => {
+  const date = new Date(timestamp);
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  if (isSameLocalDay(date, today)) {
+    return strings('perps.today');
+  }
+
+  if (isSameLocalDay(date, yesterday)) {
+    return strings('perps.yesterday');
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+};
+
+export const getActivityValue = (item: ActivityListItem) => {
+  const { data } = item;
+
+  if ('token' in data && data.token?.symbol) {
+    return `${data.token.amount ?? ''} ${data.token.symbol}`.trim();
+  }
+
+  if ('destinationToken' in data && data.destinationToken?.symbol) {
+    return `${data.destinationToken.amount ?? ''} ${
+      data.destinationToken.symbol
+    }`.trim();
+  }
+
+  if ('sourceToken' in data && data.sourceToken?.symbol) {
+    return `${data.sourceToken.amount ?? ''} ${data.sourceToken.symbol}`.trim();
+  }
+
+  return undefined;
+};
+
+export const getActivityFromTo = (item: ActivityListItem) => {
+  const { data } = item;
+
+  return {
+    from: 'from' in data && typeof data.from === 'string' ? data.from : '',
+    to: 'to' in data && typeof data.to === 'string' ? data.to : '',
+  };
+};
+
+export const getGroupedActivityListItemKey = (
+  item: GroupedActivityListItem,
+  index: number,
+) => {
+  if (item.type === 'pending-header') {
+    return 'pending-header';
+  }
+
+  if (item.type === 'date-header') {
+    return `date-header-${item.date}`;
+  }
+
+  const raw = item.item.raw;
+  if (raw?.type === 'localTransaction') {
+    const txId =
+      raw.data.primaryTransaction?.id ?? raw.data.initialTransaction?.id;
+    if (txId) {
+      return `local-transaction-${txId}`;
+    }
+  }
+
+  if (raw?.type === 'keyringTransaction' && raw.data.id) {
+    return `keyring-transaction-${raw.data.id}`;
+  }
+
+  if (raw?.type === 'apiEvmTransaction' && item.item.hash) {
+    return `api-evm-transaction-${item.item.hash}`;
+  }
+
+  return `${item.item.type}-${item.item.hash ?? item.item.timestamp}-${index}`;
+};
 
 export function activityMatchesAssetId(
   item: ActivityListItem,

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -4,7 +4,7 @@ import {
   mobileActivityAdapterEnvironment,
   type ActivityAdapterEnvironment,
 } from './adapters/environment';
-import type { ActivityListItem } from './types';
+import type { ActivityListItem, TokenAmount } from './types';
 
 const hidePlusSignActivityTypes = new Set<ActivityListItem['type']>([
   'approveSpendingCap',
@@ -51,21 +51,27 @@ export const formatActivityListDateHeader = (timestamp: number) => {
   }).format(date);
 };
 
+const getTokenActivityValue = (token: TokenAmount) => {
+  const amount = token.isUnlimitedApproval
+    ? strings('confirm.unlimited')
+    : (token.amount ?? '');
+
+  return `${amount} ${token.symbol}`.trim();
+};
+
 export const getActivityValue = (item: ActivityListItem) => {
   const { data } = item;
 
   if ('token' in data && data.token?.symbol) {
-    return `${data.token.amount ?? ''} ${data.token.symbol}`.trim();
+    return getTokenActivityValue(data.token);
   }
 
   if ('destinationToken' in data && data.destinationToken?.symbol) {
-    return `${data.destinationToken.amount ?? ''} ${
-      data.destinationToken.symbol
-    }`.trim();
+    return getTokenActivityValue(data.destinationToken);
   }
 
   if ('sourceToken' in data && data.sourceToken?.symbol) {
-    return `${data.sourceToken.amount ?? ''} ${data.sourceToken.symbol}`.trim();
+    return getTokenActivityValue(data.sourceToken);
   }
 
   return undefined;

--- a/app/util/activity-adapters/adapters/api-evm-transactions.test.ts
+++ b/app/util/activity-adapters/adapters/api-evm-transactions.test.ts
@@ -24,6 +24,7 @@ const buildApproveData = (spender: string, amount: bigint) =>
   `${approveFunctionSignature}${spender
     .replace('0x', '')
     .padStart(64, '0')}${amount.toString(16).padStart(64, '0')}`;
+const maxUint256 = 2n ** 256n - 1n;
 
 const withoutRaw = (item: ReturnType<typeof mapApiEvmTransactions>) => {
   const activity = { ...item };
@@ -139,6 +140,46 @@ describe('mapApiEvmTransactions', () => {
           symbol: 'USDC',
           decimals: 6,
           assetId: toAssetId(baseUsdc, 'eip155:8453'),
+        },
+      },
+    });
+  });
+
+  it('marks unlimited approval amounts from full calldata', () => {
+    const transaction = {
+      hash: '0x91f89897197afcc09ad98ec4282366fd7938d8a9609e4fc2a0aa2d070664bc27',
+      timestamp: '2026-05-27T13:20:27.000Z',
+      chainId: 8453,
+      accountId: `eip155:8453:${subjectAddress}`,
+      methodId: approveFunctionSignature,
+      input: buildApproveData(baseRecipientAddress, maxUint256),
+      value: '0',
+      to: baseUsdc,
+      from: subjectAddress,
+      isError: false,
+      valueTransfers: [],
+      logs: [],
+      transactionProtocol: 'ERC_20',
+      transactionCategory: 'APPROVE',
+      transactionType: 'ERC_20_APPROVE',
+    } as unknown as V1TransactionByHashResponse;
+
+    expect(
+      withoutRaw(mapApiEvmTransactions({ subjectAddress, transaction })),
+    ).toStrictEqual({
+      type: 'approveSpendingCap',
+      chainId: 'eip155:8453',
+      status: 'success',
+      timestamp: 1779888027000,
+      hash: '0x91f89897197afcc09ad98ec4282366fd7938d8a9609e4fc2a0aa2d070664bc27',
+      data: {
+        token: {
+          amount: maxUint256.toString(),
+          direction: 'out',
+          symbol: 'USDC',
+          decimals: 6,
+          assetId: toAssetId(baseUsdc, 'eip155:8453'),
+          isUnlimitedApproval: true,
         },
       },
     });

--- a/app/util/activity-adapters/adapters/api-evm-transactions.ts
+++ b/app/util/activity-adapters/adapters/api-evm-transactions.ts
@@ -13,6 +13,7 @@ import {
   getTokenMetadataFromKnownToken,
   getTokenAmountFromTransfer,
   getTokenApprovalAmountFromData,
+  isUnlimitedApprovalAmount,
   isNftTransferType,
   isNativeTransferType,
   withFallbackTokenAssetId,
@@ -191,6 +192,16 @@ export function mapApiEvmTransactions({
       getTransactionCalldata(transaction),
       environment,
     );
+    const token =
+      approveToken && approveAmount
+        ? {
+            ...approveToken,
+            amount: approveAmount,
+            ...(isUnlimitedApprovalAmount(approveAmount, approveToken.decimals)
+              ? { isUnlimitedApproval: true }
+              : {}),
+          }
+        : approveToken;
 
     return {
       type: 'approveSpendingCap',
@@ -200,10 +211,7 @@ export function mapApiEvmTransactions({
       hash,
       raw: { type: 'apiEvmTransaction', data: transaction },
       data: {
-        token:
-          approveToken && approveAmount
-            ? { ...approveToken, amount: approveAmount }
-            : approveToken,
+        token,
       },
     };
   }

--- a/app/util/activity-adapters/adapters/helpers.ts
+++ b/app/util/activity-adapters/adapters/helpers.ts
@@ -19,6 +19,7 @@ import {
 } from './environment';
 
 const MAINNET_HEX_CHAIN_ID = '0x1';
+const TOKEN_VALUE_UNLIMITED_THRESHOLD = 10 ** 15;
 
 export type ValueTransfer = NonNullable<
   V1TransactionByHashResponse['valueTransfers']
@@ -80,6 +81,19 @@ export function getTokenApprovalAmountFromData(
 
   return stringifyParsedTokenAmount(
     args._value ?? args.value ?? args.amount ?? args[1],
+  );
+}
+
+export function isUnlimitedApprovalAmount(
+  amount: string | undefined,
+  decimals = 0,
+): boolean {
+  if (!amount) {
+    return false;
+  }
+
+  return (
+    Number.parseFloat(amount) / 10 ** decimals > TOKEN_VALUE_UNLIMITED_THRESHOLD
   );
 }
 

--- a/app/util/activity-adapters/adapters/keyring-transaction.test.ts
+++ b/app/util/activity-adapters/adapters/keyring-transaction.test.ts
@@ -165,4 +165,60 @@ describe('mapKeyringTransaction', () => {
       }),
     );
   });
+
+  it('maps token approvals as spending-cap activity with unlimited metadata', () => {
+    const item = mapKeyringTransaction({
+      transaction: {
+        id: 'approve-id',
+        chain: SOLANA_CHAIN_ID,
+        account: '00000000-0000-4000-8000-000000000000',
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenApprove,
+        from: [
+          {
+            address: 'owner-address',
+            asset: {
+              fungible: true,
+              type: `${SOLANA_CHAIN_ID}/token:usdt`,
+              unit: 'USDT',
+              amount: '115792089237316195423570985.639935',
+            },
+          },
+        ],
+        to: [
+          {
+            address: 'spender-address',
+            asset: {
+              fungible: true,
+              type: `${SOLANA_CHAIN_ID}/token:usdt`,
+              unit: 'USDT',
+              amount: '115792089237316195423570985.639935',
+            },
+          },
+        ],
+        fees: [],
+        events: [],
+      } as Transaction,
+    });
+
+    expect(item).toStrictEqual(
+      expect.objectContaining({
+        type: 'approveSpendingCap',
+        chainId: SOLANA_CHAIN_ID,
+        status: 'success',
+        timestamp: 1716367781000,
+        hash: 'approve-id',
+        data: {
+          token: {
+            amount: '115792089237316195423570985.639935',
+            assetId: `${SOLANA_CHAIN_ID}/token:usdt`,
+            direction: 'out',
+            isUnlimitedApproval: true,
+            symbol: 'USDT',
+          },
+        },
+      }),
+    );
+  });
 });

--- a/app/util/activity-adapters/adapters/keyring-transaction.ts
+++ b/app/util/activity-adapters/adapters/keyring-transaction.ts
@@ -16,6 +16,9 @@ type FungibleAsset = Extract<
   { fungible: true }
 >;
 
+// Mirrors EVM TOKEN_VALUE_UNLIMITED_THRESHOLD: amounts above 10^15 are treated as unlimited.
+const APPROVE_AMOUNT_UNLIMITED_THRESHOLD = 1e15;
+
 function mapStatus(status: Transaction['status']): Status {
   switch (status) {
     case KeyringTransactionStatus.Confirmed:
@@ -58,6 +61,34 @@ function getToken(
     symbol: movement.asset.unit,
     assetId: movement.asset.type,
     direction,
+  };
+}
+
+function isUnlimitedApprovalMovement(movement: Movement) {
+  return (
+    hasFungibleAsset(movement) &&
+    Number.parseFloat(movement.asset.amount) >
+      APPROVE_AMOUNT_UNLIMITED_THRESHOLD
+  );
+}
+
+function getApprovalToken(transaction: Transaction): TokenAmount | undefined {
+  const movement =
+    transaction.to.find(hasFungibleAsset) ??
+    transaction.from.find(hasFungibleAsset);
+
+  if (!movement) {
+    return undefined;
+  }
+
+  return {
+    amount: movement.asset.amount,
+    assetId: movement.asset.type,
+    direction: 'out',
+    isUnlimitedApproval:
+      transaction.from.some(isUnlimitedApprovalMovement) ||
+      transaction.to.some(isUnlimitedApprovalMovement),
+    symbol: movement.asset.unit,
   };
 }
 
@@ -175,6 +206,20 @@ export function mapKeyringTransaction({
       data: {
         destinationToken: getToken(transaction.to, 'in'),
         sourceToken: getToken(transaction.from, 'out'),
+      },
+    };
+  }
+
+  if (transaction.type === KeyringTransactionType.TokenApprove) {
+    return {
+      type: 'approveSpendingCap',
+      chainId,
+      status,
+      timestamp,
+      hash: transaction.id,
+      raw: { type: 'keyringTransaction', data: transaction },
+      data: {
+        token: getApprovalToken(transaction),
       },
     };
   }

--- a/app/util/activity-adapters/adapters/local-transaction.test.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.test.ts
@@ -26,6 +26,7 @@ const buildApproveData = (spender: string, amount: bigint) =>
   `${approveFunctionSignature}${spender
     .replace('0x', '')
     .padStart(64, '0')}${amount.toString(16).padStart(64, '0')}`;
+const maxUint256 = 2n ** 256n - 1n;
 
 const withoutRaw = (item: ReturnType<typeof mapLocalTransaction>) => {
   const activity = { ...item };
@@ -341,6 +342,47 @@ describe('mapLocalTransaction', () => {
           assetId: toAssetId(baseUsdc, 'eip155:8453'),
           decimals: 6,
           direction: 'out',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+
+  it('marks unlimited approval amounts from transaction calldata', () => {
+    const transaction = {
+      chainId: base,
+      id: 'approve-id',
+      hash: '0xapprove',
+      status: TransactionStatus.confirmed,
+      time: 1716367781000,
+      transferInformation: {
+        contractAddress: baseUsdc,
+        decimals: 6,
+        symbol: 'USDC',
+      },
+      type: TransactionType.tokenMethodApprove,
+      txParams: {
+        from,
+        to: baseUsdc,
+        data: buildApproveData(to, maxUint256),
+      },
+    } as Partial<TransactionMeta>;
+
+    expect(
+      withoutRaw(mapLocalTransaction(makeGroup(transaction))),
+    ).toStrictEqual({
+      type: 'approveSpendingCap',
+      chainId: 'eip155:8453',
+      status: 'success',
+      timestamp: 1716367781000,
+      hash: '0xapprove',
+      data: {
+        token: {
+          amount: maxUint256.toString(),
+          assetId: toAssetId(baseUsdc, 'eip155:8453'),
+          decimals: 6,
+          direction: 'out',
+          isUnlimitedApproval: true,
           symbol: 'USDC',
         },
       },

--- a/app/util/activity-adapters/adapters/local-transaction.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.ts
@@ -26,6 +26,7 @@ import {
   getKnownTokenMetadata,
   getLocalTransactionStatus,
   getTokenApprovalAmountFromData,
+  isUnlimitedApprovalAmount,
 } from './helpers';
 import {
   mobileActivityAdapterEnvironment,
@@ -433,7 +434,17 @@ export function mapLocalTransaction(
     case TransactionType.shieldSubscriptionApprove:
     case TransactionType.swapApproval:
     case TransactionType.tokenMethodApprove:
-    case TransactionType.tokenMethodSetApprovalForAll:
+    case TransactionType.tokenMethodSetApprovalForAll: {
+      const approvalAmount = getTokenApprovalAmountFromData(
+        initialTransaction.txParams.data,
+        environment,
+      );
+      const token = getContractToken({
+        amount: approvalAmount,
+        transaction: initialTransaction,
+        direction: 'out',
+        contractAddress: initialTransaction.txParams.to,
+      });
       return {
         type: 'approveSpendingCap',
         chainId,
@@ -442,19 +453,30 @@ export function mapLocalTransaction(
         hash,
         raw: { type: 'localTransaction', data: transactionGroup },
         data: {
-          token: getContractToken({
-            amount: getTokenApprovalAmountFromData(
-              initialTransaction.txParams.data,
-              environment,
-            ),
-            transaction: initialTransaction,
-            direction: 'out',
-            contractAddress: initialTransaction.txParams.to,
-          }),
+          token:
+            token && approvalAmount
+              ? {
+                  ...token,
+                  ...(isUnlimitedApprovalAmount(approvalAmount, token.decimals)
+                    ? { isUnlimitedApproval: true }
+                    : {}),
+                }
+              : token,
         },
       };
+    }
 
-    case TransactionType.tokenMethodIncreaseAllowance:
+    case TransactionType.tokenMethodIncreaseAllowance: {
+      const approvalAmount = getTokenApprovalAmountFromData(
+        initialTransaction.txParams.data,
+        environment,
+      );
+      const token = getContractToken({
+        amount: approvalAmount,
+        transaction: initialTransaction,
+        direction: 'out',
+        contractAddress: initialTransaction.txParams.to,
+      });
       return {
         type: 'increaseSpendingCap',
         chainId,
@@ -463,17 +485,18 @@ export function mapLocalTransaction(
         hash,
         raw: { type: 'localTransaction', data: transactionGroup },
         data: {
-          token: getContractToken({
-            amount: getTokenApprovalAmountFromData(
-              initialTransaction.txParams.data,
-              environment,
-            ),
-            transaction: initialTransaction,
-            direction: 'out',
-            contractAddress: initialTransaction.txParams.to,
-          }),
+          token:
+            token && approvalAmount
+              ? {
+                  ...token,
+                  ...(isUnlimitedApprovalAmount(approvalAmount, token.decimals)
+                    ? { isUnlimitedApproval: true }
+                    : {}),
+                }
+              : token,
         },
       };
+    }
 
     case TransactionType.lendingDeposit:
       return {

--- a/app/util/activity-adapters/adapters/local-transaction.ts
+++ b/app/util/activity-adapters/adapters/local-transaction.ts
@@ -115,6 +115,30 @@ export function mapLocalTransaction(
     };
   };
 
+  const getApprovalToken = () => {
+    const approvalAmount = getTokenApprovalAmountFromData(
+      initialTransaction.txParams.data,
+      environment,
+    );
+    const token = getContractToken({
+      amount: approvalAmount,
+      transaction: initialTransaction,
+      direction: 'out',
+      contractAddress: initialTransaction.txParams.to,
+    });
+
+    if (!token || !approvalAmount) {
+      return token;
+    }
+
+    return {
+      ...token,
+      ...(isUnlimitedApprovalAmount(approvalAmount, token.decimals)
+        ? { isUnlimitedApproval: true }
+        : {}),
+    };
+  };
+
   const getLegacySwapToken = (direction: TokenAmount['direction']) => {
     const { value } = initialTransaction.txParams;
     let hasNativeValue = false;
@@ -435,16 +459,6 @@ export function mapLocalTransaction(
     case TransactionType.swapApproval:
     case TransactionType.tokenMethodApprove:
     case TransactionType.tokenMethodSetApprovalForAll: {
-      const approvalAmount = getTokenApprovalAmountFromData(
-        initialTransaction.txParams.data,
-        environment,
-      );
-      const token = getContractToken({
-        amount: approvalAmount,
-        transaction: initialTransaction,
-        direction: 'out',
-        contractAddress: initialTransaction.txParams.to,
-      });
       return {
         type: 'approveSpendingCap',
         chainId,
@@ -453,30 +467,12 @@ export function mapLocalTransaction(
         hash,
         raw: { type: 'localTransaction', data: transactionGroup },
         data: {
-          token:
-            token && approvalAmount
-              ? {
-                  ...token,
-                  ...(isUnlimitedApprovalAmount(approvalAmount, token.decimals)
-                    ? { isUnlimitedApproval: true }
-                    : {}),
-                }
-              : token,
+          token: getApprovalToken(),
         },
       };
     }
 
     case TransactionType.tokenMethodIncreaseAllowance: {
-      const approvalAmount = getTokenApprovalAmountFromData(
-        initialTransaction.txParams.data,
-        environment,
-      );
-      const token = getContractToken({
-        amount: approvalAmount,
-        transaction: initialTransaction,
-        direction: 'out',
-        contractAddress: initialTransaction.txParams.to,
-      });
       return {
         type: 'increaseSpendingCap',
         chainId,
@@ -485,15 +481,7 @@ export function mapLocalTransaction(
         hash,
         raw: { type: 'localTransaction', data: transactionGroup },
         data: {
-          token:
-            token && approvalAmount
-              ? {
-                  ...token,
-                  ...(isUnlimitedApprovalAmount(approvalAmount, token.decimals)
-                    ? { isUnlimitedApproval: true }
-                    : {}),
-                }
-              : token,
+          token: getApprovalToken(),
         },
       };
     }

--- a/app/util/activity-adapters/index.ts
+++ b/app/util/activity-adapters/index.ts
@@ -27,6 +27,10 @@ export {
 } from './fiat';
 export {
   activityMatchesAssetId,
+  formatActivityListDateHeader,
+  getActivityFromTo,
+  getActivityValue,
+  getGroupedActivityListItemKey,
   groupActivityListItems,
   shouldShowPlusSign,
   type GroupedActivityListItem,

--- a/app/util/activity-adapters/types.ts
+++ b/app/util/activity-adapters/types.ts
@@ -59,6 +59,7 @@ export type ActivityKind =
 export interface TokenAmount {
   amount?: string;
   decimals?: number;
+  isUnlimitedApproval?: boolean;
   symbol?: string;
   // CAIP-19 asset id (from adapters)
   assetId?: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates asset/token details activity lists to render the redesigned `ActivityListItemRow` when the activity redesign feature flag is enabled. It covers both EVM transactions rendered through `Transactions` and non-EVM transactions rendered through `MultichainTransactionsView`, while keeping bridge activity and the legacy path unchanged when the flag is disabled.

The implementation adds small asset-details adapter components that map existing transaction data into the unified activity item shape, preserve transaction-details navigation, and keep the legacy account-import marker behavior for EVM asset details. The activity redesign selector was moved to a shared feature flag selector module so route directories do not import from sibling routes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated asset details activity rows to use the redesigned activity list item when enabled

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-916

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Redesigned activity rows on asset details

  Scenario: user views EVM asset details with the activity redesign enabled
    Given the activity redesign feature flag is enabled
    And the selected EVM asset has local transaction activity

    When user opens the asset details screen
    Then the activity list uses the redesigned activity list item rows
    And the rows are horizontally aligned with the rest of the asset details content
    And tapping a row opens the transaction details sheet

  Scenario: user views EVM asset details with the activity redesign disabled
    Given the activity redesign feature flag is disabled
    And the selected EVM asset has local transaction activity

    When user opens the asset details screen
    Then the activity list uses the legacy transaction rows
    And tapping a row opens the legacy transaction details sheet

  Scenario: user views non-EVM asset details with the activity redesign enabled
    Given the activity redesign feature flag is enabled
    And the selected non-EVM asset has activity

    When user opens the asset details screen
    Then the activity list uses the redesigned activity list item rows
    And tapping a row opens the multichain transaction details sheet
    And bridge activity still uses the bridge transaction row

  Scenario: user views account import marker on EVM asset details
    Given the activity redesign feature flag is enabled
    And the selected EVM account has an import time insertion point

    When user opens the asset details screen
    Then the "Account added to this device" marker is shown in the same position as the legacy list
    And tapping the marker opens the import wallet tip sheet
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="391" height="387" alt="Screenshot 2026-06-18 at 14 22 10" src="https://github.com/user-attachments/assets/b90d2836-aa09-4303-94bf-6cab9b93d768" />
<img width="391" height="213" alt="Screenshot 2026-06-18 at 14 22 24" src="https://github.com/user-attachments/assets/8f8b4c04-1861-472e-a0a7-a6e87b10bccf" />


<!-- [screenshots/recordings] -->

### **After**
<img width="387" height="309" alt="Screenshot 2026-06-18 at 15 35 28" src="https://github.com/user-attachments/assets/f1fd6d85-6ecb-4634-bcd4-02bd2815d2b4" />
<img width="388" height="206" alt="Screenshot 2026-06-18 at 15 35 16" src="https://github.com/user-attachments/assets/c32a5164-1dac-42bc-8498-25f78aa3fccc" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk from a gated but user-facing activity path that changes list rendering, keys, and navigation wiring on EVM and multichain asset details; approval amount labeling affects how users read spending caps.
> 
> **Overview**
> **Asset details activity** switches to the redesigned list when `tmcuActivityRedesignEnabled` is true and `location` is asset details: **`Transactions`** and **`MultichainTransactionsView`** group items (pending/date headers), map txs through new **`AssetDetailsActivityListItem`** / **`MultichainAssetDetailsActivityListItem`** adapters, and keep legacy **`TransactionElement`** / **`MultichainTransactionListItem`** (including bridge rows) when the flag is off.
> 
> Adds **`ActivityListAccountImportTimeRow`** (EVM import-time marker + import tip navigation), **`ActivityListDateHeader`**, and centralizes **`formatActivityListDateHeader`**, **`getActivityValue`**, **`getActivityFromTo`**, and **`getGroupedActivityListItemKey`** in **`activity-adapters`** (also consumed by home **`ActivityList`**). **`selectIsActivityRedesignEnabled`** moves to **`selectors/featureFlagController/activityRedesign`**.
> 
> **Display fixes:** unlimited token approvals show localized **Unlimited** (and skip fiat) via **`isUnlimitedApproval`** on adapters and row content; pending queued state uses design-system **Clock** icon; multichain **TokenApprove** maps to spending-cap activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46558cf0595c75449165a9f24f8e2659764535b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->