### PR TITLE
fix(money): show "Debit card" without Apple Pay on Android (MUSD-1046) cp-8.0.0

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { fireEvent } from '@testing-library/react-native';
 import { TransactionType, CHAIN_IDS } from '@metamask/transaction-controller';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
@@ -137,6 +138,25 @@ describe('MoneyAddMoneySheet', () => {
     expect(
       getByTestId(MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW),
     ).toBeOnTheScreen();
+  });
+
+  it('renders the deposit option as "Debit card" without Apple Pay on Android', () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'android';
+
+    try {
+      const { getByText, queryByText, getByTestId } = renderWithProvider(
+        <MoneyAddMoneySheet />,
+      );
+
+      expect(getByText('Debit card')).toBeOnTheScreen();
+      expect(queryByText('Debit card or Apple Pay')).toBeNull();
+      expect(
+        getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
+      ).toBeOnTheScreen();
+    } finally {
+      Platform.OS = originalOS;
+    }
   });
 
   it('renders the Bank account row as a coming-soon, non-pressable option', () => {

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import BigNumber from 'bignumber.js';
@@ -209,7 +209,11 @@ const MoneyAddMoneySheet: React.FC = () => {
     ...(isFiatDepositEnabled
       ? [
           {
-            label: strings('money.add_money_sheet.deposit_funds'),
+            label: strings(
+              Platform.OS === 'android'
+                ? 'money.add_money_sheet.deposit_funds_android'
+                : 'money.add_money_sheet.deposit_funds',
+            ),
             icon: IconName.Card,
             onPress: handleDepositFunds,
             testID: MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7168,6 +7168,7 @@
       "title": "Add funds",
       "convert_crypto": "Convert crypto",
       "deposit_funds": "Debit card or Apple Pay",
+      "deposit_funds_android": "Debit card",
       "bank_account": "Bank account",
       "move_musd": "{{amount}} mUSD",
       "add_musd": "Add mUSD",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The "Add funds" bottom sheet's fiat deposit option showed "Debit card or Apple Pay" on both iOS and Android. Apple Pay is not available on Android (and we do not support Google Pay or any Android equivalent), so the reference was misleading on Android.

This makes the label platform-aware: Android now reads "Debit card", while iOS keeps "Debit card or Apple Pay" unchanged. The icon and tap behaviour for the option are untouched on both platforms.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Add funds sheet to show "Debit card" instead of "Debit card or Apple Pay" on Android, where Apple Pay is not available.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1046](https://consensyssoftware.atlassian.net/browse/MUSD-1046)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add funds sheet platform-aware debit card label

  Scenario: Android user opens the Add funds sheet
    Given the user is on the Money/mUSD account screen on Android
    When the user taps "Add funds"
    Then the fiat deposit option reads "Debit card"
    And there is no mention of Apple Pay

  Scenario: iOS user opens the Add funds sheet
    Given the user is on the Money/mUSD account screen on iOS
    When the user taps "Add funds"
    Then the fiat deposit option reads "Debit card or Apple Pay"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Android: `Debit card or Apple Pay`

### **After**

<!-- [screenshots/recordings] -->

Android: `Debit card`

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1046]: https://consensyssoftware.atlassian.net/browse/MUSD-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change with no payment or navigation logic changes; covered by a new platform-specific test.
> 
> **Overview**
> The Add funds sheet’s fiat deposit row no longer shows **Apple Pay** on Android. The label is chosen with `Platform.OS`: Android uses a new string **"Debit card"**; iOS still uses **"Debit card or Apple Pay"**. Deposit tap behavior, icon, and feature gating are unchanged.
> 
> Adds `money.add_money_sheet.deposit_funds_android` in `en.json` and a unit test that stubs `Platform.OS` to `android` and asserts the Android copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3350f1042b29b0450dbe284555aa4a797371f884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->