### PR TITLE
fix(home): align discovery pill icons and full-view navigation

### DIFF
--- a/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.test.tsx
@@ -19,14 +19,19 @@ jest.mock('../../hooks/usePillViewedEvent', () => ({
   default: () => ({ trackPillTapped: mockTrackPillTapped }),
 }));
 
-jest.mock('../../../../../constants/navigation/exploreTabIndices', () => ({
-  EXPLORE_TAB_INDEX: {
-    NOW: 0,
-    MACRO: 1,
-    RWAS: 2,
-    CRYPTO: 3,
-    SPORTS: 4,
-    SITES: 5,
+const mockTrackEvent = jest.fn();
+jest.mock('../../../../../util/analytics/analytics', () => ({
+  analytics: { trackEvent: (...args: unknown[]) => mockTrackEvent(...args) },
+}));
+
+jest.mock('../../../../../util/analytics/AnalyticsEventBuilder', () => ({
+  AnalyticsEventBuilder: {
+    createEventBuilder: jest.fn(() => ({
+      addProperties: jest.fn(function (this: { build: () => unknown }) {
+        return this;
+      }),
+      build: jest.fn(() => ({ event: 'Explore Page Interacted' })),
+    })),
   },
 }));
 
@@ -144,26 +149,26 @@ describe('HomepageDiscoveryPills', () => {
     });
   });
 
-  it('navigates to explore crypto tab when crypto pill is pressed', () => {
+  it('navigates to trending tokens full view when crypto pill is pressed', () => {
     const { getByTestId } = render(<HomepageDiscoveryPills iconStyle="gray" />);
 
     fireEvent.press(getByTestId(HomepageDiscoveryPillsTestIds.pill('crypto')));
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.TRENDING_VIEW, {
-      screen: Routes.TRENDING_FEED,
-      params: { initialTab: 3, source: HOMESCREEN_PILL_SOURCE },
-    });
+    expect(mockTrackEvent).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.WALLET.TRENDING_TOKENS_FULL_VIEW,
+    );
   });
 
-  it('navigates to explore RWAs tab when stocks pill is pressed', () => {
+  it('navigates to RWA tokens full view when stocks pill is pressed', () => {
     const { getByTestId } = render(<HomepageDiscoveryPills iconStyle="gray" />);
 
     fireEvent.press(getByTestId(HomepageDiscoveryPillsTestIds.pill('stocks')));
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.TRENDING_VIEW, {
-      screen: Routes.TRENDING_FEED,
-      params: { initialTab: 2, source: HOMESCREEN_PILL_SOURCE },
-    });
+    expect(mockTrackEvent).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Routes.WALLET.RWA_TOKENS_FULL_VIEW,
+    );
   });
 
   it('tracks pill_tapped before navigation when a pill is pressed', () => {

--- a/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.tsx
@@ -111,7 +111,7 @@ const HomepageDiscoveryPills: React.FC<HomepageDiscoveryPillsProps> = ({
             handlePillPress(pillId, HOMEPAGE_DISCOVERY_PILL_IDS.indexOf(pillId))
           }
           size={ButtonSize.Md}
-          style={tw.style('rounded-xl py-2 px-3')}
+          style={tw.style('rounded-xl py-2 pl-2 pr-3')}
           testID={HomepageDiscoveryPillsTestIds.pill(pillId)}
           accessibilityLabel={strings(PILL_LABEL_KEYS[pillId])}
         />

--- a/app/components/Views/Homepage/components/HomepageDiscoveryPills/homepageDiscoveryPills.constants.ts
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryPills/homepageDiscoveryPills.constants.ts
@@ -31,8 +31,8 @@ export const HOMEPAGE_DISCOVERY_PILL_GRAY_ICONS: Record<
 > = {
   perpetuals: IconName.Candlestick,
   predictions: IconName.Predictions,
-  stocks: IconName.Chart,
-  crypto: IconName.Coin,
+  stocks: IconName.Coin,
+  crypto: IconName.Ethereum,
 } as const;
 
 export const HOMEPAGE_DISCOVERY_PILL_COLOR_ICON_SOURCES = {

--- a/app/components/Views/Homepage/components/HomepageDiscoveryPills/useHomepageDiscoveryPillsNavigation.ts
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryPills/useHomepageDiscoveryPillsNavigation.ts
@@ -1,12 +1,26 @@
 import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import Routes from '../../../../../constants/navigation/Routes';
-import { EXPLORE_TAB_INDEX } from '../../../../../constants/navigation/exploreTabIndices';
+import { analytics } from '../../../../../util/analytics/analytics';
+import { AnalyticsEventBuilder } from '../../../../../util/analytics/AnalyticsEventBuilder';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import type { HomepageDiscoveryPillId } from './homepageDiscoveryPills.constants';
 
 export const HOMESCREEN_PILL_SOURCE =
   PredictEventValues.ENTRY_POINT.HOMESCREEN_PILL;
+
+const trackDiscoveryPillExploreNavigate = (
+  properties: Record<string, unknown>,
+): void => {
+  analytics.trackEvent(
+    AnalyticsEventBuilder.createEventBuilder(
+      MetaMetricsEvents.EXPLORE_INTERACTED,
+    )
+      .addProperties(properties)
+      .build(),
+  );
+};
 
 export function useHomepageDiscoveryPillsNavigation() {
   const navigation = useNavigation();
@@ -29,22 +43,22 @@ export function useHomepageDiscoveryPillsNavigation() {
           });
           break;
         case 'crypto':
-          navigation.navigate(Routes.TRENDING_VIEW, {
-            screen: Routes.TRENDING_FEED,
-            params: {
-              initialTab: EXPLORE_TAB_INDEX.CRYPTO,
-              source: HOMESCREEN_PILL_SOURCE,
-            },
+          trackDiscoveryPillExploreNavigate({
+            interaction_type: 'section_see_all_tapped',
+            tab_name: 'Crypto',
+            section_name: 'tokens_trending',
+            source: HOMESCREEN_PILL_SOURCE,
           });
+          navigation.navigate(Routes.WALLET.TRENDING_TOKENS_FULL_VIEW);
           break;
         case 'stocks':
-          navigation.navigate(Routes.TRENDING_VIEW, {
-            screen: Routes.TRENDING_FEED,
-            params: {
-              initialTab: EXPLORE_TAB_INDEX.RWAS,
-              source: HOMESCREEN_PILL_SOURCE,
-            },
+          trackDiscoveryPillExploreNavigate({
+            interaction_type: 'section_see_all_tapped',
+            tab_name: 'RWAs',
+            section_name: 'stocks',
+            source: HOMESCREEN_PILL_SOURCE,
           });
+          navigation.navigate(Routes.WALLET.RWA_TOKENS_FULL_VIEW);
           break;
         default: {
           const exhaustiveCheck: never = pillId;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Follow-up to the merged TMCU-926 homepage discovery pills experiment addressing post-merge feedback:

1. **Gray icon mapping (Figma)** — Stocks pill uses `Coin`, Crypto pill uses `Ethereum` (was Chart/Coin).
2. **Navigation** — Crypto and Stocks pills now open the same full-list screens as tapping **Trending >** on the Crypto tab (`TrendingTokensFullView`) and **Stocks >** on the RWAs tab (`RWATokensFullView`), instead of switching Explore tabs.
3. **Analytics** — Fires `Explore Page Interacted` (`section_see_all_tapped` + `source: homescreen_pill`) before navigating to those full views.
4. **Pill padding** — Asymmetric horizontal padding per Figma (`pl-2` / `pr-3`).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: https://consensyssoftware.atlassian.net/browse/TMCU-926

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage discovery pills follow-up (TMCU-926)

  Background:
    Given I am on the legacy wallet homepage with discovery pills visible
    And LaunchDarkly assigns grayIcons or colorIcons

  Scenario: crypto pill opens Trending full list
    When I tap the Crypto discovery pill
    Then I should land on the Trending tokens full view screen
    And I should not land on the Explore Crypto tab

  Scenario: stocks pill opens Stocks full list
    When I tap the Stocks discovery pill
    Then I should land on the Stocks (RWA tokens) full view screen
    And I should not land on the Explore RWAs tab

  Scenario: grayIcons variant shows correct gray icons
    Given I am assigned to the grayIcons variant
    When I view the Stocks and Crypto pills
    Then Stocks should show the Coin icon
    And Crypto should show the Ethereum icon

  Scenario: pill padding matches Figma
    When I inspect a discovery pill
    Then horizontal padding should be 8px on the left and 12px on the right
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/7cab9a11-28c2-43c1-8ca7-1f21840c4f83


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->