### PR TITLE
fix(rewards): gate mobile-login on OIS status to stop 401 spam on account switch

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -4105,19 +4105,39 @@ describe('RewardsController', () => {
       // Mock Date.now to return predictable timestamp
       jest.spyOn(Date, 'now').mockImplementation(() => mockTimestamp * 1000);
 
-      // Mock the AccountTreeController:getAccountsFromSelectedAccountGroup call
-      mockMessenger.call
-        .mockReturnValueOnce([hexFormatAuthAccount]) // Return accounts for handleAuthenticationTrigger
-        .mockResolvedValueOnce('0xsignature') // KeyringController:signPersonalMessage
-        .mockResolvedValueOnce({
-          sessionId: 'session123',
-          subscription: {
-            id: 'sub123',
-            referralCode: 'REF123',
-            accounts: [],
-            features: { vip: { enabled: false } },
-          },
-        }); // RewardsDataService:login
+      // Mock messenger calls by method so the OIS gate (which reports opted in)
+      // and the silent-auth login flow both resolve deterministically.
+      mockMessenger.call.mockImplementation(
+        (method: string, ..._args: unknown[]): any => {
+          if (
+            method ===
+            'AccountTreeController:getAccountsFromSelectedAccountGroup'
+          ) {
+            return [hexFormatAuthAccount];
+          }
+          if (method === 'AccountsController:listMultichainAccounts') {
+            return [hexFormatAuthAccount];
+          }
+          if (method === 'RewardsDataService:getOptInStatus') {
+            return Promise.resolve({ ois: [true], sids: ['sub123'] });
+          }
+          if (method === 'KeyringController:signPersonalMessage') {
+            return Promise.resolve('0xsignature');
+          }
+          if (method === 'RewardsDataService:login') {
+            return Promise.resolve({
+              sessionId: 'session123',
+              subscription: {
+                id: 'sub123',
+                referralCode: 'REF123',
+                accounts: [],
+                features: { vip: { enabled: false } },
+              },
+            });
+          }
+          return Promise.resolve(undefined);
+        },
+      );
 
       // Trigger authentication via account group change
       const authHexSubscribeCallback = mockMessenger.subscribe.mock.calls.find(
@@ -4477,6 +4497,106 @@ describe('RewardsController', () => {
         },
         extra: { accountType: 'eip155:eoa' },
       });
+    });
+
+    it('does NOT call login when opt-in status reports not opted in', async () => {
+      // Arrange — an EVM account that the OIS endpoint reports as not opted in.
+      const notOptedInAccount: InternalAccount = {
+        address: '0x123',
+        type: 'eip155:eoa',
+        id: 'test-id',
+        scopes: ['eip155:1'],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Test Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: 0,
+        },
+      };
+
+      mockMessenger.call.mockClear();
+      mockMessenger.call.mockImplementation(
+        (method: string, ..._args: unknown[]): any => {
+          if (method === 'AccountsController:listMultichainAccounts') {
+            return [notOptedInAccount];
+          }
+          if (method === 'RewardsDataService:getOptInStatus') {
+            return Promise.resolve({ ois: [false], sids: [null] });
+          }
+          return Promise.resolve(undefined);
+        },
+      );
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+      });
+
+      // Act — respectSkipSilentAuth=true so the OIS pre-gate runs.
+      const result = await testController.performSilentAuth(
+        notOptedInAccount,
+        false,
+        true,
+      );
+
+      // Assert — login (mobile-login) was never attempted, returns null.
+      expect(result).toBeNull();
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:login',
+        expect.anything(),
+      );
+    });
+
+    it('does NOT call login when opt-in status check throws', async () => {
+      // Arrange — the OIS endpoint fails; enrollment is unknown.
+      const unknownAccount: InternalAccount = {
+        address: '0x123',
+        type: 'eip155:eoa',
+        id: 'test-id',
+        scopes: ['eip155:1'],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Test Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: 0,
+        },
+      };
+
+      mockMessenger.call.mockClear();
+      mockMessenger.call.mockImplementation(
+        (method: string, ..._args: unknown[]): any => {
+          if (method === 'AccountsController:listMultichainAccounts') {
+            return [unknownAccount];
+          }
+          if (method === 'RewardsDataService:getOptInStatus') {
+            return Promise.reject(new Error('Network error'));
+          }
+          return Promise.resolve(undefined);
+        },
+      );
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
+      });
+
+      // Act — respectSkipSilentAuth=true so the OIS pre-gate runs.
+      const result = await testController.performSilentAuth(
+        unknownAccount,
+        false,
+        true,
+      );
+
+      // Assert — unknown enrollment must NOT fall through to mobile-login.
+      expect(result).toBeNull();
+      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+        'RewardsDataService:login',
+        expect.anything(),
+      );
     });
   });
 
@@ -7709,6 +7829,10 @@ describe('RewardsController', () => {
       };
 
       mockMessenger.call.mockReturnValueOnce([mockAccount]);
+      // OIS reports opted in so silent auth proceeds to mint a session.
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({ ois: [true], sids: ['sub123'] });
 
       // Act
       await controller.handleAuthenticationTrigger('test-reason');
@@ -7726,6 +7850,8 @@ describe('RewardsController', () => {
       expect(
         controller.state.accounts[accountId as CaipAccountId],
       ).toBeDefined();
+
+      getOptInStatusSpy.mockRestore();
     });
 
     it('tries multiple accounts', async () => {
@@ -7886,6 +8012,13 @@ describe('RewardsController', () => {
       };
 
       mockMessenger.call.mockReturnValueOnce([mockAccount1, mockAccount2]);
+      // Both accounts are opted in so silent auth is attempted for them.
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({
+          ois: [true, true],
+          sids: ['sub-1', 'sub-2'],
+        });
 
       // Mock the rewards data service to fail for first account and succeed for second
       mockRewardsDataService.login
@@ -7912,6 +8045,8 @@ describe('RewardsController', () => {
       expect(
         controller.state.accounts[accountId as CaipAccountId],
       ).toBeDefined();
+
+      getOptInStatusSpy.mockRestore();
     });
 
     it('sets activeAccount to first account when all accounts fail authentication', async () => {
@@ -8035,6 +8170,10 @@ describe('RewardsController', () => {
       };
 
       mockMessenger.call.mockReturnValueOnce([mockAccount]);
+      // OIS reports opted in so silent auth proceeds (and then fails at login).
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({ ois: [true], sids: ['sub123'] });
 
       // Mock the rewards data service to fail for the single account
       mockRewardsDataService.login.mockRejectedValue(
@@ -8052,6 +8191,8 @@ describe('RewardsController', () => {
       // Verify that activeAccount is set to the first account even when auth fails
       expect(controller.state.activeAccount).toBeDefined();
       expect(controller.state.activeAccount?.account).toBeDefined();
+
+      getOptInStatusSpy.mockRestore();
     });
 
     it('handles "Engine does not exist" errors silently', async () => {
@@ -8174,6 +8315,134 @@ describe('RewardsController', () => {
       expect(performSilentAuthSpy).toHaveBeenCalledTimes(2);
 
       // Clean up spy
+      performSilentAuthSpy.mockRestore();
+    });
+
+    it('only attempts silent auth for the opted-in account in a mixed group', async () => {
+      // Arrange — a group of three accounts, only the first is opted in.
+      const enrolledAccount = {
+        address: '0x1111111111111111',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-1',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Enrolled Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+      const notEnrolled1 = {
+        address: '0x2222222222222222',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-2',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Not Enrolled 1',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+      const notEnrolled2 = {
+        address: '0x3333333333333333',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-3',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Not Enrolled 2',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+
+      mockMessenger.call.mockReturnValueOnce([
+        enrolledAccount,
+        notEnrolled1,
+        notEnrolled2,
+      ]);
+
+      // sortAccounts preserves order here; bulk OIS reports only the first
+      // account as opted in.
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({
+          ois: [true, false, false],
+          sids: ['sub-enrolled', null, null],
+        });
+      const performSilentAuthSpy = jest
+        .spyOn(controller, 'performSilentAuth')
+        .mockResolvedValue('sub-enrolled');
+
+      // Act
+      await controller.handleAuthenticationTrigger('test-reason');
+
+      // Assert — login (via performSilentAuth) attempted exactly once, only
+      // for the enrolled account; non-enrolled accounts are skipped.
+      expect(performSilentAuthSpy).toHaveBeenCalledTimes(1);
+      expect(performSilentAuthSpy).toHaveBeenCalledWith(
+        enrolledAccount,
+        false,
+        true,
+      );
+      expect(performSilentAuthSpy).not.toHaveBeenCalledWith(
+        notEnrolled1,
+        false,
+        true,
+      );
+      expect(performSilentAuthSpy).not.toHaveBeenCalledWith(
+        notEnrolled2,
+        false,
+        true,
+      );
+
+      getOptInStatusSpy.mockRestore();
+      performSilentAuthSpy.mockRestore();
+    });
+
+    it('still mints a session for an enrolled account and sets it active', async () => {
+      // Arrange — single enrolled account; bulk OIS reports opted in.
+      const enrolledAccount = {
+        address: '0x1234567890abcdef',
+        type: 'eip155:eoa' as const,
+        id: 'test-id',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Enrolled Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+
+      mockMessenger.call.mockReturnValueOnce([enrolledAccount]);
+
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({ ois: [true], sids: ['sub-enrolled'] });
+      const performSilentAuthSpy = jest
+        .spyOn(controller, 'performSilentAuth')
+        .mockResolvedValue('sub-enrolled');
+
+      // Act
+      await controller.handleAuthenticationTrigger('test-reason');
+
+      // Assert — silent auth attempted for the enrolled account and it becomes
+      // the active account candidate.
+      expect(performSilentAuthSpy).toHaveBeenCalledTimes(1);
+      expect(performSilentAuthSpy).toHaveBeenCalledWith(
+        enrolledAccount,
+        false,
+        true,
+      );
+      expect(controller.state.activeAccount).toBeDefined();
+
+      getOptInStatusSpy.mockRestore();
       performSilentAuthSpy.mockRestore();
     });
   });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -4549,8 +4549,8 @@ describe('RewardsController', () => {
       );
     });
 
-    it('does NOT call login when opt-in status check throws', async () => {
-      // Arrange — the OIS endpoint fails; enrollment is unknown.
+    it('falls through to login when opt-in status check throws', async () => {
+      // Arrange — the OIS endpoint fails; fall back to mobile-login like main.
       const unknownAccount: InternalAccount = {
         address: '0x123',
         type: 'eip155:eoa',
@@ -4574,6 +4574,20 @@ describe('RewardsController', () => {
           if (method === 'RewardsDataService:getOptInStatus') {
             return Promise.reject(new Error('Network error'));
           }
+          if (method === 'KeyringController:signPersonalMessage') {
+            return Promise.resolve('0xsignature');
+          }
+          if (method === 'RewardsDataService:login') {
+            return Promise.resolve({
+              sessionId: 'session123',
+              subscription: {
+                id: 'sub123',
+                referralCode: 'REF123',
+                accounts: [],
+                features: { vip: { enabled: false } },
+              },
+            });
+          }
           return Promise.resolve(undefined);
         },
       );
@@ -4584,16 +4598,16 @@ describe('RewardsController', () => {
         isDisabled: () => false,
       });
 
-      // Act — respectSkipSilentAuth=true so the OIS pre-gate runs.
+      mockStoreSubscriptionToken.mockResolvedValue({ success: true });
+
       const result = await testController.performSilentAuth(
         unknownAccount,
         false,
         true,
       );
 
-      // Assert — unknown enrollment must NOT fall through to mobile-login.
-      expect(result).toBeNull();
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+      expect(result).toBe('sub123');
+      expect(mockMessenger.call).toHaveBeenCalledWith(
         'RewardsDataService:login',
         expect.anything(),
       );
@@ -8441,6 +8455,235 @@ describe('RewardsController', () => {
         true,
       );
       expect(controller.state.activeAccount).toBeDefined();
+
+      getOptInStatusSpy.mockRestore();
+      performSilentAuthSpy.mockRestore();
+    });
+
+    it('updates activeAccount when switching to a group where no accounts are opted in', async () => {
+      const oldEnrolledCaip = 'eip155:1:0x1111111111111111' as CaipAccountId;
+      const notEnrolledAccount1 = {
+        address: '0x2222222222222222',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-1',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Not Enrolled 1',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+      const notEnrolledAccount2 = {
+        address: '0x3333333333333333',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-2',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Not Enrolled 2',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+      const expectedActiveCaip = 'eip155:1:0x2222222222222222' as CaipAccountId;
+      const cachedOptInCheckTimestamp = 50;
+
+      controller = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          activeAccount: {
+            account: oldEnrolledCaip,
+            hasOptedIn: true,
+            subscriptionId: 'old-subscription',
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+          accounts: {
+            [oldEnrolledCaip]: {
+              account: oldEnrolledCaip,
+              hasOptedIn: true,
+              subscriptionId: 'old-subscription',
+              perpsFeeDiscount: null,
+              lastPerpsDiscountRateFetched: null,
+            },
+            [expectedActiveCaip]: {
+              account: expectedActiveCaip,
+              hasOptedIn: false,
+              subscriptionId: null,
+              perpsFeeDiscount: null,
+              lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: cachedOptInCheckTimestamp,
+            },
+          },
+        },
+      });
+
+      mockMessenger.call.mockReturnValueOnce([
+        notEnrolledAccount1,
+        notEnrolledAccount2,
+      ]);
+
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({
+          ois: [false, false],
+          sids: [null, null],
+        });
+      const performSilentAuthSpy = jest.spyOn(controller, 'performSilentAuth');
+
+      await controller.handleAuthenticationTrigger('account-group-changed');
+
+      expect(performSilentAuthSpy).not.toHaveBeenCalled();
+      expect(controller.state.activeAccount).toEqual({
+        account: expectedActiveCaip,
+        hasOptedIn: false,
+        subscriptionId: null,
+        perpsFeeDiscount: null,
+        lastPerpsDiscountRateFetched: null,
+        lastFreshOptInStatusCheck: cachedOptInCheckTimestamp,
+      });
+      expect(controller.state.accounts[expectedActiveCaip]).toEqual(
+        controller.state.activeAccount,
+      );
+
+      getOptInStatusSpy.mockRestore();
+      performSilentAuthSpy.mockRestore();
+    });
+
+    it('does not slide lastFreshOptInStatusCheck when bulk OIS uses cached not-opted-in state', async () => {
+      const notEnrolledAccount = {
+        address: '0x2222222222222222',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-1',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Not Enrolled',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+      const notEnrolledCaip = 'eip155:1:0x2222222222222222' as CaipAccountId;
+      const cachedOptInCheckTimestamp = 50;
+
+      controller = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          accounts: {
+            [notEnrolledCaip]: {
+              account: notEnrolledCaip,
+              hasOptedIn: false,
+              subscriptionId: null,
+              perpsFeeDiscount: null,
+              lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: cachedOptInCheckTimestamp,
+            },
+          },
+        },
+      });
+
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({
+          ois: [false],
+          sids: [null],
+        });
+      const performSilentAuthSpy = jest.spyOn(controller, 'performSilentAuth');
+
+      mockMessenger.call.mockReturnValue([notEnrolledAccount]);
+
+      await controller.handleAuthenticationTrigger('account-group-changed');
+      await controller.handleAuthenticationTrigger('account-group-changed');
+
+      expect(performSilentAuthSpy).not.toHaveBeenCalled();
+      expect(
+        controller.state.accounts[notEnrolledCaip]?.lastFreshOptInStatusCheck,
+      ).toBe(cachedOptInCheckTimestamp);
+
+      getOptInStatusSpy.mockRestore();
+      performSilentAuthSpy.mockRestore();
+    });
+
+    it('seeds candidate state when bulk OIS reports false and no prior account state exists', async () => {
+      const notEnrolledAccount = {
+        address: '0x2222222222222222',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-1',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Not Enrolled',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+      const notEnrolledCaip = 'eip155:1:0x2222222222222222' as CaipAccountId;
+
+      controller = new RewardsController({
+        messenger: mockMessenger,
+        isDisabled: () => false,
+      });
+
+      mockMessenger.call.mockReturnValueOnce([notEnrolledAccount]);
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockResolvedValue({ ois: [false], sids: [null] });
+
+      await controller.handleAuthenticationTrigger('account-group-changed');
+
+      expect(controller.state.activeAccount).toEqual({
+        account: notEnrolledCaip,
+        hasOptedIn: false,
+        subscriptionId: null,
+        perpsFeeDiscount: null,
+        lastPerpsDiscountRateFetched: null,
+      });
+      expect(
+        controller.state.activeAccount?.lastFreshOptInStatusCheck,
+      ).toBeUndefined();
+
+      getOptInStatusSpy.mockRestore();
+    });
+
+    it('falls back to performSilentAuth when bulk OIS fails', async () => {
+      const newAccount = {
+        address: '0x2222222222222222',
+        type: 'eip155:eoa' as const,
+        id: 'test-id-1',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'New Group Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+
+      mockMessenger.call.mockReturnValueOnce([newAccount]);
+      const getOptInStatusSpy = jest
+        .spyOn(controller, 'getOptInStatus')
+        .mockRejectedValue(new Error('Network error'));
+      const performSilentAuthSpy = jest
+        .spyOn(controller, 'performSilentAuth')
+        .mockResolvedValue(null);
+
+      await controller.handleAuthenticationTrigger('account-group-changed');
+
+      expect(performSilentAuthSpy).toHaveBeenCalledWith(
+        newAccount,
+        false,
+        true,
+      );
 
       getOptInStatusSpy.mockRestore();
       performSilentAuthSpy.mockRestore();

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1216,6 +1216,23 @@ export class RewardsController extends BaseController<
           const account = sortedAccounts[i];
           if (bulkOptInStatus && bulkOptInStatus[i] === false) {
             // Known not opted in — skip session mint for this account.
+            const skippedCaip = this.convertInternalAccountToCaipAccountId(
+              account as InternalAccount,
+            );
+            if (skippedCaip && !this.#getAccountState(skippedCaip)) {
+              // Seed missing state so setActiveAccountFromCandidate can run
+              // later. Do not set lastFreshOptInStatusCheck here — fresh OIS
+              // owns that timestamp.
+              this.update((state) => {
+                state.accounts[skippedCaip] = {
+                  account: skippedCaip,
+                  hasOptedIn: false,
+                  subscriptionId: null,
+                  perpsFeeDiscount: null,
+                  lastPerpsDiscountRateFetched: null,
+                };
+              });
+            }
             continue;
           }
           try {
@@ -1437,17 +1454,8 @@ export class RewardsController extends BaseController<
           });
           return null;
         }
-      } catch (error) {
-        // Opt-in status could not be determined. Treat unknown enrollment as
-        // "do not mint a session": abort silent auth instead of falling
-        // through to mobile-login, which would 401 for non-enrolled accounts
-        // and spam the backend on every account switch.
-        Logger.log(
-          'RewardsController: Failed to determine opt-in status, skipping silent auth',
-          internalAccount.address,
-          error instanceof Error ? error.message : String(error),
-        );
-        return null;
+      } catch {
+        // Continue with silent login attempt when OIS is unavailable.
       }
     }
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1195,18 +1195,29 @@ export class RewardsController extends BaseController<
       } else {
         const sortedAccounts = sortAccounts(accounts as InternalAccount[]);
 
+        let bulkOptInStatus: boolean[] | null = null;
         try {
           // Prefer to get opt in status in bulk for sorted accounts.
-          await this.getOptInStatus({
+          const bulkOptInStatusResult = await this.getOptInStatus({
             addresses: sortedAccounts.map((account) => account.address),
           });
+          bulkOptInStatus = bulkOptInStatusResult.ois ?? null;
         } catch {
           // Failed to get opt in status in bulk for sorted accounts, let silent auth do it individually
         }
 
-        // Try silent auth on each account until one succeeds
+        // Try silent auth on each account until one succeeds.
+        // When the bulk opt-in status is available, only attempt silent auth
+        // (which mints a session via mobile-login) for accounts that are
+        // opted in. This avoids spamming mobile-login with guaranteed-401
+        // requests for non-enrolled accounts on every account switch.
         let successAccount: InternalAccount | null = null;
-        for (const account of sortedAccounts) {
+        for (let i = 0; i < sortedAccounts.length; i++) {
+          const account = sortedAccounts[i];
+          if (bulkOptInStatus && bulkOptInStatus[i] === false) {
+            // Known not opted in — skip session mint for this account.
+            continue;
+          }
           try {
             const subscriptionId = await this.performSilentAuth(
               account as InternalAccount,
@@ -1426,8 +1437,17 @@ export class RewardsController extends BaseController<
           });
           return null;
         }
-      } catch {
-        // Continue with silent login attempt
+      } catch (error) {
+        // Opt-in status could not be determined. Treat unknown enrollment as
+        // "do not mint a session": abort silent auth instead of falling
+        // through to mobile-login, which would 401 for non-enrolled accounts
+        // and spam the backend on every account switch.
+        Logger.log(
+          'RewardsController: Failed to determine opt-in status, skipping silent auth',
+          internalAccount.address,
+          error instanceof Error ? error.message : String(error),
+        );
+        return null;
       }
     }
 


### PR DESCRIPTION
## **Description**

On PRD, `/auth/mobile-login` is ~98% of all rewards-api 4xx. Per-reason Prometheus counters show it's `account_not_found` (~98.7%): the app calls `mobile-login` — which *mints a session* — for non-enrolled accounts on account switch, and those 401 by design. Not token expiry; signatures/timestamps are valid.

Mobile already calls the OIS opt-in-status endpoint (`POST /public/rewards/ois`, public, clean 200s), but the gate leaks:
- `handleAuthenticationTrigger` bulk-fetches OIS on account-group switch but then silent-auths *every* account in the group without using that result.
- `performSilentAuth` could still hit `mobile-login` for accounts OIS already reported as not opted-in.

**Fix (mobile-only):**
1. Gate the account-switch loop on the bulk OIS result — skip silent auth (session mint via `mobile-login`) only when `ois[i] === false`.
2. In that bulk skip branch, seed missing `hasOptedIn: false` state inline when needed so `activeAccount` updates on switch without sliding `lastFreshOptInStatusCheck` (fresh OIS owns that timestamp).
3. When per-account OIS **throws**, fall through to `mobile-login` as on `main` (enrolled users can still get a session; bulk OIS failure falls back to per-account silent auth).

Eliminates the `account_not_found` 4xx flood for known not-enrolled accounts while preserving main-like behavior on OIS outage.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Log into a wallet with at least one Rewards-enrolled account and one or more non-enrolled accounts in the same account group.
2. Watch rewards debug logs / a network proxy.
3. Switch to a non-enrolled account → confirm the app calls `/public/rewards/ois` but does NOT call `/auth/mobile-login` for it (previously it did, returning 401).
4. Switch to an enrolled account → confirm `/auth/mobile-login` is still called and a session is minted (rewards UI shows opted-in state).
5. Simulate an OIS failure (offline/forced error) on switch → confirm the app falls back to per-account silent auth and may still call `/auth/mobile-login` (main behavior).
6. Switch from an enrolled account group to a group where no accounts are opted in → confirm rewards `activeAccount` updates to the first account in the new group with `hasOptedIn: false` (not the previous subscription).
7. Switch repeatedly between a non-enrolled group within an hour → confirm `lastFreshOptInStatusCheck` is not slid forward on each switch (cached OIS should still expire after the 1-hour threshold).

## **Screenshots/Recordings**

### **Before**

N/A — no visual change (rewards auth controller logic only).

### **After**

N/A — no visual change (rewards auth controller logic only).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rewards authentication on every account-group change; a wrong OIS gate could block enrolled users from minting sessions, though OIS failure explicitly falls back to the prior login path.
> 
> **Overview**
> **Stops calling `/auth/mobile-login` for accounts bulk OIS already marks as not opted in** when the selected account group changes, cutting the production `account_not_found` 401 noise on non-enrolled switches.
> 
> In `handleAuthenticationTrigger`, the bulk `getOptInStatus` result is now used in the silent-auth loop: accounts with `ois[i] === false` skip `performSilentAuth` (session mint). Missing per-account state is seeded as `hasOptedIn: false` so `activeAccount` can still update, **without** bumping `lastFreshOptInStatusCheck` (that stays owned by fresh OIS). If bulk OIS fails, behavior matches main—still attempts per-account silent auth / login.
> 
> Tests were expanded to cover OIS skip vs login fallback, mixed enrolled/non-enrolled groups, active-account updates when no one is opted in, and cached OIS timestamp not sliding on repeated switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b036c9f3700c0a4771f22beb2813481de76ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->