### PR TITLE
fix: MUSD-1027 rewire onboarding feature flag to skip money onboarding if crashing occurs cp-8.0.0

### DIFF
--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -210,14 +210,11 @@ describe('MoneyBalanceCard', () => {
       );
     });
 
-    it('does not render the empty or new-user container', () => {
+    it('does not render the empty container', () => {
       const { queryByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
       expect(
         queryByTestId(MoneyBalanceCardTestIds.EMPTY_CONTAINER),
-      ).not.toBeOnTheScreen();
-      expect(
-        queryByTestId(MoneyBalanceCardTestIds.NEW_USER_CONTAINER),
       ).not.toBeOnTheScreen();
     });
 
@@ -347,14 +344,6 @@ describe('MoneyBalanceCard', () => {
       mockSelectMoneyOnboardingSeen.mockReturnValue(false);
     });
 
-    it('renders the new-user container testID', () => {
-      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
-
-      expect(
-        getByTestId(MoneyBalanceCardTestIds.NEW_USER_CONTAINER),
-      ).toBeOnTheScreen();
-    });
-
     it('renders the Add button', () => {
       const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
@@ -378,14 +367,6 @@ describe('MoneyBalanceCard', () => {
           queryByTestId(MoneyBalanceCardTestIds.GET_STARTED_BUTTON),
         ).not.toBeOnTheScreen();
       });
-
-      it('still renders the new-user container', () => {
-        const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
-
-        expect(
-          getByTestId(MoneyBalanceCardTestIds.NEW_USER_CONTAINER),
-        ).toBeOnTheScreen();
-      });
     });
 
     describe('when the wallet-home onboarding stepper is displayed', () => {
@@ -404,14 +385,6 @@ describe('MoneyBalanceCard', () => {
         expect(
           queryByTestId(MoneyBalanceCardTestIds.GET_STARTED_BUTTON),
         ).not.toBeOnTheScreen();
-      });
-
-      it('still renders the new-user container', () => {
-        const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
-
-        expect(
-          getByTestId(MoneyBalanceCardTestIds.NEW_USER_CONTAINER),
-        ).toBeOnTheScreen();
       });
     });
   });

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.test.tsx
@@ -10,6 +10,7 @@ import useMoneyAccountBalance from '../../hooks/useMoneyAccountBalance';
 import useMoneyAccountInfo from '../../hooks/useMoneyAccountInfo';
 import { selectMoneyOnboardingSeen } from '../../../../../reducers/user/selectors';
 import { selectShouldShowWalletHomeOnboardingSteps } from '../../../../../selectors/onboarding';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 import { useMoneyNavigation } from '../../hooks/useMoneyNavigation';
 import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
@@ -75,6 +76,14 @@ jest.mock('../../../../../selectors/onboarding', () => ({
   selectShouldShowWalletHomeOnboardingSteps: jest.fn(),
 }));
 
+jest.mock(
+  '../../../../../selectors/featureFlagController/moneyAccount',
+  () => ({
+    __esModule: true,
+    selectMoneyOnboardingStepperAnimationEnabled: jest.fn(),
+  }),
+);
+
 jest.mock('../../../../../util/Logger', () => ({
   __esModule: true,
   default: { error: jest.fn() },
@@ -85,6 +94,9 @@ const mockUseMoneyAccountInfo = jest.mocked(useMoneyAccountInfo);
 const mockSelectMoneyOnboardingSeen = jest.mocked(selectMoneyOnboardingSeen);
 const mockSelectShouldShowWalletHomeOnboardingSteps = jest.mocked(
   selectShouldShowWalletHomeOnboardingSteps,
+);
+const mockSelectMoneyOnboardingStepperAnimationEnabled = jest.mocked(
+  selectMoneyOnboardingStepperAnimationEnabled,
 );
 const mockUseMoneyNavigation = jest.mocked(useMoneyNavigation);
 const mockUseMoneyAccountDeposit = jest.mocked(useMoneyAccountDeposit);
@@ -136,6 +148,7 @@ describe('MoneyBalanceCard', () => {
     mockUseMoneyAccountInfo.mockReturnValue(createInfoMock());
     mockSelectMoneyOnboardingSeen.mockReturnValue(true);
     mockSelectShouldShowWalletHomeOnboardingSteps.mockReturnValue(false);
+    mockSelectMoneyOnboardingStepperAnimationEnabled.mockReturnValue(true);
     mockUseMoneyNavigation.mockReturnValue({
       navigateToMoneyHome: mockNavigateToMoneyHome,
     });
@@ -461,8 +474,24 @@ describe('MoneyBalanceCard', () => {
       });
     });
 
-    describe('when onboarding has been seen', () => {
+    describe('when onboarding has been seen and onboarding flag is enabled', () => {
       it('initiates deposit when Add is pressed', () => {
+        const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
+
+        fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
+
+        expect(mockInitiateDeposit).toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalledWith(Routes.MONEY.ONBOARDING);
+      });
+    });
+
+    describe('when onboarding flag is disabled', () => {
+      beforeEach(() => {
+        mockSelectMoneyOnboardingStepperAnimationEnabled.mockReturnValue(false);
+        mockSelectMoneyOnboardingSeen.mockReturnValue(false);
+      });
+
+      it('initiates deposit when Add is pressed even if onboarding not seen', () => {
         const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
 
         fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
@@ -897,6 +926,33 @@ describe('MoneyBalanceCard', () => {
 
       expect(mockTrackSurfaceClicked).toHaveBeenCalledWith({
         redirect_target: SCREEN_NAMES.MONEY_ONBOARDING,
+      });
+    });
+
+    it('calls trackSurfaceClicked with MONEY_HOME redirect when card is pressed, onboarding not seen, and onboarding flag is disabled', () => {
+      mockSelectMoneyOnboardingSeen.mockReturnValue(false);
+      mockSelectMoneyOnboardingStepperAnimationEnabled.mockReturnValue(false);
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
+
+      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.FUNDED_CONTAINER));
+
+      expect(mockTrackSurfaceClicked).toHaveBeenCalledWith({
+        redirect_target: SCREEN_NAMES.MONEY_HOME,
+      });
+    });
+
+    it('tracks Add click with ADD_MONEY intent when onboarding not seen but onboarding flag is disabled', () => {
+      mockSelectMoneyOnboardingSeen.mockReturnValue(false);
+      mockSelectMoneyOnboardingStepperAnimationEnabled.mockReturnValue(false);
+      const { getByTestId } = renderWithProvider(<MoneyBalanceCard />);
+
+      fireEvent.press(getByTestId(MoneyBalanceCardTestIds.ADD_BUTTON));
+
+      expect(mockTrackButtonClicked).toHaveBeenCalledWith({
+        button_type: MONEY_BUTTON_TYPES.TEXT,
+        button_intent: MONEY_BUTTON_INTENTS.ADD_MONEY,
+        label_key: 'money.balance_card.add',
+        redirect_target: SCREEN_NAMES.MONEY_DEPOSIT,
       });
     });
 

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds.ts
@@ -1,5 +1,4 @@
 export const MoneyBalanceCardTestIds = {
-  NEW_USER_CONTAINER: 'money-balance-card-new-user-container',
   EMPTY_CONTAINER: 'money-balance-card-empty-container',
   FUNDED_CONTAINER: 'money-balance-card-funded-container',
   ERROR_CONTAINER: 'money-balance-card-error-container',

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -100,8 +100,6 @@ const MoneyBalanceCard = () => {
     !isUnavailable &&
     totalFiatRaw === '0';
 
-  const isNewUser = isEmpty && !hasSeenMoneyOnboarding && isOnboardingEnabled;
-
   const balanceText = totalFiatFormatted ?? '';
 
   const buttonLabelKey = 'money.balance_card.add';
@@ -120,9 +118,7 @@ const MoneyBalanceCard = () => {
     buttonVariant = hasOtherPrimaryCtaOnHome
       ? ButtonVariant.Secondary
       : ButtonVariant.Primary;
-    containerTestId = isNewUser
-      ? MoneyBalanceCardTestIds.NEW_USER_CONTAINER
-      : MoneyBalanceCardTestIds.EMPTY_CONTAINER;
+    containerTestId = MoneyBalanceCardTestIds.EMPTY_CONTAINER;
   } else {
     buttonVariant = hasOtherPrimaryCtaOnHome
       ? ButtonVariant.Secondary

--- a/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
+++ b/app/components/UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.tsx
@@ -43,6 +43,7 @@ import {
   MONEY_TOOLTIP_TYPES,
 } from '../../constants/moneyEvents';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 
 const MoneyBalanceCard = () => {
   const tw = useTailwind();
@@ -63,6 +64,9 @@ const MoneyBalanceCard = () => {
   const { navigateToMoneyHome } = useMoneyNavigation();
   const { initiateDeposit } = useMoneyAccountDeposit();
   const hasSeenMoneyOnboarding = useSelector(selectMoneyOnboardingSeen);
+  const isOnboardingEnabled = useSelector(
+    selectMoneyOnboardingStepperAnimationEnabled,
+  );
   const hasOtherPrimaryCtaOnHome = useSelector(
     selectShouldShowWalletHomeOnboardingSteps,
   );
@@ -96,7 +100,7 @@ const MoneyBalanceCard = () => {
     !isUnavailable &&
     totalFiatRaw === '0';
 
-  const isNewUser = isEmpty && !hasSeenMoneyOnboarding;
+  const isNewUser = isEmpty && !hasSeenMoneyOnboarding && isOnboardingEnabled;
 
   const balanceText = totalFiatFormatted ?? '';
 
@@ -136,15 +140,21 @@ const MoneyBalanceCard = () => {
 
   const handleCardPress = useCallback(() => {
     trackSurfaceClicked({
-      redirect_target: hasSeenMoneyOnboarding
-        ? SCREEN_NAMES.MONEY_HOME
-        : SCREEN_NAMES.MONEY_ONBOARDING,
+      redirect_target:
+        hasSeenMoneyOnboarding || !isOnboardingEnabled
+          ? SCREEN_NAMES.MONEY_HOME
+          : SCREEN_NAMES.MONEY_ONBOARDING,
     });
     navigateToMoneyHome();
-  }, [hasSeenMoneyOnboarding, navigateToMoneyHome, trackSurfaceClicked]);
+  }, [
+    hasSeenMoneyOnboarding,
+    isOnboardingEnabled,
+    navigateToMoneyHome,
+    trackSurfaceClicked,
+  ]);
 
   const handleAddPress = useCallback(() => {
-    if (!hasSeenMoneyOnboarding) {
+    if (!hasSeenMoneyOnboarding && isOnboardingEnabled) {
       trackButtonClicked({
         button_type: MONEY_BUTTON_TYPES.TEXT,
         button_intent: MONEY_BUTTON_INTENTS.GO_TO_MONEY_ONBOARDING,
@@ -168,7 +178,13 @@ const MoneyBalanceCard = () => {
         message: '[MoneyBalanceCard] Failed to initiate deposit',
       }),
     );
-  }, [hasSeenMoneyOnboarding, initiateDeposit, navigation, trackButtonClicked]);
+  }, [
+    hasSeenMoneyOnboarding,
+    initiateDeposit,
+    isOnboardingEnabled,
+    navigation,
+    trackButtonClicked,
+  ]);
 
   const handleInfoPress = useCallback(() => {
     trackTooltipClicked({

--- a/app/components/UI/Money/components/MoneyTabPressTracker/MoneyTabPressTracker.test.tsx
+++ b/app/components/UI/Money/components/MoneyTabPressTracker/MoneyTabPressTracker.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../constants/moneyEvents';
 import MoneyTabPressTracker from './MoneyTabPressTracker';
 import { selectMoneyOnboardingSeen } from '../../../../../reducers/user';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 
 jest.mock('../../../../../core/AppConstants', () => ({
   __esModule: true,
@@ -35,6 +36,13 @@ jest.mock('../../../../../reducers/user', () => ({
   selectMoneyOnboardingSeen: jest.fn(),
 }));
 
+jest.mock(
+  '../../../../../selectors/featureFlagController/moneyAccount',
+  () => ({
+    selectMoneyOnboardingStepperAnimationEnabled: jest.fn(),
+  }),
+);
+
 jest.mock('../../hooks/useMoneyAnalytics', () => ({
   useMoneyAnalytics: jest.fn(),
 }));
@@ -47,6 +55,8 @@ describe('MoneyTabPressTracker', () => {
     });
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === selectMoneyOnboardingSeen) return true;
+      if (selector === selectMoneyOnboardingStepperAnimationEnabled)
+        return true;
       return undefined;
     });
   });
@@ -102,6 +112,8 @@ describe('MoneyTabPressTracker', () => {
     beforeEach(() => {
       mockUseSelector.mockImplementation((selector: unknown) => {
         if (selector === selectMoneyOnboardingSeen) return false;
+        if (selector === selectMoneyOnboardingStepperAnimationEnabled)
+          return true;
         return undefined;
       });
     });
@@ -120,6 +132,34 @@ describe('MoneyTabPressTracker', () => {
         button_intent: MONEY_BUTTON_INTENTS.GO_TO_MONEY_ONBOARDING,
         label_key: 'bottom_nav.money',
         redirect_target: SCREEN_NAMES.MONEY_ONBOARDING,
+      });
+    });
+  });
+
+  describe('when onboarding flag is disabled', () => {
+    beforeEach(() => {
+      mockUseSelector.mockImplementation((selector: unknown) => {
+        if (selector === selectMoneyOnboardingSeen) return false;
+        if (selector === selectMoneyOnboardingStepperAnimationEnabled)
+          return false;
+        return undefined;
+      });
+    });
+
+    it('registered function calls trackButtonClicked with GO_TO_MONEY_HOME intent even when onboarding not seen', () => {
+      const onRegister = jest.fn();
+      render(<MoneyTabPressTracker onRegister={onRegister} />);
+
+      const registeredFn = onRegister.mock.calls[0][0] as () => void;
+      act(() => {
+        registeredFn();
+      });
+
+      expect(mockTrackButtonClicked).toHaveBeenCalledWith({
+        button_type: MONEY_BUTTON_TYPES.TEXT,
+        button_intent: MONEY_BUTTON_INTENTS.GO_TO_MONEY_HOME,
+        label_key: 'bottom_nav.money',
+        redirect_target: SCREEN_NAMES.MONEY_HOME,
       });
     });
   });

--- a/app/components/UI/Money/components/MoneyTabPressTracker/MoneyTabPressTracker.tsx
+++ b/app/components/UI/Money/components/MoneyTabPressTracker/MoneyTabPressTracker.tsx
@@ -10,6 +10,7 @@ import { TabBarIconKey } from '../../../../../component-library/components/Navig
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import { selectMoneyOnboardingSeen } from '../../../../../reducers/user';
 import { useSelector } from 'react-redux';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 
 /**
  * Renders nothing — exists purely to host the Money analytics hook chain so it
@@ -29,13 +30,16 @@ const MoneyTabPressTracker = ({ onRegister }: MoneyTabPressTrackerProps) => {
   });
 
   const hasSeenMoneyOnboarding = useSelector(selectMoneyOnboardingSeen);
+  const isOnboardingEnabled = useSelector(
+    selectMoneyOnboardingStepperAnimationEnabled,
+  );
 
   useEffect(() => {
     onRegister(() => {
       let redirectTarget: SCREEN_NAMES;
       let buttonIntent: MONEY_BUTTON_INTENTS;
 
-      if (hasSeenMoneyOnboarding) {
+      if (hasSeenMoneyOnboarding || !isOnboardingEnabled) {
         redirectTarget = SCREEN_NAMES.MONEY_HOME;
         buttonIntent = MONEY_BUTTON_INTENTS.GO_TO_MONEY_HOME;
       } else {
@@ -54,7 +58,12 @@ const MoneyTabPressTracker = ({ onRegister }: MoneyTabPressTrackerProps) => {
     return () => {
       onRegister(null);
     };
-  }, [trackButtonClicked, onRegister, hasSeenMoneyOnboarding]);
+  }, [
+    trackButtonClicked,
+    onRegister,
+    hasSeenMoneyOnboarding,
+    isOnboardingEnabled,
+  ]);
 
   return null;
 };

--- a/app/components/UI/Money/components/MoneyUiDeveloperOptionsSection.test.tsx
+++ b/app/components/UI/Money/components/MoneyUiDeveloperOptionsSection.test.tsx
@@ -4,6 +4,7 @@ import { MoneyUiDeveloperOptionsSection } from './MoneyUiDeveloperOptionsSection
 import { UserActionType } from '../../../../actions/user/types';
 import { selectMoneyOnboardingSeen } from '../../../../reducers/user/selectors';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
 
 const mockNavigate = jest.fn();
 
@@ -28,6 +29,10 @@ jest.mock('../../../../util/theme', () => {
   };
 });
 
+jest.mock('../../../../selectors/featureFlagController/moneyAccount', () => ({
+  selectMoneyOnboardingStepperAnimationEnabled: jest.fn(),
+}));
+
 const mockSetString = jest.fn((_str: string) => Promise.resolve());
 
 jest.mock('../../../../core/ClipboardManager', () => ({
@@ -41,6 +46,7 @@ const MOCK_ADDRESS = '0xABCDEF1234567890ABCDEF1234567890ABCDEF12';
 
 interface SelectorMockOptions {
   hasSeenMoneyOnboarding?: boolean;
+  isOnboardingEnabled?: boolean;
   /** Pass `null` to simulate no money account being available. */
   moneyAccount?: { address: string } | null;
 }
@@ -49,11 +55,12 @@ interface SelectorMockOptions {
  * Configures the useSelector mock to return appropriate values for each selector
  * used by MoneyUiDeveloperOptionsSection.
  *
- * Default: onboarding not seen, primary money account present with MOCK_ADDRESS.
+ * Default: onboarding not seen, flag enabled, primary money account present with MOCK_ADDRESS.
  * Pass `moneyAccount: null` to simulate the account being unavailable.
  */
 function setupSelectorMocks(options: SelectorMockOptions = {}) {
   const hasSeenMoneyOnboarding = options.hasSeenMoneyOnboarding ?? false;
+  const isOnboardingEnabled = options.isOnboardingEnabled ?? true;
   // `null` means "no account", `undefined` (omitted) means use the default.
   const moneyAccount =
     options.moneyAccount === null
@@ -62,6 +69,8 @@ function setupSelectorMocks(options: SelectorMockOptions = {}) {
 
   mockUseSelector.mockImplementation((selector: unknown) => {
     if (selector === selectMoneyOnboardingSeen) return hasSeenMoneyOnboarding;
+    if (selector === selectMoneyOnboardingStepperAnimationEnabled)
+      return isOnboardingEnabled;
     if (selector === selectPrimaryMoneyAccount) return moneyAccount;
     return undefined;
   });
@@ -77,6 +86,24 @@ describe('MoneyUiDeveloperOptionsSection', () => {
     const { getByText } = render(<MoneyUiDeveloperOptionsSection />);
 
     expect(getByText('Money UI')).toBeOnTheScreen();
+  });
+
+  describe('onboarding enabled state', () => {
+    it('displays onboarding enabled as true when flag is on', () => {
+      setupSelectorMocks({ isOnboardingEnabled: true });
+
+      const { getByText } = render(<MoneyUiDeveloperOptionsSection />);
+
+      expect(getByText('Onboarding enabled: true')).toBeOnTheScreen();
+    });
+
+    it('displays onboarding enabled as false when flag is off', () => {
+      setupSelectorMocks({ isOnboardingEnabled: false });
+
+      const { getByText } = render(<MoneyUiDeveloperOptionsSection />);
+
+      expect(getByText('Onboarding enabled: false')).toBeOnTheScreen();
+    });
   });
 
   describe('onboarding seen state', () => {

--- a/app/components/UI/Money/components/MoneyUiDeveloperOptionsSection.tsx
+++ b/app/components/UI/Money/components/MoneyUiDeveloperOptionsSection.tsx
@@ -24,6 +24,7 @@ import styleSheet from '../../../Views/Settings/DeveloperOptions/DeveloperOption
 import ClipboardManager from '../../../../core/ClipboardManager';
 import { STEPPER_IDS } from '../hooks/useOnboardingStep';
 import Routes from '../../../../constants/navigation/Routes';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
 
 export const MoneyUiDeveloperOptionsSection = () => {
   const dispatch = useDispatch();
@@ -32,6 +33,9 @@ export const MoneyUiDeveloperOptionsSection = () => {
   const navigation = useNavigation();
 
   const hasSeenMoneyOnboarding = useSelector(selectMoneyOnboardingSeen);
+  const isOnboardingEnabled = useSelector(
+    selectMoneyOnboardingStepperAnimationEnabled,
+  );
   const primaryMoneyAccount = useSelector(selectPrimaryMoneyAccount);
   const moneyAccountAddress = primaryMoneyAccount?.address;
 
@@ -58,6 +62,13 @@ export const MoneyUiDeveloperOptionsSection = () => {
       <Box>
         <Text variant={TextVariant.HeadingLg} style={styles.heading}>
           {'Money UI'}
+        </Text>
+        <Text
+          color={TextColor.TextAlternative}
+          variant={TextVariant.BodyMd}
+          style={styles.desc}
+        >
+          {`Onboarding enabled: ${String(isOnboardingEnabled)}`}
         </Text>
         <Text
           color={TextColor.TextAlternative}

--- a/app/components/UI/Money/hooks/useMoneyNavigation.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyNavigation.test.ts
@@ -2,11 +2,21 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { useMoneyNavigation } from './useMoneyNavigation';
 import Routes from '../../../../constants/navigation/Routes';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
+import { selectMoneyOnboardingSeen } from '../../../../reducers/user/selectors';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
 
 const mockNavigate = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../reducers/user/selectors', () => ({
+  selectMoneyOnboardingSeen: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/featureFlagController/moneyAccount', () => ({
+  selectMoneyOnboardingStepperAnimationEnabled: jest.fn(),
 }));
 
 jest.mock('../../../../core/NavigationService/NavigationService', () => ({
@@ -15,15 +25,34 @@ jest.mock('../../../../core/NavigationService/NavigationService', () => ({
 
 const { useSelector } = jest.requireMock('react-redux');
 
+const setupSelectorMocks = ({
+  hasSeenOnboarding = false,
+  isOnboardingEnabled = true,
+}: {
+  hasSeenOnboarding?: boolean;
+  isOnboardingEnabled?: boolean;
+} = {}) => {
+  useSelector.mockImplementation((selector: unknown) => {
+    if (selector === selectMoneyOnboardingSeen) return hasSeenOnboarding;
+    if (selector === selectMoneyOnboardingStepperAnimationEnabled)
+      return isOnboardingEnabled;
+    return undefined;
+  });
+};
+
 describe('useMoneyNavigation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Object.assign(NavigationService.navigation, { navigate: mockNavigate });
+    setupSelectorMocks();
   });
 
   describe('navigateToMoneyHome', () => {
-    it('navigates to onboarding when user has not seen onboarding', () => {
-      useSelector.mockReturnValue(false);
+    it('navigates to onboarding when user has not seen onboarding and flag is enabled', () => {
+      setupSelectorMocks({
+        hasSeenOnboarding: false,
+        isOnboardingEnabled: true,
+      });
 
       const { result } = renderHook(() => useMoneyNavigation());
 
@@ -34,7 +63,27 @@ describe('useMoneyNavigation', () => {
     });
 
     it('navigates to Money home when user has seen onboarding', () => {
-      useSelector.mockReturnValue(true);
+      setupSelectorMocks({
+        hasSeenOnboarding: true,
+        isOnboardingEnabled: true,
+      });
+
+      const { result } = renderHook(() => useMoneyNavigation());
+
+      act(() => result.current.navigateToMoneyHome());
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS, {
+        screen: Routes.MONEY.ROOT,
+        params: { screen: Routes.MONEY.HOME },
+      });
+    });
+
+    it('navigates to Money home when onboarding flag is disabled even if onboarding not seen', () => {
+      setupSelectorMocks({
+        hasSeenOnboarding: false,
+        isOnboardingEnabled: false,
+      });
 
       const { result } = renderHook(() => useMoneyNavigation());
 

--- a/app/components/UI/Money/hooks/useMoneyNavigation.ts
+++ b/app/components/UI/Money/hooks/useMoneyNavigation.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { selectMoneyOnboardingSeen } from '../../../../reducers/user/selectors';
 import Routes from '../../../../constants/navigation/Routes';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
 
 /**
  * Why NavigationService instead of useNavigation():
@@ -18,19 +19,22 @@ import NavigationService from '../../../../core/NavigationService/NavigationServ
  */
 export const useMoneyNavigation = () => {
   const hasSeenOnboarding = useSelector(selectMoneyOnboardingSeen);
+  const isOnboardingEnabled = useSelector(
+    selectMoneyOnboardingStepperAnimationEnabled,
+  );
 
   const redirectToOnboarding = useCallback(() => {
     NavigationService.navigation.navigate(Routes.MONEY.ONBOARDING);
   }, []);
 
   const redirectToOnboardingIfNeeded = useCallback(() => {
-    if (hasSeenOnboarding) {
+    if (hasSeenOnboarding || !isOnboardingEnabled) {
       return false;
     }
 
     redirectToOnboarding();
     return true;
-  }, [hasSeenOnboarding, redirectToOnboarding]);
+  }, [hasSeenOnboarding, isOnboardingEnabled, redirectToOnboarding]);
 
   const navigateToMoneyHome = useCallback(() => {
     if (redirectToOnboardingIfNeeded()) {

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleMoney.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleMoney.test.ts
@@ -8,6 +8,7 @@ import Logger from '../../../../../util/Logger';
 import { selectMoneyOnboardingSeen } from '../../../../../reducers/user';
 import { selectMoneyEnableMoneyAccountFlag } from '../../../../../components/UI/Money/selectors/featureFlags';
 import { selectIsMoneyAccountGeoEligible } from '../../../../../components/UI/Money/selectors/eligibility';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 import { DeepLinkModalLinkType } from '../../../types/deepLink.types';
 
 jest.mock('../../../../NavigationService');
@@ -36,6 +37,13 @@ jest.mock('../../../../../components/UI/Money/selectors/eligibility', () => ({
   selectIsMoneyAccountGeoEligible: jest.fn(),
 }));
 
+jest.mock(
+  '../../../../../selectors/featureFlagController/moneyAccount',
+  () => ({
+    selectMoneyOnboardingStepperAnimationEnabled: jest.fn(),
+  }),
+);
+
 describe('handleMoney', () => {
   let mockNavigate: jest.Mock;
   const mockState = {} as ReturnType<typeof ReduxService.store.getState>;
@@ -52,6 +60,9 @@ describe('handleMoney', () => {
     jest.mocked(selectMoneyEnableMoneyAccountFlag).mockReturnValue(true);
     jest.mocked(selectIsMoneyAccountGeoEligible).mockReturnValue(true);
     jest.mocked(selectMoneyOnboardingSeen).mockReturnValue(true);
+    jest
+      .mocked(selectMoneyOnboardingStepperAnimationEnabled)
+      .mockReturnValue(true);
   });
 
   it('opens unsupported deep link modal when money account flag is disabled', () => {
@@ -93,6 +104,20 @@ describe('handleMoney', () => {
     handleMoney();
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ONBOARDING);
+  });
+
+  it('navigates to MONEY.HOME when flag is disabled even if onboarding not seen', () => {
+    jest.mocked(selectMoneyOnboardingSeen).mockReturnValue(false);
+    jest
+      .mocked(selectMoneyOnboardingStepperAnimationEnabled)
+      .mockReturnValue(false);
+
+    handleMoney();
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS, {
+      screen: Routes.MONEY.ROOT,
+      params: { screen: Routes.MONEY.HOME },
+    });
   });
 
   it('navigates to MONEY.HOME when user has already seen onboarding', () => {

--- a/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleMoney.ts
@@ -2,6 +2,7 @@ import { selectIsMoneyAccountGeoEligible } from '../../../../components/UI/Money
 import { selectMoneyEnableMoneyAccountFlag } from '../../../../components/UI/Money/selectors/featureFlags';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectMoneyOnboardingSeen } from '../../../../reducers/user';
+import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
 import Logger from '../../../../util/Logger';
 import NavigationService from '../../../NavigationService';
 import ReduxService from '../../../redux';
@@ -17,6 +18,8 @@ export const handleMoney = () => {
     const isMoneyAccountGeoEligible = selectIsMoneyAccountGeoEligible(state);
     const isMoneyAccountEnabled = selectMoneyEnableMoneyAccountFlag(state);
     const hasSeenMoneyOnboarding = selectMoneyOnboardingSeen(state);
+    const isOnboardingEnabled =
+      selectMoneyOnboardingStepperAnimationEnabled(state);
 
     if (!isMoneyAccountEnabled) {
       handleDeepLinkModalDisplay({
@@ -35,7 +38,7 @@ export const handleMoney = () => {
       return;
     }
 
-    if (!hasSeenMoneyOnboarding) {
+    if (!hasSeenMoneyOnboarding && isOnboardingEnabled) {
       NavigationService.navigation.navigate(Routes.MONEY.ONBOARDING);
       return;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Fixes regression where Money onboarding flow was rendered even when onboarding flag was disabled.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes regression where Money onboarding flow was rendered even when onboarding flag was disabled.


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1027: Rewire onboarding feature flag to skip in prod if it causes crashes](https://consensyssoftware.atlassian.net/browse/MUSD-1027) 

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money onboarding rendering based on feature flag

  Scenario: first time user skips onboarding
    Given user hasn't seen onboarding and flag is disabled

    When user click Money tab or MoneyBalanceCard
    Then onboarding is skipped and user is redirected to Money Home
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A - was broken before
### **After**

<!-- [screenshots/recordings] -->
N/A - No UI difference; conditional redirect based on feature flag
## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user entry paths (tab, card, deeplinks, navigation) and analytics; behavior change for users who have not seen onboarding when the flag is off, but scoped to Money flows with broad test coverage.
> 
> **Overview**
> **Money onboarding is now gated by `selectMoneyOnboardingStepperAnimationEnabled`**, not only by whether the user has seen onboarding. When the flag is off, first-time users are treated like returning users: navigation goes to Money Home, Add starts deposit, and analytics use home/deposit targets instead of onboarding.
> 
> This is applied consistently across **balance card**, **Money tab press tracking**, **`useMoneyNavigation`**, **money deeplinks** (`handleMoney`), and **developer options** (displays the flag state). Tests are updated for the new branches.
> 
> The balance card **drops the separate “new user” container** (`NEW_USER_CONTAINER` test ID and `isNewUser` logic); empty zero-balance states always use the empty container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30115e7c88c900d7d5b052f2c1fc676b440a90a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->