### PR TITLE
fix(MUSD-1036): cp-8.0.0 consistently use mUSD for deposits

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts
@@ -931,6 +931,20 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
     expect(result.current.description).toBe('mUSD → ETH');
   });
 
+  it('sent → "mUSD" for a plain mUSD send (no redundant "mUSD → mUSD")', () => {
+    // A simple mUSD transfer out of the Money account: the pay token resolves
+    // to mUSD, so the pair would be "mUSD → mUSD". It collapses to just "mUSD",
+    // mirroring the deposit row.
+    const tx = makeTx(TransactionType.simpleSend, {
+      metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: CHAIN_ID },
+    });
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: makeState() },
+    );
+    expect(result.current.description).toBe('mUSD');
+  });
+
   it('sent → "mUSD → USDC" for a withdrawal whose dest token cannot be resolved', () => {
     // No metamaskPay token → falls back to the known money withdraw token.
     const tx = makeTx(TransactionType.moneyAccountWithdraw, {});
@@ -972,6 +986,78 @@ describe('useMoneyTransactionDisplayInfo — per-kind subtitles', () => {
     const { result } = renderHookWithProvider(
       () => useMoneyTransactionDisplayInfo(tx, undefined),
       { state: makeState() },
+    );
+    expect(result.current.description).toBe('mUSD');
+  });
+
+  it('canonicalises the registry "MUSD" symbol to the branded "mUSD"', () => {
+    // mUSD is registered with the uppercase symbol "MUSD"; the subtitle must
+    // still show the branded casing, not whatever the registry holds.
+    const tx = makeTx(TransactionType.moneyAccountDeposit, {
+      metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: CHAIN_ID },
+    });
+    const stateWithUppercaseMusd = {
+      engine: {
+        backgroundState: {
+          CurrencyRateController: { currentCurrency: 'usd', currencyRates: {} },
+          TokenRatesController: { marketData: {} },
+          TokensController: {
+            allTokens: {
+              [CHAIN_ID]: {
+                '0xSomeWallet': [
+                  { address: MUSD_TOKEN_ADDRESS, symbol: 'MUSD', decimals: 6 },
+                ],
+              },
+            },
+          },
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [CHAIN_ID]: { nativeCurrency: 'ETH' },
+            },
+          },
+        },
+      },
+    } as unknown as ProviderValues['state'];
+
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: stateWithUppercaseMusd },
+    );
+    expect(result.current.description).toBe('mUSD');
+  });
+
+  it('sent → "mUSD" even when the registry symbol is uppercase "MUSD"', () => {
+    // The send pair must collapse to "mUSD" (not "mUSD → MUSD") once the
+    // destination symbol is canonicalised.
+    const tx = makeTx(TransactionType.simpleSend, {
+      metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS, chainId: CHAIN_ID },
+    });
+    const stateWithUppercaseMusd = {
+      engine: {
+        backgroundState: {
+          CurrencyRateController: { currentCurrency: 'usd', currencyRates: {} },
+          TokenRatesController: { marketData: {} },
+          TokensController: {
+            allTokens: {
+              [CHAIN_ID]: {
+                '0xSomeWallet': [
+                  { address: MUSD_TOKEN_ADDRESS, symbol: 'MUSD', decimals: 6 },
+                ],
+              },
+            },
+          },
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [CHAIN_ID]: { nativeCurrency: 'ETH' },
+            },
+          },
+        },
+      },
+    } as unknown as ProviderValues['state'];
+
+    const { result } = renderHookWithProvider(
+      () => useMoneyTransactionDisplayInfo(tx, undefined),
+      { state: stateWithUppercaseMusd },
     );
     expect(result.current.description).toBe('mUSD');
   });

--- a/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.ts
@@ -139,7 +139,12 @@ function deriveSubtitle(
       const destSymbol =
         sourceTokenSymbol ??
         (isMoneyWithdrawTx(tx) ? MONEY_WITHDRAW_TOKEN_SYMBOL : undefined);
-      return destSymbol ? `${MUSD_TOKEN.symbol} → ${destSymbol}` : undefined;
+      // A plain mUSD send (destination is mUSD too) collapses to just "mUSD",
+      // mirroring the deposit row; only a cross-token withdrawal keeps the
+      // "mUSD → X" pair, where the destination token carries real information.
+      return destSymbol && destSymbol !== MUSD_TOKEN.symbol
+        ? `${MUSD_TOKEN.symbol} → ${destSymbol}`
+        : MUSD_TOKEN.symbol;
     }
     case 'received': {
       const sender = tx.txParams?.from;
@@ -212,10 +217,11 @@ export function useMoneyTransactionDisplayInfo(
   });
 
   return useMemo(() => {
-    const sourceTokenSymbol =
-      payToken?.symbol ??
-      nativeTicker ??
-      (isMusdToken(payTokenAddress) ? MUSD_TOKEN.symbol : undefined);
+    // mUSD is registered with the uppercase symbol "MUSD"; canonicalise it to
+    // the branded "mUSD" so subtitles never leak the registry casing.
+    const sourceTokenSymbol = isMusdToken(payTokenAddress)
+      ? MUSD_TOKEN.symbol
+      : (payToken?.symbol ?? nativeTicker);
     const kind = classifyMoneyActivity(tx);
     const status = getMoneyActivityStatus(tx);
     const isIncoming = isIncomingMoneyTransactionMeta(tx);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This fixes two issues related to the subtitles shown on transactions in the money activity view.

Firstly is ensures that 'deposit' transactions that are `mUSD` -> `mUSD` will simply show `mUSD`.

Additionally, it fixes a case where we would sometimes show `MUSD` rather than `mUSD`
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: render mUSD subtitles correctly in money activity list

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-1036

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: money activity
  Scenario: user views money activity
    Given there are deposits from musd -> musd

    When user reviews the activity list
    Then subtitles render correctly
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="394" height="527" alt="Screenshot 2026-06-22 at 10 13 29" src="https://github.com/user-attachments/assets/d839ea77-0f65-477b-b7d9-77e3407f62d0" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only subtitle logic in the money activity hook with added unit tests; no auth, transactions, or data handling changes.
> 
> **Overview**
> Money activity row subtitles now **always use branded `mUSD` casing** and avoid redundant token pairs for same-asset flows.
> 
> When the pay token is mUSD, `useMoneyTransactionDisplayInfo` **forces `MUSD_TOKEN.symbol`** instead of the registry’s uppercase `MUSD`. **Sent** rows that would have read `mUSD → mUSD` **collapse to `mUSD`**, matching mUSD top-up deposits; cross-token sends still show `mUSD → {dest}`.
> 
> Tests cover plain mUSD sends, registry `MUSD` on deposits, and send collapse after canonicalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f0de35c93c30050115fb2a27a993bbb64c7b84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->