### PR TITLE
feat(predict): Add Claim winnings analytics — claim events not firing across all entry points

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownPositions/PredictCryptoUpDownPosition.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownPositions/PredictCryptoUpDownPosition.tsx
@@ -132,7 +132,10 @@ const PredictCryptoUpDownPosition: React.FC<
   const handleClaimPress = useCallback(async () => {
     await executeGuardedAction(
       async () => {
-        await claim();
+        // Claims are aggregate; market attribution is derived controller-side.
+        await claim({
+          entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
+        });
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
     );

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -187,7 +187,9 @@ const PredictPositionsHeader = forwardRef<
   const handleClaim = async () => {
     await executeGuardedAction(
       async () => {
-        await claim();
+        await claim({
+          entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+        });
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
     );

--- a/app/components/UI/Predict/components/PredictPositionsViewHeader/PredictPositionsViewHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsViewHeader/PredictPositionsViewHeader.test.tsx
@@ -154,7 +154,7 @@ describe('PredictPositionsViewHeader', () => {
     expect(screen.getByText('-$18.47 (-2.1%)')).toBeOnTheScreen();
   });
 
-  it('wraps claim CTA presses in the Predict action guard and tracks the tap', async () => {
+  it('wraps claim CTA presses in the Predict action guard and passes analytics context to claim', async () => {
     renderHeader({
       portfolio: createPortfolio({
         claimableAmount: 46.35,
@@ -177,22 +177,21 @@ describe('PredictPositionsViewHeader', () => {
         { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
       );
     });
-    expect(mockTrackPortfolioTransactionInitiated).toHaveBeenCalledWith({
+    expect(mockClaim).toHaveBeenCalledWith({
       entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
       openPositionsCount: 2,
       claimablePositionsCount: 1,
       hasClaimableWinnings: true,
       predictScreen: PredictEventValues.PREDICT_SCREEN.PREDICT_POSITIONS_SCREEN,
-      transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
     });
-    const payload = mockTrackPortfolioTransactionInitiated.mock.calls[0][0];
+    const payload = mockClaim.mock.calls[0][0];
     expect(payload).not.toHaveProperty('claimableAmount');
     expect(payload).not.toHaveProperty('portfolioValue');
     expect(payload).not.toHaveProperty('totalUnrealizedPnlAmount');
     expect(mockClaim).toHaveBeenCalledTimes(1);
   });
 
-  it('does not track claim initiated when the action guard short-circuits', async () => {
+  it('does not claim when the action guard short-circuits', async () => {
     mockExecuteGuardedAction.mockImplementationOnce(async () => undefined);
 
     renderHeader({
@@ -214,7 +213,6 @@ describe('PredictPositionsViewHeader', () => {
         { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
       );
     });
-    expect(mockTrackPortfolioTransactionInitiated).not.toHaveBeenCalled();
     expect(mockClaim).not.toHaveBeenCalled();
   });
 

--- a/app/components/UI/Predict/components/PredictPositionsViewHeader/PredictPositionsViewHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsViewHeader/PredictPositionsViewHeader.tsx
@@ -12,7 +12,6 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../locales/i18n';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
-import Engine from '../../../../../core/Engine';
 import { PredictEventValues } from '../../constants/eventNames';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import type { PredictPortfolioModel } from '../../hooks/usePredictPortfolio';
@@ -79,17 +78,14 @@ const PredictPositionsViewHeader = ({
   const handleClaimPress = useCallback(async () => {
     await executeGuardedAction(
       async () => {
-        Engine.context.PredictController.trackPortfolioTransactionInitiated({
+        await claim({
           entryPoint,
           openPositionsCount: portfolio.openPositionCount,
           claimablePositionsCount: portfolio.claimablePositionCount,
           hasClaimableWinnings: portfolio.hasClaimableWinnings,
           predictScreen:
             PredictEventValues.PREDICT_SCREEN.PREDICT_POSITIONS_SCREEN,
-          transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
         });
-
-        await claim();
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
     );

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -103,11 +103,15 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   const handleClaimPress = useCallback(async () => {
     await executeGuardedAction(
       async () => {
-        await claim();
+        // Claims are aggregate; market attribution is derived controller-side.
+        await claim({
+          entryPoint:
+            resolvedEntryPoint ?? PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+        });
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
     );
-  }, [executeGuardedAction, claim]);
+  }, [executeGuardedAction, claim, resolvedEntryPoint]);
 
   const hasPositions = positions.length > 0;
   const hasClaimablePositions = claimablePositions.length > 0;

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -129,6 +129,13 @@ export const PredictEventValues = {
     MM_PREDICT_WITHDRAW: 'mm_predict_withdraw',
     MM_PREDICT_CLAIM: 'mm_predict_claim',
   },
+  CLAIM_FAILURE_REASON: {
+    PENDING_RESOLUTION: 'pending_resolution',
+    INSUFFICIENT_GAS: 'insufficient_gas',
+    NETWORK_ERROR: 'network_error',
+    USER_REJECTED: 'user_rejected',
+    UNKNOWN: 'unknown',
+  },
   MARKET_TYPE: {
     BINARY: 'binary',
     MULTI_OUTCOME: 'multi-outcome',

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -6204,6 +6204,77 @@ describe('PredictController', () => {
       });
     });
 
+    it('emits the terminal claim event only once when confirmed fires repeatedly', () => {
+      withController(({ controller, messenger }) => {
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictClaim,
+          status: TransactionStatus.confirmed,
+        });
+        mockPolymarketProvider.confirmClaim = jest.fn();
+
+        controller.updateStateForTesting((state) => {
+          state.claimablePositions = {
+            [accountAddress]: [
+              createMockPosition({
+                status: PredictPositionStatus.WON,
+                currentValue: 10,
+              }),
+            ],
+          };
+        });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        const succeededEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .filter((arg) => arg?.properties?.status === 'succeeded');
+        expect(succeededEvents).toHaveLength(1);
+      });
+    });
+
+    it('does not emit a duplicate terminal event after the resolution-lag guard fired', () => {
+      withController(({ controller, messenger }) => {
+        controller.updateStateForTesting((state) => {
+          state.claimablePositions = {
+            [accountAddress]: [
+              createMockPosition({
+                status: PredictPositionStatus.WON,
+                currentValue: 10,
+              }),
+            ],
+          };
+        });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        // Footer 5JA7 guard fires first.
+        controller.trackClaimResolutionLagFailure({ address: accountAddress });
+
+        // The confirmation rejection arrives afterwards.
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictClaim,
+          status: TransactionStatus.rejected,
+        });
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        const failedEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .filter((arg) => arg?.properties?.status === 'failed');
+        expect(failedEvents).toHaveLength(1);
+        expect(failedEvents[0].properties.failure_reason).toBe(
+          'pending_resolution',
+        );
+        expect(findPredictTradeEvent('succeeded')).toBeUndefined();
+      });
+    });
+
     it('publishes event for predict withdraw transaction with failed status', () => {
       withController(({ messenger }) => {
         const transactionStatusChangedHandler = jest.fn();

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -6252,10 +6252,13 @@ describe('PredictController', () => {
         });
         (analytics.trackEvent as jest.Mock).mockClear();
 
-        // Footer 5JA7 guard fires first.
-        controller.trackClaimResolutionLagFailure({ address: accountAddress });
+        // Footer 5JA7 guard fires first, keyed by the claim transaction id.
+        controller.trackClaimResolutionLagFailure({
+          transactionId: 'tx-1',
+          address: accountAddress,
+        });
 
-        // The confirmation rejection arrives afterwards.
+        // The confirmation rejection arrives afterwards for the same tx id.
         const transactionMeta = createPredictTransactionMeta({
           nestedType: TransactionType.predictClaim,
           status: TransactionStatus.rejected,
@@ -6272,6 +6275,72 @@ describe('PredictController', () => {
           'pending_resolution',
         );
         expect(findPredictTradeEvent('succeeded')).toBeUndefined();
+      });
+    });
+
+    it('does not let a stale terminal update for an old claim suppress or misattribute a newer claim', () => {
+      withController(({ controller, messenger }) => {
+        mockPolymarketProvider.confirmClaim = jest.fn();
+        controller.updateStateForTesting((state) => {
+          state.claimablePositions = {
+            [accountAddress]: [
+              createMockPosition({
+                status: PredictPositionStatus.WON,
+                currentValue: 10,
+              }),
+            ],
+          };
+        });
+
+        // An earlier claim's transaction already emitted its terminal event.
+        const oldClaimMeta = {
+          ...createPredictTransactionMeta({
+            nestedType: TransactionType.predictClaim,
+            status: TransactionStatus.confirmed,
+          }),
+          id: 'tx-old',
+        };
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta: oldClaimMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        // A newer claim is initiated for the same address.
+        (
+          controller as unknown as {
+            pendingClaimAnalytics: Record<string, unknown>;
+          }
+        ).pendingClaimAnalytics = {
+          [accountAddress.toLowerCase()]: {
+            entryPoint: 'predict_market_details',
+            transactionType: 'mm_predict_claim',
+          },
+        };
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        // A delayed/duplicate terminal update for the OLD transaction arrives.
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta: oldClaimMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        // It must not emit anything (already emitted for tx-old) and must leave
+        // the newer claim's stash intact.
+        expect((analytics.trackEvent as jest.Mock).mock.calls).toHaveLength(0);
+
+        // The newer claim's own terminal update still emits with its attribution.
+        const newClaimMeta = {
+          ...createPredictTransactionMeta({
+            nestedType: TransactionType.predictClaim,
+            status: TransactionStatus.confirmed,
+          }),
+          id: 'tx-new',
+        };
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta: newClaimMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        const succeeded = findPredictTradeEvent('succeeded');
+        expect(succeeded).toBeDefined();
+        expect(succeeded.properties.entry_point).toBe('predict_market_details');
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -4186,6 +4186,40 @@ describe('PredictController', () => {
       });
     });
 
+    it('tracks a user_rejected mm_predict_claim failure when signing is cancelled', async () => {
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.getPositions = jest.fn().mockResolvedValue([
+          {
+            marketId: 'test-market',
+            outcomeId: 'test-outcome',
+            balance: '100',
+          },
+        ]);
+        mockPolymarketProvider.prepareClaim = jest
+          .fn()
+          .mockRejectedValue(new Error('User denied transaction signature'));
+        await controller.getPositions({ claimable: true });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        // Act
+        const result = await controller.claimWithConfirmation({
+          analyticsProperties: {
+            entryPoint: 'predict_market_details',
+          },
+        });
+
+        // Assert
+        expect(result.status).toBe(PredictClaimStatus.CANCELLED);
+        const event = (analytics.trackEvent as jest.Mock).mock.calls
+          .map((call) => call[0])
+          .find((arg) => arg?.properties?.status === 'failed');
+        expect(event).toBeDefined();
+        expect(event.properties.transaction_type).toBe('mm_predict_claim');
+        expect(event.properties.failure_reason).toBe('user_rejected');
+        expect(event.properties.entry_point).toBe('predict_market_details');
+      });
+    });
+
     it('clears pendingClaims on claim error', async () => {
       // Arrange
       const signerAddress = '0x1234567890123456789012345678901234567890';
@@ -6046,6 +6080,127 @@ describe('PredictController', () => {
           selectedClaimablePositions,
         );
         expect(controller.state.claimablePositions[senderAddress]).toEqual([]);
+      });
+    });
+
+    const findPredictTradeEvent = (status: string) =>
+      (analytics.trackEvent as jest.Mock).mock.calls
+        .map((call) => call[0])
+        .find((arg) => arg?.properties?.status === status);
+
+    it('tracks a succeeded mm_predict_claim transaction with stashed attribution when the claim confirms', () => {
+      withController(({ controller, messenger }) => {
+        const claimablePositions = [
+          createMockPosition({
+            id: 'won-1',
+            status: PredictPositionStatus.WON,
+            currentValue: 75,
+            marketId: 'market-xyz',
+            title: 'Will it rain?',
+          }),
+        ];
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictClaim,
+          status: TransactionStatus.confirmed,
+        });
+        mockPolymarketProvider.confirmClaim = jest.fn();
+
+        controller.updateStateForTesting((state) => {
+          state.claimablePositions = {
+            [accountAddress]: claimablePositions,
+          };
+        });
+
+        // Seed the stash the same way claimWithConfirmation does, so we can
+        // verify the terminal handler emits the stashed attribution.
+        (
+          controller as unknown as {
+            pendingClaimAnalytics: Record<string, unknown>;
+          }
+        ).pendingClaimAnalytics = {
+          [accountAddress.toLowerCase()]: {
+            entryPoint: 'predict_market_details',
+            transactionType: 'mm_predict_claim',
+            marketId: 'market-xyz',
+            marketTitle: 'Will it rain?',
+            claimablePositionsCount: 1,
+          },
+        };
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        const event = findPredictTradeEvent('succeeded');
+        expect(event).toBeDefined();
+        expect(event.properties.transaction_type).toBe('mm_predict_claim');
+        expect(event.properties.entry_point).toBe('predict_market_details');
+        expect(event.properties.market_id).toBe('market-xyz');
+        expect(event.properties.market_title).toBe('Will it rain?');
+        expect(event.sensitiveProperties.amount_usd).toBe(75);
+      });
+    });
+
+    it('tracks a failed mm_predict_claim transaction with a mapped failure_reason', () => {
+      withController(({ controller, messenger }) => {
+        const transactionMeta = {
+          ...createPredictTransactionMeta({
+            nestedType: TransactionType.predictClaim,
+            status: TransactionStatus.failed,
+          }),
+          error: { message: 'insufficient funds for gas' },
+        };
+
+        controller.updateStateForTesting((state) => {
+          state.claimablePositions = {
+            [accountAddress]: [
+              createMockPosition({
+                status: PredictPositionStatus.WON,
+                currentValue: 10,
+              }),
+            ],
+          };
+        });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        const event = findPredictTradeEvent('failed');
+        expect(event).toBeDefined();
+        expect(event.properties.transaction_type).toBe('mm_predict_claim');
+        expect(event.properties.failure_reason).toBe('insufficient_gas');
+      });
+    });
+
+    it('tracks a failed mm_predict_claim transaction with user_rejected when rejected', () => {
+      withController(({ controller, messenger }) => {
+        const transactionMeta = createPredictTransactionMeta({
+          nestedType: TransactionType.predictClaim,
+          status: TransactionStatus.rejected,
+        });
+
+        controller.updateStateForTesting((state) => {
+          state.claimablePositions = {
+            [accountAddress]: [
+              createMockPosition({
+                status: PredictPositionStatus.WON,
+                currentValue: 10,
+              }),
+            ],
+          };
+        });
+        (analytics.trackEvent as jest.Mock).mockClear();
+
+        messenger.publish('TransactionController:transactionStatusUpdated', {
+          transactionMeta,
+        } as unknown as { transactionMeta: TransactionMeta });
+
+        const event = findPredictTradeEvent('failed');
+        expect(event).toBeDefined();
+        expect(event.properties.failure_reason).toBe('user_rejected');
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -472,6 +472,15 @@ export class PredictController extends BaseController<
     [address: string]: PredictTradeAnalyticsProperties;
   } = {};
 
+  /**
+   * Tracks which addresses have already emitted a terminal claim
+   * `PREDICT_TRADE_TRANSACTION` event for the current claim attempt, keyed by
+   * lowercased address. Reset on each claim initiation so the terminal event
+   * fires exactly once per attempt regardless of how many sources (footer
+   * guard, repeated transaction-status updates) try to emit it.
+   */
+  private claimTerminalEmitted = new Set<string>();
+
   private readonly traceable: TraceableController = {
     update: (updater) => this.update(updater),
     getErrorContext: (method, extra) => this.getErrorContext(method, extra),
@@ -1794,6 +1803,8 @@ export class PredictController extends BaseController<
           analyticsContext,
           claimablePositions,
         );
+      // New attempt: allow the terminal event to fire exactly once.
+      this.claimTerminalEmitted.delete(signer.address.toLowerCase());
 
       // Set pending claim placeholder before preparing the transaction
       this.update((state) => {
@@ -1893,6 +1904,7 @@ export class PredictController extends BaseController<
           analyticsProperties: claimAnalytics,
           failureReason: PredictEventValues.CLAIM_FAILURE_REASON.USER_REJECTED,
         });
+        this.claimTerminalEmitted.add(signer.address.toLowerCase());
         delete this.pendingClaimAnalytics[signer.address.toLowerCase()];
 
         // ignore error, as the user cancelled the tx
@@ -1983,6 +1995,10 @@ export class PredictController extends BaseController<
    * Fires the terminal claim `PREDICT_TRADE_TRANSACTION` event
    * (`succeeded`/`failed`) using the stashed analytics context and the claim
    * amount captured before claimable positions are cleared.
+   *
+   * Idempotent per attempt: if a terminal event was already emitted for this
+   * address (e.g. by the footer resolution-lag guard, or a repeated terminal
+   * `transactionStatusUpdated`), this is a no-op aside from clearing the stash.
    */
   private trackClaimTransactionOutcome({
     status,
@@ -1996,6 +2012,12 @@ export class PredictController extends BaseController<
     transactionMeta: TransactionMeta;
   }): void {
     const normalizedAddress = address.toLowerCase();
+
+    if (this.claimTerminalEmitted.has(normalizedAddress)) {
+      delete this.pendingClaimAnalytics[normalizedAddress];
+      return;
+    }
+
     const analyticsProperties =
       this.pendingClaimAnalytics[normalizedAddress] ??
       this.buildClaimAnalyticsProperties();
@@ -2019,6 +2041,42 @@ export class PredictController extends BaseController<
       });
     }
 
+    this.claimTerminalEmitted.add(normalizedAddress);
+    delete this.pendingClaimAnalytics[normalizedAddress];
+  }
+
+  /**
+   * Emits a terminal `failed`/`pending_resolution` claim event for the
+   * resolution-lag (no-positions-won) guard surfaced on the claim confirmation
+   * footer (Sentry 5JA7). Participates in the same per-attempt idempotency guard
+   * as {@link trackClaimTransactionOutcome}, so the eventual transaction
+   * `rejected` status update does not emit a duplicate (mislabeled
+   * `user_rejected`) terminal event.
+   */
+  public trackClaimResolutionLagFailure({
+    address,
+  }: {
+    address?: string;
+  }): void {
+    const normalizedAddress = (
+      address ?? this.getSigner().address
+    ).toLowerCase();
+
+    if (this.claimTerminalEmitted.has(normalizedAddress)) {
+      return;
+    }
+
+    const analyticsProperties =
+      this.pendingClaimAnalytics[normalizedAddress] ??
+      this.buildClaimAnalyticsProperties();
+
+    this.trackPredictOrderEvent({
+      status: PredictTradeStatus.FAILED,
+      analyticsProperties,
+      failureReason: PredictEventValues.CLAIM_FAILURE_REASON.PENDING_RESOLUTION,
+    });
+
+    this.claimTerminalEmitted.add(normalizedAddress);
     delete this.pendingClaimAnalytics[normalizedAddress];
   }
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -473,11 +473,12 @@ export class PredictController extends BaseController<
   } = {};
 
   /**
-   * Tracks which addresses have already emitted a terminal claim
-   * `PREDICT_TRADE_TRANSACTION` event for the current claim attempt, keyed by
-   * lowercased address. Reset on each claim initiation so the terminal event
-   * fires exactly once per attempt regardless of how many sources (footer
-   * guard, repeated transaction-status updates) try to emit it.
+   * Tracks which claim transactions have already emitted a terminal
+   * `PREDICT_TRADE_TRANSACTION` event, keyed by transaction id. Keyed per
+   * transaction (not per address) so a delayed/duplicate `transactionStatusUpdated`
+   * for an earlier claim cannot emit a spurious terminal event for, or suppress
+   * the real terminal event of, a newer in-flight claim on the same address.
+   * Each claim creates a unique transaction id, so no per-attempt reset is needed.
    */
   private claimTerminalEmitted = new Set<string>();
 
@@ -1803,8 +1804,6 @@ export class PredictController extends BaseController<
           analyticsContext,
           claimablePositions,
         );
-      // New attempt: allow the terminal event to fire exactly once.
-      this.claimTerminalEmitted.delete(signer.address.toLowerCase());
 
       // Set pending claim placeholder before preparing the transaction
       this.update((state) => {
@@ -1899,12 +1898,13 @@ export class PredictController extends BaseController<
         const claimAnalytics =
           this.pendingClaimAnalytics[signer.address.toLowerCase()] ??
           this.buildClaimAnalyticsProperties(analyticsContext);
+        // Signing was denied before any transaction was created, so there is no
+        // terminal `transactionStatusUpdated` to dedupe against (no guard entry).
         this.trackPredictOrderEvent({
           status: PredictTradeStatus.FAILED,
           analyticsProperties: claimAnalytics,
           failureReason: PredictEventValues.CLAIM_FAILURE_REASON.USER_REJECTED,
         });
-        this.claimTerminalEmitted.add(signer.address.toLowerCase());
         delete this.pendingClaimAnalytics[signer.address.toLowerCase()];
 
         // ignore error, as the user cancelled the tx
@@ -1996,9 +1996,10 @@ export class PredictController extends BaseController<
    * (`succeeded`/`failed`) using the stashed analytics context and the claim
    * amount captured before claimable positions are cleared.
    *
-   * Idempotent per attempt: if a terminal event was already emitted for this
-   * address (e.g. by the footer resolution-lag guard, or a repeated terminal
-   * `transactionStatusUpdated`), this is a no-op aside from clearing the stash.
+   * Idempotent per transaction: if a terminal event was already emitted for this
+   * transaction id (e.g. by the footer resolution-lag guard, or a repeated
+   * terminal `transactionStatusUpdated`), this is a no-op. The stash is left
+   * untouched on skip so a stale update cannot clear a newer claim's attribution.
    */
   private trackClaimTransactionOutcome({
     status,
@@ -2011,13 +2012,13 @@ export class PredictController extends BaseController<
     address: string;
     transactionMeta: TransactionMeta;
   }): void {
-    const normalizedAddress = address.toLowerCase();
+    const transactionId = transactionMeta.id;
 
-    if (this.claimTerminalEmitted.has(normalizedAddress)) {
-      delete this.pendingClaimAnalytics[normalizedAddress];
+    if (this.claimTerminalEmitted.has(transactionId)) {
       return;
     }
 
+    const normalizedAddress = address.toLowerCase();
     const analyticsProperties =
       this.pendingClaimAnalytics[normalizedAddress] ??
       this.buildClaimAnalyticsProperties();
@@ -2041,30 +2042,32 @@ export class PredictController extends BaseController<
       });
     }
 
-    this.claimTerminalEmitted.add(normalizedAddress);
+    this.claimTerminalEmitted.add(transactionId);
     delete this.pendingClaimAnalytics[normalizedAddress];
   }
 
   /**
    * Emits a terminal `failed`/`pending_resolution` claim event for the
    * resolution-lag (no-positions-won) guard surfaced on the claim confirmation
-   * footer (Sentry 5JA7). Participates in the same per-attempt idempotency guard
-   * as {@link trackClaimTransactionOutcome}, so the eventual transaction
-   * `rejected` status update does not emit a duplicate (mislabeled
-   * `user_rejected`) terminal event.
+   * footer (Sentry 5JA7). Participates in the same per-transaction idempotency
+   * guard as {@link trackClaimTransactionOutcome} (keyed by `transactionId`), so
+   * the eventual `rejected` status update for the same transaction does not emit
+   * a duplicate (mislabeled `user_rejected`) terminal event.
    */
   public trackClaimResolutionLagFailure({
+    transactionId,
     address,
   }: {
+    transactionId?: string;
     address?: string;
   }): void {
+    if (transactionId && this.claimTerminalEmitted.has(transactionId)) {
+      return;
+    }
+
     const normalizedAddress = (
       address ?? this.getSigner().address
     ).toLowerCase();
-
-    if (this.claimTerminalEmitted.has(normalizedAddress)) {
-      return;
-    }
 
     const analyticsProperties =
       this.pendingClaimAnalytics[normalizedAddress] ??
@@ -2076,7 +2079,9 @@ export class PredictController extends BaseController<
       failureReason: PredictEventValues.CLAIM_FAILURE_REASON.PENDING_RESOLUTION,
     });
 
-    this.claimTerminalEmitted.add(normalizedAddress);
+    if (transactionId) {
+      this.claimTerminalEmitted.add(transactionId);
+    }
     delete this.pendingClaimAnalytics[normalizedAddress];
   }
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -50,7 +50,10 @@ import {
 import { addTransactionBatch } from '../../../../util/transaction-controller';
 import { AssetType } from '../../../Views/confirmations/types/token';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
-import { PredictTradeStatus } from '../constants/eventNames';
+import {
+  PredictEventValues,
+  PredictTradeStatus,
+} from '../constants/eventNames';
 
 import { GEO_BLOCKED_COUNTRIES } from '../constants/geoblock';
 
@@ -97,6 +100,7 @@ import {
   PredictPosition,
   PredictPositionStatus,
   PredictPriceHistoryPoint,
+  PredictTradeAnalyticsProperties,
   PredictWithdraw,
   PredictWithdrawStatus,
   PrepareDepositParams,
@@ -111,6 +115,7 @@ import {
 } from '../types';
 import { PredictFeatureFlags } from '../types/flags';
 
+import { mapClaimFailureReason } from '../utils/analytics';
 import { resolveCryptoTargetPrice } from '../utils/cryptoUpDown';
 import { validateMarketBettable } from '../utils/marketState';
 import { ensureError } from '../utils/predictErrorHandler';
@@ -454,6 +459,17 @@ export class PredictController extends BaseController<
       analyticsProperties?: PlaceOrderParams['analyticsProperties'];
       activeAbTests?: PlaceOrderParams['activeAbTests'];
     };
+  } = {};
+
+  /**
+   * In-memory claim analytics context keyed by lowercased signer address.
+   * Captured when a claim is initiated and consumed when the claim transaction
+   * reaches a terminal status, so `succeeded`/`failed` events keep entry-point
+   * attribution. Keyed by address (not transactionId) because the claim has no
+   * transaction id at initiation time.
+   */
+  private pendingClaimAnalytics: {
+    [address: string]: PredictTradeAnalyticsProperties;
   } = {};
 
   private readonly traceable: TraceableController = {
@@ -1724,9 +1740,8 @@ export class PredictController extends BaseController<
     }
   }
 
-  async claimWithConfirmation(
-    _params: ClaimParams = {},
-  ): Promise<PredictClaim> {
+  async claimWithConfirmation(params: ClaimParams = {}): Promise<PredictClaim> {
+    const analyticsContext = params.analyticsProperties;
     // Start Sentry trace for claim operation
     const traceId = `claim-${Date.now()}`;
     let traceData:
@@ -1769,6 +1784,16 @@ export class PredictController extends BaseController<
       if (!claimablePositions || claimablePositions.length === 0) {
         throw new Error('No claimable positions found');
       }
+
+      // Stash claim analytics context so the terminal-status handler can fire
+      // `succeeded`/`failed` with entry-point attribution. Captured here (before
+      // `confirmClaim` clears `claimablePositions`) so single-market context is
+      // available at terminal time.
+      this.pendingClaimAnalytics[signer.address.toLowerCase()] =
+        this.buildClaimAnalyticsProperties(
+          analyticsContext,
+          claimablePositions,
+        );
 
       // Set pending claim placeholder before preparing the transaction
       this.update((state) => {
@@ -1857,6 +1882,19 @@ export class PredictController extends BaseController<
       if (e.message.includes('User denied transaction signature')) {
         traceData = { success: false, reason: 'user_cancelled' };
 
+        // This branch returns without throwing and before any on-chain
+        // transaction exists, so neither the hook catch nor the terminal-status
+        // handler fires. Track the user rejection here so it stays measurable.
+        const claimAnalytics =
+          this.pendingClaimAnalytics[signer.address.toLowerCase()] ??
+          this.buildClaimAnalyticsProperties(analyticsContext);
+        this.trackPredictOrderEvent({
+          status: PredictTradeStatus.FAILED,
+          analyticsProperties: claimAnalytics,
+          failureReason: PredictEventValues.CLAIM_FAILURE_REASON.USER_REJECTED,
+        });
+        delete this.pendingClaimAnalytics[signer.address.toLowerCase()];
+
         // ignore error, as the user cancelled the tx
         return {
           batchId: 'NA',
@@ -1894,6 +1932,10 @@ export class PredictController extends BaseController<
         state.lastUpdateTimestamp = Date.now();
       });
 
+      // The hook's catch handler tracks the `failed` event for re-thrown
+      // (pre-tx) errors, so just clear the stash here to avoid a double-fire.
+      delete this.pendingClaimAnalytics[signer.address.toLowerCase()];
+
       // Re-throw the error so the hook can handle it and show the toast
       throw error;
     } finally {
@@ -1903,6 +1945,81 @@ export class PredictController extends BaseController<
         data: traceData,
       });
     }
+  }
+
+  /**
+   * Builds the analytics properties for a claim `PREDICT_TRADE_TRANSACTION`
+   * event. Always sets `transaction_type: mm_predict_claim`. When a single
+   * market is being claimed, `market_id`/`market_title` are populated; for
+   * multi-market claims they are omitted in favor of `claimable_positions_count`.
+   */
+  private buildClaimAnalyticsProperties(
+    analyticsContext?: PredictTradeAnalyticsProperties,
+    claimablePositions?: PredictPosition[],
+  ): PredictTradeAnalyticsProperties {
+    const properties: PredictTradeAnalyticsProperties = {
+      entryPoint: PredictEventValues.ENTRY_POINT.BACKGROUND,
+      ...analyticsContext,
+      transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
+    };
+
+    if (claimablePositions && claimablePositions.length > 0) {
+      properties.claimablePositionsCount = claimablePositions.length;
+
+      const distinctMarketIds = new Set(
+        claimablePositions.map((position) => position.marketId),
+      );
+      if (distinctMarketIds.size === 1) {
+        const [singlePosition] = claimablePositions;
+        properties.marketId = properties.marketId ?? singlePosition.marketId;
+        properties.marketTitle = properties.marketTitle ?? singlePosition.title;
+      }
+    }
+
+    return properties;
+  }
+
+  /**
+   * Fires the terminal claim `PREDICT_TRADE_TRANSACTION` event
+   * (`succeeded`/`failed`) using the stashed analytics context and the claim
+   * amount captured before claimable positions are cleared.
+   */
+  private trackClaimTransactionOutcome({
+    status,
+    amount,
+    address,
+    transactionMeta,
+  }: {
+    status: PredictTransactionEventStatus;
+    amount?: number;
+    address: string;
+    transactionMeta: TransactionMeta;
+  }): void {
+    const normalizedAddress = address.toLowerCase();
+    const analyticsProperties =
+      this.pendingClaimAnalytics[normalizedAddress] ??
+      this.buildClaimAnalyticsProperties();
+
+    if (status === 'confirmed') {
+      this.trackPredictOrderEvent({
+        status: PredictTradeStatus.SUCCEEDED,
+        amountUsd: amount,
+        analyticsProperties,
+      });
+    } else {
+      const failureReason =
+        status === 'rejected'
+          ? PredictEventValues.CLAIM_FAILURE_REASON.USER_REJECTED
+          : mapClaimFailureReason(transactionMeta.error?.message);
+      this.trackPredictOrderEvent({
+        status: PredictTradeStatus.FAILED,
+        amountUsd: amount,
+        analyticsProperties,
+        failureReason,
+      });
+    }
+
+    delete this.pendingClaimAnalytics[normalizedAddress];
   }
 
   public confirmClaim({ address }: { address?: string }): void {
@@ -2572,6 +2689,21 @@ export class PredictController extends BaseController<
       ...(transactionId ? { transactionId } : {}),
       ...(amount !== undefined ? { amount } : {}),
     });
+
+    // Track terminal claim outcome on PREDICT_TRADE_TRANSACTION. `amount` is
+    // captured above before `handleTransactionSideEffects` -> `confirmClaim`
+    // clears claimable positions, so `amount_usd` reflects the claimed value.
+    if (
+      type === 'claim' &&
+      (status === 'confirmed' || status === 'failed' || status === 'rejected')
+    ) {
+      this.trackClaimTransactionOutcome({
+        status,
+        amount,
+        address,
+        transactionMeta,
+      });
+    }
   }
 
   private async syncDepositWalletBalanceAllowanceIfNeeded({

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -22,12 +22,22 @@ const mockGoBack = jest.fn();
 const mockNavigateToConfirmation = jest.fn();
 const mockClaimWinnings = jest.fn();
 const mockShowToast = jest.fn();
+const mockTrackPredictOrderEvent = jest.fn();
 
 // Mock dependencies
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
   default: {
     error: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      trackPredictOrderEvent: (...args: unknown[]) =>
+        mockTrackPredictOrderEvent(...args),
+    },
   },
 }));
 
@@ -74,6 +84,20 @@ jest.mock('../../../../util/theme', () => ({
 jest.mock('../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
   useConfirmNavigation: jest.fn(),
 }));
+
+// Mock the heavy confirm-component module to avoid loading the Perps import
+// chain (which relies on the real Engine module's load-order side effects).
+jest.mock(
+  '../../../Views/confirmations/components/confirm/confirm-component',
+  () => ({
+    ConfirmationLoader: {
+      Default: 'default',
+      CustomAmount: 'customAmount',
+      PredictClaim: 'predictClaim',
+      Transfer: 'transfer',
+    },
+  }),
+);
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -225,7 +249,9 @@ describe('usePredictClaim', () => {
         loader: ConfirmationLoader.PredictClaim,
         stack: 'Predict',
       });
-      expect(mockClaimWinnings).toHaveBeenCalledWith({});
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        analyticsProperties: { transactionType: 'mm_predict_claim' },
+      });
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
@@ -241,7 +267,55 @@ describe('usePredictClaim', () => {
       });
 
       // Assert
-      expect(mockClaimWinnings).toHaveBeenCalledWith({});
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        analyticsProperties: { transactionType: 'mm_predict_claim' },
+      });
+    });
+
+    it('fires the initiated event once with the provided entry-point context', async () => {
+      // Arrange
+      mockClaimWinnings.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.claim({ entryPoint: 'predict_market_details' });
+      });
+
+      // Assert
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith({
+        status: 'initiated',
+        analyticsProperties: {
+          entryPoint: 'predict_market_details',
+          transactionType: 'mm_predict_claim',
+        },
+      });
+    });
+
+    it('merges entry-point context into the claim analytics properties', async () => {
+      // Arrange
+      mockClaimWinnings.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.claim({
+          entryPoint: 'homepage_positions',
+          claimablePositionsCount: 3,
+        });
+      });
+
+      // Assert
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        analyticsProperties: {
+          entryPoint: 'homepage_positions',
+          claimablePositionsCount: 3,
+          transactionType: 'mm_predict_claim',
+        },
+      });
     });
 
     it('sets isClaimPending from pending claim selector', () => {
@@ -406,10 +480,36 @@ describe('usePredictClaim', () => {
         loader: ConfirmationLoader.PredictClaim,
         stack: 'Predict',
       });
-      expect(mockClaimWinnings).toHaveBeenCalledWith({});
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        analyticsProperties: { transactionType: 'mm_predict_claim' },
+      });
       expect(mockShowToast).not.toHaveBeenCalled();
       expect(mockGoBack).not.toHaveBeenCalled();
       expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+
+    it('fires a failed event with a mapped failure_reason when claim throws', async () => {
+      // Arrange
+      mockClaimWinnings.mockRejectedValue(
+        new Error('No claimable positions found'),
+      );
+
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.claim({ entryPoint: 'predict_market_details' });
+      });
+
+      // Assert
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith({
+        status: 'failed',
+        analyticsProperties: {
+          entryPoint: 'predict_market_details',
+          transactionType: 'mm_predict_claim',
+        },
+        failureReason: 'pending_resolution',
+      });
     });
 
     it('captures exception to Sentry when claim fails', async () => {

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -5,13 +5,20 @@ import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
 import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
+import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { selectSelectedAccountGroupId } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
+import {
+  PredictEventValues,
+  PredictTradeStatus,
+} from '../constants/eventNames';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { selectPredictPendingClaimByAddress } from '../selectors/predictController';
+import type { PredictTradeAnalyticsProperties } from '../types';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
+import { mapClaimFailureReason } from '../utils/analytics';
 import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
@@ -33,81 +40,107 @@ export const usePredictClaim = () => {
   );
   const isClaimPending = !!claimBatchId;
 
-  const claim = useCallback(async () => {
-    if (isClaimPending) {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: strings('predict.claim.toasts.in_progress.title'),
-            isBold: true,
-          },
-        ],
-        iconName: IconName.Info,
-        iconColor: theme.colors.primary.default,
-        hasNoTimeout: false,
-      });
-      return;
-    }
+  const claim = useCallback(
+    async (analyticsContext?: PredictTradeAnalyticsProperties) => {
+      const analyticsProperties: PredictTradeAnalyticsProperties = {
+        ...analyticsContext,
+        transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
+      };
 
-    try {
-      navigateToConfirmation({
-        headerShown: false,
-        loader: ConfirmationLoader.PredictClaim,
-        // TODO: remove once navigation stack is fixed properly
-        stack: Routes.PREDICT.ROOT,
-      });
-      await claimWinnings({});
-    } catch (err) {
-      Logger.error(ensureError(err), {
-        tags: {
-          feature: PREDICT_CONSTANTS.FEATURE_NAME,
-          component: 'usePredictClaim',
-        },
-        context: {
-          name: 'usePredictClaim',
-          data: {
-            method: 'claim',
-            action: 'claim_winnings',
-            operation: 'position_management',
-          },
-        },
+      if (isClaimPending) {
+        toastRef?.current?.showToast({
+          variant: ToastVariants.Icon,
+          labelOptions: [
+            {
+              label: strings('predict.claim.toasts.in_progress.title'),
+              isBold: true,
+            },
+          ],
+          iconName: IconName.Info,
+          iconColor: theme.colors.primary.default,
+          hasNoTimeout: false,
+        });
+        return;
+      }
+
+      // Fire the `attempted` (initiated) event once for every claim entry point.
+      Engine.context.PredictController.trackPredictOrderEvent({
+        status: PredictTradeStatus.INITIATED,
+        analyticsProperties,
       });
 
-      navigation.goBack();
+      try {
+        navigateToConfirmation({
+          headerShown: false,
+          loader: ConfirmationLoader.PredictClaim,
+          // TODO: remove once navigation stack is fixed properly
+          stack: Routes.PREDICT.ROOT,
+        });
+        await claimWinnings({ analyticsProperties });
+      } catch (err) {
+        // Synchronous/submission failures occur before any on-chain
+        // transaction is created, so the controller's terminal-status handler
+        // never runs. Track the failure here so pre-tx failures are measured.
+        Engine.context.PredictController.trackPredictOrderEvent({
+          status: PredictTradeStatus.FAILED,
+          analyticsProperties,
+          failureReason: mapClaimFailureReason(err),
+        });
 
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          { label: strings('predict.claim.toasts.error.title'), isBold: true },
-          { label: '\n', isBold: false },
-          {
-            label: strings('predict.claim.toasts.error.description'),
-            isBold: false,
+        Logger.error(ensureError(err), {
+          tags: {
+            feature: PREDICT_CONSTANTS.FEATURE_NAME,
+            component: 'usePredictClaim',
           },
-        ],
-        iconName: IconName.Error,
-        iconColor: theme.colors.error.default,
-        backgroundColor: theme.colors.accent04.normal,
-        hasNoTimeout: false,
-        linkButtonOptions: {
-          label: strings('predict.claim.toasts.error.try_again'),
-          onPress: () => {
-            claim();
+          context: {
+            name: 'usePredictClaim',
+            data: {
+              method: 'claim',
+              action: 'claim_winnings',
+              operation: 'position_management',
+            },
           },
-        },
-      });
-    }
-  }, [
-    isClaimPending,
-    toastRef,
-    theme.colors.primary.default,
-    theme.colors.error.default,
-    theme.colors.accent04.normal,
-    navigateToConfirmation,
-    claimWinnings,
-    navigation,
-  ]);
+        });
+
+        navigation.goBack();
+
+        toastRef?.current?.showToast({
+          variant: ToastVariants.Icon,
+          labelOptions: [
+            {
+              label: strings('predict.claim.toasts.error.title'),
+              isBold: true,
+            },
+            { label: '\n', isBold: false },
+            {
+              label: strings('predict.claim.toasts.error.description'),
+              isBold: false,
+            },
+          ],
+          iconName: IconName.Error,
+          iconColor: theme.colors.error.default,
+          backgroundColor: theme.colors.accent04.normal,
+          hasNoTimeout: false,
+          linkButtonOptions: {
+            label: strings('predict.claim.toasts.error.try_again'),
+            onPress: () => {
+              claim(analyticsContext);
+            },
+          },
+        });
+      }
+    },
+    [
+      isClaimPending,
+      toastRef,
+      theme.colors.primary.default,
+      theme.colors.error.default,
+      theme.colors.accent04.normal,
+      navigateToConfirmation,
+      claimWinnings,
+      navigation,
+    ],
+  );
 
   return {
     claim,

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -16,6 +16,7 @@ import type { ToastRef } from '../../../../component-library/components/Toast/To
 import Routes from '../../../../constants/navigation/Routes';
 import type { ToastRegistration } from '../../../Nav/App/ControllerEventToastBridge';
 import { useAppThemeFromContext } from '../../../../util/theme';
+import { PredictEventValues } from '../constants/eventNames';
 import type { PredictTransactionStatusChangedPayload } from '../controllers/PredictController';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { formatPrice } from '../utils/format';
@@ -284,7 +285,9 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
               ? {
                   retryLabel: strings('predict.claim.toasts.error.try_again'),
                   onRetry: () => {
-                    claim().catch(() => undefined);
+                    claim({
+                      entryPoint: PredictEventValues.ENTRY_POINT.BACKGROUND,
+                    }).catch(() => undefined);
                   },
                 }
               : {}),

--- a/app/components/UI/Predict/hooks/usePredictTrading.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTrading.test.ts
@@ -3,7 +3,6 @@ import Engine from '../../../../core/Engine';
 import { usePredictTrading } from './usePredictTrading';
 import { Side } from '../types';
 
-import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 // Mock Engine
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -153,15 +152,14 @@ describe('usePredictTrading', () => {
 
       const { result } = renderHook(() => usePredictTrading());
 
-      const response = await result.current.claim({
-        providerId: POLYMARKET_PROVIDER_ID,
-      });
+      const claimParams = {
+        analyticsProperties: { entryPoint: 'predict_market_details' },
+      };
+      const response = await result.current.claim(claimParams);
 
       expect(
         Engine.context.PredictController.claimWithConfirmation,
-      ).toHaveBeenCalledWith({
-        providerId: POLYMARKET_PROVIDER_ID,
-      });
+      ).toHaveBeenCalledWith(claimParams);
       expect(response).toEqual(mockClaimResult);
     });
 
@@ -172,9 +170,9 @@ describe('usePredictTrading', () => {
       ).mockRejectedValue(mockError);
       const { result } = renderHook(() => usePredictTrading());
 
-      await expect(
-        result.current.claim({ providerId: POLYMARKET_PROVIDER_ID }),
-      ).rejects.toThrow('Failed to claim winnings');
+      await expect(result.current.claim({})).rejects.toThrow(
+        'Failed to claim winnings',
+      );
     });
   });
 

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -507,8 +507,38 @@ export type PredictBalance = {
   validUntil: number;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ClaimParams {}
+export interface PredictTradeAnalyticsProperties {
+  marketId?: string;
+  marketTitle?: string;
+  marketCategory?: string;
+  marketTags?: string[];
+  actionType?: string;
+  entryPoint?: string;
+  predictFeedTab?: string;
+  predictScreen?: string;
+  predictComponent?: string;
+  transactionType?: string;
+  sharePrice?: number;
+  liquidity?: number;
+  volume?: number;
+  openPositionsCount?: number;
+  claimablePositionsCount?: number;
+  hasClaimableWinnings?: boolean;
+  portfolioModuleEnabled?: boolean;
+  marketType?: string;
+  outcome?: string;
+  marketSlug?: string;
+  gameId?: string;
+  gameStartTime?: string;
+  gameLeague?: string;
+  gameStatus?: string;
+  gamePeriod?: string | null;
+  gameClock?: string | null;
+}
+
+export interface ClaimParams {
+  analyticsProperties?: PredictTradeAnalyticsProperties;
+}
 
 export interface GetMarketPriceResponse {
   price: number;
@@ -696,34 +726,7 @@ export interface PlaceOrderParams {
   address?: string;
   transactionId?: string;
   activeAbTests?: TransactionActiveAbTestEntry[];
-  analyticsProperties?: {
-    marketId?: string;
-    marketTitle?: string;
-    marketCategory?: string;
-    marketTags?: string[];
-    actionType?: string;
-    entryPoint?: string;
-    predictFeedTab?: string;
-    predictScreen?: string;
-    predictComponent?: string;
-    transactionType?: string;
-    sharePrice?: number;
-    liquidity?: number;
-    volume?: number;
-    openPositionsCount?: number;
-    claimablePositionsCount?: number;
-    hasClaimableWinnings?: boolean;
-    portfolioModuleEnabled?: boolean;
-    marketType?: string;
-    outcome?: string;
-    marketSlug?: string;
-    gameId?: string;
-    gameStartTime?: string;
-    gameLeague?: string;
-    gameStatus?: string;
-    gamePeriod?: string | null;
-    gameClock?: string | null;
-  };
+  analyticsProperties?: PredictTradeAnalyticsProperties;
 }
 
 export interface PreviewOrderParams {

--- a/app/components/UI/Predict/utils/analytics.test.ts
+++ b/app/components/UI/Predict/utils/analytics.test.ts
@@ -1,4 +1,4 @@
-import { parseAnalyticsProperties } from './analytics';
+import { mapClaimFailureReason, parseAnalyticsProperties } from './analytics';
 import {
   Recurrence,
   type PredictMarket,
@@ -17,6 +17,13 @@ jest.mock('../constants/eventNames', () => ({
     MARKET_TYPE: {
       BINARY: 'binary',
       MULTI_OUTCOME: 'multi-outcome',
+    },
+    CLAIM_FAILURE_REASON: {
+      PENDING_RESOLUTION: 'pending_resolution',
+      INSUFFICIENT_GAS: 'insufficient_gas',
+      NETWORK_ERROR: 'network_error',
+      USER_REJECTED: 'user_rejected',
+      UNKNOWN: 'unknown',
     },
   },
 }));
@@ -468,6 +475,34 @@ describe('parseAnalyticsProperties', () => {
       );
 
       expect(result.sharePrice).toBe(0);
+    });
+  });
+
+  describe('mapClaimFailureReason', () => {
+    it.each([
+      ['PREDICT_MARKET_PENDING_RESOLUTION', 'pending_resolution'],
+      ['Market is pending resolution', 'pending_resolution'],
+      ['No claimable positions found', 'pending_resolution'],
+      ['Tried to claim but no positions were won', 'pending_resolution'],
+      ['User denied transaction signature', 'user_rejected'],
+      ['User rejected the request', 'user_rejected'],
+      ['insufficient funds for gas', 'insufficient_gas'],
+      ['out of gas', 'insufficient_gas'],
+      ['network request failed', 'network_error'],
+      ['Request timed out', 'network_error'],
+      ['failed to fetch', 'network_error'],
+      ['Something unexpected happened', 'unknown'],
+    ])('maps "%s" to "%s"', (message, expected) => {
+      expect(mapClaimFailureReason(new Error(message))).toBe(expected);
+    });
+
+    it('accepts a raw string message', () => {
+      expect(mapClaimFailureReason('out of gas')).toBe('insufficient_gas');
+    });
+
+    it('returns unknown for undefined or non-error values', () => {
+      expect(mapClaimFailureReason(undefined)).toBe('unknown');
+      expect(mapClaimFailureReason({ some: 'object' })).toBe('unknown');
     });
   });
 });

--- a/app/components/UI/Predict/utils/analytics.ts
+++ b/app/components/UI/Predict/utils/analytics.ts
@@ -1,4 +1,5 @@
 import { PredictEventValues } from '../constants/eventNames';
+import { PREDICT_ERROR_CODES } from '../constants/errors';
 import type { PredictMarket, PredictOutcomeToken } from '../types';
 import type { PredictEntryPoint } from '../types/navigation';
 
@@ -34,4 +35,63 @@ export function parseAnalyticsProperties(
     gamePeriod: market?.game?.period,
     gameClock: market?.game?.elapsed,
   };
+}
+
+/**
+ * Classifies a claim error into a stable `failure_reason` value for the
+ * `mm_predict_claim` analytics event. Resolution-lag is the dominant failure
+ * mode (PRED-963), so it is checked first.
+ */
+export function mapClaimFailureReason(error?: unknown): string {
+  const { CLAIM_FAILURE_REASON } = PredictEventValues;
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes(
+      PREDICT_ERROR_CODES.MARKET_PENDING_RESOLUTION.toLowerCase(),
+    ) ||
+    normalized.includes('pending resolution') ||
+    normalized.includes('no claimable positions') ||
+    normalized.includes('no positions were won') ||
+    normalized.includes('no positions won')
+  ) {
+    return CLAIM_FAILURE_REASON.PENDING_RESOLUTION;
+  }
+
+  if (
+    normalized.includes('user denied') ||
+    normalized.includes('user rejected') ||
+    normalized.includes('user cancelled') ||
+    normalized.includes('user canceled')
+  ) {
+    return CLAIM_FAILURE_REASON.USER_REJECTED;
+  }
+
+  if (
+    normalized.includes('insufficient') ||
+    normalized.includes('out of gas') ||
+    normalized.includes('gas required') ||
+    normalized.includes('intrinsic gas')
+  ) {
+    return CLAIM_FAILURE_REASON.INSUFFICIENT_GAS;
+  }
+
+  if (
+    normalized.includes('network') ||
+    normalized.includes('timeout') ||
+    normalized.includes('timed out') ||
+    normalized.includes('connection') ||
+    normalized.includes('fetch')
+  ) {
+    return CLAIM_FAILURE_REASON.NETWORK_ERROR;
+  }
+
+  return CLAIM_FAILURE_REASON.UNKNOWN;
 }

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPortfolio/PredictPortfolioModule.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPortfolio/PredictPortfolioModule.test.tsx
@@ -361,7 +361,7 @@ describe('PredictPortfolioModule', () => {
     );
   });
 
-  it('uses the claim flow from the shared portfolio model', () => {
+  it('passes portfolio analytics context to the shared claim flow', () => {
     mockUsePredictPortfolio.mockReturnValue(
       createPortfolio({
         claimableAmount: 46.35,
@@ -375,11 +375,14 @@ describe('PredictPortfolioModule', () => {
       screen.getByTestId(PREDICT_PORTFOLIO_TEST_IDS.CLAIM_BUTTON),
     );
 
-    expect(mockClaim).toHaveBeenCalled();
-    expectPortfolioTransactionInitiated(
-      PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
-      PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
-      { hasClaimableWinnings: true },
+    // Claim telemetry is centralized in usePredictClaim, so the module no
+    // longer fires trackPortfolioTransactionInitiated for claim - it forwards
+    // the entry-point context to claim() instead.
+    expect(mockClaim).toHaveBeenCalledWith(
+      expectedPortfolioContext({
+        hasClaimableWinnings: true,
+        entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+      }),
     );
   });
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPortfolio/PredictPortfolioModule.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPortfolio/PredictPortfolioModule.tsx
@@ -137,19 +137,16 @@ const PredictPortfolioModule: React.FC<PredictPortfolioModuleProps> = ({
 
   const handleClaimPress = useCallback(() => {
     executeGuardedAction(
-      () => {
-        trackPortfolioTransactionInitiated(
-          PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
-          PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
-        );
-
-        return claim();
-      },
+      () =>
+        claim({
+          ...portfolioAnalyticsProperties,
+          entryPoint: PredictEventValues.ENTRY_POINT.HOMEPAGE_POSITIONS,
+        }),
       {
         attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM,
       },
     );
-  }, [claim, executeGuardedAction, trackPortfolioTransactionInitiated]);
+  }, [claim, executeGuardedAction, portfolioAnalyticsProperties]);
 
   const isWithdrawDisabled = availableBalance > 0 && !walletType;
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -304,11 +304,18 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const handleClaimPress = useCallback(async () => {
     await executeGuardedAction(
       async () => {
-        await claim();
+        // Claims are aggregate (all claimable positions), so market_id/title are
+        // intentionally omitted here; the controller derives them when exactly
+        // one market is claimed.
+        await claim({
+          entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
+          ...(predictScreen && { predictScreen }),
+          ...(predictFeedTab && { predictFeedTab }),
+        });
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CLAIM },
     );
-  }, [executeGuardedAction, claim]);
+  }, [executeGuardedAction, claim, predictScreen, predictFeedTab]);
 
   const handleTabPress = (tabIndex: number) => {
     if (!tabsReady) return;

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -44,7 +44,10 @@ import { useUnrealizedPnL } from '../../../../UI/Predict/hooks/useUnrealizedPnL'
 import { getPredictHomepageUnrealizedPnlRowState } from './utils/getPredictHomepageUnrealizedPnlRowState';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import { PredictEventProperties } from '../../../../UI/Predict/constants/eventNames';
+import {
+  PredictEventProperties,
+  PredictEventValues,
+} from '../../../../UI/Predict/constants/eventNames';
 import {
   PredictPositionsEmptyStateVariant,
   type PredictEmptyStateCtaName,
@@ -236,7 +239,9 @@ const usePredictPositionsSectionData = (homepageQueriesEnabled: boolean) => {
     });
 
   const handleClaim = useCallback(async () => {
-    await claim();
+    await claim({
+      entryPoint: PredictEventValues.ENTRY_POINT.HOME_SECTION,
+    });
   }, [claim]);
 
   const hasPositions = positions.length > 0;

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
@@ -45,17 +45,17 @@ function render({
   );
 }
 
-const mockTrackPredictOrderEvent = jest.fn();
+const mockTrackClaimResolutionLagFailure = jest.fn();
 
 describe('PredictClaimFooter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (
       Engine.context as unknown as {
-        PredictController: { trackPredictOrderEvent: jest.Mock };
+        PredictController: { trackClaimResolutionLagFailure: jest.Mock };
       }
     ).PredictController = {
-      trackPredictOrderEvent: mockTrackPredictOrderEvent,
+      trackClaimResolutionLagFailure: mockTrackClaimResolutionLagFailure,
     };
   });
 
@@ -127,7 +127,7 @@ describe('PredictClaimFooter', () => {
     });
   });
 
-  it('tracks a failed pending_resolution claim event when there are no won positions', async () => {
+  it('routes the no-won-positions guard through the controller resolution-lag failure', async () => {
     // Arrange - state with transaction from an address with no claimable positions
     const state = merge(
       {},
@@ -154,15 +154,11 @@ describe('PredictClaimFooter', () => {
       state,
     });
 
-    // Assert - the Sentry 5JA7 guard is now measurable on the claim event
+    // Assert - the Sentry 5JA7 guard is routed through the controller so it
+    // shares the per-attempt idempotency guard (single terminal event).
     await waitFor(() => {
-      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith({
-        status: 'failed',
-        analyticsProperties: {
-          transactionType: 'mm_predict_claim',
-          entryPoint: 'background',
-        },
-        failureReason: 'pending_resolution',
+      expect(mockTrackClaimResolutionLagFailure).toHaveBeenCalledWith({
+        address: '0xunknown',
       });
     });
   });

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import Engine from '../../../../../../core/Engine';
 import { PredictClaimFooter } from './predict-claim-footer';
 import { merge, noop } from 'lodash';
 import { simpleSendTransactionControllerMock } from '../../../__mocks__/controllers/transaction-controller-mock';
@@ -44,7 +45,20 @@ function render({
   );
 }
 
+const mockTrackPredictOrderEvent = jest.fn();
+
 describe('PredictClaimFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      Engine.context as unknown as {
+        PredictController: { trackPredictOrderEvent: jest.Mock };
+      }
+    ).PredictController = {
+      trackPredictOrderEvent: mockTrackPredictOrderEvent,
+    };
+  });
+
   it('renders market count', () => {
     // Given 5 won positions
     const { getByText } = render();
@@ -110,6 +124,46 @@ describe('PredictClaimFooter', () => {
       expect(onErrorMock).toHaveBeenCalledWith(
         new Error('Tried to claim but no positions were won'),
       );
+    });
+  });
+
+  it('tracks a failed pending_resolution claim event when there are no won positions', async () => {
+    // Arrange - state with transaction from an address with no claimable positions
+    const state = merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      otherControllersMock,
+      {
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [
+                {
+                  txParams: { from: '0xunknown' },
+                },
+              ],
+            },
+          },
+        },
+      },
+    );
+
+    // Act
+    renderWithProvider(<PredictClaimFooter onPress={noop} onError={noop} />, {
+      state,
+    });
+
+    // Assert - the Sentry 5JA7 guard is now measurable on the claim event
+    await waitFor(() => {
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith({
+        status: 'failed',
+        analyticsProperties: {
+          transactionType: 'mm_predict_claim',
+          entryPoint: 'background',
+        },
+        failureReason: 'pending_resolution',
+      });
     });
   });
 

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
@@ -157,9 +157,9 @@ describe('PredictClaimFooter', () => {
     // Assert - the Sentry 5JA7 guard is routed through the controller so it
     // shares the per-attempt idempotency guard (single terminal event).
     await waitFor(() => {
-      expect(mockTrackClaimResolutionLagFailure).toHaveBeenCalledWith({
-        address: '0xunknown',
-      });
+      expect(mockTrackClaimResolutionLagFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ address: '0xunknown' }),
+      );
     });
   });
 

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -1,6 +1,11 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
+import Engine from '../../../../../../core/Engine';
+import {
+  PredictEventValues,
+  PredictTradeStatus,
+} from '../../../../../UI/Predict/constants/eventNames';
 import Avatar, {
   AvatarSize,
   AvatarVariant,
@@ -47,8 +52,27 @@ export function PredictClaimFooter({
 
   const hasNoPositions = !address || !wonPositions?.length;
 
+  const hasTrackedNoPositions = useRef(false);
+
   useEffect(() => {
     if (hasNoPositions) {
+      // Resolution-lag is the dominant claim failure mode (PRED-963). Track it
+      // explicitly so it is measurable on PREDICT_TRADE_TRANSACTION rather than
+      // surfacing only as a confirmation rejection. Guard against double-fire.
+      if (!hasTrackedNoPositions.current) {
+        hasTrackedNoPositions.current = true;
+        Engine.context.PredictController?.trackPredictOrderEvent({
+          status: PredictTradeStatus.FAILED,
+          analyticsProperties: {
+            transactionType:
+              PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
+            entryPoint: PredictEventValues.ENTRY_POINT.BACKGROUND,
+          },
+          failureReason:
+            PredictEventValues.CLAIM_FAILURE_REASON.PENDING_RESOLUTION,
+        });
+      }
+
       onError(new Error('Tried to claim but no positions were won'));
     }
   }, [hasNoPositions, onError]);

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -2,10 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
 import Engine from '../../../../../../core/Engine';
-import {
-  PredictEventValues,
-  PredictTradeStatus,
-} from '../../../../../UI/Predict/constants/eventNames';
 import Avatar, {
   AvatarSize,
   AvatarVariant,
@@ -56,26 +52,21 @@ export function PredictClaimFooter({
 
   useEffect(() => {
     if (hasNoPositions) {
-      // Resolution-lag is the dominant claim failure mode (PRED-963). Track it
-      // explicitly so it is measurable on PREDICT_TRADE_TRANSACTION rather than
-      // surfacing only as a confirmation rejection. Guard against double-fire.
+      // Resolution-lag is the dominant claim failure mode (PRED-963). Route the
+      // failure through the controller so it shares the per-attempt idempotency
+      // guard with the transaction-status terminal event (preventing a
+      // duplicate/contradictory `user_rejected` or `succeeded` for the same
+      // claim). Render-level ref avoids re-firing on re-renders.
       if (!hasTrackedNoPositions.current) {
         hasTrackedNoPositions.current = true;
-        Engine.context.PredictController?.trackPredictOrderEvent({
-          status: PredictTradeStatus.FAILED,
-          analyticsProperties: {
-            transactionType:
-              PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_CLAIM,
-            entryPoint: PredictEventValues.ENTRY_POINT.BACKGROUND,
-          },
-          failureReason:
-            PredictEventValues.CLAIM_FAILURE_REASON.PENDING_RESOLUTION,
+        Engine.context.PredictController?.trackClaimResolutionLagFailure?.({
+          address,
         });
       }
 
       onError(new Error('Tried to claim but no positions were won'));
     }
-  }, [hasNoPositions, onError]);
+  }, [hasNoPositions, onError, address]);
 
   const handlePress = useCallback(async () => {
     setIsConfirmationSubmitting(true);

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -39,6 +39,7 @@ export function PredictClaimFooter({
   const { setIsConfirmationSubmitting } = useConfirmationContext();
 
   const address = transactionMetadata?.txParams.from;
+  const transactionId = transactionMetadata?.id;
 
   const wonPositions = useSelector(
     selectPredictWonPositions({
@@ -60,13 +61,14 @@ export function PredictClaimFooter({
       if (!hasTrackedNoPositions.current) {
         hasTrackedNoPositions.current = true;
         Engine.context.PredictController?.trackClaimResolutionLagFailure?.({
+          transactionId,
           address,
         });
       }
 
       onError(new Error('Tried to claim but no positions were won'));
     }
-  }, [hasNoPositions, onError, address]);
+  }, [hasNoPositions, onError, address, transactionId]);
 
   const handlePress = useCallback(async () => {
     setIsConfirmationSubmitting(true);


### PR DESCRIPTION
## **Description**

Claim winnings is the #1 user-support theme for Predict, yet it is nearly unmeasurable in Mixpanel. Today `mm_predict_claim` fires only with `status: initiated`, and only from the Positions screen header and the home portfolio module. Every other claim entry point (market/event page, crypto up/down, wallet homepage Predictions section, feed sport cards, retry) produced no `mm_predict_claim` telemetry, and there was no `succeeded`/`failed` lifecycle for claims at all. As a result, claim success/failure rates were effectively invisible outside the Positions screen, and the dominant resolution-lag failure mode (PRED-963) could not be quantified.

This PR closes the coverage/wiring gap (no new event definition — the event token and Segment pipeline already exist):

- **Centralizes** claim telemetry in the shared `usePredictClaim` hook so every current and future claim entry point is covered with a single change. The hook fires `initiated` once per attempt and forwards an entry-point context to the controller.
- **Adds the full lifecycle**: `initiated` (attempted) at tap, then `succeeded`/`failed` emitted from `PredictController` when the claim transaction reaches a terminal status. The amount is captured before claimable positions are cleared so `amount_usd` reflects the claimed value.
- **Adds a `failure_reason` taxonomy** via a `mapClaimFailureReason` helper: `pending_resolution`, `insufficient_gas`, `network_error`, `user_rejected`, `unknown` (resolution-lag is checked first since it is the dominant mode).
- **Captures otherwise-invisible failures**: the signing-cancelled branch in the controller (`user_rejected`) and the Sentry 5JA7 "no positions won" guard in `predict-claim-footer.tsx` (`pending_resolution`).
- **Consistent properties** (`transaction_type`, `status`, `failure_reason`, `amount_usd`, `entry_point`, claimable counts) across all call sites. Because claims always submit all claimable positions (aggregate), `market_id`/`market_title` are derived controller-side only when exactly one market is claimed; otherwise they are omitted in favor of `claimable_positions_count`.

This must land before the Jun 28 Predict the Pitch leaderboard launch, when claim volume spikes.

## **Changelog**

CHANGELOG entry: null

<!-- Internal analytics/telemetry wiring only; no user-facing behavior change. Labeled no-changelog. -->

## **Related issues**

Refs: PRED-963

<!-- Replace with the tracking issue/Jira for "Claim winnings analytics incomplete" and PRED-1028 if applicable. -->

## **Manual testing steps**

```gherkin
Feature: mm_predict_claim analytics coverage

  Scenario: Claim initiated from a non-Positions entry point fires telemetry
    Given a wallet with claimable Predict winnings
    And Segment/Mixpanel debug logging is enabled
    When the user taps "Claim winnings" from the market detail page
    Then a "Predict Trade Transaction" event fires with transaction_type "mm_predict_claim" and status "initiated"
    And entry_point is "predict_market_details"

  Scenario: Successful claim emits a succeeded event with amount
    Given a claim has been initiated from any entry point
    When the claim transaction confirms on-chain
    Then a "Predict Trade Transaction" event fires with status "succeeded"
    And amount_usd reflects the claimed value
    And market_id/market_title are present only when a single market was claimed

  Scenario: Failed claim emits a failed event with a failure_reason
    Given a claim has been initiated
    When the claim transaction fails on-chain
    Then a "Predict Trade Transaction" event fires with status "failed"
    And failure_reason is one of pending_resolution, insufficient_gas, network_error, user_rejected, unknown

  Scenario: User cancels signing
    Given a claim has been initiated
    When the user rejects the signature request
    Then a "Predict Trade Transaction" event fires with status "failed" and failure_reason "user_rejected"

  Scenario: No-positions-won guard (Sentry 5JA7)
    Given the claim confirmation screen is reached but no won positions remain
    When the guard triggers
    Then a "Predict Trade Transaction" event fires with status "failed" and failure_reason "pending_resolution"
```

## **Screenshots/Recordings**

N/A — analytics/telemetry wiring only, no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## Implementation notes (for reviewers — remove before merge)

### Files changed (20)

**Core wiring**
- `app/components/UI/Predict/constants/eventNames.ts` — added `CLAIM_FAILURE_REASON` values.
- `app/components/UI/Predict/utils/analytics.ts` — added `mapClaimFailureReason(error)`.
- `app/components/UI/Predict/types/index.ts` — extracted `PredictTradeAnalyticsProperties`; added `analyticsProperties` to `ClaimParams`.
- `app/components/UI/Predict/hooks/usePredictClaim.ts` — `claim(ctx)` fires `initiated` once, forwards ctx, fires `failed` on the pre-tx catch path.
- `app/components/UI/Predict/controllers/PredictController.ts` — stashes claim analytics in `claimWithConfirmation`; fires `succeeded`/`failed` in `handleTransactionStatusUpdate` (using the pre-clear amount) and `user_rejected` in the signing-cancelled branch.

**Entry points (pass entry-point context to the shared `claim`)**
- `PredictPositionsViewHeader.tsx`, `PredictPortfolio/PredictPortfolioModule.tsx` (de-duplicated direct calls), `PredictMarketDetails.tsx`, `PredictCryptoUpDownPositions/PredictCryptoUpDownPosition.tsx`, `Homepage/Sections/Predictions/PredictionsSection.tsx`, `PredictSportCardFooter.tsx`, `PredictPositionsHeader.tsx`, `usePredictToastRegistrations.tsx` (retry).

**Sentry 5JA7 guard**
- `predict-confirmations/predict-claim-footer/predict-claim-footer.tsx` — fires `failed`/`pending_resolution` when the no-positions guard triggers.

**Tests**
- Added/updated `PredictController.test.ts` (terminal succeeded/failed/rejected + cancelled branch), `usePredictClaim.test.ts`, `utils/analytics.test.ts` (failure-reason branches), `predict-claim-footer.test.tsx` (guard event), and the two de-duplicated call-site tests.

### Reviewer decisions to confirm
1. **`predict_component` on the Positions screen `initiated` event** is no longer defaulted to `predict_portfolio_module` (the centralized path emits `predict_screen` instead). The home portfolio module still sends `predict_component` explicitly. Flag if any Mixpanel view depends on `predict_component` for the Positions screen.
2. **`predict_claim`** (the non-`mm_` transaction-controller event) already fires globally for all claims via `TransactionType.predictClaim`; no change needed there — the gap was `mm_predict_claim` only.

### Known pre-existing test issue (not introduced by this PR)
`PredictSportCardFooter.test.tsx` and `PredictionsSection.test.tsx` fail to load due to a pre-existing Perps circular-dependency in the `confirm-component` import chain (verified identical failure without these changes). The new code in those components is covered indirectly; `usePredictClaim.test.ts` and `predict-claim-footer.test.tsx` work around the same fragility via targeted mocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict claim flows and transaction-status analytics across many entry points; incorrect deduplication or double-firing could skew metrics, but user-facing claim behavior is unchanged.
> 
> **Overview**
> **Centralizes** `mm_predict_claim` telemetry in `usePredictClaim` and `PredictController` so every claim entry point (market details, feed, homepage, positions, retries) emits consistent **initiated → succeeded/failed** events with `entry_point` and portfolio context.
> 
> `claim()` now accepts optional `PredictTradeAnalyticsProperties`; call sites pass their entry point instead of ad-hoc `trackPortfolioTransactionInitiated` (removed from positions header and portfolio module). The hook fires **initiated** on tap and **failed** for pre-transaction errors; the controller stashes analytics at claim start, emits terminal outcomes on transaction status updates (with `amount_usd` before positions clear), handles **user_rejected** on signature cancel, and dedupes per transaction id.
> 
> Adds **`mapClaimFailureReason`** and **`CLAIM_FAILURE_REASON`** (`pending_resolution`, `insufficient_gas`, `network_error`, `user_rejected`, `unknown`). The claim confirmation footer routes the no-won-positions guard through **`trackClaimResolutionLagFailure`** so it shares the same idempotency guard as on-chain terminal events. Single-market claims get `market_id`/`market_title` derived controller-side when exactly one market is claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf809b7c4a99eb18be1fa9ef78cd63f76151fad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->