### PR TITLE
fix: use Maskicon avatar fallback in trading signals trader list

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react-native';
+import { AvatarAccount } from '@metamask/design-system-react-native';
+import { Image } from 'expo-image';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import {
@@ -107,11 +109,13 @@ const followedTraders: FollowedTrader[] = [
   {
     id: 'trader-1',
     username: 'trader1',
+    address: '0x0000000000000000000000000000000000000001',
     avatarUri: 'https://example.com/avatar.png',
   },
   {
     id: 'trader-2',
     username: 'pixelmage',
+    address: '0x0000000000000000000000000000000000000002',
   },
 ];
 
@@ -207,6 +211,17 @@ describe('SocialAINotificationPreferencesContent', () => {
         NotificationPreferencesSelectorsIDs.TRADER_TOGGLE('trader-2'),
       ).props.value,
     ).toBe(false);
+  });
+
+  it('renders the Maskicon fallback for traders without a profile image', () => {
+    mockUseFollowedTraders.mockReturnValue(
+      makeFollowedTradersResult({ traders: followedTraders }),
+    );
+
+    renderComponent();
+
+    expect(screen.UNSAFE_getAllByType(AvatarAccount)).toHaveLength(1);
+    expect(screen.UNSAFE_getAllByType(Image)).toHaveLength(1);
   });
 
   it('sets push notifications enabled and fires a medium switch haptic when the global toggle changes', () => {

--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback } from 'react';
-import { Image, Switch, TouchableOpacity, View } from 'react-native';
+import { Switch, TouchableOpacity, View } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
-  AvatarBase,
-  AvatarBaseSize,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -45,12 +43,15 @@ import {
 import ThresholdRadioList from '../../SocialLeaderboard/NotificationPreferences/components/ThresholdRadioList';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { NotificationPreferencesSelectorsIDs } from '../../SocialLeaderboard/NotificationPreferences/NotificationPreferences.testIds';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import TraderAvatar from '../../Homepage/Sections/TopTraders/components/TraderAvatar';
 
 const AVATAR_SIZE = 40;
 
 interface TraderNotificationRowProps {
   traderId: string;
   username: string;
+  address: string;
   avatarUri?: string;
   isEnabled: boolean;
   isDisabled: boolean;
@@ -62,6 +63,7 @@ interface TraderNotificationRowProps {
 const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
   traderId,
   username,
+  address,
   avatarUri,
   isEnabled,
   isDisabled,
@@ -88,20 +90,12 @@ const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
         style={tw.style('flex-row items-center gap-3 flex-1 min-w-0 mr-3')}
         testID={NotificationPreferencesSelectorsIDs.TRADER_PRESS(traderId)}
       >
-        {avatarUri ? (
-          <Image
-            source={{ uri: avatarUri }}
-            style={tw.style(
-              `w-[${AVATAR_SIZE}px] h-[${AVATAR_SIZE}px] rounded-full bg-muted`,
-            )}
-            resizeMode="cover"
-          />
-        ) : (
-          <AvatarBase
-            size={AvatarBaseSize.Lg}
-            fallbackText={username.charAt(0).toUpperCase()}
-          />
-        )}
+        <TraderAvatar
+          imageUrl={avatarUri}
+          address={address}
+          size={AVATAR_SIZE}
+          recyclingKey={traderId}
+        />
 
         <Text
           variant={TextVariant.BodyMd}
@@ -337,6 +331,7 @@ const SocialAINotificationPreferencesContent = ({
             key={trader.id}
             traderId={trader.id}
             username={trader.username}
+            address={trader.address}
             avatarUri={trader.avatarUri}
             isEnabled={isTraderNotificationEnabled(trader.id)}
             isDisabled={pushNotificationsOff}

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.test.ts
@@ -100,9 +100,15 @@ describe('useFollowedTraders', () => {
         {
           id: 'trader-1',
           username: 'trader1',
+          address: '0x1',
           avatarUri: 'https://example.com/a1.png',
         },
-        { id: 'trader-2', username: 'trader2', avatarUri: undefined },
+        {
+          id: 'trader-2',
+          username: 'trader2',
+          address: '0x2',
+          avatarUri: undefined,
+        },
       ]);
     });
   });

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/hooks/useFollowedTraders.ts
@@ -12,6 +12,8 @@ export interface FollowedTrader {
   id: string;
   /** Display name or truncated address. */
   username: string;
+  /** Wallet address used for the Maskicon fallback. */
+  address: string;
   /** Profile avatar URL, if any. */
   avatarUri?: string;
 }
@@ -73,6 +75,7 @@ export const useFollowedTraders = (
     return data.following.map((profile) => ({
       id: profile.profileId,
       username: profile.name,
+      address: profile.address,
       avatarUri: profile.imageUrl ?? undefined,
     }));
   }, [data]);


### PR DESCRIPTION


## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Trading Signals notification preferences previously showed a single-letter monogram (`AvatarBase`) when a followed trader had no profile image. This was inconsistent with the Top Trader Leaderboard, which already uses the shared `TraderAvatar` component to render a Maskicon/blockies fallback derived from the trader's wallet address.

This PR replaces the inline `Image` / `AvatarBase` fallback logic in `SocialAINotificationPreferencesContent` with the shared `TraderAvatar` component, and extends `FollowedTrader` / `useFollowedTraders` to expose the trader's wallet `address` so the Maskicon can be computed correctly.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed trader avatars in Trading Signals notification preferences to show address-derived Maskicon fallback instead of a monogram when no profile image is available.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Trading Signals trader avatar fallback

  Scenario: user views traders without profile images in notification preferences
    Given the user has followed one or more traders via Trading Signals
    And at least one followed trader has no profile image set

    When user navigates to Settings → Notifications → Trading Signals
    Then each trader without a profile image shows a colorful Maskicon (blockies) avatar
    And each trader with a profile image shows that image as their avatar
    And the avatar size and layout are consistent across all traders in the list
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


<img width="585" height="1266" alt="IMG_0075" src="https://github.com/user-attachments/assets/e82ffbac-caee-44cd-9ade-520844ae4614" />


### **After**

<img width="413" height="861" alt="image" src="https://github.com/user-attachments/assets/af2dc4ab-b863-4549-9a1c-e308ed5344f2" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->