### PR TITLE
refactor(perps): migrate deprecated Icon to MetaMask Design System

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -16,14 +16,13 @@ import { PerpsClosePositionViewSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import {
   Button,
-  ButtonVariant,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Icon, {
+  ButtonVariant,
+  Icon,
   IconColor,
   IconName,
   IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
 import ListItem from '../../../../../component-library/components/List/ListItem';
 import ListItemColumn, {
   WidthType,
@@ -675,7 +674,7 @@ const PerpsClosePositionView: React.FC = () => {
                 <Icon
                   name={IconName.Danger}
                   size={IconSize.Sm}
-                  color={IconColor.Error}
+                  color={IconColor.ErrorDefault}
                 />
                 <Text variant={TextVariant.BodySM} color={TextColor.Error}>
                   {error}

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { HeaderStandard } from '@metamask/design-system-react-native';
-import { View, Animated, ScrollView } from 'react-native';
-import { useStyles } from '../../../../../component-library/hooks';
-import Icon, {
+import {
+  HeaderStandard,
+  Icon,
+  IconColor,
   IconName,
   IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
+import { View, Animated, ScrollView } from 'react-native';
+import { useStyles } from '../../../../../component-library/hooks';
 import TextFieldSearch from '../../../../../component-library/components/Form/TextFieldSearch/TextFieldSearch';
 import { strings } from '../../../../../../locales/i18n';
 import Text, {
@@ -357,7 +359,7 @@ const PerpsMarketListView = ({
             <Icon
               name={IconName.Search}
               size={IconSize.Xl}
-              color={theme.colors.icon.muted}
+              color={IconColor.IconMuted}
               style={styles.emptyStateIcon}
             />
             <Text
@@ -404,7 +406,7 @@ const PerpsMarketListView = ({
           <Icon
             name={IconName.Search}
             size={IconSize.Xl}
-            color={theme.colors.icon.muted}
+            color={IconColor.IconMuted}
             style={styles.emptyStateIcon}
           />
           <Text

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsPayRow.tsx
@@ -1,4 +1,10 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import React, { useCallback, useMemo } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
@@ -9,11 +15,6 @@ import Badge, {
 import BadgeWrapper, {
   BadgePosition,
 } from '../../../../../component-library/components/Badges/BadgeWrapper';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import Text, {
   TextColor,
   TextVariant,
@@ -178,7 +179,7 @@ export const PerpsPayRow = ({
           <Icon
             name={IconName.Info}
             size={IconSize.Sm}
-            color={IconColor.Alternative}
+            color={IconColor.IconAlternative}
           />
         </TouchableOpacity>
       </Box>

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -1,4 +1,10 @@
 import { useNavigation } from '@react-navigation/native';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import BigNumber from 'bignumber.js';
 import React, { useCallback, useState } from 'react';
 import { Modal, TouchableOpacity, View } from 'react-native';
@@ -8,11 +14,6 @@ import {
   PerpsTabViewSelectorsIDs,
 } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import Text, {
   TextVariant,
   TextColor,
@@ -192,7 +193,7 @@ const PerpsTabView = () => {
         <View style={styles.startTradeIconContainer}>
           <Icon
             name={IconName.Add}
-            color={IconColor.Default}
+            color={IconColor.IconDefault}
             size={IconSize.Sm}
           />
         </View>

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx
@@ -15,17 +15,18 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   Button,
-  ButtonVariant,
   ButtonSize,
+  ButtonVariant,
   HeaderStandard,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { PerpsWithdrawViewSelectorsIDs } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import KeyValueRow from '../../../../../component-library/components-temp/KeyValueRow';
-import Icon, {
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import Text, {
   TextColor,
   TextVariant,
@@ -71,10 +72,6 @@ import Badge, {
 } from '../../../../../component-library/components/Badges/Badge';
 import BadgeWrapper from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { BadgePosition } from '../../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.types';
-import {
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon/Icon.types';
 import { NetworkBadgeSource } from '../../../../UI/AssetOverview/Balance/Balance';
 import usePerpsToasts from '../../hooks/usePerpsToasts';
 
@@ -442,7 +439,7 @@ const PerpsWithdrawView: React.FC = () => {
               <Icon
                 name={IconName.Info}
                 size={IconSize.Md}
-                color={IconColor.Alternative}
+                color={IconColor.IconAlternative}
               />
             </Pressable>
           </Box>
@@ -494,7 +491,7 @@ const PerpsWithdrawView: React.FC = () => {
                     <Icon
                       name={IconName.Info}
                       size={IconSize.Md}
-                      color={IconColor.Alternative}
+                      color={IconColor.IconAlternative}
                     />
                   </Pressable>
                 </Box>

--- a/app/components/UI/Perps/components/FoxIcon/FoxIcon.test.tsx
+++ b/app/components/UI/Perps/components/FoxIcon/FoxIcon.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import FoxIcon from './FoxIcon';
-import { IconColor } from '../../../../../component-library/components/Icons/Icon';
+import { IconColor } from '@metamask/design-system-react-native';
 
 const { mockTheme } = jest.requireActual('../../../../../util/theme');
 
@@ -56,14 +56,16 @@ describe('FoxIcon', () => {
   });
 
   it('uses muted icon color when specified', () => {
-    const { getByTestId } = render(<FoxIcon iconColor={IconColor.Muted} />);
+    const { getByTestId } = render(<FoxIcon iconColor={IconColor.IconMuted} />);
 
     const xmlContent = getByTestId('fox-icon-xml').props.children;
     expect(xmlContent).toContain(`fill="${mockTheme.colors.icon.muted}"`);
   });
 
   it('uses default icon color when specified', () => {
-    const { getByTestId } = render(<FoxIcon iconColor={IconColor.Default} />);
+    const { getByTestId } = render(
+      <FoxIcon iconColor={IconColor.IconDefault} />,
+    );
 
     const xmlContent = getByTestId('fox-icon-xml').props.children;
     expect(xmlContent).toContain(`fill="${mockTheme.colors.icon.default}"`);
@@ -126,7 +128,9 @@ describe('FoxIcon', () => {
     });
 
     it('handles Primary icon color', () => {
-      const { getByTestId } = render(<FoxIcon iconColor={IconColor.Primary} />);
+      const { getByTestId } = render(
+        <FoxIcon iconColor={IconColor.PrimaryDefault} />,
+      );
 
       const xmlContent = getByTestId('fox-icon-xml').props.children;
       expect(xmlContent).toContain(
@@ -137,12 +141,20 @@ describe('FoxIcon', () => {
     it('memoizes SVG XML to prevent unnecessary regeneration', () => {
       // Arrange
       const { rerender } = render(
-        <FoxIcon width={14} height={14} iconColor={IconColor.Alternative} />,
+        <FoxIcon
+          width={14}
+          height={14}
+          iconColor={IconColor.IconAlternative}
+        />,
       );
 
       // Act - Rerender with same props
       rerender(
-        <FoxIcon width={14} height={14} iconColor={IconColor.Alternative} />,
+        <FoxIcon
+          width={14}
+          height={14}
+          iconColor={IconColor.IconAlternative}
+        />,
       );
 
       // Assert - Component should render without errors (memoization working)
@@ -153,13 +165,19 @@ describe('FoxIcon', () => {
     it('regenerates SVG XML when props change', () => {
       // Arrange
       const { getByTestId, rerender } = render(
-        <FoxIcon width={14} height={14} iconColor={IconColor.Alternative} />,
+        <FoxIcon
+          width={14}
+          height={14}
+          iconColor={IconColor.IconAlternative}
+        />,
       );
 
       const initialXml = getByTestId('fox-icon-xml').props.children;
 
       // Act - Rerender with different props
-      rerender(<FoxIcon width={20} height={20} iconColor={IconColor.Muted} />);
+      rerender(
+        <FoxIcon width={20} height={20} iconColor={IconColor.IconMuted} />,
+      );
 
       const updatedXml = getByTestId('fox-icon-xml').props.children;
 

--- a/app/components/UI/Perps/components/FoxIcon/FoxIcon.tsx
+++ b/app/components/UI/Perps/components/FoxIcon/FoxIcon.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
+import { IconColor } from '@metamask/design-system-react-native';
 import { SvgXml } from 'react-native-svg';
 import { useStyles } from '../../../../../component-library/hooks';
-import { IconColor } from '../../../../../component-library/components/Icons/Icon';
 
 interface FoxIconProps {
   width?: number;
@@ -12,25 +12,25 @@ interface FoxIconProps {
 const FoxIcon: React.FC<FoxIconProps> = ({
   width = 14,
   height = 14,
-  iconColor = IconColor.Alternative,
+  iconColor = IconColor.IconAlternative,
 }) => {
   const { theme } = useStyles(() => ({}), {});
 
   let fillColor;
   switch (iconColor) {
-    case IconColor.Alternative:
+    case IconColor.IconAlternative:
       fillColor = theme.colors.icon.alternative;
       break;
-    case IconColor.Default:
+    case IconColor.IconDefault:
       fillColor = theme.colors.icon.default;
       break;
-    case IconColor.Muted:
+    case IconColor.IconMuted:
       fillColor = theme.colors.icon.muted;
       break;
-    case IconColor.Primary:
+    case IconColor.PrimaryDefault:
       fillColor = theme.colors.primary.default;
       break;
-    case IconColor.Warning:
+    case IconColor.WarningDefault:
       fillColor = theme.colors.warning.default;
       break;
     default:

--- a/app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.tsx
@@ -1,4 +1,10 @@
 import React, { useMemo, useCallback, useRef, useEffect } from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { View, TouchableOpacity } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import BottomSheet, {
@@ -9,11 +15,6 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
 import styleSheet from './PerpsAdjustMarginActionSheet.styles';
 import type {
@@ -102,7 +103,7 @@ const PerpsAdjustMarginActionSheet: React.FC<
               <Icon
                 name={option.iconName}
                 size={IconSize.Lg}
-                color={IconColor.Default}
+                color={IconColor.IconDefault}
               />
               <View style={styles.actionContent}>
                 <Text variant={TextVariant.BodyMDBold}>{option.label}</Text>

--- a/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { Pressable } from 'react-native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
 import { CandlePeriod, CANDLE_PERIODS } from '@metamask/perps-controller';
 import { getPerpsCandlePeriodSelector } from '../../Perps.testIds';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import { styleSheet } from './PerpsCandlePeriodSelector.styles';
 
 // Default candle periods with preset values
@@ -119,7 +122,7 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
         <Icon
           name={IconName.ArrowDown}
           size={IconSize.Xs}
-          color={IconColor.Alternative}
+          color={IconColor.IconAlternative}
         />
       </Pressable>
     </Box>

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -92,6 +92,7 @@ jest.mock('../../../../../component-library/components/Buttons/Button', () => {
 jest.mock('@metamask/design-system-react-native', () => {
   const { TouchableOpacity, Text } = jest.requireActual('react-native');
   return {
+    ...jest.requireActual('@metamask/design-system-react-native'),
     __esModule: true,
     Button: ({
       label,

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -3,14 +3,13 @@ import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import {
   Button,
-  ButtonVariant,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Icon, {
+  ButtonVariant,
+  Icon,
   IconColor,
   IconName,
   IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
   TextVariant,
@@ -76,7 +75,7 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
       <View style={styles.errorContainer}>
         <Icon
           name={IconName.Warning}
-          color={IconColor.Muted}
+          color={IconColor.IconMuted}
           size={IconSize.Xl}
           style={styles.errorIcon}
         />

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -3,14 +3,13 @@ import { View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 import {
   Button,
-  ButtonVariant,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Icon, {
+  ButtonVariant,
+  Icon,
   IconColor,
   IconName,
   IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
   TextVariant,
@@ -86,7 +85,7 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
       <View style={styles.content}>
         <Icon
           name={errorContent.icon}
-          color={IconColor.Muted}
+          color={IconColor.IconMuted}
           size={iconSize}
           style={styles.icon}
         />

--- a/app/components/UI/Perps/components/PerpsMarketCategoryBadge/PerpsMarketCategoryBadge.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketCategoryBadge/PerpsMarketCategoryBadge.types.ts
@@ -1,4 +1,4 @@
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import { IconName } from '@metamask/design-system-react-native';
 
 export interface PerpsMarketCategoryBadgeProps {
   /**

--- a/app/components/UI/Perps/components/PerpsMarketCategoryBadges/PerpsMarketCategoryBadges.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketCategoryBadges/PerpsMarketCategoryBadges.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
+import { IconName } from '@metamask/design-system-react-native';
 import Animated, { FadeIn, LinearTransition } from 'react-native-reanimated';
 import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import PerpsMarketCategoryBadge from '../PerpsMarketCategoryBadge';
 import { styleSheet } from './PerpsMarketCategoryBadges.styles';
 import type { PerpsMarketCategoryBadgesProps } from './PerpsMarketCategoryBadges.types';

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -12,6 +12,10 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   Card,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
 } from '@metamask/design-system-react-native';
 import {
   PERPS_CONSTANTS,
@@ -33,11 +37,6 @@ import PerpsBadge from '../PerpsBadge';
 import PerpsLeverage from '../PerpsLeverage/PerpsLeverage';
 import PerpsTokenLogo from '../PerpsTokenLogo';
 import { PerpsMarketRowItemProps } from './PerpsMarketRowItem.types';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import { useStyles } from '../../../../../component-library/hooks';
 import type { Theme } from '@metamask/design-tokens';
 
@@ -269,7 +268,7 @@ const PerpsMarketRowItem = ({
               <Icon
                 name={IconName.Add}
                 size={IconSize.Md}
-                color={IconColor.Default}
+                color={IconColor.IconDefault}
               />
             </View>
           </TouchableOpacity>

--- a/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.test.tsx
@@ -21,6 +21,7 @@ jest.mock('../../../../../component-library/hooks', () => ({
 jest.mock('@metamask/design-system-react-native', () => {
   const { View } = jest.requireActual('react-native');
   return {
+    ...jest.requireActual('@metamask/design-system-react-native'),
     Box: View,
   };
 });

--- a/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketSortDropdowns/PerpsMarketSortDropdowns.tsx
@@ -1,17 +1,18 @@
 import React, { useMemo } from 'react';
 import { Pressable } from 'react-native';
-import { Box } from '@metamask/design-system-react-native';
+import {
+  Box,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import { styleSheet } from './PerpsMarketSortDropdowns.styles';
 import type { PerpsMarketSortDropdownsProps } from './PerpsMarketSortDropdowns.types';
 import { MARKET_SORTING_CONFIG } from '@metamask/perps-controller';
@@ -67,7 +68,7 @@ const PerpsMarketSortDropdowns: React.FC<PerpsMarketSortDropdownsProps> = ({
         <Icon
           name={IconName.SwapVertical}
           size={IconSize.Sm}
-          color={IconColor.Alternative}
+          color={IconColor.IconAlternative}
         />
       </Pressable>
     </Box>

--- a/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketStatisticsCard/PerpsMarketStatisticsCard.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo } from 'react';
-import { TouchableOpacity, View } from 'react-native';
-import { strings } from '../../../../../../locales/i18n';
-import Icon, {
+import {
+  Icon,
   IconColor,
   IconName,
   IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
+import { TouchableOpacity, View } from 'react-native';
+import { strings } from '../../../../../../locales/i18n';
 import Text, {
   TextColor,
   TextVariant,
@@ -140,7 +141,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
             <Icon
               name={IconName.ArrowRight}
               size={IconSize.Sm}
-              color={IconColor.Alternative}
+              color={IconColor.IconAlternative}
             />
           </TouchableOpacity>
         )}
@@ -182,7 +183,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
                   <Icon
                     name={IconName.Info}
                     size={IconSize.Sm}
-                    color={IconColor.Alternative}
+                    color={IconColor.IconAlternative}
                   />
                 </TouchableOpacity>
               </View>
@@ -216,7 +217,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
                   <Icon
                     name={IconName.Info}
                     size={IconSize.Sm}
-                    color={IconColor.Alternative}
+                    color={IconColor.IconAlternative}
                   />
                 </TouchableOpacity>
               </View>
@@ -246,7 +247,7 @@ const PerpsMarketStatisticsCard: React.FC<PerpsMarketStatisticsCardProps> = ({
                   <Icon
                     name={IconName.Info}
                     size={IconSize.Sm}
-                    color={IconColor.Alternative}
+                    color={IconColor.IconAlternative}
                   />
                 </TouchableOpacity>
               </View>

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
@@ -5,15 +5,17 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import { View, Modal } from 'react-native';
 import {
   TabsList,
@@ -126,7 +128,7 @@ const OrdersTabContent = React.memo<OrdersTabContentProps>(
             <Icon
               name={IconName.Book}
               size={IconSize.Xl}
-              color={TextColor.Muted}
+              color={IconColor.IconMuted}
               style={styles.emptyStateIcon}
               testID={PerpsMarketTabsSelectorsIDs.ORDERS_EMPTY_ICON}
             />

--- a/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
@@ -110,6 +110,7 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => {
 
 // Mock Box component
 jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
   Box: function MockBox({ children }: { children: React.ReactNode }) {
     const ReactModule = jest.requireActual('react');
     const { View } = jest.requireActual('react-native');

--- a/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.tsx
@@ -9,11 +9,13 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import Icon, {
-  IconSize,
+import {
+  Box,
+  Icon,
+  IconColor,
   IconName,
-} from '../../../../../component-library/components/Icons/Icon';
-import { Box } from '@metamask/design-system-react-native';
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import styleSheet from './PerpsModifyActionSheet.styles';
 import type { ModifyAction } from './PerpsModifyActionSheet.types';
@@ -127,7 +129,7 @@ const PerpsModifyActionSheet: React.FC<PerpsModifyActionSheetProps> = ({
               <Icon
                 name={option.iconName}
                 size={IconSize.Md}
-                color={styles.iconColor.color}
+                color={IconColor.IconDefault}
               />
             </View>
             <View style={styles.actionTextContainer}>

--- a/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import { IconName } from '@metamask/design-system-react-native';
 import PerpsNavigationCard, {
   type NavigationItem,
 } from './PerpsNavigationCard';
@@ -34,21 +34,13 @@ jest.mock(
     },
   }),
 );
-jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
-  __esModule: true,
-  default: 'Icon',
+jest.mock('@metamask/design-system-react-native', () => ({
+  ...jest.requireActual('@metamask/design-system-react-native'),
+  Icon: 'Icon',
   IconName: {
     Setting: 'Setting',
     Notification: 'Notification',
     ArrowRight: 'ArrowRight',
-  },
-  IconSize: {
-    Md: 'Md',
-  },
-  IconColor: {
-    Default: 'Default',
-    Alternative: 'Alternative',
-    Primary: 'Primary',
   },
 }));
 jest.mock('../../../../../component-library/components/Texts/Text', () => ({

--- a/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.tsx
+++ b/app/components/UI/Perps/components/PerpsNavigationCard/PerpsNavigationCard.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import ListItem from '../../../../../component-library/components/List/ListItem';
 import ListItemColumn, {
   WidthType,
 } from '../../../../../component-library/components/List/ListItemColumn';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import Text, {
   TextColor,
   TextVariant,
@@ -33,7 +34,7 @@ export interface NavigationItem {
    */
   showArrow?: boolean;
   /**
-   * Optional color for the right arrow icon (defaults to IconColor.Alternative)
+   * Optional color for the right arrow icon (defaults to IconColor.IconAlternative)
    */
   arrowColor?: IconColor;
   /**
@@ -88,7 +89,7 @@ const PerpsNavigationCard: React.FC<PerpsNavigationCardProps> = ({ items }) => {
                 <Icon
                   name={item.iconName}
                   size={IconSize.Md}
-                  color={IconColor.Default}
+                  color={IconColor.IconDefault}
                 />
               )}
               <ListItemColumn widthType={WidthType.Fill}>
@@ -101,7 +102,7 @@ const PerpsNavigationCard: React.FC<PerpsNavigationCardProps> = ({ items }) => {
                   <Icon
                     name={IconName.ArrowRight}
                     size={IconSize.Md}
-                    color={item.arrowColor ?? IconColor.Alternative}
+                    color={item.arrowColor ?? IconColor.IconAlternative}
                   />
                 </ListItemColumn>
               )}

--- a/app/components/UI/Perps/components/PerpsOICapWarning/PerpsOICapWarning.tsx
+++ b/app/components/UI/Perps/components/PerpsOICapWarning/PerpsOICapWarning.tsx
@@ -1,15 +1,16 @@
 import React, { memo } from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
 import { usePerpsOICap } from '../../hooks/usePerpsOICap';
 import type { PerpsOICapWarningProps } from './PerpsOICapWarning.types';
@@ -56,7 +57,7 @@ const PerpsOICapWarning: React.FC<PerpsOICapWarningProps> = memo(
         <Icon
           name={IconName.Warning}
           size={IconSize.Md}
-          color={IconColor.Default}
+          color={IconColor.IconDefault}
           style={styles.icon}
         />
         <View style={styles.textContainer}>

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
@@ -2,18 +2,17 @@ import React, { useMemo, useState, useCallback, useRef } from 'react';
 import { Modal, TouchableOpacity, View } from 'react-native';
 import {
   Button,
-  ButtonVariant,
   ButtonSize,
+  ButtonVariant,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
 } from '@metamask/design-system-react-native';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../../component-library/components/Icons/Icon';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
@@ -248,8 +247,8 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                 <View style={styles.fillBadge}>
                   <Icon
                     name={IconName.Loading}
-                    size={IconSize.Xss}
-                    color={IconColor.Alternative}
+                    size={IconSize.Xs}
+                    color={IconColor.IconAlternative}
                     style={styles.fillBadgeIcon}
                   />
                   <Text

--- a/app/components/UI/Perps/components/PerpsPriceDeviationWarning/PerpsPriceDeviationWarning.tsx
+++ b/app/components/UI/Perps/components/PerpsPriceDeviationWarning/PerpsPriceDeviationWarning.tsx
@@ -1,15 +1,16 @@
 import React, { memo } from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
 import type { PerpsPriceDeviationWarningProps } from './PerpsPriceDeviationWarning.types';
 import styleSheet from './PerpsPriceDeviationWarning.styles';
@@ -35,7 +36,7 @@ const PerpsPriceDeviationWarning: React.FC<PerpsPriceDeviationWarningProps> =
         <Icon
           name={IconName.Info}
           size={IconSize.Md}
-          color={IconColor.Default}
+          color={IconColor.IconDefault}
           style={styles.icon}
         />
         <View style={styles.textContainer}>

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorBadge.tsx
@@ -1,4 +1,10 @@
 import React, { useCallback } from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -7,11 +13,6 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import Routes from '../../../../../constants/navigation/Routes';
 import { usePerpsProvider } from '../../hooks/usePerpsProvider';
 import { selectPerpsNetwork } from '../../selectors/perpsController';
@@ -70,7 +71,7 @@ const PerpsProviderSelectorBadge: React.FC<PerpsProviderSelectorBadgeProps> = ({
       <Icon
         name={IconName.ArrowDown}
         size={IconSize.Xs}
-        color={isTestnet ? IconColor.Warning : IconColor.Alternative}
+        color={isTestnet ? IconColor.WarningDefault : IconColor.IconAlternative}
       />
     </TouchableOpacity>
   );

--- a/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsProviderSelector/PerpsProviderSelectorSheet.tsx
@@ -1,15 +1,16 @@
 import React, { useRef, useEffect, useCallback, useMemo } from 'react';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { TouchableOpacity, View } from 'react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../component-library/components/BottomSheets/BottomSheet';
@@ -135,7 +136,7 @@ const PerpsProviderSelectorSheet: React.FC<PerpsProviderSelectorSheetProps> = ({
                 <Icon
                   name={IconName.Check}
                   size={IconSize.Md}
-                  color={IconColor.Primary}
+                  color={IconColor.PrimaryDefault}
                   style={styles.checkIcon}
                   testID={testID ? `${testID}-check-${option.id}` : undefined}
                 />

--- a/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
+++ b/app/components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx
@@ -7,14 +7,13 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import {
   Button,
-  ButtonVariant,
   ButtonSize,
-} from '@metamask/design-system-react-native';
-import Icon, {
+  ButtonVariant,
+  Icon,
+  IconColor,
   IconName,
   IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsStopLossPromptSelectorsIDs } from '../../Perps.testIds';
 import {
@@ -199,7 +198,7 @@ const PerpsStopLossPromptBanner: React.FC<PerpsStopLossPromptBannerProps> =
                 <Icon
                   name={IconName.Check}
                   size={IconSize.Sm}
-                  color={IconColor.Inverse}
+                  color={IconColor.PrimaryInverse}
                   testID={PerpsStopLossPromptSelectorsIDs.SUCCESS_ICON}
                 />
               ) : (

--- a/app/components/UI/Perps/components/PerpsTimeDurationSelector/PerpsTimeDurationSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsTimeDurationSelector/PerpsTimeDurationSelector.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Pressable } from 'react-native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
-import Icon, {
+import {
+  Box,
+  Icon,
+  IconColor,
   IconName,
   IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { type TimeDuration } from '@metamask/perps-controller';
 import { TIME_DURATIONS } from '../../constants/chartConfig';
@@ -85,7 +88,7 @@ const PerpsTimeDurationSelector: React.FC<PerpsTimeDurationSelectorProps> = ({
         <Icon
           name={IconName.Setting}
           size={IconSize.Md}
-          color={IconColor.Muted}
+          color={IconColor.IconMuted}
         />
       </Pressable>
     </Box>

--- a/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.test.tsx
+++ b/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.test.tsx
@@ -42,8 +42,7 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => ({
 }));
 
 jest.mock('@metamask/design-system-react-native', () => ({
-  IconColor: { PrimaryDefault: 'PrimaryDefault' },
-  IconSize: { Md: 'Md' },
+  ...jest.requireActual('@metamask/design-system-react-native'),
   Spinner: () => null,
 }));
 

--- a/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.tsx
+++ b/app/components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.tsx
@@ -8,7 +8,11 @@ import {
   Dimensions,
 } from 'react-native';
 import {
+  Icon,
+  IconColor,
   IconColor as ReactNativeDsIconColor,
+  IconName,
+  IconSize,
   IconSize as ReactNativeDsIconSize,
   Spinner,
 } from '@metamask/design-system-react-native';
@@ -17,11 +21,6 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../../../component-library/components/Texts/Text';
-import Icon, {
-  IconName,
-  IconSize,
-  IconColor,
-} from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
 import { WebSocketConnectionState } from '@metamask/perps-controller';
 import { PerpsWebSocketHealthToastSelectorsIDs } from '../../Perps.testIds';
@@ -128,7 +127,7 @@ const PerpsWebSocketHealthToast: React.FC = memo(() => {
           description: strings(
             'perps.connection.websocket_disconnected_message',
           ),
-          iconColor: IconColor.Error,
+          iconColor: IconColor.ErrorDefault,
           showSpinner: false,
         };
 
@@ -141,7 +140,7 @@ const PerpsWebSocketHealthToast: React.FC = memo(() => {
               attempt: reconnectionAttempt,
             },
           ),
-          iconColor: IconColor.Warning,
+          iconColor: IconColor.WarningDefault,
           showSpinner: false,
         };
 
@@ -149,7 +148,7 @@ const PerpsWebSocketHealthToast: React.FC = memo(() => {
         return {
           title: strings('perps.connection.websocket_connected'),
           description: strings('perps.connection.websocket_connected_message'),
-          iconColor: IconColor.Success,
+          iconColor: IconColor.SuccessDefault,
           showSpinner: false,
         };
 


### PR DESCRIPTION
## **Description**

Part 1 of 3 of the TAT-2918 effort to migrate deprecated `component-library` components to the MetaMask Design System (`@metamask/design-system-react-native`) within Perps. This PR migrates only the **`Icon`** component family.

**What changed**
- Replaced the deprecated `component-library/components/Icons/Icon` with the MMDS `Icon` across **30 Perps production files**.
- Remapped `IconColor` members to MMDS semantic tokens (`Default → IconDefault`, `Alternative → IconAlternative`, `Muted → IconMuted`, `Error → ErrorDefault`, `Inverse → PrimaryInverse`, etc.). `IconName` and `IconSize` member names are identical between the two libraries, so call sites are unchanged.
- A few legacy call sites that fed an `<Icon>` a raw theme color string or a `TextColor` token were mapped to the closest semantic `IconColor` token (visually equivalent).
- Updated 6 affected jest mocks to expose the real MMDS icon exports (spread `requireActual`).

**Intentionally out of scope (left for the Button PR)**
- 14 files that import `IconName` only for the legacy `ButtonIcon`/`Button` components, and 4 files that use `IconName` only for legacy toast configs. These share the legacy `IconName` enum type with components that are not migrated yet; touching them now would introduce enum type conflicts. They will migrate together with the Button family.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: TAT-2918

## **Manual testing steps**

```gherkin
Feature: Perps icons render correctly after MMDS Icon migration

  Scenario: User browses Perps and all icons render unchanged
    Given the user has a wallet with open Perps positions
    When the user opens the Perps home, markets list + search, a market detail,
      the order entry screen, the TP/SL screen, the leverage bottom sheet,
      a position detail, and an info tooltip bottom sheet
    Then every icon (back, search, star, expand, share, info, close, warning,
      swap-arrows, chevrons, token logos) renders identically to before
```

## **Screenshots/Recordings**

Visual validation was performed on iOS across 8 canonical Perps screens. Icon rendering is pixel-identical before vs after the migration.

| # | Screen | Before | After |
|---|--------|--------|-------|
| 01 | Home / portfolio | <img width="1206" height="2622" alt="01_home" src="https://github.com/user-attachments/assets/61f0f5b8-cce5-494b-a7fe-7535fa7816fe" /> | <img width="1206" height="2622" alt="01_home" src="https://github.com/user-attachments/assets/fdea3261-5ff0-4b42-87e1-f7b0eaf8a185" /> |
| 02 | Markets list + search | <img width="1206" height="2622" alt="02_markets_search" src="https://github.com/user-attachments/assets/93672b25-5711-4abc-8b21-80e8991677af" /> | <img width="1206" height="2622" alt="02_markets_search" src="https://github.com/user-attachments/assets/9902cd3e-c50c-4fd1-8fff-46d7d762c485" /> |
| 03 | Market detail (ETH-USD) | <img width="1206" height="2622" alt="03_market_detail" src="https://github.com/user-attachments/assets/06afa8a6-741c-4c39-88a7-5376261c952c" /> | <img width="1206" height="2622" alt="03_market_detail" src="https://github.com/user-attachments/assets/56aeb88a-0b18-4d6e-b462-4e52ab41e592" /> |
| 04 | Order / trade entry | <img width="1206" height="2622" alt="04_order" src="https://github.com/user-attachments/assets/d12a00c4-fd5d-40d5-81af-c9fe2fe86e89" /> | <img width="1206" height="2622" alt="04_order" src="https://github.com/user-attachments/assets/d291e262-1562-4886-98c6-0ed0f4358d06" /> |
| 05 | Take Profit / Stop Loss | <img width="1206" height="2622" alt="05_tpsl" src="https://github.com/user-attachments/assets/0d153658-c35b-41c5-8d70-308fa31ae2ed" /> | <img width="1206" height="2622" alt="05_tpsl" src="https://github.com/user-attachments/assets/cf6a9577-a40d-4c8a-8d3c-eddc9d186983" /> |
| 06 | Leverage bottom sheet | <img width="1206" height="2622" alt="06_leverage" src="https://github.com/user-attachments/assets/6fe77a06-dd57-4243-840b-76f58031ce65" /> | <img width="1206" height="2622" alt="06_leverage" src="https://github.com/user-attachments/assets/da1ce2f1-a810-4b12-8932-577267288a92" /> |
| 07 | Position detail | <img width="1206" height="2622" alt="07_positions" src="https://github.com/user-attachments/assets/2cf8c0bb-d613-4dc0-b954-1a29803d17a4" /> | <img width="1206" height="2622" alt="07_positions" src="https://github.com/user-attachments/assets/414165c4-37b0-4fe7-94ab-9ad0d5f3c52f" /> |
| 08 | Tooltip bottom sheet | <img width="1206" height="2622" alt="08_tooltip" src="https://github.com/user-attachments/assets/ad62aac9-4601-4914-833e-b2cbf5f927ae" /> | <img width="1206" height="2622" alt="08_tooltip" src="https://github.com/user-attachments/assets/6ebb4cf1-65c2-4215-971a-f462b67c2c31" /> |

<!-- Drag each PNG into its cell. Sources: ~/Desktop/tat-2918-shots/icon/before/ and ~/Desktop/tat-2918-shots/icon/after/ -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical UI import and token renames across Perps with no auth, transaction, or data-layer changes; main risk is subtle icon color/size regressions if a token mapping is wrong.
> 
> **Overview**
> Part 1 of the Perps design-system migration (TAT-2918): **Perps screens and shared components stop using** `component-library/components/Icons/Icon` **and instead import** `Icon`, `IconName`, `IconSize`, and `IconColor` **from** `@metamask/design-system-react-native`.
> 
> **`IconColor` call sites are updated** to MMDS semantic tokens (e.g. `Default` → `IconDefault`, `Alternative` → `IconAlternative`, `Muted` → `IconMuted`, `Error` → `ErrorDefault`, `Inverse` → `PrimaryInverse`, `Primary` → `PrimaryDefault`). A few spots that used raw theme colors or `TextColor` for icon tint now use the matching `IconColor` token. **`FoxIcon`** switches its prop type and switch cases to the new enum while still resolving fills from the app theme.
> 
> **Small behavior-adjacent tweaks:** empty-state search icons on the market list use `IconColor.IconMuted` instead of `theme.colors.icon.muted`; **`PerpsModifyActionSheet`** uses `IconColor.IconDefault` instead of a style-derived color; **`PerpsOpenOrderCard`** uses `IconSize.Xs` instead of `IconSize.Xss` for the fill badge.
> 
> **Tests:** `FoxIcon` expectations and several Jest mocks for `@metamask/design-system-react-native` now spread `jest.requireActual(...)` so real icon exports remain available alongside partial mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0023ee3e980343556d23e393b4368855837ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->