### PR TITLE
feat: tappable follow trading trade rows with detail sheet and chart highlight

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -644,6 +644,12 @@ describe('TraderPositionView', () => {
     expect(
       screen.getByTestId(TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(TraderPositionViewSelectorsIDs.TRADE_BUTTON),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
+    ).toBeNull();
 
     await waitFor(() => {
       const chartProps =

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -619,7 +619,7 @@ describe('TraderPositionView', () => {
     expect(screen.getByTestId('trade-row-0xolder')).toBeOnTheScreen();
   });
 
-  it('opens the trade detail sheet and highlights the chart when a trade is pressed', async () => {
+  it('highlights the chart when a trade is pressed', async () => {
     const now = Date.now();
 
     mockRouteParams.position = {
@@ -642,14 +642,11 @@ describe('TraderPositionView', () => {
 
     expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
     expect(
-      screen.getByTestId(TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER),
+      screen.queryByTestId(TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER),
+    ).toBeNull();
+    expect(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
     ).toBeOnTheScreen();
-    expect(
-      screen.queryByTestId(TraderPositionViewSelectorsIDs.TRADE_BUTTON),
-    ).toBeNull();
-    expect(
-      screen.queryByTestId(TraderPositionViewSelectorsIDs.BUY_BUTTON),
-    ).toBeNull();
 
     await waitFor(() => {
       const chartProps =

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -4,6 +4,7 @@ import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import TraderPositionView from './TraderPositionView';
 import { TraderPositionViewSelectorsIDs } from './TraderPositionView.testIds';
+import { TraderTradeDetailBottomSheetSelectorsIDs } from './components/TraderTradeDetailBottomSheet';
 import type { Position, Trade } from '@metamask/social-controllers';
 import { handleFetch } from '@metamask/controller-utils';
 import ClipboardManager from '../../../../core/ClipboardManager';
@@ -145,6 +146,14 @@ jest.mock('../../../hooks/useAnalytics/useAnalytics', () => {
   );
   return { useAnalytics: () => createMockUseAnalyticsHook() };
 });
+
+jest.mock('../../../UI/Rewards/hooks/useTransactionExplorer', () => ({
+  __esModule: true,
+  default: () => ({
+    name: 'Etherscan',
+    url: 'https://etherscan.io/tx/0xabc',
+  }),
+}));
 
 jest.mock('../../../UI/AssetOverview/PriceChart', () => {
   const { View } = jest.requireActual('react-native');
@@ -608,6 +617,41 @@ describe('TraderPositionView', () => {
     });
     expect(screen.getByTestId('trade-row-0xrecent')).toBeOnTheScreen();
     expect(screen.getByTestId('trade-row-0xolder')).toBeOnTheScreen();
+  });
+
+  it('opens the trade detail sheet and highlights the chart when a trade is pressed', async () => {
+    const now = Date.now();
+
+    mockRouteParams.position = {
+      ...makeDefaultPosition(),
+      trades: [
+        {
+          intent: 'exit',
+          direction: 'sell',
+          tokenAmount: 500,
+          usdCost: 1581.19,
+          timestamp: now - 2 * 24 * 60 * 60 * 1000,
+          transactionHash: '0xolder',
+        },
+      ],
+    };
+
+    renderWithProvider(<TraderPositionView />, { state: mockState });
+
+    fireEvent.press(screen.getByTestId('trade-row-0xolder-pressable'));
+
+    expect(mockPlayImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    expect(
+      screen.getByTestId(TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+
+    await waitFor(() => {
+      const chartProps =
+        mockTraderPriceChart.mock.calls[
+          mockTraderPriceChart.mock.calls.length - 1
+        ]?.[0];
+      expect(chartProps?.highlightedTradeHash).toBe('0xolder');
+    });
   });
 
   it('refetches position and profile on pull-to-refresh', async () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -375,10 +375,11 @@ const TraderPositionView = () => {
     !resolvedPosition && !isPositionLoading && !isProfileLoading;
 
   return (
-    <SafeAreaView
-      style={tw.style('flex-1 bg-default')}
-      testID={TraderPositionViewSelectorsIDs.CONTAINER}
-    >
+    <>
+      <SafeAreaView
+        style={tw.style('flex-1 bg-default')}
+        testID={TraderPositionViewSelectorsIDs.CONTAINER}
+      >
       <TraderPositionHeader
         traderName={traderName}
         traderImageUrl={traderImageUrl}
@@ -493,20 +494,21 @@ const TraderPositionView = () => {
               />
             </>
           )}
-
-          {selectedTrade ? (
-            <TraderTradeDetailBottomSheet
-              isVisible
-              trade={selectedTrade}
-              tokenSymbol={symbol}
-              chain={resolvedPosition?.chain ?? ''}
-              tokenAddress={resolvedPosition?.tokenAddress ?? ''}
-              onClose={handleTradeDetailClose}
-            />
-          ) : null}
         </>
       )}
-    </SafeAreaView>
+      </SafeAreaView>
+
+      {selectedTrade ? (
+        <TraderTradeDetailBottomSheet
+          isVisible
+          trade={selectedTrade}
+          tokenSymbol={symbol}
+          chain={resolvedPosition?.chain ?? ''}
+          tokenAddress={resolvedPosition?.tokenAddress ?? ''}
+          onClose={handleTradeDetailClose}
+        />
+      ) : null}
+    </>
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -450,42 +450,35 @@ const TraderPositionView = () => {
             />
           </ScrollView>
 
-          {selectedTrade ? (
-            <TraderTradeDetailBottomSheet
-              isVisible
-              trade={selectedTrade}
-              tokenSymbol={symbol}
-              chain={resolvedPosition?.chain ?? ''}
-              tokenAddress={resolvedPosition?.tokenAddress ?? ''}
-              onClose={handleTradeDetailClose}
-            />
-          ) : null}
-
           {isPerp ? (
-            <Box twClassName="px-4 py-3">
-              <Button
-                variant={ButtonVariant.Primary}
-                size={ButtonSize.Lg}
-                isFullWidth
-                onPress={handlePerpActionPress}
-                testID={TraderPositionViewSelectorsIDs.TRADE_BUTTON}
-              >
-                {strings('social_leaderboard.trader_position.trade')}
-              </Button>
-            </Box>
-          ) : (
-            <>
+            !selectedTrade ? (
               <Box twClassName="px-4 py-3">
                 <Button
                   variant={ButtonVariant.Primary}
                   size={ButtonSize.Lg}
                   isFullWidth
-                  onPress={handleBuyPress}
-                  testID={TraderPositionViewSelectorsIDs.BUY_BUTTON}
+                  onPress={handlePerpActionPress}
+                  testID={TraderPositionViewSelectorsIDs.TRADE_BUTTON}
                 >
-                  {strings('social_leaderboard.trader_position.buy')}
+                  {strings('social_leaderboard.trader_position.trade')}
                 </Button>
               </Box>
+            ) : null
+          ) : (
+            <>
+              {!selectedTrade ? (
+                <Box twClassName="px-4 py-3">
+                  <Button
+                    variant={ButtonVariant.Primary}
+                    size={ButtonSize.Lg}
+                    isFullWidth
+                    onPress={handleBuyPress}
+                    testID={TraderPositionViewSelectorsIDs.BUY_BUTTON}
+                  >
+                    {strings('social_leaderboard.trader_position.buy')}
+                  </Button>
+                </Box>
+              ) : null}
 
               <TraderPositionQuickBuy
                 isVisible={isQuickBuyVisible}
@@ -500,6 +493,17 @@ const TraderPositionView = () => {
               />
             </>
           )}
+
+          {selectedTrade ? (
+            <TraderTradeDetailBottomSheet
+              isVisible
+              trade={selectedTrade}
+              tokenSymbol={symbol}
+              chain={resolvedPosition?.chain ?? ''}
+              tokenAddress={resolvedPosition?.tokenAddress ?? ''}
+              onClose={handleTradeDetailClose}
+            />
+          ) : null}
         </>
       )}
     </SafeAreaView>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -7,7 +7,6 @@ import React, {
   useState,
 } from 'react';
 import { RefreshControl } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
 import {
   useNavigation,
   useRoute,
@@ -65,6 +64,7 @@ import {
   TransactionDetailLocation,
 } from '../../../../core/Analytics/events/transactions';
 import { SocialLeaderboardEventValues } from '../analytics';
+import { TRADE_DETAIL_BOTTOM_SHEET_ENABLED } from './features/tradeDetailFeatureFlags';
 
 const TraderPositionView = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
@@ -308,7 +308,9 @@ const TraderPositionView = () => {
       playImpact(ImpactMoment.PrimaryCTA);
       setActiveTimePeriod(findTimePeriodForTrade(trade.timestamp));
       setHighlightedTradeHash(trade.transactionHash);
-      setSelectedTrade(trade);
+      if (TRADE_DETAIL_BOTTOM_SHEET_ENABLED) {
+        setSelectedTrade(trade);
+      }
 
       const caipChainId = resolvedPosition
         ? chainNameToId(resolvedPosition.chain)
@@ -396,17 +398,7 @@ const TraderPositionView = () => {
         <TraderPositionFallback traderId={traderId} traderName={traderName} />
       ) : (
         <>
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={tw.style('pb-6')}
-            refreshControl={
-              <RefreshControl
-                refreshing={isRefreshing}
-                onRefresh={handleRefresh}
-                testID={TraderPositionViewSelectorsIDs.REFRESH_CONTROL}
-              />
-            }
-          >
+          <Box twClassName="flex-1 min-h-0">
             <TraderTokenInfoRow
               symbol={symbol}
               position={resolvedPosition}
@@ -444,15 +436,23 @@ const TraderPositionView = () => {
             />
 
             <TraderTradesSection
+              scrollable
               trades={allTrades}
               traderImageUrl={traderImageUrl}
               traderAddress={traderAddress}
               onTradePress={handleTradePress}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isRefreshing}
+                  onRefresh={handleRefresh}
+                  testID={TraderPositionViewSelectorsIDs.REFRESH_CONTROL}
+                />
+              }
             />
-          </ScrollView>
+          </Box>
 
           {isPerp ? (
-            !selectedTrade ? (
+            !TRADE_DETAIL_BOTTOM_SHEET_ENABLED || !selectedTrade ? (
               <Box twClassName="px-4 py-3">
                 <Button
                   variant={ButtonVariant.Primary}
@@ -467,7 +467,7 @@ const TraderPositionView = () => {
             ) : null
           ) : (
             <>
-              {!selectedTrade ? (
+              {!TRADE_DETAIL_BOTTOM_SHEET_ENABLED || !selectedTrade ? (
                 <Box twClassName="px-4 py-3">
                   <Button
                     variant={ButtonVariant.Primary}
@@ -498,7 +498,7 @@ const TraderPositionView = () => {
       )}
       </SafeAreaView>
 
-      {selectedTrade ? (
+      {TRADE_DETAIL_BOTTOM_SHEET_ENABLED && selectedTrade ? (
         <TraderTradeDetailBottomSheet
           isVisible
           trade={selectedTrade}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -53,9 +53,18 @@ import {
 } from '../analytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { chainNameToId } from '../utils/chainMapping';
-import { isPerpPosition } from '../utils/perp';
+import { isPerpPosition, isPerpTrade } from '../utils/perp';
 import { toAssetId } from '../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import type { PerpsMarketData } from '@metamask/perps-controller';
+import type { Trade } from '@metamask/social-controllers';
+import TraderTradeDetailBottomSheet from './components/TraderTradeDetailBottomSheet';
+import { findTimePeriodForTrade } from './utils/chartTimePeriods';
+import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import {
+  TRANSACTION_DETAIL_EVENTS,
+  TransactionDetailLocation,
+} from '../../../../core/Analytics/events/transactions';
+import { SocialLeaderboardEventValues } from '../analytics';
 
 const TraderPositionView = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
@@ -77,9 +86,14 @@ const TraderPositionView = () => {
     notificationSubtype,
   } = route.params;
   const { track } = useSocialLeaderboardAnalytics();
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const [isQuickBuyVisible, setIsQuickBuyVisible] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [selectedTrade, setSelectedTrade] = useState<Trade | null>(null);
+  const [highlightedTradeHash, setHighlightedTradeHash] = useState<
+    string | null
+  >(null);
   const buyClickedRef = useRef(false);
 
   // Position resolution: always fetch by id when we have one so pull-to-refresh
@@ -289,6 +303,53 @@ const TraderPositionView = () => {
     // TODO: update displayed price on scrub.
   }, []);
 
+  const handleTradePress = useCallback(
+    (trade: Trade) => {
+      playImpact(ImpactMoment.PrimaryCTA);
+      setActiveTimePeriod(findTimePeriodForTrade(trade.timestamp));
+      setHighlightedTradeHash(trade.transactionHash);
+      setSelectedTrade(trade);
+
+      const caipChainId = resolvedPosition
+        ? chainNameToId(resolvedPosition.chain)
+        : undefined;
+      const traderTradeType =
+        trade.intent === 'enter'
+          ? SocialLeaderboardEventValues.TRADER_TRADE_TYPE.BUY
+          : SocialLeaderboardEventValues.TRADER_TRADE_TYPE.SELL;
+
+      trackEvent(
+        createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+          .addProperties({
+            transaction_type: isPerpTrade(trade)
+              ? `social_perp_${traderTradeType}`
+              : `social_spot_${traderTradeType}`,
+            transaction_status: 'confirmed',
+            location: TransactionDetailLocation.AssetDetails,
+            ...(caipChainId && {
+              chain_id_source: caipChainId,
+              chain_id_destination: caipChainId,
+            }),
+            [SocialLeaderboardEventProperties.TX_HASH]: trade.transactionHash,
+            [SocialLeaderboardEventProperties.TRADER_TRADE_TYPE]:
+              traderTradeType,
+          })
+          .build(),
+      );
+    },
+    [
+      createEventBuilder,
+      resolvedPosition,
+      setActiveTimePeriod,
+      trackEvent,
+    ],
+  );
+
+  const handleTradeDetailClose = useCallback(() => {
+    setSelectedTrade(null);
+    setHighlightedTradeHash(null);
+  }, []);
+
   // Perp positions surface Long/Short CTAs instead of Buy. Hyperliquid has no
   // long/short preselect param on the market page (direction only exists on the
   // funded trade-entry flow), so both CTAs land the user on that market's Perps
@@ -364,6 +425,7 @@ const TraderPositionView = () => {
               isPricesLoading={isPricesLoading}
               onChartIndexChange={handleChartIndexChange}
               trades={chartTrades}
+              highlightedTradeHash={highlightedTradeHash}
             />
 
             <TraderTimePeriodSelector
@@ -384,8 +446,20 @@ const TraderPositionView = () => {
               trades={allTrades}
               traderImageUrl={traderImageUrl}
               traderAddress={traderAddress}
+              onTradePress={handleTradePress}
             />
           </ScrollView>
+
+          {selectedTrade ? (
+            <TraderTradeDetailBottomSheet
+              isVisible
+              trade={selectedTrade}
+              tokenSymbol={symbol}
+              chain={resolvedPosition?.chain ?? ''}
+              tokenAddress={resolvedPosition?.tokenAddress ?? ''}
+              onClose={handleTradeDetailClose}
+            />
+          ) : null}
 
           {isPerp ? (
             <Box twClassName="px-4 py-3">

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
 import React from 'react';
 import { Image } from 'expo-image';
 import { AvatarAccount } from '@metamask/design-system-react-native';
@@ -53,5 +53,15 @@ describe('TradeRow', () => {
 
     expect(screen.UNSAFE_queryByType(AvatarAccount)).not.toBeNull();
     expect(screen.UNSAFE_queryByType(Image)).toBeNull();
+  });
+
+  it('calls onPress when the row is pressed', () => {
+    const onPress = jest.fn();
+
+    renderWithProvider(<TradeRow trade={baseTrade} onPress={onPress} />);
+
+    fireEvent.press(screen.getByTestId('trade-row-0xabc-pressable'));
+
+    expect(onPress).toHaveBeenCalledWith(baseTrade);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TouchableOpacity } from 'react-native';
 import {
   Box,
   Text,
@@ -7,12 +8,16 @@ import {
   FontWeight,
   BoxFlexDirection,
   BoxAlignItems,
+  Icon,
+  IconName,
+  IconSize,
+  IconColor,
 } from '@metamask/design-system-react-native';
 import type { Trade } from '@metamask/social-controllers';
-import { strings } from '../../../../../../locales/i18n';
 import { formatUsd, formatTradeDate } from '../../utils/formatters';
 import PerpBadges from '../../components/PerpBadges';
 import { getPerpTradeDirection, isPerpTrade } from '../../utils/perp';
+import { getTradeActionLabel } from '../utils/getTradeActionLabel';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import TraderAvatar from '../../../Homepage/Sections/TopTraders/components/TraderAvatar';
 
@@ -22,32 +27,27 @@ export interface TradeRowProps {
   trade: Trade;
   traderImageUrl?: string;
   traderAddress?: string;
+  onPress?: (trade: Trade) => void;
 }
 
 const TradeRow: React.FC<TradeRowProps> = ({
   trade,
   traderImageUrl,
   traderAddress,
+  onPress,
 }) => {
   const isEntry = trade.intent === 'enter';
   const isPerp = isPerpTrade(trade);
   const perpDirection = getPerpTradeDirection(trade);
+  const actionLabel = getTradeActionLabel(trade);
+  const testID = `trade-row-${trade.transactionHash}`;
 
-  // Perp fills read as "opened"/"closed" (vs spot "bought"/"sold").
-  const actionLabel = isPerp
-    ? isEntry
-      ? strings('social_leaderboard.trader_position.opened')
-      : strings('social_leaderboard.trader_position.closed_action')
-    : isEntry
-      ? strings('social_leaderboard.trader_position.bought')
-      : strings('social_leaderboard.trader_position.sold');
-
-  return (
+  const content = (
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       twClassName="px-4 py-3"
-      testID={`trade-row-${trade.transactionHash}`}
+      testID={testID}
     >
       <Box
         flexDirection={BoxFlexDirection.Row}
@@ -93,7 +93,11 @@ const TradeRow: React.FC<TradeRowProps> = ({
         </Box>
       </Box>
 
-      <Box alignItems={BoxAlignItems.End}>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={2}
+      >
         <Text
           variant={TextVariant.BodyMd}
           fontWeight={FontWeight.Medium}
@@ -103,9 +107,31 @@ const TradeRow: React.FC<TradeRowProps> = ({
             isEntry ? Math.abs(trade.usdCost) : -Math.abs(trade.usdCost),
           )}
         </Text>
+        {onPress ? (
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            color={IconColor.IconAlternative}
+          />
+        ) : null}
       </Box>
     </Box>
   );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity
+        onPress={() => onPress(trade)}
+        testID={`${testID}-pressable`}
+        accessibilityRole="button"
+        accessibilityLabel={`${actionLabel}, ${formatTradeDate(trade.timestamp)}`}
+      >
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return content;
 };
 
 export default TradeRow;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionChartSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionChartSection.tsx
@@ -11,6 +11,7 @@ export interface TraderPositionChartSectionProps {
   isPricesLoading: boolean;
   onChartIndexChange: (index: number) => void;
   trades: readonly Trade[];
+  highlightedTradeHash?: string | null;
 }
 
 const TraderPositionChartSection: React.FC<TraderPositionChartSectionProps> = ({
@@ -19,6 +20,7 @@ const TraderPositionChartSection: React.FC<TraderPositionChartSectionProps> = ({
   isPricesLoading,
   onChartIndexChange,
   trades,
+  highlightedTradeHash,
 }) => (
   <PriceChartProvider>
     <Box twClassName="mx-4 my-3">
@@ -28,6 +30,7 @@ const TraderPositionChartSection: React.FC<TraderPositionChartSectionProps> = ({
         isLoading={isPricesLoading}
         onChartIndexChange={onChartIndexChange}
         trades={trades}
+        highlightedTradeHash={highlightedTradeHash}
       />
     </Box>
   </PriceChartProvider>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.test.tsx
@@ -288,6 +288,29 @@ describe('TraderPriceChart', () => {
         result.getByTestId('trade-marker-highlight-ring-0xhighlight'),
       ).toBeOnTheScreen();
     });
+
+    it('hides the scrub tooltip while a trade marker is highlighted', () => {
+      const prices = makePrices(10);
+      const trade = makeTrade({
+        intent: 'exit',
+        direction: 'sell',
+        transactionHash: '0xsell-highlight',
+      });
+      const onChartIndexChange = jest.fn();
+      const result = render(
+        <TraderPriceChart
+          {...defaultProps}
+          prices={prices}
+          trades={[trade]}
+          highlightedTradeHash="0xsell-highlight"
+          onChartIndexChange={onChartIndexChange}
+        />,
+      );
+      triggerChartLayout(result.getByTestId);
+
+      expect(onChartIndexChange).toHaveBeenCalled();
+      expect(result.queryByTestId('price-chart-area')).toBeOnTheScreen();
+    });
   });
 
   // ── PriceChartProvider integration ────────────────────────────────────────

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.test.tsx
@@ -271,6 +271,23 @@ describe('TraderPriceChart', () => {
       triggerChartLayout(result.getByTestId);
       expect(result.queryByTestId('trade-marker-0xloading')).toBeNull();
     });
+
+    it('renders a highlight ring for the highlighted trade marker', () => {
+      const prices = makePrices(10);
+      const trade = makeTrade({ transactionHash: '0xhighlight' });
+      const result = render(
+        <TraderPriceChart
+          {...defaultProps}
+          prices={prices}
+          trades={[trade]}
+          highlightedTradeHash="0xhighlight"
+        />,
+      );
+      triggerChartLayout(result.getByTestId);
+      expect(
+        result.getByTestId('trade-marker-highlight-ring-0xhighlight'),
+      ).toBeOnTheScreen();
+    });
   });
 
   // ── PriceChartProvider integration ────────────────────────────────────────

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
@@ -98,7 +98,6 @@ const TraderPriceChart = ({
       (m) => m.transactionHash === highlightedTradeHash,
     );
     if (marker) {
-      setPositionX(marker.index);
       onChartIndexChange(marker.index);
     }
   }, [highlightedTradeHash, markers, onChartIndexChange]);
@@ -225,6 +224,17 @@ const TraderPriceChart = ({
 
   const Tooltip = ({ x, y, height: svgHeight }: Partial<TooltipProps>) => {
     if (positionX < 0) return null;
+    // Trade-row highlight uses the marker ring only; skip the scrub tooltip so
+    // its always-green chart color doesn't clash with sell markers.
+    if (
+      highlightedTradeHash &&
+      markers.some(
+        (m) =>
+          m.transactionHash === highlightedTradeHash && m.index === positionX,
+      )
+    ) {
+      return null;
+    }
     const lineHeight =
       typeof svgHeight === 'number' && svgHeight > 0 ? svgHeight : chartHeight;
     return (
@@ -326,7 +336,6 @@ const TraderPriceChart = ({
                   fill="none"
                   stroke={fillColor}
                   strokeWidth={HIGHLIGHTED_TRADE_MARKER_RING_WIDTH}
-                  opacity={0.45}
                 />
               ) : null}
               <Circle

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
@@ -94,6 +94,7 @@ const TraderPriceChart = ({
     if (!highlightedTradeHash) {
       return;
     }
+    setPositionX(-1);
     const marker = markers.find(
       (m) => m.transactionHash === highlightedTradeHash,
     );
@@ -223,18 +224,7 @@ const TraderPriceChart = ({
   };
 
   const Tooltip = ({ x, y, height: svgHeight }: Partial<TooltipProps>) => {
-    if (positionX < 0) return null;
-    // Trade-row highlight uses the marker ring only; skip the scrub tooltip so
-    // its always-green chart color doesn't clash with sell markers.
-    if (
-      highlightedTradeHash &&
-      markers.some(
-        (m) =>
-          m.transactionHash === highlightedTradeHash && m.index === positionX,
-      )
-    ) {
-      return null;
-    }
+    if (positionX < 0 || highlightedTradeHash) return null;
     const lineHeight =
       typeof svgHeight === 'number' && svgHeight > 0 ? svgHeight : chartHeight;
     return (

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx
@@ -49,6 +49,8 @@ const TRADE_MARKER_INNER_RADIUS = 5;
 const TRADE_MARKER_BORDER_WIDTH = 2;
 const TRADE_MARKER_RADIUS =
   TRADE_MARKER_INNER_RADIUS + TRADE_MARKER_BORDER_WIDTH / 2;
+const HIGHLIGHTED_TRADE_MARKER_RADIUS = TRADE_MARKER_RADIUS + 3;
+const HIGHLIGHTED_TRADE_MARKER_RING_WIDTH = 2;
 
 interface TraderPriceChartProps {
   prices: TokenPrice[];
@@ -57,6 +59,8 @@ interface TraderPriceChartProps {
   onChartIndexChange: (index: number) => void;
   /** Trade markers to render as buy/sell dots on the chart line. */
   trades?: readonly Trade[];
+  /** When set, enlarges the matching marker and pins the scrub tooltip. */
+  highlightedTradeHash?: string | null;
   chartHeight?: number;
 }
 
@@ -65,6 +69,7 @@ const TraderPriceChart = ({
   isLoading,
   onChartIndexChange,
   trades,
+  highlightedTradeHash,
   chartHeight = TOKEN_OVERVIEW_CHART_HEIGHT,
 }: TraderPriceChartProps) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -79,6 +84,24 @@ const TraderPriceChart = ({
   useEffect(() => {
     setPositionX(-1);
   }, [prices]);
+
+  const markers = useMemo(
+    () => mapTradesToMarkers(trades, prices),
+    [trades, prices],
+  );
+
+  useEffect(() => {
+    if (!highlightedTradeHash) {
+      return;
+    }
+    const marker = markers.find(
+      (m) => m.transactionHash === highlightedTradeHash,
+    );
+    if (marker) {
+      setPositionX(marker.index);
+      onChartIndexChange(marker.index);
+    }
+  }, [highlightedTradeHash, markers, onChartIndexChange]);
 
   const apx = (size = 0) => {
     const width = Dimensions.get('window').width;
@@ -230,11 +253,6 @@ const TraderPriceChart = ({
 
   // ── Trade markers (computed before EndDot so suppressEndDot is available) ──
 
-  const markers = useMemo(
-    () => mapTradesToMarkers(trades, prices),
-    [trades, prices],
-  );
-
   // Suppress the end-dot when a trade marker already covers the tail of the
   // chart line (within 2 price indices). This surfaces very-recent trades that
   // would otherwise be hidden behind the end-dot (e.g. same-hour buys/sells on
@@ -286,25 +304,41 @@ const TraderPriceChart = ({
           const cy = y(priceList[m.index]);
           if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null;
           const isBuy = m.intent === 'enter';
-          // Inner disk uses the same green/red as the rest of the UI; the
-          // ring matches the chart background so the marker reads as a
-          // punched-through dot on the line. background.default adapts to
-          // light/dark automatically.
+          const isHighlighted = m.transactionHash === highlightedTradeHash;
+          const markerRadius = isHighlighted
+            ? HIGHLIGHTED_TRADE_MARKER_RADIUS
+            : TRADE_MARKER_RADIUS;
+          const fillColor = isBuy
+            ? theme.colors.success.default
+            : theme.colors.error.default;
           return (
-            <Circle
-              key={m.transactionHash}
-              testID={`trade-marker-${m.transactionHash}`}
-              cx={cx}
-              cy={cy}
-              r={TRADE_MARKER_RADIUS}
-              fill={
-                isBuy
-                  ? theme.colors.success.default
-                  : theme.colors.error.default
-              }
-              stroke={theme.colors.background.default}
-              strokeWidth={TRADE_MARKER_BORDER_WIDTH}
-            />
+            <G key={m.transactionHash}>
+              {isHighlighted ? (
+                <Circle
+                  testID={`trade-marker-highlight-ring-${m.transactionHash}`}
+                  cx={cx}
+                  cy={cy}
+                  r={
+                    markerRadius +
+                    HIGHLIGHTED_TRADE_MARKER_RING_WIDTH +
+                    TRADE_MARKER_BORDER_WIDTH
+                  }
+                  fill="none"
+                  stroke={fillColor}
+                  strokeWidth={HIGHLIGHTED_TRADE_MARKER_RING_WIDTH}
+                  opacity={0.45}
+                />
+              ) : null}
+              <Circle
+                testID={`trade-marker-${m.transactionHash}`}
+                cx={cx}
+                cy={cy}
+                r={markerRadius}
+                fill={fillColor}
+                stroke={theme.colors.background.default}
+                strokeWidth={TRADE_MARKER_BORDER_WIDTH}
+              />
+            </G>
           );
         })}
       </G>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react-native';
+import type { Trade } from '@metamask/social-controllers';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import TraderTradeDetailBottomSheet from './TraderTradeDetailBottomSheet';
+import { TraderTradeDetailBottomSheetSelectorsIDs } from './TraderTradeDetailBottomSheet.testIds';
+import ClipboardManager from '../../../../../../core/ClipboardManager';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+
+jest.mock('../../../../../UI/Rewards/hooks/useTransactionExplorer', () => ({
+  __esModule: true,
+  default: () => ({
+    name: 'Etherscan',
+    url: 'https://etherscan.io/tx/0xabc',
+  }),
+}));
+
+jest.mock('../../../../../../core/ClipboardManager', () => ({
+  setString: jest.fn().mockResolvedValue(undefined),
+}));
+
+const baseTrade: Trade = {
+  intent: 'enter',
+  direction: 'buy',
+  tokenAmount: 42,
+  usdCost: 1611.37,
+  timestamp: 1_700_000_000_000,
+  transactionHash: '0xabc1234567890abcdef1234567890abcdef12345678',
+};
+
+describe('TraderTradeDetailBottomSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders trade details when visible', () => {
+    renderWithProvider(
+      <TraderTradeDetailBottomSheet
+        isVisible
+        trade={baseTrade}
+        tokenSymbol="RE"
+        chain="base"
+        tokenAddress="0x1234567890123456789012345678901234567890"
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId(TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('Bought')).toBeOnTheScreen();
+    expect(screen.getByText('$1,611.37')).toBeOnTheScreen();
+    expect(screen.getByText('42 RE')).toBeOnTheScreen();
+    expect(screen.getByText('RE')).toBeOnTheScreen();
+  });
+
+  it('copies the transaction hash when the row is pressed', () => {
+    renderWithProvider(
+      <TraderTradeDetailBottomSheet
+        isVisible
+        trade={baseTrade}
+        tokenSymbol="RE"
+        chain="base"
+        tokenAddress="0x1234567890123456789012345678901234567890"
+        onClose={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(
+      screen.getByTestId(
+        TraderTradeDetailBottomSheetSelectorsIDs.COPY_TX_HASH_BUTTON,
+      ),
+    );
+
+    expect(ClipboardManager.setString).toHaveBeenCalledWith(
+      baseTrade.transactionHash,
+    );
+  });
+
+  it('opens the block explorer when the explorer button is pressed', () => {
+    renderWithProvider(
+      <TraderTradeDetailBottomSheet
+        isVisible
+        trade={baseTrade}
+        tokenSymbol="RE"
+        chain="base"
+        tokenAddress="0x1234567890123456789012345678901234567890"
+        onClose={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(
+      screen.getByTestId(
+        TraderTradeDetailBottomSheetSelectorsIDs.EXPLORER_BUTTON,
+      ),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+      screen: 'SimpleWebview',
+      params: {
+        url: 'https://etherscan.io/tx/0xabc',
+      },
+    });
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.testIds.ts
@@ -1,0 +1,6 @@
+export const TraderTradeDetailBottomSheetSelectorsIDs = {
+  CONTAINER: 'trader-trade-detail-bottom-sheet',
+  CLOSE_BUTTON: 'trader-trade-detail-bottom-sheet-close-button',
+  EXPLORER_BUTTON: 'trader-trade-detail-bottom-sheet-explorer-button',
+  COPY_TX_HASH_BUTTON: 'trader-trade-detail-bottom-sheet-copy-tx-hash-button',
+};

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.tsx
@@ -14,11 +14,11 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  BottomSheet,
+  type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import type { CaipAssetType } from '@metamask/utils';
 import type { Trade } from '@metamask/social-controllers';
-import BottomSheet from '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet';
-import type { BottomSheetRef } from '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet.types';
 import { strings } from '../../../../../../../locales/i18n';
 import {
   formatTokenAmount,
@@ -144,7 +144,6 @@ const TraderTradeDetailBottomSheet: React.FC<
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack={false}
       isInteractable
       onClose={handleSheetClosed}
       testID={TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/TraderTradeDetailBottomSheet.tsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  HeaderStandard,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
+import type { CaipAssetType } from '@metamask/utils';
+import type { Trade } from '@metamask/social-controllers';
+import BottomSheet from '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet';
+import type { BottomSheetRef } from '../../../../../../component-library/components/BottomSheets/BottomSheet/BottomSheet.types';
+import { strings } from '../../../../../../../locales/i18n';
+import {
+  formatTokenAmount,
+  formatTradeDate,
+  formatUsd,
+} from '../../../utils/formatters';
+import { getTradeActionLabel } from '../../utils/getTradeActionLabel';
+import PerpBadges from '../../../components/PerpBadges';
+import { getPerpTradeDirection, isPerpTrade } from '../../../utils/perp';
+import { chainNameToId } from '../../../utils/chainMapping';
+import { toAssetId } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import useTransactionExplorer from '../../../../../UI/Rewards/hooks/useTransactionExplorer';
+import { formatAddress } from '../../../../../../util/address';
+import ClipboardManager from '../../../../../../core/ClipboardManager';
+import { TraderTradeDetailBottomSheetSelectorsIDs } from './TraderTradeDetailBottomSheet.testIds';
+
+export interface TraderTradeDetailBottomSheetProps {
+  isVisible: boolean;
+  trade: Trade | null;
+  tokenSymbol: string;
+  chain: string;
+  tokenAddress: string;
+  onClose: () => void;
+}
+
+interface DetailRowProps {
+  label: string;
+  value: string;
+  valueClassName?: string;
+  testID?: string;
+}
+
+const DetailRow: React.FC<DetailRowProps> = ({
+  label,
+  value,
+  valueClassName,
+  testID,
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    justifyContent={BoxJustifyContent.Between}
+    twClassName="py-3"
+    testID={testID}
+  >
+    <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+      {label}
+    </Text>
+    <Text
+      variant={TextVariant.BodyMd}
+      fontWeight={FontWeight.Medium}
+      color={TextColor.TextDefault}
+      twClassName={valueClassName}
+      numberOfLines={1}
+    >
+      {value}
+    </Text>
+  </Box>
+);
+
+const TraderTradeDetailBottomSheet: React.FC<
+  TraderTradeDetailBottomSheetProps
+> = ({ isVisible, trade, tokenSymbol, chain, tokenAddress, onClose }) => {
+  const navigation = useNavigation();
+  const sheetRef = useRef<BottomSheetRef>(null);
+
+  const caipAssetId = useMemo((): CaipAssetType | undefined => {
+    const caipChainId = chainNameToId(chain);
+    if (!caipChainId) return undefined;
+    return toAssetId(tokenAddress, caipChainId) ?? undefined;
+  }, [chain, tokenAddress]);
+
+  const explorer = useTransactionExplorer(
+    caipAssetId,
+    trade?.transactionHash,
+  );
+
+  useEffect(() => {
+    if (isVisible) {
+      sheetRef.current?.onOpenBottomSheet();
+    }
+  }, [isVisible]);
+
+  const handleSheetClosed = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet(() => {
+      onClose();
+    });
+  }, [onClose]);
+
+  const handleCopyTxHash = useCallback(async () => {
+    if (!trade?.transactionHash) return;
+    await ClipboardManager.setString(trade.transactionHash);
+  }, [trade?.transactionHash]);
+
+  const handleViewOnExplorer = useCallback(() => {
+    if (!explorer?.url) return;
+    navigation.navigate('Webview', {
+      screen: 'SimpleWebview',
+      params: {
+        url: explorer.url,
+      },
+    });
+  }, [explorer?.url, navigation]);
+
+  if (!isVisible || !trade) {
+    return null;
+  }
+
+  const isEntry = trade.intent === 'enter';
+  const isPerp = isPerpTrade(trade);
+  const perpDirection = getPerpTradeDirection(trade);
+  const actionLabel = getTradeActionLabel(trade);
+  const usdDisplay = formatUsd(
+    isEntry ? Math.abs(trade.usdCost) : -Math.abs(trade.usdCost),
+  );
+  const tokenAmountDisplay = `${formatTokenAmount(trade.tokenAmount)} ${tokenSymbol}`;
+  const showExplorer = !isPerp && Boolean(explorer?.url);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      shouldNavigateBack={false}
+      isInteractable
+      onClose={handleSheetClosed}
+      testID={TraderTradeDetailBottomSheetSelectorsIDs.CONTAINER}
+    >
+      <HeaderStandard
+        title={strings('social_leaderboard.trader_position.trade_detail_title')}
+        titleProps={{
+          variant: TextVariant.HeadingSm,
+          fontWeight: FontWeight.Bold,
+        }}
+        onClose={handleClose}
+        closeButtonProps={{
+          testID: TraderTradeDetailBottomSheetSelectorsIDs.CLOSE_BUTTON,
+        }}
+      />
+
+      <Box twClassName="px-4 pb-4">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
+          twClassName="mb-1"
+        >
+          <Text
+            variant={TextVariant.HeadingMd}
+            fontWeight={FontWeight.Bold}
+            color={TextColor.TextDefault}
+          >
+            {actionLabel}
+          </Text>
+          {perpDirection ? (
+            <PerpBadges
+              direction={perpDirection}
+              leverage={trade.perpLeverage}
+              testID="trader-trade-detail-perp-badges"
+            />
+          ) : null}
+        </Box>
+
+        <Text
+          variant={TextVariant.HeadingLg}
+          fontWeight={FontWeight.Bold}
+          twClassName={
+            isEntry ? 'text-success-default' : 'text-error-default'
+          }
+        >
+          {usdDisplay}
+        </Text>
+
+        <Box twClassName="h-px bg-muted my-2" />
+
+        <DetailRow
+          label={strings('social_leaderboard.trader_position.trade_detail_date')}
+          value={formatTradeDate(trade.timestamp)}
+        />
+        <DetailRow
+          label={strings(
+            'social_leaderboard.trader_position.trade_detail_amount',
+          )}
+          value={tokenAmountDisplay}
+        />
+        <DetailRow
+          label={strings(
+            'social_leaderboard.trader_position.trade_detail_token',
+          )}
+          value={tokenSymbol}
+        />
+
+        <TouchableOpacity
+          onPress={handleCopyTxHash}
+          accessibilityRole="button"
+          testID={TraderTradeDetailBottomSheetSelectorsIDs.COPY_TX_HASH_BUTTON}
+        >
+          <DetailRow
+            label={strings(
+              'social_leaderboard.trader_position.trade_detail_tx_hash',
+            )}
+            value={formatAddress(trade.transactionHash, 'short')}
+          />
+        </TouchableOpacity>
+
+        {showExplorer ? (
+          <Box twClassName="mt-4">
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onPress={handleViewOnExplorer}
+              testID={TraderTradeDetailBottomSheetSelectorsIDs.EXPLORER_BUTTON}
+            >
+              {strings('perps.transactions.view_on_explorer')}
+            </Button>
+          </Box>
+        ) : null}
+      </Box>
+    </BottomSheet>
+  );
+};
+
+export default TraderTradeDetailBottomSheet;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/index.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradeDetailBottomSheet/index.ts
@@ -1,0 +1,3 @@
+export { default } from './TraderTradeDetailBottomSheet';
+export type { TraderTradeDetailBottomSheetProps } from './TraderTradeDetailBottomSheet';
+export { TraderTradeDetailBottomSheetSelectorsIDs } from './TraderTradeDetailBottomSheet.testIds';

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
 import type { Trade } from '@metamask/social-controllers';
@@ -55,5 +55,18 @@ describe('TraderTradesSection', () => {
 
     expect(screen.queryByText('Bought')).toBeNull();
     expect(screen.queryByText('Sold')).toBeNull();
+  });
+
+  it('calls onTradePress when a trade row is pressed', () => {
+    const onTradePress = jest.fn();
+    const trade = makeTrade({ transactionHash: '0xpress' });
+
+    renderWithProvider(
+      <TraderTradesSection trades={[trade]} onTradePress={onTradePress} />,
+    );
+
+    fireEvent.press(screen.getByTestId('trade-row-0xpress-pressable'));
+
+    expect(onTradePress).toHaveBeenCalledWith(trade);
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.test.tsx
@@ -5,6 +5,8 @@ import type { ReactTestInstance } from 'react-test-renderer';
 import type { Trade } from '@metamask/social-controllers';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import TraderTradesSection from './TraderTradesSection';
+import { TraderTradesSectionSelectorsIDs } from './TraderTradesSection.testIds';
+import { RefreshControl } from 'react-native';
 
 const makeTrade = (overrides: Partial<Trade> = {}): Trade => ({
   intent: 'enter',
@@ -68,5 +70,22 @@ describe('TraderTradesSection', () => {
     fireEvent.press(screen.getByTestId('trade-row-0xpress-pressable'));
 
     expect(onTradePress).toHaveBeenCalledWith(trade);
+  });
+
+  it('wraps trade rows in a scroll view when scrollable is true', () => {
+    renderWithProvider(
+      <TraderTradesSection
+        scrollable
+        trades={[makeTrade()]}
+        refreshControl={
+          <RefreshControl refreshing={false} onRefresh={jest.fn()} />
+        }
+      />,
+    );
+
+    expect(
+      screen.getByTestId(TraderTradesSectionSelectorsIDs.SCROLL_VIEW),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('Trades')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.testIds.ts
@@ -1,0 +1,3 @@
+export const TraderTradesSectionSelectorsIDs = {
+  SCROLL_VIEW: 'trader-trades-section-scroll-view',
+};

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx
@@ -14,12 +14,14 @@ export interface TraderTradesSectionProps {
   trades: Trade[];
   traderImageUrl?: string;
   traderAddress?: string;
+  onTradePress?: (trade: Trade) => void;
 }
 
 const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
   trades,
   traderImageUrl,
   traderAddress,
+  onTradePress,
 }) => (
   <>
     <Box twClassName="px-4 mt-5">
@@ -42,6 +44,7 @@ const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
           trade={trade}
           traderImageUrl={traderImageUrl}
           traderAddress={traderAddress}
+          onPress={onTradePress}
         />
       ))
     ) : (

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import type { ReactElement } from 'react';
+import { ScrollView } from 'react-native-gesture-handler';
 import {
   Box,
   Text,
@@ -9,36 +11,55 @@ import {
 import type { Trade } from '@metamask/social-controllers';
 import { strings } from '../../../../../../locales/i18n';
 import TradeRow from './TradeRow';
+import { TraderTradesSectionSelectorsIDs } from './TraderTradesSection.testIds';
 
 export interface TraderTradesSectionProps {
   trades: Trade[];
   traderImageUrl?: string;
   traderAddress?: string;
   onTradePress?: (trade: Trade) => void;
+  /** When true, only the trade rows scroll; the section title stays pinned. */
+  scrollable?: boolean;
+  refreshControl?: ReactElement;
 }
 
-const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
+const TradesTitle = () => (
+  <Box twClassName="px-4 mt-5">
+    <Box twClassName="self-start pb-2">
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Bold}
+        color={TextColor.TextDefault}
+      >
+        {strings('social_leaderboard.trader_position.trades')}
+      </Text>
+    </Box>
+    <Box twClassName="h-px bg-muted" />
+  </Box>
+);
+
+const TradeRows = ({
   trades,
   traderImageUrl,
   traderAddress,
   onTradePress,
-}) => (
-  <>
-    <Box twClassName="px-4 mt-5">
-      <Box twClassName="self-start pb-2">
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Bold}
-          color={TextColor.TextDefault}
-        >
-          {strings('social_leaderboard.trader_position.trades')}
+}: Pick<
+  TraderTradesSectionProps,
+  'trades' | 'traderImageUrl' | 'traderAddress' | 'onTradePress'
+>) => {
+  if (trades.length === 0) {
+    return (
+      <Box twClassName="px-4 py-6 items-center">
+        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          {strings('social_leaderboard.trader_position.no_trades')}
         </Text>
       </Box>
-      <Box twClassName="h-px bg-muted" />
-    </Box>
+    );
+  }
 
-    {trades.length > 0 ? (
-      trades.map((trade) => (
+  return (
+    <>
+      {trades.map((trade) => (
         <TradeRow
           key={trade.transactionHash}
           trade={trade}
@@ -46,15 +67,51 @@ const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
           traderAddress={traderAddress}
           onPress={onTradePress}
         />
-      ))
-    ) : (
-      <Box twClassName="px-4 py-6 items-center">
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {strings('social_leaderboard.trader_position.no_trades')}
-        </Text>
-      </Box>
-    )}
-  </>
-);
+      ))}
+    </>
+  );
+};
+
+const TraderTradesSection: React.FC<TraderTradesSectionProps> = ({
+  trades,
+  traderImageUrl,
+  traderAddress,
+  onTradePress,
+  scrollable = false,
+  refreshControl,
+}) => {
+  if (!scrollable) {
+    return (
+      <>
+        <TradesTitle />
+        <TradeRows
+          trades={trades}
+          traderImageUrl={traderImageUrl}
+          traderAddress={traderAddress}
+          onTradePress={onTradePress}
+        />
+      </>
+    );
+  }
+
+  return (
+    <Box twClassName="flex-1 min-h-0">
+      <TradesTitle />
+      <ScrollView
+        style={{ flex: 1 }}
+        showsVerticalScrollIndicator={false}
+        refreshControl={refreshControl}
+        testID={TraderTradesSectionSelectorsIDs.SCROLL_VIEW}
+      >
+        <TradeRows
+          trades={trades}
+          traderImageUrl={traderImageUrl}
+          traderAddress={traderAddress}
+          onTradePress={onTradePress}
+        />
+      </ScrollView>
+    </Box>
+  );
+};
 
 export default TraderTradesSection;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/features/tradeDetailFeatureFlags.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/features/tradeDetailFeatureFlags.ts
@@ -1,0 +1,5 @@
+/**
+ * Trade-row tap opens the detail bottom sheet. Disabled while the sheet UX is
+ * iterated on; row taps still drive chart highlight.
+ */
+export const TRADE_DETAIL_BOTTOM_SHEET_ENABLED = false;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/useTraderPositionData.ts
@@ -23,8 +23,11 @@ import Logger from '../../../../util/Logger';
 // Constants
 // ---------------------------------------------------------------------------
 
-const TIME_PERIODS = ['1H', '1D', '1W', '1M', 'All'] as const;
-type TimePeriod = (typeof TIME_PERIODS)[number];
+import {
+  PERIOD_DURATION_MS,
+  TIME_PERIODS,
+  type TimePeriod,
+} from './utils/chartTimePeriods';
 
 const PERIOD_TO_API: Record<TimePeriod, string> = {
   '1H': '1d',
@@ -32,14 +35,6 @@ const PERIOD_TO_API: Record<TimePeriod, string> = {
   '1W': '7d',
   '1M': '1m',
   All: '3y',
-};
-
-const PERIOD_DURATION_MS: Record<TimePeriod, number> = {
-  '1H': 60 * 60 * 1000,
-  '1D': 24 * 60 * 60 * 1000,
-  '1W': 7 * 24 * 60 * 60 * 1000,
-  '1M': 30 * 24 * 60 * 60 * 1000,
-  All: 3 * 365 * 24 * 60 * 60 * 1000,
 };
 
 /**
@@ -126,8 +121,8 @@ export interface TraderPositionData {
   timePeriods: readonly TimePeriod[];
 }
 
-export type { TimePeriod };
-export { TIME_PERIODS };
+export type { TimePeriod } from './utils/chartTimePeriods';
+export { TIME_PERIODS } from './utils/chartTimePeriods';
 
 export function useTraderPositionData(
   positionParam: Position | undefined,

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/utils/chartTimePeriods.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/utils/chartTimePeriods.test.ts
@@ -1,0 +1,43 @@
+import {
+  findTimePeriodForTrade,
+  PERIOD_DURATION_MS,
+} from './chartTimePeriods';
+
+describe('findTimePeriodForTrade', () => {
+  const now = Date.now();
+
+  it('returns 1H for trades within the last hour', () => {
+    expect(
+      findTimePeriodForTrade(now - PERIOD_DURATION_MS['1H'] + 60_000),
+    ).toBe('1H');
+  });
+
+  it('returns 1D for trades within the last day', () => {
+    expect(
+      findTimePeriodForTrade(now - PERIOD_DURATION_MS['1D'] + 60_000),
+    ).toBe('1D');
+  });
+
+  it('returns 1W for trades within the last week', () => {
+    expect(
+      findTimePeriodForTrade(now - PERIOD_DURATION_MS['1W'] + 60_000),
+    ).toBe('1W');
+  });
+
+  it('returns 1M for trades within the last month', () => {
+    expect(
+      findTimePeriodForTrade(now - PERIOD_DURATION_MS['1M'] + 60_000),
+    ).toBe('1M');
+  });
+
+  it('returns All for older trades', () => {
+    expect(
+      findTimePeriodForTrade(now - PERIOD_DURATION_MS.All - 60_000),
+    ).toBe('All');
+  });
+
+  it('normalizes second-based timestamps', () => {
+    const secondsAgo = Math.floor((now - 30 * 60 * 1000) / 1000);
+    expect(findTimePeriodForTrade(secondsAgo)).toBe('1H');
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/utils/chartTimePeriods.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/utils/chartTimePeriods.ts
@@ -1,0 +1,27 @@
+export const TIME_PERIODS = ['1H', '1D', '1W', '1M', 'All'] as const;
+export type TimePeriod = (typeof TIME_PERIODS)[number];
+
+export const PERIOD_DURATION_MS: Record<TimePeriod, number> = {
+  '1H': 60 * 60 * 1000,
+  '1D': 24 * 60 * 60 * 1000,
+  '1W': 7 * 24 * 60 * 60 * 1000,
+  '1M': 30 * 24 * 60 * 60 * 1000,
+  All: 3 * 365 * 24 * 60 * 60 * 1000,
+};
+
+const normalizeTradeTimestampMs = (timestamp: number): number =>
+  timestamp > 0 && timestamp < 1e12 ? timestamp * 1000 : timestamp;
+
+/**
+ * Picks the narrowest chart period that still contains the trade timestamp.
+ * Used when a trade row is tapped so the chart marker is visible.
+ */
+export function findTimePeriodForTrade(timestamp: number): TimePeriod {
+  const age = Date.now() - normalizeTradeTimestampMs(timestamp);
+
+  if (age <= PERIOD_DURATION_MS['1H']) return '1H';
+  if (age <= PERIOD_DURATION_MS['1D']) return '1D';
+  if (age <= PERIOD_DURATION_MS['1W']) return '1W';
+  if (age <= PERIOD_DURATION_MS['1M']) return '1M';
+  return 'All';
+}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/utils/getTradeActionLabel.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/utils/getTradeActionLabel.ts
@@ -1,0 +1,18 @@
+import type { Trade } from '@metamask/social-controllers';
+import { strings } from '../../../../../../locales/i18n';
+import { isPerpTrade } from '../../utils/perp';
+
+export function getTradeActionLabel(trade: Trade): string {
+  const isEntry = trade.intent === 'enter';
+  const isPerp = isPerpTrade(trade);
+
+  if (isPerp) {
+    return isEntry
+      ? strings('social_leaderboard.trader_position.opened')
+      : strings('social_leaderboard.trader_position.closed_action');
+  }
+
+  return isEntry
+    ? strings('social_leaderboard.trader_position.bought')
+    : strings('social_leaderboard.trader_position.sold');
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1115,7 +1115,12 @@
       "long": "Long",
       "short": "Short",
       "opened": "Opened",
-      "closed_action": "Closed"
+      "closed_action": "Closed",
+      "trade_detail_title": "Trade details",
+      "trade_detail_date": "Date",
+      "trade_detail_amount": "Amount",
+      "trade_detail_token": "Token",
+      "trade_detail_tx_hash": "Transaction"
     },
     "quick_buy": {
       "title": "Buy {{symbol}}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes Follow Trading trade list rows on `TraderPositionView` tappable for chart highlight. Trade detail bottom sheet is implemented but **disabled** behind `TRADE_DETAIL_BOTTOM_SHEET_ENABLED` while UX is iterated on.

## Changes

- **Pressable trade rows** — `TradeRow` wraps in `TouchableOpacity` with a chevron affordance; tap highlights the matching chart marker and switches timeframe.
- **Pinned header layout** — Token info, chart, time-period selector, and PnL card stay fixed; only the trades list scrolls (pull-to-refresh on the trades list).
- **Trade detail bottom sheet (disabled)** — `TraderTradeDetailBottomSheet` remains in the codebase, gated by `TRADE_DETAIL_BOTTOM_SHEET_ENABLED = false` in `features/tradeDetailFeatureFlags.ts`.
- **Chart highlight** — Enlarged marker + matching-color ring; scrub tooltip suppressed during highlight.
- **Analytics** — Fires `TRANSACTION_DETAIL_LIST_ITEM_CLICKED` on trade row tap.

## Re-enabling the bottom sheet

Set `TRADE_DETAIL_BOTTOM_SHEET_ENABLED` to `true` in `app/components/Views/SocialLeaderboard/TraderPositionView/features/tradeDetailFeatureFlags.ts`.

## Testing

```bash
yarn jest app/components/Views/SocialLeaderboard/TraderPositionView --no-coverage
```

All 573 tests in the TraderPositionView suite pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb488298-d9f6-48b6-8250-b05058aebc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb488298-d9f6-48b6-8250-b05058aebc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

