### PR TITLE
fix(money): fix incorrect token and chain display on money account transaction details view for `perpsWithdraw` and `predictWithdraw` transactions cp-8.0.0

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -386,6 +386,52 @@ describe('TransactionDetailsHero', () => {
       expect(getByText(/\+123\.46 TST/)).toBeDefined();
     });
 
+    it('renders two-asset hero for perpsWithdraw with USDC as sent and mUSD as received', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.perpsWithdraw,
+          metamaskPay: {
+            tokenAddress: TOKEN_ADDRESS_MOCK,
+            chainId: CHAIN_ID_MOCK,
+            targetFiat: '50.00',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText('You sent')).toBeDefined();
+      expect(
+        getByText(new RegExp(`-123\\.46 ${ARBITRUM_USDC.symbol}`)),
+      ).toBeDefined();
+      expect(getByText('You received')).toBeDefined();
+      expect(getByText(/\+50\.00 mUSD/)).toBeDefined();
+    });
+
+    it('renders two-asset hero for predictWithdraw with pUSD as sent and mUSD as received', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.predictWithdraw,
+          metamaskPay: {
+            tokenAddress: TOKEN_ADDRESS_MOCK,
+            chainId: CHAIN_ID_MOCK,
+            targetFiat: '10.00',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText('You sent')).toBeDefined();
+      expect(
+        getByText(new RegExp(`-123\\.46 ${POLYGON_PUSD.symbol}`)),
+      ).toBeDefined();
+      expect(getByText('You received')).toBeDefined();
+      expect(getByText(/\+10\.00 mUSD/)).toBeDefined();
+    });
+
     it('renders fiat deposit hero with green + prefix for moneyAccountDeposit with fiat orderId', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -290,6 +290,26 @@ const RECEIVED_OVERRIDE: Partial<
   },
 };
 
+/**
+ * For perpsWithdraw / predictWithdraw, metamaskPay contains the *destination*
+ * token (mUSD on Monad), but the source is always the service's native token.
+ * Override the sent data so the hero correctly shows the actual source asset.
+ */
+const SENT_OVERRIDE: Partial<
+  Record<TransactionType, Omit<TokenDisplayData, 'amount'>>
+> = {
+  [TransactionType.perpsWithdraw]: {
+    symbol: ARBITRUM_USDC.symbol,
+    address: ARBITRUM_USDC.address,
+    chainId: CHAIN_IDS.ARBITRUM as Hex,
+  },
+  [TransactionType.predictWithdraw]: {
+    symbol: POLYGON_PUSD.symbol,
+    address: POLYGON_PUSD.address,
+    chainId: CHAIN_IDS.POLYGON as Hex,
+  },
+};
+
 function resolveTwoAssetData(
   transactionMeta: TransactionMeta,
   sentData: TokenDisplayData,
@@ -298,9 +318,21 @@ function resolveTwoAssetData(
   const isOutbound = hasTransactionType(transactionMeta, [
     TransactionType.moneyAccountWithdraw,
   ]);
-  return isOutbound
-    ? { sent: receivedData, received: sentData }
-    : { sent: sentData, received: receivedData };
+
+  if (isOutbound) {
+    return { sent: receivedData, received: sentData };
+  }
+
+  for (const [type, override] of Object.entries(SENT_OVERRIDE)) {
+    if (hasTransactionType(transactionMeta, [type as TransactionType])) {
+      return {
+        sent: { amount: sentData.amount, ...override },
+        received: receivedData,
+      };
+    }
+  }
+
+  return { sent: sentData, received: receivedData };
 }
 
 function toDisplay(

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.test.tsx
@@ -201,4 +201,31 @@ describe('ReceiveSummaryLine', () => {
       ),
     ).toBeDefined();
   });
+
+  it('renders perps withdraw title with mUSD and destination network', () => {
+    useNetworkNameMock.mockImplementation((chainId?: Hex) =>
+      chainId === '0xmonad' ? 'Monad' : 'Arbitrum',
+    );
+
+    const { getByText } = render({
+      id: 'tx-id',
+      chainId: '0xa4b1' as Hex,
+      hash: '0x123',
+      submittedTime: 1755719285723,
+      type: TransactionType.perpsWithdraw,
+      metamaskPay: {
+        chainId: '0xmonad' as Hex,
+        tokenAddress: '0xmusd' as Hex,
+      },
+    } as Partial<TransactionMeta>);
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_receive', {
+          targetSymbol: 'mUSD',
+          targetChain: 'Monad',
+        }),
+      ),
+    ).toBeDefined();
+  });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/receive-summary-line.tsx
@@ -36,6 +36,10 @@ export function ReceiveSummaryLine({
     TransactionType.predictWithdraw,
   ]);
 
+  const isPerpsWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+  ]);
+
   const targetNetworkName = useNetworkName(targetChainId);
   const sourceNetworkName = useNetworkName(sourceChainId ?? '0x0');
 
@@ -52,6 +56,10 @@ export function ReceiveSummaryLine({
     targetSymbol = 'USDC';
     finalTargetNetworkName = 'Hyperliquid';
     receiveChainId = CHAIN_IDS.ARBITRUM;
+  } else if (isPerpsWithdraw) {
+    targetSymbol = 'mUSD';
+    finalTargetNetworkName = sourceNetworkName;
+    receiveChainId = sourceChainId ?? '0x0';
   } else if (isPredictDeposit) {
     targetSymbol = POLYGON_PUSD.symbol;
   } else if (isPredictWithdraw) {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.test.tsx
@@ -154,4 +154,30 @@ describe('SourceHashSummaryLine', () => {
       ),
     ).toBeDefined();
   });
+
+  it('renders perps-withdraw title with USDC and Arbitrum network', () => {
+    useNetworkNameMock.mockImplementation((chainId?: Hex) =>
+      chainId === '0xa4b1' ? 'Arbitrum' : 'Monad',
+    );
+
+    const { getByText } = render({
+      id: 'parent-id',
+      chainId: '0xa4b1' as Hex,
+      submittedTime: 1755719285723,
+      type: TransactionType.perpsWithdraw,
+      metamaskPay: {
+        tokenAddress: '0xmusd' as Hex,
+        chainId: '0xmonad' as Hex,
+      },
+    } as Partial<TransactionMeta>);
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_send', {
+          sourceSymbol: 'USDC',
+          sourceChain: 'Arbitrum',
+        }),
+      ),
+    ).toBeDefined();
+  });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/source-hash-summary-line.tsx
@@ -10,6 +10,7 @@ import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionSummaryLine } from './transaction-summary-line';
 import { hasTransactionType } from '../../../utils/transaction';
 import { POLYGON_PUSD } from '../../../constants/predict';
+import { ARBITRUM_USDC } from '../../../constants/perps';
 
 export function SourceHashSummaryLine({
   parentTransaction,
@@ -34,11 +35,21 @@ export function SourceHashSummaryLine({
     TransactionType.predictWithdraw,
   ]);
 
-  const chainId = isPredictWithdraw ? targetChainId : sourceTokenChainId;
+  const isPerpsWithdraw = hasTransactionType(parentTransaction, [
+    TransactionType.perpsWithdraw,
+  ]);
+
+  const chainId =
+    isPredictWithdraw || isPerpsWithdraw ? targetChainId : sourceTokenChainId;
 
   let title = strings('transaction_details.summary_title.bridge_send_loading');
 
-  if (sourceToken?.symbol && sourceNetworkName) {
+  if (isPerpsWithdraw) {
+    title = strings('transaction_details.summary_title.bridge_send', {
+      sourceSymbol: ARBITRUM_USDC.symbol,
+      sourceChain: targetNetworkName,
+    });
+  } else if (sourceToken?.symbol && sourceNetworkName) {
     title = strings('transaction_details.summary_title.bridge_send', {
       sourceSymbol: sourceToken.symbol,
       sourceChain: sourceNetworkName,

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -146,6 +146,7 @@ function SummaryLine({
     hasTransactionType(transactionMeta, [
       TransactionType.moneyAccountDeposit,
       TransactionType.perpsDeposit,
+      TransactionType.perpsWithdraw,
       TransactionType.predictDeposit,
       TransactionType.musdConversion,
       TransactionType.predictWithdraw,


### PR DESCRIPTION
## **Description**

Fixes incorrect token and chain display on the Money Account transaction details view for `perpsWithdraw` and `predictWithdraw` transactions.

When withdrawing from a Perps or Predictions account to the Money Account, the actual flow is:
- **Perps:** USDC on Arbitrum (Hyperliquid) → bridge → mUSD on Monad
- **Predictions:** pUSD on Polygon → bridge → mUSD on Monad

However, the UI was incorrectly showing mUSD as both the sent and received token in the hero, the Steps section showed the wrong source chain/token, and the second step linked to the wrong block explorer.

### Root Cause

For withdraw flows, `metamaskPay.tokenAddress` and `metamaskPay.chainId` represent the **destination** token (mUSD on Monad), not the source. Several components assumed these were always the source.

### Changes

**Two-asset hero (`transaction-details-hero.tsx`):**
- Added `SENT_OVERRIDE` map for `perpsWithdraw` (→ USDC on Arbitrum) and `predictWithdraw` (→ pUSD on Polygon)
- `resolveTwoAssetData` now checks this override to display the correct source token in the "You sent" line

**Step 1 — source hash line (`source-hash-summary-line.tsx`):**
- Added `isPerpsWithdraw` handling to show "Bridge USDC from Arbitrum" instead of "Bridge mUSD from Monad"
- Explorer link now points to Arbitrum (source chain) for `perpsWithdraw`

**Step 2 — receive line (`transaction-details-summary.tsx` + `receive-summary-line.tsx`):**
- Routed `perpsWithdraw` to `ReceiveSummaryLine` instead of the generic `DefaultSummaryLine`
- Added `isPerpsWithdraw` case to show "Receive mUSD on Monad" with the correct chain explorer link

## **Changelog**

CHANGELOG entry: Fixed incorrect token and chain display on transaction details for perps/predictions withdrawals to Money Account

## **Related issues**

Fixes: [MUSD-1037](https://consensyssoftware.atlassian.net/browse/MUSD-1037) (follow-up)

## **Manual testing steps**

```gherkin
Feature: Money Account Transaction Details - Perps/Predict Withdraw

  Scenario: Perps withdrawal shows correct hero tokens
    Given I have completed a withdrawal from Perps Account to Money Account
    When I tap the transaction in the Money Account activity list
    Then the hero shows "You sent" with "-X.XX USDC" and the USDC icon
    And below it shows "You received" with "+X.XX mUSD" and the Money Account icon

  Scenario: Perps withdrawal shows correct Steps
    Given I have completed a withdrawal from Perps Account to Money Account
    When I view the Steps section
    Then Step 1 shows "Bridge USDC from Arbitrum" with an Arbitrum explorer link
    And Step 2 shows "Receive mUSD on Monad" with a Monad explorer link

  Scenario: Predictions withdrawal shows correct hero tokens
    Given I have completed a withdrawal from Predictions Account to Money Account
    When I tap the transaction in the Money Account activity list
    Then the hero shows "You sent" with "-X.XX pUSD" and the pUSD icon
    And below it shows "You received" with "+X.XX mUSD" and the Money Account icon

  Scenario: Predictions withdrawal shows correct Steps
    Given I have completed a withdrawal from Predictions Account to Money Account
    When I view the Steps section
    Then Step 1 shows "Withdraw pUSD from Polygon" with a Polygon explorer link
    And Step 2 shows "Receive mUSD on Monad" with a Monad explorer link

  Scenario: Existing flows are unaffected
    Given I have completed a perpsDeposit, predictDeposit, or musdConversion
    When I view the transaction details
    Then the hero and Steps display remains unchanged from before this fix
```

## **Screenshots/Recordings**

### **Before**

<img width="441" height="977" alt="Screenshot 2026-06-23 at 13 31 39" src="https://github.com/user-attachments/assets/0a5d538b-ff59-4596-889d-2e60a5a0852d" />

### **After**

<img width="449" height="960" alt="Screenshot 2026-06-23 at 13 47 13" src="https://github.com/user-attachments/assets/9e849a1b-7e1d-45f5-8705-957e7c4decbb" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fixes in transaction details activity UI with targeted tests; no changes to transaction execution, balances, or security-sensitive paths.
> 
> **Overview**
> Fixes Money Account transaction details when users withdraw from **Perps** or **Predictions** to mUSD: the UI had been treating `metamaskPay` token/chain as the *source*, but on withdraw flows they describe the **destination** (mUSD on Monad).
> 
> The two-asset hero now uses a **`SENT_OVERRIDE`** so **You sent** shows **USDC on Arbitrum** (`perpsWithdraw`) or **pUSD on Polygon** (`predictWithdraw`), while **You received** stays mUSD from `targetFiat`.
> 
> The **Steps** section is aligned: the source-hash line labels **perps** withdraws as bridging **USDC from Arbitrum** and uses the right explorer chain; **`perpsWithdraw`** is routed through **`ReceiveSummaryLine`** so step 2 reads **Receive mUSD on Monad** (matching **`predictWithdraw`** behavior). Unit tests cover hero and summary lines for both withdraw types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cab046aa8416e6a07a13d373b79069dff2ef1b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MUSD-1037]: https://consensyssoftware.atlassian.net/browse/MUSD-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ