### PR TITLE
fix: tooltip icon size on MM Pay confirmation review page

### DIFF
--- a/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.styles.ts
+++ b/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.styles.ts
@@ -33,6 +33,9 @@ const styleSheet = (params: { theme: Theme }) => {
       color: theme.colors.text.default,
       ...fontStyles.normal,
     },
+    iconButton: {
+      marginLeft: 4,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
+++ b/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
@@ -1,12 +1,10 @@
 import React, { ReactNode, useState } from 'react';
 import { HeaderStandard } from '@metamask/design-system-react-native';
-import { View, ViewStyle } from 'react-native';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../../../component-library/components/Buttons/ButtonIcon';
-import {
+import { TouchableOpacity, View, ViewStyle } from 'react-native';
+import Icon, {
   IconColor,
   IconName,
+  IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
@@ -18,7 +16,7 @@ interface TooltipProps {
   disabled?: boolean;
   iconColor?: IconColor;
   iconName?: IconName;
-  iconSize?: ButtonIconSizes;
+  iconSize?: IconSize;
   iconStyle?: ViewStyle;
   onPress?: () => void;
   title?: string;
@@ -64,6 +62,8 @@ export const TooltipModal = ({
   );
 };
 
+const TOOLTIP_HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
+
 const Tooltip = ({
   content,
   disabled,
@@ -72,10 +72,11 @@ const Tooltip = ({
   onPress,
   iconName = IconName.Info,
   iconColor = IconColor.Muted,
-  iconSize = ButtonIconSizes.Sm,
-  iconStyle = {},
+  iconSize = IconSize.Sm,
+  iconStyle,
 }: TooltipProps) => {
   const [open, setOpen] = useState(false);
+  const { styles } = useStyles(styleSheet, {});
 
   const handlePress = () => {
     if (disabled) return;
@@ -85,15 +86,15 @@ const Tooltip = ({
 
   return (
     <View>
-      <ButtonIcon
-        iconColor={iconColor}
-        iconName={iconName}
+      <TouchableOpacity
         onPress={handlePress}
         disabled={disabled}
-        size={iconSize}
+        hitSlop={TOOLTIP_HIT_SLOP}
         testID={`${tooltipTestId}-open-btn`}
-        style={iconStyle}
-      />
+        style={[styles.iconButton, iconStyle]}
+      >
+        <Icon name={iconName} size={iconSize} color={iconColor} />
+      </TouchableOpacity>
       <TooltipModal
         open={open}
         setOpen={setOpen}

--- a/app/components/Views/confirmations/components/status-icon/status-icon.tsx
+++ b/app/components/Views/confirmations/components/status-icon/status-icon.tsx
@@ -4,7 +4,6 @@ import Icon, {
   IconName,
   IconSize,
 } from '../../../../../component-library/components/Icons/Icon';
-import { ButtonIconSizes } from '../../../../../component-library/components/Buttons/ButtonIcon';
 import { useStyles } from '../../../../hooks/useStyles';
 import Tooltip from '../UI/Tooltip';
 import styleSheet from './status-icon.styles';
@@ -28,7 +27,7 @@ export function StatusIcon({
       <Tooltip
         iconColor={iconColour}
         iconName={iconName}
-        iconSize={ButtonIconSizes.Md}
+        iconSize={IconSize.Md}
         iconStyle={styles.tooltipIcon}
         tooltipTestId={STATUS_ICON_TOOLTIP_TEST_ID}
         content={tooltip}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fix tooltip icon size on MM Pay confirmation review page

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1578

## **Manual testing steps**
NA

## **Screenshots/Recordings**
<img width="397" height="854" alt="Screenshot 2026-06-19 at 3 58 46 PM" src="https://github.com/user-attachments/assets/5889d363-0998-4600-80e5-b538751075e3" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI change in confirmations Tooltip/StatusIcon with no auth, data, or API impact.
> 
> **Overview**
> Fixes **incorrect tooltip icon size** on the MM Pay confirmation review page by changing how the trigger is rendered.
> 
> The confirmations **`Tooltip`** no longer uses **`ButtonIcon`** (which was tying size to button chrome). It now uses a **`TouchableOpacity`** wrapping the shared **`Icon`** component, with **`iconSize`** typed as **`IconSize`** instead of **`ButtonIconSizes`**. A small **`iconButton`** style (`marginLeft: 4`) and **`hitSlop`** keep layout and tap targets reasonable.
> 
> **`StatusIcon`** passes **`IconSize.Md`** into **`Tooltip`** for error tooltips, matching the non-tooltip status icons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 754004f5908f12f48348e706316d270ee244e558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->