### PR TITLE
refactor(perps): replace platform primitives with MMDS equivalents

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -3,7 +3,6 @@ import {
   Keyboard,
   Platform,
   ScrollView,
-  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -17,6 +16,7 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Input,
   TextVariant,
   TextColor,
   Text,
@@ -85,11 +85,11 @@ const PerpsTPSLView: React.FC = () => {
   // Keypad state management
   const [focusedInput, setFocusedInput] = useState<string | null>(null);
 
-  // Refs for TextInput components to programmatically blur them
-  const takeProfitPriceRef = useRef<TextInput>(null);
-  const takeProfitPercentageRef = useRef<TextInput>(null);
-  const stopLossPriceRef = useRef<TextInput>(null);
-  const stopLossPercentageRef = useRef<TextInput>(null);
+  // Refs for Input components to programmatically blur them
+  const takeProfitPriceRef = useRef<React.ElementRef<typeof Input>>(null);
+  const takeProfitPercentageRef = useRef<React.ElementRef<typeof Input>>(null);
+  const stopLossPriceRef = useRef<React.ElementRef<typeof Input>>(null);
+  const stopLossPercentageRef = useRef<React.ElementRef<typeof Input>>(null);
 
   // Guard: when we programmatically dismiss the native keyboard on iOS,
   // the TextInput fires onBlur. We store the *specific* input being
@@ -659,9 +659,11 @@ const PerpsTPSLView: React.FC = () => {
                 >
                   {strings('perps.tpsl.usd_label')}
                 </Text>
-                <TextInput
+                <Input
                   ref={takeProfitPriceRef}
                   testID={PerpsTPSLViewSelectorsIDs.TAKE_PROFIT_PRICE_INPUT}
+                  isStateStylesDisabled
+                  twClassName="bg-transparent border-0"
                   style={styles.input}
                   value={takeProfitPrice}
                   onChangeText={(text) => {
@@ -672,7 +674,7 @@ const PerpsTPSLView: React.FC = () => {
                   placeholder={strings('perps.tpsl.trigger_price_placeholder')}
                   placeholderTextColor={colors.text.muted}
                   showSoftInputOnFocus={false}
-                  editable={!inputsDisabled}
+                  isDisabled={inputsDisabled}
                   onFocus={() => {
                     handleInputFocus('takeProfitPrice');
                   }}
@@ -696,8 +698,10 @@ const PerpsTPSLView: React.FC = () => {
                   !isValid && takeProfitError && styles.inputError,
                 ]}
               >
-                <TextInput
+                <Input
                   ref={takeProfitPercentageRef}
+                  isStateStylesDisabled
+                  twClassName="bg-transparent border-0"
                   style={styles.input}
                   value={formattedTakeProfitPercentage}
                   onChangeText={(text) => {
@@ -708,7 +712,7 @@ const PerpsTPSLView: React.FC = () => {
                   placeholder={strings('perps.tpsl.profit_roe_placeholder')}
                   placeholderTextColor={colors.text.muted}
                   showSoftInputOnFocus={false}
-                  editable={!inputsDisabled}
+                  isDisabled={inputsDisabled}
                   onFocus={() => {
                     handleInputFocus('takeProfitPercentage');
                   }}
@@ -845,9 +849,11 @@ const PerpsTPSLView: React.FC = () => {
                 >
                   {strings('perps.tpsl.usd_label')}
                 </Text>
-                <TextInput
+                <Input
                   ref={stopLossPriceRef}
                   testID={PerpsTPSLViewSelectorsIDs.STOP_LOSS_PRICE_INPUT}
+                  isStateStylesDisabled
+                  twClassName="bg-transparent border-0"
                   style={styles.input}
                   value={stopLossPrice}
                   onChangeText={(text) => {
@@ -858,7 +864,7 @@ const PerpsTPSLView: React.FC = () => {
                   placeholder={strings('perps.tpsl.trigger_price_placeholder')}
                   placeholderTextColor={colors.text.muted}
                   showSoftInputOnFocus={false}
-                  editable={!inputsDisabled}
+                  isDisabled={inputsDisabled}
                   onFocus={() => {
                     handleInputFocus('stopLossPrice');
                   }}
@@ -882,8 +888,10 @@ const PerpsTPSLView: React.FC = () => {
                   !isValid && stopLossError && styles.inputError,
                 ]}
               >
-                <TextInput
+                <Input
                   ref={stopLossPercentageRef}
+                  isStateStylesDisabled
+                  twClassName="bg-transparent border-0"
                   style={styles.input}
                   value={formattedStopLossPercentage}
                   onChangeText={(text) => {
@@ -894,7 +902,7 @@ const PerpsTPSLView: React.FC = () => {
                   placeholder={strings('perps.tpsl.loss_roe_placeholder')}
                   placeholderTextColor={colors.text.muted}
                   showSoftInputOnFocus={false}
-                  editable={!inputsDisabled}
+                  isDisabled={inputsDisabled}
                   onFocus={() => {
                     handleInputFocus('stopLossPercentage');
                   }}

--- a/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx
+++ b/app/components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, Platform, TouchableOpacity, View } from 'react-native';
-import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { PerpsAmountDisplaySelectorsIDs } from '../../Perps.testIds';
 import Text, {
   TextColor,
@@ -103,9 +103,7 @@ const PerpsAmountDisplay: React.FC<PerpsAmountDisplayProps> = ({
       <View style={styles.amountRow}>
         {/* Text only takes 1 arg */}
         {isLoading ? (
-          <SkeletonPlaceholder>
-            <SkeletonPlaceholder.Item width={80} height={20} borderRadius={4} />
-          </SkeletonPlaceholder>
+          <Skeleton width={80} height={20} />
         ) : (
           <Text
             testID={PerpsAmountDisplaySelectorsIDs.AMOUNT_LABEL}

--- a/app/components/UI/Perps/components/PerpsHomeHeader/PerpsHomeHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeHeader/PerpsHomeHeader.test.tsx
@@ -38,9 +38,18 @@ jest.mock('../../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('@metamask/design-system-react-native', () => {
-  const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
+  const { View, TouchableOpacity, Text, TextInput } =
+    jest.requireActual('react-native');
   return {
     Box: View,
+    Input: ({
+      isStateStylesDisabled: _isStateStylesDisabled,
+      twClassName: _twClassName,
+      ...props
+    }: {
+      isStateStylesDisabled?: boolean;
+      twClassName?: string;
+    }) => <TextInput {...props} />,
     BoxFlexDirection: { Row: 'row' },
     BoxAlignItems: { Center: 'center' },
     BoxFlexWrap: { Wrap: 'wrap' },

--- a/app/components/UI/Perps/components/PerpsHomeHeader/PerpsHomeHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsHomeHeader/PerpsHomeHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { View, TouchableOpacity, TextInput, Pressable } from 'react-native';
+import { View, TouchableOpacity, Pressable } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import {
@@ -12,6 +12,7 @@ import {
   IconColor,
   IconName,
   IconSize,
+  Input,
   Text,
   TextColor,
   TextVariant,
@@ -134,12 +135,14 @@ const PerpsHomeHeader: React.FC<PerpsHomeHeaderProps> = ({
               color={IconColor.IconAlternative}
               style={tw.style('mr-2')}
             />
-            <TextInput
+            <Input
               value={searchQuery}
               onChangeText={onSearchQueryChange}
               placeholder={strings('perps.search_by_token_symbol')}
               placeholderTextColor={colors.text.muted}
               autoFocus
+              isStateStylesDisabled
+              twClassName="flex-1 bg-transparent border-0"
               style={tw.style('flex-1 text-base text-default')}
               testID={testID ? `${testID}-search-bar` : undefined}
             />

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -27,24 +27,13 @@ jest.mock('react-native-gesture-handler', () => ({
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
-// Mock SkeletonPlaceholder
-jest.mock('react-native-skeleton-placeholder', () => {
+// Mock MMDS Skeleton so loading states are queryable by a stable testID
+jest.mock('../../../../../component-library/components-temp/Skeleton', () => {
   const { View } = jest.requireActual('react-native');
-  const MockSkeletonPlaceholder = ({
-    children,
-  }: {
-    children: React.ReactNode;
-  }) => <View testID="skeleton-placeholder">{children}</View>;
-
-  MockSkeletonPlaceholder.Item = (props: {
-    width: number | string;
-    height: number;
-    borderRadius: number;
-  }) => <View testID="skeleton-item" {...props} />;
-
   return {
-    __esModule: true,
-    default: MockSkeletonPlaceholder,
+    Skeleton: (props: { width?: number | string; height?: number }) => (
+      <View testID="skeleton-placeholder" {...props} />
+    ),
   };
 });
 

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -46,7 +46,7 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
-import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { createStyles } from './PerpsLeverageBottomSheet.styles';
 import { usePerpsLivePrices } from '../../hooks';
 import {
@@ -708,13 +708,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
             />
             <View style={styles.warningTextContainer}>
               {isRecalculating ? (
-                <SkeletonPlaceholder>
-                  <SkeletonPlaceholder.Item
-                    width="80%"
-                    height={14}
-                    borderRadius={4}
-                  />
-                </SkeletonPlaceholder>
+                <Skeleton width="80%" height={14} />
               ) : (
                 <Text
                   variant={TextVariant.BodySm}
@@ -744,13 +738,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
                 </Text>
                 <View style={styles.priceValueContainer}>
                   {isRecalculating ? (
-                    <SkeletonPlaceholder>
-                      <SkeletonPlaceholder.Item
-                        width={80}
-                        height={16}
-                        borderRadius={4}
-                      />
-                    </SkeletonPlaceholder>
+                    <Skeleton width={80} height={16} />
                   ) : (
                     <Text
                       variant={TextVariant.BodyMd}


### PR DESCRIPTION
## **Description**

Replaces platform/3rd-party UI primitives with MetaMask Design System (MMDS) equivalents in the Perps feature, per TAT-2917. This is a non-behavioral refactor that aligns Perps with the design system while preserving visual and functional parity.

**What changed**

- **`SkeletonPlaceholder` → MMDS `Skeleton`** (via the repo's `components-temp/Skeleton` wrapper):
  - `PerpsAmountDisplay.tsx` (loading state)
  - `PerpsLeverageBottomSheet.tsx` (liquidation warning + price, 2 usages)
- **`react-native` `TextInput` → MMDS `Input`** (default chrome neutralized with `isStateStylesDisabled` + transparent/border-0 `twClassName` to keep pixel parity):
  - `PerpsHomeHeader.tsx` (search bar)
  - `PerpsTPSLView.tsx` (4 inputs: TP price/%, SL price/%). Ref types updated to `React.ElementRef<typeof Input>` and `editable` mapped to `isDisabled`.

**Out of scope (intentionally deferred)**

`Image`/`Svg` → `ImageOrSvg` and `FlatList`/`FlashList` → MMDS list equivalents were investigated and deferred: `ImageOrSvg` is not exported from the MMDS barrel, and the list swaps carry higher regression risk than fits this refactor. Scope was limited to high-confidence Skeleton/Input swaps within Perps, iOS-validated.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2917

## **Manual testing steps**

```gherkin
Feature: Perps MMDS primitives

  Scenario: Search bar uses MMDS Input
    Given the user is on the Perps home screen
    When the user opens the token search and types a symbol
    Then the search filters tokens exactly as before with no visual change

  Scenario: TP/SL inputs use MMDS Input
    Given the user opens the Take Profit / Stop Loss screen
    When the user edits the price and percentage fields via the keypad
    Then values update and validation (5 significant-figure cap) behaves as before

  Scenario: Loading skeletons use MMDS Skeleton
    Given amounts/leverage are recalculating
    Then the skeleton placeholders render in the same positions as before
```

## **Screenshots/Recordings**

### **Before**

<!-- Visual parity maintained; behavior unchanged from the previous primitives. -->

### **After**

<!-- iOS screenshots attached: Perps home, search bar (empty + typed), TP/SL view. -->
| Screen | Description |
| --- | --- |
| <!-- drag after_perps_home.png here --> <img width="1206" height="2622" alt="after_perps_home" src="https://github.com/user-attachments/assets/2f4fd2f4-3fe9-42c5-bda8-25bf33d44861" /> | Perps home with MMDS components |
|  <img width="1206" height="2622" alt="after_search_bar" src="https://github.com/user-attachments/assets/abb733dc-a891-4fe3-9212-bff6c28aac8e" /> | Search bar (MMDS Input) — empty |
| <img width="1206" height="2622" alt="after_search_typed" src="https://github.com/user-attachments/assets/27b9b562-2b35-4468-890b-8a1b1d6d8907" /> | Search bar (MMDS Input) — typed query |
| <img width="1206" height="2622" alt="tpsl_state" src="https://github.com/user-attachments/assets/58091baf-3516-4ffb-a1f2-17f9adc14ddb" /> | TP/SL view — MMDS Input fields |
| <img width="1206" height="2622" alt="tpsl_after_tap" src="https://github.com/user-attachments/assets/8c8ab48e-fec6-403b-a160-10e9aa9fda23" /> | TP/SL — keypad interaction, validation intact |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only primitive swaps in Perps with explicit visual parity props; no auth, payments, or trading logic changes.
> 
> **Overview**
> Perps screens swap **react-native** `TextInput` and **react-native-skeleton-placeholder** for MetaMask Design System **`Input`** and the repo **`Skeleton`** wrapper so the feature matches MMDS without changing trading behavior.
> 
> **`Input`** is used on the home search bar and on all four TP/SL fields (price and ROE %). Default MMDS chrome is turned off via `isStateStylesDisabled` and transparent `twClassName` so layout stays the same; `editable` becomes `isDisabled`, and refs use `React.ElementRef<typeof Input>` for programmatic blur/keypad flow.
> 
> **`Skeleton`** replaces nested placeholder items in amount loading and leverage liquidation recalculation (warning line + price). Unit tests mock MMDS `Input` as `TextInput` and point skeleton mocks at `components-temp/Skeleton` with the same `skeleton-placeholder` testID where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21f8090cddf98a3a490f4d5d4a09b515c4fea49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->