### PR TITLE
fix(money): show no-fee badge for mUSD on Monad in Earn on your crypto cp-8.0.0

### DIFF
--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
@@ -37,10 +37,11 @@ interface MoneyPotentialEarningsProps {
   apy: number | undefined;
   /**
    * Returns true when the given token qualifies for a subsidised (no-fee)
-   * deposit. Used to render the "No fee" badge on each token row. Sourced from
-   * the `confirmations_relay_fixed_spread` remote feature flag via
-   * useMoneyEarnableTokens — tokens that are a subsidised source (Relay
-   * sponsors the gas) are tagged.
+   * deposit into the Money account (target: Monad mUSD). Used to render the
+   * "No fee" badge on each token row. Sourced from the
+   * `confirmations_relay_fixed_spread` remote feature flag via
+   * useMoneyEarnableTokens — tokens with a route into Monad mUSD, plus Monad
+   * mUSD itself, are tagged.
    */
   isNoFeeToken?: (token: AssetType) => boolean;
   onTokenCardPress?: (

--- a/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
+++ b/app/components/UI/Money/components/MoneyPotentialEarnings/MoneyPotentialEarnings.tsx
@@ -37,11 +37,10 @@ interface MoneyPotentialEarningsProps {
   apy: number | undefined;
   /**
    * Returns true when the given token qualifies for a subsidised (no-fee)
-   * deposit into the Money account (target: Monad mUSD). Used to render the
-   * "No fee" badge on each token row. Sourced from the
-   * `confirmations_relay_fixed_spread` remote feature flag via
-   * useMoneyEarnableTokens — only tokens with a directional route to Monad
-   * mUSD are tagged.
+   * deposit. Used to render the "No fee" badge on each token row. Sourced from
+   * the `confirmations_relay_fixed_spread` remote feature flag via
+   * useMoneyEarnableTokens — tokens that are a subsidised source (Relay
+   * sponsors the gas) are tagged.
    */
   isNoFeeToken?: (token: AssetType) => boolean;
   onTokenCardPress?: (

--- a/app/components/UI/Money/hooks/useMoneyEarnableTokens.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyEarnableTokens.test.ts
@@ -66,6 +66,21 @@ const RELAY_CONFIG_WITH_MUSD_SOURCE_DEPOSIT: RelayFixedSpreadConfig = {
   ],
 };
 
+/**
+ * Withdraw route: Monad mUSD -> eth USDC. mUSD is a subsidized source here
+ * even though the target is NOT Monad mUSD — Relay still sponsors the gas.
+ */
+const RELAY_CONFIG_WITH_MUSD_WITHDRAW_ROUTE: RelayFixedSpreadConfig = {
+  routes: [
+    {
+      sourceChain: CHAIN_IDS.MONAD,
+      sourceToken: MUSD_TOKEN_ADDRESS, // Monad mUSD
+      targetChain: '0x1',
+      targetToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // eth USDC
+    },
+  ],
+};
+
 const EMPTY_RELAY_CONFIG: RelayFixedSpreadConfig = { routes: [] };
 
 const makeToken = (overrides: Partial<AssetType> = {}): AssetType =>
@@ -293,8 +308,8 @@ describe('useMoneyEarnableTokens', () => {
     });
   });
 
-  describe('isNoFeeToken — directional Monad mUSD route match', () => {
-    it('returns true for a token with a subsidized route TO Monad mUSD', () => {
+  describe('isNoFeeToken — subsidized source match (Relay gas sponsorship)', () => {
+    it('returns true for a token that is a subsidized deposit source', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectMetaMaskPayTokensFlags) return DEFAULT_PAY_FLAGS;
         if (selector === selectRelayFixedSpread)
@@ -328,6 +343,27 @@ describe('useMoneyEarnableTokens', () => {
       const { result } = renderHook(() => useMoneyEarnableTokens());
 
       expect(result.current.isNoFeeToken(ethMusd)).toBe(true);
+    });
+
+    it('returns true for mUSD on Monad when it is a subsidized source on a non-mUSD route (withdraw)', () => {
+      const monadMusd = makeToken({
+        address: MUSD_TOKEN_ADDRESS,
+        symbol: 'mUSD',
+        chainId: CHAIN_IDS.MONAD,
+        fiat: { balance: 500, currency: 'usd', conversionRate: 1 },
+      });
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectMetaMaskPayTokensFlags) return DEFAULT_PAY_FLAGS;
+        if (selector === selectRelayFixedSpread)
+          return RELAY_CONFIG_WITH_MUSD_WITHDRAW_ROUTE;
+        if (selector === selectMoneyDepositMinBalance) return 0.01;
+        return undefined;
+      });
+      mockUseAccountTokens.mockReturnValue([monadMusd]);
+
+      const { result } = renderHook(() => useMoneyEarnableTokens());
+
+      expect(result.current.isNoFeeToken(monadMusd)).toBe(true);
     });
 
     it('returns false when the relay config has no routes', () => {

--- a/app/components/UI/Money/hooks/useMoneyEarnableTokens.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyEarnableTokens.test.ts
@@ -67,8 +67,8 @@ const RELAY_CONFIG_WITH_MUSD_SOURCE_DEPOSIT: RelayFixedSpreadConfig = {
 };
 
 /**
- * Withdraw route: Monad mUSD -> eth USDC. mUSD is a subsidized source here
- * even though the target is NOT Monad mUSD — Relay still sponsors the gas.
+ * Withdraw route: Monad mUSD -> eth USDC. Monad mUSD appears only as a source
+ * (no route INTO Monad mUSD), so the directional match alone would not tag it.
  */
 const RELAY_CONFIG_WITH_MUSD_WITHDRAW_ROUTE: RelayFixedSpreadConfig = {
   routes: [
@@ -77,6 +77,22 @@ const RELAY_CONFIG_WITH_MUSD_WITHDRAW_ROUTE: RelayFixedSpreadConfig = {
       sourceToken: MUSD_TOKEN_ADDRESS, // Monad mUSD
       targetChain: '0x1',
       targetToken: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // eth USDC
+    },
+  ],
+};
+
+/**
+ * Deposit route into a NON-Monad mUSD: Linea USDC -> Linea mUSD. Linea USDC is
+ * a subsidized source, but its target is Linea mUSD, not Monad mUSD — so a
+ * Money deposit (which always targets Monad mUSD) is not subsidized.
+ */
+const RELAY_CONFIG_WITH_NON_MONAD_DEPOSIT: RelayFixedSpreadConfig = {
+  routes: [
+    {
+      sourceChain: '0xe708',
+      sourceToken: '0x176211869ca2b568f2a7d4ee941e073a821ee1ff', // Linea USDC
+      targetChain: '0xe708',
+      targetToken: MUSD_TOKEN_ADDRESS, // Linea mUSD
     },
   ],
 };
@@ -308,8 +324,8 @@ describe('useMoneyEarnableTokens', () => {
     });
   });
 
-  describe('isNoFeeToken — subsidized source match (Relay gas sponsorship)', () => {
-    it('returns true for a token that is a subsidized deposit source', () => {
+  describe('isNoFeeToken — directional Monad mUSD route match', () => {
+    it('returns true for a token with a subsidized route TO Monad mUSD', () => {
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectMetaMaskPayTokensFlags) return DEFAULT_PAY_FLAGS;
         if (selector === selectRelayFixedSpread)
@@ -345,7 +361,7 @@ describe('useMoneyEarnableTokens', () => {
       expect(result.current.isNoFeeToken(ethMusd)).toBe(true);
     });
 
-    it('returns true for mUSD on Monad when it is a subsidized source on a non-mUSD route (withdraw)', () => {
+    it('returns true for Monad mUSD even though the flag has no Monad mUSD -> Monad mUSD route', () => {
       const monadMusd = makeToken({
         address: MUSD_TOKEN_ADDRESS,
         symbol: 'mUSD',
@@ -364,6 +380,27 @@ describe('useMoneyEarnableTokens', () => {
       const { result } = renderHook(() => useMoneyEarnableTokens());
 
       expect(result.current.isNoFeeToken(monadMusd)).toBe(true);
+    });
+
+    it('returns false for a subsidized source whose route target is NOT Monad mUSD', () => {
+      const lineaUsdc = makeToken({
+        address: '0x176211869ca2b568f2a7d4ee941e073a821ee1ff',
+        symbol: 'USDC',
+        chainId: '0xe708',
+        fiat: { balance: 500, currency: 'usd', conversionRate: 1 },
+      });
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectMetaMaskPayTokensFlags) return DEFAULT_PAY_FLAGS;
+        if (selector === selectRelayFixedSpread)
+          return RELAY_CONFIG_WITH_NON_MONAD_DEPOSIT;
+        if (selector === selectMoneyDepositMinBalance) return 0.01;
+        return undefined;
+      });
+      mockUseAccountTokens.mockReturnValue([lineaUsdc]);
+
+      const { result } = renderHook(() => useMoneyEarnableTokens());
+
+      expect(result.current.isNoFeeToken(lineaUsdc)).toBe(false);
     });
 
     it('returns false when the relay config has no routes', () => {

--- a/app/components/UI/Money/hooks/useMoneyEarnableTokens.ts
+++ b/app/components/UI/Money/hooks/useMoneyEarnableTokens.ts
@@ -1,13 +1,12 @@
 import { useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import { TransactionType, CHAIN_IDS } from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import { useAccountTokens } from '../../../Views/confirmations/hooks/send/useAccountTokens';
 import {
   isTokenBlocked,
   getBlockedTokensForTransactionType,
 } from '../../../Views/confirmations/utils/transaction-pay';
-import { isSubsidizedRoute } from '../../../Views/confirmations/utils/relayFixedSpread';
-import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
+import { isSubsidizedSource } from '../../../Views/confirmations/utils/relayFixedSpread';
 import {
   selectMetaMaskPayTokensFlags,
   selectRelayFixedSpread,
@@ -18,16 +17,6 @@ import { safeFormatChainIdToHex } from '../../Card/util/safeFormatChainIdToHex';
 
 const isEvmToken = (token: AssetType) =>
   Boolean(token.accountType?.includes('eip155'));
-
-/**
- * Money deposits ALWAYS convert TO Monad mUSD. The no-fee tag must match a
- * subsidized route whose TARGET is Monad mUSD — NOT merely a token that is a
- * subsidized source on some other route (e.g. a withdraw mUSD->USDC route).
- */
-const MONAD_MUSD_TARGET = {
-  address: MUSD_TOKEN_ADDRESS,
-  chainId: CHAIN_IDS.MONAD,
-};
 
 /**
  * Returns tokens the user holds that are eligible for Money account deposits
@@ -43,9 +32,10 @@ const MONAD_MUSD_TARGET = {
  *
  * Sort: fiat balance descending.
  *
- * isNoFeeToken: true only when the token has a subsidized route whose target
- * is Monad mUSD (i.e. the deposit destination). Source-only matching is
- * intentionally avoided — see MONAD_MUSD_TARGET above.
+ * isNoFeeToken: true when the token is a subsidized source in the Relay
+ * fixed-spread config. Relay sponsors the gas, which is paid on the source
+ * token's chain, so the tag is keyed to the source — matching the token
+ * picker (usePayWithNoFeeToken / useMoneyNoFeeTokens) so both surfaces agree.
  */
 export const useMoneyEarnableTokens = () => {
   const payTokensFlags = useSelector(selectMetaMaskPayTokensFlags);
@@ -65,14 +55,10 @@ export const useMoneyEarnableTokens = () => {
   const isNoFeeToken = useCallback(
     (token: AssetType) =>
       Boolean(token.chainId) &&
-      isSubsidizedRoute(
-        relayFixedSpread,
-        {
-          address: token.address,
-          chainId: safeFormatChainIdToHex(token.chainId as string),
-        },
-        MONAD_MUSD_TARGET,
-      ),
+      isSubsidizedSource(relayFixedSpread, {
+        address: token.address,
+        chainId: safeFormatChainIdToHex(token.chainId as string),
+      }),
     [relayFixedSpread],
   );
 

--- a/app/components/UI/Money/hooks/useMoneyEarnableTokens.ts
+++ b/app/components/UI/Money/hooks/useMoneyEarnableTokens.ts
@@ -1,12 +1,13 @@
 import { useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import { TransactionType } from '@metamask/transaction-controller';
+import { TransactionType, CHAIN_IDS } from '@metamask/transaction-controller';
 import { useAccountTokens } from '../../../Views/confirmations/hooks/send/useAccountTokens';
 import {
   isTokenBlocked,
   getBlockedTokensForTransactionType,
 } from '../../../Views/confirmations/utils/transaction-pay';
-import { isSubsidizedSource } from '../../../Views/confirmations/utils/relayFixedSpread';
+import { isSubsidizedRoute } from '../../../Views/confirmations/utils/relayFixedSpread';
+import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
 import {
   selectMetaMaskPayTokensFlags,
   selectRelayFixedSpread,
@@ -17,6 +18,27 @@ import { safeFormatChainIdToHex } from '../../Card/util/safeFormatChainIdToHex';
 
 const isEvmToken = (token: AssetType) =>
   Boolean(token.accountType?.includes('eip155'));
+
+/**
+ * Money deposits ALWAYS convert TO Monad mUSD. The no-fee tag matches a
+ * subsidized route whose TARGET is Monad mUSD — NOT merely a token that is a
+ * subsidized source on some other route (e.g. a USDC -> Linea mUSD deposit or
+ * a Monad mUSD -> USDC withdraw), which would mislabel tokens that have no
+ * subsidized route into Monad mUSD.
+ */
+const MONAD_MUSD_TARGET = {
+  address: MUSD_TOKEN_ADDRESS,
+  chainId: CHAIN_IDS.MONAD,
+};
+
+/**
+ * Monad mUSD -> Monad mUSD needs no swap or bridge, so the fixed-spread SSOT
+ * flag omits it; depositing Monad mUSD still incurs no Relay fee, so it is
+ * tagged no-fee explicitly.
+ */
+const isMonadMusd = (address: string, chainId: string) =>
+  chainId.toLowerCase() === MONAD_MUSD_TARGET.chainId.toLowerCase() &&
+  address.toLowerCase() === MONAD_MUSD_TARGET.address.toLowerCase();
 
 /**
  * Returns tokens the user holds that are eligible for Money account deposits
@@ -32,10 +54,8 @@ const isEvmToken = (token: AssetType) =>
  *
  * Sort: fiat balance descending.
  *
- * isNoFeeToken: true when the token is a subsidized source in the Relay
- * fixed-spread config. Relay sponsors the gas, which is paid on the source
- * token's chain, so the tag is keyed to the source — matching the token
- * picker (usePayWithNoFeeToken / useMoneyNoFeeTokens) so both surfaces agree.
+ * isNoFeeToken: true when the token has a subsidized route whose target is
+ * Monad mUSD, or when the token IS Monad mUSD (see isMonadMusd above).
  */
 export const useMoneyEarnableTokens = () => {
   const payTokensFlags = useSelector(selectMetaMaskPayTokensFlags);
@@ -53,12 +73,18 @@ export const useMoneyEarnableTokens = () => {
   );
 
   const isNoFeeToken = useCallback(
-    (token: AssetType) =>
-      Boolean(token.chainId) &&
-      isSubsidizedSource(relayFixedSpread, {
-        address: token.address,
-        chainId: safeFormatChainIdToHex(token.chainId as string),
-      }),
+    (token: AssetType) => {
+      if (!token.chainId) return false;
+      const chainId = safeFormatChainIdToHex(token.chainId as string);
+      return (
+        isMonadMusd(token.address, chainId) ||
+        isSubsidizedRoute(
+          relayFixedSpread,
+          { address: token.address, chainId },
+          MONAD_MUSD_TARGET,
+        )
+      );
+    },
     [relayFixedSpread],
   );
 

--- a/app/components/UI/Money/hooks/useMoneyEarnableTokens.ts
+++ b/app/components/UI/Money/hooks/useMoneyEarnableTokens.ts
@@ -37,8 +37,8 @@ const MONAD_MUSD_TARGET = {
  * tagged no-fee explicitly.
  */
 const isMonadMusd = (address: string, chainId: string) =>
-  chainId.toLowerCase() === MONAD_MUSD_TARGET.chainId.toLowerCase() &&
-  address.toLowerCase() === MONAD_MUSD_TARGET.address.toLowerCase();
+  chainId?.toLowerCase() === MONAD_MUSD_TARGET.chainId.toLowerCase() &&
+  address?.toLowerCase() === MONAD_MUSD_TARGET.address.toLowerCase();
 
 /**
  * Returns tokens the user holds that are eligible for Money account deposits


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

mUSD on Monad did not show a "No fee" label in the "Earn on your crypto" section, even though depositing it into the Money account incurs no Relay fixed-spread fee.

`useMoneyEarnableTokens` tags a token as no-fee using a **directional** match against the `confirmations_relay_fixed_spread` SSOT flag: the token must have a subsidized route whose **target** is Monad mUSD (a Money deposit always converts into Monad mUSD). This is correct by construction — it never mislabels tokens that are subsidized into a different output (e.g. `Linea USDC -> Linea mUSD`, or the `Monad mUSD -> USDC` withdraw direction).

The one gap: Monad mUSD itself. The flag omits `Monad mUSD -> Monad mUSD` because no swap or bridge is needed when source and target are the same — so the directional match never tags it, despite the deposit being fee-free. This PR adds Monad mUSD as an explicit no-fee case in the hook. It knowingly steps outside the SSOT flag for this single edge case; see the inline comment.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed mUSD on Monad not showing the "No fee" label in the "Earn on your crypto" section.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1030

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: No-fee label on mUSD in Earn on your crypto

  Scenario: Monad mUSD shows the No fee badge
    Given I hold mUSD on the Monad network

    When I view the "Earn on your crypto" section
    Then the Monad mUSD row shows the "No fee" label

  Scenario: a token subsidized only into a non-Monad mUSD is not mislabeled
    Given I hold a token whose only subsidized route targets a non-Monad mUSD

    When I view the "Earn on your crypto" section
    Then that token row does NOT show the "No fee" label
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Money UI labeling logic with added unit tests; no changes to payments, auth, or transaction execution.
> 
> **Overview**
> **Earn on your crypto** now shows the **No fee** badge on **Monad mUSD** when depositing into the Money account.
> 
> `useMoneyEarnableTokens` still marks tokens only when the relay fixed-spread config has a subsidized route whose **target** is Monad mUSD. It adds an explicit **Monad mUSD** case because that same-token path is omitted from the SSOT flag even though the deposit is fee-free.
> 
> Tests lock in that withdraw-only Monad mUSD routes do not rely on directional matching alone, and that sources subsidized only into non-Monad mUSD (e.g. Linea) stay **not** no-fee.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95b660ca220ac06ab6048a2b6301b81bf643c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->