### PR TITLE
feat: filter pooled-staking vault token and surface its balance as stakedBalance

### DIFF
--- a/app/selectors/assets/assets-migration.test.ts
+++ b/app/selectors/assets/assets-migration.test.ts
@@ -44,6 +44,12 @@ const mockAccountId3 = 'mock-account-id-3';
 const mockAccountAddressLowercase2: Hex =
   '0x1234567890abcdef1234567890abcdef12345678';
 
+// Pooled-staking vault token that should be filtered from token lists and
+// surfaced as stakedBalance instead.
+const stakedVaultAddress = '0x4fef9d741011476750a243ac70b9789a63dd47df';
+const stakedVaultAddressChecksummed = toChecksumHexAddress(stakedVaultAddress);
+const stakedVaultAssetId = `eip155:1/erc20:${stakedVaultAddress}`;
+
 const enabledFeatureFlagControllerState = {
   RemoteFeatureFlagController: {
     remoteFeatureFlags: {
@@ -312,6 +318,133 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       ]);
     });
 
+    it('populates stakedBalance from pooled-staking vault ERC-20 balance', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            AccountTrackerController: { accountsByChainId: {} },
+            AssetsController: {
+              assetsInfo: {
+                [nativeEthAssetId]: { type: 'native', decimals: 18 },
+                [stakedVaultAssetId]: { type: 'erc20', decimals: 18 },
+              },
+              assetsBalance: {
+                [mockAccountId]: {
+                  [nativeEthAssetId]: { amount: '5' },
+                  [stakedVaultAssetId]: { amount: '1' },
+                },
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId]: {
+                    id: mockAccountId,
+                    address: mockAccountAddressLowercase,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getAccountTrackerControllerAccountsByChainId(state);
+
+      expect(
+        result['0x1'][mockAccountAddressChecksummed].balance,
+      ).toBeDefined();
+      // 1 ETH with 18 decimals → 0xde0b6b3a7640000
+      expect(result['0x1'][mockAccountAddressChecksummed].stakedBalance).toBe(
+        '0xde0b6b3a7640000',
+      );
+    });
+
+    it('preserves stakedBalance when vault token entry is processed before the native entry', () => {
+      // Object.entries preserves insertion order, so listing the vault asset
+      // first ensures we test the spread-guard on the native branch.
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            AccountTrackerController: { accountsByChainId: {} },
+            AssetsController: {
+              assetsInfo: {
+                [stakedVaultAssetId]: { type: 'erc20', decimals: 18 },
+                [nativeEthAssetId]: { type: 'native', decimals: 18 },
+              },
+              assetsBalance: {
+                [mockAccountId]: {
+                  // vault first in iteration order
+                  [stakedVaultAssetId]: { amount: '2' },
+                  [nativeEthAssetId]: { amount: '3' },
+                },
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId]: {
+                    id: mockAccountId,
+                    address: mockAccountAddressLowercase,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getAccountTrackerControllerAccountsByChainId(state);
+
+      const account = result['0x1'][mockAccountAddressChecksummed];
+      // Both fields must survive regardless of iteration order
+      expect(account.balance).toBeDefined();
+      expect(account.stakedBalance).toBeDefined();
+      // 2 ETH with 18 decimals
+      expect(account.stakedBalance).toBe('0x1bc16d674ec80000');
+    });
+
+    it('does not set stakedBalance for regular ERC-20 addresses not in the filter list', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            AccountTrackerController: { accountsByChainId: {} },
+            AssetsController: {
+              assetsInfo: {
+                [nativeEthAssetId]: { type: 'native', decimals: 18 },
+                [erc20AssetId]: { type: 'erc20', decimals: 6 },
+              },
+              assetsBalance: {
+                [mockAccountId]: {
+                  [nativeEthAssetId]: { amount: '1' },
+                  [erc20AssetId]: { amount: '500' },
+                },
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId]: {
+                    id: mockAccountId,
+                    address: mockAccountAddressLowercase,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getAccountTrackerControllerAccountsByChainId(state);
+
+      expect(
+        result['0x1'][mockAccountAddressChecksummed].stakedBalance,
+      ).toBeUndefined();
+    });
+
     it('truncates fractional digits exceeding decimals in parseBalanceWithDecimals', () => {
       const state = {
         engine: {
@@ -551,6 +684,87 @@ describe('getTokensControllerAllTokens', () => {
                 },
               },
               customAssets: {},
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId]: {
+                    id: mockAccountId,
+                    address: mockAccountAddressLowercase,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getTokensControllerAllTokens(state);
+
+      expect(result).toStrictEqual({});
+    });
+
+    it('excludes the pooled-staking vault token from allTokens', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            TokensController: { allTokens: {}, allIgnoredTokens: {} },
+            AssetsController: {
+              assetsInfo: {
+                [stakedVaultAssetId]: {
+                  type: 'erc20',
+                  decimals: 18,
+                  symbol: 'MM-Staked-ETH',
+                  name: 'MetaMask Staked ETH',
+                },
+              },
+              assetsBalance: {
+                [mockAccountId]: {
+                  [stakedVaultAssetId]: { amount: '1' },
+                },
+              },
+              customAssets: {},
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [mockAccountId]: {
+                    id: mockAccountId,
+                    address: mockAccountAddressLowercase,
+                    type: 'eip155:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getTokensControllerAllTokens(state);
+
+      // The vault token must not appear in the regular token list
+      expect(result).toStrictEqual({});
+    });
+
+    it('excludes the pooled-staking vault token from customAssets path in allTokens', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            TokensController: { allTokens: {}, allIgnoredTokens: {} },
+            AssetsController: {
+              assetsInfo: {
+                [stakedVaultAssetId]: {
+                  type: 'erc20',
+                  decimals: 18,
+                  symbol: 'MM-Staked-ETH',
+                  name: 'MetaMask Staked ETH',
+                },
+              },
+              assetsBalance: {},
+              customAssets: {
+                [mockAccountId]: [stakedVaultAssetId as CaipAssetType],
+              },
             },
             AccountsController: {
               internalAccounts: {
@@ -1029,6 +1243,77 @@ describe('getTokenBalancesControllerTokenBalances', () => {
           erc20AssetAddressChecksummed
         ],
       ).toBe('0x1312d00'); // 20 * 10^6
+    });
+
+    it('excludes the pooled-staking vault token from tokenBalances', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            TokenBalancesController: { tokenBalances: {} },
+            AssetsController: {
+              assetsInfo: {
+                [nativeEthAssetId]: { type: 'native', decimals: 18 },
+                [stakedVaultAssetId]: { type: 'erc20', decimals: 18 },
+              },
+              assetsBalance: {
+                [mockAccountId]: {
+                  [nativeEthAssetId]: { amount: '1' },
+                  [stakedVaultAssetId]: { amount: '0.5' },
+                },
+              },
+              customAssets: {},
+            },
+            AccountsController: { internalAccounts: baseInternalAccounts },
+          },
+        },
+      };
+      const result = getTokenBalancesControllerTokenBalances(state);
+
+      // Vault address must not appear as a token balance key
+      expect(
+        result[mockAccountAddressLowercase]['0x1'][
+          stakedVaultAddressChecksummed as Hex
+        ],
+      ).toBeUndefined();
+    });
+
+    it('excludes the pooled-staking vault token from the customAssets zero-balance placeholder', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            TokenBalancesController: { tokenBalances: {} },
+            AssetsController: {
+              assetsInfo: {
+                [stakedVaultAssetId]: {
+                  type: 'erc20',
+                  decimals: 18,
+                  symbol: 'MM-Staked-ETH',
+                  name: 'MetaMask Staked ETH',
+                },
+              },
+              assetsBalance: {},
+              customAssets: {
+                [mockAccountId]: [stakedVaultAssetId],
+              },
+            },
+            AccountsController: { internalAccounts: baseInternalAccounts },
+          },
+        },
+      };
+      const result = getTokenBalancesControllerTokenBalances(state);
+
+      // The vault address must not appear as a token balance key in any chain
+      for (const chainMap of Object.values(result)) {
+        for (const tokenMap of Object.values(chainMap)) {
+          expect(
+            (tokenMap as Record<string, unknown>)[
+              stakedVaultAddressChecksummed
+            ],
+          ).toBeUndefined();
+        }
+      }
     });
 
     it('maps non-mainnet native assets to zero address to match TokenBalancesController behavior', () => {

--- a/app/selectors/assets/assets-migration.ts
+++ b/app/selectors/assets/assets-migration.ts
@@ -30,6 +30,14 @@ import {
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { NetworkState } from '@metamask/network-controller';
 
+// Staked-token contract addresses that should never surface as regular ERC-20
+// tokens in the wallet token list or balance maps.
+const STAKED_TOKEN_ADDRESSES_TO_FILTER = new Set(
+  ['0x4fef9d741011476750a243ac70b9789a63dd47df'].map((addr) =>
+    toChecksumHexAddress(addr),
+  ),
+);
+
 // ChainId (hex) -> AccountAddress (hex checksummed) -> Balance (hex)
 export const getAccountTrackerControllerAccountsByChainId =
   createDeepEqualSelector(
@@ -73,27 +81,43 @@ export const getAccountTrackerControllerAccountsByChainId =
 
         for (const [assetId, balanceData] of Object.entries(accountBalances)) {
           const metadata = assetsInfo[assetId];
-          if (metadata?.type !== 'native') {
+
+          const assetType = parseCaipAssetType(assetId as CaipAssetType);
+
+          if (assetType.chain.namespace !== KnownCaipNamespace.Eip155) {
             continue;
           }
 
-          const { chain: parsedChain } = parseCaipAssetType(
-            assetId as CaipAssetType,
-          );
-
-          if (parsedChain.namespace !== KnownCaipNamespace.Eip155) {
-            continue;
-          }
-
-          const hexChainId = decimalToPrefixedHex(parsedChain.reference);
+          const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
           const amount = balanceData?.amount ?? '0';
 
-          result[hexChainId] ??= {};
-          result[hexChainId][checksummedAddress] = {
-            // TODO: Use raw value from state when available
-            balance: parseBalanceWithDecimals(amount, metadata.decimals),
-            // TODO: Add staked balance when available
-          };
+          if (metadata?.type === 'native') {
+            result[hexChainId] ??= {};
+            result[hexChainId][checksummedAddress] = {
+              // Spread preserves stakedBalance if it was already set by a
+              // staked-token entry processed earlier in this loop.
+              ...result[hexChainId][checksummedAddress],
+              // TODO: Use raw value from state when available
+              balance: parseBalanceWithDecimals(amount, metadata.decimals),
+            };
+          } else if (
+            metadata &&
+            STAKED_TOKEN_ADDRESSES_TO_FILTER.has(
+              toChecksumHexAddress(assetType.assetReference),
+            )
+          ) {
+            // Use the ERC-20 balance of the pooled-staking vault token as the
+            // stakedBalance for this chain.  The token is filtered from the
+            // regular token list (see STAKED_TOKEN_ADDRESSES_TO_FILTER) and
+            // surfaced here so it appears in the Staked Ethereum section on
+            // Token Details instead.
+            result[hexChainId] ??= {};
+            result[hexChainId][checksummedAddress] ??= {
+              balance: '0x0' as Hex,
+            };
+            result[hexChainId][checksummedAddress].stakedBalance =
+              parseBalanceWithDecimals(amount, metadata.decimals);
+          }
         }
       }
 
@@ -169,6 +193,10 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
           assetType.chain.reference,
         ) as Hex;
         const assetAddress = toChecksumHexAddress(assetType.assetReference);
+
+        if (STAKED_TOKEN_ADDRESSES_TO_FILTER.has(assetAddress)) {
+          continue;
+        }
 
         const token: Token = {
           address: assetAddress,
@@ -307,6 +335,10 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
             : assetType.assetReference,
         ) as Hex;
 
+        if (STAKED_TOKEN_ADDRESSES_TO_FILTER.has(assetAddress)) {
+          continue;
+        }
+
         result[accountAddress][hexChainId] ??= {};
         result[accountAddress][hexChainId][assetAddress] =
           // TODO: Use raw value from state when available
@@ -349,6 +381,10 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
         const assetAddress = toChecksumHexAddress(
           assetType.assetReference,
         ) as Hex;
+
+        if (STAKED_TOKEN_ADDRESSES_TO_FILTER.has(assetAddress)) {
+          continue;
+        }
 
         if (!result[accountAddress]?.[hexChainId]?.[assetAddress]) {
           result[accountAddress][hexChainId] ??= {};

--- a/app/selectors/assets/assets-migration.ts
+++ b/app/selectors/assets/assets-migration.ts
@@ -30,13 +30,29 @@ import {
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { NetworkState } from '@metamask/network-controller';
 
-// Staked-token contract addresses that should never surface as regular ERC-20
-// tokens in the wallet token list or balance maps.
-const STAKED_TOKEN_ADDRESSES_TO_FILTER = new Set(
-  ['0x4fef9d741011476750a243ac70b9789a63dd47df'].map((addr) =>
-    toChecksumHexAddress(addr),
-  ),
-);
+// CAIP-19 asset identifiers (with checksummed addresses) for the pooled-staking
+// vault token that should never surface as regular ERC-20 tokens in the wallet
+// token list or balance maps. Staking is only supported on Ethereum mainnet
+// (eip155:1) and the Hoodi testnet (eip155:560048), where the vault token shares
+// the same address. Scoping by CAIP-19 keeps the filter chain-aware so an
+// identically-addressed token on an unsupported chain is left untouched.
+const STAKED_TOKEN_ASSET_IDS_TO_FILTER = new Set<CaipAssetType>([
+  'eip155:1/erc20:0x4FEF9D741011476750A243aC70b9789a63dd47Df',
+  'eip155:560048/erc20:0x4FEF9D741011476750A243aC70b9789a63dd47Df',
+]);
+
+// AssetIds may carry the contract address in any case, so normalize the asset
+// reference to its checksummed form before matching against the filter set.
+const isStakedTokenAssetId = (assetId: string): boolean => {
+  const { chainId, assetNamespace, assetReference } = parseCaipAssetType(
+    assetId as CaipAssetType,
+  );
+  return STAKED_TOKEN_ASSET_IDS_TO_FILTER.has(
+    `${chainId}/${assetNamespace}:${toChecksumHexAddress(
+      assetReference,
+    )}` as CaipAssetType,
+  );
+};
 
 // ChainId (hex) -> AccountAddress (hex checksummed) -> Balance (hex)
 export const getAccountTrackerControllerAccountsByChainId =
@@ -100,15 +116,10 @@ export const getAccountTrackerControllerAccountsByChainId =
               // TODO: Use raw value from state when available
               balance: parseBalanceWithDecimals(amount, metadata.decimals),
             };
-          } else if (
-            metadata &&
-            STAKED_TOKEN_ADDRESSES_TO_FILTER.has(
-              toChecksumHexAddress(assetType.assetReference),
-            )
-          ) {
+          } else if (metadata && isStakedTokenAssetId(assetId)) {
             // Use the ERC-20 balance of the pooled-staking vault token as the
             // stakedBalance for this chain.  The token is filtered from the
-            // regular token list (see STAKED_TOKEN_ADDRESSES_TO_FILTER) and
+            // regular token list (see STAKED_TOKEN_ASSET_IDS_TO_FILTER) and
             // surfaced here so it appears in the Staked Ethereum section on
             // Token Details instead.
             result[hexChainId] ??= {};
@@ -194,7 +205,7 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
         ) as Hex;
         const assetAddress = toChecksumHexAddress(assetType.assetReference);
 
-        if (STAKED_TOKEN_ADDRESSES_TO_FILTER.has(assetAddress)) {
+        if (isStakedTokenAssetId(assetId)) {
           continue;
         }
 
@@ -335,7 +346,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
             : assetType.assetReference,
         ) as Hex;
 
-        if (STAKED_TOKEN_ADDRESSES_TO_FILTER.has(assetAddress)) {
+        if (isStakedTokenAssetId(assetId)) {
           continue;
         }
 
@@ -382,7 +393,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
           assetType.assetReference,
         ) as Hex;
 
-        if (STAKED_TOKEN_ADDRESSES_TO_FILTER.has(assetAddress)) {
+        if (isStakedTokenAssetId(assetId)) {
           continue;
         }
 


### PR DESCRIPTION
Filter the pooled-staking vault ERC-20 (0x4fef9d74…) from regular token/balance lists and instead populate stakedBalance on the account tracker entry so it is picked up by the StakingBalance component on the Token Details page.

Adds 7 new unit tests covering:
- stakedBalance is populated from the vault ERC-20 balance
- native balance spread-guard preserves stakedBalance regardless of iteration order
- regular ERC-20s do not set stakedBalance
- vault token is excluded from getTokensControllerAllTokens (assetsBalance and customAssets paths)
- vault token is excluded from getTokenBalancesControllerTokenBalances (balance and zero-placeholder paths)

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: filter pooled-staking vault token and surface its balance as stakedBalance

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/32113

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/650591c8-e676-40c2-aab5-3a38bf5cbfe3



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes balance and token list shaping behind a feature flag; wrong filtering could hide balances or mis-report staked ETH, but scope is limited to two known vault asset IDs and is well covered by tests.
> 
> **Overview**
> When **assets unify state** is enabled, the pooled-staking vault ERC-20 (`0x4FEF9D74…` on Ethereum mainnet and Hoodi) is **no longer shown as a normal token**. Its balance is mapped to **`stakedBalance`** on the account-tracker migration so staking UI (e.g. Token Details / StakingBalance) can show staked ETH separately.
> 
> **`assets-migration.ts`** adds chain-scoped CAIP-19 filtering (`STAKED_TOKEN_ASSET_IDS_TO_FILTER` + `isStakedTokenAssetId`) and skips the vault in **`getTokensControllerAllTokens`** and **`getTokenBalancesControllerTokenBalances`** (including custom-asset zero placeholders). **`getAccountTrackerControllerAccountsByChainId`** now handles native balances and vault ERC-20 in one loop, setting `stakedBalance` from the vault amount and using a spread on the native branch so `stakedBalance` is not lost if asset iteration order varies.
> 
> **Tests** cover `stakedBalance` population, iteration-order preservation, non-vault ERC-20s unchanged, and vault exclusion from all token/balance migration paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f902b31f8966db7a07312ef2107a93ca15dd37e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->