### PR TITLE
refactor(delegation): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.test.ts
+++ b/app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.test.ts
@@ -1,13 +1,11 @@
 import {
   GatorPermissionsController,
+  type GatorPermissionsControllerMessenger,
   type GatorPermissionsControllerState,
 } from '@metamask/gator-permissions-controller';
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
 import type { MessengerClientInitRequest } from '../../types';
-import {
-  getGatorPermissionsControllerMessenger,
-  GatorPermissionsControllerMessenger,
-} from '../../messengers/gator-permissions-controller-messenger/gator-permissions-controller-messenger';
+import { getGatorPermissionsControllerMessenger } from '../../messengers/gator-permissions-controller-messenger/gator-permissions-controller-messenger';
 import { GatorPermissionsControllerInit } from './gator-permissions-controller-init';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';

--- a/app/core/Engine/messengers/delegation/delegation-controller-messenger.ts
+++ b/app/core/Engine/messengers/delegation/delegation-controller-messenger.ts
@@ -9,19 +9,19 @@ import { RootMessenger } from '../../types';
 
 const name = 'DelegationController' as const;
 
-export type DelegationControllerInitMessenger = ReturnType<
-  typeof getDelegationControllerInitMessenger
+export type DelegationControllerInitMessenger = Messenger<
+  'DelegationControllerInit',
+  never,
+  TransactionControllerTransactionStatusUpdatedEvent
 >;
 
 export function getDelegationControllerMessenger(
-  rootMessenger: RootMessenger,
-): DelegationControllerMessenger {
-  const messenger = new Messenger<
-    typeof name,
+  rootMessenger: RootMessenger<
     MessengerActions<DelegationControllerMessenger>,
-    MessengerEvents<DelegationControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<DelegationControllerMessenger>
+  >,
+): DelegationControllerMessenger {
+  const messenger: DelegationControllerMessenger = new Messenger({
     namespace: name,
     parent: rootMessenger,
   });
@@ -37,14 +37,12 @@ export function getDelegationControllerMessenger(
 }
 
 export function getDelegationControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'DelegationControllerInit',
-    never,
-    TransactionControllerTransactionStatusUpdatedEvent,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<DelegationControllerInitMessenger>,
+    MessengerEvents<DelegationControllerInitMessenger>
+  >,
+): DelegationControllerInitMessenger {
+  const messenger: DelegationControllerInitMessenger = new Messenger({
     namespace: 'DelegationControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/gator-permissions-controller-messenger/gator-permissions-controller-messenger.ts
+++ b/app/core/Engine/messengers/gator-permissions-controller-messenger/gator-permissions-controller-messenger.ts
@@ -1,24 +1,20 @@
 import type { GatorPermissionsControllerMessenger } from '@metamask/gator-permissions-controller';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
-  MessengerActions,
-  MessengerEvents,
+  type MessengerActions,
+  type MessengerEvents,
 } from '@metamask/messenger';
 
-export type { GatorPermissionsControllerMessenger };
-
 export function getGatorPermissionsControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): GatorPermissionsControllerMessenger {
-  const messenger = new Messenger<
-    'GatorPermissionsController',
+  rootMessenger: RootMessenger<
     MessengerActions<GatorPermissionsControllerMessenger>,
-    MessengerEvents<GatorPermissionsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<GatorPermissionsControllerMessenger>
+  >,
+): GatorPermissionsControllerMessenger {
+  const messenger: GatorPermissionsControllerMessenger = new Messenger({
     namespace: 'GatorPermissionsController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
   return messenger;
 }


### PR DESCRIPTION
## **Description**

Applies the same messenger type refactoring from #31467 to the two delegation-owned messenger files (`delegation-controller-messenger`, `gator-permissions-controller-messenger`).

Narrows `rootMessenger` parameters to `RootMessenger<AllowedActions, AllowedEvents>`, simplifies `new Messenger<Namespace, Actions, Events, Root>({…})` to typed variable declarations, converts `DelegationControllerInitMessenger` from `ReturnType<typeof …>` to an explicit `Messenger<'DelegationControllerInit', never, Events>` type, and adds an explicit return type to `getDelegationControllerInitMessenger`.

Also removes the `export type { GatorPermissionsControllerMessenger }` re-export from the gator-permissions messenger file (replacing `RootExtendedMessenger` with the narrowed `RootMessenger<…>`), and updates the init test to import the type directly from `@metamask/gator-permissions-controller`.

No runtime behaviour changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A — pure TypeScript refactoring, no runtime behaviour changes.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.