### PR TITLE
fix(social-leaderboard): remove bottom safe-area cutoff in scroll views

### DIFF
--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -344,6 +344,7 @@ const TopTradersView = () => {
 
   return (
     <SafeAreaView
+      edges={['top']}
       style={tw.style('flex-1 bg-default')}
       testID={TopTradersViewSelectorsIDs.CONTAINER}
     >

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.tsx
@@ -69,7 +69,7 @@ const QuickBuyQuoteDetailsScreen: React.FC = () => {
         onClose={onClose}
       />
 
-      <Box twClassName="px-4 pt-3 pb-4" gap={3}>
+      <Box twClassName="px-4 pt-3" gap={3}>
         <KeyValueRowStubs.Root>
           <KeyValueRowStubs.Section>
             <KeyValueRowStubs.Label

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -446,7 +446,7 @@ describe('QuickBuyRoot', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('locks the content container height after the first layout', () => {
+  it('applies the measured locked height after the first layout', () => {
     renderWithProvider(
       <QuickBuyRoot
         isVisible
@@ -471,7 +471,7 @@ describe('QuickBuyRoot', () => {
     });
   });
 
-  it('keeps the locked height when a later layout reports a different height', () => {
+  it('keeps the initial locked height when a later layout reports a different height', () => {
     renderWithProvider(
       <QuickBuyRoot
         isVisible

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -1,7 +1,7 @@
 import {
   BottomSheetDialog,
-  type BottomSheetDialogRef,
   Box,
+  type BottomSheetDialogRef,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, {
@@ -12,25 +12,30 @@ import React, {
   useState,
 } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 import Animated, { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
+import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import {
   SocialLeaderboardEventProperties,
   SocialLeaderboardEventValues,
   useSocialLeaderboardAnalytics,
 } from '../../../analytics';
+import { TOP_TRADERS_QUICK_BUY_FEATURES } from './features';
 import QuickBuyAmountScreen from './QuickBuyAmountScreen';
-import QuickBuyTokenSelectScreen from './QuickBuyTokenSelectScreen';
+import QuickBuyBottomSheetSkeleton from './QuickBuyBottomSheetSkeleton';
+import { QuickBuyProvider } from './QuickBuyContext';
 import QuickBuyPriceImpactConfirmScreen from './QuickBuyPriceImpactConfirmScreen';
 import QuickBuyQuoteDetailsScreen from './QuickBuyQuoteDetailsScreen';
 import QuickBuySelectQuoteScreen from './QuickBuySelectQuoteScreen';
-import { QuickBuyProvider } from './QuickBuyContext';
-import { TOP_TRADERS_QUICK_BUY_FEATURES } from './features';
-import QuickBuyBottomSheetSkeleton from './QuickBuyBottomSheetSkeleton';
+import QuickBuyTokenSelectScreen from './QuickBuyTokenSelectScreen';
+import {
+  makeScreenTransitions,
+  SCREEN_DEPTH,
+  type ScreenDirection,
+} from './transitions';
 import type {
   QuickBuyAnalyticsContext,
   QuickBuyFeatures,
@@ -38,18 +43,8 @@ import type {
   QuickBuyScreen,
   QuickBuyTarget,
 } from './types';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
-import {
-  makeScreenTransitions,
-  SCREEN_DEPTH,
-  type ScreenDirection,
-} from './transitions';
 
 export type { QuickBuyRootProps } from './types';
-
-const AnimatedScrollView = Animated.createAnimatedComponent(
-  GestureHandlerScrollView,
-);
 
 function renderActiveScreen(
   activeScreen: QuickBuyScreen,
@@ -95,6 +90,9 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
   const [isContentReady, setIsContentReady] = useState(false);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
+  // Measured once from the first screen and reused as a fixed height for every
+  // screen so the sheet keeps a constant size during navigation (no layout
+  // shift between screens).
   const [lockedHeight, setLockedHeight] = useState<number | null>(null);
   // True once a dismissal is requested via the CTA/Cancel so the content drops
   // with the sheet instead of running its horizontal screen-exit transition.
@@ -176,21 +174,15 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     [lockedHeight],
   );
 
-  // The BottomSheetDialog always reserves a bottom safe-area inset. Keep it as
-  // breathing room only on screens that pin a CTA to the bottom; on the
-  // scroll-only screens (quote details / select quote / pay with / receive)
-  // that inset is dead space. Rather than shrink those screens (which would
-  // cause a parasite layout shift between screens), grow the content into the
-  // inset and offset it with a matching negative margin: the net layout
-  // contribution stays `lockedHeight`, so the sheet keeps a constant height
-  // across every screen while the content fills the safe-area gap.
+  // Keep the bottom safe-area inset only on screens that pin a CTA at the
+  // bottom; the scroll-only screens (quote details / select quote / pay with /
+  // receive) sit flush to the edge instead of leaving dead space below.
   const hasBottomCta =
     activeScreen === 'amount' || activeScreen === 'priceImpactConfirm';
 
   return (
     <BottomSheetDialog
       ref={bottomSheetRef}
-      isInteractable={!isSubmittingTx}
       onClose={onClose}
       twClassName={surfaceClass}
     >
@@ -206,16 +198,20 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           <Box
             testID="quick-buy-content-container"
             onLayout={handleContentLayout}
-            style={{
-              ...(lockedHeight !== null
+            style={
+              lockedHeight !== null
                 ? {
+                    // Scroll-only screens reclaim the bottom safe-area inset
+                    // that BottomSheetDialog adds, so they sit flush to the
+                    // edge while keeping the same overall sheet height as the
+                    // CTA screens (no layout shift between screens).
                     height: hasBottomCta
                       ? lockedHeight
                       : lockedHeight + bottomInset,
+                    ...(hasBottomCta ? {} : { marginBottom: -bottomInset }),
                   }
-                : {}),
-              ...(hasBottomCta ? {} : { marginBottom: -bottomInset }),
-            }}
+                : undefined
+            }
           >
             <Animated.View
               key={activeScreen}
@@ -228,13 +224,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           </Box>
         </QuickBuyProvider>
       ) : (
-        <AnimatedScrollView
-          style={tw.style('shrink')}
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-        >
-          <QuickBuyBottomSheetSkeleton />
-        </AnimatedScrollView>
+        <QuickBuyBottomSheetSkeleton />
       )}
     </BottomSheetDialog>
   );

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -14,6 +14,7 @@ import React, {
 import type { LayoutChangeEvent } from 'react-native';
 import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 import Animated, { useSharedValue } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { selectIsSubmittingTx } from '../../../../../../core/redux/slices/bridge';
@@ -89,6 +90,7 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   children,
 }) => {
   const tw = useTailwind();
+  const { bottom: bottomInset } = useSafeAreaInsets();
   const { track } = useSocialLeaderboardAnalytics();
   const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
   const [isContentReady, setIsContentReady] = useState(false);
@@ -174,6 +176,17 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     [lockedHeight],
   );
 
+  // The BottomSheetDialog always reserves a bottom safe-area inset. Keep it as
+  // breathing room only on screens that pin a CTA to the bottom; on the
+  // scroll-only screens (quote details / select quote / pay with / receive)
+  // that inset is dead space. Rather than shrink those screens (which would
+  // cause a parasite layout shift between screens), grow the content into the
+  // inset and offset it with a matching negative margin: the net layout
+  // contribution stays `lockedHeight`, so the sheet keeps a constant height
+  // across every screen while the content fills the safe-area gap.
+  const hasBottomCta =
+    activeScreen === 'amount' || activeScreen === 'priceImpactConfirm';
+
   return (
     <BottomSheetDialog
       ref={bottomSheetRef}
@@ -193,7 +206,16 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
           <Box
             testID="quick-buy-content-container"
             onLayout={handleContentLayout}
-            style={lockedHeight !== null ? { height: lockedHeight } : undefined}
+            style={{
+              ...(lockedHeight !== null
+                ? {
+                    height: hasBottomCta
+                      ? lockedHeight
+                      : lockedHeight + bottomInset,
+                  }
+                : {}),
+              ...(hasBottomCta ? {} : { marginBottom: -bottomInset }),
+            }}
           >
             <Animated.View
               key={activeScreen}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySelectQuoteScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySelectQuoteScreen.tsx
@@ -111,7 +111,7 @@ const QuickBuySelectQuoteScreen: React.FC = () => {
               {strings('bridge.select_quote_info')}
             </Text>
           </Box>
-          <Box twClassName="pb-4">
+          <Box>
             {rows.map((rowProps) => (
               <QuoteRow key={rowProps.quoteRequestId} {...rowProps} />
             ))}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyActionFooter.tsx
@@ -1,22 +1,22 @@
-import React from 'react';
 import {
+  AvatarTokenSize,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
-  Text,
-  TextVariant,
-  TextColor,
-  AvatarTokenSize,
   Icon,
   IconColor,
   IconName,
   IconSize,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
+import React from 'react';
 import { TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
-import QuickBuyConfirmButton from '../QuickBuyConfirmButton';
 import QuickBuyBanners from '../QuickBuyBanners';
+import QuickBuyConfirmButton from '../QuickBuyConfirmButton';
 import { useQuickBuyContext } from '../useQuickBuyContext';
 import { QuickBuyPercentageSlider } from './QuickBuyPercentageSlider';
 import QuickBuyTokenIcon from './QuickBuyTokenIcon';
@@ -38,7 +38,6 @@ const QuickBuyActionFooter: React.FC = () => {
     sourceToken,
     sourceBalanceFiat,
     destBalanceFiat,
-    destToken,
     selectedDestStable,
     features,
     setActiveScreen,
@@ -49,7 +48,7 @@ const QuickBuyActionFooter: React.FC = () => {
     tradeMode === 'sell' ? destBalanceFiat : sourceBalanceFiat;
 
   return (
-    <Box twClassName="px-4 pb-4">
+    <Box twClassName="px-4">
       {/* Slider — reduced top padding to tighten gap with the amount section */}
       <Box twClassName="pt-2 pb-3">
         <QuickBuyPercentageSlider

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.tsx
@@ -1,17 +1,17 @@
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { AccessibilityActionEvent, LayoutChangeEvent } from 'react-native';
 import {
-  Gesture,
-  GestureDetector,
-  GestureHandlerRootView,
-} from 'react-native-gesture-handler';
+  AccessibilityActionEvent,
+  LayoutChangeEvent,
+  View,
+} from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { playImpact, ImpactMoment } from '../../../../../../../util/haptics';
+import { ImpactMoment, playImpact } from '../../../../../../../util/haptics';
 
 const HANDLE_SIZE = 24;
 const MARKER_SIZE = 4;
@@ -189,7 +189,7 @@ export function QuickBuyPercentageSlider({
   );
 
   return (
-    <GestureHandlerRootView
+    <View
       testID={testID}
       accessibilityRole="adjustable"
       accessibilityState={{ disabled }}
@@ -235,6 +235,6 @@ export function QuickBuyPercentageSlider({
           />
         </Animated.View>
       </GestureDetector>
-    </GestureHandlerRootView>
+    </View>
   );
 }

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -332,6 +332,7 @@ const TraderProfileView = () => {
 
   return (
     <SafeAreaView
+      edges={['top']}
       style={tw.style('flex-1 bg-default')}
       testID={TraderProfileViewSelectorsIDs.CONTAINER}
     >


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Weekly Top Traders, Trader Profile, and several QuickBuy sub-screens showed an empty gap at the bottom of scrollable content because the bottom safe-area inset was applied even when no CTA was pinned there.

This PR removes the bottom safe-area inset on CTA-less full-screen views (`TopTradersView`, `TraderProfileView`) via `SafeAreaView edges={['top']}`. For QuickBuy, it reclaims the `BottomSheetDialog` bottom inset on scroll-only screens (quote details, select quote, pay with, receive) by growing content into that space with a matching negative margin, preserving the locked sheet height to avoid layout shifts when navigating between screens. Screens with a pinned bottom CTA (`amount`, `priceImpactConfirm`, and `TraderPositionView`) keep the safe-area breathing room.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed empty bottom spacing in Social Leaderboard and QuickBuy scroll views

## **Related issues**

<!--
Fixes:
-->

Fixes:

## **Manual testing steps**

<!--
```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```
-->

```gherkin
Feature: Social Leaderboard bottom spacing

  Scenario: Weekly Top Traders list extends to the bottom edge
    Given Social Leaderboard is enabled
    And the user opens Weekly Top Traders

    When the user scrolls to the last trader row
    Then no empty safe-area gap appears below the last row

  Scenario: Trader Profile positions list extends to the bottom edge
    Given the user opens a trader profile

    When the user scrolls to the last position row
    Then no empty safe-area gap appears below the last row

  Scenario: QuickBuy sub-screens fill the sheet without layout shifts
    Given the user opens a trader position and taps Buy
    And the QuickBuy amount sheet is visible

    When the user navigates to Select quote, Quote details, or Pay with / Receive
    Then list content reaches the bottom of the sheet without a dead gap
    And the sheet height stays consistent with the amount screen

  Scenario: QuickBuy amount screen keeps bottom CTA spacing
    Given the QuickBuy amount sheet is visible

    When the user views the confirm button at the bottom
    Then the button retains safe spacing above the device bottom edge
```

## **Screenshots/Recordings**

<!--
### **Before**

### **After**
-->

### **Before**

<img width="3722" height="1493" alt="image" src="https://github.com/user-attachments/assets/9d575fa1-184c-4459-8a67-eedddd0bc1f8" />

### **After**

<img width="3771" height="1478" alt="image" src="https://github.com/user-attachments/assets/bdcc7624-c0a5-4fbc-bb33-3c10029d0c9e" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)