### PR TITLE
test(activity-redesign): seed MoneyAccountController in activity component-view preset

### DIFF
--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -89,6 +89,9 @@ export const initialStateActivity = () =>
           GasFeeController: {
             gasFeeEstimates: {},
           },
+          MoneyAccountController: {
+            moneyAccounts: {},
+          },
           NetworkEnablementController: {
             enabledNetworkMap: {
               eip155: {},


### PR DESCRIPTION
## **Description**

Seeds an empty `MoneyAccountController` (`moneyAccounts: {}`) in the Activity component-view state preset.

Selecting the **Perps** filter mounts the perps render path, which reads `MoneyAccountController` via `selectPrimaryMoneyAccount` (`state.engine.backgroundState.MoneyAccountController.moneyAccounts`). The activity preset didn't provide that controller, so the Perps `ActivityScreen.view.test.tsx` cases crashed into the error boundary (`Cannot read properties of undefined (reading 'moneyAccounts')`). This mirrors what the perps state preset already does, so the Perps activity view tests render once that work lands. Harmless on `main` today (no test exercises the money path yet).

Test-infra only — no production code changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/31772

## **Manual testing steps**

```gherkin
Feature: Activity component-view test preset

  Scenario: Perps filter renders without crashing in component-view tests
    Given the Activity component-view preset
    When a test selects the Perps type filter
    Then the screen renders instead of throwing on a missing MoneyAccountController
```

N/A — automated component-view test infra change.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only preset change with no production code paths affected.
> 
> **Overview**
> Adds an empty **`MoneyAccountController`** (`moneyAccounts: {}`) to the Activity component-view state preset in `tests/component-view/presets/activity.ts`, aligned with the perps and card presets.
> 
> This prevents Activity component-view tests that mount the **Perps** filter path from crashing when selectors read `backgroundState.MoneyAccountController.moneyAccounts` on undefined controller state.
> 
> **Test infrastructure only** — no production behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abca9bef95e8af25970e9d4b29da408ac3e67a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->