### PR TITLE
test(predict): Appium smoke — geo restriction and withdraw

### DIFF
--- a/tests/smoke-appium/predict/predict-geo-restriction.spec.ts
+++ b/tests/smoke-appium/predict/predict-geo-restriction.spec.ts
@@ -1,0 +1,116 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokePredictions } from '../../tags.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
+import WalletActionsBottomSheet from '../../page-objects/wallet/WalletActionsBottomSheet.js';
+import Assertions from '../../framework/Assertions.js';
+import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage.js';
+import WalletView from '../../page-objects/wallet/WalletView.js';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
+import {
+  remoteFeatureFlagPredictEnabled,
+  remoteFeatureFlagHomepageSectionsV1Enabled,
+} from '../../api-mocking/mock-responses/feature-flags-mocks.js';
+import {
+  POLYMARKET_COMPLETE_MOCKS,
+  POLYMARKET_GEO_BLOCKED_MOCKS,
+  POLYMARKET_MARKET_FEEDS_MOCKS,
+} from '../../api-mocking/mock-responses/polymarket/polymarket-mocks.js';
+import PredictAddFunds from '../../page-objects/Predict/PredictAddFunds.js';
+import PredictUnavailableView from '../../page-objects/Predict/PredictUnavailableView.js';
+import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
+import { SPURS_PELICANS_POSITION_ID } from '../../api-mocking/mock-responses/polymarket/polymarket-constants.js';
+import { geoBlockedCombinedExpectations } from '../../helpers/analytics/expectations/predict-geo-restriction.analytics.js';
+import {
+  loginForPredictTests,
+  remoteFeatureFlagPerpsDisabledForPredictSmoke,
+} from './helpers/predict-helpers.js';
+
+const predictionGeoBlockedFeature = async (mockServer: Mockttp) => {
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagPerpsDisabledForPredictSmoke(),
+    ...remoteFeatureFlagPredictEnabled(true),
+    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
+    carouselBanners: false,
+  });
+  await POLYMARKET_MARKET_FEEDS_MOCKS(mockServer);
+  await POLYMARKET_GEO_BLOCKED_MOCKS(mockServer);
+  await POLYMARKET_COMPLETE_MOCKS(mockServer);
+};
+
+appiumTest.describe(SmokePredictions('Predictions - Geo Restriction'), () => {
+  appiumTest(
+    'displays unavailable modal for feed action, cashout, and add funds when geo blocked',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder()
+            .withPolygon()
+            .withMetaMetricsOptIn()
+            .build(),
+          restartDevice: true,
+          disableLocalNodes: true,
+          testSpecificMock: predictionGeoBlockedFeature,
+          analyticsExpectations: geoBlockedCombinedExpectations,
+          currentDeviceDetails,
+        },
+        async () => {
+          await loginForPredictTests();
+          await TabBarComponent.tapActions();
+          await WalletActionsBottomSheet.tapPredictButton();
+          await Assertions.expectElementToBeVisible(
+            PredictMarketList.container,
+            {
+              description:
+                'Predict market list container is visible before feed action',
+            },
+          );
+
+          await PredictMarketList.tapCategoryTab('new');
+          await PredictMarketList.tapYesBasedOnCategoryAndIndex('new', 1);
+          await PredictUnavailableView.expectVisible();
+          await PredictUnavailableView.tapGotIt();
+          await PredictMarketList.tapBackButton();
+          await TabBarComponent.tapWallet();
+          await Assertions.expectElementToBeVisible(WalletView.container, {
+            description: 'Wallet home after leaving predict market list',
+            timeout: 15_000,
+          });
+
+          await WalletView.scrollAndTapPredictionsPosition(
+            'Spurs vs. Pelicans',
+            SPURS_PELICANS_POSITION_ID,
+          );
+          await PredictDetailsPage.tapGameCashOutButton(
+            SPURS_PELICANS_POSITION_ID,
+          );
+          await PredictUnavailableView.expectVisible();
+          await PredictUnavailableView.tapGotIt();
+
+          await PredictDetailsPage.tapBackButton();
+          await TabBarComponent.tapActions();
+          await WalletActionsBottomSheet.tapPredictButton();
+          await Assertions.expectElementToBeVisible(
+            PredictDetailsPage.balanceCard,
+            {
+              description:
+                'Predict balance card is visible before attempting add funds',
+            },
+          );
+          await PredictAddFunds.tapAddFunds();
+          await PredictUnavailableView.expectVisible();
+          await PredictUnavailableView.tapGotIt();
+          await Assertions.expectElementToBeVisible(
+            PredictDetailsPage.balanceCard,
+            {
+              description:
+                'Predict balance card is visible after dismissing unavailable modal',
+            },
+          );
+        },
+      );
+    },
+  );
+});

--- a/tests/smoke-appium/predict/predict-withdraw.spec.ts
+++ b/tests/smoke-appium/predict/predict-withdraw.spec.ts
@@ -1,0 +1,115 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokePredictions } from '../../tags.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import { Assertions } from '../../framework/index.js';
+import {
+  remoteFeatureFlagPredictEnabled,
+  confirmationFeatureFlags,
+} from '../../api-mocking/mock-responses/feature-flags-mocks.js';
+import {
+  POLYMARKET_ACTIVITY_MOCKS,
+  POLYMARKET_LEGACY_SAFE_ACCOUNT_MOCKS,
+  POLYMARKET_POLYGON_RELAY_NETWORK_FLAGS_MOCKS,
+  POLYMARKET_POLYGON_RELAY_POLLING_MOCKS,
+  POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS,
+  POLYMARKET_TRANSACTION_SENTINEL_MOCKS,
+  POLYMARKET_USDC_BALANCE_MOCKS,
+  POLYMARKET_WITHDRAW_BALANCE_LOAD_MOCKS,
+} from '../../api-mocking/mock-responses/polymarket/polymarket-mocks.js';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Mockttp } from 'mockttp';
+import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
+import TabBarComponent from '../../page-objects/wallet/TabBarComponent.js';
+import WalletActionsBottomSheet from '../../page-objects/wallet/WalletActionsBottomSheet.js';
+import PredictBalance from '../../page-objects/Predict/PredictBalance.js';
+import PredictMarketList from '../../page-objects/Predict/PredictMarketList.js';
+import TransactionPayConfirmation from '../../page-objects/Confirmation/TransactionPayConfirmation.js';
+import FooterActions from '../../page-objects/Browser/Confirmations/FooterActions.js';
+import {
+  loginForPredictTests,
+  remoteFeatureFlagPerpsDisabledForPredictSmoke,
+} from './helpers/predict-helpers.js';
+
+const PredictionMarketFeature = async (mockServer: Mockttp) => {
+  // Polygon predict withdraw publishes via EIP-7702 transaction relay, not Infura eth_sendRawTransaction.
+  await POLYMARKET_POLYGON_RELAY_NETWORK_FLAGS_MOCKS(mockServer);
+  await POLYMARKET_POLYGON_RELAY_POLLING_MOCKS(mockServer);
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    ...remoteFeatureFlagPerpsDisabledForPredictSmoke(),
+    ...remoteFeatureFlagPredictEnabled(true),
+    ...Object.assign({}, ...confirmationFeatureFlags),
+    carouselBanners: false,
+  }); // we need to mock the confirmations redesign Feature flag
+  await POLYMARKET_USDC_BALANCE_MOCKS(mockServer); // Sets up all RPC mocks needed for withdraw flow
+  // Keep this smoke test on the legacy Safe withdraw path.
+  await POLYMARKET_LEGACY_SAFE_ACCOUNT_MOCKS(mockServer);
+  await POLYMARKET_ACTIVITY_MOCKS(mockServer);
+  await POLYMARKET_TRANSACTION_SENTINEL_MOCKS(mockServer); // needed to load the withdraw/deposit/claim screen
+  await POLYMARKET_POSITIONS_WITH_WINNINGS_MOCKS(mockServer, false); // do not include winnings for claim flow
+  await POLYMARKET_WITHDRAW_BALANCE_LOAD_MOCKS(mockServer);
+};
+
+appiumTest.describe(SmokePredictions('Predictions Withdraw'), () => {
+  appiumTest(
+    'withdraws from Predict balance',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder()
+            .withPolygon()
+            // Polygon bridged USDC must be in TokenController so confirmation's
+            // useUpdateTokenAmount gets decimals=6. Otherwise decimals fall back to 18 and
+            // "5" USDC is encoded as 5e18 raw — Predict signWithdraw then throws
+            // "Decoded USDC amount is invalid or too large".
+            .withTokens(
+              [
+                {
+                  address: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+                  decimals: 6,
+                  name: 'USD Coin (PoS)',
+                  symbol: 'USDC.e',
+                },
+              ],
+              CHAIN_IDS.POLYGON,
+            )
+            // STX + sendBundle on Polygon would skip Delegation7702PublishHook and use the
+            // smart-transaction publish path (not covered by POLYMARKET_TRANSACTION_SENTINEL_MOCKS).
+            .withDisabledSmartTransactions()
+            .build(),
+          restartDevice: true,
+          disableLocalNodes: true,
+          testSpecificMock: PredictionMarketFeature,
+          currentDeviceDetails,
+        },
+        async () => {
+          await loginForPredictTests();
+
+          await TabBarComponent.tapActions();
+          await WalletActionsBottomSheet.tapPredictButton();
+
+          await Assertions.expectElementToBeVisible(
+            PredictMarketList.container,
+            {
+              description: 'Predict market list container should be visible',
+            },
+          );
+          await PredictBalance.expectBalanceCardVisible();
+          await PredictBalance.tapWithdraw();
+
+          await TransactionPayConfirmation.tapKeyboardAmount('5');
+          await TransactionPayConfirmation.tapKeyboardContinueButton();
+          await FooterActions.tapConfirmButton();
+
+          await Assertions.expectElementToBeVisible(
+            PredictMarketList.container,
+            {
+              description:
+                'Predict market list should be visible after withdraw confirmation',
+            },
+          );
+        },
+      );
+    },
+  );
+});

--- a/tests/smoke/predict/predict-geo-restriction.spec.ts
+++ b/tests/smoke/predict/predict-geo-restriction.spec.ts
@@ -9,7 +9,10 @@ import PredictDetailsPage from '../../page-objects/Predict/PredictDetailsPage';
 import WalletView from '../../page-objects/wallet/WalletView';
 import { Mockttp } from 'mockttp';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
-import { remoteFeatureFlagPredictEnabled } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import {
+  remoteFeatureFlagHomepageSectionsV1Enabled,
+  remoteFeatureFlagPredictEnabled,
+} from '../../api-mocking/mock-responses/feature-flags-mocks';
 import {
   POLYMARKET_COMPLETE_MOCKS,
   POLYMARKET_GEO_BLOCKED_MOCKS,
@@ -24,6 +27,11 @@ import { geoBlockedCombinedExpectations } from '../../helpers/analytics/expectat
 const predictionGeoBlockedFeature = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(mockServer, {
     ...remoteFeatureFlagPredictEnabled(true),
+    ...remoteFeatureFlagHomepageSectionsV1Enabled(),
+    perpsPerpTradingEnabled: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
     carouselBanners: false,
   });
   await POLYMARKET_MARKET_FEEDS_MOCKS(mockServer);
@@ -58,8 +66,16 @@ describe(SmokePredictions('Predictions - Geo Restriction'), () => {
         await PredictUnavailableView.expectVisible();
         await PredictUnavailableView.tapGotIt();
         await PredictMarketList.tapBackButton();
+        await TabBarComponent.tapWallet();
+        await Assertions.expectElementToBeVisible(WalletView.container, {
+          description: 'Wallet home after leaving predict market list',
+          timeout: 15_000,
+        });
 
-        await WalletView.scrollAndTapPredictionsPosition('Spurs vs. Pelicans');
+        await WalletView.scrollAndTapPredictionsPosition(
+          'Spurs vs. Pelicans',
+          SPURS_PELICANS_POSITION_ID,
+        );
         await PredictDetailsPage.tapGameCashOutButton(
           SPURS_PELICANS_POSITION_ID,
         );
@@ -79,6 +95,7 @@ describe(SmokePredictions('Predictions - Geo Restriction'), () => {
         await PredictAddFunds.tapAddFunds();
         await PredictUnavailableView.expectVisible();
         await PredictUnavailableView.tapGotIt();
+        await device.enableSynchronization();
         await Assertions.expectElementToBeVisible(
           PredictDetailsPage.balanceCard,
           {


### PR DESCRIPTION
## Summary
Completes the Predict Appium smoke suite (6 specs total). Aligns Detox `predict-geo-restriction` with homepage-sections navigation.

**Depends on:** tests-2 branch (stacked). Replaces the monolithic #32065 scope.

## Specs
- `predict-geo-restriction.spec.ts`
- `predict-withdraw.spec.ts`
- Detox tweak: `tests/smoke/predict/predict-geo-restriction.spec.ts`

## Test plan
- [x] `yarn format:check` / `yarn lint:tsc`

Made with [Cursor](https://cursor.com)