### PR TITLE
feat(ContactForm): add network configuration handling and custom label for deleted networks

### DIFF
--- a/app/components/Views/Settings/Contacts/ContactForm/index.js
+++ b/app/components/Views/Settings/Contacts/ContactForm/index.js
@@ -154,6 +154,17 @@ const createStyles = (colors) =>
 const ADD = 'add';
 const EDIT = 'edit';
 
+const getNetworkConfiguration = (networkConfigurations, chainId) => {
+  if (!chainId) return undefined;
+
+  return (
+    networkConfigurations[chainId] ||
+    (/^\d+$/.test(chainId)
+      ? networkConfigurations[`0x${Number(chainId).toString(16)}`]
+      : undefined)
+  );
+};
+
 /**
  * View that contains app information
  */
@@ -463,10 +474,19 @@ class ContactForm extends PureComponent {
     const themeAppearance = this.context.themeAppearance || 'light';
     const styles = createStyles(colors);
 
+    const contactNetworkConfiguration = getNetworkConfiguration(
+      this.props.networkConfigurations,
+      contactChainId,
+    );
+    const currentNetworkConfiguration = getNetworkConfiguration(
+      this.props.networkConfigurations,
+      this.props.chainId,
+    );
     const networkName =
-      this.props.networkConfigurations[contactChainId]?.name ||
-      this.props.networkConfigurations[this.props.chainId]?.name ||
-      '';
+      contactNetworkConfiguration?.name ||
+      (contactChainId
+        ? strings('address_book.custom')
+        : currentNetworkConfiguration?.name || '');
     const isAddMode = editable && mode === ADD;
     const isEditMode = editable && mode === EDIT;
     const headerTitle = strings(

--- a/app/components/Views/Settings/Contacts/ContactForm/index.test.tsx
+++ b/app/components/Views/Settings/Contacts/ContactForm/index.test.tsx
@@ -281,6 +281,39 @@ describe('ContactForm', () => {
     });
   });
 
+  it('shows Custom when editing a contact whose network was deleted', async () => {
+    const stateWithDeletedContactNetwork = {
+      ...initialState,
+      engine: {
+        backgroundState: {
+          ...initialState.engine.backgroundState,
+          AddressBookController: {
+            addressBook: {
+              '0x2a': {
+                [MOCK_ADDRESS]: {
+                  address: MOCK_ADDRESS,
+                  name: 'Deleted Network Contact',
+                  chainId: '0x2a',
+                  memo: 'Saved on a deleted network',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const { findByText } = renderContactForm(
+      {
+        mode: 'edit',
+        address: MOCK_ADDRESS,
+      },
+      stateWithDeletedContactNetwork,
+    );
+
+    expect(await findByText(strings('address_book.custom'))).toBeOnTheScreen();
+  });
+
   it('handles ENS names correctly', async () => {
     const validateAddressOrENSMock = jest.requireMock(
       '../../../../../util/address',

--- a/app/components/Views/Settings/Contacts/ContactForm/index.test.tsx
+++ b/app/components/Views/Settings/Contacts/ContactForm/index.test.tsx
@@ -295,12 +295,14 @@ describe('ContactForm', () => {
                   name: 'Deleted Network Contact',
                   chainId: '0x2a',
                   memo: 'Saved on a deleted network',
+                  isEns: false,
                 },
               },
             },
           },
-        },
+        } as EngineState,
       },
+      user: initialState.user,
     };
 
     const { findByText } = renderContactForm(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4914,7 +4914,8 @@
     "between_account": "Transfer between my accounts",
     "others": "Others",
     "memo": "Memo",
-    "network": "Network"
+    "network": "Network",
+    "custom": "Custom"
   },
   "duplicate_address": {
     "title": "This is a duplicate address",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Contacts saved on a custom network could display the wrong network name after that network was deleted. In that case, the contact form fell back to the currently selected network, so a deleted-network contact could appear to be on Ethereum.

This change resolves contact network labels by the saved contact chain ID first, including legacy decimal chain IDs, and displays `Custom` when the saved chain no longer exists in the wallet network configuration. This avoids mislabeling deleted-network contacts as Ethereum while keeping the existing current-network fallback for new contacts.
## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that showed contacts saved on deleted networks as Ethereum

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/29393
https://consensyssoftware.atlassian.net/browse/TMCU-690

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Contact network label fallback

  Scenario: user views a contact after deleting its network
    Given the user has saved a contact on a custom network
    And the user deletes that custom network from the wallet networks list

    When the user opens that contact from Contacts settings
    Then the contact network field shows "Custom"
    And the contact network field does not show "Ethereum"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/4d935ec2-8eb8-4f8b-995b-eed070d611e6


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label logic in Contacts settings with a targeted unit test; no changes to saving, auth, or transaction flows.
> 
> **Overview**
> Fixes **misleading network labels** on the contact form when a contact was saved on a custom network that was later removed from the wallet.
> 
> Lookup now goes through **`getNetworkConfiguration`**, which resolves the saved **`contactChainId`** against `networkConfigurations` (including legacy decimal chain IDs mapped to hex). If the contact has a chain ID but no matching config, the network field shows **`Custom`** instead of falling back to the currently selected network (e.g. Ethereum). New contacts without a saved chain still use the current network name as before.
> 
> Adds the **`address_book.custom`** string and a test that edits a contact on a deleted network (`0x2a`) and expects **Custom** on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4704900bc5b3356b4fcb87260749a32ec7121553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->