### PR TITLE
feat: MUSD-999 add deeplink to money onboarding

### DIFF
--- a/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import MoneyGeoBlockSheet from './MoneyGeoBlockSheet';
+import { MoneyGeoBlockSheetTestIds } from './MoneyGeoBlockSheet.testIds';
+import { strings } from '../../../../../../locales/i18n';
+import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockTrackBottomSheetViewed = jest.fn();
+const mockOnCloseBottomSheet = jest.fn((callback?: () => void) => callback?.());
+const mockNavigate = jest.fn();
+
+jest.mock('../../hooks/useMoneyAnalytics', () => ({
+  useMoneyAnalytics: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+
+  const MockBottomSheet = ReactActual.forwardRef(
+    (
+      {
+        children,
+        testID,
+        onClose,
+      }: {
+        children: React.ReactNode;
+        testID?: string;
+        onClose?: () => void;
+      },
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: mockOnCloseBottomSheet,
+        onOpenBottomSheet: jest.fn(),
+      }));
+
+      return ReactActual.createElement(View, { testID, onClose }, children);
+    },
+  );
+
+  return {
+    ...actual,
+    BottomSheet: MockBottomSheet,
+  };
+});
+
+describe('MoneyGeoBlockSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMoneyAnalytics as jest.Mock).mockReturnValue({
+      trackBottomSheetViewed: mockTrackBottomSheetViewed,
+    });
+  });
+
+  it('renders geo-block bottom sheet container', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+
+    expect(getByTestId(MoneyGeoBlockSheetTestIds.SHEET)).toBeOnTheScreen();
+  });
+
+  it('renders geo-block title copy', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+
+    expect(getByTestId(MoneyGeoBlockSheetTestIds.TITLE)).toHaveTextContent(
+      strings('money.geo_block.title'),
+    );
+  });
+
+  it('renders geo-block description copy', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+
+    expect(getByTestId(MoneyGeoBlockSheetTestIds.BODY)).toHaveTextContent(
+      strings('money.geo_block.description'),
+    );
+  });
+
+  it('renders continue button copy', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+
+    expect(
+      getByTestId(MoneyGeoBlockSheetTestIds.CONTINUE_BUTTON),
+    ).toHaveTextContent(strings('money.geo_block.button'));
+  });
+
+  it('closes sheet and navigates to wallet home when continue button is pressed', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+
+    fireEvent.press(getByTestId(MoneyGeoBlockSheetTestIds.CONTINUE_BUTTON));
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+  });
+
+  it('closes sheet and navigates to wallet home when bottom sheet close callback runs', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+    const sheet = getByTestId(MoneyGeoBlockSheetTestIds.SHEET);
+
+    sheet.props.onClose();
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+  });
+
+  it('closes sheet and navigates to wallet home when header close button is pressed', () => {
+    const { getByTestId } = renderWithProvider(<MoneyGeoBlockSheet />);
+
+    fireEvent.press(getByTestId(MoneyGeoBlockSheetTestIds.CLOSE_BUTTON));
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+  });
+
+  describe('analytics', () => {
+    it('initialises useMoneyAnalytics with MONEY_GEO_BLOCK_SHEET bottom_sheet_name', () => {
+      renderWithProvider(<MoneyGeoBlockSheet />);
+
+      expect(useMoneyAnalytics).toHaveBeenCalledWith({
+        bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_GEO_BLOCK_SHEET,
+      });
+    });
+
+    it('calls trackBottomSheetViewed on mount', () => {
+      renderWithProvider(<MoneyGeoBlockSheet />);
+
+      expect(mockTrackBottomSheetViewed).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.testIds.ts
+++ b/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.testIds.ts
@@ -1,0 +1,7 @@
+export const MoneyGeoBlockSheetTestIds = {
+  SHEET: 'money-geo-block-sheet-sheet',
+  TITLE: 'money-geo-block-sheet-title',
+  BODY: 'money-geo-block-sheet-body',
+  CLOSE_BUTTON: 'money-geo-block-sheet-close-button',
+  CONTINUE_BUTTON: 'money-geo-block-sheet-continue-button',
+} as const;

--- a/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.tsx
+++ b/app/components/UI/Money/components/MoneyGeoBlockSheet/MoneyGeoBlockSheet.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  BottomSheetRef,
+  Box,
+  ButtonsAlignment,
+  ButtonSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
+import { MoneyGeoBlockSheetTestIds } from './MoneyGeoBlockSheet.testIds';
+import { strings } from '../../../../../../locales/i18n';
+import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+import { BOTTOM_SHEET_NAMES } from '../../constants/moneyEvents';
+import useMountEffect from '../../hooks/useMountEffect';
+import { useNavigation } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const MoneyGeoBlockSheet = () => {
+  const navigation = useNavigation();
+
+  const surfaceClass = useElevatedSurface();
+
+  const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+  const { trackBottomSheetViewed } = useMoneyAnalytics({
+    bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_GEO_BLOCK_SHEET,
+  });
+
+  useMountEffect(trackBottomSheetViewed);
+
+  const handleClose = useCallback(() => {
+    bottomSheetRef.current?.onCloseBottomSheet(() => {
+      navigation.navigate(Routes.WALLET.HOME);
+    });
+  }, [navigation]);
+
+  const primaryButtonProps = useMemo(
+    () => ({
+      children: strings('money.geo_block.button'),
+      onPress: handleClose,
+      testID: MoneyGeoBlockSheetTestIds.CONTINUE_BUTTON,
+      size: ButtonSize.Lg,
+    }),
+    [handleClose],
+  );
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      testID={MoneyGeoBlockSheetTestIds.SHEET}
+      twClassName={surfaceClass}
+      onClose={handleClose}
+    >
+      <BottomSheetHeader
+        onClose={handleClose}
+        testID={MoneyGeoBlockSheetTestIds.TITLE}
+        closeButtonProps={{
+          testID: MoneyGeoBlockSheetTestIds.CLOSE_BUTTON,
+        }}
+      >
+        {strings('money.geo_block.title')}
+      </BottomSheetHeader>
+      <Box paddingHorizontal={4}>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          testID={MoneyGeoBlockSheetTestIds.BODY}
+          twClassName="text-center"
+        >
+          {strings('money.geo_block.description')}
+        </Text>
+      </Box>
+      <BottomSheetFooter
+        buttonsAlignment={ButtonsAlignment.Horizontal}
+        primaryButtonProps={primaryButtonProps}
+        twClassName="pt-6"
+      />
+    </BottomSheet>
+  );
+};
+
+export default MoneyGeoBlockSheet;

--- a/app/components/UI/Money/constants/moneyEvents.ts
+++ b/app/components/UI/Money/constants/moneyEvents.ts
@@ -29,6 +29,7 @@ export enum BOTTOM_SHEET_NAMES {
   MONEY_EARN_CRYPTO_INFO_SHEET = 'money_earn_crypto_info_sheet',
   MONEY_MORE_SHEET = 'money_more_sheet',
   MONEY_BALANCE_INFO_SHEET = 'money_balance_info_sheet',
+  MONEY_GEO_BLOCK_SHEET = 'money_geo_block_sheet',
 }
 
 export enum REDIRECT_TARGETS_TYPES {

--- a/app/components/UI/Money/routes/index.test.tsx
+++ b/app/components/UI/Money/routes/index.test.tsx
@@ -106,6 +106,9 @@ jest.mock('../components/MoneyEarnCryptoInfoSheet', () => () => (
 jest.mock('../../../Views/confirmations/components/confirm', () => ({
   Confirm: () => <MockView testID="mock-confirm" />,
 }));
+jest.mock('../components/MoneyGeoBlockSheet/MoneyGeoBlockSheet', () => () => (
+  <MockView testID="mock-money-geo-block-sheet" />
+));
 
 describe('MoneyTabScreenStack', () => {
   beforeEach(() => {
@@ -261,5 +264,13 @@ describe('MoneyModalStack', () => {
     expect(
       getByTestId('money-screen-MoneyEarnCryptoInfoSheet'),
     ).toBeOnTheScreen();
+  });
+
+  it('registers the Geo block sheet as a modal screen', () => {
+    const { getByTestId } = renderWithProvider(<MoneyModalStack />, {
+      theme: themeWithCustomBackground,
+    });
+
+    expect(getByTestId('money-screen-MoneyGeoBlockSheet')).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -21,6 +21,7 @@ import MoneyCardTransactionDetailsSheet from '../components/MoneyCardTransaction
 import { Confirm } from '../../../Views/confirmations/components/confirm';
 import { useEmptyNavHeaderForConfirmations } from '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations';
 import { useUpgradeMoneyAccountOnMount } from '../hooks/useUpgradeMoneyAccountOnMount';
+import MoneyGeoBlockSheet from '../components/MoneyGeoBlockSheet/MoneyGeoBlockSheet';
 
 const Stack = createNativeStackNavigator();
 const ModalStack = createNativeStackNavigator();
@@ -129,6 +130,11 @@ const MoneyModalStack = () => (
     <ModalStack.Screen
       name={Routes.MONEY.MODALS.CARD_TRANSACTION_DETAILS_SHEET}
       component={MoneyCardTransactionDetailsSheet}
+      options={{ headerShown: false }}
+    />
+    <ModalStack.Screen
+      name={Routes.MONEY.MODALS.GEO_BLOCK_SHEET}
+      component={MoneyGeoBlockSheet}
       options={{ headerShown: false }}
     />
   </ModalStack.Navigator>

--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -54,6 +54,7 @@ export enum ACTIONS {
   NFT = 'nft',
   AGENTIC_CLI = 'agentic-cli',
   ON_RAMP = 'on-ramp',
+  MONEY = 'money',
 }
 
 export const PREFIXES = {
@@ -94,5 +95,6 @@ export const PREFIXES = {
   [ACTIONS.NFT]: '',
   [ACTIONS.AGENTIC_CLI]: '',
   [ACTIONS.ON_RAMP]: '',
+  [ACTIONS.MONEY]: '',
   METAMASK: 'metamask://',
 };

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -476,6 +476,7 @@ const Routes = {
       EARN_CRYPTO_INFO_SHEET: 'MoneyEarnCryptoInfoSheet',
       TRANSACTION_DETAILS_SHEET: 'MoneyTransactionDetailsSheet',
       CARD_TRANSACTION_DETAILS_SHEET: 'MoneyCardTransactionDetailsSheet',
+      GEO_BLOCK_SHEET: 'MoneyGeoBlockSheet',
     },
   },
   FULL_SCREEN_CONFIRMATIONS: {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleMoney.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleMoney.test.ts
@@ -1,0 +1,149 @@
+import { handleMoney } from '../handleMoney';
+import handleDeepLinkModalDisplay from '../handleDeepLinkModalDisplay';
+import NavigationService from '../../../../NavigationService';
+import ReduxService from '../../../../redux';
+import Routes from '../../../../../constants/navigation/Routes';
+import DevLogger from '../../../../SDKConnect/utils/DevLogger';
+import Logger from '../../../../../util/Logger';
+import { selectMoneyOnboardingSeen } from '../../../../../reducers/user';
+import { selectMoneyEnableMoneyAccountFlag } from '../../../../../components/UI/Money/selectors/featureFlags';
+import { selectIsMoneyAccountGeoEligible } from '../../../../../components/UI/Money/selectors/eligibility';
+import { DeepLinkModalLinkType } from '../../../types/deepLink.types';
+
+jest.mock('../../../../NavigationService');
+jest.mock('../../../../SDKConnect/utils/DevLogger');
+jest.mock('../../../../../util/Logger');
+jest.mock('../handleDeepLinkModalDisplay', () => jest.fn());
+
+jest.mock('../../../../redux', () => ({
+  __esModule: true,
+  default: {
+    store: {
+      getState: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../../reducers/user', () => ({
+  selectMoneyOnboardingSeen: jest.fn(),
+}));
+
+jest.mock('../../../../../components/UI/Money/selectors/featureFlags', () => ({
+  selectMoneyEnableMoneyAccountFlag: jest.fn(),
+}));
+
+jest.mock('../../../../../components/UI/Money/selectors/eligibility', () => ({
+  selectIsMoneyAccountGeoEligible: jest.fn(),
+}));
+
+describe('handleMoney', () => {
+  let mockNavigate: jest.Mock;
+  const mockState = {} as ReturnType<typeof ReduxService.store.getState>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockNavigate = jest.fn();
+    NavigationService.navigation = {
+      navigate: mockNavigate,
+    } as unknown as typeof NavigationService.navigation;
+
+    jest.mocked(ReduxService.store.getState).mockReturnValue(mockState);
+    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(true);
+    jest.mocked(selectIsMoneyAccountGeoEligible).mockReturnValue(true);
+    jest.mocked(selectMoneyOnboardingSeen).mockReturnValue(true);
+  });
+
+  it('opens unsupported deep link modal when money account flag is disabled', () => {
+    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(false);
+
+    handleMoney();
+
+    expect(handleDeepLinkModalDisplay).toHaveBeenCalledWith({
+      linkType: DeepLinkModalLinkType.UNSUPPORTED,
+      onBack: expect.any(Function),
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to WALLET.HOME when unsupported modal back callback runs', () => {
+    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(false);
+
+    handleMoney();
+
+    const [{ onBack }] = jest.mocked(handleDeepLinkModalDisplay).mock.calls[0];
+    onBack();
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+  });
+
+  it('navigates to geo block modal when user is not geo eligible', () => {
+    jest.mocked(selectIsMoneyAccountGeoEligible).mockReturnValue(false);
+
+    handleMoney();
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.MODALS.ROOT, {
+      screen: Routes.MONEY.MODALS.GEO_BLOCK_SHEET,
+    });
+  });
+
+  it('navigates to MONEY.ONBOARDING when user has not seen onboarding', () => {
+    jest.mocked(selectMoneyOnboardingSeen).mockReturnValue(false);
+
+    handleMoney();
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ONBOARDING);
+  });
+
+  it('navigates to MONEY.HOME when user has already seen onboarding', () => {
+    handleMoney();
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS, {
+      screen: Routes.MONEY.ROOT,
+      params: { screen: Routes.MONEY.HOME },
+    });
+  });
+
+  it('logs error and navigates to WALLET.HOME when selector throws', () => {
+    const error = new Error('Selector failed');
+    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockImplementation(() => {
+      throw error;
+    });
+
+    handleMoney();
+
+    expect(DevLogger.log).toHaveBeenCalledWith(
+      '[handleMoney] Failed to handle deeplink:',
+      error,
+    );
+    expect(Logger.error).toHaveBeenCalledWith(
+      error,
+      '[handleMoney] Error handling money deeplink',
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
+  });
+
+  it('logs fallback navigation error when fallback screen navigation fails', () => {
+    const deepLinkError = new Error('Deep link failed');
+    const fallbackNavigationError = new Error('Fallback navigation failed');
+    jest.mocked(selectMoneyEnableMoneyAccountFlag).mockImplementation(() => {
+      throw deepLinkError;
+    });
+    mockNavigate.mockImplementation(() => {
+      throw fallbackNavigationError;
+    });
+
+    handleMoney();
+
+    expect(Logger.error).toHaveBeenNthCalledWith(
+      1,
+      deepLinkError,
+      '[handleMoney] Error handling money deeplink',
+    );
+    expect(Logger.error).toHaveBeenNthCalledWith(
+      2,
+      fallbackNavigationError,
+      '[handleMoney] Failed to navigate to fallback screen',
+    );
+  });
+});

--- a/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
@@ -1,0 +1,58 @@
+import { selectIsMoneyAccountGeoEligible } from '../../../../components/UI/Money/selectors/eligibility';
+import { selectMoneyEnableMoneyAccountFlag } from '../../../../components/UI/Money/selectors/featureFlags';
+import Routes from '../../../../constants/navigation/Routes';
+import { selectMoneyOnboardingSeen } from '../../../../reducers/user';
+import Logger from '../../../../util/Logger';
+import NavigationService from '../../../NavigationService';
+import ReduxService from '../../../redux';
+import DevLogger from '../../../SDKConnect/utils/DevLogger';
+import { DeepLinkModalLinkType } from '../../types/deepLink.types';
+import handleDeepLinkModalDisplay from './handleDeepLinkModalDisplay';
+
+export const handleMoney = () => {
+  DevLogger.log('[handleMoney] Starting deeplink handling');
+
+  try {
+    const state = ReduxService.store.getState();
+    const isMoneyAccountGeoEligible = selectIsMoneyAccountGeoEligible(state);
+    const isMoneyAccountEnabled = selectMoneyEnableMoneyAccountFlag(state);
+    const hasSeenMoneyOnboarding = selectMoneyOnboardingSeen(state);
+
+    if (!isMoneyAccountEnabled) {
+      handleDeepLinkModalDisplay({
+        linkType: DeepLinkModalLinkType.UNSUPPORTED,
+        onBack: () => {
+          NavigationService.navigation.navigate(Routes.WALLET.HOME);
+        },
+      });
+      return;
+    }
+
+    if (!isMoneyAccountGeoEligible) {
+      NavigationService.navigation.navigate(Routes.MONEY.MODALS.ROOT, {
+        screen: Routes.MONEY.MODALS.GEO_BLOCK_SHEET,
+      });
+      return;
+    }
+
+    if (!hasSeenMoneyOnboarding) {
+      NavigationService.navigation.navigate(Routes.MONEY.ONBOARDING);
+      return;
+    }
+    NavigationService.navigation.navigate(Routes.HOME_TABS, {
+      screen: Routes.MONEY.ROOT,
+      params: { screen: Routes.MONEY.HOME },
+    });
+  } catch (error) {
+    DevLogger.log('[handleMoney] Failed to handle deeplink:', error);
+    Logger.error(error as Error, '[handleMoney] Error handling money deeplink');
+    try {
+      NavigationService.navigation.navigate(Routes.WALLET.HOME);
+    } catch (navError) {
+      Logger.error(
+        navError as Error,
+        '[handleMoney] Failed to navigate to fallback screen',
+      );
+    }
+  }
+};

--- a/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleUniversalLink.ts
@@ -77,6 +77,7 @@ import branch from 'react-native-branch';
 import Logger from '../../../../util/Logger';
 import type { DeeplinkParseMode } from '../../utils/parseDeeplink';
 import type { DeeplinkIntent } from '../../types/DeeplinkIntent';
+import { handleMoney } from './handleMoney';
 
 const { MM_IO_UNIVERSAL_LINK_HOST } = AppConstants;
 
@@ -115,6 +116,7 @@ const SUPPORTED_ACTIONS = {
   ANDROID_SDK: ACTIONS.ANDROID_SDK,
   CONNECT: ACTIONS.CONNECT,
   MMSDK: ACTIONS.MMSDK,
+  MONEY: ACTIONS.MONEY,
 } as const;
 
 type SUPPORTED_ACTIONS =
@@ -148,6 +150,7 @@ const WHITELISTED_ACTIONS: SUPPORTED_ACTIONS[] = [
   SUPPORTED_ACTIONS.EARN_MUSD,
   SUPPORTED_ACTIONS.AGENTIC_CLI,
   SUPPORTED_ACTIONS.ON_RAMP,
+  SUPPORTED_ACTIONS.MONEY,
 ];
 
 const interstitialWhitelistUrls = [] as const;
@@ -781,6 +784,10 @@ async function handleUniversalLink({
     }
     case SUPPORTED_ACTIONS.AGENTIC_CLI: {
       handleAgenticCliApproval({ actionPath: actionBasedRampPath });
+      break;
+    }
+    case SUPPORTED_ACTIONS.MONEY: {
+      handleMoney();
       break;
     }
   }

--- a/app/core/DeeplinkManager/types/deepLink.types.ts
+++ b/app/core/DeeplinkManager/types/deepLink.types.ts
@@ -152,6 +152,7 @@ export const SUPPORTED_ACTIONS = [
   ACTIONS.CONNECT,
   ACTIONS.MMSDK,
   ACTIONS.ANDROID_SDK,
+  ACTIONS.MONEY,
 ] as const satisfies readonly ACTIONS[];
 
 export type SupportedAction = (typeof SUPPORTED_ACTIONS)[number];

--- a/app/core/DeeplinkManager/types/deepLinkAnalytics.types.ts
+++ b/app/core/DeeplinkManager/types/deepLinkAnalytics.types.ts
@@ -73,6 +73,7 @@ export enum DeepLinkRoute {
   SDK_CONNECT = 'sdk-connect',
   // MetaMask SDK `mmsdk` deeplinks (the SDK's RPC message channel).
   SDK_MMSDK = 'sdk-mmsdk',
+  MONEY = 'money',
   INVALID = 'invalid',
 }
 

--- a/app/core/DeeplinkManager/util/deeplinks/deepLinkAnalytics.test.ts
+++ b/app/core/DeeplinkManager/util/deeplinks/deepLinkAnalytics.test.ts
@@ -488,6 +488,11 @@ describe('deepLinkAnalytics', () => {
       const result = mapSupportedActionToRoute(ACTIONS.ANDROID_SDK);
       expect(result).toBe(DeepLinkRoute.SDK_CONNECT);
     });
+
+    it('maps MONEY action to MONEY route', () => {
+      const result = mapSupportedActionToRoute(ACTIONS.MONEY);
+      expect(result).toBe(DeepLinkRoute.MONEY);
+    });
   });
 
   describe('extractRouteFromUrl', () => {
@@ -578,6 +583,11 @@ describe('deepLinkAnalytics', () => {
     it('extract home route for home path', () => {
       const result = extractRouteFromUrl('https://link.metamask.io/home');
       expect(result).toBe(DeepLinkRoute.HOME);
+    });
+
+    it('extract money route', () => {
+      const result = extractRouteFromUrl('https://link.metamask.io/money');
+      expect(result).toBe(DeepLinkRoute.MONEY);
     });
 
     it('return INVALID for unknown routes', () => {

--- a/app/core/DeeplinkManager/util/deeplinks/deepLinkAnalytics.ts
+++ b/app/core/DeeplinkManager/util/deeplinks/deepLinkAnalytics.ts
@@ -487,6 +487,7 @@ const routeExtractors: Record<
   [DeepLinkRoute.SDK_CONNECT]: extractInvalidProperties,
   [DeepLinkRoute.SDK_MMSDK]: extractInvalidProperties,
   [DeepLinkRoute.INVALID]: extractInvalidProperties,
+  [DeepLinkRoute.MONEY]: extractInvalidProperties,
 };
 
 /**
@@ -640,6 +641,8 @@ export const mapSupportedActionToRoute = (
       return DeepLinkRoute.SDK_CONNECT;
     case ACTIONS.MMSDK:
       return DeepLinkRoute.SDK_MMSDK;
+    case ACTIONS.MONEY:
+      return DeepLinkRoute.MONEY;
     default:
       return DeepLinkRoute.INVALID;
   }
@@ -704,6 +707,8 @@ export const extractRouteFromUrl = (url: string): DeepLinkRoute => {
         return DeepLinkRoute.NFT;
       case 'agentic-cli':
         return DeepLinkRoute.AGENTIC_CLI;
+      case 'money':
+        return DeepLinkRoute.MONEY;
       case undefined: // Empty path (no segments after filtering)
         return DeepLinkRoute.HOME;
       default:

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7277,6 +7277,11 @@
       "faq_a9": "Opening a Money Account and holding mUSD does not require identity verification. However, certain MetaMask features—including MetaMask Card and Ramps—require KYC (Know Your Customer) verification as required by applicable regulations. These checks are carried out by the third-party providers that operate these regulated services, not by MetaMask. If needed, you will be guided through the process inside the app during sign-up.",
       "faq_q10": "Which countries is MetaMask Money Account available in?",
       "faq_a10": "MetaMask Money Account is available globally except in the following regions: the UK, and countries on the USA sanctions list."
+    },
+    "geo_block": {
+      "title": "Money account unavailable",
+      "description": "Money account isn't available in your location due to local restrictions or sanctions.",
+      "button": "Got it"
     }
   },
   "stake": {


### PR DESCRIPTION
# feat: add Money deeplink flow with geo-block handling

## **Description**
Adds Money deeplinking support and `MoneyGeoBlockSheet`.

Navigation cases
- First time user is eligible -> redirected to MoneyOnboarding
- Returning user is eligible -> redirected to Money Home
- Geo-blocked user -> MoneyGeoBlockSheet displayed
- Money account disabled -> Unsupported sheet displayed


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds a dedicated Money deeplink entry (`metamask://money` and `/money` universal link path) so users can jump directly into Money. It routes users based on Money availability, geo eligibility, and onboarding state, including a new geo-block sheet for restricted regions.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added direct Money deeplink support and geo-block handling for restricted users.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

- Fixes: [MUSD-999](https://consensyssoftware.atlassian.net/browse/MUSD-999)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

- To test on a physical device use this link `metamask://money`
- To test in the iOS simulator you can use the command `xcrun simctl openurl booted "https://link-test.metamask.io/money"`

```gherkin
Feature: Money deeplink routing

  Scenario: New user navigated to Money Onboarding via deeplink
    Given the app is installed and the user has onboarded to their wallet
    And user has not seen the Money Onboarding flow before
    And user is not geo-blocked from Money account
    And Money account feature is enabled
    When the deeplink is opened
    Then the app opens the Money Onboarding flow

  Scenario: Returning user navigated to Money Onboarding via deeplink
    Given the app is installed and the user has onboarded to their wallet
    And user has seen the Money Onboarding flow before
    And user is not geo-blocked from Money account
    And Money account feature is enabled
    When the deeplink is opened
    Then the app opens the Money Home view

  Scenario: Geo-restricted user sees MoneyGeoBlockSheet
    Given the app is installed and the user has onboarded to their wallet
    And user is geo-blocked from Money account
    And Money account feature is enabled
    When the deeplink is opened
    Then the app opens and user sees the Money account geo block sheet
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - deeplink didn't exist

### **After**

#### First time user (Money Onboarding redirect)

https://github.com/user-attachments/assets/0a08315a-57de-44ea-a72f-2f44921a2bb8

#### Returning user (Money Home redirect)

https://github.com/user-attachments/assets/74b09cf9-f30f-483c-874c-811886f60bc8

#### Geo-blocked user (MoneyGeoBlockSheet redirect)

https://github.com/user-attachments/assets/3fc6f294-d611-421c-8d10-d4c45a3a2158

#### Money account feature flag disabled (Unsupported feature redirect)

https://github.com/user-attachments/assets/21634a53-263b-46a9-a002-f5cc4ab20bb6

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[MUSD-999]: https://consensyssoftware.atlassian.net/browse/MUSD-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New deeplink navigation touches eligibility gating and multiple entry paths; scope is bounded by tests and mirrors existing deeplink patterns, but wrong routing could expose Money flows to ineligible users.
> 
> **Overview**
> Adds a **`money`** deeplink entry (`metamask://money` / universal `/money`) and routes users into Money based on feature flag, geo eligibility, and onboarding state.
> 
> **`handleMoney`** branches to: unsupported deeplink modal when Money is disabled; **`MoneyGeoBlockSheet`** when geo-ineligible; Money onboarding for first-time users; Money Home on the home tabs for returning eligible users. Errors fall back to wallet home with logging.
> 
> Introduces **`MoneyGeoBlockSheet`** (localized copy, bottom-sheet analytics, dismiss → wallet home), registers it on **`MoneyModalStack`**, and wires **`MONEY`** through deeplink constants, navigation routes, supported actions (interstitial whitelist), and **`DeepLinkRoute.MONEY`** analytics mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93441a42d7e0c48d6dd14f24811c48ad3e4cd7a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->