### PR TITLE
fix(onboarding): TMCU-938 interest grid i18n layout

### DIFF
--- a/app/components/Views/OnboardingInterestQuestionnaire/InterestOptionCard.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/InterestOptionCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  Image,
+  type ImageSourcePropType,
+  TouchableOpacity,
+} from 'react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  BoxAlignItems,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
+import { InterestSelectionIndicator } from './InterestSelectionIndicator';
+
+interface InterestOptionCardProps {
+  labelKey: string;
+  imageSource: ImageSourcePropType;
+  isSelected: boolean;
+  onPress: () => void;
+  testID: string;
+}
+
+export const InterestOptionCard = ({
+  labelKey,
+  imageSource,
+  isSelected,
+  onPress,
+  testID,
+}: InterestOptionCardProps) => {
+  const tw = useTailwind();
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={tw.style(
+        'min-h-[120px] flex-1 overflow-hidden rounded-xl bg-background-muted p-3',
+        isSelected
+          ? 'border border-border-default bg-background-muted-hover'
+          : 'border border-muted',
+      )}
+      testID={testID}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: isSelected }}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName="min-h-[96px] flex-1"
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          alignItems={BoxAlignItems.Start}
+        >
+          <Image
+            source={imageSource}
+            style={tw.style('h-10 w-10')}
+            resizeMode="contain"
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          />
+          <InterestSelectionIndicator isSelected={isSelected} />
+        </Box>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextDefault}
+          style={tw.style('mt-2 shrink')}
+        >
+          {strings(labelKey)}
+        </Text>
+      </Box>
+    </TouchableOpacity>
+  );
+};

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.test.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.test.tsx
@@ -13,6 +13,18 @@ import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { strings } from '../../../../locales/i18n';
 import Routes from '../../../constants/navigation/Routes';
 
+const { strings: actualStrings } = jest.requireActual<
+  typeof import('../../../../locales/i18n')
+>('../../../../locales/i18n');
+
+jest.mock('../../../../locales/i18n', () => {
+  const actual = jest.requireActual('../../../../locales/i18n');
+  return {
+    ...actual,
+    strings: jest.fn(actual.strings),
+  };
+});
+
 jest.mock('../../hooks/useAnalytics/useAnalytics');
 
 const mockNavigate = jest.fn();
@@ -134,6 +146,36 @@ describe('OnboardingInterestQuestionnaire', () => {
           ),
         ).toBeOnTheScreen();
       });
+    });
+
+    it('renders three two-column grid rows', () => {
+      renderComponent();
+
+      [0, 1, 2].forEach((rowIndex) => {
+        expect(
+          screen.getByTestId(
+            `${OnboardingInterestQuestionnaireTestIds.GRID_ROW_PREFIX}${rowIndex}`,
+          ),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('renders all option cards when labels are long', () => {
+      const longLabel =
+        'Compra y vende tokens de criptomonedas con MetaMask para varias líneas';
+      const stringsSpy = jest.mocked(strings);
+      stringsSpy.mockImplementation((key: string) => {
+        if (key.startsWith('onboarding_interest_questionnaire.option_')) {
+          return longLabel;
+        }
+        return actualStrings(key);
+      });
+
+      renderComponent();
+
+      expect(screen.getAllByText(longLabel)).toHaveLength(6);
+
+      stringsSpy.mockRestore();
     });
 
     it('renders the Continue button', () => {

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.testIds.ts
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.testIds.ts
@@ -1,5 +1,6 @@
 export enum OnboardingInterestQuestionnaireTestIds {
   SCREEN = 'onboarding-interest-questionnaire-screen',
+  GRID_ROW_PREFIX = 'onboarding-interest-grid-row-',
   OPTION_PREFIX = 'onboarding-interest-option-',
   CONTINUE_BUTTON = 'onboarding-interest-continue-button',
 }

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   BackHandler,
-  Image,
-  type ImageSourcePropType,
   Platform,
   ScrollView,
   StatusBar,
-  TouchableOpacity,
+  type ImageSourcePropType,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -25,9 +23,9 @@ import {
   TextColor,
   FontWeight,
   BoxFlexDirection,
-  BoxFlexWrap,
+  BoxAlignItems,
 } from '@metamask/design-system-react-native';
-import { InterestSelectionIndicator } from './InterestSelectionIndicator';
+import { InterestOptionCard } from './InterestOptionCard';
 import { strings } from '../../../../locales/i18n';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -91,6 +89,12 @@ const INTEREST_OPTION_IMAGES: Record<InterestOptionId, ImageSourcePropType> = {
   crypto_as_money: cryptoAsMoneyImage,
   connect_apps_sites: connectAppsSitesImage,
 };
+
+const INTEREST_OPTION_ROWS = [
+  INTEREST_OPTIONS.slice(0, 2),
+  INTEREST_OPTIONS.slice(2, 4),
+  INTEREST_OPTIONS.slice(4, 6),
+];
 
 /** 8px gutters between 2-column grid cells (4px padding per column side). */
 const GRID_GUTTER_PX = 4;
@@ -215,56 +219,37 @@ const OnboardingInterestQuestionnaire = () => {
         contentContainerStyle={tw.style('px-4 pb-4')}
         showsVerticalScrollIndicator={false}
       >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          flexWrap={BoxFlexWrap.Wrap}
-          style={tw.style('py-2', { marginHorizontal: -GRID_GUTTER_PX })}
-        >
-          {INTEREST_OPTIONS.map((option) => {
-            const isSelected = selectedIds.has(option.id);
-            return (
-              <Box
-                key={option.id}
-                style={tw.style({
-                  width: '50%',
-                  paddingHorizontal: GRID_GUTTER_PX,
-                  marginBottom: GRID_GUTTER_PX * 2,
-                })}
-              >
-                <TouchableOpacity
-                  onPress={() => toggleOption(option.id)}
-                  style={tw.style(
-                    'relative h-[120px] w-full rounded-xl bg-background-muted',
-                    isSelected
-                      ? 'border border-border-default bg-background-muted-hover'
-                      : 'border border-muted',
-                  )}
-                  testID={`${OnboardingInterestQuestionnaireTestIds.OPTION_PREFIX}${option.id}`}
-                  accessibilityRole="checkbox"
-                  accessibilityState={{ checked: isSelected }}
+        <Box twClassName="py-2">
+          {INTEREST_OPTION_ROWS.map((rowOptions, rowIndex) => (
+            <Box
+              key={rowOptions.map((option) => option.id).join('-')}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Stretch}
+              testID={`${OnboardingInterestQuestionnaireTestIds.GRID_ROW_PREFIX}${rowIndex}`}
+              style={tw.style({
+                marginHorizontal: -GRID_GUTTER_PX,
+                marginBottom: GRID_GUTTER_PX * 2,
+              })}
+            >
+              {rowOptions.map((option) => (
+                <Box
+                  key={option.id}
+                  style={tw.style({
+                    width: '50%',
+                    paddingHorizontal: GRID_GUTTER_PX,
+                  })}
                 >
-                  <Box style={tw.style('absolute top-3 right-3')}>
-                    <InterestSelectionIndicator isSelected={isSelected} />
-                  </Box>
-                  <Image
-                    source={INTEREST_OPTION_IMAGES[option.id]}
-                    style={tw.style('absolute top-3 left-3 h-10 w-10')}
-                    resizeMode="contain"
-                    accessibilityElementsHidden
-                    importantForAccessibility="no-hide-descendants"
+                  <InterestOptionCard
+                    labelKey={option.labelKey}
+                    imageSource={INTEREST_OPTION_IMAGES[option.id]}
+                    isSelected={selectedIds.has(option.id)}
+                    onPress={() => toggleOption(option.id)}
+                    testID={`${OnboardingInterestQuestionnaireTestIds.OPTION_PREFIX}${option.id}`}
                   />
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    fontWeight={FontWeight.Medium}
-                    color={TextColor.TextDefault}
-                    style={tw.style('absolute bottom-3 left-3 right-3')}
-                  >
-                    {strings(option.labelKey)}
-                  </Text>
-                </TouchableOpacity>
-              </Box>
-            );
-          })}
+                </Box>
+              ))}
+            </Box>
+          ))}
         </Box>
       </ScrollView>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Fixes the onboarding interest questionnaire two-column grid breaking with longer translated labels (e.g. Spanish).

- Extracted `InterestOptionCard` with a flex column layout (`minHeight` 120px) so icons and labels no longer overlap when text wraps
- Replaced flat `flexWrap` rendering with three explicit two-column rows using `BoxAlignItems.Stretch` so paired cards share equal height
- Added grid row test IDs and unit tests for long-label rendering

## **Changelog**

CHANGELOG entry: Fixed onboarding interest questionnaire grid layout for languages with longer option labels.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-938

## **Manual testing steps**

```gherkin
Feature: Onboarding interest questionnaire grid (TMCU-938)

  Scenario: long translated labels render without layout breakage
    Given the app language is set to Spanish
    And the user is in onboarding after opting in to basic usage data
    And the interest questionnaire eligibility check returns true

    When the interest questionnaire is shown
    Then six options appear in a two-column grid
    And icons do not overlap option labels
    And left and right cards in each row share the same height
    And the user can select multiple options and continue onboarding

  Scenario: short English labels still render correctly
    Given the app language is set to English
    And the user is on the interest questionnaire screen

    When the screen renders
    Then the grid remains two columns with even gutters
    And short labels remain visually balanced within each card
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300"  src="https://github.com/user-attachments/assets/1c83b93c-6d3a-4c11-975f-24e3ea027f38" />


### **After**

<img width="300" src="https://github.com/user-attachments/assets/cec35ae7-c3a8-4750-ad6d-14258e4d3c91" />
<img width="300" src="https://github.com/user-attachments/assets/237d3c04-7aec-4715-a3ab-708e1ae25cdb" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI layout refactor only; selection, analytics, and navigation behavior are unchanged.
> 
> **Overview**
> Fixes the onboarding interest questionnaire **two-column grid** when option labels wrap in longer locales (e.g. Spanish).
> 
> **`InterestOptionCard`** is extracted so each option uses a **flex column** (`min-h-[120px]`, padded content) instead of absolutely positioned icon, checkbox, and label—so wrapped text no longer overlaps the artwork.
> 
> **`OnboardingInterestQuestionnaire`** stops rendering a single `flexWrap` list and instead maps **three explicit two-column rows** with `BoxAlignItems.Stretch`, so cards in the same row share height. Selection, analytics, and navigation are unchanged.
> 
> Tests add **grid row test IDs**, assert three rows render, and mock long option strings to verify all six cards still show their labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5784ffdac546452399f7e3648125faa6c5cdbc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->