### PR TITLE
Fix: Duplicate TRON rows in Earn tab (#32110)

### DIFF
--- a/app/core/Multichain/test/utils.test.ts
+++ b/app/core/Multichain/test/utils.test.ts
@@ -25,6 +25,7 @@ import {
   getAddressUrl,
   getTransactionUrl,
   isTronAddress,
+  isTronSpecialAsset,
 } from '../utils';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
@@ -523,6 +524,30 @@ describe('MultiChain utils', () => {
         expect(formatAddress).toHaveBeenCalledWith(MOCK_BTC_TX_ID, 'short');
         expect(result).toBe(shortenedBtcTxId);
       });
+    });
+  });
+
+  describe('isTronSpecialAsset', () => {
+    it('returns false for non-Tron chain ID', () => {
+      expect(isTronSpecialAsset('eip155:1', 'TRX')).toBe(false);
+      expect(isTronSpecialAsset(undefined, 'TRX')).toBe(false);
+    });
+
+    it('returns true if symbol is falsy', () => {
+      expect(isTronSpecialAsset('tron:mainnet', '')).toBe(true);
+      expect(isTronSpecialAsset('tron:mainnet', undefined)).toBe(true);
+    });
+
+    it('returns true for known special assets', () => {
+      expect(isTronSpecialAsset('tron:mainnet', 'energy')).toBe(true);
+      expect(isTronSpecialAsset('tron:mainnet', 'bandwidth')).toBe(true);
+      expect(isTronSpecialAsset('tron:mainnet', 'trx-in-lock-period')).toBe(true);
+    });
+
+    it('returns false for valid TRON tokens with normal symbols', () => {
+      expect(isTronSpecialAsset('tron:mainnet', 'TRX')).toBe(false);
+      expect(isTronSpecialAsset('tron:mainnet', 'USDT')).toBe(false);
+      expect(isTronSpecialAsset('tron:mainnet', 'BTT')).toBe(false);
     });
   });
 });

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -274,8 +274,11 @@ export const isTronSpecialAsset = (
   chainId: string | undefined,
   symbol: string | undefined,
 ): boolean => {
-  if (!chainId?.startsWith('tron:') || !symbol) {
+  if (!chainId?.startsWith('tron:')) {
     return false;
+  }
+  if (!symbol) {
+    return true;
   }
   return TRON_SPECIAL_ASSET_SYMBOLS_SET.has(
     symbol.toLowerCase() as TronSpecialAssetSymbol,

--- a/app/selectors/earnController/earn/index.ts
+++ b/app/selectors/earnController/earn/index.ts
@@ -174,9 +174,9 @@ const selectEarnTokens = createDeepEqualSelector(
     };
 
     // flatten the tokens across all chains
-    const allTokens = Object.values(
-      accountTokensAcrossChains,
-    ).flat() as TokenI[];
+    const allTokens = (
+      Object.values(accountTokensAcrossChains).flat() as TokenI[]
+    ).filter((token) => Boolean(token.symbol) || Boolean(token.name));
 
     if (allTokens.length === 0) {
       return emptyEarnTokensData;


### PR DESCRIPTION
## **Description**
Fixes #32110. The Earn deposit token picker previously showed duplicate TRON rows with blank names. This was caused by the multichain assets controller emitting TRON special assets (or tokens missing metadata) without a symbol or name. Since `isTronSpecialAsset` checked the symbol, it failed to filter them out when the symbol was missing, and `selectEarnTokens` subsequently treated each one as a native TRON staking token.

This PR:
1. Updates `isTronSpecialAsset` to correctly filter out Tron tokens missing a symbol.
2. Adds a robust guard in `selectEarnTokens` to completely ignore tokens across all chains that lack both a symbol and a name.

## **Changelog**
CHANGELOG entry: Fixed a bug in the Earn deposit token list where duplicate blank TRON rows were displayed due to unparsed multichain assets.

## **Related issues**
Fixes #32110

## **Pre-merge author checklist**
- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and token-list filtering only; no auth, payments, or persistence changes. Slight risk that legitimately unnamed tokens on any chain are excluded from Earn.
> 
> **Overview**
> Fixes duplicate **blank TRON rows** in the Earn deposit token list when multichain assets arrive without metadata.
> 
> **`isTronSpecialAsset`** now treats Tron-chain tokens with a **missing or empty symbol** as special assets (filtered like energy/bandwidth), instead of letting them pass through when `symbol` was falsy.
> 
> **`selectEarnTokens`** additionally drops tokens **across all chains** that lack both `symbol` and `name` before building earn token lists.
> 
> Unit tests cover the updated `isTronSpecialAsset` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b877d3148af47dda2eb45ecd0a4a829574c12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->