### PR TITLE
fix: swap ARC prevent native pre-select

### DIFF
--- a/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
+++ b/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
@@ -7,6 +7,11 @@ import {
 import { BridgeToken } from '../types';
 import { CaipAssetType, Hex } from '@metamask/utils';
 import { NETWORK_CHAIN_ID } from '../../../../util/networks/customNetworks';
+import {
+  ARC_CAIP_CHAIN_ID,
+  ARC_HEX_CHAIN_ID,
+  ARC_USDC_BRIDGE_TOKEN,
+} from '../../../../enablement/assets/arc';
 
 /**
  * Per-chain swap destination configuration.
@@ -26,6 +31,13 @@ interface ChainSwapDestConfig {
    */
   [sourceAddress: Hex | CaipChainId]: BridgeToken;
 }
+
+export const BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN: {
+  [key: `0x${string}` | `${string}:${string}`]: BridgeToken;
+} = {
+  [ARC_HEX_CHAIN_ID]: ARC_USDC_BRIDGE_TOKEN,
+  [ARC_CAIP_CHAIN_ID]: ARC_USDC_BRIDGE_TOKEN,
+};
 
 export const DefaultSwapDestTokens: Partial<
   Record<Hex | CaipChainId, ChainSwapDestConfig>

--- a/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
+++ b/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
@@ -32,7 +32,7 @@ interface ChainSwapDestConfig {
   [sourceAddress: Hex | CaipChainId]: BridgeToken;
 }
 
-export const BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN: {
+export const BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN: {
   [key: Hex | CaipChainId]: BridgeToken;
 } = {
   [ARC_HEX_CHAIN_ID]: ARC_USDC_BRIDGE_TOKEN,

--- a/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
+++ b/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
@@ -33,7 +33,7 @@ interface ChainSwapDestConfig {
 }
 
 export const BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN: {
-  [key: `0x${string}` | `${string}:${string}`]: BridgeToken;
+  [key: Hex | CaipChainId]: BridgeToken;
 } = {
   [ARC_HEX_CHAIN_ID]: ARC_USDC_BRIDGE_TOKEN,
   [ARC_CAIP_CHAIN_ID]: ARC_USDC_BRIDGE_TOKEN,

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/tokenUtils';
 import { areAddressesEqual } from '../../../../../util/address';
 import { BridgeToken } from '../../types';
+import { BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN } from '../../constants/default-swap-dest-tokens';
 
 /**
  * Hook that provides a function to auto-update the destination token when the source changes.
@@ -79,7 +80,10 @@ export const useAutoUpdateDestToken = () => {
         // Fall back to native token if:
         // 1. No default dest token exists for this chain, OR
         // 2. Default dest equals source token
-        expectedDestToken = nativeToken;
+        // 3. No default "from" token is defined in BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN.
+        const defaultFromToken =
+          BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN[newSourceToken.chainId];
+        expectedDestToken = defaultFromToken ?? nativeToken;
       }
 
       // Only dispatch if expected dest is different from current dest

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
@@ -80,7 +80,7 @@ export const useAutoUpdateDestToken = () => {
         // Fall back to native token if:
         // 1. No default dest token exists for this chain, OR
         // 2. Default dest equals source token
-        // 3. No default "from" token is defined in BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN.
+        // 3. No default "source" token is defined in BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN.
         const defaultSourceToken =
           BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN[newSourceToken.chainId];
         expectedDestToken = defaultSourceToken ?? nativeToken;

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/index.ts
@@ -13,7 +13,7 @@ import {
 } from '../../utils/tokenUtils';
 import { areAddressesEqual } from '../../../../../util/address';
 import { BridgeToken } from '../../types';
-import { BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN } from '../../constants/default-swap-dest-tokens';
+import { BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN } from '../../constants/default-swap-dest-tokens';
 
 /**
  * Hook that provides a function to auto-update the destination token when the source changes.
@@ -81,9 +81,9 @@ export const useAutoUpdateDestToken = () => {
         // 1. No default dest token exists for this chain, OR
         // 2. Default dest equals source token
         // 3. No default "from" token is defined in BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN.
-        const defaultFromToken =
-          BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN[newSourceToken.chainId];
-        expectedDestToken = defaultFromToken ?? nativeToken;
+        const defaultSourceToken =
+          BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN[newSourceToken.chainId];
+        expectedDestToken = defaultSourceToken ?? nativeToken;
       }
 
       // Only dispatch if expected dest is different from current dest

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/useAutoUpdateDestToken.test.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/useAutoUpdateDestToken.test.ts
@@ -12,6 +12,7 @@ import { BtcScope, SolScope } from '@metamask/keyring-api';
 import * as bridgeSlice from '../../../../../core/redux/slices/bridge';
 // eslint-disable-next-line import-x/no-namespace
 import * as tokenUtils from '../../utils/tokenUtils';
+import { ARC_HEX_CHAIN_ID } from '../../../../../enablement/assets/arc';
 
 describe('useAutoUpdateDestToken', () => {
   const mockEthToken: BridgeToken = {
@@ -276,6 +277,55 @@ describe('useAutoUpdateDestToken', () => {
           symbol: 'ETH',
           chainId: ethChainId,
           address: '0x0000000000000000000000000000000000000000',
+        }),
+      );
+    });
+
+    it('updates dest to default from token when source changes to match default dest and default from token is defined (ARC)', () => {
+      const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');
+
+      // Current dest is the default EURC
+      const eurcTokenOnArc: BridgeToken = {
+        address: '0xbEf5f6d51CB62b58e6A8f77868681825C6fe21c1',
+        symbol: 'EURC',
+        name: 'EURC',
+        decimals: 6,
+        chainId: ARC_HEX_CHAIN_ID,
+      };
+
+      // New source is also EURC (conflicts with dest)
+      const eurcTokenOnArcSource: BridgeToken = {
+        address: '0xbEf5f6d51CB62b58e6A8f77868681825C6fe21c1',
+        symbol: 'EURC',
+        name: 'EURC',
+        decimals: 6,
+        chainId: ARC_HEX_CHAIN_ID,
+      };
+
+      const { result } = renderHookWithProvider(
+        () => useAutoUpdateDestToken(),
+        {
+          state: {
+            ...initialState,
+            bridge: {
+              ...initialState.bridge,
+              destToken: eurcTokenOnArc,
+              isDestTokenManuallySet: false,
+            },
+          },
+        },
+      );
+
+      // Change source to EURC (same as current dest)
+      result.current.autoUpdateDestToken(eurcTokenOnArcSource);
+
+      // Dest should update to native USDC (the ERC20 version) since source now conflicts with default
+      // and a corresponding entry is defined in BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN.
+      expect(setDestTokenSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'USDC',
+          chainId: ARC_HEX_CHAIN_ID,
+          address: '0x3600000000000000000000000000000000000000',
         }),
       );
     });

--- a/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/useAutoUpdateDestToken.test.ts
+++ b/app/components/UI/Bridge/hooks/useAutoUpdateDestToken/useAutoUpdateDestToken.test.ts
@@ -59,6 +59,10 @@ describe('useAutoUpdateDestToken', () => {
     jest.clearAllMocks();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('when source chain changes and dest was not manually set', () => {
     it('updates dest token to default for new source chain', () => {
       const setDestTokenSpy = jest.spyOn(bridgeSlice, 'setDestToken');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Context:

On ARC, we want to avoid the case where the native version of USDC is being selected as "from" and "to" token.
Although this has been addressed already in the "go to swap" routes and the "source token" pre-selection, the logic was missing from the "destination token" autoselection in some particular cases.

This is a similar fix as what was done [for Extension](https://github.com/MetaMask/metamask-extension/blob/57b834d9eb930c765c98cb6c13013a32e3aa38ac/shared/constants/bridge.ts#L146-L155).

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: swap ARC prevent native pre-selec

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/WPN-1450

## **Manual testing steps**

- Go on Arc native USDC token page.
- Tap Swap CTA to reach [USDC -> EURC] view.
- Click [USDC] to pick [EURC]
- Verify that the widget becomes [EURC -> USDC] and not [EURC -> USDC-native]
- Verify as many similar flows as possible to check that the selector nevers selects `USDC-native` as "from" or "to" token.

<!-- mms-check: type=manual-testing required=true -->


## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c01bd329-c6d1-4b4d-b033-e5300df765a5" />


### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bridge/swap token pre-selection change on ARC with unit test coverage; no auth, payments, or broad routing changes.
> 
> **Overview**
> Fixes **ARC swap** flows where changing the source token could auto-select **native USDC** as the destination when the default destination (e.g. EURC) matches the new source.
> 
> Adds **`BRIDGE_CHAINID_TO_DEFAULT_SOURCE_TOKEN`** for ARC (hex and CAIP chain IDs) pointing at **`ARC_USDC_BRIDGE_TOKEN`**, aligned with the Extension bridge constants. **`useAutoUpdateDestToken`** now uses that map in the existing “default dest conflicts with source” fallback instead of always using **`getNativeSourceToken`**, so pairs like **EURC → USDC (ERC20)** stay correct instead of **EURC → USDC-native**.
> 
> Includes a hook unit test for the ARC conflict case and **`jest.restoreAllMocks`** in **`afterEach`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5071f1dc140a9f2c711ae125bdd86f1cdb4e00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->