### PR TITLE
test(predict): Appium smoke — cash out and open position

### DIFF
--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -101,3 +101,27 @@ jobs:
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
+
+  appium-predictions-android-smoke:
+    if: >-
+      ${{
+        !cancelled() &&
+        (contains(fromJson(inputs.selected_tags), 'ALL') ||
+         contains(fromJson(inputs.selected_tags), 'SmokePredictions'))
+      }}
+    strategy:
+      matrix:
+        split: [1, 2, 3]
+      fail-fast: false
+    uses: ./.github/workflows/run-appium-e2e-workflow.yml
+    with:
+      test-suite-name: appium-predictions-android-smoke-${{ matrix.split }}
+      platform: android
+      test_suite_tag: SmokePredictions
+      split_number: ${{ matrix.split }}
+      total_splits: 3
+      test-timeout-minutes: 60
+      build_type: ${{ inputs.build_type }}
+      metamask_environment: ${{ inputs.metamask_environment }}
+      runner_provider: ${{ inputs.runner_provider }}
+    secrets: inherit

--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -80,3 +80,27 @@ jobs:
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}
     secrets: inherit
+
+  appium-predictions-ios-smoke:
+    if: >-
+      ${{
+        !cancelled() &&
+        (contains(fromJson(inputs.selected_tags || '["ALL"]'), 'ALL') ||
+         contains(fromJson(inputs.selected_tags || '["ALL"]'), 'SmokePredictions'))
+      }}
+    strategy:
+      matrix:
+        split: [1, 2, 3]
+      fail-fast: false
+    uses: ./.github/workflows/run-appium-e2e-workflow.yml
+    with:
+      test-suite-name: appium-predictions-ios-smoke-${{ matrix.split }}
+      platform: ios
+      test_suite_tag: SmokePredictions
+      split_number: ${{ matrix.split }}
+      total_splits: 3
+      test-timeout-minutes: 60
+      build_type: ${{ inputs.build_type || 'main' }}
+      metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
+      runner_provider: ${{ inputs.runner_provider || 'current' }}
+    secrets: inherit

--- a/tests/smoke-appium/predict/predict-cash-out.spec.ts
+++ b/tests/smoke-appium/predict/predict-cash-out.spec.ts
@@ -1,0 +1,140 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokePredictions } from '../../tags.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage.js';
+import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
+import Assertions from '../../framework/Assertions.js';
+import WalletView from '../../page-objects/wallet/WalletView.js';
+import {
+  remoteFeatureFlagPredictEnabled,
+  remoteFeatureFlagHomepageSectionsV1Enabled,
+} from '../../api-mocking/mock-responses/feature-flags-mocks.js';
+import {
+  POLYMARKET_COMPLETE_MOCKS,
+  POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS,
+  POLYMARKET_POST_CASH_OUT_MOCKS,
+  POLYMARKET_REMOVE_CASHED_OUT_POSITION_MOCKS,
+  POLYMARKET_UPDATE_USDC_BALANCE_MOCKS,
+} from '../../api-mocking/mock-responses/polymarket/polymarket-mocks.js';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
+import PredictCashOutPage from '../../page-objects/Predict/PredictCashOutPage.js';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
+import ActivitiesView from '../../page-objects/Transactions/ActivitiesView.js';
+import PredictActivityDetails from '../../page-objects/Transactions/predictionsActivityDetails.js';
+import { predictCashOutFlowAnalyticsExpectations } from '../../helpers/analytics/expectations/predict-cash-out.analytics.js';
+import { SPURS_PELICANS_POSITION_ID } from '../../api-mocking/mock-responses/polymarket/polymarket-constants.js';
+import {
+  loginForPredictTests,
+  remoteFeatureFlagPerpsDisabledForPredictSmoke,
+} from './helpers/predict-helpers.js';
+import { resolveE2EWaitTimeoutMs } from '../../framework/Constants.js';
+
+/*
+Test Scenario: Cash out on open position - Spurs vs. Pelicans
+  Verifies the cash out flow for a predictions position (homepage sections v1 — no wallet tabs):
+  1. From wallet homepage Predictions section, open Spurs vs. Pelicans position details
+  2. Cash out the position with updated mocks
+  3. Verify balance and cash out in Activities tab
+  */
+const positionDetails = {
+  name: 'Spurs vs. Pelicans',
+  cashOutValue: '$30.75',
+  initialBalance: '$28.16',
+  newBalance: '$58.66',
+};
+
+const PredictionMarketFeature = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagPerpsDisabledForPredictSmoke(),
+    ...remoteFeatureFlagPredictEnabled(true),
+    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
+    // TODO: Fix this test to support the FF-enabled Predict bottom sheet / any-token flow.
+    predictBottomSheet: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    predictWithAnyToken: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    carouselBanners: false,
+  });
+  await POLYMARKET_COMPLETE_MOCKS(mockServer);
+  await POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS(mockServer, false); // do not include winnings. Claim Button is animated and problematic for e2e
+};
+
+appiumTest.describe(SmokePredictions('Predictions'), () => {
+  appiumTest(
+    'cashes out on open position: Spurs vs. Pelicans',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder()
+            .withPolygon()
+            .withMetaMetricsOptIn()
+            .build(),
+          restartDevice: true,
+          disableLocalNodes: true,
+          testSpecificMock: PredictionMarketFeature,
+          analyticsExpectations: predictCashOutFlowAnalyticsExpectations,
+          currentDeviceDetails,
+        },
+        async ({ mockServer }) => {
+          await loginForPredictTests();
+          await WalletView.scrollAndTapPredictionsPosition(
+            positionDetails.name,
+            SPURS_PELICANS_POSITION_ID,
+          );
+          await Assertions.expectElementToBeVisible(
+            PredictDetailsPage.container,
+            {
+              timeout: resolveE2EWaitTimeoutMs(20_000),
+              description: 'Predict market details screen should be visible',
+            },
+          );
+          await POLYMARKET_POST_CASH_OUT_MOCKS(mockServer);
+
+          await PredictDetailsPage.tapGameCashOutButton(
+            SPURS_PELICANS_POSITION_ID,
+          );
+          await Assertions.expectElementToBeVisible(
+            PredictCashOutPage.container,
+          );
+
+          await Assertions.expectElementToBeVisible(
+            PredictCashOutPage.cashOutButton,
+          );
+
+          await PredictCashOutPage.tapCashOutButton();
+
+          // Register position-removal and balance-update mocks only AFTER the
+          // cash-out confirmation tap. Registering them earlier causes a race
+          // condition: a background refetch can pick up the "position removed"
+          // response while the Cash Out button is still needed, making it vanish.
+          await POLYMARKET_REMOVE_CASHED_OUT_POSITION_MOCKS(mockServer);
+          await POLYMARKET_UPDATE_USDC_BALANCE_MOCKS(mockServer, 'cash-out');
+
+          await PredictDetailsPage.tapBackButton();
+          await WalletView.scrollAndTapPredictionsSection();
+          await WalletView.tapOnAvailableBalance();
+          await Assertions.expectTextDisplayed(positionDetails.newBalance, {
+            description: 'Predictions balance should be updated to $58.66',
+          });
+
+          await PredictMarketList.tapBackButton();
+          await TabBarComponent.tapActivity();
+
+          await ActivitiesView.tapOnPredictionsTab();
+          await Assertions.expectTextDisplayed('Cashed out');
+          await ActivitiesView.tapPredictPosition(positionDetails.name);
+          await Assertions.expectElementToBeVisible(
+            PredictActivityDetails.container,
+          );
+          await Assertions.expectTextDisplayed(positionDetails.cashOutValue);
+        },
+      );
+    },
+  );
+});

--- a/tests/smoke-appium/predict/predict-open-position.spec.ts
+++ b/tests/smoke-appium/predict/predict-open-position.spec.ts
@@ -1,0 +1,147 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokePredictions } from '../../tags.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
+import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage.js';
+import Assertions from '../../framework/Assertions.js';
+import {
+  remoteFeatureFlagHomepageSectionsV1Enabled,
+  remoteFeatureFlagPredictEnabled,
+} from '../../api-mocking/mock-responses/feature-flags-mocks.js';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
+import {
+  POLYMARKET_COMPLETE_MOCKS,
+  POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS,
+  POLYMARKET_POST_OPEN_POSITION_MOCKS,
+  POLYMARKET_UPDATE_USDC_BALANCE_MOCKS,
+  POLYMARKET_LEGACY_SAFE_ACCOUNT_MOCKS,
+} from '../../api-mocking/mock-responses/polymarket/polymarket-mocks.js';
+import WalletView from '../../page-objects/wallet/WalletView.js';
+import { predictOpenPositionAnalyticsExpectations } from '../../helpers/analytics/expectations/predict-open-position.analytics.js';
+import {
+  loginForPredictTests,
+  remoteFeatureFlagPerpsDisabledForPredictSmoke,
+} from './helpers/predict-helpers.js';
+import { CELTICS_NETS_POSITION_ID } from '../../api-mocking/mock-responses/polymarket/polymarket-constants.js';
+
+/*
+Test Scenario: Open position on Celtics vs. Nets market
+  Verifies the open position flow for a predictions market:
+  1. Navigate to Predictions tab and open market list
+  2. Select Celtics vs. Nets market from sports category
+  3. Open a position with $10 investment
+  4. Verify position appears in Positions tab
+  5. Verify balance updates to $17.76
+  6. Verify position appears in Activities tab
+*/
+const positionDetails = {
+  name: 'Celtics vs. Nets',
+  positionAmount: '10',
+  newBalance: '$17.76',
+  category: 'sports' as const,
+  marketIndex: 1,
+};
+
+const PredictionMarketFeature = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagPerpsDisabledForPredictSmoke(),
+    ...remoteFeatureFlagPredictEnabled(true),
+    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
+    // TODO: Fix this test to support the FF-enabled Predict bottom sheet / any-token flow.
+    predictBottomSheet: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    predictWithAnyToken: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    predictHomeRedesign: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    carouselBanners: false,
+  });
+  await POLYMARKET_COMPLETE_MOCKS(mockServer);
+  await POLYMARKET_LEGACY_SAFE_ACCOUNT_MOCKS(mockServer);
+  await POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS(mockServer, false); // do not include winnings. Claim Button is animated and problematic for e2e
+};
+
+appiumTest.describe(SmokePredictions('Predictions'), () => {
+  appiumTest(
+    'opens position on Celtics vs. Nets market',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder()
+            .withPolygon()
+            .withMetaMetricsOptIn()
+            .build(),
+          restartDevice: true,
+          disableLocalNodes: true,
+          testSpecificMock: PredictionMarketFeature,
+          analyticsExpectations: predictOpenPositionAnalyticsExpectations,
+          currentDeviceDetails,
+        },
+        async ({ mockServer }) => {
+          await loginForPredictTests();
+
+          await WalletView.scrollAndTapPredictionsSection();
+
+          await Assertions.expectElementToBeVisible(
+            PredictMarketList.container,
+            {
+              description: 'Predict market list container should be visible',
+            },
+          );
+
+          await PredictMarketList.tapCategoryTab(positionDetails.category);
+          await PredictMarketList.tapMarketCard(
+            positionDetails.category,
+            positionDetails.marketIndex,
+          );
+          await PredictDetailsPage.tapGameBetYesButton();
+
+          await POLYMARKET_POST_OPEN_POSITION_MOCKS(mockServer);
+
+          await PredictDetailsPage.tapPositionAmount(
+            positionDetails.positionAmount,
+          );
+          await PredictDetailsPage.tapDoneButton();
+
+          await PredictDetailsPage.tapOpenPosition();
+
+          await PredictDetailsPage.tapBackButton();
+          await Assertions.expectTextDisplayed(positionDetails.newBalance, {
+            description: `USDC balance should display ${positionDetails.newBalance} after opening position`,
+          });
+          await PredictMarketList.tapBackButton();
+
+          await WalletView.scrollAndTapPredictionsPosition(
+            positionDetails.name,
+            CELTICS_NETS_POSITION_ID,
+          );
+
+          /*
+          When opening a position, the balance is optimistically updated in PredictController
+          with a cache valid for 5 seconds. When getBalance() is called after cache expiration
+          it invalidates the NetworkController's block cache and
+          makes a fresh RPC balance request. The mock is placed here to
+          verify that when the cache expires and a balance refresh request
+          is made, it successfully returns the updated balance.
+         */
+          await POLYMARKET_UPDATE_USDC_BALANCE_MOCKS(
+            mockServer,
+            'open-position',
+          );
+
+          await PredictDetailsPage.tapBackButton();
+          await WalletView.scrollAndTapPredictionsSection();
+          await Assertions.expectTextDisplayed(positionDetails.newBalance);
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
Adds the first two Predict Appium smoke specs and wires `SmokePredictions` CI jobs (Android/iOS).

**Depends on:** Predict Appium framework/POM PR (stacked).

## Specs
- `predict-cash-out.spec.ts`
- `predict-open-position.spec.ts`

## Test plan
- [x] `yarn format:check` / `yarn lint:tsc` on stacked branch

Made with [Cursor](https://cursor.com)