### PR TITLE
chore: Add optional react compiler error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ ios/GoogleService-Info.plist
 node_modules/
 npm-debug.log
 yarn-error.log
+
+# React Compiler bailout log (generated at build time)
+react-compiler.log
 .yalc
 yalc.lock
 

--- a/.js.env.example
+++ b/.js.env.example
@@ -245,3 +245,7 @@ export MM_HARDWARE_WALLET_ONBOARDING_REDESIGN=
 # Set to "true" to render dark mode against the DS pure-black preview tokens
 # Audit tool for the pure-black migration — does not ship the preview package
 export MM_PURE_BLACK_PREVIEW="false"
+
+# For babel use
+# Set to "true" to log react compiler failures
+export REACT_COMPILER_LOG_FAILURES='false'

--- a/babel.config.js
+++ b/babel.config.js
@@ -66,6 +66,7 @@ module.exports = {
   presets: ['babel-preset-expo'],
   plugins: [
     ...reactCompilerBabelConfig,
+    'transform-inline-environment-variables',
     dynamicImportToRequire,
     // NOTE: react-native-reanimated/plugin must be listed LAST.
     // Required by reanimated v3 to compile `'worklet'` directives; without it,

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,8 @@
-const isTestEnv = process.env.NODE_ENV === 'test';
+// React Compiler plugin (incl. bailout logging and test-env gating) lives in its
+// own module so this config stays focused on wiring plugins together.
+// `reactCompilerPlugins` is empty under Jest and a single-element array otherwise.
+// eslint-disable-next-line import-x/no-commonjs
+const { reactCompilerBabelConfig } = require('./scripts/react-compiler');
 
 // Hermes (RN's bytecode compiler) does not accept dynamic `import()` syntax —
 // even inside dead code branches — and aborts with "Invalid expression
@@ -60,12 +64,8 @@ module.exports = {
         /\/expo\/virtual\/streams\.js$/.test(filename)),
   ],
   presets: ['babel-preset-expo'],
-  // Babel can find the plugin without the `babel-plugin-` prefix. Ex. `babel-plugin-react-compiler` -> `react-compiler`
   plugins: [
-    // Disabled under Jest (see isTestEnv note above) to avoid the jest.mock
-    // hoisting conflict with the compiler-injected `_c` helper.
-    ...(isTestEnv ? [] : ['react-compiler']),
-    'transform-inline-environment-variables',
+    ...reactCompilerBabelConfig,
     dynamicImportToRequire,
     // NOTE: react-native-reanimated/plugin must be listed LAST.
     // Required by reanimated v3 to compile `'worklet'` directives; without it,

--- a/scripts/react-compiler.js
+++ b/scripts/react-compiler.js
@@ -19,37 +19,42 @@ const shouldLogReactCompilerFailures = process.env.REACT_COMPILER_LOG_FAILURES =
 // can be reviewed after a build instead of scrolling through Metro's output.
 const reactCompilerLogPath = path.join(__dirname, '..', 'react-compiler.log');
 
-// Truncate + write a header once per build process so each run starts with a
-// clean, self-describing log instead of endlessly appending across builds.
+// Append-only logging. We deliberately do NOT truncate the file at runtime:
+// Metro runs Babel transforms across multiple worker processes, each with its
+// own module state, so a truncate-on-first-write would let a worker that hits
+// its first bailout late wipe entries already written by its siblings. Instead
+// every process writes a header once, then appends each error below it. The
+// file is git-ignored — delete it to clear.
 let reactCompilerLogInitialized = false;
 const initReactCompilerLog = () => {
   if (reactCompilerLogInitialized) {
     return;
   }
   reactCompilerLogInitialized = true;
-  const header =
-    `# React Compiler bailout log\n` +
-    `# Generated: ${new Date().toISOString()}\n` +
-    `# Each entry lists a component the compiler could not optimize.\n` +
-    `${'='.repeat(80)}\n\n`;
+  const divider = '─'.repeat(80);
+  const runHeader =
+    `\n${divider}\n` +
+    `React Compiler errors — ${new Date().toLocaleString()}\n` +
+    `These components could not be optimized and were skipped by the compiler.\n` +
+    `${divider}\n`;
   try {
-    fs.writeFileSync(reactCompilerLogPath, header);
+    fs.appendFileSync(reactCompilerLogPath, runHeader);
   } catch {
     // Logging must never break a build; ignore filesystem errors.
   }
 };
 
 const appendReactCompilerLog = (filename, event) => {
-  initReactCompilerLog();
-  const detail = event.detail ?? event;
-  const formattedDetail =
-    typeof detail === 'string' ? detail : JSON.stringify(detail, null, 2);
-  const entry =
-    `[${new Date().toISOString()}] ${event.kind}\n` +
-    `  File:   ${filename}\n` +
-    `  Detail: ${formattedDetail.replace(/\n/g, '\n          ')}\n` +
-    `${'-'.repeat(80)}\n`;
   try {
+    initReactCompilerLog();
+    const detail = event.detail ?? event;
+    const formattedDetail =
+      typeof detail === 'string' ? detail : JSON.stringify(detail, null, 2);
+    const entry =
+      `[${new Date().toISOString()}] ${event.kind}\n` +
+      `  File:   ${filename}\n` +
+      `  Detail: ${formattedDetail.replace(/\n/g, '\n          ')}\n` +
+      `${'-'.repeat(80)}\n`;
     fs.appendFileSync(reactCompilerLogPath, entry);
   } catch {
     // Logging must never break a build; ignore filesystem errors.

--- a/scripts/react-compiler.js
+++ b/scripts/react-compiler.js
@@ -1,0 +1,91 @@
+// React Compiler configuration + bailout logging, extracted from babel.config.js
+// so the Babel config stays focused on wiring plugins together.
+//
+// The compiler silently skips any component it can't safely optimize (e.g. a
+// Rules-of-React violation). To surface those events we attach a `logger` that
+// both warns to the console and persists a structured, readable record to a
+// git-ignored log file for review after the build.
+
+// eslint-disable-next-line import-x/no-commonjs
+const fs = require('fs');
+// eslint-disable-next-line import-x/no-commonjs
+const path = require('path');
+
+// Toggle for logging React Compiler bailouts/failures. When false, the compiler
+// keeps its quiet default behavior and no logger is attached.
+const shouldLogReactCompilerFailures = process.env.REACT_COMPILER_LOG_FAILURES === 'true';
+
+// All React Compiler bailouts are persisted to this git-ignored file so they
+// can be reviewed after a build instead of scrolling through Metro's output.
+const reactCompilerLogPath = path.join(__dirname, '..', 'react-compiler.log');
+
+// Truncate + write a header once per build process so each run starts with a
+// clean, self-describing log instead of endlessly appending across builds.
+let reactCompilerLogInitialized = false;
+const initReactCompilerLog = () => {
+  if (reactCompilerLogInitialized) {
+    return;
+  }
+  reactCompilerLogInitialized = true;
+  const header =
+    `# React Compiler bailout log\n` +
+    `# Generated: ${new Date().toISOString()}\n` +
+    `# Each entry lists a component the compiler could not optimize.\n` +
+    `${'='.repeat(80)}\n\n`;
+  try {
+    fs.writeFileSync(reactCompilerLogPath, header);
+  } catch {
+    // Logging must never break a build; ignore filesystem errors.
+  }
+};
+
+const appendReactCompilerLog = (filename, event) => {
+  initReactCompilerLog();
+  const detail = event.detail ?? event;
+  const formattedDetail =
+    typeof detail === 'string' ? detail : JSON.stringify(detail, null, 2);
+  const entry =
+    `[${new Date().toISOString()}] ${event.kind}\n` +
+    `  File:   ${filename}\n` +
+    `  Detail: ${formattedDetail.replace(/\n/g, '\n          ')}\n` +
+    `${'-'.repeat(80)}\n`;
+  try {
+    fs.appendFileSync(reactCompilerLogPath, entry);
+  } catch {
+    // Logging must never break a build; ignore filesystem errors.
+  }
+};
+
+// React Compiler plugin options. A `logger` is only attached when logging is
+// enabled so normal builds keep their quiet default behavior.
+const reactCompilerOptions = shouldLogReactCompilerFailures
+  ? {
+      logger: {
+        logEvent(filename, event) {
+          if (event.kind === 'CompileError' || event.kind === 'CompileSkip') {
+            appendReactCompilerLog(filename, event);
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[REACT-COMPILER] ${event.kind} in ${filename}: See ${reactCompilerLogPath} for more details.`,
+            );
+          }
+        },
+      },
+    }
+  : null;
+
+// Babel can find the plugin without the `babel-plugin-` prefix.
+// Ex. `babel-plugin-react-compiler` -> `react-compiler`
+const reactCompilerPlugin = reactCompilerOptions
+  ? ['react-compiler', reactCompilerOptions]
+  : 'react-compiler';
+
+// Don't run React Compiler in a test environment such as Jest. It's disabled
+// under Jest to avoid the jest.mock hoisting conflict with the compiler-injected
+// `_c` helper. Exposed as a ready-to-spread array so the Babel config doesn't
+// have to know about the test-env gating at all.
+const isTestEnv = process.env.NODE_ENV === 'test';
+const reactCompilerBabelConfig = isTestEnv ? [] : [reactCompilerPlugin];
+
+// eslint-disable-next-line import-x/no-commonjs
+module.exports = { reactCompilerBabelConfig };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds the option to log react compiler failures by setting the `REACT_COMPILER_LOG_FAILURES` env var to "true". It is disabled by default to reduce development noise. When enabled, the terminal will show react compiler logs and write to a git ignored file named `react-compiler.log`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-668

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - No app change. Just set `REACT_COMPILER_LOG_FAILURES` in `.js.env`, run `yarn watch:clean` and re-run the app

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A - just no react-compiler logs

### **After**

<!-- [screenshots/recordings] -->
<img width="659" height="635" alt="Screenshot 2026-06-18 at 10 25 11 AM" src="https://github.com/user-attachments/assets/16cf63dd-6916-4e15-9820-b81e7e3a3a69" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time Babel tooling only; logging is off by default and filesystem errors are swallowed so builds should not break.
> 
> **Overview**
> **Optional React Compiler diagnostics** for Metro/Babel builds: set `REACT_COMPILER_LOG_FAILURES=true` (documented in `.js.env.example`) to surface `CompileError` / `CompileSkip` events in the console and append structured entries to a git-ignored **`react-compiler.log`**. Default behavior stays quiet (no logger attached).
> 
> React Compiler wiring is **moved out of `babel.config.js`** into **`scripts/react-compiler.js`**, which still exports `reactCompilerBabelConfig` (compiler off under Jest, unchanged). **`react-compiler.log`** is added to **`.gitignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c24bf38016cdee1bda67d20ae717419d1c51f024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->