### PR TITLE
feat: support editing price alerts

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -5,13 +5,14 @@ import { CreatePriceAlertTestIds } from '../../constants';
 
 const mockGoBack = jest.fn();
 const mockPop = jest.fn();
-const mockSave = jest.fn();
+const mockSubmit = jest.fn();
 const mockShowToast = jest.fn();
 const mockCloseToast = jest.fn();
-const mockUseSavePriceAlert = jest.fn(() => ({
-  save: mockSave,
+const mockUseSubmitPriceAlert = jest.fn(() => ({
+  submit: mockSubmit,
   isSubmitting: false,
 }));
+const mockSetQueryData = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -27,8 +28,14 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({ setQueryData: mockSetQueryData }),
+}));
+
 jest.mock('../../api', () => ({
-  useSavePriceAlert: () => mockUseSavePriceAlert(),
+  priceAlertsQueryKey: (assetId: string) => ['priceAlerts', assetId],
+  useSubmitPriceAlert: (...args: unknown[]) => mockUseSubmitPriceAlert(...args),
 }));
 
 import { ToastContext } from '../../../../../../component-library/components/Toast';
@@ -60,9 +67,9 @@ const setRoute = (params: object) =>
 describe('CreatePriceAlertView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSave.mockResolvedValue(undefined);
-    mockUseSavePriceAlert.mockImplementation(() => ({
-      save: mockSave,
+    mockSubmit.mockResolvedValue(undefined);
+    mockUseSubmitPriceAlert.mockImplementation(() => ({
+      submit: mockSubmit,
       isSubmitting: false,
     }));
   });
@@ -199,7 +206,7 @@ describe('CreatePriceAlertView', () => {
   });
 
   describe('Set price alert button', () => {
-    it('calls save with the correct asset, threshold, and recurring values', async () => {
+    it('calls submit with the correct asset, threshold, and recurring values', async () => {
       const { getByTestId } = renderWithToast();
 
       fireEvent.press(getByTestId('keypad-key-1'));
@@ -211,7 +218,7 @@ describe('CreatePriceAlertView', () => {
         fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
       });
 
-      expect(mockSave).toHaveBeenCalledWith({
+      expect(mockSubmit).toHaveBeenCalledWith({
         asset: 'eip155:1/slip44:60',
         threshold: 1500,
         recurring: true,
@@ -232,7 +239,7 @@ describe('CreatePriceAlertView', () => {
         fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
       });
 
-      expect(mockSave).toHaveBeenCalledWith(
+      expect(mockSubmit).toHaveBeenCalledWith(
         expect.objectContaining({ recurring: false }),
       );
     });
@@ -278,8 +285,8 @@ describe('CreatePriceAlertView', () => {
       expect(mockGoBack).not.toHaveBeenCalled();
     });
 
-    it('does not navigate or show toast when save throws', async () => {
-      mockSave.mockRejectedValueOnce(new Error('HTTP 500'));
+    it('does not navigate or show toast when submit throws', async () => {
+      mockSubmit.mockRejectedValueOnce(new Error('HTTP 500'));
       const { getByTestId } = renderWithToast();
 
       fireEvent.press(getByTestId('keypad-key-1'));
@@ -292,12 +299,9 @@ describe('CreatePriceAlertView', () => {
       expect(mockShowToast).not.toHaveBeenCalled();
     });
 
-    it('does not call save a second time when the button is pressed while already submitting', async () => {
-      // The real hook sets isSubmitting=true and the Button becomes disabled+loading,
-      // preventing re-presses. Here we verify the component only calls save once
-      // even if the underlying hook guard is bypassed in tests.
+    it('does not call submit a second time when the button is pressed while already submitting', async () => {
       let resolveFirst!: () => void;
-      mockSave.mockReturnValueOnce(
+      mockSubmit.mockReturnValueOnce(
         new Promise<void>((res) => {
           resolveFirst = res;
         }),
@@ -311,7 +315,7 @@ describe('CreatePriceAlertView', () => {
         resolveFirst();
       });
 
-      expect(mockSave).toHaveBeenCalledTimes(1);
+      expect(mockSubmit).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -319,9 +323,9 @@ describe('CreatePriceAlertView', () => {
 describe('CreatePriceAlertView — duplicate threshold validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSave.mockResolvedValue(undefined);
-    mockUseSavePriceAlert.mockImplementation(() => ({
-      save: mockSave,
+    mockSubmit.mockResolvedValue(undefined);
+    mockUseSubmitPriceAlert.mockImplementation(() => ({
+      submit: mockSubmit,
       isSubmitting: false,
     }));
     // Route has an existing alert at $1500
@@ -368,7 +372,7 @@ describe('CreatePriceAlertView — duplicate threshold validation', () => {
     ).not.toBeDisabled();
   });
 
-  it('does not call save when Set button is pressed on a duplicate threshold', async () => {
+  it('does not call submit when Set button is pressed on a duplicate threshold', async () => {
     const { getByTestId } = renderWithToast();
 
     fireEvent.press(getByTestId('keypad-key-1'));
@@ -380,14 +384,14 @@ describe('CreatePriceAlertView — duplicate threshold validation', () => {
       fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
     });
 
-    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockSubmit).not.toHaveBeenCalled();
   });
 });
 
 describe('CreatePriceAlertView — tiny price token', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSave.mockResolvedValue(undefined);
+    mockSubmit.mockResolvedValue(undefined);
     setRoute({
       symbol: 'SHIB',
       ticker: 'SHIB',
@@ -471,5 +475,170 @@ describe('CreatePriceAlertView — tiny price token', () => {
     fireEvent.press(getByTestId('keypad-key-2'));
 
     expect(getByText('$0.111111111111111')).toBeOnTheScreen();
+  });
+});
+
+describe('CreatePriceAlertView — edit mode', () => {
+  const editingAlert = {
+    id: 'alert-42',
+    userId: 'user-1',
+    asset: 'eip155:1/slip44:60',
+    threshold: 1500,
+    recurring: true,
+    active: true,
+    createdAt: '2025-01-01T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubmit.mockResolvedValue(undefined);
+    mockUseSubmitPriceAlert.mockImplementation(() => ({
+      submit: mockSubmit,
+      isSubmitting: false,
+    }));
+    setRoute({
+      symbol: 'ETH',
+      ticker: 'ETH',
+      currentPrice: 1201.98,
+      currentCurrency: 'USD',
+      assetId: 'eip155:1/slip44:60',
+      fromManage: true,
+      existingThresholds: [1500],
+      editingAlert,
+    });
+  });
+
+  it('renders the edit title instead of the create title', () => {
+    const { getByText } = renderWithToast();
+    expect(getByText('Edit ETH price alert')).toBeOnTheScreen();
+  });
+
+  it('pre-populates the keypad with the existing threshold', () => {
+    const { getByText } = renderWithToast();
+    expect(getByText('$1500')).toBeOnTheScreen();
+  });
+
+  it('shows the Set button immediately because threshold is pre-populated', () => {
+    const { getByTestId } = renderWithToast();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows "Update price alert" as the button label', () => {
+    const { getByText } = renderWithToast();
+    expect(getByText('Update price alert')).toBeOnTheScreen();
+  });
+
+  it('pre-sets the recurring toggle from the existing alert', () => {
+    const { getByTestId } = renderWithToast();
+    expect(getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE)).toHaveProp(
+      'value',
+      true,
+    );
+  });
+
+  it('disables the button when threshold and recurring are unchanged', () => {
+    const { getByTestId } = renderWithToast();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
+  });
+
+  it('enables the button after the threshold is changed', () => {
+    const { getByTestId } = renderWithToast();
+
+    fireEvent.press(getByTestId('keypad-delete-button'));
+    fireEvent.press(getByTestId('keypad-key-2'));
+
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
+  });
+
+  it('enables the button when only the recurring toggle changes', () => {
+    const { getByTestId } = renderWithToast();
+
+    fireEvent(
+      getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE),
+      'valueChange',
+      false,
+    );
+
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
+  });
+
+  it('does not treat the own threshold as a duplicate', () => {
+    const { getByTestId, queryByText } = renderWithToast();
+
+    expect(queryByText('An alert at this price already exists.')).toBeNull();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toHaveTextContent('An alert at this price already exists.');
+  });
+
+  it('calls submit with threshold and recurring on update', async () => {
+    const { getByTestId } = renderWithToast();
+
+    fireEvent(
+      getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE),
+      'valueChange',
+      false,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+    });
+
+    expect(mockSubmit).toHaveBeenCalledWith({
+      asset: 'eip155:1/slip44:60',
+      threshold: 1500,
+      recurring: false,
+    });
+  });
+
+  it('updates the query cache with the new threshold and recurring after a successful update', async () => {
+    const { getByTestId } = renderWithToast();
+
+    fireEvent(
+      getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE),
+      'valueChange',
+      false,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+    });
+
+    expect(mockSetQueryData).toHaveBeenCalledWith(
+      ['priceAlerts', 'eip155:1/slip44:60'],
+      expect.any(Function),
+    );
+  });
+
+  it('calls goBack (not pop) after a successful update', async () => {
+    const { getByTestId } = renderWithToast();
+
+    fireEvent(
+      getByTestId(CreatePriceAlertTestIds.RECURRING_TOGGLE),
+      'valueChange',
+      false,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON));
+    });
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockPop).not.toHaveBeenCalled();
+  });
+
+  it('passes editingAlert to useSubmitPriceAlert', () => {
+    renderWithToast();
+    expect(mockUseSubmitPriceAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'alert-42' }),
+    );
   });
 });

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -617,6 +617,19 @@ describe('CreatePriceAlertView — edit mode', () => {
       ['priceAlerts', 'eip155:1/slip44:60'],
       expect.any(Function),
     );
+
+    const updater = mockSetQueryData.mock.calls[0][1] as (
+      prev: (typeof editingAlert)[] | undefined,
+    ) => (typeof editingAlert)[] | undefined;
+
+    // Cache miss → leave it undefined so ManagePriceAlertsView can refetch
+    expect(updater(undefined)).toBeUndefined();
+
+    // Cache hit → update only the matching alert
+    const updated = updater([editingAlert]);
+    expect(updated).toEqual([
+      { ...editingAlert, threshold: 1500, recurring: false },
+    ]);
   });
 
   it('calls goBack (not pop) after a successful update', async () => {

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -8,7 +8,7 @@ const mockPop = jest.fn();
 const mockSubmit = jest.fn();
 const mockShowToast = jest.fn();
 const mockCloseToast = jest.fn();
-const mockUseSubmitPriceAlert = jest.fn(() => ({
+const mockUseSubmitPriceAlert = jest.fn((_editingAlert?: unknown) => ({
   submit: mockSubmit,
   isSubmitting: false,
 }));
@@ -35,7 +35,8 @@ jest.mock('@tanstack/react-query', () => ({
 
 jest.mock('../../api', () => ({
   priceAlertsQueryKey: (assetId: string) => ['priceAlerts', assetId],
-  useSubmitPriceAlert: (...args: unknown[]) => mockUseSubmitPriceAlert(...args),
+  useSubmitPriceAlert: (editingAlert?: unknown) =>
+    mockUseSubmitPriceAlert(editingAlert),
 }));
 
 import { ToastContext } from '../../../../../../component-library/components/Toast';

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -248,7 +248,7 @@ const CreatePriceAlertView: React.FC = () => {
               a.id === editingAlert.id
                 ? { ...a, threshold: targetPrice, recurring: isRecurring }
                 : a,
-            ) ?? [],
+            ),
         );
       }
       toastRef?.current?.showToast({

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   Animated,
   StyleSheet,
@@ -51,9 +52,10 @@ import {
   CreatePriceAlertTestIds,
   CURRENCY_SYMBOLS,
   PRICE_ALERT_QUICK_PERCENTAGES,
+  PriceAlert,
   PriceAlertType,
 } from '../../constants';
-import { useSavePriceAlert } from '../../api';
+import { priceAlertsQueryKey, useSubmitPriceAlert } from '../../api';
 import { trimTrailingZeros } from '../../../../Bridge/utils/trimTrailingZeros';
 
 const KEYPAD_EMPTY = '0';
@@ -124,14 +126,20 @@ const CreatePriceAlertView: React.FC = () => {
     assetId,
     fromManage,
     existingThresholds,
+    editingAlert,
   } = route.params;
 
+  const isEditing = Boolean(editingAlert);
   const displayTicker = ticker || symbol;
   const [alertType, setAlertType] = useState<PriceAlertType>(
     PriceAlertType.PriceReaches,
   );
-  const [targetAmount, setTargetAmount] = useState(KEYPAD_EMPTY);
-  const [isRecurring, setIsRecurring] = useState(true);
+  const [targetAmount, setTargetAmount] = useState(
+    editingAlert ? toKeypadString(editingAlert.threshold) : KEYPAD_EMPTY,
+  );
+  const [isRecurring, setIsRecurring] = useState(
+    editingAlert?.recurring ?? true,
+  );
   const fadeAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -165,8 +173,18 @@ const CreatePriceAlertView: React.FC = () => {
   const isDuplicateThreshold = useMemo(
     () =>
       hasValidTarget &&
-      (existingThresholds ?? []).some((t) => t === targetPrice),
-    [hasValidTarget, existingThresholds, targetPrice],
+      (existingThresholds ?? []).some(
+        (t) => t === targetPrice && t !== editingAlert?.threshold,
+      ),
+    [hasValidTarget, existingThresholds, targetPrice, editingAlert],
+  );
+
+  const isUnchanged = useMemo(
+    () =>
+      isEditing &&
+      targetPrice === editingAlert?.threshold &&
+      isRecurring === editingAlert?.recurring,
+    [isEditing, editingAlert, targetPrice, isRecurring],
   );
 
   const percentDiff = useMemo(() => {
@@ -204,7 +222,8 @@ const CreatePriceAlertView: React.FC = () => {
     [currentPrice],
   );
 
-  const { save, isSubmitting } = useSavePriceAlert();
+  const { submit, isSubmitting } = useSubmitPriceAlert(editingAlert);
+  const queryClient = useQueryClient();
   const { toastRef } = useContext(ToastContext);
 
   const handleBack = useCallback(() => {
@@ -216,11 +235,22 @@ const CreatePriceAlertView: React.FC = () => {
       return;
     }
     try {
-      await save({
+      await submit({
         asset: assetId,
         threshold: targetPrice,
         recurring: isRecurring,
       });
+      if (isEditing && editingAlert) {
+        queryClient.setQueryData<PriceAlert[]>(
+          priceAlertsQueryKey(assetId),
+          (prev) =>
+            prev?.map((a) =>
+              a.id === editingAlert.id
+                ? { ...a, threshold: targetPrice, recurring: isRecurring }
+                : a,
+            ) ?? [],
+        );
+      }
       toastRef?.current?.showToast({
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
@@ -234,22 +264,24 @@ const CreatePriceAlertView: React.FC = () => {
         ],
         hasNoTimeout: false,
       });
-      // If opened from the manage list, pop both CreatePriceAlert and ManagePriceAlerts
-      // so the user lands back on TokenDetails instead of the list.
-      if (fromManage) {
-        navigation.pop(2);
-      } else {
+      // Editing always returns to Manage. Creating from Manage pops both screens to land on TokenDetails.
+      if (isEditing || !fromManage) {
         navigation.goBack();
+      } else {
+        navigation.pop(2);
       }
     } catch {
-      // save() surfaces the error via its thrown rejection; nothing to do here
+      // submit() surfaces the error via its thrown rejection; nothing to do here
     }
   }, [
-    save,
+    submit,
     assetId,
     targetPrice,
     hasValidTarget,
     isRecurring,
+    isEditing,
+    editingAlert,
+    queryClient,
     fromManage,
     navigation,
     toastRef,
@@ -279,9 +311,10 @@ const CreatePriceAlertView: React.FC = () => {
     >
       <Box twClassName="flex-1 bg-default">
         <HeaderStandard
-          title={strings('price_alerts.create_title', {
-            ticker: displayTicker,
-          })}
+          title={strings(
+            isEditing ? 'price_alerts.edit_title' : 'price_alerts.create_title',
+            { ticker: displayTicker },
+          )}
           subtitle={formattedCurrentPrice}
           onBack={handleBack}
         />
@@ -401,14 +434,21 @@ const CreatePriceAlertView: React.FC = () => {
                   onPress={handleSaveAlert}
                   isLoading={isSubmitting}
                   isDisabled={
-                    isSubmitting || !hasValidTarget || isDuplicateThreshold
+                    isSubmitting ||
+                    !hasValidTarget ||
+                    isDuplicateThreshold ||
+                    isUnchanged
                   }
                   testID={CreatePriceAlertTestIds.SET_ALERT_BUTTON}
                   twClassName="mb-3 w-full"
                 >
                   {isDuplicateThreshold
                     ? strings('price_alerts.duplicate_threshold')
-                    : strings('price_alerts.set_price_alert')}
+                    : strings(
+                        isEditing
+                          ? 'price_alerts.update_price_alert'
+                          : 'price_alerts.set_price_alert',
+                      )}
                 </Button>
               ) : (
                 <Box

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.test.tsx
@@ -71,6 +71,7 @@ jest.mock('../../api', () => ({
   fetchAlerts: (...args: unknown[]) => mockFetchAlerts(...args),
   deleteAlert: (...args: unknown[]) => mockDeleteAlert(...args),
   updateAlert: (...args: unknown[]) => mockUpdateAlert(...args),
+  priceAlertsQueryKey: (assetId: string) => ['priceAlerts', assetId],
 }));
 
 const makeAlert = (overrides: Partial<PriceAlert> = {}): PriceAlert => ({
@@ -285,6 +286,125 @@ describe('ManagePriceAlertsView', () => {
           existingThresholds: expect.arrayContaining([3000, 1500]),
         }),
       );
+    });
+
+    it('does not pass editingAlert when "Add alert" is pressed', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(ManagePriceAlertsTestIds.ADD_ALERT_BUTTON),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.CREATE_PRICE_ALERT,
+        expect.not.objectContaining({ editingAlert: expect.anything() }),
+      );
+    });
+  });
+
+  describe('edit alert', () => {
+    const twoAlerts = [
+      makeAlert({ id: 'alert-1', threshold: 3000, recurring: true }),
+      makeAlert({
+        id: 'alert-2',
+        threshold: 1500,
+        recurring: false,
+        active: false,
+      }),
+    ];
+
+    beforeEach(() => {
+      mockFetchAlerts.mockResolvedValue(makeFetchResponse(twoAlerts));
+    });
+
+    it('navigates to CreatePriceAlert with editingAlert when a row is tapped', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_EDIT_PREFIX}-alert-1`,
+        ),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.CREATE_PRICE_ALERT,
+        expect.objectContaining({
+          editingAlert: expect.objectContaining({ id: 'alert-1' }),
+          fromManage: true,
+        }),
+      );
+    });
+
+    it('passes the correct alert data for the tapped row', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_EDIT_PREFIX}-alert-2`,
+        ),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.CREATE_PRICE_ALERT,
+        expect.objectContaining({
+          editingAlert: expect.objectContaining({
+            id: 'alert-2',
+            threshold: 1500,
+            recurring: false,
+          }),
+        }),
+      );
+    });
+
+    it('passes existingThresholds of all current alerts when editing', async () => {
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_EDIT_PREFIX}-alert-1`,
+        ),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.CREATE_PRICE_ALERT,
+        expect.objectContaining({
+          existingThresholds: expect.arrayContaining([3000, 1500]),
+        }),
+      );
+    });
+
+    it('does not navigate when the row tap is disabled during a delete', async () => {
+      let resolveDelete!: (value: unknown) => void;
+      mockDeleteAlert.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveDelete = r;
+        }),
+      );
+
+      const screen = renderView();
+      await waitForLoaded(screen);
+
+      // Trigger delete — row tap is now disabled
+      fireEvent.press(
+        screen.getByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      );
+
+      // The delete button is replaced by a spinner, so the tap target is gone
+      expect(
+        screen.queryByTestId(
+          `${ManagePriceAlertsTestIds.ALERT_DELETE_PREFIX}-alert-1`,
+        ),
+      ).toBeNull();
+
+      await act(async () => {
+        resolveDelete(makeOkResponse(204));
+      });
     });
   });
 

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
@@ -11,6 +11,7 @@ import {
   FlatList,
   StyleSheet,
   Switch,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import {
@@ -49,9 +50,12 @@ import {
   PriceAlert,
   PriceAlertRouteParams,
 } from '../../constants';
-import { fetchAlerts, deleteAlert, updateAlert } from '../../api';
-
-const priceAlertsQueryKey = (assetId: string) => ['priceAlerts', assetId];
+import {
+  fetchAlerts,
+  deleteAlert,
+  updateAlert,
+  priceAlertsQueryKey,
+} from '../../api';
 
 const styles = StyleSheet.create({
   switchDisabled: { opacity: 0.5 },
@@ -130,25 +134,29 @@ const ManagePriceAlertsView: React.FC = () => {
     navigation.goBack();
   }, [navigation]);
 
-  const handleAddAlert = useCallback(() => {
-    navigation.navigate(Routes.CREATE_PRICE_ALERT, {
+  const handleNavigateToCreate = useCallback(
+    (editingAlert?: PriceAlert) => {
+      navigation.navigate(Routes.CREATE_PRICE_ALERT, {
+        symbol,
+        ticker,
+        currentPrice,
+        currentCurrency,
+        assetId,
+        fromManage: true,
+        existingThresholds: alerts.map((a) => a.threshold),
+        editingAlert,
+      });
+    },
+    [
+      navigation,
       symbol,
       ticker,
       currentPrice,
       currentCurrency,
       assetId,
-      fromManage: true,
-      existingThresholds: alerts.map((a) => a.threshold),
-    });
-  }, [
-    navigation,
-    symbol,
-    ticker,
-    currentPrice,
-    currentCurrency,
-    assetId,
-    alerts,
-  ]);
+      alerts,
+    ],
+  );
 
   const handleDeleteAlert = useCallback(
     async (id: string) => {
@@ -240,7 +248,12 @@ const ManagePriceAlertsView: React.FC = () => {
         twClassName="px-4 py-3 border-b border-muted"
         testID={`${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${item.id}`}
       >
-        <Box twClassName="flex-1 mr-3">
+        <TouchableOpacity
+          onPress={() => handleNavigateToCreate(item)}
+          disabled={isDeleting || isToggling}
+          style={tw.style('flex-1 mr-3')}
+          testID={`${ManagePriceAlertsTestIds.ALERT_EDIT_PREFIX}-${item.id}`}
+        >
           <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {strings('price_alerts.reaches_threshold', {
               threshold: formatPriceWithSubscriptNotation(
@@ -255,7 +268,7 @@ const ManagePriceAlertsView: React.FC = () => {
               ? strings('price_alerts.recurring')
               : strings('price_alerts.once_label')}
           </Text>
-        </Box>
+        </TouchableOpacity>
 
         {isDeleting ? (
           <ActivityIndicator
@@ -332,7 +345,7 @@ const ManagePriceAlertsView: React.FC = () => {
           <View style={tw.style('px-4 pb-4 pt-2')}>
             <Button
               variant={ButtonVariant.Primary}
-              onPress={handleAddAlert}
+              onPress={() => handleNavigateToCreate()}
               testID={ManagePriceAlertsTestIds.ADD_ALERT_BUTTON}
               twClassName="w-full"
             >

--- a/app/components/UI/Assets/PriceAlerts/api.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.test.ts
@@ -8,8 +8,10 @@ import {
   deleteAlert,
   updateAlert,
   fetchSupportedChains,
-  useSavePriceAlert,
+  priceAlertsQueryKey,
+  useSubmitPriceAlert,
 } from './api';
+import type { PriceAlert } from './constants';
 
 // Prevents teardown crashes with unstable_batchedUpdates in Jest
 notifyManager.setBatchNotifyFunction((callback: () => void) => {
@@ -223,10 +225,36 @@ describe('updateAlert', () => {
   });
 });
 
-describe('useSavePriceAlert', () => {
+describe('priceAlertsQueryKey', () => {
+  it('returns a stable tuple with the assetId', () => {
+    expect(priceAlertsQueryKey('eip155:1/slip44:60')).toEqual([
+      'priceAlerts',
+      'eip155:1/slip44:60',
+    ]);
+  });
+
+  it('produces different keys for different assets', () => {
+    const a = priceAlertsQueryKey('eip155:1/slip44:60');
+    const b = priceAlertsQueryKey('eip155:1/erc20:0xABC');
+    expect(a).not.toEqual(b);
+  });
+});
+
+const makeAlert = (overrides: Partial<PriceAlert> = {}): PriceAlert => ({
+  id: 'alert-1',
+  userId: 'user-1',
+  asset: 'eip155:1/slip44:60',
+  threshold: 2000,
+  recurring: true,
+  active: true,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('useSubmitPriceAlert — create mode (no editingAlert)', () => {
   it('starts with isSubmitting = false', () => {
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => useSavePriceAlert(), {
+    const { result } = renderHook(() => useSubmitPriceAlert(), {
       wrapper: Wrapper,
     });
     expect(result.current.isSubmitting).toBe(false);
@@ -241,12 +269,12 @@ describe('useSavePriceAlert', () => {
     );
 
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => useSavePriceAlert(), {
+    const { result } = renderHook(() => useSubmitPriceAlert(), {
       wrapper: Wrapper,
     });
 
     act(() => {
-      result.current.save({
+      result.current.submit({
         asset: 'eip155:1/slip44:60',
         threshold: 1000,
         recurring: true,
@@ -266,36 +294,37 @@ describe('useSavePriceAlert', () => {
     });
   });
 
-  it('resets isSubmitting = false even when the request fails', async () => {
-    mockFetch.mockResolvedValueOnce(makeErrorResponse(500, 'Server Error'));
+  it('POSTs to createAlert with the full params', async () => {
+    const params = {
+      asset: 'eip155:1/erc20:0xABC',
+      threshold: 3500,
+      recurring: false,
+    };
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => useSavePriceAlert(), {
+    const { result } = renderHook(() => useSubmitPriceAlert(), {
       wrapper: Wrapper,
     });
 
     await act(async () => {
-      await expect(
-        result.current.save({
-          asset: 'eip155:1/slip44:60',
-          threshold: 1000,
-          recurring: true,
-        }),
-      ).rejects.toThrow();
+      await result.current.submit(params);
     });
 
-    expect(result.current.isSubmitting).toBe(false);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(ALERTS_URL);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify(params));
   });
 
   it('throws with the HTTP status and body text on a non-ok response', async () => {
     mockFetch.mockResolvedValueOnce(makeErrorResponse(409, 'Conflict'));
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => useSavePriceAlert(), {
+    const { result } = renderHook(() => useSubmitPriceAlert(), {
       wrapper: Wrapper,
     });
 
     await act(async () => {
       await expect(
-        result.current.save({
+        result.current.submit({
           asset: 'eip155:1/slip44:60',
           threshold: 1000,
           recurring: true,
@@ -312,13 +341,13 @@ describe('useSavePriceAlert', () => {
     } as unknown as Response;
     mockFetch.mockResolvedValueOnce(response);
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => useSavePriceAlert(), {
+    const { result } = renderHook(() => useSubmitPriceAlert(), {
       wrapper: Wrapper,
     });
 
     await act(async () => {
       await expect(
-        result.current.save({
+        result.current.submit({
           asset: 'eip155:1/slip44:60',
           threshold: 1000,
           recurring: true,
@@ -327,22 +356,92 @@ describe('useSavePriceAlert', () => {
     });
   });
 
-  it('forwards the exact params to createAlert', async () => {
-    const params = {
-      asset: 'eip155:1/erc20:0xABC',
-      threshold: 3500,
-      recurring: false,
-    };
+  it('resets isSubmitting = false even when the request fails', async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(500, 'Server Error'));
     const { Wrapper } = createWrapper();
-    const { result } = renderHook(() => useSavePriceAlert(), {
+    const { result } = renderHook(() => useSubmitPriceAlert(), {
       wrapper: Wrapper,
     });
 
     await act(async () => {
-      await result.current.save(params);
+      await expect(
+        result.current.submit({
+          asset: 'eip155:1/slip44:60',
+          threshold: 1000,
+          recurring: true,
+        }),
+      ).rejects.toThrow();
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+  });
+});
+
+describe('useSubmitPriceAlert — edit mode (with editingAlert)', () => {
+  it('PATCHes the correct alert id with threshold and recurring', async () => {
+    const alert = makeAlert({
+      id: 'alert-42',
+      threshold: 2000,
+      recurring: true,
+    });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubmitPriceAlert(alert), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.submit({
+        asset: 'eip155:1/slip44:60',
+        threshold: 2500,
+        recurring: false,
+      });
+    });
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${ALERTS_URL}/alert-42`);
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body as string)).toEqual({
+      threshold: 2500,
+      recurring: false,
+    });
+  });
+
+  it('does not include asset in the PATCH body', async () => {
+    const alert = makeAlert({ id: 'alert-42' });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubmitPriceAlert(alert), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.submit({
+        asset: 'eip155:1/slip44:60',
+        threshold: 2500,
+        recurring: true,
+      });
     });
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(init.body).toBe(JSON.stringify(params));
+    const body = JSON.parse(init.body as string);
+    expect(body.asset).toBeUndefined();
+  });
+
+  it('throws with HTTP status on a non-ok PATCH response', async () => {
+    mockFetch.mockResolvedValueOnce(makeErrorResponse(404, 'Not Found'));
+    const alert = makeAlert({ id: 'alert-42' });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubmitPriceAlert(alert), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.submit({
+          asset: 'eip155:1/slip44:60',
+          threshold: 2500,
+          recurring: true,
+        }),
+      ).rejects.toThrow('HTTP 404: Not Found');
+    });
   });
 });

--- a/app/components/UI/Assets/PriceAlerts/api.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.ts
@@ -1,9 +1,16 @@
 import { useMutation } from '@tanstack/react-query';
 import AppConstants from '../../../../core/AppConstants';
 import Engine from '../../../../core/Engine';
-import type { SaveAlertParams, UpdateAlertParams } from './constants';
+import type {
+  PriceAlert,
+  SaveAlertParams,
+  UpdateAlertParams,
+} from './constants';
 
 const ALERTS_URL = `${AppConstants.PRICE_ALERTS_API.URL}/alerts`;
+
+export const priceAlertsQueryKey = (assetId: string) =>
+  ['priceAlerts', assetId] as const;
 
 async function authenticatedFetch(
   url: string,
@@ -50,15 +57,17 @@ export const updateAlert = (
     body: JSON.stringify(params),
   });
 
-export const useSavePriceAlert = () => {
+export const useSubmitPriceAlert = (editingAlert?: PriceAlert) => {
   const { mutateAsync, isPending } = useMutation<void, Error, SaveAlertParams>({
-    mutationFn: async (params) => {
-      const response = await createAlert(params);
+    mutationFn: async ({ asset, threshold, recurring }) => {
+      const response = editingAlert
+        ? await updateAlert(editingAlert.id, { threshold, recurring })
+        : await createAlert({ asset, threshold, recurring });
       if (!response.ok) {
         const body = await response.text().catch(() => '(no body)');
         throw new Error(`HTTP ${response.status}: ${body}`);
       }
     },
   });
-  return { save: mutateAsync, isSubmitting: isPending };
+  return { submit: mutateAsync, isSubmitting: isPending };
 };

--- a/app/components/UI/Assets/PriceAlerts/constants.ts
+++ b/app/components/UI/Assets/PriceAlerts/constants.ts
@@ -19,6 +19,8 @@ export interface CreatePriceAlertRouteParams extends PriceAlertRouteParams {
   fromManage?: boolean;
   /** Thresholds of existing alerts for this asset, used for duplicate-threshold validation. */
   existingThresholds?: number[];
+  /** When present the screen is in edit mode; pre-populates threshold/recurring and calls PATCH on save. */
+  editingAlert?: PriceAlert;
 }
 
 /** API response shape for a single price alert. */
@@ -76,6 +78,7 @@ export const ManagePriceAlertsTestIds = {
   LOADING: 'manage-price-alerts-loading',
   ALERT_LIST: 'manage-price-alerts-list',
   ALERT_ITEM_PREFIX: 'manage-price-alerts-item',
+  ALERT_EDIT_PREFIX: 'manage-price-alerts-edit',
   ALERT_TOGGLE_PREFIX: 'manage-price-alerts-toggle',
   ALERT_DELETE_PREFIX: 'manage-price-alerts-delete',
   ALERT_DELETE_SPINNER_PREFIX: 'manage-price-alerts-delete-spinner',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4117,6 +4117,7 @@
   },
   "price_alerts": {
     "create_title": "Create {{ticker}} price alert",
+    "edit_title": "Edit {{ticker}} price alert",
     "price_reaches": "Price reaches",
     "price_change": "Price change",
     "enter_target_price": "Enter target price",
@@ -4127,6 +4128,7 @@
     "quick_percentage": "{{percentage}}%",
     "price_change_under_development": "This experience is currently under development",
     "set_price_alert": "Set price alert",
+    "update_price_alert": "Update price alert",
     "save_success": "Price alert for {{ticker}} saved successfully.",
     "delete_success": "Price alert deleted.",
     "duplicate_threshold": "An alert at this price already exists.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

- Adds the ability to tap an existing alert row in the manage list to edit its price threshold and recurring setting, reusing `CreatePriceAlertView` entirely rather than introducing a new screen
- Replaces `useSavePriceAlert` with a unified `useSubmitPriceAlert(editingAlert?)` hook that internally routes to `POST` (create) or `PATCH` (edit) — the view calls `submit()` identically in both modes
- Moves `priceAlertsQueryKey` from a local constant in `ManagePriceAlertsView` into `api.ts` so both screens share the same cache key definition
- Merges `handleAddAlert` and `handleEditAlert` into a single `handleNavigateToCreate(editingAlert?)` in `ManagePriceAlertsView`, eliminating duplicated navigation params
- After a successful edit, the query cache is updated optimistically before navigating back so the manage list reflects changes immediately without a refetch



<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: support editing price alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3415

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/074d0040-f529-4e76-b8ed-2d0b5b54a703



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped feature work in Price Alerts UI with PATCH/create routing and cache updates; well-covered by tests and no auth or payment changes.
> 
> **Overview**
> Users can **edit** existing price alerts by tapping a row on the manage screen, reusing **CreatePriceAlertView** instead of a new screen.
> 
> **API & hooks:** `useSavePriceAlert` is replaced by **`useSubmitPriceAlert(editingAlert?)`**, which **POST**s on create and **PATCH**es on edit; **`priceAlertsQueryKey`** is exported from `api.ts` for shared React Query cache keys.
> 
> **Create flow:** Route param **`editingAlert`** drives edit UI (title, pre-filled threshold/recurring, “Update price alert”, disabled submit when unchanged). Duplicate-threshold checks **ignore the alert being edited**. After a successful edit, the list cache is updated via **`setQueryData`** and navigation uses **`goBack`** (create-from-manage still **`pop(2)`**).
> 
> **Manage flow:** Add and edit share **`handleNavigateToCreate(editingAlert?)`**; rows are tappable **`TouchableOpacity`** targets (disabled during delete/toggle).
> 
> **i18n:** `edit_title` and `update_price_alert` strings added; tests updated for submit hook and edit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85473d0f1eccd5da5dd9a3a3dc18d094f1abb7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->