### PR TITLE
fix: ARC bridge/swap USDC hide max button + cleanup

### DIFF
--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
@@ -5,12 +5,12 @@ import {
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { useLatestBalance } from '../useLatestBalance';
-import { ethers } from 'ethers';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { BigNumber } from 'bignumber.js';
 import { isNumberValue } from '../../../../../util/number';
+import { parseUnitsSafe } from '../../utils/parseUnitSafe';
 
 interface Props {
   quote: ReturnType<typeof useBridgeQuoteData>['activeQuote'];
@@ -62,10 +62,7 @@ export const useHasSufficientGas = ({ quote }: Props): boolean | null => {
 
   const atomicGasFee =
     effectiveGasFee && !isGasless
-      ? ethers.utils.parseUnits(
-          effectiveGasFee,
-          sourceChainNativeAsset?.decimals,
-        )
+      ? parseUnitsSafe(effectiveGasFee, sourceChainNativeAsset?.decimals)
       : null;
 
   return gasTokenBalance?.atomicBalance && atomicGasFee

--- a/app/components/UI/Bridge/hooks/useHasSufficientGasEvenIfGasIncludedOrSponsored/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGasEvenIfGasIncludedOrSponsored/index.ts
@@ -5,12 +5,12 @@ import {
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { useLatestBalance } from '../useLatestBalance';
-import { ethers } from 'ethers';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { BigNumber } from 'bignumber.js';
 import { isNumberValue } from '../../../../../util/number/bigint';
+import { parseUnitsSafe } from '../../utils/parseUnitSafe';
 
 interface Props {
   quote: ReturnType<typeof useBridgeQuoteData>['activeQuote'];
@@ -56,7 +56,7 @@ export const useHasSufficientGasEvenIfGasIncludedOrSponsored = ({
       : null;
 
   const atomicGasFee = effectiveGasFee
-    ? ethers.utils.parseUnits(effectiveGasFee, sourceChainNativeAsset?.decimals)
+    ? parseUnitsSafe(effectiveGasFee, sourceChainNativeAsset?.decimals)
     : null;
 
   return gasTokenBalance?.atomicBalance && atomicGasFee

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -36,6 +36,8 @@ import { getTokenIconUrl } from '../../utils';
 import { toHex } from '@metamask/controller-utils';
 import {
   formatAddressToAssetId,
+  getNativeAssetForChainId,
+  isNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { isTradableToken } from '../../utils/isTradableToken';
@@ -205,11 +207,29 @@ export const useTokensWithBalance: ({
       return [...acc, chainId as Hex];
     }, [] as Hex[]);
 
-    const allEvmAccountTokens = (
+    const rawEvmAccountTokens = (
       Object.values(evmAccountTokensAcrossChains).flat() as TokenI[]
     )
       .filter((token) => evmChainIds.includes(token.chainId as Hex))
       .filter((token) => !token.isStaked);
+
+    // Bridge-controller is the source of truth for native-asset decimals (e.g.
+    // Arc's native gas asset is USDC at 6 decimals, not the 18 some chains
+    // assume). TokensController may have stale/incorrect decimals cached for
+    // native addresses; correct it here BEFORE any balance math runs, so the
+    // computed balance string and the decimals field never diverge.
+    const allEvmAccountTokens = rawEvmAccountTokens.map((token) => {
+      const chainId = token.chainId as Hex | CaipChainId;
+      if (!isNativeAddress(token.address)) {
+        return token;
+      }
+      try {
+        const bridgeNative = getNativeAssetForChainId(chainId);
+        return { ...token, decimals: bridgeNative.decimals };
+      } catch {
+        return token;
+      }
+    });
 
     const allNonEvmAccountTokens = Object.values(nonEvmTokens)
       .flat()
@@ -268,7 +288,7 @@ export const useTokensWithBalance: ({
         return {
           address: normalizeTokenAddress(token.address, chainId),
           name: token.name,
-          decimals: token.decimals,
+          decimals: token.decimals, // already corrected upstream for native addresses
           symbol: token.isETH ? 'ETH' : token.symbol, // TODO: not sure why symbol is ETHEREUM, will also break the token icon for ETH
           chainId,
           image: tokenImage,

--- a/app/components/UI/Bridge/utils/parseUnitSafe.ts
+++ b/app/components/UI/Bridge/utils/parseUnitSafe.ts
@@ -1,0 +1,28 @@
+import { ethers } from 'ethers';
+import { BigNumber } from 'bignumber.js';
+
+/**
+ * Parses a decimal amount string into atomic units, safely handling cases where
+ * the amount has more fractional precision than the token's decimals support.
+ * Rounds up (away from zero) when truncation is needed, so amounts representing
+ * a required/threshold value are never under-counted.
+ *
+ * @param amount - The decimal amount string (may exceed `decimals` precision)
+ * @param decimals - The token's decimal precision
+ * @returns The atomic-unit BigNumber, or null if amount/decimals are unavailable
+ */
+export const parseUnitsSafe = (
+  amount: string | null | undefined,
+  decimals: number | null | undefined,
+): ethers.BigNumber | null => {
+  if (!amount || decimals == null) {
+    return null;
+  }
+
+  const safeAmount =
+    decimals === 18
+      ? amount
+      : new BigNumber(amount).toFixed(decimals, BigNumber.ROUND_UP);
+
+  return ethers.utils.parseUnits(safeAmount, decimals);
+};

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     ]
   },
   "resolutions": {
+    "@metamask/bridge-controller": "npm:@metamask-previews/bridge-controller@75.1.1-preview-2c09cc947",
     "@metamask/network-controller": "32.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
     "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7918,7 +7918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^9.0.0, @metamask/assets-controller@npm:^9.0.1":
+"@metamask/assets-controller@npm:^9.0.1":
   version: 9.0.1
   resolution: "@metamask/assets-controller@npm:9.0.1"
   dependencies:
@@ -8122,9 +8122,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^75.0.0, @metamask/bridge-controller@npm:^75.1.0, @metamask/bridge-controller@npm:^75.1.1":
-  version: 75.1.1
-  resolution: "@metamask/bridge-controller@npm:75.1.1"
+"@metamask/bridge-controller@npm:@metamask-previews/bridge-controller@75.1.1-preview-2c09cc947":
+  version: 75.1.1-preview-2c09cc947
+  resolution: "@metamask-previews/bridge-controller@npm:75.1.1-preview-2c09cc947"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -8132,10 +8132,10 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/accounts-controller": "npm:^39.0.1"
-    "@metamask/assets-controller": "npm:^9.0.0"
-    "@metamask/assets-controllers": "npm:^109.0.0"
+    "@metamask/assets-controller": "npm:^9.0.1"
+    "@metamask/assets-controllers": "npm:^109.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.1"
+    "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
     "@metamask/keyring-api": "npm:^23.1.0"
     "@metamask/messenger": "npm:^1.2.0"
@@ -8143,15 +8143,15 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^3.1.3"
     "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/polling-controller": "npm:^16.0.6"
-    "@metamask/profile-sync-controller": "npm:^28.1.1"
+    "@metamask/profile-sync-controller": "npm:^28.2.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/transaction-controller": "npm:^67.1.0"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/transaction-controller": "npm:^68.0.1"
+    "@metamask/utils": "npm:^11.11.0"
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/d8a5f4777f38b3f951d61025ae2488b1a53e89ba78c15e7d1588debf734c729a0dff6735c67b0f4fcd719a981ead3917a8f57fb27708d0c7e0afa62364624f9a
+  checksum: 10/4efc60efe7474bafc60ef82758b43ca95ff37df0e0ef704dad8b6808eceba5e9d1b4bf807a8c07857cca75e4003c2c1831b3854ec60ca74ba25dfb4572f52737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: hide max button for ARC USDC Swap

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token balance and gas sufficiency math in bridge flows; incorrect decimals or rounding could mis-state balances or block/allow swaps, though scope is limited to bridge hooks and a dependency preview pin.
> 
> **Overview**
> Fixes **bridge/swap balance and gas checks** for chains whose native gas asset is not 18-decimal ETH (e.g. **Arc native USDC at 6 decimals**), which was skewing displayed balances and sufficiency logic.
> 
> **`useTokensWithBalance`** now overrides **native-address** token decimals from **`getNativeAssetForChainId`** before EVM balance math, so formatted balances and the `decimals` field stay aligned when TokensController has stale 18-decimal data.
> 
> Adds **`parseUnitsSafe`** (rounds fractional amounts **up** to the token’s precision, then `parseUnits`) and wires it into **`useHasSufficientGas`** and **`useHasSufficientGasEvenIfGasIncludedOrSponsored`** instead of raw `ethers.utils.parseUnits`, avoiding under-counting when quote gas strings exceed decimal precision.
> 
> Pins **`@metamask/bridge-controller`** to preview **`75.1.1-preview-2c09cc947`** via `package.json` resolutions (with matching `yarn.lock` updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0195ea193fe89f8753c38386369753e01100de93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->