### PR TITLE
fix(activity-redesign): show token amount on indexed contract interaction activity

### DIFF
--- a/app/util/activity-adapters/adapters/api-evm-transactions.test.ts
+++ b/app/util/activity-adapters/adapters/api-evm-transactions.test.ts
@@ -853,4 +853,56 @@ describe('mapApiEvmTransactions', () => {
       },
     });
   });
+
+  it('maps a generic contract call to a contract interaction with its token amount', () => {
+    const mainnetUsdc = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const transaction = {
+      hash: '0xd206cc6c16974409bae072ce4cd1559743041af40c2bae84775a0bbb4dff5fee',
+      timestamp: '2026-05-01T13:39:47.000Z',
+      chainId: 1,
+      from: subjectAddress,
+      to: subjectAddress,
+      methodId: '0xe9ae5c53',
+      value: '0',
+      transactionCategory: 'CONTRACT_CALL',
+      transactionType: 'GENERIC_CONTRACT_CALL',
+      valueTransfers: [
+        {
+          from: subjectAddress,
+          to: '0x4cd00e387622c35bddb9b4c962c136462338bc31',
+          amount: '580060',
+          decimal: 6,
+          contractAddress: mainnetUsdc,
+          symbol: 'USDC',
+          name: 'USD Coin',
+          transferType: 'erc20',
+        },
+      ],
+    } as unknown as V1TransactionByHashResponse;
+
+    expect(
+      withoutRaw(mapApiEvmTransactions({ subjectAddress, transaction })),
+    ).toStrictEqual({
+      type: 'contractInteraction',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 1777642787000,
+      hash: '0xd206cc6c16974409bae072ce4cd1559743041af40c2bae84775a0bbb4dff5fee',
+      data: {
+        from: subjectAddress,
+        methodId: '0xe9ae5c53',
+        to: subjectAddress,
+        transactionCategory: 'CONTRACT_CALL',
+        transactionProtocol: undefined,
+        transactionType: 'GENERIC_CONTRACT_CALL',
+        token: {
+          amount: '580060',
+          assetId: toAssetId(mainnetUsdc, 'eip155:1'),
+          decimals: 6,
+          direction: 'out',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
 });

--- a/app/util/activity-adapters/adapters/api-evm-transactions.ts
+++ b/app/util/activity-adapters/adapters/api-evm-transactions.ts
@@ -454,6 +454,15 @@ export function mapApiEvmTransactions({
     };
   }
 
+  const contractInteractionTransfer = sentTransfer ?? receivedTransfer;
+  const contractInteractionToken = getToken(
+    contractInteractionTransfer,
+    sentTransfer ? 'out' : 'in',
+  );
+  const contractInteractionTokenWithAmount = contractInteractionToken?.amount
+    ? contractInteractionToken
+    : undefined;
+
   return {
     type: 'contractInteraction',
     chainId,
@@ -468,6 +477,9 @@ export function mapApiEvmTransactions({
       transactionCategory,
       transactionProtocol: transaction.transactionProtocol,
       transactionType: transaction.transactionType,
+      ...(contractInteractionTokenWithAmount
+        ? { token: contractInteractionTokenWithAmount }
+        : {}),
     },
   };
 }


### PR DESCRIPTION
## **Description**

The redesigned Activity list (behind `tmcuActivityRedesignEnabled`) rendered some contract interactions without a token amount, while the extension showed it (e.g. `-0.5801 USDC`).

The cause is in the API/indexed-history adapter: its `contractInteraction` branch never read the transaction's `valueTransfers`, so `data.token` was `undefined` and no amount was displayed. Every other branch already extracts the transfer via `getToken(...)`.

This change extracts the user-involved transfer (sent first, else received) and attaches it as `data.token` when it has an amount, mirroring the extension's `api-evm-transactions` adapter. The local-transaction path already handled native value, so only the indexed path needed the fix.

## **Changelog**

CHANGELOG entry: Fixed contract interactions in the redesigned Activity list not showing the token amount

## **Related issues**

Fixes: [TMCU-935](https://consensyssoftware.atlassian.net/browse/TMCU-935)

## **Manual testing steps**

```gherkin
Feature: Contract interaction activity amount

  Scenario: user views a contract interaction that moved an ERC-20
    Given the activity redesign feature flag is enabled
    And the account has an indexed contract interaction that transferred an ERC-20 token

    When the user opens the Activity tab
    Then the contract interaction row shows the token amount (e.g. -0.01 aEthUSDC)
    And it matches what the extension displays
```

## **Screenshots/Recordings**

### **Before**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2026-06-22 at 16 29 24" src="https://github.com/user-attachments/assets/366e9dee-5122-4bf4-80d0-a67fa2646f24" />

### **After**

<img width="500" alt="Simulator Screenshot - iPhone 17 - 2026-06-23 at 09 53 55" src="https://github.com/user-attachments/assets/706d19d0-f60e-46f5-8464-55c6cc534437" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow adapter change for activity display only; optional `data.token` on contract interactions with no auth or transaction execution impact.
> 
> **Overview**
> Fixes **contract interaction** rows in the redesigned Activity list showing no token amount when indexed history includes ERC-20 (or other) **value transfers**.
> 
> The `mapApiEvmTransactions` fallback **`contractInteraction`** branch now picks the user’s **sent** transfer, or **received** if none, runs it through the existing **`getToken`** helper, and spreads **`data.token`** only when the result has an **`amount`**—same pattern as send/receive/swap branches. Interactions without a quantified transfer stay unchanged (no `token` field).
> 
> Adds a unit test for a **GENERIC_CONTRACT_CALL** with an outbound USDC transfer asserting **`direction: 'out'`** and formatted amount metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b6cc6098c58cc3045ba5c818c9fb15e093f964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[TMCU-935]: https://consensyssoftware.atlassian.net/browse/TMCU-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ