### PR TITLE
chore: copy changes for money account

### DIFF
--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.test.tsx
@@ -109,7 +109,7 @@ describe('MoneyPotentialEarnings', () => {
       getByText(strings('money.potential_earnings.title')),
     ).toBeOnTheScreen();
     const description = getByTestId(MoneyPotentialEarningsTestIds.TEXT);
-    expect(description).toHaveTextContent(/Convert your/);
+    expect(description).toHaveTextContent(/Add your/);
     expect(description).toHaveTextContent(/in one year\./);
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7061,7 +7061,7 @@
       "title": "How it works",
       "description_prefix": "Add mUSD and earn up to",
       "description_suffix": " (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime.",
-      "description_no_apy": "Add mUSD and earn APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."
+      "description_no_apy": "Add mUSD and earn APY. Your balance is dollar-backed and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "Add"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7061,7 +7061,7 @@
       "title": "How it works",
       "description_prefix": "Add mUSD and earn up to",
       "description_suffix": " (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime.",
-      "description_no_apy": "Add mUSD. Your balance is dollar-backed and ready to spend, trade, or send anytime."
+      "description_no_apy": "Add mUSD and earn APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "Add"
@@ -7075,7 +7075,7 @@
     "potential_earnings": {
       "title": "Earn on your crypto",
       "description": "See how your money can grow over time by converting your crypto to mUSD.",
-      "description_with_amounts_prefix": "Convert your {{total}} in assets and you could earn up to",
+      "description_with_amounts_prefix": "Add your {{total}} in assets and you could earn up to",
       "description_with_amounts_suffix": "in one year.",
       "add": "Add",
       "convert_cta": "Convert your crypto",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -6961,7 +6961,7 @@
       "title": "報酬獲得の仕組み",
       "description_prefix": "Add mUSD and earn up to",
       "description_suffix": " (変動制)。残高はドルの裏付けがあり、いつでも支払い、取引、送金に利用できます。",
-      "description_no_apy": "Add mUSD. Your balance is dollar-backed and ready to spend, trade, or send anytime."
+      "description_no_apy": "Add mUSD and earn APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "追加"

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -6961,7 +6961,7 @@
       "title": "報酬獲得の仕組み",
       "description_prefix": "Add mUSD and earn up to",
       "description_suffix": " (変動制)。残高はドルの裏付けがあり、いつでも支払い、取引、送金に利用できます。",
-      "description_no_apy": "Add mUSD and earn APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."
+      "description_no_apy": "Add mUSD and earn APY. Your balance is dollar-backed and ready to spend, trade, or send anytime."
     },
     "musd_row": {
       "add": "追加"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Updates Money account home screen copy to match the latest Figma designs (MUSD-1028).

Changes:
1. **"How it works" subcopy** — Updated the `description_no_apy` fallback from "Add mUSD. Your balance is dollar-backed…" to "Add mUSD and earn APY (variable). Your balance is dollar-backed…" so the no-APY state still mentions earning. The with-APY version already matched Figma.
2. **"Earn on your crypto" subcopy** — Changed `description_with_amounts_prefix` from "Convert your" to "Add your" to match Figma wording.
3. **"What you get" transfers copy** — Already matched Figma ("Send to any of your wallets across MetaMask"), no change needed.

Updated both `en.json` and `ja.json` locale files.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated Money account home screen copy to match latest designs

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1028

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account home screen copy

  Scenario: User views "How it works" section without APY loaded
    Given the user is on the Money home screen
    And APY data has not loaded yet

    When user views the "How it works" section
    Then the description reads "Add mUSD and earn APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."

  Scenario: User views "How it works" section with APY loaded
    Given the user is on the Money home screen
    And APY data has loaded (e.g. 4%)

    When user views the "How it works" section
    Then the description reads "Add mUSD and earn up to 4% APY (variable). Your balance is dollar-backed and ready to spend, trade, or send anytime."

  Scenario: User views "Earn on your crypto" section with eligible tokens
    Given the user is on the Money home screen
    And the user has tokens eligible for conversion

    When user views the "Earn on your crypto" section
    Then the description reads "Add your $X in assets and you could earn up to +$Y in one year."
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — copy-only change in locale JSON files.

### **After**

N/A — copy-only change in locale JSON files.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [[MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)](https://github.com/MetaMask/contributor-docs) and [[MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [[JSDoc](https://jsdoc.app/)](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [[labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A — locale string changes only, no runtime behavior change.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Locale-only copy and a matching test assertion; no business logic, navigation, or data handling changes.
> 
> **Overview**
> Updates **Money account home** user-facing strings in `en.json` and `ja.json` to match the latest Figma copy—no component or runtime logic changes.
> 
> **How it works:** The no-APY / loading fallback `money.how_it_works.description_no_apy` now says users can **add mUSD and earn APY** before the existing dollar-backed balance line (replacing the shorter “Add mUSD.”-only wording).
> 
> **Earn on your crypto:** `money.potential_earnings.description_with_amounts_prefix` changes from **“Convert your {{total}}…”** to **“Add your {{total}}…”**; `MoneyPotentialEarnings.test.tsx` is updated to assert **“Add your”** instead of **“Convert your”**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ee846e9c804a9ddc561b4c7b8597d69951dbbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->