### PR TITLE
fix(confirmations): show skeleton until required token resolves

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -24,9 +24,10 @@ import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransact
 import { AssetType } from '../../../types/token';
 import {
   useTransactionPayFiatPayment,
-  useTransactionPayRequiredTokens,
   useIsTransactionPayLoading,
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
 import { strings } from '../../../../../../../locales/i18n';
@@ -225,6 +226,10 @@ describe('CustomAmountInfo', () => {
     useTransactionPayRequiredTokens,
   );
 
+  const useTransactionPayPrimaryRequiredTokenMock = jest.mocked(
+    useTransactionPayPrimaryRequiredToken,
+  );
+
   const useTransactionPayAvailableTokensMock = jest.mocked(
     useTransactionPayAvailableTokens,
   );
@@ -345,6 +350,9 @@ describe('CustomAmountInfo', () => {
       hasTokens: true,
     });
     useTransactionPayRequiredTokensMock.mockReturnValue([REQUIRED_TOKEN_MOCK]);
+    useTransactionPayPrimaryRequiredTokenMock.mockReturnValue(
+      REQUIRED_TOKEN_MOCK,
+    );
     useConfirmActionsMock.mockReturnValue({
       onConfirm: jest.fn(),
       onReject: jest.fn(),
@@ -385,7 +393,7 @@ describe('CustomAmountInfo', () => {
 
   describe('awaiting required token', () => {
     it('renders the skeleton when pay is enabled but no primary required token is resolved', () => {
-      useTransactionPayRequiredTokensMock.mockReturnValue([]);
+      useTransactionPayPrimaryRequiredTokenMock.mockReturnValue(undefined);
 
       const { getByTestId, queryByTestId, queryByText } = render({
         disablePay: false,
@@ -405,6 +413,7 @@ describe('CustomAmountInfo', () => {
           skipIfBalance: true,
         },
       ]);
+      useTransactionPayPrimaryRequiredTokenMock.mockReturnValue(undefined);
 
       const { getByTestId, queryByTestId } = render({ disablePay: false });
 
@@ -413,18 +422,22 @@ describe('CustomAmountInfo', () => {
     });
 
     it('does not render the skeleton when pay is disabled and no primary required token is resolved', () => {
-      useTransactionPayRequiredTokensMock.mockReturnValue([]);
+      useTransactionPayPrimaryRequiredTokenMock.mockReturnValue(undefined);
 
       const { getByTestId, queryByTestId } = render({ disablePay: true });
 
-      expect(getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK)).toBeOnTheScreen();
+      expect(
+        getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK),
+      ).toBeOnTheScreen();
       expect(queryByTestId('custom-amount-skeleton')).toBeNull();
     });
 
     it('renders the full UI once a primary required token is resolved', () => {
       const { getByTestId, queryByTestId } = render({ disablePay: false });
 
-      expect(getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK)).toBeOnTheScreen();
+      expect(
+        getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK),
+      ).toBeOnTheScreen();
       expect(queryByTestId('custom-amount-skeleton')).toBeNull();
     });
   });

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -432,6 +432,27 @@ describe('CustomAmountInfo', () => {
       expect(queryByTestId('custom-amount-skeleton')).toBeNull();
     });
 
+    it.each([TransactionType.predictWithdraw, TransactionType.perpsWithdraw])(
+      'does not render the skeleton for %s even when no primary required token is resolved',
+      (transactionType) => {
+        useTransactionPayPrimaryRequiredTokenMock.mockReturnValue(undefined);
+        useTransactionMetadataRequestMock.mockReturnValue({
+          type: transactionType,
+          txParams: { from: '0x123' },
+        } as never);
+
+        const { getByTestId, queryByTestId } = render({
+          disablePay: false,
+          transactionType,
+        });
+
+        expect(
+          getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK),
+        ).toBeOnTheScreen();
+        expect(queryByTestId('custom-amount-skeleton')).toBeNull();
+      },
+    );
+
     it('renders the full UI once a primary required token is resolved', () => {
       const { getByTestId, queryByTestId } = render({ disablePay: false });
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -176,6 +176,11 @@ jest.mock('../../../../../UI/Ramp/hooks/useRampsPaymentMethods', () => ({
 
 const TOKEN_ADDRESS_MOCK = '0x123' as Hex;
 const CHAIN_ID_MOCK = '0x1' as Hex;
+const REQUIRED_TOKEN_MOCK = {
+  address: TOKEN_ADDRESS_MOCK,
+  chainId: CHAIN_ID_MOCK,
+  skipIfBalance: false,
+} as TransactionPayRequiredToken;
 
 function render(
   props: CustomAmountInfoProps & { transactionType?: TransactionType } = {},
@@ -339,7 +344,7 @@ describe('CustomAmountInfo', () => {
       availableTokens: [{}] as AssetType[],
       hasTokens: true,
     });
-    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useTransactionPayRequiredTokensMock.mockReturnValue([REQUIRED_TOKEN_MOCK]);
     useConfirmActionsMock.mockReturnValue({
       onConfirm: jest.fn(),
       onReject: jest.fn(),
@@ -376,6 +381,52 @@ describe('CustomAmountInfo', () => {
   it('does not render payment token if disablePay', () => {
     const { queryByText } = render({ disablePay: true });
     expect(queryByText('TST')).toBeNull();
+  });
+
+  describe('awaiting required token', () => {
+    it('renders the skeleton when pay is enabled but no primary required token is resolved', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+      const { getByTestId, queryByTestId, queryByText } = render({
+        disablePay: false,
+      });
+
+      expect(getByTestId('custom-amount-skeleton')).toBeOnTheScreen();
+      expect(getByTestId('pay-token-amount-skeleton')).toBeOnTheScreen();
+      expect(getByTestId('pay-with-row-skeleton')).toBeOnTheScreen();
+      expect(queryByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK)).toBeNull();
+      expect(queryByText('123.45')).toBeNull();
+    });
+
+    it('renders the skeleton when only skipIfBalance required tokens are resolved', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          ...REQUIRED_TOKEN_MOCK,
+          skipIfBalance: true,
+        },
+      ]);
+
+      const { getByTestId, queryByTestId } = render({ disablePay: false });
+
+      expect(getByTestId('custom-amount-skeleton')).toBeOnTheScreen();
+      expect(queryByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK)).toBeNull();
+    });
+
+    it('does not render the skeleton when pay is disabled and no primary required token is resolved', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+      const { getByTestId, queryByTestId } = render({ disablePay: true });
+
+      expect(getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK)).toBeOnTheScreen();
+      expect(queryByTestId('custom-amount-skeleton')).toBeNull();
+    });
+
+    it('renders the full UI once a primary required token is resolved', () => {
+      const { getByTestId, queryByTestId } = render({ disablePay: false });
+
+      expect(getByTestId(CustomAmountInfoTestIds.BOTTOM_BLOCK)).toBeOnTheScreen();
+      expect(queryByTestId('custom-amount-skeleton')).toBeNull();
+    });
   });
 
   it('renders alert', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -153,7 +153,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const selectedFiatPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const hasPaymentOption = hasAvailableTokens || isFiatAvailable;
-    const isAwaitingRequiredToken = !disablePay && !primaryRequiredToken;
+    const isWithdraw = isTransactionPayWithdraw(transactionMeta);
+
+    // Withdraw flows never have required tokens (user receives, not pays),
+    // so only gate on primaryRequiredToken for deposit/swap flows.
+    const isAwaitingRequiredToken =
+      !disablePay && !isWithdraw && !primaryRequiredToken;
+
     const fiatEverSelectedRef = useRef(false);
     if (selectedFiatPaymentMethodId) {
       fiatEverSelectedRef.current = true;
@@ -162,7 +168,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       hideAccountSelector && !fiatEverSelectedRef.current;
     const transactionId = transactionMeta?.id;
     const accountOverride = useTransactionAccountOverride();
-    const isWithdraw = isTransactionPayWithdraw(transactionMeta);
 
     const isResultReady = useIsResultReady({ isKeyboardVisible });
     const quotes = useTransactionPayQuotes();

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -34,6 +34,7 @@ import {
 import {
   useIsTransactionPayLoading,
   useTransactionPayFiatPayment,
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
@@ -147,10 +148,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const [isKeyboardVisible, setIsKeyboardVisible] = useState(true);
     const { hasTokens: hasAvailableTokens } =
       useTransactionPayAvailableTokens();
-    const requiredTokens = useTransactionPayRequiredTokens();
-    const primaryRequiredToken = requiredTokens.find(
-      (token) => !token.skipIfBalance,
-    );
+    const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
     const fiatPayment = useTransactionPayFiatPayment();
     const selectedFiatPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
     const isFiatAvailable = useIsFiatPaymentAvailable();

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -147,10 +147,15 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const [isKeyboardVisible, setIsKeyboardVisible] = useState(true);
     const { hasTokens: hasAvailableTokens } =
       useTransactionPayAvailableTokens();
+    const requiredTokens = useTransactionPayRequiredTokens();
+    const primaryRequiredToken = requiredTokens.find(
+      (token) => !token.skipIfBalance,
+    );
     const fiatPayment = useTransactionPayFiatPayment();
     const selectedFiatPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const hasPaymentOption = hasAvailableTokens || isFiatAvailable;
+    const isAwaitingRequiredToken = !disablePay && !primaryRequiredToken;
     const fiatEverSelectedRef = useRef(false);
     if (selectedFiatPaymentMethodId) {
       fiatEverSelectedRef.current = true;
@@ -245,6 +250,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       supportAccountSelection && !accountOverride;
 
     const { headlessBuyError } = useConfirmationContext();
+
+    if (!transactionMeta || isAwaitingRequiredToken) {
+      return <CustomAmountInfoSkeleton />;
+    }
 
     return (
       <Box style={styles.container}>

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.test.ts
@@ -17,6 +17,7 @@ import {
   useTransactionPayIsMaxAmount,
   useTransactionPayIsPostQuote,
   useTransactionPayFiatPayment,
+  useTransactionPayPrimaryRequiredToken,
 } from './useTransactionPayData';
 import { cloneDeep, merge } from 'lodash';
 import {
@@ -99,6 +100,31 @@ describe('useTransactionPayData', () => {
       renderHookWithProvider(useTransactionPayRequiredTokens, { state }).result
         .current,
     ).toStrictEqual([REQUIRED_TOKEN_MOCK]);
+  });
+
+  it('returns the primary required token', () => {
+    expect(
+      renderHookWithProvider(useTransactionPayPrimaryRequiredToken, { state })
+        .result.current,
+    ).toStrictEqual(REQUIRED_TOKEN_MOCK);
+  });
+
+  it('ignores skipIfBalance required tokens for the primary required token', () => {
+    const updatedState = cloneDeep(state);
+    updatedState.engine.backgroundState.TransactionPayController.transactionData[
+      transactionIdMock
+    ].tokens = [
+      {
+        ...REQUIRED_TOKEN_MOCK,
+        skipIfBalance: true,
+      },
+    ];
+
+    expect(
+      renderHookWithProvider(useTransactionPayPrimaryRequiredToken, {
+        state: updatedState,
+      }).result.current,
+    ).toBeUndefined();
   });
 
   it('returns source amounts', () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayData.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import {
@@ -19,6 +20,15 @@ export function useTransactionPayQuotes() {
 
 export function useTransactionPayRequiredTokens() {
   return useTransactionPayData(selectTransactionPayTokensByTransactionId);
+}
+
+export function useTransactionPayPrimaryRequiredToken() {
+  const requiredTokens = useTransactionPayRequiredTokens();
+
+  return useMemo(
+    () => requiredTokens?.find((token) => !token.skipIfBalance),
+    [requiredTokens],
+  );
 }
 
 export function useTransactionPaySourceAmounts() {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -22,8 +22,8 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { Json } from '@metamask/utils';
 import {
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
-  useTransactionPayRequiredTokens,
   useTransactionPayFiatPayment,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
@@ -91,8 +91,8 @@ describe('useTransactionPayMetrics', () => {
   const updateConfirmationMetricMock = jest.mocked(updateConfirmationMetric);
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
 
-  const useTransactionPayRequiredTokensMock = jest.mocked(
-    useTransactionPayRequiredTokens,
+  const useTransactionPayPrimaryRequiredTokenMock = jest.mocked(
+    useTransactionPayPrimaryRequiredToken,
   );
 
   const useTransactionPayAvailableTokensMock = jest.mocked(
@@ -122,11 +122,9 @@ describe('useTransactionPayMetrics', () => {
       setPayToken: noop as never,
     });
 
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        amountHuman: TOKEN_AMOUNT_MOCK,
-      } as TransactionPayRequiredToken,
-    ]);
+    useTransactionPayPrimaryRequiredTokenMock.mockReturnValue({
+      amountHuman: TOKEN_AMOUNT_MOCK,
+    } as TransactionPayRequiredToken);
 
     updateConfirmationMetricMock.mockReturnValue({
       type: 'test',

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -14,8 +14,8 @@ import { useTransactionPayToken } from './useTransactionPayToken';
 import { BridgeToken } from '../../../../UI/Bridge/types';
 import { hasTransactionType } from '../../utils/transaction';
 import {
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
-  useTransactionPayRequiredTokens,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { useAccountTokens } from '../send/useAccountTokens';
@@ -62,9 +62,7 @@ export function useTransactionPayMetrics() {
     [tokens],
   );
 
-  const primaryRequiredToken = useTransactionPayRequiredTokens().find(
-    (t) => !t.skipIfBalance,
-  );
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
   const sendingValue = Number(primaryRequiredToken?.amountHuman ?? '0');
 
   if (!automaticPayToken.current && payToken) {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -14,7 +14,7 @@ import { RootState } from '../../../../../reducers';
 import { selectTransactionPaymentTokenByTransactionId } from '../../../../../selectors/transactionPayController';
 import { updateTransaction } from '../../../../../util/transaction-controller';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { useTransactionPayRequiredTokens } from './useTransactionPayData';
+import { useTransactionPayPrimaryRequiredToken } from './useTransactionPayData';
 import { hasTransactionType } from '../../utils/transaction';
 import Logger from '../../../../../util/Logger';
 
@@ -30,10 +30,7 @@ export function useTransactionPayToken(): {
     selectTransactionPaymentTokenByTransactionId(state, transactionId),
   );
 
-  const requiredTokens = useTransactionPayRequiredTokens();
-  const primaryRequiredToken = (requiredTokens ?? []).find(
-    (token) => !token.skipIfBalance,
-  );
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
   const isNative =
     payToken && payToken?.address === getNativeTokenAddress(payToken?.chainId);


### PR DESCRIPTION
## **Description**

The custom amount confirmation can render before `TransactionPayController` has resolved its primary required token. In that state, the amount entry and Pay With controls can appear against incomplete Pay state.

This PR keeps the existing custom amount skeleton visible while Pay is enabled and no non-`skipIfBalance` required token has resolved. Once the primary required token is present, the normal custom amount UI renders; flows with `disablePay` continue to bypass Pay gating.

## **Changelog**

CHANGELOG entry: Fixed a bug where some custom amount confirmations could show payment controls before token requirements finished loading

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Custom amount loading state

  Scenario: required token is still loading
    Given a custom amount confirmation with MetaMask Pay enabled
    And TransactionPayController has not resolved a primary required token

    When the confirmation renders
    Then the custom amount skeleton is shown
    And the amount input and Pay With content are hidden

  Scenario: required token has loaded
    Given a custom amount confirmation with MetaMask Pay enabled
    And TransactionPayController has resolved a primary required token

    When the confirmation renders
    Then the normal custom amount UI is shown
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
