### PR TITLE
chore(rewards): cache VIP dashboard fetch for 5 minutes

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7281,7 +7281,7 @@ describe('RewardsController', () => {
       ...overrides,
     });
 
-    it('bypasses the cache (TTL=0) and refetches on any time advance', async () => {
+    it('returns the cached VIP dashboard within the TTL window without refetching', async () => {
       const cachedState: VipDashboardState = {
         ...createMockVIPDashboard({
           currentTier: {
@@ -7307,19 +7307,54 @@ describe('RewardsController', () => {
 
       mockMessenger.call.mockResolvedValue(apiDashboard);
 
-      // First call: cache has lastFetched=100, Date.now()=123 → stale (delta>0) → fetch.
-      const first = await controller.getVIPDashboard(mockSubscriptionId);
-      // Advance the clock so the just-written cache entry (lastFetched=123) is also stale.
-      jest.spyOn(Date, 'now').mockReturnValue(124);
-      const second = await controller.getVIPDashboard(mockSubscriptionId);
+      // cache lastFetched=100, Date.now()=123 → delta 23ms < 5min TTL → fresh → no fetch.
+      const result = await controller.getVIPDashboard(mockSubscriptionId);
 
-      expect(first).toEqual({ ...apiDashboard, lastFetched: 123 });
-      expect(second).toEqual({ ...apiDashboard, lastFetched: 124 });
+      expect(result).toEqual(cachedState);
       expect(
         mockMessenger.call.mock.calls.filter(
           ([method]) => method === 'RewardsDataService:getVIPDashboard',
         ),
-      ).toHaveLength(2);
+      ).toHaveLength(0);
+    });
+
+    it('refetches the VIP dashboard once the TTL window has expired', async () => {
+      const cachedState: VipDashboardState = {
+        ...createMockVIPDashboard({
+          currentTier: {
+            id: 'mock-tier-alpha-2',
+            name: 'Mock Tier Alpha 2',
+            tier: 2,
+          },
+        }),
+        lastFetched: 100,
+      };
+      const apiDashboard = createMockVIPDashboard();
+
+      controller = new RewardsController({
+        messenger: mockMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          vipDashboard: {
+            [mockSubscriptionId]: cachedState,
+          },
+        },
+        isDisabled: () => false,
+      });
+
+      mockMessenger.call.mockResolvedValue(apiDashboard);
+
+      // Advance the clock past the 5-minute TTL so the cached entry is stale.
+      const now = 100 + 1000 * 60 * 5 + 1;
+      jest.spyOn(Date, 'now').mockReturnValue(now);
+      const result = await controller.getVIPDashboard(mockSubscriptionId);
+
+      expect(result).toEqual({ ...apiDashboard, lastFetched: now });
+      expect(
+        mockMessenger.call.mock.calls.filter(
+          ([method]) => method === 'RewardsDataService:getVIPDashboard',
+        ),
+      ).toHaveLength(1);
     });
 
     it('fetches fresh VIP dashboard when cache is empty', async () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -119,8 +119,9 @@ const REFERRAL_DETAILS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minutes
 // Benefits details cache threshold
 const BENEFITS_DETAILS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minutes
 
-// VIP dashboard cache threshold — disabled while backend still serves hardcoded data
-const VIP_DASHBOARD_CACHE_THRESHOLD_MS = 0;
+// VIP dashboard cache threshold — re-fetched on every dashboard screen focus,
+// so cache for 5 minutes to avoid redundant backend calls.
+const VIP_DASHBOARD_CACHE_THRESHOLD_MS = 1000 * 60 * 5;
 
 // VIP perps fees cache threshold — read on every perps trade UI render, so
 // cache for the same 5-minute window as the legacy public-discount path.


### PR DESCRIPTION
## **Description**

The VIP dashboard is re-fetched on **every** dashboard screen focus — `useVipDashboard` calls `RewardsController:getVIPDashboard` inside a `useFocusEffect` — but `VIP_DASHBOARD_CACHE_THRESHOLD_MS` was `0`, so each focus resulted in a fresh backend call. The `0` was a placeholder ("disabled while backend still serves hardcoded data").

This PR sets the threshold to **5 minutes**, matching the existing `VIP_PERPS_FEES_CACHE_THRESHOLD_MS` window, so repeated focus events on the VIP dashboard no longer hit the backend every time.

Notes:
- The same constant is shared by `getVIPDashboard` and `getVipRefereeDashboard`, so both surfaces are cached for the same 5-minute window.
- Caching is safe for the tap-to-unlock easter egg: `null` / not-VIP responses are **never** written to the cache (`writeCache` deletes the entry when the payload is null), so a non-VIP tap always re-fetches. Only already-VIP (non-null) dashboards get cached, and for those the easter egg is already a no-op.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Sign in with a VIP-eligible account and open the Rewards VIP dashboard.
2. Navigate away and back to the dashboard several times within 5 minutes.
3. Observe (via network logs / `RewardsController` logs) that `RewardsDataService:getVIPDashboard` is only called once within the window, then again after 5 minutes.
4. With a non-VIP account, confirm the 5-tap title easter egg still triggers a fresh fetch each attempt (null responses are not cached).

## **Screenshots/Recordings**

### **Before**

N/A — no visual change (caching/timing only).

### **After**

N/A — no visual change (caching/timing only).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timing-only rewards caching with existing null-response handling; no auth or payment paths changed.
> 
> **Overview**
> Re-enables VIP dashboard caching by setting **`VIP_DASHBOARD_CACHE_THRESHOLD_MS`** from `0` to **5 minutes**, aligned with **`VIP_PERPS_FEES_CACHE_THRESHOLD_MS`**. That constant drives **`wrapWithCache`** for both **`getVIPDashboard`** and **`getVipRefereeDashboard`**, so repeated screen-focus refetches within the window no longer call **`RewardsDataService:getVIPDashboard`** on every visit.
> 
> Tests now assert a **fresh cache hit** (no messenger call) inside the TTL and a **single refetch** after the window expires, replacing the old behavior that treated every call as stale when TTL was zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4b3c7e48218135fe5c2c7656b4658dcff357c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->