### PR TITLE
chore: bump network-controller to v34 force failover build

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
   },
   "resolutions": {
     "@metamask/perps-controller": "^9.0.0",
-    "@metamask/network-controller": "33.0.0",
+    "@metamask/network-controller": "34.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.5",
     "@appium/schema/json-schema": "^0.4.0",
@@ -310,7 +310,7 @@
     "@metamask/multichain-network-controller": "^3.1.0",
     "@metamask/multichain-transactions-controller": "^7.1.0",
     "@metamask/native-utils": "^0.8.0",
-    "@metamask/network-controller": "^33.0.0",
+    "@metamask/network-controller": "^34.0.0",
     "@metamask/network-enablement-controller": "^5.3.0",
     "@metamask/notification-services-controller": "^24.2.0",
     "@metamask/permission-controller": "^13.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9356,9 +9356,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:33.0.0":
-  version: 33.0.0
-  resolution: "@metamask/network-controller@npm:33.0.0"
+"@metamask/network-controller@npm:34.0.0":
+  version: 34.0.0
+  resolution: "@metamask/network-controller@npm:34.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/connectivity-controller": "npm:^0.2.0"
@@ -9380,7 +9380,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/656cc33da4afc17b76623ed286ceac72035810eae467f4389f97aaf37376adc4e6d1e31facf4d26aca469f8ee5ab6217b982f10ae8777616019ff6d9ed7c1a67
+  checksum: 10/6afb874ca5702e1be616bf6ea92b35332d1969878794ce118138ca8f3733a1521a266d00bb658cf7a37e126545ac942ef5bc09bbd64159612b5424d848dbdc67
   languageName: node
   linkType: hard
 
@@ -35475,7 +35475,7 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^3.1.0"
     "@metamask/multichain-transactions-controller": "npm:^7.1.0"
     "@metamask/native-utils": "npm:^0.8.0"
-    "@metamask/network-controller": "npm:^33.0.0"
+    "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/network-enablement-controller": "npm:^5.3.0"
     "@metamask/notification-services-controller": "npm:^24.2.0"
     "@metamask/object-multiplex": "npm:^1.1.0"


### PR DESCRIPTION
## **Description**

Bumps the `@metamask/network-controller` preview build to `34.0.0`.

RPC failover is now controlled by a single remote feature flag, `corePlatformRpcFailoverMode`, a string with three values: `disabled` (failover off), `enabled` (divert to the failover URLs when the primary endpoint is unavailable), and `forced` (Infura endpoints that have failover URLs route all traffic, including block tracker polling, to those failover URLs, bypassing Infura entirely). `forced` is the emergency kill switch for when the automatic failover logic itself misbehaves.

No app code changes are needed: network-controller reads the flag through `RemoteFeatureFlagController`, and the networks already carry failover URLs. This is a breaking bump to the network-controller major (33.0.0); the controller no longer reads `walletFrameworkRpcFailoverEnabled`.

Core PR: https://github.com/MetaMask/core/pull/9175

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-1112

## **Manual testing steps**

```gherkin
Feature: Forced RPC failover

  Scenario: forced mode routes Infura traffic to the failover endpoint
    Given corePlatformRpcFailoverMode is set to forced
    And the selected network is an Infura network with failover URLs configured
    When the app makes RPC requests on that network
    Then the requests go to the failover endpoint and not to Infura

  Scenario: disabled mode keeps Infura
    Given corePlatformRpcFailoverMode is disabled
    When the app makes RPC requests on an Infura network
    Then the requests go to Infura as usual
```

## **Screenshots/Recordings**

N/A, dependency bump with no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major bump to core networking/RPC routing logic can affect all chain reads and transactions when remote flags change, though the mobile diff itself is only a version pin with no local code updates.
> 
> **Overview**
> **Dependency-only change:** bumps `@metamask/network-controller` from **33.0.0** to **34.0.0** in `package.json` (direct dependency and `resolutions`) and refreshes `yarn.lock`. There are **no mobile app source changes** in this PR.
> 
> The new major brings **RPC failover** behavior controlled remotely via `corePlatformRpcFailoverMode` (`disabled` / `enabled` / `forced`) through `RemoteFeatureFlagController`, replacing the old `walletFrameworkRpcFailoverEnabled` flag. In **`forced`** mode, Infura networks with failover URLs can route all RPC traffic (including block tracker polling) to failover endpoints. Existing network configs with failover URLs are expected to work without app wiring changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9596e22e2ef84b97da20894ba8366c07144c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->