### PR TITLE
fix(money): transaction details fee section incorrectly showing paid by metamask cp-8.0.0

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-fee-section/transaction-details-fee-section.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-fee-section/transaction-details-fee-section.test.tsx
@@ -49,7 +49,7 @@ describe('TransactionDetailsFeeSection', () => {
         type: TransactionType.musdConversion,
         metamaskPay: {
           networkFeeFiat: '0',
-          bridgeFeeFiat: '2.00',
+          bridgeFeeFiat: '0',
         },
       } as unknown as TransactionMeta,
     });
@@ -80,6 +80,29 @@ describe('TransactionDetailsFeeSection', () => {
       getByText(strings('transaction_details.label.transaction_fees')),
     ).toBeDefined();
     expect(getByText(strings('transactions.paid_by_metamask'))).toBeDefined();
+  });
+
+  it('renders both fee rows individually when gas is sponsored but a bridge fee is charged', () => {
+    useIsMoneyAccountContextMock.mockReturnValue(true);
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        type: TransactionType.musdConversion,
+        metamaskPay: {
+          networkFeeFiat: '0',
+          bridgeFeeFiat: '0.89',
+        },
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText, queryByText } = render();
+
+    expect(
+      getByText(strings('transaction_details.label.network_fee')),
+    ).toBeDefined();
+    expect(
+      getByText(strings('transaction_details.label.bridge_fee')),
+    ).toBeDefined();
+    expect(queryByText(strings('transactions.paid_by_metamask'))).toBeNull();
   });
 
   it('renders both fee rows when not sponsored', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-fee-section/transaction-details-fee-section.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-fee-section/transaction-details-fee-section.tsx
@@ -30,13 +30,15 @@ export function TransactionDetailsFeeSection() {
   const isMoneyContext = useIsMoneyAccountContext();
 
   const { metamaskPay } = transactionMeta;
-  const { networkFeeFiat: payNetworkFeeFiat } = metamaskPay || {};
+  const { networkFeeFiat: payNetworkFeeFiat, bridgeFeeFiat: payBridgeFeeFiat } =
+    metamaskPay || {};
 
   const isSponsored =
     isMoneyContext &&
     hasTransactionType(transactionMeta, SPONSORED_FEE_TYPES) &&
     payNetworkFeeFiat !== undefined &&
-    new BigNumber(payNetworkFeeFiat).isZero();
+    new BigNumber(payNetworkFeeFiat).isZero() &&
+    new BigNumber(payBridgeFeeFiat ?? 0).isZero();
 
   if (isSponsored) {
     return (


### PR DESCRIPTION
## **Description**

Fixes a bug where the "Paid by MetaMask" label was incorrectly shown on the transaction details fee section for Money Account deposits that had a non-zero bridge/service fee.

The `isSponsored` condition in `TransactionDetailsFeeSection` only checked whether the network (gas) fee was zero, ignoring the bridge fee entirely. This caused the fee section to collapse into a single "Paid by MetaMask" row even when the user was still charged a bridge fee (e.g. $0.89), hiding the real cost while the Total row still reflected it.

The fix aligns the activity view with the confirmation screen's contract (`useIsPaidByMetaMask`): the unified "Paid by MetaMask" row now only renders when **both** the network fee and the bridge fee are zero. When gas is sponsored but a bridge fee is charged, the individual fee rows render with their real amounts instead.

## **Changelog**

CHANGELOG entry: Fixed a bug where "Paid by MetaMask" was incorrectly displayed on transaction details when a bridge fee was still charged

## **Related issues**

Fixes: Follow-up to #31908

## **Manual testing steps**

```gherkin
Feature: Transaction Details Fee Section - Paid by MetaMask

  Scenario: Fully sponsored deposit shows "Paid by MetaMask"
    Given I have completed a Money Account deposit where both network and bridge fees are zero
    When I view the transaction details from the Money Account activity list
    Then I see a single "Transaction fees" row showing "Paid by MetaMask" with a green checkmark

  Scenario: Partially sponsored deposit shows individual fee rows
    Given I have completed a Convert Crypto deposit where gas was sponsored but a bridge fee was charged
    When I view the transaction details from the Money Account activity list
    Then I see a "Network fee" row showing "$0.00"
    And I see a "Bridge fee" row showing the actual bridge fee amount (e.g. "$0.89")
    And I do NOT see "Paid by MetaMask"
    And the "Total" row correctly reflects the deposit amount plus the bridge fee
```

## **Screenshots/Recordings**

### **Before**

<img width="452" height="966" alt="Screenshot 2026-06-19 at 16 37 23" src="https://github.com/user-attachments/assets/dc735813-3be3-46e8-871c-d8f254990b6b" />

### **After**

<img width="439" height="955" alt="Screenshot 2026-06-19 at 17 00 06" src="https://github.com/user-attachments/assets/a0644ca6-3c09-4599-a1a2-a1b02830162c" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.