### PR TITLE
fix(rewards): Android keyboard obscuring Rewards text inputs

### DIFF
--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useMemo, useRef } from 'react';
-import { PanResponder } from 'react-native';
+import { PanResponder, Platform } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Text,
@@ -108,6 +108,9 @@ const OnboardingStepComponent: React.FC<OnboardingStepProps> = ({
   return (
     <KeyboardAwareScrollView
       keyboardShouldPersistTaps="handled"
+      enableOnAndroid
+      enableAutomaticScroll
+      extraScrollHeight={Platform.OS === 'android' ? 120 : 20}
       testID="onboarding-step-container"
       contentContainerStyle={tw.style(
         `min-h-full px-4 ${isLargeDevice ? 'py-8' : 'py-2'}`,

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react-native';
-import { Text, PanResponder } from 'react-native';
+import { Text, PanResponder, Platform } from 'react-native';
 import OnboardingStep from '../OnboardingStep';
 import { renderWithProviders } from '../testUtils';
 import { REWARDS_VIEW_SELECTORS } from '../../../Views/RewardsView.constants';
@@ -100,6 +100,19 @@ jest.mock('react-native', () => {
         },
       }),
     },
+  };
+});
+
+jest.mock('react-native-keyboard-aware-scroll-view', () => {
+  const ReactActual = jest.requireActual('react');
+  const { ScrollView } = jest.requireActual('react-native');
+  return {
+    KeyboardAwareScrollView: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+    }) => ReactActual.createElement(ScrollView, props, children),
   };
 });
 
@@ -717,6 +730,47 @@ describe('edge cases and prop variations', () => {
     expect(
       screen.getByText('mocked_rewards.onboarding.step_confirm'),
     ).toBeDefined();
+  });
+});
+
+describe('KeyboardAwareScrollView configuration', () => {
+  let originalPlatform: string;
+
+  beforeEach(() => {
+    originalPlatform = Platform.OS;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', {
+      value: originalPlatform,
+      writable: true,
+    });
+  });
+
+  it('enables Android keyboard avoidance with extra scroll height', () => {
+    Object.defineProperty(Platform, 'OS', {
+      value: 'android',
+      writable: true,
+    });
+
+    const { UNSAFE_root } = renderWithProviders(
+      <OnboardingStep {...defaultProps} />,
+    );
+
+    const scrollView = UNSAFE_root.findByProps({ enableOnAndroid: true });
+    expect(scrollView.props.extraScrollHeight).toBe(120);
+    expect(scrollView.props.enableAutomaticScroll).toBe(true);
+  });
+
+  it('uses smaller extra scroll height on iOS', () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios', writable: true });
+
+    const { UNSAFE_root } = renderWithProviders(
+      <OnboardingStep {...defaultProps} />,
+    );
+
+    const scrollView = UNSAFE_root.findByProps({ enableOnAndroid: true });
+    expect(scrollView.props.extraScrollHeight).toBe(20);
   });
 });
 

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.test.tsx
@@ -918,4 +918,38 @@ describe('ReferredByCodeSection', () => {
       expect(queryByTestId('rewards-vip-referral-tag')).toBeNull();
     });
   });
+
+  describe('keyboard handling', () => {
+    it('calls onInputFocus when referral input is focused', () => {
+      const onInputFocus = jest.fn();
+      mockUseSelector.mockImplementation(
+        createMockSelectors({
+          referredByCode: null,
+        }),
+      );
+
+      const { getByTestId } = render(
+        <ReferredByCodeSection onInputFocus={onInputFocus} />,
+      );
+
+      fireEvent(getByTestId('referred-by-code-input-input'), 'focus');
+      expect(onInputFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onInputFocus when referral code is already linked', () => {
+      const onInputFocus = jest.fn();
+      mockUseSelector.mockImplementation(
+        createMockSelectors({
+          referredByCode: 'EXISTING',
+        }),
+      );
+
+      const { getByTestId } = render(
+        <ReferredByCodeSection onInputFocus={onInputFocus} />,
+      );
+
+      fireEvent(getByTestId('referred-by-code-input-input'), 'focus');
+      expect(onInputFocus).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
+++ b/app/components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx
@@ -30,7 +30,13 @@ import RewardsErrorBanner from '../RewardsErrorBanner';
 import RewardsVipReferralTag from '../RewardsVipReferralTag/RewardsVipReferralTag';
 import { selectVipProgramEnabled } from '../../../../../selectors/featureFlagController/vipProgram';
 
-const ReferredByCodeSection: React.FC = () => {
+interface ReferredByCodeSectionProps {
+  onInputFocus?: () => void;
+}
+
+const ReferredByCodeSection: React.FC<ReferredByCodeSectionProps> = ({
+  onInputFocus,
+}) => {
   const { colors } = useTheme();
   const referredByCode = useSelector(selectReferredByCode);
   const isVipReferee = useSelector(selectIsVipReferee);
@@ -217,6 +223,7 @@ const ReferredByCodeSection: React.FC = () => {
             placeholder={strings('rewards.referred_by_code.input_placeholder')}
             value={hasReferredByCode ? (referredByCode ?? '') : inputCode}
             onChangeText={hasReferredByCode ? undefined : handleInputChange}
+            onFocus={hasReferredByCode ? undefined : onInputFocus}
             isDisabled={hasReferredByCode}
             autoCapitalize="characters"
             endAccessory={renderIcon()}

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.test.tsx
@@ -62,34 +62,46 @@ jest.mock('../../../../../util/theme', () => {
 });
 
 // Mock FlashList
+const mockFlashListScrollToIndex = jest.fn();
+const mockFlashListScrollToOffset = jest.fn();
+
 jest.mock('@shopify/flash-list', () => {
   const ReactActual = jest.requireActual('react');
   const { View } = jest.requireActual('react-native');
 
-  return {
-    FlashList: ({
-      data,
-      renderItem,
-      keyExtractor,
-      getItemType,
-      ListHeaderComponent,
-      ListEmptyComponent,
-      ListFooterComponent,
-      ...props
-    }: {
-      data: unknown[];
-      renderItem: (info: {
-        item: unknown;
-        index: number;
-      }) => React.ReactElement;
-      keyExtractor: (item: unknown, index: number) => string;
-      getItemType?: (item: unknown) => string;
-      ListHeaderComponent?: () => React.ReactElement;
-      ListEmptyComponent?: () => React.ReactElement;
-      ListFooterComponent?: () => React.ReactElement;
-      [key: string]: unknown;
-    }) =>
-      ReactActual.createElement(
+  const FlashList = ReactActual.forwardRef(
+    (
+      {
+        data,
+        renderItem,
+        keyExtractor,
+        getItemType,
+        ListHeaderComponent,
+        ListEmptyComponent,
+        ListFooterComponent,
+        ...props
+      }: {
+        data: unknown[];
+        renderItem: (info: {
+          item: unknown;
+          index: number;
+        }) => React.ReactElement;
+        keyExtractor: (item: unknown, index: number) => string;
+        getItemType?: (item: unknown) => string;
+        ListHeaderComponent?: () => React.ReactElement;
+        ListEmptyComponent?: () => React.ReactElement;
+        ListFooterComponent?: () => React.ReactElement;
+        [key: string]: unknown;
+      },
+      ref,
+    ) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        scrollToIndex: mockFlashListScrollToIndex,
+        scrollToOffset: mockFlashListScrollToOffset,
+        scrollToEnd: jest.fn(),
+      }));
+
+      return ReactActual.createElement(
         View,
         { testID: 'rewards-settings-flash-list', ...props },
         ListHeaderComponent &&
@@ -107,7 +119,6 @@ jest.mock('@shopify/flash-list', () => {
                 {
                   key,
                   testID: `flash-list-item-${key}`,
-                  // Store item type as accessibility label for testing
                   accessibilityLabel: itemType,
                 },
                 renderItem({
@@ -128,8 +139,11 @@ jest.mock('@shopify/flash-list', () => {
             { testID: 'list-footer' },
             ReactActual.createElement(ListFooterComponent),
           ),
-      ),
-  };
+      );
+    },
+  );
+
+  return { FlashList };
 });
 
 // Mock component library components
@@ -354,12 +368,18 @@ jest.mock('./RewardSettingsAccountGroup', () => {
 // Mock ReferredByCodeSection component to avoid navigation context requirement
 jest.mock('./ReferredByCodeSection', () => {
   const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+  const { View, TouchableOpacity } = jest.requireActual('react-native');
 
-  return () =>
-    ReactActual.createElement(View, {
-      testID: 'referred-by-code-section',
-    });
+  return ({ onInputFocus }: { onInputFocus?: () => void }) =>
+    ReactActual.createElement(
+      View,
+      { testID: 'referred-by-code-section' },
+      onInputFocus &&
+        ReactActual.createElement(TouchableOpacity, {
+          testID: 'referred-by-code-focus-trigger',
+          onPress: onInputFocus,
+        }),
+    );
 });
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
@@ -649,11 +669,30 @@ describe('RewardSettingsAccountGroupList', () => {
       expect(getByTestId('account-group-group-3')).toBeOnTheScreen();
     });
 
-    it('renders header and footer components', () => {
+    it('renders header and settings footer list items', () => {
       const { getByTestId } = render(<RewardSettingsAccountGroupList />);
 
       expect(getByTestId('rewards-settings-header')).toBeOnTheScreen();
-      expect(getByTestId('list-footer')).toBeOnTheScreen();
+      expect(getByTestId('flash-list-item-referredByCode')).toBeOnTheScreen();
+      expect(
+        getByTestId('flash-list-item-environmentToggle'),
+      ).toBeOnTheScreen();
+    });
+
+    it('scrolls to referral section on input focus', () => {
+      jest.useFakeTimers();
+      const { getByTestId } = render(<RewardSettingsAccountGroupList />);
+
+      fireEvent.press(getByTestId('referred-by-code-focus-trigger'));
+      jest.runAllTimers();
+
+      expect(mockFlashListScrollToIndex).toHaveBeenCalledWith(
+        expect.objectContaining({
+          viewPosition: 0.2,
+          animated: true,
+        }),
+      );
+      jest.useRealTimers();
     });
   });
 

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.test.tsx
@@ -93,7 +93,7 @@ jest.mock('@shopify/flash-list', () => {
         ListFooterComponent?: () => React.ReactElement;
         [key: string]: unknown;
       },
-      ref,
+      ref: unknown,
     ) => {
       ReactActual.useImperativeHandle(ref, () => ({
         scrollToIndex: mockFlashListScrollToIndex,

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
@@ -33,6 +33,8 @@ import { useBulkLinkState } from '../../hooks/useBulkLinkState';
 import { useTheme } from '../../../../../util/theme';
 
 const INITIAL_ACCOUNTS_TO_SHOW = 2;
+const REFERRAL_INPUT_SCROLL_VIEW_POSITION = 0.2;
+const REFERRAL_INPUT_SCROLL_DELAY_MS = 100;
 
 // Separate component for progress section to prevent header remounting on progress updates
 interface AccountProgressSectionProps {
@@ -171,12 +173,6 @@ const RewardSettingsAccountGroupList: React.FC<
     new Set(),
   );
 
-  const handleReferralInputFocus = useCallback(() => {
-    setTimeout(() => {
-      flashListRef.current?.scrollToEnd({ animated: true });
-    }, 100);
-  }, []);
-
   // Move all expensive operations to parent component
   const avatarAccountType = useSelector(selectAvatarAccountType);
 
@@ -238,6 +234,76 @@ const RewardSettingsAccountGroupList: React.FC<
       return newSet;
     });
   }, []);
+
+  // Flatten data for FlatList with collapse/expand support
+  const flattenedData =
+    useMemo((): RewardSettingsAccountGroupListFlatListItem[] => {
+      const items: RewardSettingsAccountGroupListFlatListItem[] = [];
+
+      byWallet.forEach((walletItem) => {
+        const walletId =
+          walletItem.wallet?.id?.replace('keyring:', '') || 'unknown';
+        const isExpanded = expandedWallets.has(walletId);
+        const totalGroups = walletItem.groups.length;
+        const hasMoreThanInitial = totalGroups > INITIAL_ACCOUNTS_TO_SHOW;
+
+        // Add wallet header
+        items.push({
+          type: 'wallet',
+          walletItem,
+        });
+
+        // Add account groups (limited if not expanded)
+        const groupsToShow = isExpanded
+          ? walletItem.groups
+          : walletItem.groups.slice(0, INITIAL_ACCOUNTS_TO_SHOW);
+
+        groupsToShow.forEach((accountGroup) => {
+          items.push({
+            type: 'accountGroup',
+            accountGroup,
+            allAddresses: allAddresses?.[accountGroup.id] || [],
+          });
+        });
+
+        // Add "Show more/less" button if there are more than initial accounts
+        if (hasMoreThanInitial) {
+          items.push({
+            type: 'showMore',
+            walletId,
+            remainingCount: totalGroups - INITIAL_ACCOUNTS_TO_SHOW,
+            isExpanded,
+          });
+        }
+      });
+
+      items.push({ type: 'referredByCode' });
+      if (onRequestOptOut) {
+        items.push({ type: 'optOut' });
+      }
+      items.push({ type: 'environmentToggle' });
+
+      return items;
+    }, [byWallet, allAddresses, expandedWallets, onRequestOptOut]);
+
+  const referralSectionIndex = useMemo(
+    () => flattenedData.findIndex((item) => item.type === 'referredByCode'),
+    [flattenedData],
+  );
+
+  const handleReferralInputFocus = useCallback(() => {
+    if (referralSectionIndex < 0) {
+      return;
+    }
+
+    setTimeout(() => {
+      flashListRef.current?.scrollToIndex({
+        index: referralSectionIndex,
+        viewPosition: REFERRAL_INPUT_SCROLL_VIEW_POSITION,
+        animated: true,
+      });
+    }, REFERRAL_INPUT_SCROLL_DELAY_MS);
+  }, [referralSectionIndex]);
 
   const renderFlatListItem: ListRenderItem<RewardSettingsAccountGroupListFlatListItem> =
     useCallback(
@@ -310,11 +376,27 @@ const RewardSettingsAccountGroupList: React.FC<
               </ButtonBase>
             );
           }
+          case 'referredByCode':
+            return (
+              <ReferredByCodeSection onInputFocus={handleReferralInputFocus} />
+            );
+          case 'optOut':
+            return onRequestOptOut ? (
+              <OptOutSection onErasePress={onRequestOptOut} />
+            ) : null;
+          case 'environmentToggle':
+            return <RewardsEnvironmentToggle />;
           default:
             return null;
         }
       },
-      [avatarAccountType, toggleWalletExpanded, tw],
+      [
+        avatarAccountType,
+        handleReferralInputFocus,
+        onRequestOptOut,
+        toggleWalletExpanded,
+        tw,
+      ],
     );
 
   const getItemType = useCallback(
@@ -336,6 +418,18 @@ const RewardSettingsAccountGroupList: React.FC<
 
       if (item.type === 'showMore' && item.walletId) {
         return `showMore-${item.walletId}`;
+      }
+
+      if (item.type === 'referredByCode') {
+        return 'referredByCode';
+      }
+
+      if (item.type === 'optOut') {
+        return 'optOut';
+      }
+
+      if (item.type === 'environmentToggle') {
+        return 'environmentToggle';
       }
 
       return `item-${index}`;
@@ -366,61 +460,16 @@ const RewardSettingsAccountGroupList: React.FC<
     [linkedAccounts, totalAccounts, isLoadingOptInSummary],
   );
 
-  const ListFooterComponent = useCallback(
+  const SettingsFooterSections = useCallback(
     () => (
       <Box twClassName="gap-4">
-        <ReferredByCodeSection onInputFocus={handleReferralInputFocus} />
+        <ReferredByCodeSection />
         {onRequestOptOut && <OptOutSection onErasePress={onRequestOptOut} />}
         <RewardsEnvironmentToggle />
       </Box>
     ),
-    [handleReferralInputFocus, onRequestOptOut],
+    [onRequestOptOut],
   );
-
-  // Flatten data for FlatList with collapse/expand support
-  const flattenedData =
-    useMemo((): RewardSettingsAccountGroupListFlatListItem[] => {
-      const items: RewardSettingsAccountGroupListFlatListItem[] = [];
-
-      byWallet.forEach((walletItem) => {
-        const walletId =
-          walletItem.wallet?.id?.replace('keyring:', '') || 'unknown';
-        const isExpanded = expandedWallets.has(walletId);
-        const totalGroups = walletItem.groups.length;
-        const hasMoreThanInitial = totalGroups > INITIAL_ACCOUNTS_TO_SHOW;
-
-        // Add wallet header
-        items.push({
-          type: 'wallet',
-          walletItem,
-        });
-
-        // Add account groups (limited if not expanded)
-        const groupsToShow = isExpanded
-          ? walletItem.groups
-          : walletItem.groups.slice(0, INITIAL_ACCOUNTS_TO_SHOW);
-
-        groupsToShow.forEach((accountGroup) => {
-          items.push({
-            type: 'accountGroup',
-            accountGroup,
-            allAddresses: allAddresses?.[accountGroup.id] || [],
-          });
-        });
-
-        // Add "Show more/less" button if there are more than initial accounts
-        if (hasMoreThanInitial) {
-          items.push({
-            type: 'showMore',
-            walletId,
-            remainingCount: totalGroups - INITIAL_ACCOUNTS_TO_SHOW,
-            isExpanded,
-          });
-        }
-      });
-
-      return items;
-    }, [byWallet, allAddresses, expandedWallets]);
 
   if (isLoadingOptInSummary) {
     return (
@@ -444,7 +493,7 @@ const RewardSettingsAccountGroupList: React.FC<
           ))}
         </Box>
 
-        <ListFooterComponent />
+        <SettingsFooterSections />
       </Box>
     );
   }
@@ -472,7 +521,7 @@ const RewardSettingsAccountGroupList: React.FC<
           />
         </Box>
 
-        <ListFooterComponent />
+        <SettingsFooterSections />
       </Box>
     );
   }
@@ -487,7 +536,6 @@ const RewardSettingsAccountGroupList: React.FC<
       keyExtractor={keyExtractor}
       getItemType={getItemType}
       ListHeaderComponent={ListHeaderComponent}
-      ListFooterComponent={ListFooterComponent}
       showsVerticalScrollIndicator={false}
       removeClippedSubviews
       keyboardShouldPersistTaps="handled"

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroupList.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, memo, useState } from 'react';
+import React, { useCallback, useMemo, memo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { FlashList, ListRenderItem } from '@shopify/flash-list';
+import { FlashList, FlashListRef, ListRenderItem } from '@shopify/flash-list';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -161,10 +161,21 @@ const RewardSettingsAccountGroupList: React.FC<
 > = ({ onRequestOptOut }) => {
   const tw = useTailwind();
 
+  const flashListRef =
+    useRef<FlashListRef<RewardSettingsAccountGroupListFlatListItem> | null>(
+      null,
+    );
+
   // State to track which wallets are expanded
   const [expandedWallets, setExpandedWallets] = useState<Set<string>>(
     new Set(),
   );
+
+  const handleReferralInputFocus = useCallback(() => {
+    setTimeout(() => {
+      flashListRef.current?.scrollToEnd({ animated: true });
+    }, 100);
+  }, []);
 
   // Move all expensive operations to parent component
   const avatarAccountType = useSelector(selectAvatarAccountType);
@@ -358,12 +369,12 @@ const RewardSettingsAccountGroupList: React.FC<
   const ListFooterComponent = useCallback(
     () => (
       <Box twClassName="gap-4">
-        <ReferredByCodeSection />
+        <ReferredByCodeSection onInputFocus={handleReferralInputFocus} />
         {onRequestOptOut && <OptOutSection onErasePress={onRequestOptOut} />}
         <RewardsEnvironmentToggle />
       </Box>
     ),
-    [onRequestOptOut],
+    [handleReferralInputFocus, onRequestOptOut],
   );
 
   // Flatten data for FlatList with collapse/expand support
@@ -469,6 +480,7 @@ const RewardSettingsAccountGroupList: React.FC<
   // Account list using FlashList for better performance
   return (
     <FlashList
+      ref={flashListRef}
       testID="rewards-settings-flash-list"
       data={flattenedData}
       renderItem={renderFlatListItem}

--- a/app/components/UI/Rewards/components/Settings/types.ts
+++ b/app/components/UI/Rewards/components/Settings/types.ts
@@ -4,7 +4,13 @@ import {
 } from '../../hooks/useRewardOptinSummary';
 
 export interface RewardSettingsAccountGroupListFlatListItem {
-  type: 'wallet' | 'accountGroup' | 'showMore';
+  type:
+    | 'wallet'
+    | 'accountGroup'
+    | 'showMore'
+    | 'referredByCode'
+    | 'optOut'
+    | 'environmentToggle';
   walletItem?: WalletWithAccountGroupsWithOptInStatus;
   accountGroup?: AccountGroupWithOptInStatus;
   allAddresses?: string[];

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.test.tsx
@@ -96,11 +96,37 @@ jest.mock(
   () => {
     const ReactActual = jest.requireActual('react');
     return ReactActual.forwardRef(
-      ({ children }: { children: React.ReactNode }) =>
-        ReactActual.createElement('View', { testID: 'bottom-sheet' }, children),
+      (
+        {
+          children,
+          keyboardAvoidingViewEnabled,
+        }: {
+          children: React.ReactNode;
+          keyboardAvoidingViewEnabled?: boolean;
+        },
+        _ref,
+      ) =>
+        ReactActual.createElement(
+          'View',
+          { testID: 'bottom-sheet', keyboardAvoidingViewEnabled },
+          children,
+        ),
     );
   },
 );
+
+jest.mock('react-native-keyboard-aware-scroll-view', () => {
+  const ReactActual = jest.requireActual('react');
+  const { ScrollView } = jest.requireActual('react-native');
+  return {
+    KeyboardAwareScrollView: ({
+      children,
+      ...props
+    }: {
+      children?: React.ReactNode;
+    }) => ReactActual.createElement(ScrollView, props, children),
+  };
+});
 
 // Mock TextField component
 jest.mock(
@@ -675,6 +701,39 @@ describe('RewardsClaimBottomSheetModal', () => {
           <RewardsClaimBottomSheetModal route={routeWithConflictingParams} />,
         ),
       ).not.toThrow();
+    });
+  });
+
+  describe('KeyboardAwareScrollView configuration', () => {
+    it('disables BottomSheet keyboard avoidance when showInput is true', () => {
+      const { getByTestId } = render(
+        <RewardsClaimBottomSheetModal route={routeWithAlphaFoxInviteReward} />,
+      );
+
+      expect(getByTestId('bottom-sheet')).toHaveProp(
+        'keyboardAvoidingViewEnabled',
+        false,
+      );
+    });
+
+    it('uses KeyboardAwareScrollView with enableOnAndroid when showInput is true', () => {
+      const { UNSAFE_root } = render(
+        <RewardsClaimBottomSheetModal route={routeWithAlphaFoxInviteReward} />,
+      );
+
+      const scrollView = UNSAFE_root.findByProps({ enableOnAndroid: true });
+      expect(scrollView.props.extraScrollHeight).toBe(20);
+    });
+
+    it('keeps BottomSheet keyboard avoidance enabled when showInput is false', () => {
+      const { getByTestId } = render(
+        <RewardsClaimBottomSheetModal route={defaultRoute} />,
+      );
+
+      expect(getByTestId('bottom-sheet')).toHaveProp(
+        'keyboardAvoidingViewEnabled',
+        true,
+      );
     });
   });
 });

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.test.tsx
@@ -104,7 +104,7 @@ jest.mock(
           children: React.ReactNode;
           keyboardAvoidingViewEnabled?: boolean;
         },
-        _ref,
+        _ref: unknown,
       ) =>
         ReactActual.createElement(
           'View',

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
@@ -33,6 +33,7 @@ import BottomSheet, {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { REWARDS_VIEW_SELECTORS } from '../../../Views/RewardsView.constants';
 import { Linking, TouchableOpacity } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { formatUrl } from '../../../utils/formatUtils';
 import TextField from '../../../../../../component-library/components/Form/TextField';
 import useRewardsToast from '../../../hooks/useRewardsToast';
@@ -310,20 +311,38 @@ const RewardsClaimBottomSheetModal = ({
     return null;
   };
 
+  const renderContent = () => (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      twClassName="p-4"
+    >
+      {renderTitle()}
+      {renderDescription()}
+      {renderInput()}
+      {renderError()}
+      {renderActions()}
+    </Box>
+  );
+
   return (
-    <BottomSheet ref={sheetRef} testID={REWARDS_VIEW_SELECTORS.CLAIM_MODAL}>
-      <Box
-        flexDirection={BoxFlexDirection.Column}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Center}
-        twClassName="p-4"
-      >
-        {renderTitle()}
-        {renderDescription()}
-        {renderInput()}
-        {renderError()}
-        {renderActions()}
-      </Box>
+    <BottomSheet
+      ref={sheetRef}
+      testID={REWARDS_VIEW_SELECTORS.CLAIM_MODAL}
+      keyboardAvoidingViewEnabled={!showInput}
+    >
+      {showInput ? (
+        <KeyboardAwareScrollView
+          keyboardShouldPersistTaps="handled"
+          enableOnAndroid
+          extraScrollHeight={20}
+        >
+          {renderContent()}
+        </KeyboardAwareScrollView>
+      ) : (
+        renderContent()
+      )}
     </BottomSheet>
   );
 };


### PR DESCRIPTION
## **Description**

On Android, the soft keyboard was covering text inputs in several Rewards flows. iOS was largely unaffected because `KeyboardAwareScrollView` enables keyboard avoidance by default on iOS but not on Android, and `BottomSheet`'s built-in `KeyboardAvoidingView` only applies padding behavior on iOS.

This PR fixes keyboard overlap in three places:

1. **Rewards onboarding** — enable `enableOnAndroid`, `enableAutomaticScroll`, and platform-specific `extraScrollHeight` on the onboarding `KeyboardAwareScrollView` so the referral code field stays visible while typing.
2. **Claim reward bottom sheet** — when a reward requires text input (e.g. Alpha Fox invite / Telegram handle), disable BottomSheet keyboard avoidance and wrap content in `KeyboardAwareScrollView` with `enableOnAndroid` (same pattern as `EndOfSeasonClaimBottomSheet`).
3. **Rewards Settings referral code** — move footer sections (referral code, opt-out, environment toggle) into FlashList items and scroll to the referral row on focus via `scrollToIndex`, instead of `scrollToEnd`, which pinned the footer bottom and could leave the input under the keyboard when opt-out/env-toggle content sits below it.

Unit tests cover platform scroll props, bottom-sheet keyboard flags, focus callbacks, and list scroll behavior.

## **Changelog**

CHANGELOG entry: Fixed Android soft keyboard obscuring text inputs in Rewards onboarding, claim rewards, and settings flows

## **Related issues**

Refs: N/A — Android keyboard UX fix (no linked ticket)

## **Manual testing steps**

```gherkin
Feature: Rewards Android keyboard avoidance

  Scenario: referral code input stays visible during onboarding
    Given the user is on Rewards onboarding on Android
    When the user taps "Have a referral code?" and focuses the referral input
    Then the referral input remains visible above the soft keyboard while typing

  Scenario: claim reward text input stays visible in bottom sheet
    Given the user opens a claim reward modal that requires text input (e.g. Alpha Fox invite)
    When the user focuses the text input on Android
    Then the input and primary CTA remain visible above the soft keyboard

  Scenario: settings referral code scrolls into view on focus
    Given the user is on Rewards Settings on Android with a scrollable account list
    When the user focuses the "Referred by code" input
    Then the referral section scrolls into view above the soft keyboard and is not obscured by footer content below it

  Scenario: iOS regression smoke check
    Given the user is on iOS
    When the user repeats the three flows above
    Then keyboard behavior and layout remain correct with no regressions
```

Automated: `OnboardingStep.test.tsx`, `RewardsClaimBottomSheetModal.test.tsx`, `ReferredByCodeSection.test.tsx`, `RewardSettingsAccountGroupList.test.tsx`

## **Screenshots/Recordings**

N/A — keyboard overlap fix; manual verification on Android device/emulator recommended.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only keyboard and scroll behavior in Rewards screens with no auth, payment, or data-model changes; risk is mainly layout regressions on iOS/Android.
> 
> **Overview**
> Fixes **Android** soft-keyboard overlap in several Rewards flows by turning on `KeyboardAwareScrollView` avoidance where it was iOS-only, and by scrolling settings to the referral row on focus.
> 
> **Onboarding** and **claim reward** modals now use `enableOnAndroid` (and larger `extraScrollHeight` on onboarding for Android). For claim flows with a text field, **BottomSheet** keyboard avoidance is turned off and the content is wrapped in `KeyboardAwareScrollView` so Android can scroll the input and CTA into view.
> 
> **Rewards Settings** moves referral code, opt-out, and environment toggle from a list footer into **FlashList** rows so `scrollToIndex` can target the referral section when the code field is focused (via new `onInputFocus` on `ReferredByCodeSection`), instead of `scrollToEnd` leaving the input under the keyboard. Loading/error states still render the same footer blocks outside the list.
> 
> Unit tests cover platform scroll props, bottom-sheet keyboard flags, focus callbacks, and list scroll behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5d6f9c9c1e73208219a23e8cfa5afe822c17a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->