### PR TITLE
fix: fix price line color with ambient TDP theme

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -818,6 +818,31 @@ function generatePaletteShades(hex) {
   return shades;
 }
 
+// ============================================
+// Theme color helpers (series line, last-price overlays, end dot)
+// ============================================
+
+/**
+ * Ambient / series stroke color: line chart, filled last-close pill, line-end dot.
+ * Falls back to successColor when lineColorOverride is unset (ambient feature off).
+ * @param {object} [theme] — defaults to window.CONFIG.theme
+ */
+function getThemeLineColor(theme) {
+  const t = theme || (window.CONFIG && window.CONFIG.theme) || {};
+  return t.lineColor || t.successColor;
+}
+
+/**
+ * Custom dashed last-price horizontal_line. Honors currentPriceLineColorOverride when set,
+ * else matches series line / filled pill via {@link getThemeLineColor}.
+ * @param {object} [theme] — defaults to window.CONFIG.theme
+ */
+function getThemeLastPriceLineColor(theme) {
+  const t = theme || (window.CONFIG && window.CONFIG.theme) || {};
+  const lineColor = getThemeLineColor(t);
+  return t.currentPriceColor || lineColor;
+}
+
 function getSeriesColorOverrides(color) {
   return {
     'mainSeriesProperties.lineStyle.color': color,
@@ -848,8 +873,7 @@ function getSeriesColorOverrides(color) {
  */
 function applySeriesColors() {
   if (!window.chartWidget) return;
-  const color =
-    window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+  const color = getThemeLineColor();
   try {
     window.chartWidget.applyOverrides(getSeriesColorOverrides(color));
     let series = window.chartWidget.activeChart().getSeries();
@@ -895,8 +919,8 @@ function handleSetThemeColors(payload) {
   applySeriesColors();
 
   let chart = window.chartWidget.activeChart();
-  let lineColor = theme.lineColor || theme.successColor;
-  let currentPriceColor = theme.currentPriceColor || lineColor;
+  let lineColor = getThemeLineColor(theme);
+  let lastPriceLineColor = getThemeLastPriceLineColor(theme);
 
   // Update volume study colors if present
   if (window.volumeStudyId) {
@@ -927,7 +951,7 @@ function handleSetThemeColors(payload) {
   if (window.lastPriceShapeId) {
     try {
       chart.getShapeById(window.lastPriceShapeId).setProperties({
-        linecolor: theme.currentPriceColor || theme.successColor,
+        linecolor: lastPriceLineColor,
       });
     } catch (e) {}
   }
@@ -935,9 +959,20 @@ function handleSetThemeColors(payload) {
   if (window.lineLastPriceShapeId) {
     try {
       chart.getShapeById(window.lineLastPriceShapeId).setProperties({
-        linecolor: currentPriceColor,
+        linecolor: lastPriceLineColor,
       });
     } catch (e) {}
+  }
+
+  // Recreate dashed last-price lines when ambient lineColor diverges from successColor
+  // (setProperties alone can miss updates on horizontal_line shapes).
+  if (window.currentChartType === 2) {
+    refreshLineChartOverlays();
+  } else if (
+    window.currentChartType === 1 &&
+    getLineChrome().useCustomDashedLastPriceLine
+  ) {
+    createLastPriceLine();
   }
 
   // Outline pill + visible-edge re-derive color from theme on next frame
@@ -1412,7 +1447,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
 
   const theme = (w.CONFIG && w.CONFIG.theme) || {};
   const upColor = theme.successColor || '#0C9F76';
-  const lineColor = theme.lineColor || upColor;
+  const lineColor = getThemeLineColor(theme) || upColor;
   const downColor = theme.errorColor || '#E06470';
   let outlineColor = ct === 2 ? lineColor : upColor;
   if (ct === 1) {
@@ -2163,8 +2198,7 @@ function handleSetChartType(payload) {
     let ac = window.chartWidget.activeChart();
     ac.setChartType(type);
 
-    const color =
-      window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+    const color = getThemeLineColor();
     let series = ac.getSeries();
     if (type === 2) {
       series.setChartStyleProperties(2, {
@@ -2318,7 +2352,7 @@ function handleSetPositionLines(payload) {
 }
 
 // ============================================
-// Last close: green dashed horizontal_line (showPrice:false) + DOM pill (#last-close-price-label,
+// Last close: dashed horizontal_line (showPrice:false) + DOM pill (#last-close-price-label,
 // same styles as crosshair labels in AdvancedChartTemplate)
 // ============================================
 window.lastPriceShapeId = null;
@@ -2374,8 +2408,7 @@ function createLastPriceLine() {
 
   let lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   let chart = window.chartWidget.activeChart();
-  let color =
-    window.CONFIG.theme.currentPriceColor || window.CONFIG.theme.successColor;
+  let color = getThemeLastPriceLineColor();
   let candlePt = getLineEndDotTimeAndPriceFromSeries(chart);
   let candlePrice =
     candlePt && isFinite(candlePt.price) ? candlePt.price : lastBar.close;
@@ -2460,10 +2493,7 @@ function createLineLastPriceLine() {
 
   let lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   let chart = window.chartWidget.activeChart();
-  const color =
-    window.CONFIG.theme.currentPriceColor ||
-    window.CONFIG.theme.lineColor ||
-    window.CONFIG.theme.successColor;
+  const color = getThemeLastPriceLineColor();
   let seriesPt = resolveLineEndOverlayPoint(chart);
   let linePrice =
     seriesPt && isFinite(seriesPt.price) ? seriesPt.price : lastBar.close;
@@ -3245,8 +3275,7 @@ function refreshLineEndDot() {
     return;
   }
 
-  const color =
-    window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+  const color = getThemeLineColor();
 
   function placeLineEndIcon() {
     if (placementGen !== window.__lineEndDotPlacementGen) {
@@ -4515,7 +4544,7 @@ function initChart() {
           'mainSeriesProperties.candleStyle.wickUpColor': theme.successColor,
           'mainSeriesProperties.candleStyle.wickDownColor': theme.errorColor,
         },
-        getSeriesColorOverrides(theme.lineColor || theme.successColor),
+        getSeriesColorOverrides(getThemeLineColor(theme)),
       ),
 
       loading_screen: {

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogic.js
@@ -964,17 +964,6 @@ function handleSetThemeColors(payload) {
     } catch (e) {}
   }
 
-  // Recreate dashed last-price lines when ambient lineColor diverges from successColor
-  // (setProperties alone can miss updates on horizontal_line shapes).
-  if (window.currentChartType === 2) {
-    refreshLineChartOverlays();
-  } else if (
-    window.currentChartType === 1 &&
-    getLineChrome().useCustomDashedLastPriceLine
-  ) {
-    createLastPriceLine();
-  }
-
   // Outline pill + visible-edge re-derive color from theme on next frame
   scheduleLastCloseLabelUpdate();
 }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -973,17 +973,6 @@ function handleSetThemeColors(payload) {
     } catch (e) {}
   }
 
-  // Recreate dashed last-price lines when ambient lineColor diverges from successColor
-  // (setProperties alone can miss updates on horizontal_line shapes).
-  if (window.currentChartType === 2) {
-    refreshLineChartOverlays();
-  } else if (
-    window.currentChartType === 1 &&
-    getLineChrome().useCustomDashedLastPriceLine
-  ) {
-    createLastPriceLine();
-  }
-
   // Outline pill + visible-edge re-derive color from theme on next frame
   scheduleLastCloseLabelUpdate();
 }

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -827,6 +827,31 @@ function generatePaletteShades(hex) {
   return shades;
 }
 
+// ============================================
+// Theme color helpers (series line, last-price overlays, end dot)
+// ============================================
+
+/**
+ * Ambient / series stroke color: line chart, filled last-close pill, line-end dot.
+ * Falls back to successColor when lineColorOverride is unset (ambient feature off).
+ * @param {object} [theme] — defaults to window.CONFIG.theme
+ */
+function getThemeLineColor(theme) {
+  const t = theme || (window.CONFIG && window.CONFIG.theme) || {};
+  return t.lineColor || t.successColor;
+}
+
+/**
+ * Custom dashed last-price horizontal_line. Honors currentPriceLineColorOverride when set,
+ * else matches series line / filled pill via {@link getThemeLineColor}.
+ * @param {object} [theme] — defaults to window.CONFIG.theme
+ */
+function getThemeLastPriceLineColor(theme) {
+  const t = theme || (window.CONFIG && window.CONFIG.theme) || {};
+  const lineColor = getThemeLineColor(t);
+  return t.currentPriceColor || lineColor;
+}
+
 function getSeriesColorOverrides(color) {
   return {
     'mainSeriesProperties.lineStyle.color': color,
@@ -857,8 +882,7 @@ function getSeriesColorOverrides(color) {
  */
 function applySeriesColors() {
   if (!window.chartWidget) return;
-  const color =
-    window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+  const color = getThemeLineColor();
   try {
     window.chartWidget.applyOverrides(getSeriesColorOverrides(color));
     let series = window.chartWidget.activeChart().getSeries();
@@ -904,8 +928,8 @@ function handleSetThemeColors(payload) {
   applySeriesColors();
 
   let chart = window.chartWidget.activeChart();
-  let lineColor = theme.lineColor || theme.successColor;
-  let currentPriceColor = theme.currentPriceColor || lineColor;
+  let lineColor = getThemeLineColor(theme);
+  let lastPriceLineColor = getThemeLastPriceLineColor(theme);
 
   // Update volume study colors if present
   if (window.volumeStudyId) {
@@ -936,7 +960,7 @@ function handleSetThemeColors(payload) {
   if (window.lastPriceShapeId) {
     try {
       chart.getShapeById(window.lastPriceShapeId).setProperties({
-        linecolor: theme.currentPriceColor || theme.successColor,
+        linecolor: lastPriceLineColor,
       });
     } catch (e) {}
   }
@@ -944,9 +968,20 @@ function handleSetThemeColors(payload) {
   if (window.lineLastPriceShapeId) {
     try {
       chart.getShapeById(window.lineLastPriceShapeId).setProperties({
-        linecolor: currentPriceColor,
+        linecolor: lastPriceLineColor,
       });
     } catch (e) {}
+  }
+
+  // Recreate dashed last-price lines when ambient lineColor diverges from successColor
+  // (setProperties alone can miss updates on horizontal_line shapes).
+  if (window.currentChartType === 2) {
+    refreshLineChartOverlays();
+  } else if (
+    window.currentChartType === 1 &&
+    getLineChrome().useCustomDashedLastPriceLine
+  ) {
+    createLastPriceLine();
   }
 
   // Outline pill + visible-edge re-derive color from theme on next frame
@@ -1421,7 +1456,7 @@ function updateVisibleEdgeOutlinePriceLabel() {
 
   const theme = (w.CONFIG && w.CONFIG.theme) || {};
   const upColor = theme.successColor || '#0C9F76';
-  const lineColor = theme.lineColor || upColor;
+  const lineColor = getThemeLineColor(theme) || upColor;
   const downColor = theme.errorColor || '#E06470';
   let outlineColor = ct === 2 ? lineColor : upColor;
   if (ct === 1) {
@@ -2172,8 +2207,7 @@ function handleSetChartType(payload) {
     let ac = window.chartWidget.activeChart();
     ac.setChartType(type);
 
-    const color =
-      window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+    const color = getThemeLineColor();
     let series = ac.getSeries();
     if (type === 2) {
       series.setChartStyleProperties(2, {
@@ -2327,7 +2361,7 @@ function handleSetPositionLines(payload) {
 }
 
 // ============================================
-// Last close: green dashed horizontal_line (showPrice:false) + DOM pill (#last-close-price-label,
+// Last close: dashed horizontal_line (showPrice:false) + DOM pill (#last-close-price-label,
 // same styles as crosshair labels in AdvancedChartTemplate)
 // ============================================
 window.lastPriceShapeId = null;
@@ -2383,8 +2417,7 @@ function createLastPriceLine() {
 
   let lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   let chart = window.chartWidget.activeChart();
-  let color =
-    window.CONFIG.theme.currentPriceColor || window.CONFIG.theme.successColor;
+  let color = getThemeLastPriceLineColor();
   let candlePt = getLineEndDotTimeAndPriceFromSeries(chart);
   let candlePrice =
     candlePt && isFinite(candlePt.price) ? candlePt.price : lastBar.close;
@@ -2469,10 +2502,7 @@ function createLineLastPriceLine() {
 
   let lastBar = window.ohlcvData[window.ohlcvData.length - 1];
   let chart = window.chartWidget.activeChart();
-  const color =
-    window.CONFIG.theme.currentPriceColor ||
-    window.CONFIG.theme.lineColor ||
-    window.CONFIG.theme.successColor;
+  const color = getThemeLastPriceLineColor();
   let seriesPt = resolveLineEndOverlayPoint(chart);
   let linePrice =
     seriesPt && isFinite(seriesPt.price) ? seriesPt.price : lastBar.close;
@@ -3254,8 +3284,7 @@ function refreshLineEndDot() {
     return;
   }
 
-  const color =
-    window.CONFIG.theme.lineColor || window.CONFIG.theme.successColor;
+  const color = getThemeLineColor();
 
   function placeLineEndIcon() {
     if (placementGen !== window.__lineEndDotPlacementGen) {
@@ -4524,7 +4553,7 @@ function initChart() {
           'mainSeriesProperties.candleStyle.wickUpColor': theme.successColor,
           'mainSeriesProperties.candleStyle.wickDownColor': theme.errorColor,
         },
-        getSeriesColorOverrides(theme.lineColor || theme.successColor),
+        getSeriesColorOverrides(getThemeLineColor(theme)),
       ),
 
       loading_screen: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When the ambient price color experiment is enabled on Token Details (`useAmbientPriceColor` treatment), the advanced chart correctly hot-swaps the **series line** and **filled last-close price pill** to orange when price is negative — but the **dashed last-price horizontal line** stayed green.



**Root cause:** `createLastPriceLine` and the `SET_THEME_COLORS` shape update for candle-mode dashed lines resolved color via `currentPriceColor || successColor` instead of following `lineColor` (which ambient pricing drives independently of `successColor`). Realtime bar updates then recreated the dashed line with the same wrong fallback on every tick.
**Changes (WebView only — `chartLogic.js`, synced to `chartLogicString.ts`):**
* **`createLastPriceLine`:** Dashed line color now uses the same resolution as line-chart mode.
* **`handleSetThemeColors`:** Updates and recreates dashed last-price shapes using the corrected color;
* **Refactor:** Introduced `getThemeLineColor()` and `getThemeLastPriceLineColor()` helpers so series line, filled pill, end marker, and dashed line share one color source and cannot drift again.

**No behavior change when the ambient feature flag is off** — `lineColor` and `successColor` are identical in that path.



## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed token details advanced chart dashed last-price line not matching ambient price color when price is negative.


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3430

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/a06e93a9-01ec-4100-9e92-288e37d94b5d


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> WebView-only chart styling refactor with centralized fallbacks; no auth, data, or API changes.
> 
> **Overview**
> Fixes the token details advanced chart so the **dashed last-price horizontal line** matches ambient pricing when `useAmbientPriceColor` is on (e.g. orange for negative moves instead of staying green).
> 
> The WebView chart logic now uses shared **`getThemeLineColor()`** and **`getThemeLastPriceLineColor()`** helpers (`lineColor` → `successColor`, and `currentPriceColor` → line color) everywhere series strokes, last-close pills, end dots, and dashed overlays are painted—including **`createLastPriceLine`**, **`createLineLastPriceLine`**, **`handleSetThemeColors`**, chart init, and realtime redraw paths. The same edits are mirrored in **`chartLogicString.ts`**.
> 
> When ambient pricing is off, behavior is unchanged because `lineColor` and `successColor` stay aligned on the existing path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 291d35d4f0a23ed0ba1fae1d59423f5a6d404937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->