### PR TITLE
fix(activity-redesign): rename Activity 'MetaMask Card' type filter to 'Card'

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3040,7 +3040,7 @@
       "buy_sell": "Buy/Sell",
       "perps": "Perps",
       "predictions": "Predictions",
-      "metamask_card": "MetaMask Card",
+      "metamask_card": "Card",
       "money": "Money"
     },
     "empty_state": {


### PR DESCRIPTION
## **Description**

The Activity type-filter option labeled **"MetaMask Card"** now reads **"Card"** (matching the design intent for the filter list).

Only the dedicated filter label string is changed — `activity_view.type_filter.metamask_card`. That key has a single consumer (the `ActivityTypeFilterSheet` label map), and the actual MetaMask Card feature uses separate i18n keys, so no other copy is affected. The key name is left as-is (it maps to the `MetamaskCard` filter enum); only the displayed value changed.

## **Changelog**

CHANGELOG entry: null

<!-- Behind the Activity redesign feature flag; not yet user-facing. -->

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-934

## **Manual testing steps**

```gherkin
Feature: Activity type filter copy

  Scenario: Card filter label reads "Card"
    Given the Activity redesign is enabled
    And I am on the Activity screen
    When I open the "Types" filter sheet
    Then the card option reads "Card" (not "MetaMask Card")
```

## **Screenshots/Recordings**

### **Before**

Types sheet option read "MetaMask Card".

### **After**

Types sheet option reads "Card".

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display-string change in one locale with no logic or other copy affected.
> 
> **Overview**
> Updates the English copy for the Activity **Types** filter so the MetaMask Card option displays **"Card"** instead of **"MetaMask Card"**, per design.
> 
> Only `activity_view.type_filter.metamask_card` in `en.json` changes; the i18n key and filter enum wiring stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62d3fd8efe58736bc9c713f8ecfa948d861f5b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->