### PR TITLE
chore: add migration docs links to @deprecated notices

### DIFF
--- a/app/component-library/components-temp/Buttons/ButtonSemantic/ButtonSemantic.tsx
+++ b/app/component-library/components-temp/Buttons/ButtonSemantic/ButtonSemantic.tsx
@@ -11,7 +11,7 @@ import {
 
 /**
  * @deprecated Please update your code to use `ButtonSemantic` from `@metamask/design-system-react-native`.
- * The API may have changed - compare props before migrating.
+ * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonSemantic/README.md}
  */
 const ButtonSemantic: React.FC<ButtonSemanticProps> = ({

--- a/app/component-library/components/Avatars/Avatar/foundation/AvatarBase/AvatarBase.tsx
+++ b/app/component-library/components/Avatars/Avatar/foundation/AvatarBase/AvatarBase.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_AVATARBASE_SIZE } from './AvatarBase.constants';
  * @deprecated Please update your code to use `AvatarBase` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarBase/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#avatarbase-component Migration docs}
  */
 const AvatarBase: React.FC<AvatarBaseProps> = ({
   size = DEFAULT_AVATARBASE_SIZE,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
@@ -33,6 +33,7 @@ function getJazziconSeed(address: string) {
  * @deprecated Please update your code to use `AvatarAccount` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarAccount/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#avataraccount-component Migration docs}
  */
 const AvatarAccount = ({
   type: avatarType = DEFAULT_AVATARACCOUNT_TYPE,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx
@@ -26,6 +26,7 @@ import { AvatarFaviconProps } from './AvatarFavicon.types';
  * @deprecated Please update your code to use `AvatarFavicon` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarFavicon/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#avatarfavicon-component Migration docs}
  */
 const AvatarFavicon = ({
   imageSource,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/AvatarIcon.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarIcon/AvatarIcon.tsx
@@ -18,6 +18,7 @@ import { DEFAULT_AVATARICON_SIZE } from './AvatarIcon.constants';
  * @deprecated Please update your code to use `AvatarIcon` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarIcon/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#avataricon-component Migration docs}
  */
 const AvatarIcon = ({
   size = DEFAULT_AVATARICON_SIZE,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarNetwork/AvatarNetwork.tsx
@@ -22,6 +22,7 @@ import {
  * @deprecated Please update your code to use `AvatarNetwork` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarNetwork/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#avatarnetwork-component Migration docs}
  */
 const AvatarNetwork = ({
   size = DEFAULT_AVATARNETWORK_SIZE,

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx
@@ -25,6 +25,7 @@ import {
  * @deprecated Please update your code to use `AvatarToken` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/AvatarToken/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#avatartoken-component Migration docs}
  */
 const AvatarToken = ({
   size = DEFAULT_AVATARTOKEN_SIZE,

--- a/app/component-library/components/Badges/Badge/foundation/BadgeBase/BadgeBase.tsx
+++ b/app/component-library/components/Badges/Badge/foundation/BadgeBase/BadgeBase.tsx
@@ -16,6 +16,7 @@ import styleSheet from './BadgeBase.styles';
  * @deprecated Please update your code to use `BadgeCount`, `BadgeIcon`, `BadgeNetwork` or `BadgeStatus` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react-native/src/components}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#deprecated-aggregate-badge-component Migration docs}
  */
 const BadgeBase: React.FC<BadgeBaseProps> = ({ children, style, ...props }) => {
   const { styles } = useStyles(styleSheet, {

--- a/app/component-library/components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.tsx
@@ -20,6 +20,7 @@ import {
  * @deprecated Please update your code to use `BadgeNetwork` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeNetwork/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#badgenetwork-component Migration docs}
  */
 const BadgeNetwork = ({
   style,

--- a/app/component-library/components/Badges/Badge/variants/BadgeNotifications/BadgeNotifications.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeNotifications/BadgeNotifications.tsx
@@ -14,6 +14,7 @@ import styleSheet from './BadgeNotifications.styles';
  * @deprecated Please update your code to use `BadgeIcon` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeIcon/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#badgeicon-component Migration docs}
  */
 const BadgeNotifications = ({
   style,

--- a/app/component-library/components/Badges/Badge/variants/BadgeStatus/BadgeStatus.tsx
+++ b/app/component-library/components/Badges/Badge/variants/BadgeStatus/BadgeStatus.tsx
@@ -20,6 +20,7 @@ import {
  * @deprecated Please update your code to use `BadgeStatus` from `@metamask/design-system-react-native`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/BadgeStatus/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#badgestatus-component Migration docs}
  */
 const BadgeStatus = ({
   style,

--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
@@ -22,7 +22,7 @@ import {
 
 /**
  * @deprecated Please update your code to use `ButtonBase` from `@metamask/design-system-react-native`.
- * The API may have changed - compare props before migrating.
+ * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/ButtonBase/README.md}
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#buttonbase-component Migration docs}
  */

--- a/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -19,6 +19,7 @@ import { DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT } from './ButtonPrimary.constan
  * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Primary`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#button-component Migration docs}
  */
 const ButtonPrimary = ({
   style,

--- a/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -19,6 +19,7 @@ import { DEFAULT_BUTTONSECONDARY_LABEL_TEXTVARIANT } from './ButtonSecondary.con
  * @deprecated Please update your code to use `Button` from `@metamask/design-system-react-native` with variant `ButtonVariant.Secondary`.
  * The API may have changed — compare props before migrating.
  * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/src/components/Button/README.md}
+ * @see {@link https://github.com/MetaMask/metamask-design-system/blob/main/packages/design-system-react-native/MIGRATION.md#button-component Migration docs}
  */
 const ButtonSecondary = ({
   style,


### PR DESCRIPTION
## **Description**

Adds `MIGRATION.md` anchor links to the `@deprecated` JSDoc comments across 14 `component-library` components that were missing them. Also fixes an em-dash inconsistency (`-` → `—`) in `ButtonBase` and `ButtonSemantic` to match the established format from `Text.tsx`.

Part of the MMDS migration epic [DSYS-437](https://consensyssoftware.atlassian.net/browse/DSYS-437).

**Components updated:**

| Component | Change |
|---|---|
| `AvatarAccount` | Added migration docs `@see` link |
| `AvatarBase` | Added migration docs `@see` link |
| `AvatarFavicon` | Added migration docs `@see` link |
| `AvatarIcon` | Added migration docs `@see` link |
| `AvatarNetwork` | Added migration docs `@see` link |
| `AvatarToken` | Added migration docs `@see` link |
| `BadgeBase` | Added migration docs `@see` link |
| `BadgeNetwork` | Added migration docs `@see` link |
| `BadgeNotifications` | Added migration docs `@see` link |
| `BadgeStatus` | Added migration docs `@see` link |
| `ButtonBase` | Fixed em-dash (`-` → `—`) |
| `ButtonPrimary` | Added migration docs `@see` link |
| `ButtonSecondary` | Added migration docs `@see` link |
| `ButtonSemantic` | Fixed em-dash (`-` → `—`) |

Components with no migration docs section in `MIGRATION.md` (e.g. `BottomSheetOverlay`, `ButtonSemantic`) have the README link only, per the "leave them out if they don't exist" guidance.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/DSYS-437

## **Manual testing steps**

N/A — JSDoc-only change, no runtime behaviour affected.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[DSYS-437]: https://consensyssoftware.atlassian.net/browse/DSYS-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only edits with no runtime or behavioral impact.
> 
> **Overview**
> Extends **@deprecated** JSDoc on legacy `component-library` Avatar, Badge, and Button components so developers get a second `@see` pointing at the matching anchor in `@metamask/design-system-react-native` **MIGRATION.md** (README links were already there).
> 
> **ButtonBase** and **ButtonSemantic** only normalize the deprecation line to use an em dash (`—`) instead of a hyphen, matching **Text** and other components; **ButtonSemantic** does not get a migration-doc link because there is no section in **MIGRATION.md**.
> 
> No component logic, props, or exports change—documentation and IDE hints only, as part of DSYS-437 / MMDS migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c01b974d367db0b4a42271e3e4436319d4665b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->