### PR TITLE
refactor(mobile-platform): remove duplicate messenger types

### DIFF
--- a/app/core/Engine/messengers/account-tracker-controller-messenger.ts
+++ b/app/core/Engine/messengers/account-tracker-controller-messenger.ts
@@ -4,7 +4,6 @@ import {
   MessengerEvents,
 } from '@metamask/messenger';
 import { AccountTrackerControllerMessenger } from '@metamask/assets-controllers';
-import { RootMessenger } from '../types';
 
 /**
  * Get the AccountTrackerControllerMessenger for the AccountTrackerController.
@@ -13,14 +12,13 @@ import { RootMessenger } from '../types';
  * @returns The AccountTrackerControllerMessenger.
  */
 export function getAccountTrackerControllerMessenger(
-  rootMessenger: RootMessenger,
-): AccountTrackerControllerMessenger {
-  const messenger = new Messenger<
-    'AccountTrackerController',
+  rootMessenger: Messenger<
+    'Root',
     MessengerActions<AccountTrackerControllerMessenger>,
-    MessengerEvents<AccountTrackerControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AccountTrackerControllerMessenger>
+  >,
+): AccountTrackerControllerMessenger {
+  const messenger: AccountTrackerControllerMessenger = new Messenger({
     namespace: 'AccountTrackerController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/address-book-controller-messenger.ts
+++ b/app/core/Engine/messengers/address-book-controller-messenger.ts
@@ -13,14 +13,12 @@ import { RootMessenger } from '../types';
  * @returns The AddressBookControllerMessenger.
  */
 export function getAddressBookControllerMessenger(
-  rootMessenger: RootMessenger,
-): AddressBookControllerMessenger {
-  const messenger = new Messenger<
-    'AddressBookController',
+  rootMessenger: RootMessenger<
     MessengerActions<AddressBookControllerMessenger>,
-    MessengerEvents<AddressBookControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AddressBookControllerMessenger>
+  >,
+): AddressBookControllerMessenger {
+  const messenger: AddressBookControllerMessenger = new Messenger({
     namespace: 'AddressBookController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/analytics-controller-messenger.ts
+++ b/app/core/Engine/messengers/analytics-controller-messenger.ts
@@ -14,22 +14,22 @@ import { RootMessenger } from '../types';
  * @returns The AnalyticsControllerMessenger.
  */
 export function getAnalyticsControllerMessenger(
-  rootMessenger: RootMessenger,
-): AnalyticsControllerMessenger {
-  const messenger = new Messenger<
-    'AnalyticsController',
+  rootMessenger: RootMessenger<
     MessengerActions<AnalyticsControllerMessenger>,
-    MessengerEvents<AnalyticsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AnalyticsControllerMessenger>
+  >,
+): AnalyticsControllerMessenger {
+  const messenger: AnalyticsControllerMessenger = new Messenger({
     namespace: 'AnalyticsController',
     parent: rootMessenger,
   });
   return messenger;
 }
 
-export type AnalyticsControllerInitMessenger = ReturnType<
-  typeof getAnalyticsControllerInitMessenger
+export type AnalyticsControllerInitMessenger = Messenger<
+  'AnalyticsControllerInit',
+  never,
+  AccountsControllerChangeEvent
 >;
 
 /**
@@ -41,14 +41,12 @@ export type AnalyticsControllerInitMessenger = ReturnType<
  * @returns The AnalyticsControllerInitMessenger.
  */
 export function getAnalyticsControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'AnalyticsControllerInit',
-    never,
-    AccountsControllerChangeEvent,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<AnalyticsControllerInitMessenger>,
+    MessengerEvents<AnalyticsControllerInitMessenger>
+  >,
+): AnalyticsControllerInitMessenger {
+  const messenger: AnalyticsControllerInitMessenger = new Messenger({
     namespace: 'AnalyticsControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/app-metadata-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/app-metadata-controller-messenger/index.ts
@@ -4,25 +4,23 @@ import {
   MessengerEvents,
 } from '@metamask/messenger';
 import { AppMetadataControllerMessenger } from '@metamask/app-metadata-controller';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 
 /**
  * Get the AppMetadataControllerMessenger for the AppMetadataController.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The AppMetadataControllerMessenger.
  */
 export function getAppMetadataControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): AppMetadataControllerMessenger {
-  const messenger = new Messenger<
-    'AppMetadataController',
+  rootMessenger: RootMessenger<
     MessengerActions<AppMetadataControllerMessenger>,
-    MessengerEvents<AppMetadataControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AppMetadataControllerMessenger>
+  >,
+): AppMetadataControllerMessenger {
+  const messenger: AppMetadataControllerMessenger = new Messenger({
     namespace: 'AppMetadataController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
   return messenger;
 }

--- a/app/core/Engine/messengers/assets-contract-controller-messenger.ts
+++ b/app/core/Engine/messengers/assets-contract-controller-messenger.ts
@@ -14,14 +14,12 @@ import { AssetsContractControllerMessenger } from '@metamask/assets-controllers'
  * @returns The AssetsContractControllerMessenger.
  */
 export function getAssetsContractControllerMessenger(
-  rootMessenger: RootMessenger,
-): AssetsContractControllerMessenger {
-  const messenger = new Messenger<
-    'AssetsContractController',
+  rootMessenger: RootMessenger<
     MessengerActions<AssetsContractControllerMessenger>,
-    MessengerEvents<AssetsContractControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AssetsContractControllerMessenger>
+  >,
+): AssetsContractControllerMessenger {
+  const messenger: AssetsContractControllerMessenger = new Messenger({
     namespace: 'AssetsContractController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
+++ b/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
@@ -8,28 +8,26 @@ import { AuthenticationController } from '@metamask/profile-sync-controller';
 import type { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { AnalyticsControllerActions } from '@metamask/analytics-controller';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 
 /**
  * Get the messenger for the AssetsController. This is scoped to the
  * actions and events that the AssetsController is allowed to handle.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The AssetsControllerMessenger.
  */
 export function getAssetsControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): AssetsControllerMessenger {
-  const messenger = new Messenger<
-    'AssetsController',
+  rootMessenger: RootMessenger<
     MessengerActions<AssetsControllerMessenger>,
-    MessengerEvents<AssetsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AssetsControllerMessenger>
+  >,
+): AssetsControllerMessenger {
+  const messenger: AssetsControllerMessenger = new Messenger({
     namespace: 'AssetsController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
       'NetworkEnablementController:getState',
@@ -67,8 +65,16 @@ export function getAssetsControllerMessenger(
   return messenger;
 }
 
-export type AssetsControllerInitMessenger = ReturnType<
-  typeof getAssetsControllerInitMessenger
+type AssetsControllerInitMessengerActions =
+  | AuthenticationController.AuthenticationControllerGetBearerTokenAction
+  | PreferencesControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction
+  | AnalyticsControllerActions;
+
+export type AssetsControllerInitMessenger = Messenger<
+  'AssetsControllerInit',
+  AssetsControllerInitMessengerActions,
+  never
 >;
 
 /**
@@ -76,25 +82,20 @@ export type AssetsControllerInitMessenger = ReturnType<
  * actions and events that the AssetsController is allowed to handle during
  * initialization.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The AssetsControllerInitMessenger.
  */
 export function getAssetsControllerInitMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-) {
-  const messenger = new Messenger<
-    'AssetsControllerInit',
-    | AuthenticationController.AuthenticationControllerGetBearerTokenAction
-    | PreferencesControllerGetStateAction
-    | RemoteFeatureFlagControllerGetStateAction
-    | AnalyticsControllerActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<AssetsControllerInitMessenger>,
+    MessengerEvents<AssetsControllerInitMessenger>
+  >,
+): AssetsControllerInitMessenger {
+  const messenger: AssetsControllerInitMessenger = new Messenger({
     namespace: 'AssetsControllerInit',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AuthenticationController:getBearerToken',
       'PreferencesController:getState',

--- a/app/core/Engine/messengers/authenticated-user-storage-service-messenger.ts
+++ b/app/core/Engine/messengers/authenticated-user-storage-service-messenger.ts
@@ -13,14 +13,12 @@ import type { RootMessenger } from '../types';
  * @returns The AuthenticatedUserStorageMessenger.
  */
 export function getAuthenticatedUserStorageServiceMessenger(
-  rootMessenger: RootMessenger,
-): AuthenticatedUserStorageMessenger {
-  const serviceMessenger = new Messenger<
-    'AuthenticatedUserStorageService',
+  rootMessenger: RootMessenger<
     MessengerActions<AuthenticatedUserStorageMessenger>,
-    MessengerEvents<AuthenticatedUserStorageMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AuthenticatedUserStorageMessenger>
+  >,
+): AuthenticatedUserStorageMessenger {
+  const serviceMessenger: AuthenticatedUserStorageMessenger = new Messenger({
     namespace: 'AuthenticatedUserStorageService',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/bridge-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/bridge-controller-messenger/index.ts
@@ -1,7 +1,7 @@
 import { BridgeControllerMessenger } from '@metamask/bridge-controller';
 import { AnalyticsControllerActions } from '@metamask/analytics-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -11,22 +11,20 @@ import {
 /**
  * Get the BridgeControllerMessenger for the BridgeController.
  *
- * @param rootExtendedMessenger - The base controller messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The BridgeControllerMessenger.
  */
 export function getBridgeControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): BridgeControllerMessenger {
-  const messenger = new Messenger<
-    'BridgeController',
+  rootMessenger: RootMessenger<
     MessengerActions<BridgeControllerMessenger>,
-    MessengerEvents<BridgeControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<BridgeControllerMessenger>
+  >,
+): BridgeControllerMessenger {
+  const messenger: BridgeControllerMessenger = new Messenger({
     namespace: 'BridgeController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountsController:getAccountByAddress',
       'SnapController:handleRequest',
@@ -49,6 +47,12 @@ type BridgeControllerInitMessengerActions =
   | AnalyticsControllerActions
   | RemoteFeatureFlagControllerGetStateAction;
 
+export type BridgeControllerInitMessenger = Messenger<
+  'BridgeControllerInit',
+  BridgeControllerInitMessengerActions,
+  never
+>;
+
 /**
  * Get the BridgeControllerInitMessenger for the BridgeController.
  * This messenger is used during controller initialization to call other controllers.
@@ -56,24 +60,13 @@ type BridgeControllerInitMessengerActions =
  * @param rootMessenger - The root messenger.
  * @returns The BridgeControllerInitMessenger.
  */
-export type BridgeControllerInitMessenger = ReturnType<
-  typeof getBridgeControllerInitMessenger
->;
-
 export function getBridgeControllerInitMessenger(
-  rootMessenger: RootMessenger,
-): Messenger<
-  'BridgeControllerInit',
-  BridgeControllerInitMessengerActions,
-  never,
-  RootMessenger
-> {
-  const messenger = new Messenger<
-    'BridgeControllerInit',
-    BridgeControllerInitMessengerActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<BridgeControllerInitMessenger>,
+    MessengerEvents<BridgeControllerInitMessenger>
+  >,
+): BridgeControllerInitMessenger {
+  const messenger: BridgeControllerInitMessenger = new Messenger({
     namespace: 'BridgeControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/bridge-status-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/bridge-status-controller-messenger/index.ts
@@ -1,5 +1,5 @@
 import { BridgeStatusControllerMessenger } from '@metamask/bridge-status-controller';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -9,22 +9,20 @@ import {
 /**
  * Get the BridgeControllerMessenger for the BridgeController.
  *
- * @param rootExtendedMessenger - The base controller messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The BridgeControllerMessenger.
  */
 export function getBridgeStatusControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): BridgeStatusControllerMessenger {
-  const messenger = new Messenger<
-    'BridgeStatusController',
+  rootMessenger: RootMessenger<
     MessengerActions<BridgeStatusControllerMessenger>,
-    MessengerEvents<BridgeStatusControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<BridgeStatusControllerMessenger>
+  >,
+): BridgeStatusControllerMessenger {
+  const messenger: BridgeStatusControllerMessenger = new Messenger({
     namespace: 'BridgeStatusController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountsController:getAccountByAddress',
       'NetworkController:getNetworkClientById',

--- a/app/core/Engine/messengers/client-controller-messenger.ts
+++ b/app/core/Engine/messengers/client-controller-messenger.ts
@@ -6,8 +6,6 @@ import {
 } from '@metamask/messenger';
 import { RootMessenger } from '../types';
 
-export type { ClientControllerMessenger } from '@metamask/client-controller';
-
 /**
  * Get the ClientControllerMessenger for the ClientController.
  *
@@ -15,14 +13,12 @@ export type { ClientControllerMessenger } from '@metamask/client-controller';
  * @returns The ClientControllerMessenger.
  */
 export function getClientControllerMessenger(
-  rootMessenger: RootMessenger,
-): ClientControllerMessenger {
-  const messenger = new Messenger<
-    'ClientController',
+  rootMessenger: RootMessenger<
     MessengerActions<ClientControllerMessenger>,
-    MessengerEvents<ClientControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<ClientControllerMessenger>
+  >,
+): ClientControllerMessenger {
+  const messenger: ClientControllerMessenger = new Messenger({
     namespace: 'ClientController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/connectivity-controller-messenger.ts
+++ b/app/core/Engine/messengers/connectivity-controller-messenger.ts
@@ -13,15 +13,14 @@ import { RootMessenger } from '../types';
  * @returns The ConnectivityControllerMessenger.
  */
 export function getConnectivityControllerMessenger(
-  rootMessenger: RootMessenger,
-): ConnectivityControllerMessenger {
-  return new Messenger<
-    'ConnectivityController',
+  rootMessenger: RootMessenger<
     MessengerActions<ConnectivityControllerMessenger>,
-    MessengerEvents<ConnectivityControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<ConnectivityControllerMessenger>
+  >,
+): ConnectivityControllerMessenger {
+  const messenger: ConnectivityControllerMessenger = new Messenger({
     namespace: 'ConnectivityController',
     parent: rootMessenger,
   });
+  return messenger;
 }

--- a/app/core/Engine/messengers/core-backend/account-activity-service-messenger.ts
+++ b/app/core/Engine/messengers/core-backend/account-activity-service-messenger.ts
@@ -1,5 +1,5 @@
 import { AccountActivityServiceMessenger } from '@metamask/core-backend';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -10,22 +10,20 @@ import {
  * Get a messenger for the Account Activity service. This is scoped to the
  * actions and events that the Account Activity service is allowed to handle.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The AccountActivityServiceMessenger.
  */
 export function getAccountActivityServiceMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): AccountActivityServiceMessenger {
-  const messenger = new Messenger<
-    'AccountActivityService',
+  rootMessenger: RootMessenger<
     MessengerActions<AccountActivityServiceMessenger>,
-    MessengerEvents<AccountActivityServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<AccountActivityServiceMessenger>
+  >,
+): AccountActivityServiceMessenger {
+  const messenger: AccountActivityServiceMessenger = new Messenger({
     namespace: 'AccountActivityService',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountsController:getSelectedAccount',
       'BackendWebSocketService:connect',

--- a/app/core/Engine/messengers/core-backend/backend-websocket-service-messenger.test.ts
+++ b/app/core/Engine/messengers/core-backend/backend-websocket-service-messenger.test.ts
@@ -1,25 +1,12 @@
-import {
-  Messenger,
-  type MessengerActions,
-  type MessengerEvents,
-  type MockAnyNamespace,
-  MOCK_ANY_NAMESPACE,
-} from '@metamask/messenger';
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import {
   getBackendWebSocketServiceInitMessenger,
   getBackendWebSocketServiceMessenger,
 } from './backend-websocket-service-messenger';
-import { BackendWebSocketServiceMessenger } from '@metamask/core-backend';
-import { ExtendedMessenger } from '../../../ExtendedMessenger';
-
-type RootMessenger = ExtendedMessenger<
-  MockAnyNamespace,
-  MessengerActions<BackendWebSocketServiceMessenger>,
-  MessengerEvents<BackendWebSocketServiceMessenger>
->;
+import { RootMessenger } from '../../types';
 
 const getRootMessenger = (): RootMessenger =>
-  new ExtendedMessenger({
+  new Messenger({
     namespace: MOCK_ANY_NAMESPACE,
   });
 

--- a/app/core/Engine/messengers/core-backend/backend-websocket-service-messenger.ts
+++ b/app/core/Engine/messengers/core-backend/backend-websocket-service-messenger.ts
@@ -1,5 +1,5 @@
 import { BackendWebSocketServiceMessenger as BackendPlatformWebSocketServiceMessenger } from '@metamask/core-backend';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -15,22 +15,20 @@ export type BackendWebSocketServiceMessenger =
  * Get a restricted messenger for the Backend Platform WebSocket service.
  * This is scoped to backend platform operations and services.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The BackendWebSocketServiceMessenger.
  */
 export function getBackendWebSocketServiceMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): BackendPlatformWebSocketServiceMessenger {
-  const messenger = new Messenger<
-    'BackendWebSocketService',
+  rootMessenger: RootMessenger<
     MessengerActions<BackendPlatformWebSocketServiceMessenger>,
-    MessengerEvents<BackendPlatformWebSocketServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<BackendPlatformWebSocketServiceMessenger>
+  >,
+): BackendPlatformWebSocketServiceMessenger {
+  const messenger: BackendPlatformWebSocketServiceMessenger = new Messenger({
     namespace: 'BackendWebSocketService',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AuthenticationController:getBearerToken', // Get auth token (includes wallet unlock check)
     ],
@@ -44,24 +42,27 @@ export function getBackendWebSocketServiceMessenger(
   return messenger;
 }
 
-export type BackendWebSocketServiceInitMessenger = ReturnType<
-  typeof getBackendWebSocketServiceInitMessenger
+type BackendWebSocketServiceInitMessengerActions =
+  | RemoteFeatureFlagControllerGetStateAction
+  | AuthenticationController.AuthenticationControllerGetBearerTokenAction;
+
+export type BackendWebSocketServiceInitMessenger = Messenger<
+  'BackendWebSocketServiceInit',
+  BackendWebSocketServiceInitMessengerActions,
+  never
 >;
 
 export function getBackendWebSocketServiceInitMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-) {
-  const messenger = new Messenger<
-    'BackendWebSocketServiceInit',
-    | RemoteFeatureFlagControllerGetStateAction
-    | AuthenticationController.AuthenticationControllerGetBearerTokenAction,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<BackendWebSocketServiceInitMessenger>,
+    MessengerEvents<BackendWebSocketServiceInitMessenger>
+  >,
+): BackendWebSocketServiceInitMessenger {
+  const messenger: BackendWebSocketServiceInitMessenger = new Messenger({
     namespace: 'BackendWebSocketServiceInit',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'RemoteFeatureFlagController:getState',
       'AuthenticationController:getBearerToken',

--- a/app/core/Engine/messengers/core-backend/ohlcv-service-messenger.ts
+++ b/app/core/Engine/messengers/core-backend/ohlcv-service-messenger.ts
@@ -1,5 +1,5 @@
 import { OHLCVServiceMessenger } from '@metamask/core-backend';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -10,22 +10,20 @@ import {
  * Get a messenger for the OHLCV service. This is scoped to the
  * actions and events that the OHLCV service is allowed to handle.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The OHLCVServiceMessenger.
  */
 export function getOHLCVServiceMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): OHLCVServiceMessenger {
-  const messenger = new Messenger<
-    'OHLCVService',
+  rootMessenger: RootMessenger<
     MessengerActions<OHLCVServiceMessenger>,
-    MessengerEvents<OHLCVServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<OHLCVServiceMessenger>
+  >,
+): OHLCVServiceMessenger {
+  const messenger: OHLCVServiceMessenger = new Messenger({
     namespace: 'OHLCVService',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'BackendWebSocketService:connect',
       'BackendWebSocketService:forceReconnection',

--- a/app/core/Engine/messengers/currency-rate-controller-messenger/currency-rate-controller-messenger.ts
+++ b/app/core/Engine/messengers/currency-rate-controller-messenger/currency-rate-controller-messenger.ts
@@ -1,5 +1,5 @@
 import { CurrencyRateMessenger } from '@metamask/assets-controllers';
-import { RootMessenger, RootExtendedMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import {
   Messenger,
   MessengerActions,
@@ -9,22 +9,20 @@ import {
 /**
  * Get the CurrencyRateMessenger for the CurrencyRateController.
  *
- * @param baseControllerMessenger - The base controller messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The CurrencyRateMessenger.
  */
 export function getCurrencyRateControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): CurrencyRateMessenger {
-  const messenger = new Messenger<
-    'CurrencyRateController',
+  rootMessenger: RootMessenger<
     MessengerActions<CurrencyRateMessenger>,
-    MessengerEvents<CurrencyRateMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<CurrencyRateMessenger>
+  >,
+): CurrencyRateMessenger {
+  const messenger: CurrencyRateMessenger = new Messenger({
     namespace: 'CurrencyRateController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'NetworkController:getNetworkClientById',
       'NetworkController:getState',

--- a/app/core/Engine/messengers/geolocation-api-service-messenger.ts
+++ b/app/core/Engine/messengers/geolocation-api-service-messenger.ts
@@ -14,14 +14,12 @@ import type { GeolocationApiServiceMessenger } from '@metamask/geolocation-contr
  * @returns The GeolocationApiServiceMessenger.
  */
 export function getGeolocationApiServiceMessenger(
-  rootMessenger: RootMessenger,
-): GeolocationApiServiceMessenger {
-  const messenger = new Messenger<
-    'GeolocationApiService',
+  rootMessenger: RootMessenger<
     MessengerActions<GeolocationApiServiceMessenger>,
-    MessengerEvents<GeolocationApiServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<GeolocationApiServiceMessenger>
+  >,
+): GeolocationApiServiceMessenger {
+  const messenger: GeolocationApiServiceMessenger = new Messenger({
     namespace: 'GeolocationApiService',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/geolocation-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/geolocation-controller-messenger/index.ts
@@ -3,11 +3,7 @@ import {
   type MessengerActions,
   type MessengerEvents,
 } from '@metamask/messenger';
-import type {
-  GeolocationControllerMessenger,
-  GeolocationControllerActions,
-  GeolocationControllerEvents,
-} from '@metamask/geolocation-controller';
+import type { GeolocationControllerMessenger } from '@metamask/geolocation-controller';
 import type { RootMessenger } from '../../types';
 
 const name = 'GeolocationController' as const;
@@ -21,14 +17,12 @@ const name = 'GeolocationController' as const;
  * @returns The GeolocationControllerMessenger.
  */
 export function getGeolocationControllerMessenger(
-  rootMessenger: RootMessenger,
-): GeolocationControllerMessenger {
-  const messenger = new Messenger<
-    typeof name,
+  rootMessenger: RootMessenger<
     MessengerActions<GeolocationControllerMessenger>,
-    MessengerEvents<GeolocationControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<GeolocationControllerMessenger>
+  >,
+): GeolocationControllerMessenger {
+  const messenger: GeolocationControllerMessenger = new Messenger({
     namespace: name,
     parent: rootMessenger,
   });
@@ -41,5 +35,3 @@ export function getGeolocationControllerMessenger(
 
   return messenger;
 }
-
-export type { GeolocationControllerActions, GeolocationControllerEvents };

--- a/app/core/Engine/messengers/logging-controller-messenger.ts
+++ b/app/core/Engine/messengers/logging-controller-messenger.ts
@@ -13,14 +13,12 @@ import { RootMessenger } from '../types';
  * @returns The LoggingControllerMessenger.
  */
 export function getLoggingControllerMessenger(
-  rootMessenger: RootMessenger,
-): LoggingControllerMessenger {
-  const messenger = new Messenger<
-    'LoggingController',
+  rootMessenger: RootMessenger<
     MessengerActions<LoggingControllerMessenger>,
-    MessengerEvents<LoggingControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<LoggingControllerMessenger>
+  >,
+): LoggingControllerMessenger {
+  const messenger: LoggingControllerMessenger = new Messenger({
     namespace: 'LoggingController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/money-account-balance-service-messenger.ts
+++ b/app/core/Engine/messengers/money-account-balance-service-messenger.ts
@@ -14,14 +14,15 @@ import { RootMessenger } from '../types';
  * @returns The MoneyAccountBalanceServiceMessenger.
  */
 export function getMoneyAccountBalanceServiceMessenger(
-  rootMessenger: RootMessenger,
-): MoneyAccountBalanceServiceMessenger {
-  const messenger = new Messenger<
-    'MoneyAccountBalanceService',
+  rootMessenger: RootMessenger<
     MessengerActions<MoneyAccountBalanceServiceMessenger>,
-    MessengerEvents<MoneyAccountBalanceServiceMessenger>,
-    RootMessenger
-  >({ namespace: 'MoneyAccountBalanceService', parent: rootMessenger });
+    MessengerEvents<MoneyAccountBalanceServiceMessenger>
+  >,
+): MoneyAccountBalanceServiceMessenger {
+  const messenger: MoneyAccountBalanceServiceMessenger = new Messenger({
+    namespace: 'MoneyAccountBalanceService',
+    parent: rootMessenger,
+  });
 
   rootMessenger.delegate({
     messenger,

--- a/app/core/Engine/messengers/money-account-controller-messenger.ts
+++ b/app/core/Engine/messengers/money-account-controller-messenger.ts
@@ -20,14 +20,15 @@ import { RootMessenger } from '../types';
  * @returns The restricted controller messenger.
  */
 export function getMoneyAccountControllerMessenger(
-  rootMessenger: RootMessenger,
-): MoneyAccountControllerMessenger {
-  const messenger = new Messenger<
-    'MoneyAccountController',
+  rootMessenger: RootMessenger<
     MessengerActions<MoneyAccountControllerMessenger>,
-    MessengerEvents<MoneyAccountControllerMessenger>,
-    RootMessenger
-  >({ namespace: 'MoneyAccountController', parent: rootMessenger });
+    MessengerEvents<MoneyAccountControllerMessenger>
+  >,
+): MoneyAccountControllerMessenger {
+  const messenger: MoneyAccountControllerMessenger = new Messenger({
+    namespace: 'MoneyAccountController',
+    parent: rootMessenger,
+  });
 
   rootMessenger.delegate({
     messenger,
@@ -51,8 +52,10 @@ type AllowedInitializationEvents = ControllerStateChangeEvent<
   RemoteFeatureFlagControllerState
 >;
 
-export type MoneyAccountControllerInitMessenger = ReturnType<
-  typeof getMoneyAccountControllerInitMessenger
+export type MoneyAccountControllerInitMessenger = Messenger<
+  'MoneyAccountControllerInit',
+  AllowedInitializationActions,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -63,14 +66,12 @@ export type MoneyAccountControllerInitMessenger = ReturnType<
  * @returns The MoneyAccountControllerInitMessenger.
  */
 export function getMoneyAccountControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'MoneyAccountControllerInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<MoneyAccountControllerInitMessenger>,
+    MessengerEvents<MoneyAccountControllerInitMessenger>
+  >,
+): MoneyAccountControllerInitMessenger {
+  const messenger: MoneyAccountControllerInitMessenger = new Messenger({
     namespace: 'MoneyAccountControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/multichain-assets-controller-messenger/multichain-assets-controller-messenger.ts
+++ b/app/core/Engine/messengers/multichain-assets-controller-messenger/multichain-assets-controller-messenger.ts
@@ -3,28 +3,26 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import { MultichainAssetsControllerMessenger } from '@metamask/assets-controllers';
 
 /**
  * Get the MultichainAssetsControllerMessenger for the MultichainAssetsController.
  *
- * @param baseControllerMessenger - The base controller messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The MultichainAssetsControllerMessenger.
  */
 export function getMultichainAssetsControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): MultichainAssetsControllerMessenger {
-  const messenger = new Messenger<
-    'MultichainAssetsController',
+  rootMessenger: RootMessenger<
     MessengerActions<MultichainAssetsControllerMessenger>,
-    MessengerEvents<MultichainAssetsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MultichainAssetsControllerMessenger>
+  >,
+): MultichainAssetsControllerMessenger {
+  const messenger: MultichainAssetsControllerMessenger = new Messenger({
     namespace: 'MultichainAssetsController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'PermissionController:getPermissions',
       'SnapController:handleRequest',

--- a/app/core/Engine/messengers/multichain-assets-rates-controller-messenger/multichain-assets-rates-controller-messenger.ts
+++ b/app/core/Engine/messengers/multichain-assets-rates-controller-messenger/multichain-assets-rates-controller-messenger.ts
@@ -3,28 +3,26 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import { MultichainAssetsRatesControllerMessenger } from '@metamask/assets-controllers';
 
 /**
  * Get the MultichainAssetsRatesControllerMessenger for the MultichainAssetsRatesController.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The MultichainAssetsRatesControllerMessenger.
  */
 export function getMultichainAssetsRatesControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): MultichainAssetsRatesControllerMessenger {
-  const messenger = new Messenger<
-    'MultichainAssetsRatesController',
+  rootMessenger: RootMessenger<
     MessengerActions<MultichainAssetsRatesControllerMessenger>,
-    MessengerEvents<MultichainAssetsRatesControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MultichainAssetsRatesControllerMessenger>
+  >,
+): MultichainAssetsRatesControllerMessenger {
+  const messenger: MultichainAssetsRatesControllerMessenger = new Messenger({
     namespace: 'MultichainAssetsRatesController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountsController:listMultichainAccounts',
       'SnapController:handleRequest',

--- a/app/core/Engine/messengers/multichain-balances-controller-messenger/multichain-balances-controller-messenger.ts
+++ b/app/core/Engine/messengers/multichain-balances-controller-messenger/multichain-balances-controller-messenger.ts
@@ -3,28 +3,26 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import { MultichainBalancesControllerMessenger } from '@metamask/assets-controllers';
 
 /**
  * Get the MultichainBalancesControllerMessenger for the MultichainBalancesController.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The MultichainBalancesControllerMessenger.
  */
 export function getMultichainBalancesControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): MultichainBalancesControllerMessenger {
-  const messenger = new Messenger<
-    'MultichainBalancesController',
+  rootMessenger: RootMessenger<
     MessengerActions<MultichainBalancesControllerMessenger>,
-    MessengerEvents<MultichainBalancesControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MultichainBalancesControllerMessenger>
+  >,
+): MultichainBalancesControllerMessenger {
+  const messenger: MultichainBalancesControllerMessenger = new Messenger({
     namespace: 'MultichainBalancesController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountsController:listMultichainAccounts',
       'SnapController:handleRequest',

--- a/app/core/Engine/messengers/multichain-network-controller-messenger/multichain-network-controller-messenger.ts
+++ b/app/core/Engine/messengers/multichain-network-controller-messenger/multichain-network-controller-messenger.ts
@@ -3,28 +3,26 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import { MultichainNetworkControllerMessenger } from '@metamask/multichain-network-controller';
 
 /**
  * Get the MultichainNetworkControllerMessenger for the MultichainNetworkController.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The MultichainNetworkControllerMessenger.
  */
 export function getMultichainNetworkControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): MultichainNetworkControllerMessenger {
-  const messenger = new Messenger<
-    'MultichainNetworkController',
+  rootMessenger: RootMessenger<
     MessengerActions<MultichainNetworkControllerMessenger>,
-    MessengerEvents<MultichainNetworkControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MultichainNetworkControllerMessenger>
+  >,
+): MultichainNetworkControllerMessenger {
+  const messenger: MultichainNetworkControllerMessenger = new Messenger({
     namespace: 'MultichainNetworkController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'NetworkController:setActiveNetwork',
       'NetworkController:getState',

--- a/app/core/Engine/messengers/multichain-routing-service-messenger.ts
+++ b/app/core/Engine/messengers/multichain-routing-service-messenger.ts
@@ -1,4 +1,8 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { MultichainRoutingServiceMessenger } from '@metamask/snaps-controllers';
 import { RootMessenger } from '../types';
 import { SnapAccountServiceGetLegacySnapKeyringAction } from '@metamask/snap-account-service';
@@ -11,7 +15,11 @@ import { SnapAccountServiceGetLegacySnapKeyringAction } from '@metamask/snap-acc
  * @returns The multichain routing service messenger.
  */
 export function getMultichainRoutingServiceMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: Messenger<
+    'Root',
+    MessengerActions<MultichainRoutingServiceMessenger>,
+    MessengerEvents<MultichainRoutingServiceMessenger>
+  >,
 ): MultichainRoutingServiceMessenger {
   const messenger: MultichainRoutingServiceMessenger = new Messenger({
     namespace: 'MultichainRoutingService',
@@ -35,8 +43,10 @@ export function getMultichainRoutingServiceMessenger(
 type AllowedInitializationActions =
   SnapAccountServiceGetLegacySnapKeyringAction;
 
-export type MultichainRoutingServiceInitMessenger = ReturnType<
-  typeof getMultichainRoutingServiceInitMessenger
+export type MultichainRoutingServiceInitMessenger = Messenger<
+  'MultichainRoutingServiceInit',
+  AllowedInitializationActions,
+  never
 >;
 
 /**
@@ -48,14 +58,12 @@ export type MultichainRoutingServiceInitMessenger = ReturnType<
  * @returns The multichain routing service init messenger.
  */
 export function getMultichainRoutingServiceInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'MultichainRoutingServiceInit',
-    AllowedInitializationActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<MultichainRoutingServiceInitMessenger>,
+    MessengerEvents<MultichainRoutingServiceInitMessenger>
+  >,
+): MultichainRoutingServiceInitMessenger {
+  const messenger: MultichainRoutingServiceInitMessenger = new Messenger({
     namespace: 'MultichainRoutingServiceInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/multichain-transactions-controller-messenger/multichain-transactions-controller-messenger.ts
+++ b/app/core/Engine/messengers/multichain-transactions-controller-messenger/multichain-transactions-controller-messenger.ts
@@ -3,28 +3,26 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RootExtendedMessenger, RootMessenger } from '../../types';
+import { RootMessenger } from '../../types';
 import { MultichainTransactionsControllerMessenger } from './types';
 
 /**
  * Get the MultichainTransactionsControllerMessenger for the MultichainTransactionsController.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The MultichainTransactionsControllerMessenger.
  */
 export function getMultichainTransactionsControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): MultichainTransactionsControllerMessenger {
-  const messenger = new Messenger<
-    'MultichainTransactionsController',
+  rootMessenger: RootMessenger<
     MessengerActions<MultichainTransactionsControllerMessenger>,
-    MessengerEvents<MultichainTransactionsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<MultichainTransactionsControllerMessenger>
+  >,
+): MultichainTransactionsControllerMessenger {
+  const messenger: MultichainTransactionsControllerMessenger = new Messenger({
     namespace: 'MultichainTransactionsController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'AccountsController:listMultichainAccounts',
       'SnapController:handleRequest',

--- a/app/core/Engine/messengers/network-controller-messenger.ts
+++ b/app/core/Engine/messengers/network-controller-messenger.ts
@@ -24,14 +24,12 @@ import { AnalyticsControllerActions } from '@metamask/analytics-controller';
  * @returns The NetworkControllerMessenger.
  */
 export function getNetworkControllerMessenger(
-  rootMessenger: RootMessenger,
-): NetworkControllerMessenger {
-  const messenger = new Messenger<
-    'NetworkController',
+  rootMessenger: RootMessenger<
     MessengerActions<NetworkControllerMessenger>,
-    MessengerEvents<NetworkControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NetworkControllerMessenger>
+  >,
+): NetworkControllerMessenger {
+  const messenger: NetworkControllerMessenger = new Messenger({
     namespace: 'NetworkController',
     parent: rootMessenger,
   });
@@ -55,8 +53,10 @@ type AllowedInitializationEvents =
       RemoteFeatureFlagControllerState
     >;
 
-export type NetworkControllerInitMessenger = ReturnType<
-  typeof getNetworkControllerInitMessenger
+export type NetworkControllerInitMessenger = Messenger<
+  'NetworkControllerInit',
+  AllowedInitializationActions,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -68,14 +68,12 @@ export type NetworkControllerInitMessenger = ReturnType<
  * @returns The NetworkControllerInitMessenger.
  */
 export function getNetworkControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'NetworkControllerInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<NetworkControllerInitMessenger>,
+    MessengerEvents<NetworkControllerInitMessenger>
+  >,
+): NetworkControllerInitMessenger {
+  const messenger: NetworkControllerInitMessenger = new Messenger({
     namespace: 'NetworkControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/network-enablement-controller-messenger/network-enablement-controller-messenger.ts
+++ b/app/core/Engine/messengers/network-enablement-controller-messenger/network-enablement-controller-messenger.ts
@@ -4,26 +4,25 @@ import {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { RootMessenger, RootExtendedMessenger } from '../../types';
+import { RootMessenger } from '../../types';
+
 /**
  * Get the messenger for the NetworkEnablementController.
  *
- * @param rootExtendedMessenger - The root extended messenger.
+ * @param rootMessenger - The root messenger.
  * @returns The NetworkEnablementControllerMessenger.
  */
 export function getNetworkEnablementControllerMessenger(
-  rootExtendedMessenger: RootExtendedMessenger,
-): NetworkEnablementControllerMessenger {
-  const messenger = new Messenger<
-    'NetworkEnablementController',
+  rootMessenger: RootMessenger<
     MessengerActions<NetworkEnablementControllerMessenger>,
-    MessengerEvents<NetworkEnablementControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NetworkEnablementControllerMessenger>
+  >,
+): NetworkEnablementControllerMessenger {
+  const messenger: NetworkEnablementControllerMessenger = new Messenger({
     namespace: 'NetworkEnablementController',
-    parent: rootExtendedMessenger,
+    parent: rootMessenger,
   });
-  rootExtendedMessenger.delegate({
+  rootMessenger.delegate({
     actions: [
       'NetworkController:getState',
       'MultichainNetworkController:getState',

--- a/app/core/Engine/messengers/nft-controller-messenger.ts
+++ b/app/core/Engine/messengers/nft-controller-messenger.ts
@@ -14,14 +14,12 @@ import { RootMessenger } from '../types';
  * @returns The NftControllerMessenger.
  */
 export function getNftControllerMessenger(
-  rootMessenger: RootMessenger,
-): NftControllerMessenger {
-  const messenger = new Messenger<
-    'NftController',
+  rootMessenger: RootMessenger<
     MessengerActions<NftControllerMessenger>,
-    MessengerEvents<NftControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NftControllerMessenger>
+  >,
+): NftControllerMessenger {
+  const messenger: NftControllerMessenger = new Messenger({
     namespace: 'NftController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/nft-detection-controller-messenger.ts
+++ b/app/core/Engine/messengers/nft-detection-controller-messenger.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/messenger';
 import { RootMessenger } from '../types';
 import { NftDetectionControllerMessenger } from '@metamask/assets-controllers';
+
 /**
  * Get the messenger for the NFT detection controller. This is scoped to the
  * NFT detection controller is allowed to handle.
@@ -13,14 +14,12 @@ import { NftDetectionControllerMessenger } from '@metamask/assets-controllers';
  * @returns The NftDetectionControllerMessenger.
  */
 export function getNftDetectionControllerMessenger(
-  rootMessenger: RootMessenger,
-): NftDetectionControllerMessenger {
-  const messenger = new Messenger<
-    'NftDetectionController',
+  rootMessenger: RootMessenger<
     MessengerActions<NftDetectionControllerMessenger>,
-    MessengerEvents<NftDetectionControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NftDetectionControllerMessenger>
+  >,
+): NftDetectionControllerMessenger {
+  const messenger: NftDetectionControllerMessenger = new Messenger({
     namespace: 'NftDetectionController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/permission-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.test.ts
@@ -1,24 +1,9 @@
-import {
-  Messenger,
-  type MessengerActions,
-  type MessengerEvents,
-  MOCK_ANY_NAMESPACE,
-  type MockAnyNamespace,
-} from '@metamask/messenger';
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import {
   getPermissionControllerMessenger,
   getPermissionControllerInitMessenger,
-  PermissionControllerInitMessenger,
 } from './permission-controller-messenger';
-import { PermissionControllerMessenger } from '@metamask/permission-controller';
-
-type RootMessenger = Messenger<
-  MockAnyNamespace,
-  | MessengerActions<PermissionControllerMessenger>
-  | MessengerActions<PermissionControllerInitMessenger>,
-  | MessengerEvents<PermissionControllerMessenger>
-  | MessengerEvents<PermissionControllerInitMessenger>
->;
+import { RootMessenger } from '../types';
 
 function getRootMessenger(): RootMessenger {
   return new Messenger({

--- a/app/core/Engine/messengers/permission-controller-messenger.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.ts
@@ -20,6 +20,11 @@ import { RootMessenger } from '../types.ts';
 import { PermissionControllerMessenger } from '@metamask/permission-controller';
 import { SnapAccountServiceHandleKeyringSnapMessageAction } from '@metamask/snap-account-service';
 
+type PermissionControllerMessengerActions =
+  | MessengerActions<PermissionControllerMessenger>
+  | SnapControllerGetPermittedSnapsAction
+  | SnapControllerInstallSnapsAction;
+
 /**
  * Get the messenger for the permission controller. This is scoped to the
  * actions and events that the permission controller is allowed to handle.
@@ -27,15 +32,17 @@ import { SnapAccountServiceHandleKeyringSnapMessageAction } from '@metamask/snap
  * @param rootMessenger - The root messenger.
  * @returns The PermissionControllerMessenger.
  */
-export function getPermissionControllerMessenger(rootMessenger: RootMessenger) {
-  const messenger = new Messenger<
+export function getPermissionControllerMessenger(
+  rootMessenger: RootMessenger<
+    PermissionControllerMessengerActions,
+    MessengerEvents<PermissionControllerMessenger>
+  >,
+): PermissionControllerMessenger {
+  const messenger: Messenger<
     'PermissionController',
-    | MessengerActions<PermissionControllerMessenger>
-    | SnapControllerGetPermittedSnapsAction
-    | SnapControllerInstallSnapsAction,
-    MessengerEvents<PermissionControllerMessenger>,
-    RootMessenger
-  >({
+    PermissionControllerMessengerActions,
+    MessengerEvents<PermissionControllerMessenger>
+  > = new Messenger({
     namespace: 'PermissionController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/phishing-controller-messenger.ts
+++ b/app/core/Engine/messengers/phishing-controller-messenger.ts
@@ -7,14 +7,12 @@ import { RootMessenger } from '../types';
 import { PhishingControllerMessenger } from '@metamask/phishing-controller';
 
 export function getPhishingControllerMessenger(
-  rootMessenger: RootMessenger,
-): PhishingControllerMessenger {
-  const messenger = new Messenger<
-    'PhishingController',
+  rootMessenger: RootMessenger<
     MessengerActions<PhishingControllerMessenger>,
-    MessengerEvents<PhishingControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<PhishingControllerMessenger>
+  >,
+): PhishingControllerMessenger {
+  const messenger: PhishingControllerMessenger = new Messenger({
     namespace: 'PhishingController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/preferences-controller-messenger.ts
+++ b/app/core/Engine/messengers/preferences-controller-messenger.ts
@@ -7,14 +7,12 @@ import { PreferencesControllerMessenger } from '@metamask/preferences-controller
 import { RootMessenger } from '../types';
 
 export function getPreferencesControllerMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'PreferencesController',
+  rootMessenger: RootMessenger<
     MessengerActions<PreferencesControllerMessenger>,
-    MessengerEvents<PreferencesControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<PreferencesControllerMessenger>
+  >,
+): PreferencesControllerMessenger {
+  const messenger: PreferencesControllerMessenger = new Messenger({
     namespace: 'PreferencesController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/profile-metrics-controller-messenger.ts
+++ b/app/core/Engine/messengers/profile-metrics-controller-messenger.ts
@@ -18,20 +18,18 @@ type ProfileMetricsControllerInitMessengerActions =
  * Create a messenger restricted to the allowed actions and events of the
  * profile metrics controller.
  *
- * @param messenger - The base messenger used to create the restricted
+ * @param rootMessenger - The base messenger used to create the restricted
  * messenger.
  */
-export function getProfileMetricsControllerMessenger(messenger: RootMessenger) {
-  const profileMetricsControllerMessenger = new Messenger<
-    'ProfileMetricsController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
-    namespace: 'ProfileMetricsController',
-    parent: messenger,
-  });
-  messenger.delegate({
+export function getProfileMetricsControllerMessenger(
+  rootMessenger: RootMessenger<AllowedActions, AllowedEvents>,
+): ProfileMetricsControllerMessenger {
+  const profileMetricsControllerMessenger: ProfileMetricsControllerMessenger =
+    new Messenger({
+      namespace: 'ProfileMetricsController',
+      parent: rootMessenger,
+    });
+  rootMessenger.delegate({
     messenger: profileMetricsControllerMessenger,
     actions: [
       'AccountsController:getState',
@@ -48,30 +46,30 @@ export function getProfileMetricsControllerMessenger(messenger: RootMessenger) {
   return profileMetricsControllerMessenger;
 }
 
-export type ProfileMetricsControllerInitMessenger = ReturnType<
-  typeof getProfileMetricsControllerInitMessenger
+export type ProfileMetricsControllerInitMessenger = Messenger<
+  'ProfileMetricsControllerInit',
+  ProfileMetricsControllerInitMessengerActions,
+  never
 >;
 
 /**
  * Create a messenger for ProfileMetricsController initialization.
  * This messenger provides access to AnalyticsController state.
  *
- * @param messenger - The base messenger used to create the restricted
+ * @param rootMessenger - The base messenger used to create the restricted
  * messenger.
  */
 export function getProfileMetricsControllerInitMessenger(
-  messenger: RootMessenger,
-) {
-  const initMessenger = new Messenger<
-    'ProfileMetricsControllerInit',
-    ProfileMetricsControllerInitMessengerActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<ProfileMetricsControllerInitMessenger>,
+    MessengerEvents<ProfileMetricsControllerInitMessenger>
+  >,
+): ProfileMetricsControllerInitMessenger {
+  const initMessenger: ProfileMetricsControllerInitMessenger = new Messenger({
     namespace: 'ProfileMetricsControllerInit',
-    parent: messenger,
+    parent: rootMessenger,
   });
-  messenger.delegate({
+  rootMessenger.delegate({
     actions: ['AnalyticsController:getState'],
     messenger: initMessenger,
   });

--- a/app/core/Engine/messengers/profile-metrics-service-messenger.ts
+++ b/app/core/Engine/messengers/profile-metrics-service-messenger.ts
@@ -14,22 +14,17 @@ type AllowedEvents = MessengerEvents<ProfileMetricsServiceMessenger>;
  * Create a messenger restricted to the allowed actions and events of the
  * profile metrics service.
  *
- * @param messenger - The base messenger used to create the restricted
+ * @param rootMessenger - The base messenger used to create the restricted
  * messenger.
  */
 export function getProfileMetricsServiceMessenger(
-  messenger: RootMessenger,
+  rootMessenger: RootMessenger<AllowedActions, AllowedEvents>,
 ): ProfileMetricsServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'ProfileMetricsService',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const serviceMessenger: ProfileMetricsServiceMessenger = new Messenger({
     namespace: 'ProfileMetricsService',
-    parent: messenger,
+    parent: rootMessenger,
   });
-  messenger.delegate({
+  rootMessenger.delegate({
     messenger: serviceMessenger,
     actions: ['AuthenticationController:getBearerToken'],
   });

--- a/app/core/Engine/messengers/remote-feature-flag-controller-messenger.ts
+++ b/app/core/Engine/messengers/remote-feature-flag-controller-messenger.ts
@@ -7,14 +7,12 @@ import { RootMessenger } from '../types';
 import { RemoteFeatureFlagControllerMessenger } from '@metamask/remote-feature-flag-controller';
 
 export function getRemoteFeatureFlagControllerMessenger(
-  rootMessenger: RootMessenger,
-): RemoteFeatureFlagControllerMessenger {
-  const messenger = new Messenger<
-    'RemoteFeatureFlagController',
+  rootMessenger: RootMessenger<
     MessengerActions<RemoteFeatureFlagControllerMessenger>,
-    MessengerEvents<RemoteFeatureFlagControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<RemoteFeatureFlagControllerMessenger>
+  >,
+): RemoteFeatureFlagControllerMessenger {
+  const messenger: RemoteFeatureFlagControllerMessenger = new Messenger({
     namespace: 'RemoteFeatureFlagController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/rewards-data-service-messenger.ts
+++ b/app/core/Engine/messengers/rewards-data-service-messenger.ts
@@ -14,14 +14,12 @@ import { RewardsDataServiceMessenger } from '../controllers/rewards-controller/s
  * @returns The RewardsDataServiceMessenger.
  */
 export function getRewardsDataServiceMessenger(
-  rootMessenger: RootMessenger,
-): RewardsDataServiceMessenger {
-  const messenger = new Messenger<
-    'RewardsDataService',
+  rootMessenger: RootMessenger<
     MessengerActions<RewardsDataServiceMessenger>,
-    MessengerEvents<RewardsDataServiceMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<RewardsDataServiceMessenger>
+  >,
+): RewardsDataServiceMessenger {
+  const messenger: RewardsDataServiceMessenger = new Messenger({
     namespace: 'RewardsDataService',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/selected-network-controller-messenger.ts
+++ b/app/core/Engine/messengers/selected-network-controller-messenger.ts
@@ -14,14 +14,12 @@ import { SelectedNetworkControllerMessenger } from '@metamask/selected-network-c
  * @returns The SelectedNetworkControllerMessenger.
  */
 export function getSelectedNetworkControllerMessenger(
-  rootMessenger: RootMessenger,
-): SelectedNetworkControllerMessenger {
-  const messenger = new Messenger<
-    'SelectedNetworkController',
+  rootMessenger: RootMessenger<
     MessengerActions<SelectedNetworkControllerMessenger>,
-    MessengerEvents<SelectedNetworkControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<SelectedNetworkControllerMessenger>
+  >,
+): SelectedNetworkControllerMessenger {
+  const messenger: SelectedNetworkControllerMessenger = new Messenger({
     namespace: 'SelectedNetworkController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/smart-transactions-controller-messenger.ts
+++ b/app/core/Engine/messengers/smart-transactions-controller-messenger.ts
@@ -15,14 +15,12 @@ import { AnalyticsControllerActions } from '@metamask/analytics-controller';
  * @returns The SmartTransactionsControllerMessenger.
  */
 export function getSmartTransactionsControllerMessenger(
-  rootMessenger: RootMessenger,
-): SmartTransactionsControllerMessenger {
-  const messenger = new Messenger<
-    'SmartTransactionsController',
+  rootMessenger: RootMessenger<
     MessengerActions<SmartTransactionsControllerMessenger>,
-    MessengerEvents<SmartTransactionsControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<SmartTransactionsControllerMessenger>
+  >,
+): SmartTransactionsControllerMessenger {
+  const messenger: SmartTransactionsControllerMessenger = new Messenger({
     namespace: 'SmartTransactionsController',
     parent: rootMessenger,
   });
@@ -48,6 +46,12 @@ export function getSmartTransactionsControllerMessenger(
 type SmartTransactionsControllerInitMessengerActions =
   AnalyticsControllerActions;
 
+export type SmartTransactionsControllerInitMessenger = Messenger<
+  'SmartTransactionsControllerInit',
+  SmartTransactionsControllerInitMessengerActions,
+  never
+>;
+
 /**
  * Get the SmartTransactionsControllerInitMessenger for the SmartTransactionsController.
  * This messenger is used during controller initialization to call other controllers.
@@ -55,24 +59,13 @@ type SmartTransactionsControllerInitMessengerActions =
  * @param rootMessenger - The root messenger.
  * @returns The SmartTransactionsControllerInitMessenger.
  */
-export type SmartTransactionsControllerInitMessenger = ReturnType<
-  typeof getSmartTransactionsControllerInitMessenger
->;
-
 export function getSmartTransactionsControllerInitMessenger(
-  rootMessenger: RootMessenger,
-): Messenger<
-  'SmartTransactionsControllerInit',
-  SmartTransactionsControllerInitMessengerActions,
-  never,
-  RootMessenger
-> {
-  const messenger = new Messenger<
-    'SmartTransactionsControllerInit',
-    SmartTransactionsControllerInitMessengerActions,
-    never,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<SmartTransactionsControllerInitMessenger>,
+    MessengerEvents<SmartTransactionsControllerInitMessenger>
+  >,
+): SmartTransactionsControllerInitMessenger {
+  const messenger: SmartTransactionsControllerInitMessenger = new Messenger({
     namespace: 'SmartTransactionsControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/snap-account-service-messenger/snap-account-service-messenger.ts
+++ b/app/core/Engine/messengers/snap-account-service-messenger/snap-account-service-messenger.ts
@@ -4,7 +4,6 @@ import {
   MessengerEvents,
 } from '@metamask/messenger';
 import type { SnapAccountServiceMessenger as ServiceMessenger } from '@metamask/snap-account-service';
-import type { RootMessenger } from '../../types';
 
 type Actions = MessengerActions<ServiceMessenger>;
 type Events = MessengerEvents<ServiceMessenger>;
@@ -19,14 +18,9 @@ export type SnapAccountServiceMessenger = ServiceMessenger;
  * @returns The SnapAccountServiceMessenger.
  */
 export function getSnapAccountServiceMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: Messenger<'Root', Actions, Events>,
 ): SnapAccountServiceMessenger {
-  const messenger = new Messenger<
-    'SnapAccountService',
-    Actions,
-    Events,
-    RootMessenger
-  >({
+  const messenger: SnapAccountServiceMessenger = new Messenger({
     namespace: 'SnapAccountService',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/subject-metadata-controller-messenger.ts
+++ b/app/core/Engine/messengers/subject-metadata-controller-messenger.ts
@@ -14,14 +14,12 @@ import { RootMessenger } from '../types';
  * @returns The SubjectMetadataControllerMessenger.
  */
 export function getSubjectMetadataControllerMessenger(
-  rootMessenger: RootMessenger,
-): SubjectMetadataControllerMessenger {
-  const messenger = new Messenger<
-    'SubjectMetadataController',
+  rootMessenger: RootMessenger<
     MessengerActions<SubjectMetadataControllerMessenger>,
-    MessengerEvents<SubjectMetadataControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<SubjectMetadataControllerMessenger>
+  >,
+): SubjectMetadataControllerMessenger {
+  const messenger: SubjectMetadataControllerMessenger = new Messenger({
     namespace: 'SubjectMetadataController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/token-balances-controller-messenger.ts
+++ b/app/core/Engine/messengers/token-balances-controller-messenger.ts
@@ -15,14 +15,12 @@ import { RootMessenger } from '../types';
  * @returns The TokenBalancesControllerMessenger.
  */
 export function getTokenBalancesControllerMessenger(
-  rootMessenger: RootMessenger,
-): TokenBalancesControllerMessenger {
-  const messenger = new Messenger<
-    'TokenBalancesController',
+  rootMessenger: RootMessenger<
     MessengerActions<TokenBalancesControllerMessenger>,
-    MessengerEvents<TokenBalancesControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TokenBalancesControllerMessenger>
+  >,
+): TokenBalancesControllerMessenger {
+  const messenger: TokenBalancesControllerMessenger = new Messenger({
     namespace: 'TokenBalancesController',
     parent: rootMessenger,
   });
@@ -64,8 +62,10 @@ type AllowedInitializationActions = PreferencesControllerGetStateAction;
 
 type AllowedInitializationEvents = never;
 
-export type TokenBalancesControllerInitMessenger = ReturnType<
-  typeof getTokenBalancesControllerInitMessenger
+export type TokenBalancesControllerInitMessenger = Messenger<
+  'TokenBalancesControllerInit',
+  AllowedInitializationActions,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -77,14 +77,12 @@ export type TokenBalancesControllerInitMessenger = ReturnType<
  * @returns The TokenBalancesControllerInitMessenger.
  */
 export function getTokenBalancesControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'TokenBalancesControllerInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<TokenBalancesControllerInitMessenger>,
+    MessengerEvents<TokenBalancesControllerInitMessenger>
+  >,
+): TokenBalancesControllerInitMessenger {
+  const messenger: TokenBalancesControllerInitMessenger = new Messenger({
     namespace: 'TokenBalancesControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/token-detection-controller-messenger.ts
+++ b/app/core/Engine/messengers/token-detection-controller-messenger.ts
@@ -18,14 +18,12 @@ import { AnalyticsControllerActions } from '@metamask/analytics-controller';
  * @returns The TokenDetectionControllerMessenger.
  */
 export function getTokenDetectionControllerMessenger(
-  rootMessenger: RootMessenger,
-): TokenDetectionControllerMessenger {
-  const messenger = new Messenger<
-    'TokenDetectionController',
+  rootMessenger: RootMessenger<
     MessengerActions<TokenDetectionControllerMessenger>,
-    MessengerEvents<TokenDetectionControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TokenDetectionControllerMessenger>
+  >,
+): TokenDetectionControllerMessenger {
+  const messenger: TokenDetectionControllerMessenger = new Messenger({
     namespace: 'TokenDetectionController',
     parent: rootMessenger,
   });
@@ -62,8 +60,10 @@ type AllowedInitializationActions =
 
 type AllowedInitializationEvents = never;
 
-export type TokenDetectionControllerInitMessenger = ReturnType<
-  typeof getTokenDetectionControllerInitMessenger
+export type TokenDetectionControllerInitMessenger = Messenger<
+  'TokenDetectionControllerInit',
+  AllowedInitializationActions,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -75,14 +75,12 @@ export type TokenDetectionControllerInitMessenger = ReturnType<
  * @returns The TokenDetectionControllerInitMessenger.
  */
 export function getTokenDetectionControllerInitMessenger(
-  rootMessenger: RootMessenger,
-) {
-  const messenger = new Messenger<
-    'TokenDetectionControllerInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+  rootMessenger: RootMessenger<
+    MessengerActions<TokenDetectionControllerInitMessenger>,
+    MessengerEvents<TokenDetectionControllerInitMessenger>
+  >,
+): TokenDetectionControllerInitMessenger {
+  const messenger: TokenDetectionControllerInitMessenger = new Messenger({
     namespace: 'TokenDetectionControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/token-rates-controller-messenger.ts
+++ b/app/core/Engine/messengers/token-rates-controller-messenger.ts
@@ -5,6 +5,7 @@ import {
 } from '@metamask/messenger';
 import type { TokenRatesControllerMessenger } from '@metamask/assets-controllers';
 import { RootMessenger } from '../types';
+
 /**
  * Get the messenger for the token rates controller. This is scoped to the
  * actions and events that the token rates controller is allowed to handle.
@@ -13,14 +14,12 @@ import { RootMessenger } from '../types';
  * @returns The TokenRatesControllerMessenger.
  */
 export function getTokenRatesControllerMessenger(
-  rootMessenger: RootMessenger,
-): TokenRatesControllerMessenger {
-  const messenger = new Messenger<
-    'TokenRatesController',
+  rootMessenger: RootMessenger<
     MessengerActions<TokenRatesControllerMessenger>,
-    MessengerEvents<TokenRatesControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TokenRatesControllerMessenger>
+  >,
+): TokenRatesControllerMessenger {
+  const messenger: TokenRatesControllerMessenger = new Messenger({
     namespace: 'TokenRatesController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/token-search-discovery-data-controller-messenger.ts
+++ b/app/core/Engine/messengers/token-search-discovery-data-controller-messenger.ts
@@ -7,14 +7,12 @@ import { TokenSearchDiscoveryDataControllerMessenger } from '@metamask/assets-co
 import { RootMessenger } from '../types';
 
 export function getTokenSearchDiscoveryDataControllerMessenger(
-  rootMessenger: RootMessenger,
-): TokenSearchDiscoveryDataControllerMessenger {
-  const messenger = new Messenger<
-    'TokenSearchDiscoveryDataController',
+  rootMessenger: RootMessenger<
     MessengerActions<TokenSearchDiscoveryDataControllerMessenger>,
-    MessengerEvents<TokenSearchDiscoveryDataControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TokenSearchDiscoveryDataControllerMessenger>
+  >,
+): TokenSearchDiscoveryDataControllerMessenger {
+  const messenger: TokenSearchDiscoveryDataControllerMessenger = new Messenger({
     namespace: 'TokenSearchDiscoveryDataController',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/tokens-controller-messenger.ts
+++ b/app/core/Engine/messengers/tokens-controller-messenger.ts
@@ -16,14 +16,12 @@ import { RootMessenger } from '../types';
  * @returns The TokensControllerMessenger.
  */
 export function getTokensControllerMessenger(
-  rootMessenger: RootMessenger,
-): TokensControllerMessenger {
-  const messenger = new Messenger<
-    'TokensController',
+  rootMessenger: RootMessenger<
     MessengerActions<TokensControllerMessenger>,
-    MessengerEvents<TokensControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<TokensControllerMessenger>
+  >,
+): TokensControllerMessenger {
+  const messenger: TokensControllerMessenger = new Messenger({
     namespace: 'TokensController',
     parent: rootMessenger,
   });
@@ -51,8 +49,10 @@ type AllowedInitializationActions =
 
 type AllowedInitializationEvents = never;
 
-export type TokensControllerInitMessenger = ReturnType<
-  typeof getTokensControllerInitMessenger
+export type TokensControllerInitMessenger = Messenger<
+  'TokensControllerInit',
+  AllowedInitializationActions,
+  AllowedInitializationEvents
 >;
 
 /**
@@ -63,13 +63,13 @@ export type TokensControllerInitMessenger = ReturnType<
  * @param rootMessenger - The root messenger.
  * @returns The TokensControllerInitMessenger.
  */
-export function getTokensControllerInitMessenger(rootMessenger: RootMessenger) {
-  const messenger = new Messenger<
-    'TokensControllerInit',
-    AllowedInitializationActions,
-    AllowedInitializationEvents,
-    RootMessenger
-  >({
+export function getTokensControllerInitMessenger(
+  rootMessenger: RootMessenger<
+    MessengerActions<TokensControllerInitMessenger>,
+    MessengerEvents<TokensControllerInitMessenger>
+  >,
+): TokensControllerInitMessenger {
+  const messenger: TokensControllerInitMessenger = new Messenger({
     namespace: 'TokensControllerInit',
     parent: rootMessenger,
   });

--- a/app/core/Engine/messengers/transak-service-messenger/transak-service-messenger.ts
+++ b/app/core/Engine/messengers/transak-service-messenger/transak-service-messenger.ts
@@ -17,15 +17,11 @@ type AllowedEvents = MessengerEvents<TransakServiceMessenger>;
  * @returns The TransakServiceMessenger.
  */
 export function getTransakServiceMessenger(
-  rootMessenger: RootMessenger,
+  rootMessenger: RootMessenger<AllowedActions, AllowedEvents>,
 ): TransakServiceMessenger {
-  return new Messenger<
-    'TransakService',
-    AllowedActions,
-    AllowedEvents,
-    typeof rootMessenger
-  >({
+  const messenger: TransakServiceMessenger = new Messenger({
     namespace: 'TransakService',
     parent: rootMessenger,
   });
+  return messenger;
 }


### PR DESCRIPTION
## **Description**

Apply the messenger type refactoring from PR #31467 to the messenger files owned by `@MetaMask/mobile-platform`. This is the final team in a series of per-team PRs (see #31969, #31971, #31973, #31974, #31977, #31978, #31979, #31980, #32005).

The refactoring:
- Narrows `rootMessenger` parameters from the unnarrowed `RootMessenger` to `RootMessenger<MessengerActions<X>, MessengerEvents<X>>`, making callers' requirements explicit in the type signature.
- Simplifies 4-param `new Messenger<N, A, E, Root>({...})` constructors to typed variable declarations (`const messenger: XMessenger = new Messenger({...})`), letting TypeScript infer the generic arguments.
- Converts `ReturnType<typeof getXInitMessenger>` type aliases to explicit `Messenger<'Namespace', Actions, Events>` types.
- Removes re-exports of package types from two messenger files (`ClientControllerMessenger`, `GeolocationControllerActions/Events`) — callers should import directly from the package.

Three files (`account-tracker-controller-messenger`, `multichain-routing-service-messenger`, `snap-account-service-messenger`) have package-defined action types that do not extend `GlobalActions` (the same structural mismatch as `SnapInterfaceControllerMessenger`). These use `Messenger<'Root', A, E>` directly in the parameter type to bypass the `extends GlobalActions` constraint on the `RootMessenger` type alias while still providing equivalent narrowing.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/31467

## **Manual testing steps**

N/A — type-only changes; no runtime behaviour altered.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only changes across messenger wiring; delegate action/event lists are unchanged, so runtime Engine behavior should be unaffected aside from stricter TypeScript at call sites.
> 
> **Overview**
> Applies the messenger typing refactor from #31467 across **mobile-platform** Engine messenger factories: callers must pass a **narrowed** `rootMessenger` (`RootMessenger<MessengerActions<X>, MessengerEvents<X>>` or equivalent) instead of an unnarrowed root, and child messengers are created via **typed** `const messenger: XMessenger = new Messenger({...})` rather than four-parameter `new Messenger<...>` generics.
> 
> **Init messenger** type aliases move from `ReturnType<typeof getXInitMessenger>` to explicit `Messenger<'Namespace', Actions, Events>`. Several factories that previously took **`RootExtendedMessenger`** now take **`RootMessenger`** with the same delegate wiring. **`ClientControllerMessenger`** and **Geolocation** action/event re-exports are removed from messenger modules (import from packages instead). Messenger tests import **`RootMessenger`** from `../types` instead of ad-hoc `ExtendedMessenger` / local root types.
> 
> **Exceptions:** `account-tracker-controller-messenger`, `multichain-routing-service-messenger`, and `snap-account-service-messenger` narrow the root parameter with `Messenger<'Root', Actions, Events>` where package action types do not satisfy `GlobalActions` on the `RootMessenger` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d73fd3e2bc1615ca416122fa85c456d78c52bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->