### PR TITLE
fix(money-account): use celing division in getSharesForWithdrawal cp-8.0.0

### DIFF
--- a/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
@@ -136,29 +136,104 @@ describe('moneyAccountTransactions', () => {
   });
 
   describe('getSharesForWithdrawal', () => {
-    it('converts amount to shares using the rate', () => {
+    const SHARE_SCALAR = BigInt(1_000_000);
+
+    it('converts amount to shares at 1:1 rate (exact division)', () => {
       const amount = BigInt(1_000_000);
       const rate = BigInt(1_000_000);
+      // 1_000_000 * 1_000_000 / 1_000_000 = exact, ceiling = floor
       expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(1_000_000));
     });
 
-    it('scales down when rate is higher than 1:1', () => {
+    it('scales down when rate is higher than 1:1 (exact division)', () => {
       const amount = BigInt(1_000_000);
       const rate = BigInt(2_000_000);
+      // 1_000_000 * 1_000_000 / 2_000_000 = exact 500_000
       expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(500_000));
     });
 
-    it('scales up when rate is lower than 1:1', () => {
+    it('scales up when rate is lower than 1:1 (exact division)', () => {
       const amount = BigInt(2_000_000);
       const rate = BigInt(1_000_000);
       expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(2_000_000));
     });
 
-    it('handles large amounts without overflow', () => {
-      const amount = BigInt('1000000000000');
+    it('uses ceiling division — rounds up when remainder exists', () => {
+      // 1_000_000 * 1_000_000 = 1_000_000_000_000
+      // floor(1_000_000_000_000 / 3_000_000) = 333_333
+      // ceil should be 333_334
+      const amount = BigInt(1_000_000);
+      const rate = BigInt(3_000_000);
+      const floorResult = (amount * SHARE_SCALAR) / rate;
+      expect(floorResult).toBe(BigInt(333_333));
+      expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(333_334));
+    });
+
+    it('reproduces the exact reported scenario — $1.96 at rate ~1,000,094', () => {
+      // This was the failing case: floor division gave 1,959,815 shares,
+      // contract mulDivDown produced 1,959,999 assetsOut < 1,960,000 minimumAssets
+      const amount = BigInt(1_960_000); // $1.96 in 6 decimals
+      const rate = BigInt(1_000_094);
+
+      const floorShares = (amount * SHARE_SCALAR) / rate;
+      expect(floorShares).toBe(BigInt(1_959_815)); // old buggy value
+
+      const ceilShares = getSharesForWithdrawal(amount, rate);
+      expect(ceilShares).toBe(BigInt(1_959_816)); // fixed: one more share
+
+      // Verify: contract mulDivDown(ceilShares * rate / SCALAR) >= amount
+      const assetsOut = (ceilShares * rate) / SHARE_SCALAR;
+      expect(assetsOut).toBeGreaterThanOrEqual(amount);
+    });
+
+    it('reproduces the reported $1.00 scenario — was passing by luck', () => {
+      const amount = BigInt(1_000_000);
+      const rate = BigInt(1_000_094);
+
+      const floorShares = (amount * SHARE_SCALAR) / rate;
+      const ceilShares = getSharesForWithdrawal(amount, rate);
+
+      // With ceiling, we get at least as many shares as floor
+      expect(ceilShares).toBeGreaterThanOrEqual(floorShares);
+
+      // Contract-side check still passes
+      const assetsOut = (ceilShares * rate) / SHARE_SCALAR;
+      expect(assetsOut).toBeGreaterThanOrEqual(amount);
+    });
+
+    it('handles large amounts with ceiling division', () => {
+      const amount = BigInt('1000000000000'); // $1M in 6 decimals
       const rate = BigInt('1500000');
       const result = getSharesForWithdrawal(amount, rate);
-      expect(result).toBe((amount * BigInt(1_000_000)) / rate);
+      const floorResult = (amount * SHARE_SCALAR) / rate;
+      // Ceiling >= floor always
+      expect(result).toBeGreaterThanOrEqual(floorResult);
+      // And at most 1 more than floor
+      expect(result - floorResult).toBeLessThanOrEqual(1n);
+    });
+
+    it('ceiling division equals floor when division is exact', () => {
+      // 2_000_000 * 1_000_000 / 500_000 = 4_000_000_000 (exact)
+      const amount = BigInt(2_000_000);
+      const rate = BigInt(500_000);
+      const floorResult = (amount * SHARE_SCALAR) / rate;
+      expect(getSharesForWithdrawal(amount, rate)).toBe(floorResult);
+    });
+
+    it('returns 0 for zero amount', () => {
+      expect(getSharesForWithdrawal(0n, BigInt(1_000_000))).toBe(0n);
+    });
+
+    it('guarantees assetsOut >= amount for many rate values', () => {
+      // Fuzz-like: sweep a range of rates near 1:1
+      const amount = BigInt(1_960_000);
+      for (let r = 999_900; r <= 1_000_200; r++) {
+        const rate = BigInt(r);
+        const shares = getSharesForWithdrawal(amount, rate);
+        // Simulate contract mulDivDown
+        const assetsOut = (shares * rate) / SHARE_SCALAR;
+        expect(assetsOut).toBeGreaterThanOrEqual(amount);
+      }
     });
   });
 
@@ -563,6 +638,82 @@ describe('moneyAccountTransactions', () => {
       expect(result.transferTx.params.data.toLowerCase()).toContain(
         MOCK_RECIPIENT_ADDRESS.toLowerCase().slice(2),
       );
+    });
+
+    it('encodes minimumAssets as amount - 1 for defense-in-depth', async () => {
+      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
+
+      const amount = BigInt(1_960_000);
+      const result = await buildMoneyAccountWithdrawBatch({
+        amount,
+        chainId: MOCK_CHAIN_ID,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
+        recipient: MOCK_RECIPIENT_ADDRESS,
+        provider: MOCK_PROVIDER,
+      });
+
+      // Decode withdraw calldata to verify minimumAssets = amount - 1
+      const iface = new ethers.utils.Interface([
+        'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
+      ]);
+      const decoded = iface.decodeFunctionData(
+        'withdraw',
+        result.withdrawTx.params.data,
+      );
+      const encodedMinimumAssets = BigInt(decoded.minimumAssets.toString());
+      expect(encodedMinimumAssets).toBe(amount - 1n);
+    });
+
+    it('encodes minimumAssets as 0 when amount is 0 (placeholder batch)', async () => {
+      const result = await buildMoneyAccountWithdrawBatch({
+        amount: BigInt(0),
+        chainId: MOCK_CHAIN_ID,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
+        recipient: MOCK_RECIPIENT_ADDRESS,
+        provider: MOCK_PROVIDER,
+      });
+
+      const iface = new ethers.utils.Interface([
+        'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
+      ]);
+      const decoded = iface.decodeFunctionData(
+        'withdraw',
+        result.withdrawTx.params.data,
+      );
+      expect(BigInt(decoded.minimumAssets.toString())).toBe(0n);
+    });
+
+    it('uses ceiling division for shareAmount in withdraw calldata', async () => {
+      // Use a rate that produces a remainder to verify ceiling division
+      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000094'));
+
+      const amount = BigInt(1_960_000);
+      const result = await buildMoneyAccountWithdrawBatch({
+        amount,
+        chainId: MOCK_CHAIN_ID,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
+        recipient: MOCK_RECIPIENT_ADDRESS,
+        provider: MOCK_PROVIDER,
+      });
+
+      const iface = new ethers.utils.Interface([
+        'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
+      ]);
+      const decoded = iface.decodeFunctionData(
+        'withdraw',
+        result.withdrawTx.params.data,
+      );
+      const shareAmount = BigInt(decoded.shareAmount.toString());
+
+      // With ceiling division: (1_960_000 * 1_000_000 + 1_000_094 - 1) / 1_000_094 = 1_959_816
+      // Old floor division would give 1_959_815
+      expect(shareAmount).toBe(BigInt(1_959_816));
     });
   });
 

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -471,10 +471,13 @@ export async function buildMoneyAccountWithdrawBatch({
         );
   // Allow 1-unit slippage on minimumAssets as defense-in-depth against
   // rounding: the contract's mulDivDown can truncate assetsOut by up to
-  // 1 unit relative to the requested amount. The subsequent ERC-20
-  // transfer uses the original `amount`, so the 1-unit tolerance here
-  // does not affect how much the user receives — it only prevents a
-  // spurious revert from the teller's MinimumAssetsNotMet check.
+  // 1 unit relative to the requested amount. This tolerance is safe
+  // because ceiling division in getSharesForWithdrawal already guarantees
+  // assetsOut >= amount; the 1-unit slack here is a second line of
+  // defense, not a standalone fix. The subsequent ERC-20 transfer uses
+  // the original `amount`, so the tolerance does not affect how much the
+  // user receives — it only prevents a spurious revert from the teller's
+  // MinimumAssetsNotMet check.
   const minimumAssets = amount > 0n ? amount - 1n : 0n;
   const withdrawData = buildWithdrawData(
     musdAddress,

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -400,9 +400,14 @@ const SHARE_DECIMALS_SCALAR = BigInt(1_000_000);
 /**
  * Converts a USD asset amount (6 decimals) to vault shares given a pre-fetched rate.
  * Pure arithmetic — no I/O, safe to call directly inside workflows.
+ *
+ * Uses ceiling division so the contract's `mulDivDown(shares × rate / ONE_SHARE)`
+ * always produces `assetsOut >= minimumAssets`. Floor division caused a double-
+ * truncation bug where `assetsOut` could land 1 unit below `minimumAssets`,
+ * reverting with `MinimumAssetsNotMet`.
  */
 export function getSharesForWithdrawal(amount: bigint, rate: bigint): bigint {
-  return (amount * SHARE_DECIMALS_SCALAR) / rate;
+  return (amount * SHARE_DECIMALS_SCALAR + rate - 1n) / rate;
 }
 
 function buildWithdrawData(
@@ -464,11 +469,13 @@ export async function buildMoneyAccountWithdrawBatch({
           amount,
           await getVaultRate({ accountantAddress, provider }),
         );
-  // No slippage on minimumAssets — the exact amount is needed for the
-  // subsequent transfer. If the rate moves down between encoding and
-  // execution, the batch reverts atomically and the user retries with a
-  // fresh quote; we accept that over partial-fill fragility.
-  const minimumAssets = amount;
+  // Allow 1-unit slippage on minimumAssets as defense-in-depth against
+  // rounding: the contract's mulDivDown can truncate assetsOut by up to
+  // 1 unit relative to the requested amount. The subsequent ERC-20
+  // transfer uses the original `amount`, so the 1-unit tolerance here
+  // does not affect how much the user receives — it only prevents a
+  // spurious revert from the teller's MinimumAssetsNotMet check.
+  const minimumAssets = amount > 0n ? amount - 1n : 0n;
   const withdrawData = buildWithdrawData(
     musdAddress,
     shareAmount,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

mUSD withdrawals were failing intermittently with `TellerWithMultiAssetSupport__MinimumAssetsNotMet` (`0x9883d840`). The root cause is a double-truncation bug: `getSharesForWithdrawal()` uses BigInt floor division to compute the number of shares, and then the on-chain teller's `mulDivDown` floors again when converting shares back to assets. This causes `assetsOut` to land up to 1 base unit below `minimumAssets`, triggering a revert.

For example, a $1.96 withdrawal at rate ≈1,000,094 computed `shareAmount = 1,959,815` (floored), which the contract converted back to `assetsOut = 1,959,999` — 1 unit below the `minimumAssets` of `1,960,000`. A $1.00 withdrawal at the same rate passed only by coincidence (the double-floor happened to land exactly on the minimum).

This PR applies two defense-in-depth fixes in `moneyAccountTransactions.ts`:

1. **Ceiling division for shares**: `getSharesForWithdrawal` now uses `(amount * SCALAR + rate - 1n) / rate` instead of floor division, guaranteeing enough shares to cover the requested withdrawal amount after the contract's `mulDivDown`.
2. **1-unit slippage on `minimumAssets`**: `minimumAssets` is now set to `amount - 1n` (with a `0n` guard) instead of the exact `amount`. This tolerates any residual rounding error without affecting the user — the subsequent ERC-20 transfer still uses the original `amount`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug causing mUSD withdrawals to fail intermittently due to a rounding precision error

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1029

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: mUSD withdrawal rounding fix

  Scenario: user withdraws a non-round mUSD amount successfully
    Given the user has an mUSD money account with a balance of at least $5
    And the vault rate is not exactly 1:1

    When user initiates a withdrawal of $1.96
    Then the withdrawal transaction completes successfully
    And the user receives the expected USDC amount

  Scenario: user withdraws $1.00 successfully
    Given the user has an mUSD money account with a balance of at least $2

    When user initiates a withdrawal of $1.00
    Then the withdrawal transaction completes successfully

  Scenario: repeated withdrawals have a high success rate
    Given the user has an mUSD money account with sufficient balance

    When user performs 10+ withdrawals of varying amounts ($1.00, $1.50, $1.96, $2.50, $5.00)
    Then all withdrawal transactions complete successfully
    And none revert with MinimumAssetsNotMet
```

Joao Tavares' visual agent testing tool can be used to run withdrawals at volume against a branch to verify success rate (previously very low, should now be ~100%).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — This is a pure arithmetic fix in transaction encoding logic with no UI changes. Verification is via automated withdrawal testing and unit tests.

### **Before**

### **After**

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live withdrawal transaction encoding for money accounts; logic is narrow and well-tested but incorrect rounding could still affect on-chain success or slippage checks.
> 
> **Overview**
> Fixes intermittent mUSD withdrawal reverts from **`MinimumAssetsNotMet`** when floor division in **`getSharesForWithdrawal`** and on-chain **`mulDivDown`** both truncate, so **`assetsOut`** can sit one base unit below the encoded minimum.
> 
> **`getSharesForWithdrawal`** now uses **ceiling division** so share count is high enough that contract-side conversion back to assets meets the requested amount. **`buildMoneyAccountWithdrawBatch`** sets **`minimumAssets`** to **`amount - 1`** (or **`0`** for zero-amount placeholder batches) as a second guard; the follow-on ERC-20 transfer still uses the full **`amount`**, so payout to the user is unchanged.
> 
> Tests add the reported **$1.96** case, rate sweeps, and calldata checks for **`shareAmount`** and **`minimumAssets`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43d77dcb4c1d059bd5da2924957972ed6e7e58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->