### PR TITLE
fix: ARC swap usdc input force hide max button

### DIFF
--- a/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import {
   HeaderStandard,
@@ -37,7 +37,6 @@ import { BridgeToken } from '../../types';
 import {
   formatChainIdToCaip,
   formatChainIdToHex,
-  getNativeAssetForChainId,
   isNonEvmChainId,
   StatusTypes,
   AllowedBridgeChainIds,
@@ -59,6 +58,7 @@ import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../constants/brid
 import { getNetworkImageSource } from '../../../../../util/networks';
 import AvatarNetwork from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarNetwork';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
+import { useNativeCurrencySymbol } from '../../../../Views/confirmations/hooks/useNativeCurrencySymbol';
 
 const styles = StyleSheet.create({
   detailRow: {
@@ -213,6 +213,16 @@ export const BridgeTransactionDetails = (
       multiChainTx,
     });
 
+  const sourceChainId = useMemo(() => {
+    if (bridgeTxHistoryItem?.quote.srcChainId) {
+      const { srcChainId } = bridgeTxHistoryItem.quote;
+      return isNonEvmChainId(srcChainId)
+        ? formatChainIdToCaip(srcChainId)
+        : formatChainIdToHex(srcChainId);
+    }
+  }, [bridgeTxHistoryItem?.quote]);
+
+  const { nativeCurrencySymbol } = useNativeCurrencySymbol(sourceChainId);
   // Get source chain explorer data for swaps
   const swapSrcExplorerData = useMultichainBlockExplorerTxUrl({
     chainId: bridgeTxHistoryItem?.quote.srcChainId,
@@ -239,7 +249,7 @@ export const BridgeTransactionDetails = (
     />
   );
 
-  if (!bridgeTxHistoryItem) {
+  if (!bridgeTxHistoryItem || !sourceChainId) {
     return <ScreenView>{bridgeTransactionDetailsHeader}</ScreenView>;
   }
 
@@ -249,11 +259,6 @@ export const BridgeTransactionDetails = (
   const isBridge = !isSwap;
   const isIntentNotCompletedItem =
     quote.intent && !(bridgeStatus.status === StatusTypes.COMPLETE);
-
-  // Create token objects directly from the quote data
-  const sourceChainId = isNonEvmChainId(quote.srcChainId)
-    ? formatChainIdToCaip(quote.srcChainId)
-    : formatChainIdToHex(quote.srcChainId);
 
   const sourceToken: BridgeToken = {
     address: quote.srcAsset.address,
@@ -478,14 +483,12 @@ export const BridgeTransactionDetails = (
               {/* TODO get solana gas fee from multiChainTx */}
               {evmTotalGasFee && (
                 <Text variant={TextVariant.BodyMd}>
-                  {evmTotalGasFee}{' '}
-                  {getNativeAssetForChainId(quote.srcChainId).symbol}
+                  {evmTotalGasFee} {nativeCurrencySymbol}
                 </Text>
               )}
               {multiChainTotalGasFee && (
                 <Text variant={TextVariant.BodyMd}>
-                  {multiChainTotalGasFee}{' '}
-                  {getNativeAssetForChainId(quote.srcChainId).symbol}
+                  {multiChainTotalGasFee} {nativeCurrencySymbol}
                 </Text>
               )}
             </>

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/index.ts
@@ -4,6 +4,7 @@ import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
 import { isNativeAddress, isSolanaChainId } from '@metamask/bridge-controller';
 import { BigNumber } from 'bignumber.js';
+import { isArcTokenUSDC } from '../../../../../enablement/assets/arc';
 
 export const useShouldRenderMaxOption = (
   token?: BridgeToken,
@@ -22,8 +23,8 @@ export const useShouldRenderMaxOption = (
     return false;
   }
 
-  // Always show for non-native tokens
-  if (!isNativeAsset) {
+  // Always show for non-native tokens. Arc ERC20 USDC considered as native.
+  if (!isNativeAsset && !isArcTokenUSDC(token)) {
     return true;
   }
 

--- a/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
+++ b/app/components/UI/Bridge/hooks/useShouldRenderMaxOption/useShouldRenderMaxOption.test.ts
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { useShouldRenderMaxOption } from '.';
 import { BridgeToken } from '../../types';
 import { useTokenAddress } from '../useTokenAddress';
+import { ARC_USDC_BRIDGE_TOKEN } from '../../../../../enablement/assets/arc';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -131,6 +132,34 @@ describe('useShouldRenderMaxOption', () => {
 
     const { result } = renderHook(() =>
       useShouldRenderMaxOption(nativeToken, '1.25'),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true for ERC20 USDC on Arc when 7702 is enabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: true,
+    });
+    mockIsNativeAddress.mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(ARC_USDC_BRIDGE_TOKEN, '1.25'),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false for ERC20 USDC on Arc when gasIncluded and 7702 are both disabled', () => {
+    setSelectorValues({
+      gasIncluded: false,
+      gasIncluded7702: false,
+    });
+    mockIsNativeAddress.mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useShouldRenderMaxOption(ARC_USDC_BRIDGE_TOKEN, '1.25'),
     );
 
     expect(result.current).toBe(false);

--- a/app/enablement/assets/arc.ts
+++ b/app/enablement/assets/arc.ts
@@ -1,6 +1,8 @@
+import { BridgeToken } from '../../components/UI/Bridge/types';
 import { Hex } from '@metamask/utils';
 
 export const ARC_HEX_CHAIN_ID: Hex = '0x13b2';
+export const ARC_CAIP_CHAIN_ID = 'eip155:5042';
 export const ARC_USDC_ERC20_ADDRESS =
   '0x3600000000000000000000000000000000000000';
 
@@ -11,3 +13,15 @@ export const ARC_USDC_BRIDGE_TOKEN = {
   chainId: ARC_HEX_CHAIN_ID,
   decimals: 6, // ERC20, hence 6 decimals
 };
+
+/**
+ * Checks if token is the ERC20 USDC on Arc chain.
+ * @param token
+ * @returns true if bridge token corresponds to the ERC20 version of USDC on Arc
+ */
+export function isArcTokenUSDC(token: BridgeToken) {
+  return (
+    [ARC_HEX_CHAIN_ID, ARC_CAIP_CHAIN_ID].includes(token.chainId) &&
+    token.address === ARC_USDC_ERC20_ADDRESS
+  );
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## Context:

On Arc, there are two USDC:
Native one, 18 decimals.
ERC20 one, 6 decimals.
After some back-and-forth, the deduplication approach is now the following:

For Asset list / Send features: We show the native USDC.
For Bridge/Swap: We show the ERC20 USDC.

Problem: For Swap/Bridge, when Arc USDC is the input token, the "max" button still appears, because it is not considered as native. However we know for sure that swapping max amount of USDC will deplete the USDC native balance, resulting in a revert.

20/80 solution: Start with hiding the "max" button for USDC (ERC20) on Arc.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: force-hide MAX button for Arc USDC swap/bridge

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

Check fixes:

Max button hidden:
- Use the Swap widget and select Arc USDC as "from" token.
- Check that the "max" button isn't there.

Transaction detail `USDC-native` as symbol glitch:
- Make a bridge Arc USDC -> Polygon USDC 0.30$ to save funds)
- Check in Activity tab that unit of the current is `USDC` and not `USDC-native`

Non-regression:
- Play with the Swap widget and keep observing that "max" button appears for non-native tokens on other networks. It should also appear for native for gasless-supported networks, except when using a HW.
- Make bridges from most Swap-supported chains and check that Activity Tab shows items with the right token symbol for those existing networks.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only bridge input and display logic with targeted tests; no auth, payments, or broad behavioral refactors.
> 
> **Overview**
> **Arc bridge/swap:** The MAX control no longer always appears for Arc’s ERC20 USDC input. Arc USDC is treated like a native asset for `useShouldRenderMaxOption`, so MAX only shows when gas-included / 7702 gas-included quoting is enabled—avoiding full-balance swaps that can drain native USDC and revert.
> 
> **Supporting changes:** `isArcTokenUSDC` and `ARC_CAIP_CHAIN_ID` were added in `arc.ts`, with hook tests for the Arc USDC cases.
> 
> **Transaction details (related cleanup):** Bridge transaction details now derive the source chain id earlier (memoized) and label total gas fees with `useNativeCurrencySymbol` instead of `getNativeAssetForChainId`; the screen waits until `sourceChainId` is available before rendering full content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 716ab37c1a2330b0c47fe6540d54127fa10a9c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->