### PR TITLE
fix(quick-buy): restore bottom sheet drag tracking during slow swipes

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.test.tsx
@@ -37,39 +37,40 @@ jest.mock('../../../analytics', () => {
 let storedOnOpenCallback: (() => void) | undefined;
 const mockOnCloseDialog = jest.fn((cb?: () => void) => cb?.());
 
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
-  const ReactMock = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+jest.mock(
+  '../../../../../../component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog',
+  () => {
+    const ReactMock = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
 
-  return {
-    ...actual,
-    BottomSheetDialog: ReactMock.forwardRef(
-      (
-        {
-          children,
-          onClose,
-        }: {
-          children: unknown;
-          onClose?: () => void;
-        },
-        ref: unknown,
-      ) => {
-        ReactMock.useImperativeHandle(ref, () => ({
-          onOpenDialog: (cb: () => void) => {
-            storedOnOpenCallback = cb;
+    return {
+      __esModule: true,
+      default: ReactMock.forwardRef(
+        (
+          {
+            children,
+            onOpen,
+          }: {
+            children: unknown;
+            onOpen?: () => void;
           },
-          onCloseDialog: mockOnCloseDialog,
-        }));
-        return ReactMock.createElement(
-          View,
-          { testID: 'mock-bottom-sheet-dialog', onTouchEnd: onClose },
-          children,
-        );
-      },
-    ),
-  };
-});
+          ref: unknown,
+        ) => {
+          storedOnOpenCallback = onOpen;
+          ReactMock.useImperativeHandle(ref, () => ({
+            onOpenDialog: (cb?: () => void) => cb?.(),
+            onCloseDialog: mockOnCloseDialog,
+          }));
+          return ReactMock.createElement(
+            View,
+            { testID: 'mock-bottom-sheet-dialog' },
+            children,
+          );
+        },
+      ),
+    };
+  },
+);
 
 // Render Animated.View as a plain host View that forwards layout-animation props
 // (entering/exiting) so the suppression of the exit transition is observable.

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -1,12 +1,9 @@
-import {
-  BottomSheetDialog,
-  type BottomSheetDialogRef,
-  Box,
-} from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
+import BottomSheetDialog from '../../../../../../component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog';
+import type { BottomSheetDialogRef } from '../../../../../../component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.types';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, {
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -37,12 +34,16 @@ import type {
   QuickBuyScreen,
   QuickBuyTarget,
 } from './types';
-import { useElevatedSurface } from '../../../../../../util/theme/themeUtils';
 import {
   makeScreenTransitions,
   SCREEN_DEPTH,
   type ScreenDirection,
 } from './transitions';
+
+/** Activate sheet drag after a small downward move so the pan tracks the finger. */
+const QUICK_BUY_SHEET_PAN_PROPS = {
+  activeOffsetY: [5, 9999] as [number, number],
+};
 
 export type { QuickBuyRootProps } from './types';
 
@@ -98,7 +99,6 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   // with the sheet instead of running its horizontal screen-exit transition.
   const [isClosing, setIsClosing] = useState(false);
   const isSubmittingTx = useSelector(selectIsSubmittingTx);
-  const surfaceClass = useElevatedSurface();
 
   const directionSV = useSharedValue<ScreenDirection>(1);
   // Suppresses the enter animation on the initial screen when the sheet opens;
@@ -141,11 +141,9 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
     });
   }, [analyticsContext, target.tokenSymbol, track]);
 
-  useEffect(() => {
-    bottomSheetRef.current?.onOpenDialog(() => {
-      setIsContentReady(true);
-      trackSheetViewed();
-    });
+  const handleSheetOpen = useCallback(() => {
+    setIsContentReady(true);
+    trackSheetViewed();
   }, [trackSheetViewed]);
 
   // Animate the sheet down (then run the parent's onClose) and flag the content
@@ -179,7 +177,8 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
       ref={bottomSheetRef}
       isInteractable={!isSubmittingTx}
       onClose={onClose}
-      twClassName={surfaceClass}
+      onOpen={handleSheetOpen}
+      panGestureHandlerProps={QUICK_BUY_SHEET_PAN_PROPS}
     >
       {isContentReady ? (
         <QuickBuyProvider

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyRoot.tsx
@@ -2,12 +2,7 @@ import { Box } from '@metamask/design-system-react-native';
 import BottomSheetDialog from '../../../../../../component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog';
 import type { BottomSheetDialogRef } from '../../../../../../component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.types';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, {
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { ScrollView as GestureHandlerScrollView } from 'react-native-gesture-handler';
 import Animated, { useSharedValue } from 'react-native-reanimated';

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuySheet.test.tsx
@@ -38,45 +38,45 @@ jest.mock('../../../analytics', () => {
   };
 });
 
-// Captures the onOpenDialog callback registered by QuickBuyRootInner.
+// Captures the onOpen callback registered by QuickBuyRootInner.
 // Call storedOnOpenCallback() inside act() after render to simulate the sheet
 // finishing its open animation and make isContentReady become true.
 let storedOnOpenCallback: (() => void) | undefined;
 
-// Render children directly so inner component content is visible
-jest.mock('@metamask/design-system-react-native', () => {
-  const actual = jest.requireActual('@metamask/design-system-react-native');
-  const ReactMock = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+jest.mock(
+  '../../../../../../component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog',
+  () => {
+    const ReactMock = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
 
-  return {
-    ...actual,
-    BottomSheetDialog: ReactMock.forwardRef(
-      (
-        {
-          children,
-          onClose,
-        }: {
-          children: unknown;
-          onClose?: () => void;
-        },
-        ref: unknown,
-      ) => {
-        ReactMock.useImperativeHandle(ref, () => ({
-          onOpenDialog: (cb: () => void) => {
-            storedOnOpenCallback = cb;
+    return {
+      __esModule: true,
+      default: ReactMock.forwardRef(
+        (
+          {
+            children,
+            onOpen,
+          }: {
+            children: unknown;
+            onOpen?: () => void;
           },
-          onCloseDialog: (cb?: () => void) => cb?.(),
-        }));
-        return ReactMock.createElement(
-          View,
-          { testID: 'mock-bottom-sheet-dialog', onTouchEnd: onClose },
-          children,
-        );
-      },
-    ),
-  };
-});
+          ref: unknown,
+        ) => {
+          storedOnOpenCallback = onOpen;
+          ReactMock.useImperativeHandle(ref, () => ({
+            onOpenDialog: (cb?: () => void) => cb?.(),
+            onCloseDialog: (cb?: () => void) => cb?.(),
+          }));
+          return ReactMock.createElement(
+            View,
+            { testID: 'mock-bottom-sheet-dialog' },
+            children,
+          );
+        },
+      ),
+    };
+  },
+);
 
 // Mock sub-components so their own dep trees don't pollute these tests
 jest.mock('./components/QuickBuyToolbar', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.test.tsx
@@ -24,6 +24,8 @@ jest.mock('react-native-gesture-handler', () => {
       }),
       Pan: () => {
         const panBuilder = {
+          activeOffsetX: () => panBuilder,
+          failOffsetY: () => panBuilder,
           onStart: (cb: () => void) => {
             panOnStart = cb;
             return panBuilder;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { AccessibilityActionEvent, LayoutChangeEvent } from 'react-native';
+import { AccessibilityActionEvent, LayoutChangeEvent, View } from 'react-native';
 import {
   Gesture,
   GestureDetector,
-  GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
@@ -158,6 +157,8 @@ export function QuickBuyPercentageSlider({
       runOnJS(commitFromPosition)(event.x, sliderWidth.value);
     }),
     Gesture.Pan()
+      .activeOffsetX([-5, 5])
+      .failOffsetY([-10, 10])
       .onStart(() => {
         // Pick up — fire the grip haptic the moment the drag is recognized.
         runOnJS(handleGrip)();
@@ -189,7 +190,7 @@ export function QuickBuyPercentageSlider({
   );
 
   return (
-    <GestureHandlerRootView
+    <View
       testID={testID}
       accessibilityRole="adjustable"
       accessibilityState={{ disabled }}
@@ -235,6 +236,6 @@ export function QuickBuyPercentageSlider({
           />
         </Animated.View>
       </GestureDetector>
-    </GestureHandlerRootView>
+    </View>
   );
 }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyPercentageSlider.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { AccessibilityActionEvent, LayoutChangeEvent, View } from 'react-native';
 import {
-  Gesture,
-  GestureDetector,
-} from 'react-native-gesture-handler';
+  AccessibilityActionEvent,
+  LayoutChangeEvent,
+  View,
+} from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
   useAnimatedStyle,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Quick Buy bottom sheet did not follow the finger on slow downward drags — it stayed fixed until release, while fast swipes still dismissed via velocity. This restores interactive drag behavior consistent with other bottom sheets in the app.

## Root cause

Quick Buy was the only feature using `@metamask/design-system-react-native`'s `BottomSheetDialog` directly (introduced in #31550 to remove the dark backdrop overlay). That implementation uses the new RNGH `Gesture.Pan()` API without activation offsets. Child touch targets and the percentage slider's nested `GestureHandlerRootView` competed with the sheet pan, so `onUpdate` never ran during slow drags. Only `onEnd` fired on fast swipes (velocity-based dismiss).

Other bottom sheets in the app use the component-library `BottomSheetDialog`, which wraps content in `PanGestureHandler` and tracks finger movement reliably.

## Fix

1. **QuickBuyRoot** — Switch back to the component-library `BottomSheetDialog` (still no backdrop overlay) and pass `panGestureHandlerProps={{ activeOffsetY: [5, 9999] }}` so downward pans activate after 5px and track the finger. Deferred content loading now uses the `onOpen` prop instead of an `onOpenDialog` callback.
2. **QuickBuyPercentageSlider** — Remove the nested `GestureHandlerRootView` (app root already provides one) and constrain the slider pan with `activeOffsetX` / `failOffsetY` so vertical drags pass through to the sheet.

## Test plan

- [x] `yarn jest QuickBuyRoot.test.tsx QuickBuySheet.test.tsx QuickBuyPercentageSlider.test.tsx`
- [ ] Manual: open Quick Buy → drag the sheet down slowly with your finger → sheet follows the thumb
- [ ] Manual: release before 60% threshold → sheet snaps back open
- [ ] Manual: fast swipe down → sheet dismisses
- [ ] Manual: drag vertically on the percentage slider area → sheet dismiss gesture still works; horizontal drag still moves the slider
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3005c38-ff7d-4f0c-adfc-fd6b2fe1a26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3005c38-ff7d-4f0c-adfc-fd6b2fe1a26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

