### PR TITLE
fix(predict): harden crypto up/down chart price-history polling cp-8.0.0

### DIFF
--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -177,46 +177,62 @@ describe('useCryptoUpDownChartData', () => {
       (mockLastUseQueryConfig.current?.onSuccess as () => void)();
     };
 
-    it('does not poll while live when the live socket is connected', () => {
-      mockUseLiveCryptoPrices.mockImplementation(
-        (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
-          liveUpdateHandler = onUpdate;
-          return { isConnected: true };
-        },
-      );
+    const sendLiveTick = (price = 51000, timestamp = 100): void => {
+      act(() => {
+        liveUpdateHandler?.({ symbol: 'btc/usd', price, timestamp });
+      });
+    };
+
+    // The live stream is considered stale after LIVE_STREAM_STALE_TIMEOUT_MS
+    // (30s) without a tick. Advancing past it simulates a silent socket drop.
+    const advancePastStaleTimeout = (): void => {
+      act(() => {
+        jest.advanceTimersByTime(30_001);
+      });
+    };
+
+    // A live market whose end date is far enough in the future that advancing
+    // timers exercises the stale-stream path rather than market expiry.
+    const createLiveMarket = () =>
+      createMarket({ endDate: '2026-01-01T01:00:00.000Z' });
+
+    it('polls every 10s while live before the stream delivers fresh ticks', () => {
       const { Wrapper } = createWrapper();
       const market = createMarket();
 
       renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
 
-      expect(evaluateRefetchInterval()).toBe(false);
-      // Stays disabled even after failures accumulate.
-      recordFailures(5);
+      // The stream starts stale (no ticks yet), so HTTP polling fills the gap.
+      expect(evaluateRefetchInterval()).toBe(10000);
+    });
+
+    it('pauses polling while the live stream is delivering fresh ticks', () => {
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+
+      renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
+
+      sendLiveTick();
+
       expect(evaluateRefetchInterval()).toBe(false);
     });
 
-    it('polls every 10s while live when the live socket is disconnected', () => {
-      mockUseLiveCryptoPrices.mockImplementation(
-        (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
-          liveUpdateHandler = onUpdate;
-          return { isConnected: false };
-        },
-      );
+    it('resumes polling when the live stream goes stale after a silent drop', () => {
       const { Wrapper } = createWrapper();
-      const market = createMarket();
+      const market = createLiveMarket();
 
       renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
 
+      sendLiveTick();
+      expect(evaluateRefetchInterval()).toBe(false);
+
+      // Ticks stop arriving (socket dropped silently) -> stream goes stale and
+      // HTTP polling resumes as a fallback.
+      advancePastStaleTimeout();
       expect(evaluateRefetchInterval()).toBe(10000);
     });
 
     it('backs off, stops, then recovers as failures accumulate and clear', () => {
-      mockUseLiveCryptoPrices.mockImplementation(
-        (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
-          liveUpdateHandler = onUpdate;
-          return { isConnected: false };
-        },
-      );
       const { Wrapper } = createWrapper();
       const market = createMarket();
 
@@ -231,6 +247,26 @@ describe('useCryptoUpDownChartData', () => {
       expect(evaluateRefetchInterval()).toBe(false);
       // A successful fetch resets the count and restores the base cadence.
       recordSuccess();
+      expect(evaluateRefetchInterval()).toBe(10000);
+    });
+
+    it('resets the circuit breaker when the live stream recovers', () => {
+      const { Wrapper } = createWrapper();
+      const market = createLiveMarket();
+
+      renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
+
+      // Polling keeps failing until it disables itself.
+      recordFailures(7);
+      expect(evaluateRefetchInterval()).toBe(false);
+
+      // The socket recovers and delivers a tick -> breaker resets, polling paused.
+      sendLiveTick();
+      expect(evaluateRefetchInterval()).toBe(false);
+
+      // The socket later drops again -> the stream goes stale and polling resumes
+      // from the base cadence instead of staying latched at the disabled state.
+      advancePastStaleTimeout();
       expect(evaluateRefetchInterval()).toBe(10000);
     });
 

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -1,7 +1,10 @@
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useCryptoUpDownChartData } from './useCryptoUpDownChartData';
+import {
+  getHistoricalPollInterval,
+  useCryptoUpDownChartData,
+} from './useCryptoUpDownChartData';
 import type { CryptoPriceUpdate, PredictMarket, PredictSeries } from '../types';
 import type { LivelinePoint } from '../../Charts/LivelineChart/LivelineChart.types';
 
@@ -155,6 +158,25 @@ describe('useCryptoUpDownChartData', () => {
   });
 
   describe('historical query polling', () => {
+    type RefetchIntervalFn = () => number | false;
+
+    const evaluateRefetchInterval = (): number | false => {
+      const refetchInterval = mockLastUseQueryConfig.current
+        ?.refetchInterval as RefetchIntervalFn;
+      return refetchInterval();
+    };
+
+    const recordFailures = (count: number): void => {
+      const onError = mockLastUseQueryConfig.current?.onError as () => void;
+      for (let i = 0; i < count; i += 1) {
+        onError();
+      }
+    };
+
+    const recordSuccess = (): void => {
+      (mockLastUseQueryConfig.current?.onSuccess as () => void)();
+    };
+
     it('does not poll while live when the live socket is connected', () => {
       mockUseLiveCryptoPrices.mockImplementation(
         (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
@@ -167,7 +189,10 @@ describe('useCryptoUpDownChartData', () => {
 
       renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
 
-      expect(mockLastUseQueryConfig.current?.refetchInterval).toBe(false);
+      expect(evaluateRefetchInterval()).toBe(false);
+      // Stays disabled even after failures accumulate.
+      recordFailures(5);
+      expect(evaluateRefetchInterval()).toBe(false);
     });
 
     it('polls every 10s while live when the live socket is disconnected', () => {
@@ -182,7 +207,31 @@ describe('useCryptoUpDownChartData', () => {
 
       renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
 
-      expect(mockLastUseQueryConfig.current?.refetchInterval).toBe(10000);
+      expect(evaluateRefetchInterval()).toBe(10000);
+    });
+
+    it('backs off, stops, then recovers as failures accumulate and clear', () => {
+      mockUseLiveCryptoPrices.mockImplementation(
+        (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
+          liveUpdateHandler = onUpdate;
+          return { isConnected: false };
+        },
+      );
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+
+      renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
+
+      expect(evaluateRefetchInterval()).toBe(10000);
+      recordFailures(3);
+      expect(evaluateRefetchInterval()).toBe(30000);
+      recordFailures(2); // 5 total
+      expect(evaluateRefetchInterval()).toBe(60000);
+      recordFailures(2); // 7 total
+      expect(evaluateRefetchInterval()).toBe(false);
+      // A successful fetch resets the count and restores the base cadence.
+      recordSuccess();
+      expect(evaluateRefetchInterval()).toBe(10000);
     });
 
     it('does not poll for a non-live (historical-only) chart', () => {
@@ -197,7 +246,29 @@ describe('useCryptoUpDownChartData', () => {
         { wrapper: Wrapper },
       );
 
-      expect(mockLastUseQueryConfig.current?.refetchInterval).toBe(false);
+      expect(evaluateRefetchInterval()).toBe(false);
+      // Even with many failures recorded, a disabled poll stays disabled.
+      recordFailures(99);
+      expect(evaluateRefetchInterval()).toBe(false);
+    });
+  });
+
+  describe('getHistoricalPollInterval', () => {
+    it('uses the base 10s cadence below the backoff threshold', () => {
+      expect(getHistoricalPollInterval(0)).toBe(10000);
+      expect(getHistoricalPollInterval(2)).toBe(10000);
+    });
+
+    it('backs off to 30s then 60s as failures accumulate', () => {
+      expect(getHistoricalPollInterval(3)).toBe(30000);
+      expect(getHistoricalPollInterval(4)).toBe(30000);
+      expect(getHistoricalPollInterval(5)).toBe(60000);
+      expect(getHistoricalPollInterval(6)).toBe(60000);
+    });
+
+    it('stops polling once the disable threshold is reached', () => {
+      expect(getHistoricalPollInterval(7)).toBe(false);
+      expect(getHistoricalPollInterval(100)).toBe(false);
     });
   });
 

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts
@@ -23,6 +23,25 @@ jest.mock('./useLiveCryptoPrices', () => ({
   useLiveCryptoPrices: (...args: unknown[]) => mockUseLiveCryptoPrices(...args),
 }));
 
+// Captures the config passed to the most recent `useQuery` call so tests can
+// assert on dynamically-computed options (e.g. `refetchInterval`) while still
+// running the real React Query implementation.
+const mockLastUseQueryConfig: { current: Record<string, unknown> | undefined } =
+  {
+    current: undefined,
+  };
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: (config: Record<string, unknown>) => {
+      mockLastUseQueryConfig.current = config;
+      return actual.useQuery(config);
+    },
+  };
+});
+
 jest.mock('../utils/cryptoUpDown', () => ({
   getCryptoSymbol: (...args: unknown[]) => mockGetCryptoSymbol(...args),
   getVariant: (...args: unknown[]) => mockGetVariant(...args),
@@ -133,6 +152,53 @@ describe('useCryptoUpDownChartData', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  describe('historical query polling', () => {
+    it('does not poll while live when the live socket is connected', () => {
+      mockUseLiveCryptoPrices.mockImplementation(
+        (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
+          liveUpdateHandler = onUpdate;
+          return { isConnected: true };
+        },
+      );
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+
+      renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
+
+      expect(mockLastUseQueryConfig.current?.refetchInterval).toBe(false);
+    });
+
+    it('polls every 10s while live when the live socket is disconnected', () => {
+      mockUseLiveCryptoPrices.mockImplementation(
+        (_symbol: string, onUpdate: (update: CryptoPriceUpdate) => void) => {
+          liveUpdateHandler = onUpdate;
+          return { isConnected: false };
+        },
+      );
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+
+      renderHook(() => useCryptoUpDownChartData(market), { wrapper: Wrapper });
+
+      expect(mockLastUseQueryConfig.current?.refetchInterval).toBe(10000);
+    });
+
+    it('does not poll for a non-live (historical-only) chart', () => {
+      const { Wrapper } = createWrapper();
+      const market = createMarket();
+
+      renderHook(
+        () =>
+          useCryptoUpDownChartData(market, undefined, {
+            liveUpdatesEnabled: false,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      expect(mockLastUseQueryConfig.current?.refetchInterval).toBe(false);
+    });
   });
 
   describe('live path', () => {

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -20,7 +20,33 @@ const CURRENT_TIMESTAMP_TOLERANCE_SECS = 5;
 const MIN_LIVE_POINT_DELTA_SECS = 0.001;
 const LIVE_STREAM_STALE_TIMEOUT_MS = LIVE_CHART_WINDOW_SECS * 1000;
 const CONNECTION_ERROR_TIMEOUT_MS = 12000;
+
+// Circuit breaker for the historical-candle poll. When the endpoint is
+// unreachable we don't want to keep hammering it every 10s indefinitely, so the
+// interval backs off as consecutive failures accumulate and eventually stops.
+// React Query resets `fetchFailureCount` to 0 on the first successful fetch,
+// which automatically restores the normal cadence once the endpoint recovers.
 const POLL_INTERVAL_MS = 10000;
+const POLL_BACKOFF_30S_MS = 30000;
+const POLL_BACKOFF_60S_MS = 60000;
+const POLL_BACKOFF_30S_THRESHOLD = 3; // 3rd consecutive failure -> 30s
+const POLL_BACKOFF_60S_THRESHOLD = 5; // 5th consecutive failure -> 60s
+const POLL_DISABLE_THRESHOLD = 7; // 7th consecutive failure -> stop polling
+
+export const getHistoricalPollInterval = (
+  fetchFailureCount: number,
+): number | false => {
+  if (fetchFailureCount >= POLL_DISABLE_THRESHOLD) {
+    return false;
+  }
+  if (fetchFailureCount >= POLL_BACKOFF_60S_THRESHOLD) {
+    return POLL_BACKOFF_60S_MS;
+  }
+  if (fetchFailureCount >= POLL_BACKOFF_30S_THRESHOLD) {
+    return POLL_BACKOFF_30S_MS;
+  }
+  return POLL_INTERVAL_MS;
+};
 
 const mergeLivelinePoints = (
   historicalData: LivelinePoint[],
@@ -287,6 +313,13 @@ export const useCryptoUpDownChartData = (
     ? options.historicalWindow.endDate
     : liveHistoryEndDate;
 
+  // Counts consecutive failed historical-poll cycles. React Query's
+  // `fetchFailureCount` only counts retries *within a single fetch* and resets
+  // to 0 at the start of every fetch, so it cannot drive a backoff across
+  // separate interval polls. We track the count ourselves: increment on each
+  // settled error and reset on the next successful fetch (and on market change).
+  const consecutivePollFailuresRef = useRef(0);
+
   const historicalQuery = useQuery({
     ...predictQueries.cryptoPriceHistory.options({
       symbol: symbol ?? '',
@@ -298,11 +331,22 @@ export const useCryptoUpDownChartData = (
     keepPreviousData: true,
     staleTime: shouldStreamLive ? 1000 : Infinity,
     refetchOnMount: shouldStreamLive || !liveUpdatesEnabled ? 'always' : false,
+    onError: () => {
+      consecutivePollFailuresRef.current += 1;
+    },
+    onSuccess: () => {
+      consecutivePollFailuresRef.current = 0;
+    },
     // Only poll while streaming live AND the WebSocket is down. `refetchOnMount`
     // still seeds the historical baseline once; the socket supplies live ticks
     // when connected, so redundant interval polling is disabled in that case.
-    refetchInterval:
-      shouldStreamLive && !isLiveSocketConnected ? POLL_INTERVAL_MS : false,
+    // When polling is active, the interval backs off (and ultimately stops) as
+    // consecutive failures accumulate so an unreachable endpoint is not hit
+    // every 10s indefinitely.
+    refetchInterval: () =>
+      shouldStreamLive && !isLiveSocketConnected
+        ? getHistoricalPollInterval(consecutivePollFailuresRef.current)
+        : false,
   });
 
   const historicalData = historicalQuery.data ?? EMPTY_DATA;
@@ -407,6 +451,7 @@ export const useCryptoUpDownChartData = (
       connectionErrorTimerRef.current = undefined;
     }
     setConnectionError(false);
+    consecutivePollFailuresRef.current = 0;
   }, [market.id]);
 
   const isAwaitingLiveData =

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -20,6 +20,7 @@ const CURRENT_TIMESTAMP_TOLERANCE_SECS = 5;
 const MIN_LIVE_POINT_DELTA_SECS = 0.001;
 const LIVE_STREAM_STALE_TIMEOUT_MS = LIVE_CHART_WINDOW_SECS * 1000;
 const CONNECTION_ERROR_TIMEOUT_MS = 12000;
+const POLL_INTERVAL_MS = 10000;
 
 const mergeLivelinePoints = (
   historicalData: LivelinePoint[],
@@ -270,7 +271,14 @@ export const useCryptoUpDownChartData = (
   const wsSymbol =
     enabled && shouldStreamLive && symbol ? `${symbol.toLowerCase()}/usd` : '';
 
-  useLiveCryptoPrices(wsSymbol, handleLiveUpdate);
+  // When the live-data WebSocket is connected it already streams real-time
+  // ticks, so the HTTP query only needs its initial historical baseline fetch.
+  // We use `isConnected` below to pause interval polling while the socket is
+  // healthy and resume it if the socket drops.
+  const { isConnected: isLiveSocketConnected } = useLiveCryptoPrices(
+    wsSymbol,
+    handleLiveUpdate,
+  );
 
   const historyStartDate =
     options.historicalWindow?.startDate ?? eventStartTime;
@@ -290,7 +298,11 @@ export const useCryptoUpDownChartData = (
     keepPreviousData: true,
     staleTime: shouldStreamLive ? 1000 : Infinity,
     refetchOnMount: shouldStreamLive || !liveUpdatesEnabled ? 'always' : false,
-    refetchInterval: shouldStreamLive ? 10000 : false,
+    // Only poll while streaming live AND the WebSocket is down. `refetchOnMount`
+    // still seeds the historical baseline once; the socket supplies live ticks
+    // when connected, so redundant interval polling is disabled in that case.
+    refetchInterval:
+      shouldStreamLive && !isLiveSocketConnected ? POLL_INTERVAL_MS : false,
   });
 
   const historicalData = historicalQuery.data ?? EMPTY_DATA;

--- a/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
+++ b/app/components/UI/Predict/hooks/useCryptoUpDownChartData.ts
@@ -297,14 +297,14 @@ export const useCryptoUpDownChartData = (
   const wsSymbol =
     enabled && shouldStreamLive && symbol ? `${symbol.toLowerCase()}/usd` : '';
 
-  // When the live-data WebSocket is connected it already streams real-time
-  // ticks, so the HTTP query only needs its initial historical baseline fetch.
-  // We use `isConnected` below to pause interval polling while the socket is
-  // healthy and resume it if the socket drops.
-  const { isConnected: isLiveSocketConnected } = useLiveCryptoPrices(
-    wsSymbol,
-    handleLiveUpdate,
-  );
+  // The live-data WebSocket streams real-time ticks while healthy, so the HTTP
+  // query only needs its initial historical baseline in that case. Interval
+  // polling is gated on `liveStreamStale` (see `refetchInterval` below) rather
+  // than this hook's `isConnected` flag: `isConnected` latches true on the first
+  // tick and never flips back on a silent RTDS drop, whereas `liveStreamStale`
+  // flips back to true when ticks stop arriving — correctly resuming HTTP
+  // polling as a fallback.
+  useLiveCryptoPrices(wsSymbol, handleLiveUpdate);
 
   const historyStartDate =
     options.historicalWindow?.startDate ?? eventStartTime;
@@ -319,6 +319,16 @@ export const useCryptoUpDownChartData = (
   // separate interval polls. We track the count ourselves: increment on each
   // settled error and reset on the next successful fetch (and on market change).
   const consecutivePollFailuresRef = useRef(0);
+
+  // A fresh live stream is a recovery signal: reset the polling circuit breaker
+  // so that if the socket later drops (stream goes stale again), HTTP polling
+  // resumes from the base cadence instead of staying latched at the disabled
+  // threshold.
+  useEffect(() => {
+    if (!liveStreamStale) {
+      consecutivePollFailuresRef.current = 0;
+    }
+  }, [liveStreamStale]);
 
   const historicalQuery = useQuery({
     ...predictQueries.cryptoPriceHistory.options({
@@ -337,14 +347,15 @@ export const useCryptoUpDownChartData = (
     onSuccess: () => {
       consecutivePollFailuresRef.current = 0;
     },
-    // Only poll while streaming live AND the WebSocket is down. `refetchOnMount`
-    // still seeds the historical baseline once; the socket supplies live ticks
-    // when connected, so redundant interval polling is disabled in that case.
+    // Only poll while streaming live AND the live stream is not currently
+    // delivering fresh ticks (`liveStreamStale`). `refetchOnMount` still seeds
+    // the historical baseline once; while the socket streams real-time ticks the
+    // interval poll is redundant, but it resumes automatically if ticks stop.
     // When polling is active, the interval backs off (and ultimately stops) as
     // consecutive failures accumulate so an unreachable endpoint is not hit
     // every 10s indefinitely.
     refetchInterval: () =>
-      shouldStreamLive && !isLiveSocketConnected
+      shouldStreamLive && liveStreamStale
         ? getHistoricalPollInterval(consecutivePollFailuresRef.current)
         : false,
   });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1741,6 +1741,54 @@ describe('PolymarketProvider', () => {
       }),
     ).rejects.toThrow('Failed to get crypto price history');
   });
+
+  it('downgrades transient network failures to a breadcrumb instead of a Sentry error', async () => {
+    const Logger = jest.requireMock('../../../../../util/Logger').default;
+    (Logger.error as jest.Mock).mockClear();
+    (Logger.log as jest.Mock).mockClear();
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new TypeError('Network request failed'));
+
+    await expect(
+      createProvider().getCryptoPriceHistory({
+        symbol: 'BTC',
+        eventStartTime: '2025-01-01T00:00:00Z',
+        variant: 'hourly',
+      }),
+    ).rejects.toThrow('Network request failed');
+
+    expect(Logger.error).not.toHaveBeenCalled();
+    expect(Logger.log).toHaveBeenCalledWith(
+      'Predict crypto price history fetch failed (transient network/availability):',
+      'Network request failed',
+      expect.any(Object),
+    );
+  });
+
+  it('still reports unexpected (non-network) crypto price history errors to Sentry', async () => {
+    const Logger = jest.requireMock('../../../../../util/Logger').default;
+    (Logger.error as jest.Mock).mockClear();
+    (Logger.log as jest.Mock).mockClear();
+    const unexpectedError = new Error('Unexpected parsing failure');
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockRejectedValue(unexpectedError),
+    });
+
+    await expect(
+      createProvider().getCryptoPriceHistory({
+        symbol: 'BTC',
+        eventStartTime: '2025-01-01T00:00:00Z',
+        variant: 'hourly',
+      }),
+    ).rejects.toThrow('Unexpected parsing failure');
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      unexpectedError,
+      expect.any(Object),
+    );
+  });
 });
 
 describe('PolymarketProvider.subscribeToOrderbook', () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -266,6 +266,19 @@ const isWithinWindow = ({
   (startSeconds === undefined || timestamp >= startSeconds) &&
   (endSeconds === undefined || timestamp <= endSeconds);
 
+/**
+ * Whether an error from the crypto price history fetch is an expected,
+ * transient availability issue (low-level network failure or a non-OK HTTP
+ * response from the upstream endpoint) rather than an unexpected bug. These are
+ * routinely produced while polling an unreachable endpoint and should not raise
+ * error-level Sentry events.
+ */
+const isTransientPriceHistoryError = (error: Error): boolean =>
+  error instanceof TypeError ||
+  /network request failed|failed to get crypto price history/i.test(
+    error.message,
+  );
+
 export class PolymarketProvider implements PredictProvider {
   readonly providerId = POLYMARKET_PROVIDER_ID;
   readonly name = 'Polymarket';
@@ -1344,15 +1357,28 @@ export class PolymarketProvider implements PredictProvider {
         error,
       );
 
-      Logger.error(
-        error instanceof Error ? error : new Error(String(error)),
-        this.getErrorContext('getCryptoPriceHistory', {
-          symbol,
-          eventStartTime,
-          variant,
-          endDate,
-        } as Record<string, unknown>),
-      );
+      const normalizedError =
+        error instanceof Error ? error : new Error(String(error));
+      const errorContext = this.getErrorContext('getCryptoPriceHistory', {
+        symbol,
+        eventStartTime,
+        variant,
+        endDate,
+      } as Record<string, unknown>);
+
+      // Transient network/availability failures are expected while polling and
+      // would otherwise flood Sentry with error-level events. Record them as
+      // breadcrumbs (Logger.log) instead, and reserve Logger.error for
+      // unexpected failures.
+      if (isTransientPriceHistoryError(normalizedError)) {
+        Logger.log(
+          'Predict crypto price history fetch failed (transient network/availability):',
+          normalizedError.message,
+          errorContext,
+        );
+      } else {
+        Logger.error(normalizedError, errorContext);
+      }
 
       throw error;
     }

--- a/app/components/UI/Predict/queries/cryptoPriceHistory.test.ts
+++ b/app/components/UI/Predict/queries/cryptoPriceHistory.test.ts
@@ -67,6 +67,14 @@ describe('cryptoPriceHistory queries', () => {
     });
   });
 
+  describe('predictCryptoPriceHistoryOptions', () => {
+    it('disables retries so interval polling does not multiply failed requests', () => {
+      const options = predictCryptoPriceHistoryOptions(defaultParams);
+
+      expect(options.retry).toBe(0);
+    });
+  });
+
   describe('queryFn', () => {
     it('converts millisecond timestamps to Liveline seconds', async () => {
       (

--- a/app/components/UI/Predict/queries/cryptoPriceHistory.ts
+++ b/app/components/UI/Predict/queries/cryptoPriceHistory.ts
@@ -56,4 +56,9 @@ export const predictCryptoPriceHistoryOptions = ({
       return toLivelinePoints(history ?? []);
     },
     staleTime: Infinity,
+    // The chart hook re-polls this query on an interval while a market is live,
+    // which already provides natural retries. Inheriting the global `retry: 2`
+    // default just triples the failed-request count (and Sentry noise) whenever
+    // the Chainlink candles endpoint is unreachable, so disable retries here.
+    retry: 0,
   });


### PR DESCRIPTION
## **Description**

The Predict crypto up/down chart polls Polymarket's Chainlink candles endpoint (`/api/chainlink-candles`) on an interval while a market is live. When that endpoint is unreachable, the polling loop had no safeguards and generated a large volume of failed requests and error-level Sentry events (observed ~186 failed requests + matching Sentry errors in a ~10 minute session).

This PR hardens that data path with four focused fixes, one per commit:

1. **Disable retries on the price-history query** (`retry: 0`). The query inherited the global `retry: 2` default, so every failed poll fired 3 requests instead of 1. The interval poll already provides natural retries, so the extra attempts just tripled the failure/Sentry-event count.
2. **Pause HTTP polling while the live WebSocket is connected.** The chart runs two data paths: a live-data WebSocket (real-time ticks) and the HTTP query (historical candle baseline). The previously-discarded `isConnected` signal now gates `refetchInterval`, so we poll only while live **and** the socket is down. `refetchOnMount: 'always'` still seeds the baseline once, and polling resumes automatically if the socket drops.
3. **Add a circuit-breaker backoff.** When polling is active, the interval now backs off as consecutive failed poll cycles accumulate (10s → 30s at 3 failures → 60s at 5 → stop at 7), instead of hammering an unreachable endpoint every 10s indefinitely. The count is tracked in a ref (React Query's `fetchFailureCount` resets every fetch and cannot drive cross-cycle backoff) and resets on the first successful fetch and on market change, restoring the normal cadence on recovery.
4. **Downgrade transient failures from Sentry errors to breadcrumbs.** Transient network/availability failures (e.g. `Network request failed`, non-OK HTTP) are routine while polling and are now logged via `Logger.log` (a breadcrumb, no error event). `Logger.error` is reserved for unexpected failures. The error is still rethrown to React Query unchanged.

No user-visible behavior changes: the chart renders the same; it just polls far less and stops flooding telemetry when the endpoint is unhealthy.

## **Changelog**

CHANGELOG entry: null

<!-- Internal robustness/telemetry fix with no user-facing behavior change. Please apply the `no-changelog` label. -->

## **Related issues**

Fixes: [PRED-1033](https://consensyssoftware.atlassian.net/browse/PRED-1033)

## **Manual testing steps**

```gherkin
Feature: Crypto up/down chart price-history polling resilience

  Scenario: Polling does not multiply requests when the endpoint fails
    Given a live crypto up/down market is displayed
    And the Chainlink candles endpoint is forced to fail fast (e.g. proxy map-to-failure)
    When a poll cycle fails
    Then exactly one request is sent per cycle (not three)

  Scenario: Polling pauses while the live WebSocket is connected
    Given a live crypto up/down market is displayed
    And the live-data WebSocket is connected and streaming ticks
    Then the chainlink-candles request fires once on mount and then stops
    When the WebSocket connection drops
    Then interval polling resumes

  Scenario: Polling backs off and stops when the endpoint stays unreachable
    Given a live crypto up/down market is displayed
    And the WebSocket is down and the candles endpoint keeps failing
    When consecutive poll cycles fail
    Then the interval backs off 10s -> 30s (after 3 failures) -> 60s (after 5) -> stops (after 7)
    And it returns to the 10s cadence once a request succeeds

  Scenario: Transient failures do not raise Sentry errors
    Given the candles endpoint returns a network/availability failure while polling
    Then the failure is recorded as a breadcrumb (Logger.log), not an error-level Sentry event
```

Automated coverage: `yarn jest app/components/UI/Predict/queries/cryptoPriceHistory.test.ts app/components/UI/Predict/hooks/useCryptoUpDownChartData.test.ts app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts` — 120 tests passing. `yarn lint:tsc` passes.

## **Screenshots/Recordings**

### **Before**

N/A — no visual changes. This is a network-polling/telemetry robustness fix; the chart UI is unchanged.

### **After**

N/A — no visual changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1033]: https://consensyssoftware.atlassian.net/browse/PRED-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predict chart data-path and telemetry only; no auth or payment changes, with broad unit test coverage and no intended user-visible chart behavior change.
> 
> **Overview**
> Hardens live **crypto up/down** chart fetches when Polymarket’s Chainlink candles endpoint is down, without changing chart UI.
> 
> **React Query** for `cryptoPriceHistory` now uses **`retry: 0`** so each failed poll cycle is a single request instead of three. In `useCryptoUpDownChartData`, HTTP **`refetchInterval`** only runs while the market is live **and** the live price stream is stale (no fresh WebSocket ticks for ~30s), not on a fixed 10s loop whenever streaming. When polling is active, **`getHistoricalPollInterval`** backs off on consecutive failures (10s → 30s → 60s → stop) via a ref-tracked counter; success, market change, or a healthy live stream resets the breaker.
> 
> **PolymarketProvider** logs expected transient network/availability failures as breadcrumbs (`Logger.log`) instead of Sentry **`Logger.error`**, while unexpected errors still report to Sentry. Tests cover polling gating, backoff, retry disable, and logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97330021f11e5bf5497ba4ebde7047ac7fd11b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->