### PR TITLE
chore: redesign price alerts UI

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.test.tsx
@@ -97,30 +97,38 @@ describe('CreatePriceAlertView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('shows percentage pickers and hides Set button before any input', () => {
-    const { getByTestId, queryByTestId } = renderWithToast();
+  it('shows percentage pickers and Set button before any input', () => {
+    const { getByTestId } = renderWithToast();
 
     expect(
       getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
     ).toBeOnTheScreen();
-    expect(queryByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON)).toBeNull();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
   });
 
-  it('hides percentage pickers and shows Set button once user types a digit', () => {
-    const { getByTestId, queryByTestId } = renderWithToast();
+  it('keeps percentage pickers visible and enables Set button once user types a digit', () => {
+    const { getByTestId } = renderWithToast();
 
     fireEvent.press(getByTestId('keypad-key-1'));
 
     expect(
-      queryByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
-    ).toBeNull();
+      getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
+    ).toBeOnTheScreen();
     expect(
       getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
     ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
   });
 
-  it('keeps percentage pickers and hides Set button for zero-valued keypad input like "0."', () => {
-    const { getByTestId, getByText, queryByTestId } = renderWithToast();
+  it('keeps percentage pickers visible and Set button disabled for zero-valued keypad input like "0."', () => {
+    const { getByTestId, getByText } = renderWithToast();
 
     fireEvent.press(getByTestId('keypad-key-dot'));
 
@@ -128,10 +136,12 @@ describe('CreatePriceAlertView', () => {
     expect(
       getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
     ).toBeOnTheScreen();
-    expect(queryByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON)).toBeNull();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).toBeDisabled();
   });
 
-  it('shows Set button after a quick-percentage pill is pressed', () => {
+  it('enables Set button after a quick-percentage pill is pressed', () => {
     const { getByTestId } = renderWithToast();
 
     fireEvent.press(
@@ -141,6 +151,9 @@ describe('CreatePriceAlertView', () => {
     expect(
       getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
     ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
   });
 
   it('shows under development message when price change is selected', () => {
@@ -190,7 +203,9 @@ describe('CreatePriceAlertView', () => {
       getByTestId(`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-5`),
     );
 
-    expect(getByText('5%')).toBeOnTheScreen();
+    expect(getByTestId(CreatePriceAlertTestIds.PERCENT_DIFF)).toHaveTextContent(
+      /5%/,
+    );
     expect(getByText(/above current ETH price/)).toBeOnTheScreen();
   });
 
@@ -413,7 +428,7 @@ describe('CreatePriceAlertView — tiny price token', () => {
     expect(getByText('$0.000000000000011')).toBeOnTheScreen();
   });
 
-  it('quick-percentage pill produces a non-zero value and reveals the Set button', () => {
+  it('quick-percentage pill produces a non-zero value and enables the Set button', () => {
     const { getByTestId } = render(<CreatePriceAlertView />);
 
     fireEvent.press(
@@ -423,6 +438,9 @@ describe('CreatePriceAlertView — tiny price token', () => {
     expect(
       getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
     ).toBeOnTheScreen();
+    expect(
+      getByTestId(CreatePriceAlertTestIds.SET_ALERT_BUTTON),
+    ).not.toBeDisabled();
   });
 
   it('allows manual keypad entry beyond two decimal places for sub-cent tokens', () => {

--- a/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView.tsx
@@ -427,47 +427,23 @@ const CreatePriceAlertView: React.FC = () => {
                 />
               </Box>
 
-              {/* Quick-percentage pickers → hidden once a positive target is set */}
-              {hasValidTarget ? (
-                <Button
-                  variant={ButtonVariant.Primary}
-                  onPress={handleSaveAlert}
-                  isLoading={isSubmitting}
-                  isDisabled={
-                    isSubmitting ||
-                    !hasValidTarget ||
-                    isDuplicateThreshold ||
-                    isUnchanged
-                  }
-                  testID={CreatePriceAlertTestIds.SET_ALERT_BUTTON}
-                  twClassName="mb-3 w-full"
-                >
-                  {isDuplicateThreshold
-                    ? strings('price_alerts.duplicate_threshold')
-                    : strings(
-                        isEditing
-                          ? 'price_alerts.update_price_alert'
-                          : 'price_alerts.set_price_alert',
-                      )}
-                </Button>
-              ) : (
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  twClassName="mb-3 gap-2"
-                >
-                  {PRICE_ALERT_QUICK_PERCENTAGES.map((percentage) => (
-                    <Button
-                      key={percentage}
-                      variant={ButtonVariant.Secondary}
-                      onPress={() => handleQuickPercentagePress(percentage)}
-                      testID={`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-${percentage}`}
-                      twClassName="flex-1"
-                    >
-                      {strings('price_alerts.quick_percentage', { percentage })}
-                    </Button>
-                  ))}
-                </Box>
-              )}
+              {/* Quick-percentage pickers — always visible */}
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                twClassName="mb-3 gap-2"
+              >
+                {PRICE_ALERT_QUICK_PERCENTAGES.map((percentage) => (
+                  <Button
+                    key={percentage}
+                    variant={ButtonVariant.Secondary}
+                    onPress={() => handleQuickPercentagePress(percentage)}
+                    testID={`${CreatePriceAlertTestIds.QUICK_PERCENTAGE_PREFIX}-${percentage}`}
+                    twClassName="flex-1"
+                  >
+                    {strings('price_alerts.quick_percentage', { percentage })}
+                  </Button>
+                ))}
+              </Box>
 
               {/* "price_alert" is intentionally not in the Keypad CURRENCIES map —
                   unknown codes fall through to the decimals-aware branch in useCurrency,
@@ -478,6 +454,29 @@ const CreatePriceAlertView: React.FC = () => {
                 currency="price_alert"
                 decimals={keypadDecimals}
               />
+
+              {/* Save button — always visible, sits below the keypad */}
+              <Button
+                variant={ButtonVariant.Primary}
+                onPress={handleSaveAlert}
+                isLoading={isSubmitting}
+                isDisabled={
+                  isSubmitting ||
+                  !hasValidTarget ||
+                  isDuplicateThreshold ||
+                  isUnchanged
+                }
+                testID={CreatePriceAlertTestIds.SET_ALERT_BUTTON}
+                twClassName="mt-3 w-full"
+              >
+                {isDuplicateThreshold
+                  ? strings('price_alerts.duplicate_threshold')
+                  : strings(
+                      isEditing
+                        ? 'price_alerts.update_price_alert'
+                        : 'price_alerts.set_price_alert',
+                    )}
+              </Button>
             </View>
           </>
         ) : (

--- a/app/components/UI/Assets/PriceAlerts/constants.ts
+++ b/app/components/UI/Assets/PriceAlerts/constants.ts
@@ -34,7 +34,7 @@ export interface PriceAlert {
   createdAt: string;
 }
 
-export const PRICE_ALERT_QUICK_PERCENTAGES = [5, 10, 20, 30] as const;
+export const PRICE_ALERT_QUICK_PERCENTAGES = [-10, -5, 5, 10] as const;
 
 export const CURRENCY_SYMBOLS: Record<string, string> = {
   usd: '$',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

- The `5% / 10% / 20% / 30%` quick-percentage pills are replaced with `-10% / -5% / +5% / +10%` to cover both above and below the current price.
- The quick-percentage pills and the "Set / Update price alert" button are now always visible (previously they were mutually exclusive — pills hid when a target was set, and the button only appeared after input).
- The save button is repositioned below the keypad so it stays anchored at the bottom of the screen.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: redesign price alerts UI

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3441

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/15539ca5-2c1d-40f9-9f16-595893ad6359

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and constant changes on the create price alert screen; submit validation and API behavior are unchanged.
> 
> **Overview**
> **Create price alert** now keeps quick-percentage pills and the save action on screen at the same time, instead of swapping one for the other when a target is set.
> 
> Quick picks change from **5 / 10 / 20 / 30** (all above spot) to **-10 / -5 / +5 / +10**, so users can set below-market targets in one tap. The **Set / Update price alert** button sits **below the keypad** and stays visible; it is **disabled** until there is a valid positive target (and existing duplicate/unchanged rules still apply).
> 
> Tests are updated to expect pills to remain visible, the button always present, and enabled/disabled state instead of show/hide behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc7f4429b5f776c77b33a719e580e7c4fbc58da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->