### PR TITLE
fix: Switch to Fit.Layout with layoutScaleFactor for Money Rive animations cp-8.0.0

### DIFF
--- a/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
+++ b/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { BackHandler, Platform } from 'react-native';
+import { BackHandler, PixelRatio, Platform } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { type StackNavigationProp } from '@react-navigation/stack';
 import { Accelerometer } from 'expo-sensors';
@@ -311,7 +311,8 @@ const MoneyFirstTimeDepositView = () => {
       source={MoneyFirstTimeDepositAnimationWithParallaxV2}
       artboardName={RIVE_ARTBOARD_NAME}
       dataBinding={AutoBind(true)}
-      fit={Fit.FitWidth}
+      fit={Fit.Layout}
+      layoutScaleFactor={PixelRatio.get()}
       onError={handleError}
       testID={MoneyFirstTimeDepositViewTestIds.RIVE_ANIMATION}
     />

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -22,6 +22,7 @@ import Rive, {
 } from 'rive-react-native';
 import { MoneyOnboardingViewTestIds } from './MoneyOnboardingView.testIds';
 import { selectIsUsUnauthenticatedNonCardholder } from '../../selectors/eligibility';
+import { PixelRatio } from 'react-native';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import-x/no-commonjs
 const MoneyOnboardingAnimationV6 = require('../../../../../animations/money_account_onboarding_animation_v6.riv');
@@ -261,7 +262,8 @@ const MoneyOnboardingView = () => {
       artboardName={RIVE_ARTBOARD_NAME}
       stateMachineName={RIVE_STATE_MACHINE_NAME}
       dataBinding={AutoBind(true)}
-      fit={Fit.FitWidth}
+      fit={Fit.Layout}
+      layoutScaleFactor={PixelRatio.get()}
       onStateChanged={handleStateChanged}
       testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
     />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Updated the `fit` to `Fit.Layout` for the Money Onboarding and first time deposit animations.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated the `fit` to `Fit.Layout` for the Money Onboarding and first time deposit animations.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1031: Money Onboarding Rive animation overlaps with iPhone's Dynamic island](https://consensyssoftware.atlassian.net/browse/MUSD-1031)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Onboarding doesn't clash with system navbar, dynamic island (iPhone only), or bottom navbar.

  Scenario: user onboard to Money account
    Given user hasn't seen the Money onboarding before

    When user enters onboarding flow
    Then system (OS) top and bottom bars aren't interfering with Rive animation
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="960" height="1280" alt="image" src="https://github.com/user-attachments/assets/ef426eb0-065a-4659-9082-84fb6d7f6fde" />

### **After**

<!-- [screenshots/recordings] -->
<img width="828" height="1792" alt="image" src="https://github.com/user-attachments/assets/5484949c-66d1-441e-84e4-7e1b3749dc7b" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Rive fit props on two Money screens; no auth, data, or navigation logic changes.
> 
> **Overview**
> Fixes Money onboarding and first-time deposit Rive screens overlapping the system UI (e.g. iPhone Dynamic Island) by changing how the animation is fitted to the viewport.
> 
> Both `MoneyOnboardingView` and `MoneyFirstTimeDepositView` now use **`Fit.Layout`** with **`layoutScaleFactor={PixelRatio.get()}`** instead of **`Fit.FitWidth`**, so layout authored in the Rive file can respect safe areas rather than stretching edge-to-edge by width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be3f0b3c6729baaf5e85b372f455f623f1f37b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->