### PR TITLE
feat(networks): add Polygon mainnet chain ID check and update deletion logic

### DIFF
--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -244,6 +244,9 @@ export const isLineaMainnet = (networkType) => networkType === LINEA_MAINNET;
 export const isLineaMainnetChainId = (chainId) =>
   chainId === CHAIN_IDS.LINEA_MAINNET;
 
+export const isPolygonMainnetChainId = (chainId) =>
+  chainId === NETWORKS_CHAIN_ID.POLYGON;
+
 export const isMonadMainnetChainId = (chainId) => chainId === CHAIN_IDS.MONAD;
 
 export const isSolanaMainnet = (chainId) => chainId === SolScope.Mainnet;
@@ -348,7 +351,7 @@ export const isTestNet = (chainId) => TESTNET_CHAIN_IDS.includes(chainId);
 
 /**
  * Returns whether the network can be deleted by the user.
- * Aligns with NetworkSelector: mainnet, Linea mainnet, and testnets cannot be removed.
+ * Aligns with NetworkSelector: default networks and testnets cannot be removed.
  *
  * @param {string} chainId - The chain ID to check (e.g. '0x1', '0x89').
  * @returns {boolean} True if the network can be deleted, false otherwise.
@@ -359,6 +362,7 @@ export const canDeleteNetwork = (chainId) =>
       !isTestNet(chainId) &&
       !isMainNet(chainId) &&
       !isLineaMainnetChainId(chainId) &&
+      !isPolygonMainnetChainId(chainId) &&
       !isMonadMainnetChainId(chainId),
   );
 

--- a/app/util/networks/index.test.ts
+++ b/app/util/networks/index.test.ts
@@ -177,6 +177,9 @@ describe('network-utils', () => {
     it('returns false for Linea mainnet', () => {
       expect(canDeleteNetwork(NETWORKS_CHAIN_ID.LINEA_MAINNET)).toBe(false);
     });
+    it('returns false for Polygon mainnet', () => {
+      expect(canDeleteNetwork(NETWORKS_CHAIN_ID.POLYGON)).toBe(false);
+    });
     it('returns false for Goerli', () => {
       expect(canDeleteNetwork(NETWORKS_CHAIN_ID.GOERLI)).toBe(false);
     });
@@ -188,9 +191,6 @@ describe('network-utils', () => {
     );
     it('returns false for empty/falsy chainId', () => {
       expect(canDeleteNetwork('')).toBe(false);
-    });
-    it('returns true for custom mainnet (e.g. Polygon)', () => {
-      expect(canDeleteNetwork(NETWORKS_CHAIN_ID.POLYGON)).toBe(true);
     });
     it('returns true for custom chain ID 0x2a', () => {
       expect(canDeleteNetwork('0x2a')).toBe(true);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR prevents Polygon mainnet from being deleted by the user, matching the existing behavior for Ethereum mainnet, Linea mainnet, Monad mainnet, and testnets.

The change adds Polygon mainnet to the shared `canDeleteNetwork` guard in `app/util/networks/index.js`, so any UI using that guard no longer shows the delete affordance for Polygon. Unit coverage was updated to assert Polygon mainnet is non-deletable while custom mainnets remain deletable.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that showed the delete option for Polygon network.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-707
https://github.com/MetaMask/metamask-mobile/issues/29485
## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Network deletion guard

  Scenario: Polygon mainnet cannot be deleted from network management
    Given Polygon mainnet is available in the network list
    When the user opens the Polygon mainnet overflow menu or details screen
    Then the delete option is not shown

  Scenario: Custom mainnets can still be deleted
    Given a custom mainnet with chain ID 0x2a is added
    When the user opens the custom network overflow menu or details screen
    Then the delete option is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="398" height="832" alt="Screenshot 2026-06-23 at 13 20 17" src="https://github.com/user-attachments/assets/defda0f4-a9fa-4c58-8397-0b32dd003a6a" />

<!-- [screenshots/recordings] -->

### **After**
<img width="393" height="830" alt="Screenshot 2026-06-23 at 13 15 04" src="https://github.com/user-attachments/assets/3028360e-fb41-43b2-ad8b-8f2cf55241bd" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to network deletion guards with updated unit tests; no auth, funds, or RPC logic touched.
> 
> **Overview**
> **Polygon mainnet** is now treated like other built-in mainnets (Ethereum, Linea, Monad): users can no longer delete it from network management.
> 
> The shared `canDeleteNetwork` guard in `app/util/networks/index.js` gains `isPolygonMainnetChainId` and excludes Polygon (`NETWORKS_CHAIN_ID.POLYGON`), so **NetworkSelector** overflow menus and **NetworkDetailsView** no longer show delete for Polygon. JSDoc for that helper is updated to say **default networks** (not only named mainnets) are protected. Unit tests now expect Polygon to be non-deletable and drop the old case that treated it as a deletable custom mainnet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770a6dba365da09f0232c718a4f54387003b38a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->