### PR TITLE
fix(confirmations): cp-8.0.0 skip initial gas estimate for sponsored money account transactions

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -476,6 +476,7 @@ describe('useMoneyAccountWithdrawal', () => {
     expect(mockAddTransactionBatch).toHaveBeenCalledWith(
       expect.objectContaining({
         isGasFeeSponsored: true,
+        skipInitialGasEstimate: true,
       }),
     );
   });

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -120,13 +120,12 @@ export function useMoneyAccountDeposit() {
         // so `from` must be the money account and `networkClientId` its chain.
         await addTransactionBatch({
           batchId,
-          from: primaryMoneyAccount.address as Hex,
-          networkClientId,
-          origin: ORIGIN_METAMASK,
-          isInternal: true,
           disableHook: true,
           disableSequential: true,
-          transactions: [approveTx, depositTx],
+          from: primaryMoneyAccount.address as Hex,
+          isInternal: true,
+          networkClientId,
+          origin: ORIGIN_METAMASK,
           requiredAssets: [
             {
               address: getMoneyAccountDepositAssetAddress(chainIdHex),
@@ -134,6 +133,8 @@ export function useMoneyAccountDeposit() {
               standard: 'erc20',
             },
           ],
+          skipInitialGasEstimate: true,
+          transactions: [approveTx, depositTx],
         });
       } catch (error) {
         depositIntentByBatchId.delete(batchId.toLowerCase());
@@ -178,6 +179,7 @@ export function useMoneyAccountWithdrawal() {
     }
 
     const networkClientId = resolveNetworkClientId(chainIdHex);
+    const isGasFeeSponsored = isMonadMainnetChainId(chainIdHex);
 
     // Placeholder amount — MM Pay re-encodes both calls via
     // `updateMoneyAccountWithdrawTokenAmount` once the user picks an amount.
@@ -199,13 +201,14 @@ export function useMoneyAccountWithdrawal() {
 
     try {
       await addTransactionBatch({
-        from: primaryMoneyAccount.address as Hex,
-        networkClientId,
-        origin: ORIGIN_METAMASK,
-        isInternal: true,
         disableHook: true,
         disableSequential: true,
-        isGasFeeSponsored: isMonadMainnetChainId(chainIdHex),
+        from: primaryMoneyAccount.address as Hex,
+        isGasFeeSponsored,
+        isInternal: true,
+        networkClientId,
+        origin: ORIGIN_METAMASK,
+        skipInitialGasEstimate: isGasFeeSponsored,
         transactions: [withdrawTx, transferTx],
       });
     } catch (error) {

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -92,6 +92,7 @@ export function useMoneyAccountDeposit() {
       }
 
       const networkClientId = resolveNetworkClientId(chainIdHex);
+      const isGasFeeSponsored = isMonadMainnetChainId(chainIdHex);
 
       const batchId = bytesToHex(new Uint8Array(uuidParse(uuidv4())));
       depositIntentByBatchId.set(batchId.toLowerCase(), intent);
@@ -123,6 +124,7 @@ export function useMoneyAccountDeposit() {
           disableHook: true,
           disableSequential: true,
           from: primaryMoneyAccount.address as Hex,
+          isGasFeeSponsored,
           isInternal: true,
           networkClientId,
           origin: ORIGIN_METAMASK,
@@ -133,7 +135,7 @@ export function useMoneyAccountDeposit() {
               standard: 'erc20',
             },
           ],
-          skipInitialGasEstimate: true,
+          skipInitialGasEstimate: isGasFeeSponsored,
           transactions: [approveTx, depositTx],
         });
       } catch (error) {


### PR DESCRIPTION
## **Description**

Money Account deposit and withdrawal batches trigger synchronous gas estimation when `addTransactionBatch` is called. On networks where gas is sponsored (e.g. Monad Mainnet), a bug in gas estimation can cause a crash when the RPC unexpectedly returns `null` for the latest block — an error condition we are now handling defensively.

This PR passes `skipInitialGasEstimate: true` to deposit and withdrawal batches when `isGasFeeSponsored` is true, deferring gas estimation to the async background path where this error condition is handled safely. Non-sponsored flows are unaffected.

## **Changelog**

CHANGELOG entry: Fixed a crash that could occur when initiating Money Account transactions on Monad

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Money Account deposit and withdrawal on a sponsored-gas network

  Scenario: user initiates a deposit on Monad Mainnet
    Given the user has a Money Account on Monad Mainnet
    And Monad Mainnet is selected

    When user taps Deposit and confirms the transaction
    Then the batch is submitted without crashing
    And gas estimation completes in the background

  Scenario: user initiates a withdrawal on Monad Mainnet
    Given the user has a Money Account with a mUSD balance on Monad Mainnet

    When user taps Withdraw and confirms the transaction
    Then the batch is submitted without crashing

  Scenario: user initiates a withdrawal on a non-sponsored network
    Given the user has a Money Account on a non-Monad network

    When user taps Withdraw and confirms the transaction
    Then skipInitialGasEstimate is false and gas is estimated synchronously as before
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation/transaction submission for Money Account flows; behavior change is gated to sponsored-gas (Monad) chains, with tests updated for withdrawals only.
> 
> **Overview**
> **Money Account** deposit and withdrawal now pass **`skipInitialGasEstimate: true`** into `addTransactionBatch` when the vault chain is Monad Mainnet (same condition as **`isGasFeeSponsored`** via `isMonadMainnetChainId`), so synchronous gas estimation is skipped and runs on the async path instead.
> 
> Deposits also set **`isGasFeeSponsored`** on the batch (previously only withdrawals did). Withdrawal tests on Monad assert both sponsored flags; non-Monad withdrawal behavior is unchanged aside from not setting `skipInitialGasEstimate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a41fe127d265d793c993dd5ef27fda1c33797c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->