### PR TITLE
fix(activity-redesign): render ERC-20 fiat in Activity by checksumming market-rate lookups

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -14,6 +14,7 @@ import { ActivityListItemRowPendingActions } from './ActivityListItemRowPendingA
 import { strings } from '../../../../locales/i18n';
 import { getNetworkImageSource } from '../../../util/networks';
 import { hasGasFeeTokenSelected } from '../../Views/confirmations/utils/transaction';
+import { selectContractExchangeRatesByChainId } from '../../../selectors/tokenRatesController';
 
 const LINEA_MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
 const LINEA_MUSD_CHECKSUM_ADDRESS =
@@ -144,6 +145,8 @@ jest.mock('../../../util/networks', () => ({
 
 jest.mock('../../../util/address', () => ({
   renderShortAddress: jest.fn((address: string) => `${address.slice(0, 6)}...`),
+  safeToChecksumAddress: jest.requireActual('../../../util/address')
+    .safeToChecksumAddress,
 }));
 
 jest.mock('../../../component-library/components/Badges/BadgeWrapper', () => {
@@ -857,6 +860,48 @@ describe('ActivityListItemRow — amount display', () => {
 
     expect(getByText('+1 mUSD')).toBeOnTheScreen();
     expect(queryByText('+$1')).toBeNull();
+  });
+});
+
+describe('ActivityListItemRow — ERC-20 fiat address casing (TMCU-937)', () => {
+  const mockContractExchangeRates = jest.mocked(
+    selectContractExchangeRatesByChainId,
+  );
+  const USDC_LOWER = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+  const USDC_CHECKSUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+  const ratesFor = (address: string) =>
+    ({ [address]: { price: 0.0004 } }) as ReturnType<
+      typeof selectContractExchangeRatesByChainId
+    >;
+
+  // This mock uses a persistent return value (clearAllMocks does not reset it),
+  // so restore the suite default (lowercased mUSD key) after each test.
+  afterEach(() => {
+    mockContractExchangeRates.mockReturnValue(ratesFor(LINEA_MUSD_ADDRESS));
+  });
+
+  it('renders fiat for an ERC-20 when market data is keyed by a checksummed address', () => {
+    // Production keys marketData by checksummed addresses while the lookup
+    // address is lowercased (CAIP asset references). The fiat line must still
+    // resolve. Regression guard for the missing-ERC-20-fiat bug.
+    mockContractExchangeRates.mockReturnValue(ratesFor(USDC_CHECKSUM));
+
+    const item = makeItem({
+      status: 'success',
+      token: {
+        amount: '1000000',
+        decimals: 6,
+        symbol: 'USDC',
+        assetId: `eip155:1/erc20:${USDC_LOWER}`,
+        direction: 'in',
+      },
+    });
+
+    const { getByText } = render(<ActivityListItemRow item={item} index={0} />);
+
+    expect(getByText('+1 USDC')).toBeOnTheScreen();
+    expect(getByText('+$1')).toBeOnTheScreen();
   });
 });
 

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -16,7 +16,10 @@ import {
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../Earn/constants/musd';
-import { renderShortAddress } from '../../../util/address';
+import {
+  renderShortAddress,
+  safeToChecksumAddress,
+} from '../../../util/address';
 import {
   applyDisplaySign,
   type ActivityKind,
@@ -781,6 +784,34 @@ function getMusdNativeExchangeRate({
   return 1 / usdConversionRate;
 }
 
+/**
+ * Looks up a token's market `price` from contractExchangeRates. Market data is
+ * keyed by checksummed addresses, but the lookup address is lowercased (CAIP
+ * asset references are normalized to lowercase), so try the checksum first and
+ * fall back to a case-insensitive match. Mirrors `getTokenToEthPrice` in
+ * `Money/utils/moneyActivityFiat`.
+ */
+function getMarketPriceForAddress(
+  contractExchangeRates:
+    | Record<string, { price?: number | null } | undefined>
+    | undefined,
+  address: string,
+): number | null | undefined {
+  if (!contractExchangeRates) return undefined;
+
+  const checksum = safeToChecksumAddress(address);
+  if (checksum) {
+    const price = contractExchangeRates[checksum]?.price;
+    if (price !== undefined && price !== null) return price;
+  }
+
+  const lower = address.toLowerCase();
+  const key = Object.keys(contractExchangeRates).find(
+    (k) => k.toLowerCase() === lower,
+  );
+  return key !== undefined ? contractExchangeRates[key]?.price : undefined;
+}
+
 function resolveFiatAmount({
   activityType,
   contractExchangeRates,
@@ -811,7 +842,7 @@ function resolveFiatAmount({
   const exchangeRate = isNativeAsset(token)
     ? 1
     : lookupToken
-      ? (contractExchangeRates?.[lookupToken.address]?.price ??
+      ? (getMarketPriceForAddress(contractExchangeRates, lookupToken.address) ??
         (lookupToken.symbol === MUSD_TOKEN.symbol
           ? getMusdNativeExchangeRate({ usdConversionRate })
           : undefined))


### PR DESCRIPTION
## **Description**

ERC-20 rows in the redesigned Activity screen showed no fiat value, while native tokens (ETH/POL) did. `resolveFiatAmount` looked up a token's market price by a **lowercased** address, but token market data (`contractExchangeRates`/`marketData`) is keyed by **checksummed** addresses — so the lookup missed for every ERC-20. Native tokens were unaffected because they skip the lookup (`exchangeRate = 1`).

Fix: a checksum-aware lookup helper (`getMarketPriceForAddress`) that tries the checksummed address first and falls back to a case-insensitive match, mirroring `getTokenToEthPrice` in `Money/utils/moneyActivityFiat`. Applied at the lookup site so other consumers of `getTokenAddressForMarketRates` keep their existing behavior.

## **Changelog**

CHANGELOG entry: null

<!-- Behind the Activity redesign feature flag; not yet user-facing. -->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-937

## **Manual testing steps**

```gherkin
Feature: ERC-20 fiat in the redesigned Activity screen

  Scenario: ERC-20 transaction shows its fiat value
    Given the Activity redesign is enabled
    And I have an ERC-20 transaction (e.g. USDC) in my activity
    When I open the Activity screen
    Then the row shows the fiat value alongside the token amount
```

## **Screenshots/Recordings**

### **Before**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2026-06-22 at 11 09 04" src="https://github.com/user-attachments/assets/9f5293b9-5372-440a-b73d-e395a0fc6a59" />

### **After**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2026-06-22 at 11 09 12" src="https://github.com/user-attachments/assets/c6edad1c-5f49-428b-8f88-bb7c8854937d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fiat formatting in the Activity redesign path; no auth, transactions, or shared selector behavior changes beyond the lookup site.
> 
> **Overview**
> Restores **fiat values on redesigned Activity rows for ERC-20s** when token market data is keyed by checksummed contract addresses but the row looks up rates using lowercased CAIP asset references.
> 
> `resolveFiatAmount` now resolves prices through **`getMarketPriceForAddress`**, which tries `safeToChecksumAddress` first and then a case-insensitive key match—same approach as `getTokenToEthPrice` in Money activity fiat helpers. Native-token fiat behavior is unchanged.
> 
> Adds a **TMCU-937 regression test** (USDC with checksummed rates + lowercased `assetId`) and wires the real `safeToChecksumAddress` into the row test mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e4206253a00a3bae5016a231c98bdf70f893149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->