### PR TITLE
fix(money): geo-block sending to Perps/Predict from Money account cp-8.0.0

### DIFF
--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
@@ -155,6 +155,12 @@ jest.mock(
   '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit',
   () => ({ useMoneyPredictDeposit: jest.fn() }),
 );
+jest.mock('../../../Perps/selectors/perpsController', () => ({
+  selectPerpsEligibility: jest.fn(() => true),
+}));
+jest.mock('../../../Predict/hooks/usePredictEligibility', () => ({
+  usePredictEligibility: jest.fn(() => ({ isEligible: true })),
+}));
 jest.mock('../../hooks/useMoneyAnalytics', () => ({
   useMoneyAnalytics: jest.fn(),
 }));

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
@@ -217,35 +217,18 @@ describe('MoneyTransferSheet', () => {
     expect(mockInitiatePerpsDeposit).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the "Perps account" option when flag is enabled but user is geo-blocked', () => {
+  it('hides the "Perps account" option when user is geo-blocked, even if flag is enabled', () => {
     (useMoneyPerpsDeposit as jest.Mock).mockReturnValue({
       isEnabled: true,
       initiatePerpsDeposit: mockInitiatePerpsDeposit,
     });
     (selectPerpsEligibility as unknown as jest.Mock).mockReturnValue(false);
 
-    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
+    const { queryByTestId } = renderWithProvider(<MoneyTransferSheet />);
 
     expect(
-      getByTestId(MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION),
-    ).toBeDisabled();
-  });
-
-  it('does nothing when "Perps account" is pressed and user is geo-blocked', () => {
-    (useMoneyPerpsDeposit as jest.Mock).mockReturnValue({
-      isEnabled: true,
-      initiatePerpsDeposit: mockInitiatePerpsDeposit,
-    });
-    (selectPerpsEligibility as unknown as jest.Mock).mockReturnValue(false);
-
-    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
-
-    fireEvent.press(
-      getByTestId(MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION),
-    );
-
-    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
-    expect(mockInitiatePerpsDeposit).not.toHaveBeenCalled();
+      queryByTestId(MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION),
+    ).toBeNull();
   });
 
   it('disables the "Predictions account" option when flag is disabled', () => {
@@ -296,35 +279,18 @@ describe('MoneyTransferSheet', () => {
     expect(mockInitiatePredictDeposit).toHaveBeenCalledTimes(1);
   });
 
-  it('disables the "Predictions account" option when flag is enabled but user is geo-blocked', () => {
+  it('hides the "Predictions account" option when user is geo-blocked, even if flag is enabled', () => {
     (useMoneyPredictDeposit as jest.Mock).mockReturnValue({
       isEnabled: true,
       initiatePredictDeposit: mockInitiatePredictDeposit,
     });
     (usePredictEligibility as jest.Mock).mockReturnValue({ isEligible: false });
 
-    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
+    const { queryByTestId } = renderWithProvider(<MoneyTransferSheet />);
 
     expect(
-      getByTestId(MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION),
-    ).toBeDisabled();
-  });
-
-  it('does nothing when "Predictions account" is pressed and user is geo-blocked', () => {
-    (useMoneyPredictDeposit as jest.Mock).mockReturnValue({
-      isEnabled: true,
-      initiatePredictDeposit: mockInitiatePredictDeposit,
-    });
-    (usePredictEligibility as jest.Mock).mockReturnValue({ isEligible: false });
-
-    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
-
-    fireEvent.press(
-      getByTestId(MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION),
-    );
-
-    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
-    expect(mockInitiatePredictDeposit).not.toHaveBeenCalled();
+      queryByTestId(MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION),
+    ).toBeNull();
   });
 
   describe('analytics', () => {

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.test.tsx
@@ -7,6 +7,8 @@ import { strings } from '../../../../../../locales/i18n';
 import { useMoneyAccountWithdrawal } from '../../hooks/useMoneyAccount';
 import { useMoneyPerpsDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPerpsDeposit';
 import { useMoneyPredictDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit';
+import { selectPerpsEligibility } from '../../../Perps/selectors/perpsController';
+import { usePredictEligibility } from '../../../Predict/hooks/usePredictEligibility';
 import { useMoneyAnalytics } from '../../hooks/useMoneyAnalytics';
 import {
   BOTTOM_SHEET_NAMES,
@@ -50,6 +52,14 @@ jest.mock(
     useMoneyPredictDeposit: jest.fn(),
   }),
 );
+
+jest.mock('../../../Perps/selectors/perpsController', () => ({
+  selectPerpsEligibility: jest.fn(() => true),
+}));
+
+jest.mock('../../../Predict/hooks/usePredictEligibility', () => ({
+  usePredictEligibility: jest.fn(() => ({ isEligible: true })),
+}));
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -104,6 +114,8 @@ describe('MoneyTransferSheet', () => {
       isEnabled: false,
       initiatePredictDeposit: mockInitiatePredictDeposit,
     });
+    (selectPerpsEligibility as unknown as jest.Mock).mockReturnValue(true);
+    (usePredictEligibility as jest.Mock).mockReturnValue({ isEligible: true });
     (useMoneyAnalytics as jest.Mock).mockReturnValue({
       trackBottomSheetViewed: mockTrackBottomSheetViewed,
       trackSurfaceClicked: mockTrackSurfaceClicked,
@@ -205,6 +217,37 @@ describe('MoneyTransferSheet', () => {
     expect(mockInitiatePerpsDeposit).toHaveBeenCalledTimes(1);
   });
 
+  it('disables the "Perps account" option when flag is enabled but user is geo-blocked', () => {
+    (useMoneyPerpsDeposit as jest.Mock).mockReturnValue({
+      isEnabled: true,
+      initiatePerpsDeposit: mockInitiatePerpsDeposit,
+    });
+    (selectPerpsEligibility as unknown as jest.Mock).mockReturnValue(false);
+
+    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
+
+    expect(
+      getByTestId(MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION),
+    ).toBeDisabled();
+  });
+
+  it('does nothing when "Perps account" is pressed and user is geo-blocked', () => {
+    (useMoneyPerpsDeposit as jest.Mock).mockReturnValue({
+      isEnabled: true,
+      initiatePerpsDeposit: mockInitiatePerpsDeposit,
+    });
+    (selectPerpsEligibility as unknown as jest.Mock).mockReturnValue(false);
+
+    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockInitiatePerpsDeposit).not.toHaveBeenCalled();
+  });
+
   it('disables the "Predictions account" option when flag is disabled', () => {
     const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
 
@@ -251,6 +294,37 @@ describe('MoneyTransferSheet', () => {
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
     expect(mockInitiatePredictDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the "Predictions account" option when flag is enabled but user is geo-blocked', () => {
+    (useMoneyPredictDeposit as jest.Mock).mockReturnValue({
+      isEnabled: true,
+      initiatePredictDeposit: mockInitiatePredictDeposit,
+    });
+    (usePredictEligibility as jest.Mock).mockReturnValue({ isEligible: false });
+
+    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
+
+    expect(
+      getByTestId(MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION),
+    ).toBeDisabled();
+  });
+
+  it('does nothing when "Predictions account" is pressed and user is geo-blocked', () => {
+    (useMoneyPredictDeposit as jest.Mock).mockReturnValue({
+      isEnabled: true,
+      initiatePredictDeposit: mockInitiatePredictDeposit,
+    });
+    (usePredictEligibility as jest.Mock).mockReturnValue({ isEligible: false });
+
+    const { getByTestId } = renderWithProvider(<MoneyTransferSheet />);
+
+    fireEvent.press(
+      getByTestId(MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION),
+    );
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockInitiatePredictDeposit).not.toHaveBeenCalled();
   });
 
   describe('analytics', () => {

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
@@ -24,6 +24,8 @@ import { rejectPendingTransactions } from '../../utils/rejectPendingTransactions
 import { useMoneyAccountWithdrawal } from '../../hooks/useMoneyAccount';
 import { useMoneyPerpsDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPerpsDeposit';
 import { useMoneyPredictDeposit } from '../../../../Views/confirmations/hooks/pay/useMoneyPredictDeposit';
+import { selectPerpsEligibility } from '../../../Perps/selectors/perpsController';
+import { usePredictEligibility } from '../../../Predict/hooks/usePredictEligibility';
 import Logger from '../../../../../util/Logger';
 import MoneySheetOptionsList, {
   type MoneySheetOption,
@@ -51,6 +53,8 @@ const MoneyTransferSheet = () => {
     useMoneyPerpsDeposit();
   const { isEnabled: isPredictEnabled, initiatePredictDeposit } =
     useMoneyPredictDeposit();
+  const isPerpsEligible = useSelector(selectPerpsEligibility);
+  const { isEligible: isPredictEligible } = usePredictEligibility();
 
   const { trackBottomSheetViewed, trackSurfaceClicked } = useMoneyAnalytics({
     bottom_sheet_name: BOTTOM_SHEET_NAMES.MONEY_TRANSFER_MONEY_SHEET,
@@ -168,14 +172,14 @@ const MoneyTransferSheet = () => {
       icon: IconName.Candlestick,
       onPress: handlePerpsAccount,
       testID: MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION,
-      disabled: !isPerpsEnabled,
+      disabled: !isPerpsEnabled || !isPerpsEligible,
     },
     {
       label: strings('money.transfer_sheet.predictions_account'),
       icon: IconName.Speedometer,
       onPress: handlePredictionsAccount,
       testID: MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION,
-      disabled: !isPredictEnabled,
+      disabled: !isPredictEnabled || !isPredictEligible,
     },
     {
       label: strings('money.transfer_sheet.send_external'),

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.tsx
@@ -167,20 +167,28 @@ const MoneyTransferSheet = () => {
       onPress: handleBetweenAccounts,
       testID: MoneyTransferSheetTestIds.BETWEEN_ACCOUNTS_OPTION,
     },
-    {
-      label: strings('money.transfer_sheet.perps_account'),
-      icon: IconName.Candlestick,
-      onPress: handlePerpsAccount,
-      testID: MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION,
-      disabled: !isPerpsEnabled || !isPerpsEligible,
-    },
-    {
-      label: strings('money.transfer_sheet.predictions_account'),
-      icon: IconName.Speedometer,
-      onPress: handlePredictionsAccount,
-      testID: MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION,
-      disabled: !isPredictEnabled || !isPredictEligible,
-    },
+    ...(isPerpsEligible
+      ? [
+          {
+            label: strings('money.transfer_sheet.perps_account'),
+            icon: IconName.Candlestick,
+            onPress: handlePerpsAccount,
+            testID: MoneyTransferSheetTestIds.PERPS_ACCOUNT_OPTION,
+            disabled: !isPerpsEnabled,
+          },
+        ]
+      : []),
+    ...(isPredictEligible
+      ? [
+          {
+            label: strings('money.transfer_sheet.predictions_account'),
+            icon: IconName.Speedometer,
+            onPress: handlePredictionsAccount,
+            testID: MoneyTransferSheetTestIds.PREDICTIONS_ACCOUNT_OPTION,
+            disabled: !isPredictEnabled,
+          },
+        ]
+      : []),
     {
       label: strings('money.transfer_sheet.send_external'),
       icon: IconName.Arrow2Up,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money transfer sheet ("Send" from the Money home screen) only gated the **Perps account** and **Predictions account** options on their feature flag (`enableMoneyAccountTransactions[...]`). The Perps and Predict feature UIs, however, also gate entry to their deposit flows on **geo-eligibility**. This asymmetry meant a user in a geo-blocked region was correctly blocked from the Perps/Predict front door but could still route Money-account funds into those services from the Money UI — risking funds getting stuck in a feature the user cannot access.

This change combines each option's existing eligibility signal with the feature flag:

- **Perps** → `selectPerpsEligibility` (the same selector the Perps UI uses).
- **Predict** → `usePredictEligibility()` (the same hook the Predict UI uses; it also refreshes eligibility when the sheet mounts).

When the user is geo-blocked the corresponding option is disabled (greyed out), matching how the sheet already renders unavailable options. Both signals fail closed (default to ineligible when eligibility is unknown), so the safe default is to block.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Money account allowing funds to be sent to Perps/Predict in geo-blocked regions, which could leave funds stuck.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1050

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Geo-blocking sending Money-account funds to Perps/Predict

  Scenario: User in a geo-blocked region cannot send to Predict from the Money account
    Given the user is in a region geo-blocked for Predict
    And the user opens the Money home screen
    When the user taps "Send" and opens the transfer sheet
    Then the "Predictions account" option is disabled
    And tapping it does nothing

  Scenario: User in a geo-blocked region cannot send to Perps from the Money account
    Given the user is in a region geo-blocked for Perps
    And the user opens the Money home screen
    When the user taps "Send" and opens the transfer sheet
    Then the "Perps account" option is disabled
    And tapping it does nothing

  Scenario: Eligible user can still send to Perps/Predict
    Given the user is in an eligible region
    And the relevant feature flag is enabled
    When the user opens the transfer sheet
    Then the "Perps account" and "Predictions account" options are enabled
    And tapping them starts the deposit flow
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — change only gates an existing option behind geo-eligibility; no new UI.

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/67f805db-2de3-429a-ad62-cbef3b7027ed
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c7c86614-2403-4b5b-957f-e41d6476822a" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Money-account transfer entry points and fund-routing UX; risk is mitigated by reusing existing eligibility checks and adding targeted tests, but incorrect eligibility could block or expose transfers.
> 
> **Overview**
> Aligns the Money **Send** transfer sheet with Perps/Predict geo rules so Money-account funds cannot be routed into those products when the user is ineligible.
> 
> `MoneyTransferSheet` now reads **`selectPerpsEligibility`** and **`usePredictEligibility()`** (same signals as the Perps/Predict UIs). The **Perps account** and **Predictions account** rows are only added to the options list when the user is eligible; feature flags still control whether an shown row is enabled or greyed out. Tests mock those eligibility hooks/selectors and assert the options are absent when geo-blocked even if the deposit flags are on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa87a11c91cc691901c3965a23603f1831c17ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->