### PR TITLE
fix(top-traders): expand homepage trader card pressable area

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.test.tsx
@@ -121,6 +121,20 @@ describe('TopTraderCard', () => {
     expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'alpha.eth', 1);
   });
 
+  it('calls onTraderPress when the card pressable area is tapped', () => {
+    renderWithProvider(
+      <TopTraderCard
+        trader={baseTrader}
+        onFollowPress={mockOnFollowPress}
+        onTraderPress={mockOnTraderPress}
+      />,
+    );
+
+    fireEvent.press(screen.getByText('+$963.1K'));
+
+    expect(mockOnTraderPress).toHaveBeenCalledWith('trader-1', 'alpha.eth', 1);
+  });
+
   it('forwards trader.overallRank (not the filtered rank) to onTraderPress so the profile podium gates on true top-3 traders', () => {
     const filteredTrader: TopTrader = {
       ...baseTrader,

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TopTraderCard.tsx
@@ -10,8 +10,9 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import type { TopTrader } from '../types';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -39,11 +40,15 @@ export interface TopTraderCardProps {
 const AVATAR_SIZE = 40;
 export const TOP_TRADER_CARD_WIDTH = 155;
 
+// Matches the button placeholder height in TopTraderCardSkeleton.
+const FOLLOW_BUTTON_HEIGHT = 32;
+
 /**
  * TopTraderCard -- compact card for the homepage horizontal scroll.
  *
  * Lays out the trader's avatar with the username + 7D PnL stacked to its
- * right, and a small Follow / Following toggle pinned below.
+ * right, and a small Follow / Following toggle pinned below. The card body
+ * is fully pressable; the follow button is overlaid so it stays independent.
  */
 const TopTraderCard: React.FC<TopTraderCardProps> = ({
   trader,
@@ -51,12 +56,13 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
   onTraderPress,
   testID,
 }) => {
+  const tw = useTailwind();
   const pnlText = formatSignedAbbreviatedUsd(trader.pnlValue);
   const isPnlPositive = trader.pnlValue >= 0;
 
   return (
     <Box
-      twClassName={`w-[${TOP_TRADER_CARD_WIDTH}px] rounded-xl bg-muted p-4 overflow-hidden gap-4`}
+      twClassName={`relative w-[${TOP_TRADER_CARD_WIDTH}px] rounded-xl bg-muted overflow-hidden`}
       testID={testID ?? `top-trader-card-${trader.id}`}
     >
       <TouchableOpacity
@@ -70,54 +76,63 @@ const TopTraderCard: React.FC<TopTraderCardProps> = ({
         disabled={!onTraderPress}
         testID={`top-trader-card-pressable-${trader.id}`}
       >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="gap-2"
-        >
-          <TraderAvatar
-            imageUrl={trader.avatarUri}
-            address={trader.address}
-            size={AVATAR_SIZE}
-            testID={`top-trader-avatar-${trader.id}`}
-          />
+        <Box twClassName="gap-4 p-4">
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="gap-2"
+          >
+            <TraderAvatar
+              imageUrl={trader.avatarUri}
+              address={trader.address}
+              size={AVATAR_SIZE}
+              testID={`top-trader-avatar-${trader.id}`}
+            />
 
-          <Box twClassName="flex-1 min-w-0">
-            <Text
-              variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextDefault}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {trader.username}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              numberOfLines={1}
-              twClassName={
-                isPnlPositive ? 'text-success-default' : 'text-error-default'
-              }
-            >
-              {pnlText}
-            </Text>
+            <Box twClassName="flex-1 min-w-0">
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {trader.username}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                numberOfLines={1}
+                twClassName={
+                  isPnlPositive ? 'text-success-default' : 'text-error-default'
+                }
+              >
+                {pnlText}
+              </Text>
+            </Box>
           </Box>
+
+          <Box style={{ height: FOLLOW_BUTTON_HEIGHT }} />
         </Box>
       </TouchableOpacity>
 
-      <Button
-        variant={
-          trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
-        }
-        size={ButtonSize.Sm}
-        isFullWidth
-        onPress={() => onFollowPress(trader.id)}
+      <View
+        pointerEvents="box-none"
+        style={tw.style('absolute bottom-0 left-0 right-0 px-4 pb-4')}
       >
-        {trader.isFollowing
-          ? strings('social_leaderboard.following')
-          : strings('social_leaderboard.follow')}
-      </Button>
+        <Button
+          variant={
+            trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
+          }
+          size={ButtonSize.Sm}
+          isFullWidth
+          onPress={() => onFollowPress(trader.id)}
+        >
+          {trader.isFollowing
+            ? strings('social_leaderboard.following')
+            : strings('social_leaderboard.follow')}
+        </Button>
+      </View>
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the homepage Weekly Top Traders carousel, only the trader avatar and username row responded to taps even though the card reads as a single unit. This made much of the card feel dead and harder to open a trader profile.

This PR expands the press target to the full card body (padding and gap included) while keeping the Follow/Following button independent. The card uses a full-width press layer with the follow button absolutely overlaid and `pointerEvents="box-none"` so follow taps do not also navigate to the profile.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed homepage Weekly Top Traders cards so tapping anywhere on the card opens the trader profile

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage Weekly Top Traders card interactions

  Scenario: user opens a trader profile from the card body
    Given social leaderboard is enabled and the homepage Weekly Top Traders carousel is visible
    When user taps the card padding or empty space above the Follow button on a trader card
    Then the app navigates to that trader's profile

  Scenario: user follows a trader without navigating away
    Given social leaderboard is enabled and the homepage Weekly Top Traders carousel is visible
    When user taps the Follow or Following button on a trader card
    Then the follow state toggles and the app does not navigate to the trader profile
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1294" height="1594" alt="image" src="https://github.com/user-attachments/assets/db933ef1-5d56-43be-973f-0953aaa516e7" />


### **After**

<img width="1239" height="1593" alt="image" src="https://github.com/user-attachments/assets/bfebcf8d-6eed-4f02-a7f4-ca32d4cd83c3" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)