### PR TITLE
test(e2e): Predict Appium migration — framework and POM foundation

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -286,6 +286,7 @@ jobs:
           ANDROID_APK_PATH: ${{ steps.android-artifacts.outputs.apk-target-path }}/${{ steps.android-artifacts.outputs.apk-file-name }}
           ANDROID_AVD_NAME: appium_smoke_avd
           ANDROID_APPIUM_USE_PACKAGE_ONLY: 'true'
+          ANDROID_BOOT_TIMEOUT_MS: '300000'
           ANDROID_EMULATOR_CI_CORES: '8'
           ANDROID_EMULATOR_POST_BOOT_SETTLE_MS: '30000'
           ANDROID_EMULATOR_NETWORK_READY_TIMEOUT_MS: '90000'

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -66,6 +66,8 @@ const newOverrides = [
       'app/store/migrations/**',
       'app/util/networks/customNetworks.tsx',
       'tests/framework/playwrightLogger.ts',
+      'tests/framework/PlaywrightUtilities.ts',
+      'tests/framework/fixtures/FixtureHelper.ts',
       'tests/framework/services/providers/emulator/reinstallLocalBuildFromPath.ts',
       'tests/framework/services/appium/ScreenRecording.ts',
       'tests/framework/services/appium/AppiumServer.ts',

--- a/tests/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/tests/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -66,6 +66,9 @@ const E2E_SAFE_DEFAULTS: Record<string, unknown> = {
   // Production uses a percentage rollout for this A/B test. Pin E2E to control
   // so homepage section labels do not depend on the generated analytics ID.
   homeTMCU470AbtestTrendingSections: 'control',
+  // Pin discovery tabs to control so wallet E2E uses the scrollable Homepage
+  // (wallet-scroll-view) instead of HomepageDiscoveryTabs tab swipes.
+  coreMCU589AbtestHubPageDiscoveryTabs: 'control',
 };
 
 /**

--- a/tests/api-mocking/mock-responses/polymarket/polymarket-constants.ts
+++ b/tests/api-mocking/mock-responses/polymarket/polymarket-constants.ts
@@ -46,6 +46,14 @@ export const POLYGON_EIP7702_CONTRACT_ADDRESS =
 export const SPURS_PELICANS_POSITION_ID =
   '110743925263777693447488608878982152642205002490046349037358337248548507433643';
 
+// Predict position ID for Celtics vs. Nets (open-position flow)
+export const CELTICS_NETS_POSITION_ID =
+  '51851880223290407825872150827934296608070009371891114025629582819868766043137';
+
+// Predict position ID for Blue Jays vs. Mariners (claim winnings flow)
+export const BLUE_JAYS_MARINERS_POSITION_ID =
+  '42939601076825532550105235762150970758026025994237741085435131668957359315522';
+
 // EIP-7702 format: 0xef01 (magic byte) + 00 (padding) + 20-byte contract address
 // This format indicates an EOA is upgraded with EIP-7702
 export const EIP7702_CODE_FORMAT = (contractAddress: string): string => {

--- a/tests/flows/general.flow.test.ts
+++ b/tests/flows/general.flow.test.ts
@@ -1,4 +1,5 @@
 jest.mock('../framework/logger', () => ({
+  ...jest.requireActual('../framework/logger'),
   createLogger: jest.fn(() => ({
     debug: jest.fn(),
     error: jest.fn(),

--- a/tests/flows/general.flow.ts
+++ b/tests/flows/general.flow.ts
@@ -9,7 +9,11 @@ import {
 import Matchers from '../framework/Matchers';
 import Utilities, { sleep } from '../framework/Utilities';
 import LoginView from '../page-objects/wallet/LoginView';
+import WalletView from '../page-objects/wallet/WalletView';
 import { PlatformDetector } from '../framework/PlatformLocator';
+import { resolveE2EWaitTimeoutMs } from '../framework/Constants';
+// eslint-disable-next-line import-x/no-nodejs-modules
+import { execSync } from 'node:child_process';
 
 const logger = createLogger({
   name: 'GeneralFlow',
@@ -155,20 +159,6 @@ const closeDeveloperMenuPlaywright = async (): Promise<void> => {
       }`,
     );
   }
-
-  if (!PlatformDetector.isAndroid()) {
-    return;
-  }
-
-  try {
-    await globalThis.driver?.back();
-  } catch (backError) {
-    logger.debug(
-      `Playwright developer menu Android back dismissal failed: ${
-        backError instanceof Error ? backError.message : String(backError)
-      }`,
-    );
-  }
 };
 
 const dismissDeveloperMenuOnboardingPlaywright = async (): Promise<void> => {
@@ -200,6 +190,34 @@ export const dismissDeveloperMenuPlaywright = async (): Promise<void> => {
 };
 
 /**
+ * Collapses the Android notification shade / Quick Settings panel.
+ * Accidental status-bar swipes during launch or gestures can leave the shade
+ * open and block all in-app interactions.
+ */
+export const dismissAndroidSystemOverlaysPlaywright =
+  async (): Promise<void> => {
+    if (!PlatformDetector.isAndroid()) {
+      return;
+    }
+
+    const serial = process.env.ANDROID_DEVICE_UDID?.trim();
+    const adbFlag = serial ? `-s ${serial}` : '';
+
+    try {
+      execSync(`adb ${adbFlag} shell cmd statusbar collapse`, {
+        stdio: 'ignore',
+      });
+      logger.debug('Collapsed Android status bar via adb shell');
+    } catch (error) {
+      logger.debug(
+        `statusbar collapse failed (best effort): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  };
+
+/**
  * Waits for app initialization and rehydration to complete.
  * This ensures the app is in a stable state before proceeding with tests.
  * Handles the case where React Native reload triggers state rehydration that may
@@ -212,44 +230,48 @@ export const dismissDeveloperMenuPlaywright = async (): Promise<void> => {
  * @throws {Error} Throws an error if app fails to stabilize within timeout
  */
 export const waitForAppReady = async (
-  timeout: number = 60000,
+  timeout: number = resolveE2EWaitTimeoutMs(60_000),
 ): Promise<void> => {
   const startTime = Date.now();
+  const deadline = startTime + timeout;
 
-  logger.debug('Waiting for app to complete rehydration and stabilize...');
+  logger.debug('Waiting for app to reach login or wallet home...');
 
-  try {
-    // Initial wait for app to finish launching and start rehydration
-    await sleep(1000);
-    await Utilities.executeWithRetry(
-      async () => {
-        await Assertions.expectElementToBeVisible(LoginView.container, {
-          description: 'Login view should be stable',
-          timeout: 3000,
-        });
+  while (Date.now() < deadline) {
+    try {
+      await Assertions.expectElementToBeVisible(WalletView.container, {
+        description: 'Wallet home should be visible',
+        timeout: 3000,
+      });
+      logger.debug(
+        `App on wallet home after ${Date.now() - startTime}ms — skipping login wait`,
+      );
+      return;
+    } catch {
+      // Not on wallet yet.
+    }
 
-        // Verify it stays visible (not flickering during rehydration)
-        await sleep(1500);
+    try {
+      await Assertions.expectElementToBeVisible(LoginView.container, {
+        description: 'Login view should be stable',
+        timeout: 3000,
+      });
+      await sleep(1500);
+      await Assertions.expectElementToBeVisible(LoginView.container, {
+        description: 'Login view should remain visible',
+        timeout: 2000,
+      });
+      logger.debug(`App ready on login after ${Date.now() - startTime}ms`);
+      return;
+    } catch {
+      // Still booting — keep polling.
+    }
 
-        await Assertions.expectElementToBeVisible(LoginView.container, {
-          description: 'Login view should remain visible',
-          timeout: 2000,
-        });
-      },
-      {
-        timeout,
-        interval: 2000,
-        description:
-          'wait for app to complete rehydration and stabilize on login screen',
-      },
-    );
-
-    logger.debug(`App ready after ${Date.now() - startTime}ms`);
-  } catch (error) {
-    logger.error(`App failed to stabilize within ${timeout}ms`, error);
-    throw new Error(
-      `App did not stabilize on login screen within ${timeout}ms. ` +
-        `This may indicate rehydration issues or state corruption.`,
-    );
+    await sleep(2000);
   }
+
+  throw new Error(
+    `App did not reach login or wallet home within ${timeout}ms. ` +
+      `This may indicate rehydration issues or state corruption.`,
+  );
 };

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -36,10 +36,17 @@ import ManualBackupStep1View from '../page-objects/Onboarding/ManualBackupStep1V
 import NetworkListModal from '../page-objects/Network/NetworkListModal';
 import { CustomNetworks } from '../resources/networks.e2e';
 import ToastModal from '../page-objects/wallet/ToastModal';
-import { waitForAppReady } from './general.flow';
+import {
+  dismissAndroidSystemOverlaysPlaywright,
+  dismissDeveloperMenuPlaywright,
+  waitForAppReady,
+} from './general.flow';
 import LoginView from '../page-objects/wallet/LoginView';
 import { getPasswordForScenario } from '../framework/utils/TestConstants';
-import PlaywrightUtilities from '../framework/PlaywrightUtilities';
+import { resolveE2EWaitTimeoutMs } from '../framework/Constants';
+import PlaywrightUtilities, {
+  withImplicitWait,
+} from '../framework/PlaywrightUtilities';
 import AccountListBottomSheet from '../page-objects/wallet/AccountListBottomSheet';
 import MetaMetricsOptInView from '../page-objects/Onboarding/MetaMetricsOptInView';
 import PredictModalView from '../page-objects/Predict/PredictModalView';
@@ -473,24 +480,25 @@ export const loginToApp = async (password?: string): Promise<void> => {
 export const dismissPushNotificationExistingUserSheet =
   async (): Promise<void> => {
     try {
-      const btn = await asPlaywrightElement(
-        encapsulated({
-          detox: () =>
-            Matchers.getElementByID(
-              ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM,
-            ),
-          appium: () =>
-            PlaywrightMatchers.getElementById(
-              ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM,
-              { exact: true },
-            ),
-        }),
-      );
-      const isDisplayed = await btn.unwrap().isDisplayed();
-      if (isDisplayed) {
-        await PlaywrightGestures.waitAndTap(btn, { timeout: 5_000 });
-        logger.debug('Dismissed push notification existing user sheet');
-      }
+      await withImplicitWait(500, async () => {
+        const btn = await asPlaywrightElement(
+          encapsulated({
+            detox: () =>
+              Matchers.getElementByID(
+                ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM,
+              ),
+            appium: () =>
+              PlaywrightMatchers.getElementById(
+                ExistingUserSheetSelectorsIDs.BUTTON_CONFIRM,
+                { exact: true },
+              ),
+          }),
+        );
+        if (await btn.unwrap().isDisplayed()) {
+          await PlaywrightGestures.waitAndTap(btn, { timeout: 5_000 });
+          logger.debug('Dismissed push notification existing user sheet');
+        }
+      });
     } catch {
       // Sheet not present — no-op
     }
@@ -515,18 +523,43 @@ export const loginToAppPlaywright = async (
 ): Promise<void> => {
   const { scenarioType = 'login' } = options;
 
+  const dismissPostLoginModals = async (): Promise<void> => {
+    await PlaywrightUtilities.wait(500);
+    await dismissPushNotificationExistingUserSheet();
+    await dismissExperienceEnhancerModal();
+  };
+
+  await dismissAndroidSystemOverlaysPlaywright();
+  await waitForAppReady(resolveE2EWaitTimeoutMs(30_000));
+  await dismissDeveloperMenuPlaywright();
+  await dismissAndroidSystemOverlaysPlaywright();
+
+  try {
+    await PlaywrightAssertions.expectElementToBeVisible(
+      asPlaywrightElement(WalletView.container),
+      {
+        description: 'Wallet already visible — skip password unlock',
+        timeout: 3_000,
+      },
+    );
+    await dismissPostLoginModals();
+    return;
+  } catch {
+    // Login screen expected — continue below.
+  }
+
   await PlaywrightAssertions.expectElementToBeVisible(
     asPlaywrightElement(LoginView.container),
     {
       description: 'Login view container',
-      timeout: 45_000,
+      timeout: resolveE2EWaitTimeoutMs(30_000),
     },
   );
   await PlaywrightAssertions.expectElementToBeVisible(
     asPlaywrightElement(LoginView.passwordInput),
     {
       description: 'Login password input',
-      timeout: 15_000,
+      timeout: resolveE2EWaitTimeoutMs(10_000),
     },
   );
 
@@ -535,9 +568,15 @@ export const loginToAppPlaywright = async (
   await LoginView.enterPassword(password ?? '');
   await LoginView.tapLoginButton();
 
-  await PlaywrightUtilities.wait(5000);
-  await dismissPushNotificationExistingUserSheet();
-  await dismissExperienceEnhancerModal();
+  await dismissPostLoginModals();
+
+  await PlaywrightAssertions.expectElementToBeVisible(
+    asPlaywrightElement(WalletView.container),
+    {
+      description: 'Wallet should be visible after login',
+      timeout: resolveE2EWaitTimeoutMs(30_000),
+    },
+  );
 };
 
 /**

--- a/tests/framework/Constants.ts
+++ b/tests/framework/Constants.ts
@@ -8,6 +8,31 @@ import { DEFAULT_ANVIL_PORT } from '../seeder/anvil-manager';
 // The port is then translated to the actual allocated port
 export const LOCAL_NODE_RPC_URL = `http://localhost:${DEFAULT_ANVIL_PORT}`;
 
+/**
+ * Optional cap for E2E wait/poll timeouts (ms). Set `E2E_WAIT_TIMEOUT_MS=30000`
+ * locally to fail fast when a step is stuck instead of waiting minutes.
+ */
+export const resolveE2EWaitTimeoutMs = (fallbackMs: number): number => {
+  const raw = process.env.E2E_WAIT_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return fallbackMs;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
+};
+
+/** Bootstrap-only timeout (fixture /state.json, cold app after pm clear). */
+export const resolveE2EFixtureBootstrapTimeoutMs = (): number => {
+  const raw = process.env.E2E_FIXTURE_BOOTSTRAP_TIMEOUT_MS?.trim();
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return process.env.E2E_WAIT_TIMEOUT_MS ? 90_000 : 300_000;
+};
+
 // Default implicit wait timeout for WebDriverIO element lookups (in ms).
 // Kept low to enable fast retries in polling loops; use withImplicitWait() for longer waits.
 export const DEFAULT_IMPLICIT_WAIT_MS = 3_500;

--- a/tests/framework/FrameworkDetector.ts
+++ b/tests/framework/FrameworkDetector.ts
@@ -13,6 +13,10 @@ declare const device: unknown;
 declare const driver: unknown;
 declare const browser: unknown;
 
+interface DriverGlobal {
+  driver?: WebdriverIO.Browser;
+}
+
 /**
  * Framework detector - determines which testing framework is currently running
  *
@@ -50,7 +54,9 @@ export class FrameworkDetector {
    */
   private static hasAppiumGlobals(): boolean {
     try {
+      const globalDriver = (globalThis as DriverGlobal).driver;
       return (
+        (typeof globalDriver !== 'undefined' && globalDriver !== null) ||
         (typeof driver !== 'undefined' && driver !== null) ||
         (typeof browser !== 'undefined' && browser !== null)
       );

--- a/tests/framework/GestureStrategy.ts
+++ b/tests/framework/GestureStrategy.ts
@@ -8,6 +8,7 @@ import {
   asPlaywrightElement,
 } from './EncapsulatedElement.ts';
 import type { ScrollContainer } from './types.ts';
+import { getDriver } from './PlaywrightUtilities.ts';
 
 export type { ScrollContainer, ScrollViewMatcher } from './types.ts';
 
@@ -466,10 +467,42 @@ export class AppiumGestureStrategy implements GestureStrategy {
   async swipe(
     elem: EncapsulatedElementType,
     direction: 'up' | 'down' | 'left' | 'right',
+    opts?: UnifiedGestureOptions,
   ): Promise<void> {
-    const el = await asPlaywrightElement(elem);
-    await PlaywrightGestures.swipe({
-      scrollParams: { direction: direction as 'up' | 'down' },
+    const percent = opts?.percentage ?? 0.75;
+
+    if (direction === 'left' || direction === 'right') {
+      await PlaywrightGestures.swipe({
+        scrollParams: { direction },
+        percent,
+      });
+      return;
+    }
+
+    await this.scrollWithinContainer(elem, direction, percent);
+  }
+
+  private async scrollWithinContainer(
+    scrollView: EncapsulatedElementType,
+    swipeDirection: 'up' | 'down' | 'left' | 'right',
+    percent = 0.6,
+  ): Promise<void> {
+    const drv = getDriver();
+    if (!drv) {
+      throw new Error('Driver is not available');
+    }
+
+    const container = await asPlaywrightElement(scrollView);
+    const location = await container.unwrap().getLocation();
+    const size = await container.unwrap().getSize();
+
+    await drv.execute('mobile: scrollGesture', {
+      left: location.x,
+      top: location.y,
+      width: size.width,
+      height: size.height,
+      direction: swipeDirection,
+      percent,
     });
   }
 

--- a/tests/framework/Gestures.ts
+++ b/tests/framework/Gestures.ts
@@ -588,7 +588,7 @@ export default class Gestures {
    */
   static async scrollToElement(
     targetElement: DetoxElement | EncapsulatedElementType,
-    scrollableContainer: ScrollContainer,
+    scrollableContainer?: ScrollContainer,
     options: ScrollOptions = {},
   ): Promise<void> {
     if (FrameworkDetector.isAppium()) {

--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -6,6 +6,7 @@ import PlaywrightGestures from './PlaywrightGestures.ts';
 import {
   addOverhead,
   isOverheadTrackingActive,
+  withImplicitWait,
 } from './PlaywrightUtilities.ts';
 import { createPlaywrightLogger } from './playwrightLogger.ts';
 
@@ -59,6 +60,10 @@ export default class PlaywrightAssertions {
    * - After detection a {@link probeOverhead} call measures the pure
    * per-command cost and registers it for subtraction.
    */
+  private static readonly FINAL_WAIT_RESERVE_MS = 2_000;
+  /** Fast implicit wait for poll probes — avoids 3.5s find penalty per attempt. */
+  private static readonly POLL_IMPLICIT_WAIT_MS = 300;
+
   private static async pollUntilVisible(
     el: PlaywrightElement,
     timeout: number,
@@ -66,24 +71,34 @@ export default class PlaywrightAssertions {
     const interval = 300;
     const start = Date.now();
     let attempt = 0;
-    while (Date.now() - start < timeout - interval) {
+    while (Date.now() - start < timeout - this.FINAL_WAIT_RESERVE_MS) {
+      const remaining = timeout - (Date.now() - start);
+      if (remaining <= 0) {
+        break;
+      }
       try {
         attempt++;
         const t0 = Date.now();
-        const exists = await el.unwrap().isExisting();
+        const exists = await withImplicitWait(this.POLL_IMPLICIT_WAIT_MS, () =>
+          el.unwrap().isExisting(),
+        );
         if (exists) {
-          if (isOverheadTrackingActive()) {
-            await this.probeOverhead(el);
+          const displayed = await el.isVisible();
+          if (displayed) {
+            if (isOverheadTrackingActive()) {
+              addOverhead(Date.now() - t0);
+            }
+            return;
           }
-          return;
         }
       } catch {
         // element not ready yet
       }
-      await sleep(interval);
+      await sleep(Math.min(interval, remaining));
     }
+    const remainingTimeout = timeout - (Date.now() - start);
     await el.waitForDisplayed({
-      timeout: Math.max(interval, timeout - (Date.now() - start)),
+      timeout: Math.max(interval, remainingTimeout),
     });
     if (isOverheadTrackingActive()) {
       await this.probeOverhead(el);
@@ -264,7 +279,8 @@ export default class PlaywrightAssertions {
     } catch (error) {
       if (
         error instanceof Error &&
-        error.message.includes('No elements found for XPath')
+        (error.message.includes('No elements found for XPath') ||
+          error.message.includes('No elements found'))
       ) {
         return;
       }

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -17,6 +17,8 @@ export interface ScrollOptions {
   percent?: number;
   scrollableElement?: PlaywrightElement;
   duration?: number;
+  /** WDIO native scrollIntoView limit; default is 10. */
+  maxScrolls?: number;
 }
 
 /**
@@ -316,6 +318,7 @@ export default class PlaywrightGestures {
       percent,
       scrollableElement,
       duration,
+      maxScrolls = 30,
     } = options || {};
     await debugElementAction(logger, 'Scrolling element into view', elem);
     await elem.unwrap().scrollIntoView({
@@ -325,6 +328,7 @@ export default class PlaywrightGestures {
       percent,
       scrollableElement: scrollableElement?.unwrap(),
       duration,
+      maxScrolls,
     });
   }
 

--- a/tests/framework/PlaywrightMatchers.ts
+++ b/tests/framework/PlaywrightMatchers.ts
@@ -146,15 +146,16 @@ export default class PlaywrightMatchers {
 
     this.logFind('text', `${text}${exactMatch ? ' (exact)' : ''}`);
     const isAndroid = await PlatformDetector.isAndroid();
+    const escapedText = text.replace(/'/g, "\\'");
     let xpath: string;
     if (exactMatch) {
       xpath = isAndroid
-        ? `//*[@name='${text}' or @label='${text}' or @text='${text}' or @content-desc='${text}']`
-        : `//*[@name='${text}' or @label='${text}' or @text='${text}']`;
+        ? `//*[@name='${escapedText}' or @label='${escapedText}' or @text='${escapedText}' or @content-desc='${escapedText}']`
+        : `//*[@name='${escapedText}' or @label='${escapedText}' or @text='${escapedText}']`;
     } else {
       xpath = isAndroid
-        ? `//*[contains(@name,'${text}') or contains(@label,'${text}') or contains(@text,'${text}') or contains(@content-desc,'${text}')]`
-        : `//*[contains(@name,'${text}') or contains(@label,'${text}') or contains(@text,'${text}')]`;
+        ? `//*[contains(@name,'${escapedText}') or contains(@label,'${escapedText}') or contains(@text,'${escapedText}') or contains(@content-desc,'${escapedText}')]`
+        : `//*[contains(@name,'${escapedText}') or contains(@label,'${escapedText}') or contains(@text,'${escapedText}')]`;
     }
     return await this.getElementByXPath(xpath, options);
   }

--- a/tests/framework/PlaywrightUtilities.test.ts
+++ b/tests/framework/PlaywrightUtilities.test.ts
@@ -23,6 +23,7 @@ describe('PlaywrightUtilities.launchApp', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    process.env.CI = 'true';
     executeMock.mockResolvedValue(undefined);
     terminateAppMock.mockResolvedValue(undefined);
     globalThis.driver = {
@@ -33,6 +34,7 @@ describe('PlaywrightUtilities.launchApp', () => {
 
   afterEach(() => {
     delete globalThis.driver;
+    delete process.env.CI;
     jest.useRealTimers();
     jest.clearAllMocks();
   });
@@ -146,4 +148,65 @@ describe('PlaywrightUtilities.launchApp', () => {
       expect.arrayContaining(['-stop', 'false', '-wait', 'false']),
     );
   });
+
+  it('launches local Android debug builds via Expo dev-client deep link', async () => {
+    jest.useRealTimers();
+    process.env.CI = 'false';
+    const execSyncMock = jest.spyOn(
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, import-x/no-nodejs-modules
+      require('child_process'),
+      'execSync',
+    );
+    execSyncMock.mockImplementation(() => Buffer.from(''));
+
+    const fetchMock = jest.fn((url: string | URL | Request) => {
+      const urlStr = String(url);
+      if (urlStr.includes('/status')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve('packager-status:running'),
+        } as Response);
+      }
+      if (urlStr.includes('index.bundle')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve('// metro bundle'),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${urlStr}`));
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      await PlaywrightUtilities.launchApp(androidDevice);
+
+      expect(execSyncMock).toHaveBeenCalledWith(
+        'adb -s emulator-5554 reverse tcp:8081 tcp:8081',
+        expect.objectContaining({ stdio: 'ignore' }),
+      );
+      expect(executeMock).toHaveBeenCalledWith(
+        'mobile: startActivity',
+        expect.objectContaining({
+          component: 'io.metamask/io.metamask.MainActivity',
+          action: 'android.intent.action.MAIN',
+          categories: ['android.intent.category.LAUNCHER'],
+        }),
+      );
+      expect(executeMock).toHaveBeenCalledWith(
+        'mobile: deepLink',
+        expect.objectContaining({
+          package: 'io.metamask',
+          url: expect.stringContaining(
+            'expo-metamask://expo-development-client',
+          ),
+        }),
+      );
+      expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+      execSyncMock.mockRestore();
+      jest.useFakeTimers();
+    }
+  }, 10_000);
 });

--- a/tests/framework/PlaywrightUtilities.ts
+++ b/tests/framework/PlaywrightUtilities.ts
@@ -11,6 +11,7 @@ import {
   FALLBACK_FIXTURE_SERVER_PORT,
   FALLBACK_COMMAND_QUEUE_SERVER_PORT,
   FALLBACK_MOCKSERVER_PORT,
+  resolveE2EWaitTimeoutMs,
 } from './Constants';
 import Utilities from './Utilities';
 import { ACCOUNT_ACTIVITY_WS } from '../websocket/constants.ts';
@@ -28,10 +29,31 @@ type AndroidIntentExtra = ['s', string, string];
 
 /** Brief pause after force-stopping Android before startActivity (CI emulators). */
 const ANDROID_PRE_LAUNCH_SETTLE_MS = 1500;
+/** Let UiAutomator2 stabilize after Expo dev-client deep link before element queries. */
+const ANDROID_POST_DEEPLINK_SETTLE_MS = 3000;
+/** Cold Metro bundles can exceed 2 min; pre-warm before deep link to avoid DevLauncherError. */
+const METRO_PREWARM_TIMEOUT_MS = process.env.E2E_WAIT_TIMEOUT_MS
+  ? 120_000
+  : 300_000;
+const METRO_STATUS_POLL_MS = 1_000;
 const APPIUM_START_ACTIVITY_CONTROL_KEYS = new Set<keyof LaunchArgs>([
   'stop',
   'wait',
 ]);
+
+const getMetroPort = (): string =>
+  process.env.METRO_PORT_E2E || process.env.WATCHER_PORT || '8081';
+
+const isCiEnvironment = (): boolean => {
+  const ci = process.env.CI?.toLowerCase();
+  return ci === 'true' || ci === '1';
+};
+
+/**
+ * Whether local debug builds should bypass the Expo dev server picker via deep link.
+ * Mirrors Detox `TestHelpers.launchAppForDebugBuild` (non-CI configs).
+ */
+const shouldUseDebugDeepLinkLaunch = (): boolean => !isCiEnvironment();
 
 /**
  * Get the driver instance.
@@ -407,6 +429,160 @@ class PlaywrightUtilities {
     return argumentsList;
   }
 
+  private static getDevLauncherPackagerUrl(
+    platform: 'android' | 'ios',
+  ): string {
+    const port = getMetroPort();
+    const host = platform === 'android' ? '10.0.2.2' : 'localhost';
+    return `http://${host}:${port}/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
+  }
+
+  private static getDeepLinkUrl(bundleUrl: string): string {
+    return `expo-metamask://expo-development-client/?url=${encodeURIComponent(
+      bundleUrl,
+    )}`;
+  }
+
+  private static setupAndroidMetroReverse(
+    currentDeviceDetails: CurrentDeviceDetails,
+  ): void {
+    const port = getMetroPort();
+    const serial = currentDeviceDetails.udid?.trim();
+    const adbFlag = serial ? `-s ${serial}` : '';
+    execSync(`adb ${adbFlag} reverse tcp:${port} tcp:${port}`, {
+      stdio: 'ignore',
+    });
+  }
+
+  /**
+   * Ensures Metro is running and the platform bundle is built before the dev-client
+   * deep link. Without this, cold bundles (60–160s) can land on DevLauncherErrorActivity
+   * while FixtureHelper waits for `/state.json`.
+   */
+  private static async ensureMetroBundleReady(
+    platform: 'android' | 'ios',
+  ): Promise<void> {
+    const port = getMetroPort();
+    const statusUrl = `http://127.0.0.1:${port}/status`;
+    const bundleUrl = `http://127.0.0.1:${port}/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
+    const deadline = Date.now() + METRO_PREWARM_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      try {
+        const statusResponse = await fetch(statusUrl);
+        const statusBody = await statusResponse.text();
+        if (statusResponse.ok && statusBody.includes('running')) {
+          break;
+        }
+      } catch {
+        // Metro not ready yet.
+      }
+      await new Promise((resolve) => setTimeout(resolve, METRO_STATUS_POLL_MS));
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Metro is not running on port ${port}. Start Metro before Appium smoke tests.`,
+      );
+    }
+
+    logger.debug(`Pre-warming Metro bundle: ${bundleUrl}`);
+    const controller = new AbortController();
+    const abortTimer = setTimeout(
+      () => controller.abort(),
+      METRO_PREWARM_TIMEOUT_MS,
+    );
+    try {
+      const bundleResponse = await fetch(bundleUrl, {
+        signal: controller.signal,
+      });
+      if (!bundleResponse.ok) {
+        throw new Error(
+          `Metro bundle pre-warm failed with status ${bundleResponse.status}`,
+        );
+      }
+      await bundleResponse.text();
+      logger.debug('Metro bundle pre-warm complete');
+    } finally {
+      clearTimeout(abortTimer);
+    }
+  }
+
+  /**
+   * Launches a local debug Android build via Expo dev-client deep link (no Metro picker).
+   * Two steps mirror Detox `launchApp({ url, launchArgs })` and iOS debug launch:
+   * 1. MAIN/LAUNCHER with intent extras (fixture ports)
+   * 2. `mobile: deepLink` scoped to the app package (avoids system "Open with" chooser)
+   */
+  private static async launchAppAndroidForDebugBuild(
+    currentDeviceDetails: CurrentDeviceDetails,
+    { launchArgs }: { launchArgs?: Partial<LaunchArgs> } = {
+      launchArgs: {} as Partial<LaunchArgs>,
+    },
+  ): Promise<void> {
+    const drv = getDriver();
+    const pkg = currentDeviceDetails.packageName?.trim();
+    const activity = currentDeviceDetails.launchableActivity?.trim();
+    if (!pkg || !activity) {
+      throw new Error(
+        'Android debug launch requires packageName and launchableActivity on currentDeviceDetails.',
+      );
+    }
+
+    this.setupAndroidMetroReverse(currentDeviceDetails);
+    await this.ensureMetroBundleReady('android');
+    const deepLinkUrl = this.getDeepLinkUrl(
+      this.getDevLauncherPackagerUrl('android'),
+    );
+    const extras = PlaywrightUtilities.buildAndroidIntentExtras({
+      launchArgs,
+    });
+
+    await drv.terminateApp(pkg).catch(() => undefined);
+    await new Promise((resolve) =>
+      setTimeout(resolve, ANDROID_PRE_LAUNCH_SETTLE_MS),
+    );
+
+    logger.debug(
+      `Launching Android debug app ${pkg}/${activity} with fixture extras`,
+    );
+    await drv.execute('mobile: startActivity', {
+      component: `${pkg}/${activity}`,
+      action: 'android.intent.action.MAIN',
+      categories: ['android.intent.category.LAUNCHER'],
+      stop: true,
+      wait: true,
+      ...(extras.length > 0 ? { extras } : {}),
+    });
+
+    logger.debug(`Opening Android debug deep link in ${pkg}: ${deepLinkUrl}`);
+    await drv.execute('mobile: deepLink', {
+      url: deepLinkUrl,
+      package: pkg,
+    });
+    await new Promise((resolve) =>
+      setTimeout(resolve, ANDROID_POST_DEEPLINK_SETTLE_MS),
+    );
+  }
+
+  /**
+   * Launches a local debug iOS build: XCUITest launchApp then Expo dev-client deep link.
+   */
+  private static async launchAppIOSForDebugBuild(
+    currentDeviceDetails: CurrentDeviceDetails,
+    { launchArgs }: { launchArgs?: Partial<LaunchArgs> } = {
+      launchArgs: {} as Partial<LaunchArgs>,
+    },
+  ): Promise<void> {
+    await this.launchAppIOS(currentDeviceDetails, { launchArgs });
+
+    const deepLinkUrl = this.getDeepLinkUrl(
+      this.getDevLauncherPackagerUrl('ios'),
+    );
+    logger.debug(`Opening iOS debug deep link: ${deepLinkUrl}`);
+    await getDriver().execute('mobile: deepLink', { url: deepLinkUrl });
+  }
+
   /**
    *
    * @param currentDeviceDetails - The current device details
@@ -505,11 +681,23 @@ class PlaywrightUtilities {
     }
 
     if (currentDeviceDetails.platform === 'android') {
-      await this.launchAppAndroid(currentDeviceDetails, {
-        launchArgs,
-      });
+      if (shouldUseDebugDeepLinkLaunch()) {
+        await this.launchAppAndroidForDebugBuild(currentDeviceDetails, {
+          launchArgs,
+        });
+      } else {
+        await this.launchAppAndroid(currentDeviceDetails, {
+          launchArgs,
+        });
+      }
     } else if (currentDeviceDetails.platform === 'ios') {
-      await this.launchAppIOS(currentDeviceDetails, { launchArgs });
+      if (shouldUseDebugDeepLinkLaunch()) {
+        await this.launchAppIOSForDebugBuild(currentDeviceDetails, {
+          launchArgs,
+        });
+      } else {
+        await this.launchAppIOS(currentDeviceDetails, { launchArgs });
+      }
     } else {
       throw new Error('Unsupported platform');
     }

--- a/tests/framework/Utilities.ts
+++ b/tests/framework/Utilities.ts
@@ -10,11 +10,12 @@ import PlaywrightAssertions from './PlaywrightAssertions.ts';
 import PlaywrightGestures from './PlaywrightGestures.ts';
 import { PlatformDetector } from './PlatformLocator.ts';
 import { createLogger } from './logger.ts';
+import { resolveE2EWaitTimeoutMs } from './Constants.ts';
 // eslint-disable-next-line import-x/no-nodejs-modules
 import { setTimeout as asyncSetTimeout } from 'node:timers/promises';
 
 const TEST_CONFIG_DEFAULTS = {
-  timeout: 15000,
+  timeout: resolveE2EWaitTimeoutMs(15000),
   retryInterval: 500,
   actionDelay: 100,
   stabilityCheckInterval: 200,
@@ -50,6 +51,24 @@ export default class Utilities {
   static async checkElementEnabled(
     elem: EncapsulatedElementType,
   ): Promise<void> {
+    if (FrameworkDetector.isAppium()) {
+      const el = await asPlaywrightElement(elem);
+      if (!(await el.isEnabled())) {
+        throw new Error(
+          [
+            '🚫 Element is not enabled.',
+            '',
+            '💡 If this element might be disabled in some situations,',
+            '   consider using the {checkEnabled: false} option.',
+            '',
+            '📝 Example:',
+            '   await Gestures.waitAndTap(element, {checkEnabled: false})',
+          ].join('\n'),
+        );
+      }
+      return;
+    }
+
     const el = (await elem) as Detox.IndexableNativeElement;
     const attributes = await el.getAttributes();
     if (!('enabled' in attributes) || !attributes.enabled) {

--- a/tests/framework/config/ConfigHandler.ts
+++ b/tests/framework/config/ConfigHandler.ts
@@ -10,6 +10,7 @@ import { WebDriverConfig } from '../types';
 import {
   DEFAULT_ACTION_TIMEOUT_MS,
   DEFAULT_IMPLICIT_WAIT_MS,
+  resolveE2EWaitTimeoutMs,
 } from '../Constants';
 
 const resolveGlobalSetup = () => path.join(__dirname, 'global.setup.ts');
@@ -26,7 +27,7 @@ const defaultConfig: PlaywrightTestConfig<WebDriverConfig> = {
   retries: isCI ? 2 : 0,
   workers: 1,
   reporter: [['list'], ['html', { open: 'always' }]],
-  timeout: 300_000,
+  timeout: resolveE2EWaitTimeoutMs(300_000),
 };
 
 export function defineConfig(config: PlaywrightTestConfig<WebDriverConfig>) {
@@ -42,8 +43,8 @@ export function defineConfig(config: PlaywrightTestConfig<WebDriverConfig>) {
     globalSetup: [resolveGlobalSetup()],
     reporter: [...reporterConfig],
     use: {
-      actionTimeout: DEFAULT_ACTION_TIMEOUT_MS,
-      expectTimeout: DEFAULT_IMPLICIT_WAIT_MS,
+      actionTimeout: resolveE2EWaitTimeoutMs(DEFAULT_ACTION_TIMEOUT_MS),
+      expectTimeout: resolveE2EWaitTimeoutMs(DEFAULT_IMPLICIT_WAIT_MS),
       ...config.use,
     },
   });

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -17,6 +17,7 @@ import {
 } from './FixtureUtils';
 import Utilities, { sleep } from '../Utilities';
 import {
+  dismissAndroidSystemOverlaysPlaywright,
   dismissDevScreens,
   dismissDeveloperMenuPlaywright,
   dismissDevelopmentServerPickerPlaywright,
@@ -45,6 +46,7 @@ import {
   FALLBACK_MOCKSERVER_PORT,
   FALLBACK_FIXTURE_SERVER_PORT,
   FALLBACK_COMMAND_QUEUE_SERVER_PORT,
+  resolveE2EFixtureBootstrapTimeoutMs,
 } from '../Constants';
 import ContractAddressRegistry from '../../../app/util/test/contract-address-registry';
 import FixtureBuilder from './FixtureBuilder';
@@ -697,7 +699,11 @@ export async function withFixtures(
           await deviceCommands.clearAppData();
         }
 
-        const appStateRequest = fixtureServer.waitForNextStateRequest();
+        // Cold Metro bundles can take 60–160s locally; pre-warm runs in launchApp but
+        // device-side load + E2E bootstrap still need headroom after deep link.
+        const appStateRequest = fixtureServer.waitForNextStateRequest(
+          resolveE2EFixtureBootstrapTimeoutMs(),
+        );
         try {
           await PlaywrightUtilities.launchApp(currentDeviceDetails, {
             launchArgs: testArgs,
@@ -739,7 +745,8 @@ export async function withFixtures(
       }
     }
 
-    // Dismiss dev screens if running locally (not in CI)
+    // Dismiss dev menu after bootstrap (Appium: adb-only overlay dismiss — element
+    // queries here crash UiAutomator2 while Metro is still loading).
     if (process.env.CI !== 'true') {
       if (FrameworkDetector.isDetox()) {
         await dismissDevScreens();

--- a/tests/framework/fixtures/FixtureServer.ts
+++ b/tests/framework/fixtures/FixtureServer.ts
@@ -6,6 +6,7 @@ import type { Fixture } from './types.ts';
 import { createLogger } from '../logger.ts';
 import { Resource, ServerStatus } from '../types.ts';
 import PortManager, { ResourceType } from '../PortManager.ts';
+import { resolveE2EWaitTimeoutMs } from '../Constants.ts';
 
 const logger = createLogger({
   name: 'FixtureServer',
@@ -20,7 +21,7 @@ const fixtureSubstitutionCommands = {
   currentDateInMilliseconds: 'currentDateInMilliseconds',
 };
 
-const DEFAULT_STATE_REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_STATE_REQUEST_TIMEOUT_MS = resolveE2EWaitTimeoutMs(60_000);
 
 /**
  * Interface for contract registry objects

--- a/tests/framework/fixtures/playwright/driver.fixture.ts
+++ b/tests/framework/fixtures/playwright/driver.fixture.ts
@@ -9,6 +9,8 @@ import {
   stopFailureRecordingAndAttach,
 } from '../../services/appium/ScreenRecording.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
+import { FrameworkDetector, TestFramework } from '../../FrameworkDetector.ts';
+import UnifiedGestures from '../../UnifiedGestures.ts';
 
 const logger = createPlaywrightLogger('driver');
 
@@ -52,6 +54,9 @@ export const driverFixture = {
       }
 
       globalThis.driver = driver;
+      FrameworkDetector.reset();
+      FrameworkDetector.setFramework(TestFramework.APPIUM);
+      UnifiedGestures.resetStrategy();
 
       const platformName = (await driver.capabilities)?.platformName;
       const windowSize = await driver.getWindowSize();
@@ -138,6 +143,8 @@ export const driverFixture = {
 
       try {
         delete globalThis.driver;
+        FrameworkDetector.reset();
+        UnifiedGestures.resetStrategy();
       } catch (error) {
         logger.error('Failed to clean up global driver:', error);
       }

--- a/tests/framework/services/appium/AppiumServer.ts
+++ b/tests/framework/services/appium/AppiumServer.ts
@@ -99,7 +99,7 @@ export async function startAppiumServer(
       'yarn',
       [
         'appium',
-        '--allow-insecure=chromedriver_autodownload',
+        '--allow-insecure=chromedriver_autodownload,adb_shell',
         '--port',
         String(port),
         '--address',

--- a/tests/framework/services/appium/EmulatorHelpers.test.ts
+++ b/tests/framework/services/appium/EmulatorHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   findAnrDialogWaitTapPoint,
   isAndroidPingSuccessful,
   shouldWaitForOfflineEmulator,
+  shouldWaitForUnidentifiedOfflineEmulator,
 } from './EmulatorHelpers.ts';
 
 describe('EmulatorHelpers', () => {
@@ -24,6 +25,32 @@ describe('EmulatorHelpers', () => {
       expect(shouldWaitForOfflineEmulator('appium_smoke_avd', 'emulator')).toBe(
         false,
       );
+    });
+  });
+
+  describe('shouldWaitForUnidentifiedOfflineEmulator', () => {
+    it('returns true in CI when exactly one emulator is starting', () => {
+      expect(
+        shouldWaitForUnidentifiedOfflineEmulator({
+          isCI: true,
+          offlineOrAuthorizingCount: 1,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when multiple emulators are starting or not in CI', () => {
+      expect(
+        shouldWaitForUnidentifiedOfflineEmulator({
+          isCI: true,
+          offlineOrAuthorizingCount: 2,
+        }),
+      ).toBe(false);
+      expect(
+        shouldWaitForUnidentifiedOfflineEmulator({
+          isCI: false,
+          offlineOrAuthorizingCount: 1,
+        }),
+      ).toBe(false);
     });
   });
 

--- a/tests/framework/services/appium/EmulatorHelpers.ts
+++ b/tests/framework/services/appium/EmulatorHelpers.ts
@@ -6,7 +6,7 @@ import { createLogger } from '../../logger.ts';
 
 const logger = createLogger({ name: 'EmulatorHelpers' });
 
-const ANDROID_BOOT_TIMEOUT_MS = 3 * 60 * 1000;
+const DEFAULT_ANDROID_BOOT_TIMEOUT_MS = 3 * 60 * 1000;
 const ANDROID_BOOT_POLL_INTERVAL_MS = 2000;
 const ANDROID_CI_INITIAL_SETTLE_MS = 30_000;
 const ANDROID_ANR_DISMISS_INTERVAL_MS = 3000;
@@ -55,6 +55,18 @@ function execAsync(cmd: string): Promise<{ stdout: string; stderr: string }> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveAndroidBootTimeoutMs(): number {
+  const raw = process.env.ANDROID_BOOT_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_ANDROID_BOOT_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_ANDROID_BOOT_TIMEOUT_MS;
+  }
+  return parsed;
 }
 
 function parseAdbDevices(stdout: string): AdbDevice[] {
@@ -121,6 +133,17 @@ export function shouldWaitForOfflineEmulator(
   resolvedAvdName: string | undefined,
 ): boolean {
   return resolvedAvdName === requestedAvdName;
+}
+
+/**
+ * During cold boot `adb emu avd name` can fail while the device is still offline.
+ * Wait on a lone starting emulator instead of spawning a duplicate (CI uses `-read-only`).
+ */
+export function shouldWaitForUnidentifiedOfflineEmulator(options: {
+  isCI: boolean;
+  offlineOrAuthorizingCount: number;
+}): boolean {
+  return options.isCI && options.offlineOrAuthorizingCount === 1;
 }
 
 interface TapPoint {
@@ -400,7 +423,8 @@ async function stabilizeAndroidEmulatorAfterBoot(
 async function waitForEmulatorBoot(serial: string): Promise<void> {
   await execAsync(`adb -s ${serial} wait-for-device`);
 
-  const deadline = Date.now() + ANDROID_BOOT_TIMEOUT_MS;
+  const bootTimeoutMs = resolveAndroidBootTimeoutMs();
+  const deadline = Date.now() + bootTimeoutMs;
   let booted = false;
 
   while (Date.now() < deadline) {
@@ -424,7 +448,7 @@ async function waitForEmulatorBoot(serial: string): Promise<void> {
 
   if (!booted) {
     throw new Error(
-      `Android emulator ${serial} did not complete booting within ${ANDROID_BOOT_TIMEOUT_MS / 1000}s.`,
+      `Android emulator ${serial} did not complete booting within ${bootTimeoutMs / 1000}s.`,
     );
   }
 
@@ -446,6 +470,68 @@ export async function isAndroidEmulatorRunning(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Ensures an Android emulator is booted before Appium session creation.
+ * Prefers `preferredSerial` or `ANDROID_DEVICE_UDID` so tests attach to a
+ * specific adb serial instead of whichever emulator matches the AVD name.
+ */
+async function killAndroidEmulatorsForAvd(avdName: string): Promise<void> {
+  const devices = await listAdbDevices();
+  for (const device of devices) {
+    if (!device.serial.startsWith('emulator-')) {
+      continue;
+    }
+    let resolvedAvdName: string | undefined;
+    try {
+      resolvedAvdName = await getEmulatorAvdName(device.serial);
+    } catch {
+      resolvedAvdName = undefined;
+    }
+    if (resolvedAvdName && resolvedAvdName !== avdName) {
+      continue;
+    }
+    logger.warn(
+      `Stopping Android emulator ${device.serial}${resolvedAvdName ? ` (${resolvedAvdName})` : ''} before restarting "${avdName}".`,
+    );
+    await execAsync(`adb -s ${device.serial} emu kill`).catch(() => undefined);
+  }
+  await sleep(2000);
+}
+
+export async function ensureAndroidEmulatorReady(
+  avdName: string,
+  preferredSerial?: string,
+): Promise<string> {
+  const serial =
+    preferredSerial?.trim() || process.env.ANDROID_DEVICE_UDID?.trim();
+  if (serial) {
+    const devices = await listAdbDevices();
+    const device = devices.find((entry) => entry.serial === serial);
+    if (device?.state === 'device') {
+      logger.info(
+        `Using configured Android emulator ${serial} — skipping AVD name lookup.`,
+      );
+      await waitForEmulatorBoot(serial);
+      return serial;
+    }
+    if (
+      device &&
+      (device.state === 'offline' || device.state === 'authorizing')
+    ) {
+      logger.info(
+        `Configured Android emulator ${serial} is ${device.state} — waiting for boot instead of spawning a duplicate.`,
+      );
+      await waitForEmulatorBoot(serial);
+      return serial;
+    }
+    logger.warn(
+      `Configured Android serial ${serial} not found in adb devices — restarting emulator for AVD "${avdName}".`,
+    );
+    await killAndroidEmulatorsForAvd(avdName);
+  }
+  return startAndroidEmulator(avdName);
 }
 
 /**
@@ -483,6 +569,21 @@ export async function startAndroidEmulator(avdName: string): Promise<string> {
     if (shouldWaitForOfflineEmulator(avdName, offlineAvdName)) {
       logger.info(
         `Waiting for Android emulator ${offlineEmulator.serial} (${offlineAvdName}) to finish booting instead of spawning a duplicate.`,
+      );
+      await waitForEmulatorBoot(offlineEmulator.serial);
+      return offlineEmulator.serial;
+    }
+    if (
+      offlineAvdName === undefined &&
+      shouldWaitForUnidentifiedOfflineEmulator({
+        isCI: process.env.CI === 'true',
+        offlineOrAuthorizingCount: devices.filter(
+          (entry) => entry.state === 'offline' || entry.state === 'authorizing',
+        ).length,
+      })
+    ) {
+      logger.info(
+        `Waiting for unidentified offline emulator ${offlineEmulator.serial} — likely "${avdName}" still booting.`,
       );
       await waitForEmulatorBoot(offlineEmulator.serial);
       return offlineEmulator.serial;
@@ -553,7 +654,8 @@ export async function startAndroidEmulator(avdName: string): Promise<string> {
   emulatorProcess.unref();
 
   logger.info('Waiting for Android emulator to appear in adb...');
-  const deadline = Date.now() + ANDROID_BOOT_TIMEOUT_MS;
+  const bootTimeoutMs = resolveAndroidBootTimeoutMs();
+  const deadline = Date.now() + bootTimeoutMs;
   let serial: string | undefined;
 
   while (Date.now() < deadline) {
@@ -570,7 +672,7 @@ export async function startAndroidEmulator(avdName: string): Promise<string> {
 
   if (!serial) {
     throw new Error(
-      `Android emulator for AVD "${avdName}" did not appear in adb within ${ANDROID_BOOT_TIMEOUT_MS / 1000}s.`,
+      `Android emulator for AVD "${avdName}" did not appear in adb within ${bootTimeoutMs / 1000}s.`,
     );
   }
 

--- a/tests/framework/services/providers/emulator/EmulatorProvider.ts
+++ b/tests/framework/services/providers/emulator/EmulatorProvider.ts
@@ -8,6 +8,7 @@ import { EmulatorConfigBuilder } from './EmulatorConfigBuilder';
 import { Platform, type EmulatorConfig } from '../../../types';
 import {
   applyResolvedAndroidAdbToDevice,
+  clearAndroidAdbUdidResolutionCache,
   resolveAndroidAdbUdidForDevice,
 } from './android/resolveAndroidAdbUdid';
 import {
@@ -16,6 +17,7 @@ import {
 } from './reinstallLocalBuildFromPath';
 import {
   startAndroidEmulator,
+  ensureAndroidEmulatorReady,
   ensureIosSimulatorReady,
   getIosSimulatorUdid,
 } from '../../appium/EmulatorHelpers';
@@ -137,6 +139,17 @@ export class EmulatorProvider extends BaseServiceProvider {
   }
 
   /**
+   * Persist adb serial across Playwright tests and retries in the same worker.
+   */
+  private persistAndroidEmulatorSerial(
+    serial: string,
+    emulatorDevice: EmulatorConfig,
+  ): void {
+    emulatorDevice.udid = serial;
+    process.env.ANDROID_DEVICE_UDID = serial;
+  }
+
+  /**
    * Boot the configured device (emulator/simulator) if it is not already
    * running. Controlled by the SKIP_DEVICE_BOOT env var:
    *
@@ -153,14 +166,18 @@ export class EmulatorProvider extends BaseServiceProvider {
     }
 
     if (this.project.use.platform === Platform.ANDROID) {
-      const avdName = (this.project.use.device as EmulatorConfig).name;
-      if (!avdName) {
+      const emulatorDevice = this.project.use.device as EmulatorConfig;
+      const avdName = emulatorDevice.name;
+      if (!avdName && !emulatorDevice.udid) {
         throw new Error(
-          'Android device boot requires `use.device.name` (AVD name) in the project config.',
+          'Android device boot requires `use.device.name` (AVD name) or `use.device.udid` (adb serial) in the project config.',
         );
       }
-      const serial = await startAndroidEmulator(avdName);
-      (this.project.use.device as EmulatorConfig).udid = serial;
+      const serial = await ensureAndroidEmulatorReady(
+        avdName ?? '',
+        emulatorDevice.udid,
+      );
+      this.persistAndroidEmulatorSerial(serial, emulatorDevice);
     } else if (this.project.use.platform === Platform.IOS) {
       const deviceName = this.project.use.device?.name;
       if (!deviceName) {
@@ -246,6 +263,14 @@ export class EmulatorProvider extends BaseServiceProvider {
           'Android local emulator: set `use.device.name` (AVD name) or `use.device.udid` (e.g. emulator-5554).',
         );
       }
+      // Re-ensure the emulator on every session (including Playwright retries).
+      // globalSetup boots once; a failed test can leave adb offline until we wait or reboot.
+      clearAndroidAdbUdidResolutionCache();
+      const serial = await ensureAndroidEmulatorReady(
+        emulatorDevice.name ?? '',
+        emulatorDevice.udid,
+      );
+      this.persistAndroidEmulatorSerial(serial, emulatorDevice);
       await applyResolvedAndroidAdbToDevice(emulatorDevice, {
         setAndroidSerialEnv: true,
       });

--- a/tests/framework/services/providers/emulator/android/resolveAndroidAdbUdid.ts
+++ b/tests/framework/services/providers/emulator/android/resolveAndroidAdbUdid.ts
@@ -123,6 +123,11 @@ export async function resolveAndroidAdbUdidForDevice(
 
   const promise = (async () => {
     try {
+      const envUdid = process.env.ANDROID_DEVICE_UDID?.trim();
+      if (!device.udid && envUdid) {
+        return envUdid;
+      }
+
       if (device.udid) {
         const udid = device.udid;
         if (device.name) {
@@ -216,8 +221,16 @@ export async function applyResolvedAndroidAdbToDevice(
 }
 
 /**
+ * Clears the in-process adb serial resolution cache.
+ * Call before re-resolving after Playwright retries or emulator restarts.
+ */
+export function clearAndroidAdbUdidResolutionCache(): void {
+  resolutionCache.clear();
+}
+
+/**
  * Clears the in-process resolution cache (for tests).
  */
 export function __clearAndroidAdbUdidCacheForTests(): void {
-  resolutionCache.clear();
+  clearAndroidAdbUdidResolutionCache();
 }

--- a/tests/page-objects/Confirmation/TransactionPayConfirmation.ts
+++ b/tests/page-objects/Confirmation/TransactionPayConfirmation.ts
@@ -429,14 +429,32 @@ class TransactionPayConfirmation {
         }
       },
       appium: async () => {
+        const waitForKeypad = async (): Promise<void> => {
+          await Assertions.expectElementToBeVisible(this.getKeypadButton('0'), {
+            timeout: 60_000,
+            description: 'Transaction pay amount keypad',
+          });
+        };
+
+        try {
+          await waitForKeypad();
+        } catch {
+          await Assertions.expectElementToBeVisible(this.keyboardContainer, {
+            timeout: 60_000,
+            description: 'Custom amount input before opening keypad',
+          });
+          await UnifiedGestures.waitAndTap(this.keyboardContainer, {
+            description: 'Custom amount input field',
+            timeout: 15_000,
+          });
+          await waitForKeypad();
+        }
+
         for (const char of amount) {
-          await PlaywrightGestures.waitAndTap(
-            await asPlaywrightElement(this.getKeypadButton(char)),
-            {
-              checkForDisplayed: true,
-              checkForEnabled: true,
-            },
-          );
+          await UnifiedGestures.waitAndTap(this.getKeypadButton(char), {
+            description: `Keyboard Key ${char}`,
+            timeout: 15_000,
+          });
         }
       },
     });

--- a/tests/page-objects/Onboarding/ExperienceEnhancerBottomSheet.ts
+++ b/tests/page-objects/Onboarding/ExperienceEnhancerBottomSheet.ts
@@ -11,6 +11,7 @@ import {
 import { encapsulatedAction } from '../../framework/encapsulatedAction';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import PlaywrightGestures from '../../framework/PlaywrightGestures';
+import { withImplicitWait } from '../../framework/PlaywrightUtilities';
 
 class ExperienceEnhancerBottomSheet {
   get container(): EncapsulatedElementType {
@@ -69,14 +70,20 @@ class ExperienceEnhancerBottomSheet {
       },
       appium: async () => {
         try {
-          const noThanks = await asPlaywrightElement(this.noThanksButton);
-          if (await noThanks.unwrap().isDisplayed()) {
-            await PlaywrightGestures.waitAndTap(noThanks, {
-              checkForDisplayed: true,
-              checkForEnabled: true,
-              timeout: 5_000,
-            });
-          }
+          await withImplicitWait(500, async () => {
+            const noThanks = await asPlaywrightElement(this.noThanksButton);
+            const exists = await noThanks.unwrap().isExisting();
+            if (!exists) {
+              return;
+            }
+            if (await noThanks.isVisible()) {
+              await PlaywrightGestures.waitAndTap(noThanks, {
+                checkForDisplayed: true,
+                checkForEnabled: true,
+                timeout: 5_000,
+              });
+            }
+          });
         } catch {
           // Modal not shown
         }

--- a/tests/page-objects/Predict/PredictDetailsPage.ts
+++ b/tests/page-objects/Predict/PredictDetailsPage.ts
@@ -8,6 +8,7 @@ import {
   encapsulatedAction,
   type EncapsulatedElementType,
 } from '../../framework';
+import { resolveE2EWaitTimeoutMs } from '../../framework/Constants';
 import {
   PredictBalanceSelectorsIDs,
   PredictBuyPreviewSelectorsIDs,
@@ -195,16 +196,20 @@ class PredictDetailsPage {
   }
 
   private getKeypadDigitButton(digit: string): EncapsulatedElementType {
+    const testID = digit === '.' ? 'keypad-key-dot' : `keypad-key-${digit}`;
     return encapsulated({
       detox: () => Matchers.getElementByText(digit),
-      appium: () => PlaywrightMatchers.getElementByText(digit),
+      appium: () => PlaywrightMatchers.getElementById(testID, { exact: true }),
     });
   }
 
   private getDoneButton(): EncapsulatedElementType {
     return encapsulated({
       detox: () => Matchers.getElementByText('Done'),
-      appium: () => PlaywrightMatchers.getElementByText('Done'),
+      appium: () =>
+        PlaywrightMatchers.getElementByText('Done', false, {
+          lastElement: true,
+        }),
     });
   }
 
@@ -226,7 +231,7 @@ class PredictDetailsPage {
   async waitForScreenToDisplay(): Promise<void> {
     await Assertions.expectElementToBeVisible(this.container, {
       description: 'Predict market details screen',
-      timeout: 15000,
+      timeout: resolveE2EWaitTimeoutMs(30_000),
     });
   }
 
@@ -235,8 +240,33 @@ class PredictDetailsPage {
   }
 
   async tapBackButton(): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.backButton, {
-      description: 'Back button',
+    await encapsulatedAction({
+      detox: async () => {
+        await UnifiedGestures.waitAndTap(this.backButton, {
+          description: 'Back button',
+          timeout: 30_000,
+        });
+      },
+      appium: async () => {
+        try {
+          await Assertions.expectElementToBeVisible(this.backButton, {
+            description: 'Market details back button',
+            timeout: 30_000,
+          });
+          await UnifiedGestures.waitAndTap(this.backButton, {
+            description: 'Back button',
+            timeout: 30_000,
+          });
+        } catch {
+          const driver = globalThis.driver;
+          if (!driver) {
+            throw new Error(
+              'WebDriver session not available for Android back navigation',
+            );
+          }
+          await driver.back();
+        }
+      },
     });
   }
 
@@ -320,8 +350,18 @@ class PredictDetailsPage {
         });
       },
       appium: async () => {
+        await Assertions.expectElementToBeVisible(this.placeBetButton, {
+          description: 'Place bet button before submitting order',
+          timeout: 30_000,
+        });
         await UnifiedGestures.waitAndTap(this.placeBetButton, {
           description: 'Place bet button',
+          delay: 1000,
+          waitForInteractive: true,
+        });
+        await Assertions.expectElementToBeVisible(this.container, {
+          description: 'Market details screen after order submission',
+          timeout: 60_000,
         });
       },
     });

--- a/tests/page-objects/Predict/PredictMarketList.ts
+++ b/tests/page-objects/Predict/PredictMarketList.ts
@@ -1,20 +1,32 @@
 import {
+  Assertions,
+  Gestures,
   Matchers,
+  PlaywrightGestures,
   PlaywrightMatchers,
   UnifiedGestures,
   Utilities,
+  asPlaywrightElement,
   encapsulated,
+  encapsulatedAction,
   type EncapsulatedElementType,
 } from '../../framework';
 import {
   PredictBalanceSelectorsIDs,
   PredictBalanceSelectorsText,
+  PredictFeedSelectorsIDs,
   PredictMarketListSelectorsIDs,
   getPredictFeedSelector,
   getPredictMarketListSelector,
 } from '../../../app/components/UI/Predict/Predict.testIds';
 
 type CategoryTab = 'trending' | 'new' | 'sports' | 'crypto' | 'politics';
+type CategoryTabScrollDirection = 'left' | 'right';
+
+/** TabsBar assigns `predict-feed-tabs-tab-{runtimeIndex}`; match pressable by label, not fixed index. */
+const PREDICT_FEED_TAB_PRESSABLE_ID = new RegExp(
+  `^${PredictFeedSelectorsIDs.TABS}-tab-\\d+$`,
+);
 
 const CATEGORY_LABELS: Record<CategoryTab, string> = {
   trending: 'Trending',
@@ -51,13 +63,11 @@ class PredictMarketList {
 
   get categoryTabs(): EncapsulatedElementType {
     return encapsulated({
-      detox: () =>
-        Matchers.getElementByID(PredictMarketListSelectorsIDs.CATEGORY_TABS),
+      detox: () => Matchers.getElementByID(PredictFeedSelectorsIDs.TABS),
       appium: () =>
-        PlaywrightMatchers.getElementById(
-          PredictMarketListSelectorsIDs.CATEGORY_TABS,
-          { exact: true },
-        ),
+        PlaywrightMatchers.getElementById(PredictFeedSelectorsIDs.TABS, {
+          exact: true,
+        }),
     });
   }
 
@@ -180,8 +190,117 @@ class PredictMarketList {
     const label = CATEGORY_LABELS[category];
 
     return encapsulated({
-      detox: () => Matchers.getElementByText(label),
+      detox: () =>
+        element(
+          by
+            .id(PREDICT_FEED_TAB_PRESSABLE_ID)
+            .withAncestor(by.id(PredictFeedSelectorsIDs.TABS))
+            .withDescendant(by.text(label)),
+        ) as unknown as DetoxElement,
       appium: () => PlaywrightMatchers.getElementByText(label),
+    });
+  }
+
+  /**
+   * Reveal an off-screen feed category tab, then tap it.
+   * TabsBar testID is on the outer wrapper (not the inner ScrollView), so Detox
+   * swipes the bar horizontally; Appium scrolls the tab into view.
+   *
+   * @param options.direction - Scroll the tab bar toward this edge to reveal the target (`right` = tabs further right, e.g. Sports; `left` = tabs further left).
+   */
+  private async scrollAndTapCategoryTab(
+    tab: EncapsulatedElementType,
+    description: string,
+    options: {
+      direction?: CategoryTabScrollDirection;
+      maxSwipeAttempts?: number;
+      swipePercentage?: number;
+      timeout?: number;
+    } = {},
+  ): Promise<void> {
+    const {
+      direction = 'right',
+      maxSwipeAttempts = 6,
+      swipePercentage = 0.75,
+      timeout = 30_000,
+    } = options;
+    const detoxSwipeDirection = direction === 'right' ? 'left' : 'right';
+
+    await encapsulatedAction({
+      detox: async () => {
+        const tabEl = (await tab) as Detox.IndexableNativeElement;
+
+        await Utilities.executeWithRetry(
+          async () => {
+            for (let attempt = 0; attempt < maxSwipeAttempts; attempt += 1) {
+              try {
+                await waitFor(tabEl).toBeVisible().withTimeout(1000);
+                return;
+              } catch {
+                await Gestures.swipe(this.categoryTabs, detoxSwipeDirection, {
+                  elemDescription: `Swipe tabs ${direction} to reveal ${description} (attempt ${attempt + 1})`,
+                  speed: 'slow',
+                  percentage: swipePercentage,
+                });
+              }
+            }
+            await waitFor(tabEl).toBeVisible().withTimeout(3000);
+          },
+          {
+            timeout,
+            description: `Reveal ${description}`,
+          },
+        );
+        await Gestures.waitAndTap(tab, {
+          elemDescription: description,
+          checkStability: true,
+          timeout: 15_000,
+        });
+      },
+      appium: async () => {
+        const tabEl = await asPlaywrightElement(tab);
+        const tabsBar = await asPlaywrightElement(this.categoryTabs);
+        const appiumSwipeDirection = direction === 'right' ? 'left' : 'right';
+
+        await Utilities.executeWithRetry(
+          async () => {
+            for (let attempt = 0; attempt < maxSwipeAttempts; attempt += 1) {
+              try {
+                await Assertions.expectElementToBeVisible(tab, {
+                  timeout: 1000,
+                });
+                return;
+              } catch {
+                try {
+                  await PlaywrightGestures.scrollIntoView(tabEl, {
+                    scrollParams: { direction },
+                    scrollableElement: tabsBar,
+                    maxScrolls: 2,
+                  });
+                } catch {
+                  await UnifiedGestures.swipe(
+                    this.categoryTabs,
+                    appiumSwipeDirection,
+                    {
+                      description: `Swipe tabs ${direction} to reveal ${description} (attempt ${attempt + 1})`,
+                      percentage: swipePercentage,
+                    },
+                  );
+                }
+              }
+            }
+            await Assertions.expectElementToBeVisible(tab, { timeout: 3000 });
+          },
+          {
+            timeout,
+            description: `Reveal ${description}`,
+          },
+        );
+        await PlaywrightGestures.waitAndTap(tabEl, {
+          timeout: 15_000,
+          checkForStable: true,
+        });
+      },
     });
   }
 
@@ -211,37 +330,45 @@ class PredictMarketList {
     category: CategoryTab = 'trending',
     cardIndex: number = 1,
   ): Promise<void> {
-    await UnifiedGestures.waitAndTap(this.getMarketCard(category, cardIndex), {
-      description: `Predict market card ${cardIndex} in ${category} category`,
-    });
-  }
+    const card = this.getMarketCard(category, cardIndex);
+    const listContainerId = getPredictFeedSelector.marketList(category);
 
-  async tapCategoryTab(category: CategoryTab): Promise<void> {
-    const firstTab = encapsulated({
-      detox: () => Matchers.getElementByID(getPredictFeedSelector.tab(0)),
-      appium: () =>
-        PlaywrightMatchers.getElementById(getPredictFeedSelector.tab(0)),
-    });
-    const tab = this.getCategoryTab(category);
     await Utilities.executeWithRetry(
       async () => {
-        if (!(await Utilities.isElementVisible(tab, 1000))) {
-          await UnifiedGestures.swipe(firstTab, 'left', {
-            description: `Swipe tabs to reveal ${category}`,
-            speed: 'slow',
-            percentage: 0.5,
+        try {
+          await Assertions.expectElementToBeVisible(card, { timeout: 3000 });
+        } catch {
+          await UnifiedGestures.scrollToElement(card, listContainerId, {
+            description: `Predict market card ${cardIndex} in ${category}`,
+            direction: 'down',
           });
+          await Assertions.expectElementToBeVisible(card, { timeout: 10_000 });
         }
-        await Utilities.waitForElementToBeVisible(tab, 2000);
+        await UnifiedGestures.waitAndTap(card, {
+          description: `Predict market card ${cardIndex} in ${category} category`,
+          timeout: 15_000,
+        });
       },
       {
-        timeout: 15000,
-        description: `Scroll to ${category} category tab`,
+        timeout: 60_000,
+        description: `Tap predict market card ${cardIndex} in ${category}`,
       },
     );
-    await UnifiedGestures.waitAndTap(tab, {
-      description: `${category} category tab`,
-      checkStability: true,
+  }
+
+  async tapCategoryTab(
+    category: CategoryTab,
+    options: { direction?: CategoryTabScrollDirection } = {},
+  ): Promise<void> {
+    const tab = this.getCategoryTab(category);
+    await this.scrollAndTapCategoryTab(
+      tab,
+      `${CATEGORY_LABELS[category]} category tab`,
+      options,
+    );
+    await Assertions.expectElementToBeVisible(this.getMarketCard(category, 1), {
+      timeout: 60_000,
+      description: `${category} feed first market card loaded`,
     });
   }
 

--- a/tests/page-objects/Transactions/ActivitiesView.ts
+++ b/tests/page-objects/Transactions/ActivitiesView.ts
@@ -11,8 +11,13 @@ import {
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
 import Assertions from '../../framework/Assertions';
+import Utilities from '../../framework/Utilities';
+import UnifiedGestures from '../../framework/UnifiedGestures';
 import { encapsulatedAction } from '../../framework/encapsulatedAction';
-import { EncapsulatedElementType } from '../../framework/EncapsulatedElement';
+import {
+  encapsulated,
+  EncapsulatedElementType,
+} from '../../framework/EncapsulatedElement';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import PlaywrightAssertions from '../../framework/PlaywrightAssertions';
 
@@ -21,9 +26,11 @@ class ActivitiesView {
     return Matchers.getElementByText(ActivitiesViewSelectorsText.TITLE);
   }
   get predictionsTab(): EncapsulatedElementType {
-    return Matchers.getElementByLabel(
-      ActivitiesViewSelectorsText.PREDICTIONS_TAB,
-    );
+    const label = ActivitiesViewSelectorsText.PREDICTIONS_TAB;
+    return encapsulated({
+      detox: () => Matchers.getElementByLabel(label),
+      appium: () => PlaywrightMatchers.getElementByText(label),
+    });
   }
   get transferTab(): EncapsulatedElementType {
     return Matchers.getElementByID(ActivitiesViewSelectorsIDs.TRANSFER_TAB);
@@ -157,16 +164,32 @@ class ActivitiesView {
   }
 
   async tapOnPredictionsTab(): Promise<void> {
-    // Swipe left on the tabs bar to reveal the Predictions tab (it may be off-screen)
-    await Gestures.swipe(this.tabsBar, 'left', {
-      percentage: 0.5,
-      speed: 'slow',
-      elemDescription: 'Activity View Tabs Bar',
-    });
-    await Gestures.waitAndTap(this.predictionsTab, {
-      elemDescription: 'Predictions Tab in Activity View',
-      timeout: 3500,
-    });
+    await Utilities.executeWithRetry(
+      async () => {
+        for (let attempt = 0; attempt < 4; attempt += 1) {
+          try {
+            await Assertions.expectElementToBeVisible(this.predictionsTab, {
+              timeout: 1000,
+            });
+            break;
+          } catch {
+            await UnifiedGestures.swipe(this.tabsBar, 'left', {
+              percentage: 0.5,
+              speed: 'slow',
+              description: `Swipe activity tabs to reveal Predictions (attempt ${attempt + 1})`,
+            });
+          }
+        }
+        await UnifiedGestures.waitAndTap(this.predictionsTab, {
+          description: 'Predictions Tab in Activity View',
+          timeout: 10_000,
+        });
+      },
+      {
+        timeout: 30_000,
+        description: 'Tap Predictions tab in Activity View',
+      },
+    );
   }
 
   async tapOnTransfersTab(): Promise<void> {

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -6,6 +6,7 @@ import {
   Utilities,
   resolve,
   EncapsulatedElementType,
+  sleep,
 } from '../../framework';
 import { encapsulated } from '../../framework/EncapsulatedElement';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
@@ -13,6 +14,7 @@ import ActivitiesView from '../Transactions/ActivitiesView';
 import SettingsView from '../Settings/SettingsView';
 import AccountMenu from '../AccountMenu/AccountMenu';
 import WalletView from './WalletView';
+import WalletActionsBottomSheet from './WalletActionsBottomSheet';
 import TrendingView from '../Trending/TrendingView';
 
 class TabBarComponent {
@@ -102,9 +104,26 @@ class TabBarComponent {
   }
 
   async tapActions(): Promise<void> {
-    await Gestures.waitAndTap(this.tabBarActionButton, {
-      elemDescription: 'Tab Bar - Actions Button',
-    });
+    await Utilities.executeWithRetry(
+      async () => {
+        // TradeTabBarItem measures buttonLayout async; tap before layout is ready
+        // opens TradeWalletActions with invalid params and the sheet dismisses.
+        await sleep(500);
+        await Gestures.waitAndTap(this.tabBarActionButton, {
+          elemDescription: 'Tab Bar - Actions Button',
+          timeout: 5000,
+        });
+        // TradeWalletActions (not legacy WalletActionsBottomSheet) exposes swap/perps/predict — not send.
+        await Assertions.expectElementToBeVisible(
+          WalletActionsBottomSheet.swapButton,
+          { timeout: 10000 },
+        );
+      },
+      {
+        timeout: 45000,
+        description: 'Open wallet actions bottom sheet',
+      },
+    );
   }
 
   async tapTrade(): Promise<void> {

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -9,6 +9,7 @@ import {
   PredictPositionsHeaderSelectorsIDs,
   PredictPositionSelectorsIDs,
   PredictClaimConfirmationSelectorsIDs,
+  PredictMarketDetailsSelectorsIDs,
 } from '../../../app/components/UI/Predict/Predict.testIds';
 import Gestures from '../../framework/Gestures';
 import UnifiedGestures from '../../framework/UnifiedGestures';
@@ -26,8 +27,11 @@ import {
 import { encapsulatedAction } from '../../framework/encapsulatedAction';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import { PlatformDetector } from '../../framework/PlatformLocator';
+import { FrameworkDetector } from '../../framework/FrameworkDetector';
 import PlaywrightGestures from '../../framework/PlaywrightGestures';
+import { getDriver } from '../../framework/PlaywrightUtilities';
 import { getAssetTestId } from '../../selectors/Wallet/WalletView.selectors';
+import { resolveE2EWaitTimeoutMs } from '../../framework/Constants';
 
 class WalletView {
   static readonly MAX_SCROLL_ITERATIONS = 4;
@@ -46,6 +50,29 @@ class WalletView {
     return Matchers.getElementByID(WalletViewSelectorsIDs.WALLET_SCROLL_VIEW);
   }
 
+  private async tapIfAlreadyVisible(
+    target: DetoxElement | EncapsulatedElementType,
+    description: string,
+  ): Promise<boolean> {
+    if (!FrameworkDetector.isAppium()) {
+      return false;
+    }
+
+    try {
+      await PlaywrightAssertions.expectElementToBeVisible(
+        asPlaywrightElement(target),
+        { timeout: 2000, description },
+      );
+      await Gestures.waitAndTap(target, {
+        elemDescription: description,
+        timeout: 30_000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /**
    * Progressive scroll for homepage sections:
    * try tap -> small scroll down -> retry, until the section is tappable.
@@ -60,26 +87,58 @@ class WalletView {
     options: {
       scrollAmount?: number;
       overshootSwipe?: { direction: 'up' | 'down'; percentage?: number };
+      timeout?: number;
     } = {},
   ): Promise<void> {
-    const { scrollAmount = 200, overshootSwipe } = options;
+    const { scrollAmount = 200, overshootSwipe, timeout = 15_000 } = options;
 
-    await Gestures.scrollToElement(target, this.walletScrollContainer, {
-      direction,
-      scrollAmount,
-      elemDescription: `Scroll to ${description}`,
-    });
-
-    if (overshootSwipe) {
-      await Gestures.swipe(this.walletScrollView, overshootSwipe.direction, {
-        percentage: overshootSwipe.percentage ?? 0.15,
-        speed: 'slow',
-        elemDescription: `Overshoot swipe for ${description}`,
-      });
-    }
-
-    await Gestures.waitAndTap(target, {
-      elemDescription: description,
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.scrollToElement(target, this.walletScrollContainer, {
+          direction,
+          scrollAmount,
+          timeout,
+          elemDescription: `Scroll to ${description}`,
+        });
+        if (overshootSwipe) {
+          await Gestures.swipe(
+            this.walletScrollView,
+            overshootSwipe.direction,
+            {
+              percentage: overshootSwipe.percentage ?? 0.15,
+              speed: 'slow',
+              elemDescription: `Overshoot swipe for ${description}`,
+            },
+          );
+        }
+        await Gestures.waitAndTap(target, {
+          elemDescription: description,
+          timeout: 30_000,
+        });
+      },
+      appium: async () => {
+        const el = await asPlaywrightElement(target as EncapsulatedElementType);
+        const scrollable = await asPlaywrightElement(this.walletScrollView);
+        await PlaywrightGestures.scrollIntoView(el, {
+          scrollParams: {
+            direction: direction === 'down' ? 'down' : 'up',
+          },
+          scrollableElement: scrollable,
+          maxScrolls: 20,
+        });
+        if (overshootSwipe) {
+          await Gestures.swipe(
+            this.walletScrollView,
+            overshootSwipe.direction,
+            {
+              percentage: overshootSwipe.percentage ?? 0.15,
+              speed: 'slow',
+              elemDescription: `Overshoot swipe for ${description}`,
+            },
+          );
+        }
+        await PlaywrightGestures.waitAndTap(el, { timeout: 30_000 });
+      },
     });
   }
 
@@ -921,6 +980,15 @@ class WalletView {
       overshootSwipe?: { direction: 'up' | 'down'; percentage?: number };
     } = {},
   ): Promise<void> {
+    if (
+      await this.tapIfAlreadyVisible(
+        this.predictionsSectionHeader,
+        'Predictions section',
+      )
+    ) {
+      return;
+    }
+
     const getScrollOptions = (scrollDirection: 'up' | 'down') => ({
       overshootSwipe: options.overshootSwipe ?? {
         direction:
@@ -934,7 +1002,7 @@ class WalletView {
         this.predictionsSectionHeader,
         'Predictions section',
         direction,
-        getScrollOptions(direction),
+        { ...getScrollOptions(direction), timeout: 60_000 },
       );
     } catch {
       const fallbackDirection = direction === 'down' ? 'up' : 'down';
@@ -942,32 +1010,163 @@ class WalletView {
         this.predictionsSectionHeader,
         'Predictions section',
         fallbackDirection,
-        getScrollOptions(fallbackDirection),
+        { ...getScrollOptions(fallbackDirection), timeout: 60_000 },
       );
     }
   }
 
-  async scrollAndTapPredictionsPosition(positionName: string): Promise<void> {
-    const target = Matchers.getElementByText(positionName);
-    try {
-      await Gestures.scrollToElement(target, this.walletScrollContainer, {
-        direction: 'down',
-        scrollAmount: 220,
-        timeout: 12000,
-        elemDescription: `Scroll to prediction position: ${positionName}`,
-      });
-    } catch {
-      await Gestures.scrollToElement(target, this.walletScrollContainer, {
-        direction: 'up',
-        scrollAmount: 220,
-        timeout: 12000,
-        elemDescription: `Scroll up fallback to prediction position: ${positionName}`,
-      });
-    }
+  private async scrollPredictionsSectionIntoView(
+    direction: 'up' | 'down' = 'down',
+  ): Promise<void> {
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.scrollToElement(
+          this.predictionsSectionHeader,
+          this.walletScrollContainer,
+          {
+            direction,
+            scrollAmount: 200,
+            timeout: 60_000,
+            elemDescription: 'Scroll to Predictions section',
+          },
+        );
+      },
+      appium: async () => {
+        const header = await asPlaywrightElement(this.predictionsSectionHeader);
+        const scrollable = await asPlaywrightElement(this.walletScrollView);
+        await PlaywrightGestures.scrollIntoView(header, {
+          scrollParams: {
+            direction: direction === 'down' ? 'down' : 'up',
+          },
+          scrollableElement: scrollable,
+          maxScrolls: 20,
+        });
+      },
+    });
+  }
 
-    await Gestures.waitAndTap(target, {
-      checkStability: true,
-      elemDescription: `Predictions Position: ${positionName}`,
+  async scrollAndTapPredictionsPosition(
+    positionName: string,
+    positionId?: string,
+  ): Promise<void> {
+    const target = positionId
+      ? Matchers.getElementByID(`predict-position-row-${positionId}`)
+      : Matchers.getElementByText(positionName);
+
+    await encapsulatedAction({
+      detox: async () => {
+        if (
+          await this.tapIfAlreadyVisible(
+            target,
+            `Predictions Position: ${positionName}`,
+          )
+        ) {
+          return;
+        }
+
+        try {
+          await this.scrollPredictionsSectionIntoView('down');
+        } catch {
+          await this.scrollPredictionsSectionIntoView('up');
+        }
+
+        if (
+          await this.tapIfAlreadyVisible(
+            target,
+            `Predictions Position: ${positionName}`,
+          )
+        ) {
+          return;
+        }
+
+        try {
+          await this.scrollAndTapSection(
+            target,
+            `Predictions Position: ${positionName}`,
+            'down',
+            { timeout: 60_000 },
+          );
+        } catch {
+          await this.scrollAndTapSection(
+            target,
+            `Predictions Position: ${positionName}`,
+            'up',
+            { timeout: 60_000 },
+          );
+        }
+      },
+      appium: async () => {
+        const driver = getDriver();
+        const description = `Predictions Position: ${positionName}`;
+        const marketDetailsScreen = Matchers.getElementByID(
+          PredictMarketDetailsSelectorsIDs.SCREEN,
+        );
+        const predictNavigationTimeoutMs = resolveE2EWaitTimeoutMs(30_000);
+
+        if (await this.tapIfAlreadyVisible(target, description)) {
+          await Assertions.expectElementToBeVisible(marketDetailsScreen, {
+            timeout: predictNavigationTimeoutMs,
+            description: 'Predict market details screen after position tap',
+          });
+          return;
+        }
+
+        try {
+          await this.scrollPredictionsSectionIntoView('down');
+        } catch {
+          await this.scrollPredictionsSectionIntoView('up');
+        }
+
+        await Utilities.executeWithRetry(
+          async () => {
+            for (const direction of ['down', 'up'] as const) {
+              for (let attempt = 0; attempt < 8; attempt += 1) {
+                try {
+                  await Assertions.expectElementToBeVisible(target, {
+                    timeout: 2000,
+                  });
+                } catch {
+                  await driver.execute('mobile: scrollGesture', {
+                    left: 50,
+                    top: 300,
+                    width: 900,
+                    height: 1400,
+                    direction,
+                    percent: 0.55,
+                  });
+                  continue;
+                }
+
+                await UnifiedGestures.waitAndTap(target, {
+                  description,
+                  timeout: 30_000,
+                });
+                await Assertions.expectElementToBeVisible(marketDetailsScreen, {
+                  timeout: predictNavigationTimeoutMs,
+                  description:
+                    'Predict market details screen after position tap',
+                });
+                return;
+              }
+            }
+            await Assertions.expectElementToBeVisible(target, {
+              timeout: 5000,
+            });
+            await UnifiedGestures.waitAndTap(target, {
+              description,
+              timeout: 30_000,
+            });
+            await Assertions.expectElementToBeVisible(marketDetailsScreen, {
+              timeout: predictNavigationTimeoutMs,
+              description: 'Predict market details screen after position tap',
+            });
+          },
+          {
+            timeout: 90_000,
+            description: `Scroll and tap ${description}`,
+          },
+        );
+      },
     });
   }
 
@@ -982,17 +1181,53 @@ class WalletView {
   }
 
   async tapClaimButton(): Promise<void> {
-    await Gestures.scrollToElement(
-      this.claimButton,
-      this.walletScrollContainer,
-      {
-        direction: 'down',
-        scrollAmount: 200,
-        elemDescription: 'Scroll to Claim Button',
+    await encapsulatedAction({
+      detox: async () => {
+        await Gestures.scrollToElement(
+          this.claimButton,
+          this.walletScrollContainer,
+          {
+            direction: 'down',
+            scrollAmount: 200,
+            elemDescription: 'Scroll to Claim Button',
+          },
+        );
+        await Gestures.waitAndTap(this.claimButton, {
+          elemDescription: 'Claim Button',
+        });
       },
-    );
-    await Gestures.waitAndTap(this.claimButton, {
-      elemDescription: 'Claim Button',
+      appium: async () => {
+        const driver = getDriver();
+        await Utilities.executeWithRetry(
+          async () => {
+            for (let attempt = 0; attempt < 12; attempt += 1) {
+              try {
+                await Assertions.expectElementToBeVisible(this.claimButton, {
+                  timeout: 2000,
+                });
+                break;
+              } catch {
+                await driver.execute('mobile: scrollGesture', {
+                  left: 50,
+                  top: 300,
+                  width: 900,
+                  height: 1400,
+                  direction: 'down',
+                  percent: 0.6,
+                });
+              }
+            }
+            await UnifiedGestures.waitAndTap(this.claimButton, {
+              description: 'Claim Button',
+              timeout: 30_000,
+            });
+          },
+          {
+            timeout: 90_000,
+            description: 'Tap claim button on wallet homepage',
+          },
+        );
+      },
     });
   }
 

--- a/tests/smoke-appium/predict/helpers/predict-helpers.ts
+++ b/tests/smoke-appium/predict/helpers/predict-helpers.ts
@@ -1,0 +1,59 @@
+import { createLogger, LogLevel } from '../../../framework/logger.js';
+import { loginToAppPlaywright } from '../../../flows/wallet.flow.js';
+
+const logger = createLogger({
+  name: 'PredictHelpers',
+  level: LogLevel.INFO,
+});
+
+/**
+ * Location coordinates for Portugal (required for Predictions, specifically when US engineers are debugging locally)
+ */
+export const PORTUGAL_LOCATION = {
+  lat: 41.1318702,
+  lon: -7.798836,
+};
+
+/**
+ * Disables the Perps homepage section for predict smoke tests.
+ * With homepageSectionsV1 enabled, an uninitialized Perps stream crashes wallet home
+ * (`PERPS_EVENT_VALUE.SECTION_NAME.BALANCE` / `usePerpsLivePositions`).
+ */
+export const remoteFeatureFlagPerpsDisabledForPredictSmoke = () => ({
+  perpsPerpTradingEnabled: {
+    enabled: false,
+    minimumVersion: '0.0.0',
+  },
+});
+
+export class PredictHelpers {
+  /**
+   * Sets the device location to Portugal coordinates.
+   * Required for Predictions feature access in e2e tests.
+   */
+  static async setPortugalLocation(): Promise<void> {
+    const driver = globalThis.driver;
+    if (!driver) {
+      throw new Error(
+        'WebDriver session not available — setPortugalLocation requires an active Appium session',
+      );
+    }
+
+    logger.info('[PredictHelpers] Setting device location to Portugal...');
+    await driver.setGeoLocation({
+      latitude: String(PORTUGAL_LOCATION.lat),
+      longitude: String(PORTUGAL_LOCATION.lon),
+    });
+    logger.info(
+      '[PredictHelpers] Device location set to Portugal successfully',
+    );
+  }
+}
+
+/**
+ * Logs into the app and waits for the wallet screen (Appium smoke tests).
+ * Mirrors Detox `loginToApp()` — wallet wait is handled by `loginToAppPlaywright`.
+ */
+export async function loginForPredictTests(): Promise<void> {
+  await loginToAppPlaywright({ scenarioType: 'e2e' });
+}


### PR DESCRIPTION
## Summary
First slice of the Predictions Detox → Appium migration ([MMQA-1941](https://consensyssoftware.atlassian.net/browse/MMQA-1941) / [MMQA-1999](https://consensyssoftware.atlassian.net/browse/MMQA-1999)).

Shared E2E framework updates, predict/wallet page objects, `predict-helpers`, and emulator/login stability. **No Appium predict specs or SmokePredictions CI jobs yet.**

## Stack
1. **This PR (#32160)** → `main`
2. #32161 — cash out + open position
3. #32162 — claim winnings
4. #32163 — geo + withdraw (replaces monolithic #32065)

## Test plan
- [x] `yarn format:check`
- [x] `yarn lint:tsc`

[MMQA-1941]: https://consensyssoftware.atlassian.net/browse/MMQA-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMQA-1999]: https://consensyssoftware.atlassian.net/browse/MMQA-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ