### PR TITLE
chore: add Cursor rule for version-gated feature flags

### DIFF
--- a/.cursor/rules/version-gated-feature-flags.mdc
+++ b/.cursor/rules/version-gated-feature-flags.mdc
@@ -1,0 +1,95 @@
+---
+description: Use shared version-gated feature flag helpers; never duplicate hasMinimumRequiredVersion or validatedVersionGatedFeatureFlag
+globs: app/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# Version-Gated Feature Flags
+
+## Canonical source (SSOT)
+
+All version-gated feature flag logic lives in `app/util/remoteFeatureFlag/index.ts`:
+
+- `validatedVersionGatedFeatureFlag` — preferred for remote flags shaped as `{ enabled, minimumVersion }` (or progressive-rollout wrappers)
+- `hasMinimumRequiredVersion` — version comparison only; import when needed, never redefine
+
+## Required patterns
+
+### ✅ Use `validatedVersionGatedFeatureFlag` in selectors
+
+```typescript
+import { validatedVersionGatedFeatureFlag, VersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
+
+export const selectMyFeatureEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag = remoteFeatureFlags?.myFeature as unknown as VersionGatedFeatureFlag;
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);
+```
+
+### ✅ Non-standard flag shapes — map, don't duplicate
+
+Configs that use `active` instead of `enabled` (e.g. `depositConfig`) must map to the canonical shape and call the shared helper:
+
+```typescript
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
+
+return (
+  validatedVersionGatedFeatureFlag({
+    enabled: depositConfig.active ?? false,
+    minimumVersion: depositConfig.minimumVersion ?? '',
+  }) ?? false
+);
+```
+
+### ✅ Import `hasMinimumRequiredVersion` only from the util
+
+```typescript
+import { hasMinimumRequiredVersion } from '../../../util/remoteFeatureFlag';
+```
+
+Never copy the `compare-versions` + `getVersion` pattern into feature modules.
+
+## Forbidden patterns
+
+### ❌ Do not define local version-gating helpers
+
+```typescript
+// FORBIDDEN — duplicate of app/util/remoteFeatureFlag
+function hasMinimumRequiredVersion(minVersion: string) { ... }
+const validatedVersionGatedFeatureFlag = (flag: unknown) => { ... }
+```
+
+### ❌ Do not inline version checks for feature flags
+
+```typescript
+// FORBIDDEN
+import { getVersion } from 'react-native-device-info';
+import compareVersions from 'compare-versions';
+
+const ok = compareVersions.compare(getVersion(), flag.minimumVersion, '>=');
+```
+
+### ❌ Do not add duplicate utils under feature folders
+
+Do not create files like:
+
+- `app/components/UI/**/utils/hasMinimumRequiredVersion.ts`
+- `app/core/redux/slices/**/hasMinimumRequiredVersion.ts`
+
+## Where logic belongs
+
+| Layer | Responsibility |
+|-------|----------------|
+| `RemoteFeatureFlagController` | Fetch/store raw flags — **no** client version gating |
+| `app/util/remoteFeatureFlag` | Version comparison + `validatedVersionGatedFeatureFlag` |
+| Selectors (`featureFlagController`, `**/selectors/featureFlags`) | Call shared helpers; return `boolean` |
+| Hooks / components | `useSelector(selectXEnabled)` — not local version math |
+
+## Enforcement
+
+- **REJECT** new local definitions of `hasMinimumRequiredVersion` or `validatedVersionGatedFeatureFlag`
+- **REJECT** new `compare-versions` + `getVersion` usage for feature-flag gating outside `app/util/remoteFeatureFlag`
+- **REQUIRE** imports from `app/util/remoteFeatureFlag` for all version-gated flag checks

--- a/.gitignore
+++ b/.gitignore
@@ -217,10 +217,12 @@ release-signoffs.json
 .claude/skills/
 .claude/commands/
 .agents/skills/
-.cursor/rules/
+.cursor/rules/*
+!.cursor/rules/*.mdc
 .cursor/skills/
 .cursor/commands/
 # Carve-outs: IDE/bugbot config that must stay tracked
+!.cursor/rules/*.mdc
 !.cursor/BUGBOT.md
 !.cursor/hooks.json
 !.cursor/worktrees.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ General coding, UI, deeplink-handler, and PR-creation guidance now lives in the 
 - **Components**: Design system first → `component-library` second → custom last
 - **Styling**: Use `useTailwind()` hook, `Box`/`Text` components, design tokens
 - **Testing**: Mandatory for all code, AAA pattern, mock everything external
+- **Version-gated feature flags**: Use shared helpers from `app/util/remoteFeatureFlag` — see [`.cursor/rules/version-gated-feature-flags.mdc`](.cursor/rules/version-gated-feature-flags.mdc)
 - **Commands**: ONLY use yarn (never npm/npx)
 
 ## Environment Setup


### PR DESCRIPTION
## **Description**

Contributors and AI agents have occasionally duplicated version-gating logic for remote feature flags — local `hasMinimumRequiredVersion` helpers, inline `compare-versions` + `getVersion` checks, or copies of `validatedVersionGatedFeatureFlag` under feature folders. That drifts from the canonical implementation in `app/util/remoteFeatureFlag/index.ts`.

This PR adds a **tracked** Cursor rule (`.cursor/rules/version-gated-feature-flags.mdc`) that instructs agents and developers to:

1. Use `validatedVersionGatedFeatureFlag` for standard `{ enabled, minimumVersion }` remote flags (in selectors).
2. Map non-standard shapes (e.g. `depositConfig.active`) to the canonical shape instead of reimplementing checks.
3. Import `hasMinimumRequiredVersion` only from `app/util/remoteFeatureFlag` when needed — never redefine it.

Also updates `.gitignore` with a carve-out (`!.cursor/rules/*.mdc`) so repo-specific Cursor rules can be committed alongside synced skills content (ADR #57 still applies to `yarn skills` output). Adds a pointer in `AGENTS.md` for non-Cursor contributors.

**Reason for change:** Prevent duplicate version-gating helpers and keep feature-flag behavior consistent across Ramp, Bridge, Money, Perps, etc.

**Improvement:** Cursor users get automatic guidance when editing `app/**/*.{ts,tsx}`; all agents reading `AGENTS.md` see the SSOT reference.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A — documentation and agent-guidance only. No runtime behavior change.

Verify locally (optional):

1. Open any file under `app/` in Cursor.
2. Confirm `.cursor/rules/version-gated-feature-flags.mdc` appears in Cursor Rules (or ask the agent to add a local `hasMinimumRequiredVersion` — it should refuse and cite the rule).

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've tested instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)