### PR TITLE
chore: align weekly top traders carousel spacing with homepage sections

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -290,7 +290,7 @@ const TopTradersSection = forwardRef<
           onPress={handleViewAll}
           testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('top-traders')}
         />
-        <Box paddingTop={2}>
+        <Box paddingTop={3}>
           {showSkeletons ? (
             <ScrollView
               horizontal

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -290,30 +290,32 @@ const TopTradersSection = forwardRef<
           onPress={handleViewAll}
           testID={WalletViewSelectorsIDs.HOMEPAGE_SECTION_TITLE('top-traders')}
         />
-        {showSkeletons ? (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={tw.style('px-4 gap-3')}
-            testID="homepage-top-traders-carousel"
-          >
-            {SKELETON_KEYS.map((key) => (
-              <TopTraderCardSkeleton key={key} />
-            ))}
-          </ScrollView>
-        ) : (
-          <FlatList
-            horizontal
-            data={carouselData}
-            renderItem={renderCarouselItem}
-            keyExtractor={keyExtractor}
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={tw.style('px-4 gap-3 items-stretch')}
-            testID="homepage-top-traders-carousel"
-            viewabilityConfig={viewabilityConfig}
-            onViewableItemsChanged={onViewableItemsChanged}
-          />
-        )}
+        <Box paddingTop={2}>
+          {showSkeletons ? (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={tw.style('px-4 gap-3')}
+              testID="homepage-top-traders-carousel"
+            >
+              {SKELETON_KEYS.map((key) => (
+                <TopTraderCardSkeleton key={key} />
+              ))}
+            </ScrollView>
+          ) : (
+            <FlatList
+              horizontal
+              data={carouselData}
+              renderItem={renderCarouselItem}
+              keyExtractor={keyExtractor}
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={tw.style('px-4 gap-3 items-stretch')}
+              testID="homepage-top-traders-carousel"
+              viewabilityConfig={viewabilityConfig}
+              onViewableItemsChanged={onViewableItemsChanged}
+            />
+          )}
+        </Box>
       </Box>
     </View>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Weekly Top Traders carousel on the homepage sat too close to its section header compared with neighboring sections. Those sections use a 12px (`paddingTop={3}` / `py-3`) gap between the header and content.
Wrapped the Top Traders carousel (loaded `FlatList` and loading skeleton `ScrollView`) in a `Box` with `paddingTop={3}` so the spacing matches the rest of the homepage.

<img height="810" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-23 at 12 23 05" src="https://github.com/user-attachments/assets/3783c5b6-cc59-497d-bb46-7aa25db315bf" />

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage Weekly Top Traders section spacing
  Background:
    Given I am logged into MetaMask Mobile
    And the Social Leaderboard feature flag is enabled
    And the homepage has loaded with the Weekly Top Traders section visible
  Scenario: user views Weekly Top Traders spacing on the homepage
    Given I am on the Wallet home screen
    And the Weekly Top Traders section is rendered with trader cards
    When user scrolls to the Weekly Top Traders section
    Then the gap between the "Weekly Top Traders" header and the carousel cards should match the spacing used in adjacent sections such as Predictions

```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout spacing in one homepage section with no logic, data, or navigation changes.
> 
> **Overview**
> Adds **12px top padding** between the Weekly Top Traders **section header** and its horizontal carousel so the gap matches neighboring homepage sections (e.g. Predictions).
> 
> The change wraps both the loading **skeleton** `ScrollView` and the loaded **`FlatList`** in a `Box` with `paddingTop={3}`; carousel behavior and test IDs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bef2b1708f0c3e9f225368b72b947891730b3bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->