### PR TITLE
feat:  provide more information in errors from money account upgrade cp-8.0.0

### DIFF
--- a/app/actions/money/index.test.ts
+++ b/app/actions/money/index.test.ts
@@ -110,11 +110,16 @@ describe('upgradeMoneyAccount', () => {
     );
   });
 
-  it('tags the failing step when the controller throws a MoneyAccountUpgradeStepError', async () => {
+  it('tags the failing step and preserves the underlying cause message for Sentry', async () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: ADDRESS });
+    // `MoneyAccountUpgradeStepError.message` embeds the underlying step error's
+    // message, which is what `Logger.error` forwards to Sentry's
+    // `captureException`. Asserting on it guards against the thunk dropping the
+    // original message (e.g. by re-wrapping in a generic Error).
+    const causeMessage = 'eth_getTransactionCount returned a non-hex value';
     const error = Object.assign(
       new Error(
-        'Money Account upgrade failed at step "eip-7702-authorization": nope',
+        `Money Account upgrade failed at step "eip-7702-authorization": ${causeMessage}`,
       ),
       { name: 'MoneyAccountUpgradeStepError', step: 'eip-7702-authorization' },
     );
@@ -124,7 +129,9 @@ describe('upgradeMoneyAccount', () => {
     await flushPromises();
 
     expect(mockLogError).toHaveBeenCalledWith(
-      error,
+      expect.objectContaining({
+        message: expect.stringContaining(causeMessage),
+      }),
       expect.objectContaining({
         tags: {
           feature: 'money-account-upgrade',
@@ -136,6 +143,9 @@ describe('upgradeMoneyAccount', () => {
         },
       }),
     );
+    // The error is forwarded unchanged (not re-wrapped), so its identity and
+    // step survive too.
+    expect(mockLogError.mock.calls[0][0]).toBe(error);
   });
 
   it('wraps non-Error rejections', async () => {

--- a/app/actions/money/index.test.ts
+++ b/app/actions/money/index.test.ts
@@ -5,6 +5,7 @@ import {
 import Engine from '../../core/Engine';
 import Logger from '../../util/Logger';
 import { selectPrimaryMoneyAccount } from '../../selectors/moneyAccountController';
+import { whenMoneyAccountUpgradeReady } from '../../core/Engine/controllers/money-account-upgrade-controller-init';
 import type { RootState } from '../../reducers';
 
 jest.mock('../../core/Engine', () => ({
@@ -43,6 +44,7 @@ const mockSelectPrimaryMoneyAccount =
   selectPrimaryMoneyAccount as unknown as jest.Mock;
 const mockLogError = Logger.error as jest.Mock;
 const mockLogLog = Logger.log as jest.Mock;
+const mockWhenReady = whenMoneyAccountUpgradeReady as jest.Mock;
 
 const ADDRESS = '0x1111111111111111111111111111111111111111' as const;
 const OTHER_ADDRESS = '0x2222222222222222222222222222222222222222' as const;
@@ -92,7 +94,7 @@ describe('upgradeMoneyAccount', () => {
     );
   });
 
-  it('catches rejected upgradeAccount promises and logs', async () => {
+  it('catches rejected upgradeAccount promises and reports to Sentry with a feature tag', async () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: ADDRESS });
     const error = new Error('boom');
     mockUpgradeAccount.mockRejectedValueOnce(error);
@@ -100,7 +102,40 @@ describe('upgradeMoneyAccount', () => {
     upgradeMoneyAccount()(dispatch, getState, undefined);
     await flushPromises();
 
-    expect(mockLogError).toHaveBeenCalledWith(error, expect.any(String));
+    expect(mockLogError).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        tags: expect.objectContaining({ feature: 'money-account-upgrade' }),
+      }),
+    );
+  });
+
+  it('tags the failing step when the controller throws a MoneyAccountUpgradeStepError', async () => {
+    mockSelectPrimaryMoneyAccount.mockReturnValue({ address: ADDRESS });
+    const error = Object.assign(
+      new Error(
+        'Money Account upgrade failed at step "eip-7702-authorization": nope',
+      ),
+      { name: 'MoneyAccountUpgradeStepError', step: 'eip-7702-authorization' },
+    );
+    mockUpgradeAccount.mockRejectedValueOnce(error);
+
+    upgradeMoneyAccount()(dispatch, getState, undefined);
+    await flushPromises();
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        tags: {
+          feature: 'money-account-upgrade',
+          step: 'eip-7702-authorization',
+        },
+        context: {
+          name: 'money_account_upgrade',
+          data: { phase: 'upgrade', step: 'eip-7702-authorization' },
+        },
+      }),
+    );
   });
 
   it('wraps non-Error rejections', async () => {
@@ -112,7 +147,25 @@ describe('upgradeMoneyAccount', () => {
 
     expect(mockLogError).toHaveBeenCalledWith(
       expect.any(Error),
-      expect.any(String),
+      expect.objectContaining({
+        tags: expect.objectContaining({ feature: 'money-account-upgrade' }),
+      }),
+    );
+  });
+
+  it('skips quietly (no Sentry error) when the controller is not ready', async () => {
+    mockSelectPrimaryMoneyAccount.mockReturnValue({ address: ADDRESS });
+    mockWhenReady.mockRejectedValueOnce(new Error('bootstrap not scheduled'));
+
+    upgradeMoneyAccount()(dispatch, getState, undefined);
+    await flushPromises();
+
+    expect(mockUpgradeAccount).not.toHaveBeenCalled();
+    expect(mockLogError).not.toHaveBeenCalled();
+    expect(mockLogLog).toHaveBeenCalledWith(
+      expect.stringContaining('upgradeMoneyAccount'),
+      'upgrade controller not ready; skipping',
+      expect.objectContaining({ address: ADDRESS }),
     );
   });
 

--- a/app/actions/money/index.ts
+++ b/app/actions/money/index.ts
@@ -1,6 +1,7 @@
 import type { AnyAction } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 import { type Hex, isStrictHexString } from '@metamask/utils';
+import { isMoneyAccountUpgradeStepError } from '@metamask/money-account-upgrade-controller';
 import type { RootState } from '../../reducers';
 import { selectPrimaryMoneyAccount } from '../../selectors/moneyAccountController';
 import Engine from '../../core/Engine';
@@ -8,6 +9,9 @@ import Logger from '../../util/Logger';
 import { whenMoneyAccountUpgradeReady } from '../../core/Engine/controllers/money-account-upgrade-controller-init';
 
 const LOG_PREFIX = '[upgradeMoneyAccount]';
+
+/** Sentry tag used to group/filter Money Account upgrade failures. */
+const SENTRY_FEATURE_TAG = 'money-account-upgrade';
 
 const upgradesInFlight = new Set<Hex>();
 
@@ -36,13 +40,38 @@ export const upgradeMoneyAccount =
 
     upgradesInFlight.add(address);
     whenMoneyAccountUpgradeReady()
-      .then(() =>
-        Engine.context.MoneyAccountUpgradeController.upgradeAccount(address),
+      .then(
+        () =>
+          Engine.context.MoneyAccountUpgradeController.upgradeAccount(address),
+        (error: unknown) => {
+          // The controller isn't ready: the feature flag is off, the keyring
+          // is locked, or bootstrap failed. "Not ready" is a normal state, and
+          // bootstrap failures are already reported to Sentry by the
+          // controller-init module — so we skip quietly here rather than
+          // double-reporting a Sentry error.
+          Logger.log(LOG_PREFIX, 'upgrade controller not ready; skipping', {
+            address,
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        },
       )
       .catch((error: unknown) => {
+        // Reached only for errors thrown by upgradeAccount itself.
         const wrapped =
           error instanceof Error ? error : new Error(String(error));
-        Logger.error(wrapped, `${LOG_PREFIX} failed`);
+        const step = isMoneyAccountUpgradeStepError(error)
+          ? error.step
+          : undefined;
+        Logger.error(wrapped, {
+          tags: {
+            feature: SENTRY_FEATURE_TAG,
+            ...(step ? { step } : {}),
+          },
+          context: {
+            name: 'money_account_upgrade',
+            data: { phase: 'upgrade', ...(step ? { step } : {}) },
+          },
+        });
       })
       .finally(() => {
         upgradesInFlight.delete(address);

--- a/app/core/Engine/controllers/money-account-upgrade-controller-init.test.ts
+++ b/app/core/Engine/controllers/money-account-upgrade-controller-init.test.ts
@@ -236,7 +236,9 @@ describe('moneyAccountUpgradeControllerInit', () => {
       expect.objectContaining({
         message: 'Missing Money Account vault config',
       }),
-      'MoneyAccountUpgradeController bootstrap',
+      expect.objectContaining({
+        tags: expect.objectContaining({ feature: 'money-account-upgrade' }),
+      }),
     );
   });
 
@@ -417,7 +419,10 @@ describe('moneyAccountUpgradeControllerInit', () => {
         expect.objectContaining({
           message: expect.stringContaining(UNSUPPORTED_CHAIN_ID),
         }),
-        'MoneyAccountUpgradeController bootstrap',
+        expect.objectContaining({
+          tags: expect.objectContaining({ feature: 'money-account-upgrade' }),
+          context: expect.objectContaining({ name: 'money_account_upgrade' }),
+        }),
       );
     });
   });

--- a/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
@@ -20,6 +20,9 @@ import { PopularList } from '../../../util/networks/customNetworks';
 import { isMoneyAccountEnabled } from '../../../lib/Money/feature-flags';
 import Logger from '../../../util/Logger';
 
+/** Sentry tag used to group/filter Money Account upgrade failures. */
+const SENTRY_FEATURE_TAG = 'money-account-upgrade';
+
 /**
  * Ensures the given chain exists in the user's NetworkController configuration.
  * If missing, adds it from `PopularList`. The upgrade flow's
@@ -132,7 +135,13 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
   const runBootstrap = (vaultConfig: MoneyAccountVaultConfig) => {
     bootstrapPromise = bootstrap(vaultConfig);
     bootstrapPromise.catch((error) => {
-      Logger.error(error as Error, 'MoneyAccountUpgradeController bootstrap');
+      Logger.error(error as Error, {
+        tags: { feature: SENTRY_FEATURE_TAG },
+        context: {
+          name: 'money_account_upgrade',
+          data: { phase: 'bootstrap' },
+        },
+      });
     });
   };
 
@@ -167,10 +176,13 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
     }
     const vaultConfig = getMoneyAccountVaultConfig(flags);
     if (!vaultConfig) {
-      Logger.error(
-        new Error('Missing Money Account vault config'),
-        'MoneyAccountUpgradeController bootstrap',
-      );
+      Logger.error(new Error('Missing Money Account vault config'), {
+        tags: { feature: SENTRY_FEATURE_TAG },
+        context: {
+          name: 'money_account_upgrade',
+          data: { phase: 'bootstrap' },
+        },
+      });
       return false;
     }
     scheduleBootstrap(vaultConfig);

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
     "@metamask/mobile-wallet-protocol-wallet-client": "^0.3.0",
     "@metamask/money-account-balance-service": "^2.1.0",
     "@metamask/money-account-controller": "^0.2.0",
-    "@metamask/money-account-upgrade-controller": "^2.0.5",
+    "@metamask/money-account-upgrade-controller": "^2.1.0",
     "@metamask/multichain-account-service": "^10.0.2",
     "@metamask/multichain-api-client": "^0.11.0",
     "@metamask/multichain-api-middleware": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9222,9 +9222,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-upgrade-controller@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@metamask/money-account-upgrade-controller@npm:2.0.5"
+"@metamask/money-account-upgrade-controller@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/money-account-upgrade-controller@npm:2.1.0"
   dependencies:
     "@metamask/authenticated-user-storage": "npm:^2.0.0"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -9232,11 +9232,11 @@ __metadata:
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-core": "npm:^2.2.1"
     "@metamask/delegation-deployments": "npm:^1.4.0"
-    "@metamask/keyring-controller": "npm:^27.0.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-controller": "npm:^33.0.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/ce7c34035abe401f310832fe15cd8cd99c3740d72ead914b170667cd65c2612820c6936eaaf8b9bf1bf2407aed92ff7cc2bff7bebfc12ce40683e68344b6c606
+  checksum: 10/5e24234658b903fca1ebd27e4bde110d4157fb10e046d1400f6c786b62a4a7a25a34f6bb45d90ff33b611ebffea3baa202ac731ddf4d56a25b4ad9156465c5f1
   languageName: node
   linkType: hard
 
@@ -35456,7 +35456,7 @@ __metadata:
     "@metamask/mobile-wallet-protocol-wallet-client": "npm:^0.3.0"
     "@metamask/money-account-balance-service": "npm:^2.1.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
-    "@metamask/money-account-upgrade-controller": "npm:^2.0.5"
+    "@metamask/money-account-upgrade-controller": "npm:^2.1.0"
     "@metamask/multichain-account-service": "npm:^10.0.2"
     "@metamask/multichain-api-client": "npm:^0.11.0"
     "@metamask/multichain-api-middleware": "npm:^3.1.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR improves how we report errors that may occur during the money account upgrade process
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: improve the reporting of errors that occur in money account upgrade process

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->
N/A 
```gherkin
```

## **Screenshots/Recordings**
N/A
<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only error reporting and readiness handling for the money upgrade path, not core upgrade logic, but mis-tagged or suppressed Sentry events could hide real production failures in a sensitive wallet feature.
> 
> **Overview**
> Improves **observability** for Money Account upgrade by replacing plain `Logger.error` strings with structured Sentry payloads: a shared **`money-account-upgrade`** feature tag, optional **`step`** when the rejection is a `MoneyAccountUpgradeStepError`, and **`money_account_upgrade`** context with **`phase`** (`bootstrap` vs `upgrade`).
> 
> In **`upgradeMoneyAccount`**, rejections from **`whenMoneyAccountUpgradeReady`** (flag off, locked keyring, bootstrap not scheduled) are handled in a **`then`** rejection handler that **logs and skips Sentry**, so bootstrap issues are not double-reported alongside **`money-account-upgrade-controller-init`**.
> 
> Upgrade failures from **`upgradeAccount`** still go to Sentry but now include step/context when available; tests lock in forwarding the original error and cause message.
> 
> Bumps **`@metamask/money-account-upgrade-controller`** to **^2.1.0** for **`isMoneyAccountUpgradeStepError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c64beddc6fa7214443441b3cd30316b2252a2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->