### PR TITLE
feat(PerpsSection): add dynamic padding based on content state

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -364,6 +364,9 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       return null;
     }
 
+    const shouldAddContentTopGap =
+      !showHomepageUnrealizedPnl && !shouldShowPillsEmptyState;
+
     const sectionContent = (
       <>
         <SectionDivider />
@@ -372,9 +375,8 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
           isInteractive
           onPress={handleViewAllPerps}
           testID={homepageSectionTitleTestId(analyticsName)}
-          twClassName="pb-1"
         />
-        <Box gap={3}>
+        <Box gap={3} paddingTop={shouldAddContentTopGap ? 3 : undefined}>
           {showHomepageUnrealizedPnl && (
             <HomepageSectionUnrealizedPnlRow
               isLoading={perpsAccountLoading}

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionTrendingOnly.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionTrendingOnly.tsx
@@ -86,19 +86,21 @@ const PerpsSectionTrendingOnly = forwardRef<
             onPress={handleViewAllPerps}
             testID={homepageSectionTitleTestId(analyticsName)}
           />
-          {marketsLoading ? (
-            <SectionRow>
-              <PerpsPositionSkeleton />
-            </SectionRow>
-          ) : (
-            <PerpsTrendingCarousel
-              markets={allCarouselMarkets}
-              watchlistSymbolSet={watchlistSymbolSet}
-              sparklines={sparklines}
-              onPressMarket={handleTilePress}
-              onPressViewMore={handleViewMorePerps}
-            />
-          )}
+          <Box paddingTop={3}>
+            {marketsLoading ? (
+              <SectionRow>
+                <PerpsPositionSkeleton />
+              </SectionRow>
+            ) : (
+              <PerpsTrendingCarousel
+                markets={allCarouselMarkets}
+                watchlistSymbolSet={watchlistSymbolSet}
+                sparklines={sparklines}
+                onPressMarket={handleTilePress}
+                onPressViewMore={handleViewMorePerps}
+              />
+            )}
+          </Box>
         </Box>
       </View>
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes missing vertical spacing between the Perps section header and the empty-state Perps cards on the wallet homepage.

The previous layout relied on header padding / container gaps that did not affect the rendered empty-state carousel in all Perps homepage modes. This PR adds explicit `paddingTop={3}` to the content immediately below the Perps section header for both the default Perps section and the trending-only Perps section, restoring the intended 12px gap without reintroducing vertical padding inside the horizontal carousel itself.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed missing spacing above Perps cards on the wallet homepage

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-911

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet homepage Perps section spacing

  Scenario: user views the Perps empty state on the wallet homepage
    Given Perps is enabled
    And the selected account has no open Perps positions or orders
    And Perps empty-state cards are visible on the wallet homepage

    When user views the Perps section
    Then there is a 12px gap between the Perps section header and the Perps cards
    And the horizontal Perps carousel does not have extra vertical padding inside the card rail

  Scenario: user views the trending-only Perps section
    Given the homepage separate trending treatment is active
    And trending Perps cards are visible on the wallet homepage

    When user views the Trending Perpetuals section
    Then there is a 12px gap between the section header and the Perps cards
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="394" height="265" alt="Screenshot 2026-06-23 at 11 39 37" src="https://github.com/user-attachments/assets/cc68df9a-b3e5-4240-91f2-e3dd99125ab4" />

<!-- [screenshots/recordings] -->

### **After**
<img width="396" height="285" alt="Screenshot 2026-06-23 at 11 31 22" src="https://github.com/user-attachments/assets/284608d7-db7c-4a7c-974f-aebbf39ecf45" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only spacing changes in homepage Perps sections with no logic, data, or security impact.
> 
> **Overview**
> Fixes missing vertical space between the Perps section header and the card rail on the wallet homepage by moving spacing from the header onto the content block below it.
> 
> In **`PerpsSectionMain`**, removes `SectionHeader` bottom padding (`pb-1`) and applies **`paddingTop={3}`** on the inner `Box` only when neither the unrealized PnL row nor the pills empty state is shown—so trending/empty carousel layouts get a 12px gap without double spacing when those rows are visible.
> 
> In **`PerpsSectionTrendingOnly`**, wraps the skeleton/carousel block in a **`Box` with `paddingTop={3}`** so the trending-only section matches the same header-to-cards gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 191c1c44c901cf850371854680cc67f64ad8d19f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->