### PR TITLE
feat(card): use dynamic registration settings links

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -254,7 +254,15 @@ const mockUseAssetBalances = jest.fn(() =>
 const mockNavigateToTravelPage = jest.fn();
 const mockNavigateToCardTosPage = jest.fn();
 
-const mockUseNavigateToCardPage = jest.fn(() => ({
+interface NavigateToCardPageHookReturn {
+  navigateToTravelPage: jest.Mock;
+  navigateToCardTosPage: jest.Mock;
+}
+
+const mockUseNavigateToCardPage = jest.fn<
+  NavigateToCardPageHookReturn,
+  [unknown, string | undefined]
+>(() => ({
   navigateToTravelPage: mockNavigateToTravelPage,
   navigateToCardTosPage: mockNavigateToCardTosPage,
 }));

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -277,7 +277,20 @@ jest.mock('../../hooks/useAssetBalances', () => ({
 }));
 
 jest.mock('../../hooks/useNavigateToCardPage', () => ({
-  useNavigateToCardPage: () => mockUseNavigateToCardPage(),
+  useNavigateToCardPage: (...args: unknown[]) =>
+    mockUseNavigateToCardPage(...args),
+}));
+
+const mockUseRegistrationSettings = jest.fn(() => ({
+  data: null,
+  isLoading: false,
+  error: null,
+  fetchData: jest.fn(),
+}));
+
+jest.mock('../../hooks/useRegistrationSettings', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseRegistrationSettings(...args),
 }));
 
 jest.mock('../../../Bridge/hooks/useSwapBridgeNavigation', () => ({
@@ -1132,6 +1145,12 @@ describe('CardHome Component', () => {
       navigateToTravelPage: mockNavigateToTravelPage,
       navigateToCardTosPage: mockNavigateToCardTosPage,
     });
+    mockUseRegistrationSettings.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      fetchData: jest.fn(),
+    });
 
     mockUseSwapBridgeNavigation.mockReturnValue({
       goToSwaps: mockGoToSwaps,
@@ -1413,7 +1432,110 @@ describe('CardHome Component', () => {
     });
   });
 
-  it('opens mailto link when contact support item is pressed', async () => {
+  it('loads registration settings on Card Home', () => {
+    render();
+
+    expect(mockUseRegistrationSettings).toHaveBeenCalledWith();
+  });
+
+  it('passes dynamic TOS URL to Card navigation actions', () => {
+    const dynamicTosUrl = 'https://docs.baanx.us/metamask/terms.pdf';
+    mockUseRegistrationSettings.mockReturnValue({
+      data: {
+        countries: [],
+        usStates: [],
+        links: {
+          us: {
+            termsAndConditions: dynamicTosUrl,
+            accountOpeningDisclosure: '',
+            noticeOfPrivacy: '',
+            eSignConsentDisclosure: '',
+          },
+          intl: {
+            termsAndConditions: '',
+            rightToInformation: '',
+          },
+        },
+        config: {
+          us: {
+            emailSpecialCharactersDomainsException: '',
+            consentSmsNumber: '',
+            supportEmail: CARD_SUPPORT_EMAIL,
+          },
+          intl: {
+            emailSpecialCharactersDomainsException: '',
+            consentSmsNumber: '',
+            supportEmail: CARD_SUPPORT_EMAIL,
+          },
+        },
+      },
+      isLoading: false,
+      error: null,
+      fetchData: jest.fn(),
+    });
+    setupMockSelectors({ userLocation: 'us' });
+
+    render();
+
+    expect(mockUseNavigateToCardPage).toHaveBeenCalledWith(
+      expect.any(Object),
+      dynamicTosUrl,
+    );
+  });
+
+  it('opens dynamic support email when contact support item is pressed', async () => {
+    const dynamicSupportEmail = 'us-support@cl-cards.com';
+    mockUseRegistrationSettings.mockReturnValue({
+      data: {
+        countries: [],
+        usStates: [],
+        links: {
+          us: {
+            termsAndConditions: '',
+            accountOpeningDisclosure: '',
+            noticeOfPrivacy: '',
+            eSignConsentDisclosure: '',
+          },
+          intl: {
+            termsAndConditions: '',
+            rightToInformation: '',
+          },
+        },
+        config: {
+          us: {
+            emailSpecialCharactersDomainsException: '',
+            consentSmsNumber: '',
+            supportEmail: dynamicSupportEmail,
+          },
+          intl: {
+            emailSpecialCharactersDomainsException: '',
+            consentSmsNumber: '',
+            supportEmail: CARD_SUPPORT_EMAIL,
+          },
+        },
+      },
+      isLoading: false,
+      error: null,
+      fetchData: jest.fn(),
+    });
+    setupMockSelectors({ isAuthenticated: true, userLocation: 'us' });
+    setupLoadCardDataMock({ isAuthenticated: true });
+
+    render();
+
+    const contactSupportItem = screen.getByTestId(
+      CardHomeSelectors.CONTACT_SUPPORT_ITEM,
+    );
+    fireEvent.press(contactSupportItem);
+
+    await waitFor(() => {
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        `mailto:${dynamicSupportEmail}`,
+      );
+    });
+  });
+
+  it('opens fallback support email when contact support item is pressed', async () => {
     setupMockSelectors({ isAuthenticated: true });
     setupLoadCardDataMock({ isAuthenticated: true });
 

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -78,6 +78,7 @@ import {
   CardStateWarning,
   CardStatus,
   CardType,
+  type RegistrationSettingsResponse,
 } from '../../types';
 import type { TokenI } from '../../../Tokens/types';
 import { useCardHomeData } from '../../hooks/useCardHomeData';
@@ -262,6 +263,13 @@ const mockUseSwapBridgeNavigation = jest.fn(() => ({
   goToSwaps: mockGoToSwaps,
 }));
 
+interface RegistrationSettingsHookReturn {
+  data: RegistrationSettingsResponse | null;
+  isLoading: boolean;
+  error: Error | null;
+  fetchData: jest.Mock;
+}
+
 jest.mock('../../hooks/useCardHomeData', () => ({
   __esModule: true,
   useCardHomeData: jest.fn(),
@@ -277,20 +285,24 @@ jest.mock('../../hooks/useAssetBalances', () => ({
 }));
 
 jest.mock('../../hooks/useNavigateToCardPage', () => ({
-  useNavigateToCardPage: (...args: unknown[]) =>
-    mockUseNavigateToCardPage(...args),
+  useNavigateToCardPage: (
+    navigation: unknown,
+    cardTermsAndConditionsUrl?: string,
+  ) => mockUseNavigateToCardPage(navigation, cardTermsAndConditionsUrl),
 }));
 
-const mockUseRegistrationSettings = jest.fn(() => ({
-  data: null,
-  isLoading: false,
-  error: null,
-  fetchData: jest.fn(),
-}));
+const mockUseRegistrationSettings = jest.fn<RegistrationSettingsHookReturn, []>(
+  () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+    fetchData: jest.fn(),
+  }),
+);
 
 jest.mock('../../hooks/useRegistrationSettings', () => ({
   __esModule: true,
-  default: (...args: unknown[]) => mockUseRegistrationSettings(...args),
+  default: () => mockUseRegistrationSettings(),
 }));
 
 jest.mock('../../../Bridge/hooks/useSwapBridgeNavigation', () => ({

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -40,6 +40,11 @@ import {
   selectCardUserLocation,
   selectCardHomeDataStatus,
 } from '../../../../../selectors/cardController';
+import useRegistrationSettings from '../../hooks/useRegistrationSettings';
+import {
+  getCardSupportEmail,
+  getCardTermsAndConditionsUrl,
+} from '../../util/registrationSettings';
 import {
   CardStatus,
   FundingAssetStatus,
@@ -87,6 +92,7 @@ const CardHome = () => {
   const capabilities = useCardCapabilities();
   const isAuthenticated = useSelector(selectIsCardAuthenticated);
   const userLocation = useSelector(selectCardUserLocation);
+  const { data: registrationSettings } = useRegistrationSettings();
   const privacyMode = useSelector(selectPrivacyMode);
   const isMetalCardCheckoutEnabled = useSelector(
     selectMetalCardCheckoutFeatureFlag,
@@ -107,12 +113,21 @@ const CardHome = () => {
   const hasSetupActions = (data?.actions ?? []).some(
     (a) => a.type === 'enable_card',
   );
+  const cardTermsAndConditionsUrl = useMemo(
+    () => getCardTermsAndConditionsUrl(registrationSettings, userLocation),
+    [registrationSettings, userLocation],
+  );
+  const supportEmail = useMemo(
+    () => getCardSupportEmail(registrationSettings, userLocation),
+    [registrationSettings, userLocation],
+  );
 
   // --- Extracted hooks ---
   const actions = useCardHomeActions({
     data,
     primaryToken,
     isFrozen,
+    cardTermsAndConditionsUrl,
   });
 
   const { initiateProvisioning, isProvisioning, canAddToWallet } =
@@ -482,6 +497,7 @@ const CardHome = () => {
           isLoading={isLoading}
           hasAlerts={hasAlertOnlyState}
           hasSetupActions={hasSetupActions}
+          supportEmail={supportEmail}
           onNavigateToCardTos={actions.navigateToCardTosPage}
           onLogout={actions.logoutAction}
         />

--- a/app/components/UI/Card/Views/CardHome/components/CardHomeFooter.tsx
+++ b/app/components/UI/Card/Views/CardHome/components/CardHomeFooter.tsx
@@ -4,13 +4,13 @@ import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../../locales/i18n';
 import { CardHomeSelectors } from '../CardHome.testIds';
-import { CARD_SUPPORT_EMAIL } from '../../../constants';
 
 interface CardHomeFooterProps {
   isAuthenticated: boolean;
   isLoading: boolean;
   hasAlerts: boolean;
   hasSetupActions: boolean;
+  supportEmail: string;
   onNavigateToCardTos: () => void;
   onLogout: () => void;
 }
@@ -20,6 +20,7 @@ const CardHomeFooter = ({
   isLoading,
   hasAlerts,
   hasSetupActions,
+  supportEmail,
   onNavigateToCardTos,
   onLogout,
 }: CardHomeFooterProps) => {
@@ -46,7 +47,7 @@ const CardHomeFooter = ({
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
-          onPress={() => Linking.openURL(`mailto:${CARD_SUPPORT_EMAIL}`)}
+          onPress={() => Linking.openURL(`mailto:${supportEmail}`)}
           testID={CardHomeSelectors.CONTACT_SUPPORT_ITEM}
           style={tw.style('px-4')}
         >

--- a/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts
+++ b/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts
@@ -35,12 +35,14 @@ interface UseCardHomeActionsParams {
   data: CardHomeData | null | undefined;
   primaryToken: CardFundingTokenWithBalance | null;
   isFrozen: boolean;
+  cardTermsAndConditionsUrl: string;
 }
 
 export function useCardHomeActions({
   data,
   primaryToken,
   isFrozen,
+  cardTermsAndConditionsUrl,
 }: UseCardHomeActionsParams) {
   const navigation = useNavigation();
   const isAuthenticated = useSelector(selectIsCardAuthenticated);
@@ -49,8 +51,10 @@ export function useCardHomeActions({
   const { toastRef } = useContext(ToastContext);
   const { reauthenticate } = useAuthentication();
 
-  const { navigateToTravelPage, navigateToCardTosPage } =
-    useNavigateToCardPage(navigation);
+  const { navigateToTravelPage, navigateToCardTosPage } = useNavigateToCardPage(
+    navigation,
+    cardTermsAndConditionsUrl,
+  );
   const { freeze, unfreeze } = useCardFreeze(data?.card?.id);
   const {
     fetchCardDetailsToken,

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
@@ -1761,6 +1761,56 @@ describe('PhysicalAddress Component', () => {
       );
     });
 
+    it('opens the dynamic auth-settings URLs when provided', () => {
+      mockUseRegistrationSettings.mockReturnValue({
+        data: {
+          usStates: [
+            {
+              id: '1',
+              name: 'California',
+              postalAbbreviation: 'CA',
+              canSignUp: true,
+            },
+          ],
+          links: {
+            us: {
+              termsAndConditions: 'https://docs.baanx.us/metamask/terms.pdf',
+              accountOpeningDisclosure:
+                'https://docs.baanx.us/metamask/account-opening.pdf',
+              noticeOfPrivacy: 'https://docs.baanx.us/metamask/privacy.pdf',
+              eSignConsentDisclosure:
+                'https://docs.baanx.us/metamask/esign.pdf',
+            },
+            intl: { termsAndConditions: '', rightToInformation: '' },
+          },
+        },
+        isLoading: false,
+        error: null,
+        fetchData: jest.fn(),
+      } as unknown as ReturnType<typeof useRegistrationSettings>);
+
+      const { getByText } = render(
+        <Provider store={store}>
+          <PhysicalAddress />
+        </Provider>,
+      );
+
+      fireEvent.press(getByText('Terms & Conditions'));
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://docs.baanx.us/metamask/terms.pdf',
+      );
+
+      fireEvent.press(getByText('Account Opening Disclosures'));
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://docs.baanx.us/metamask/account-opening.pdf',
+      );
+
+      fireEvent.press(getByText('Notice of Privacy Practices'));
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://docs.baanx.us/metamask/privacy.pdf',
+      );
+    });
+
     it('opens CRB CL Privacy Policy URL when link is pressed', () => {
       const { getByText } = render(
         <Provider store={store}>

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -52,13 +52,8 @@ import {
   setOnValueChange,
 } from './RegionSelectorModal';
 import { countryCodeToFlag } from '../../util/countryCodeToFlag';
-import {
-  COINME_TERMS_URL,
-  CRB_ACCOUNT_OPENING_URL,
-  CRB_PRIVACY_NOTICE_URL,
-  CRB_PRIVACY_POLICY_URL,
-  CRB_TERMS_URL,
-} from '../../constants';
+import { COINME_TERMS_URL, CRB_PRIVACY_POLICY_URL } from '../../constants';
+import { getCardUsDisclosureUrls } from '../../util/registrationSettings';
 
 const VERIFICATION_POLLING_INTERVAL_MS = 3000;
 
@@ -270,9 +265,14 @@ const PhysicalAddress = () => {
     }
   }, [user]);
 
-  const eSignConsentDisclosureUSUrl = useMemo(
-    () => registrationSettings?.links?.us?.eSignConsentDisclosure || '',
-    [registrationSettings?.links?.us?.eSignConsentDisclosure],
+  const {
+    eSignConsentDisclosureUSUrl,
+    crbTermsUrl,
+    crbAccountOpeningUrl,
+    crbNoticeOfPrivacyUrl,
+  } = useMemo(
+    () => getCardUsDisclosureUrls(registrationSettings),
+    [registrationSettings],
   );
 
   const {
@@ -306,22 +306,22 @@ const PhysicalAddress = () => {
   }, []);
 
   const openCrbTerms = useCallback(() => {
-    if (CRB_TERMS_URL) {
-      Linking.openURL(CRB_TERMS_URL);
+    if (crbTermsUrl) {
+      Linking.openURL(crbTermsUrl);
     }
-  }, []);
+  }, [crbTermsUrl]);
 
   const openCrbAccountOpening = useCallback(() => {
-    if (CRB_ACCOUNT_OPENING_URL) {
-      Linking.openURL(CRB_ACCOUNT_OPENING_URL);
+    if (crbAccountOpeningUrl) {
+      Linking.openURL(crbAccountOpeningUrl);
     }
-  }, []);
+  }, [crbAccountOpeningUrl]);
 
   const openCrbPrivacyNotice = useCallback(() => {
-    if (CRB_PRIVACY_NOTICE_URL) {
-      Linking.openURL(CRB_PRIVACY_NOTICE_URL);
+    if (crbNoticeOfPrivacyUrl) {
+      Linking.openURL(crbNoticeOfPrivacyUrl);
     }
-  }, []);
+  }, [crbNoticeOfPrivacyUrl]);
 
   const openCrbPrivacyPolicy = useCallback(() => {
     if (CRB_PRIVACY_POLICY_URL) {

--- a/app/components/UI/Card/hooks/useNavigateToCardPage.test.ts
+++ b/app/components/UI/Card/hooks/useNavigateToCardPage.test.ts
@@ -24,7 +24,6 @@ jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
 
 jest.mock('../../../../util/url', () => ({
   isCardTravelUrl: jest.fn(),
-  isCardTosUrl: jest.fn(),
 }));
 
 jest.mock('../../../../core/AppConstants', () => ({
@@ -35,9 +34,13 @@ jest.mock('../../../../core/AppConstants', () => ({
   },
 }));
 
+const FALLBACK_TOS_URL =
+  'https://secure.baanx.co.uk/MM-Card-RoW-Terms-2025-Sept.pdf';
+const DYNAMIC_TOS_URL = 'https://docs.baanx.us/metamask/terms-of-service.pdf';
+
 jest.mock('react-native', () => ({
   Linking: {
-    openURL: jest.fn(),
+    openURL: jest.fn(() => Promise.resolve()),
   },
 }));
 
@@ -90,15 +93,18 @@ const createMockEventBuilder = () => ({
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn();
 
+const STABLE_EMPTY_TABS: BrowserTab[] = [];
+
 const setupMocks = (
   mockEventBuilder: ReturnType<typeof createMockEventBuilder>,
 ) => {
-  (useSelector as jest.Mock).mockReturnValue([]);
+  (useSelector as jest.Mock).mockReturnValue(STABLE_EMPTY_TABS);
   (useAnalytics as jest.Mock).mockReturnValue({
     trackEvent: mockTrackEvent,
     createEventBuilder: mockCreateEventBuilder,
   });
   (isCardTravelUrl as jest.Mock).mockReturnValue(false);
+  (Linking.openURL as jest.Mock).mockResolvedValue(undefined);
   mockCreateEventBuilder.mockReturnValue(mockEventBuilder);
 };
 
@@ -201,45 +207,6 @@ describe('useNavigateToInternalBrowserPage', () => {
       });
     },
   );
-
-  describe('CardInternalBrowserPage.TOS', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockNavigation = createMockNavigation();
-      mockEventBuilder = createMockEventBuilder();
-      setupMocks(mockEventBuilder);
-    });
-
-    it('opens TOS URL with Linking.openURL', () => {
-      const { result } = renderHook(() =>
-        useNavigateToInternalBrowserPage(mockNavigation),
-      );
-
-      act(() => {
-        result.current.navigateToInternalBrowserPage(
-          CardInternalBrowserPage.TOS,
-        );
-      });
-
-      expect(Linking.openURL).toHaveBeenCalledWith(
-        'https://secure.baanx.co.uk/MM-Card-RoW-Terms-2025-Sept.pdf',
-      );
-    });
-
-    it('does not navigate to browser when opening TOS', () => {
-      const { result } = renderHook(() =>
-        useNavigateToInternalBrowserPage(mockNavigation),
-      );
-
-      act(() => {
-        result.current.navigateToInternalBrowserPage(
-          CardInternalBrowserPage.TOS,
-        );
-      });
-
-      expect(mockNavigation.navigate).not.toHaveBeenCalled();
-    });
-  });
 
   describe('edge cases', () => {
     it.each([undefined, null, []])(
@@ -381,9 +348,19 @@ describe('useNavigateToCardPage', () => {
         result.current.navigateToCardTosPage();
       });
 
-      expect(Linking.openURL).toHaveBeenCalledWith(
-        'https://secure.baanx.co.uk/MM-Card-RoW-Terms-2025-Sept.pdf',
+      expect(Linking.openURL).toHaveBeenCalledWith(FALLBACK_TOS_URL);
+    });
+
+    it('opens dynamic TOS URL when provided', () => {
+      const { result } = renderHook(() =>
+        useNavigateToCardPage(mockNavigation, DYNAMIC_TOS_URL),
       );
+
+      act(() => {
+        result.current.navigateToCardTosPage();
+      });
+
+      expect(Linking.openURL).toHaveBeenCalledWith(DYNAMIC_TOS_URL);
     });
 
     it('does not navigate to browser', () => {

--- a/app/components/UI/Card/hooks/useNavigateToCardPage.tsx
+++ b/app/components/UI/Card/hooks/useNavigateToCardPage.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../reducers';
 import { BrowserTab } from '../../Tokens/types';
-import { isCardTravelUrl, isCardTosUrl } from '../../../../util/url';
+import { isCardTravelUrl } from '../../../../util/url';
 import AppConstants from '../../../../core/AppConstants';
 import Routes from '../../../../constants/navigation/Routes';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
@@ -10,10 +10,10 @@ import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { CardActions } from '../util/metrics';
 import { Linking } from 'react-native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
+import Logger from '../../../../util/Logger';
 
 export enum CardInternalBrowserPage {
   TRAVEL = 'travel',
-  TOS = 'tos',
 }
 
 const PAGE_CONFIG: Record<
@@ -29,11 +29,6 @@ const PAGE_CONFIG: Record<
     getUrl: () => AppConstants.CARD.TRAVEL_URL,
     action: CardActions.NAVIGATE_TO_TRAVEL_PAGE,
   },
-  [CardInternalBrowserPage.TOS]: {
-    urlCheck: isCardTosUrl,
-    getUrl: () => AppConstants.CARD.CARD_TOS_URL,
-    action: CardActions.NAVIGATE_TO_CARD_TOS_PAGE,
-  },
 };
 
 export const useNavigateToInternalBrowserPage = (
@@ -45,18 +40,6 @@ export const useNavigateToInternalBrowserPage = (
   const navigateToInternalBrowserPage = useCallback(
     (page: CardInternalBrowserPage) => {
       const { urlCheck, getUrl, action } = PAGE_CONFIG[page];
-
-      if (page === CardInternalBrowserPage.TOS) {
-        Linking.openURL(getUrl());
-        trackEvent(
-          createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-            .addProperties({
-              action,
-            })
-            .build(),
-        );
-        return;
-      }
 
       const existingTab = browserTabs?.find(({ url }: BrowserTab) =>
         urlCheck(url),
@@ -102,17 +85,36 @@ export const useNavigateToInternalBrowserPage = (
  * Hook that provides navigation functions for Card-related internal browser flows.
  * Returns convenience methods for Travel (in-app browser) and TOS (external link).
  */
-export const useNavigateToCardPage = (navigation: AppNavigationProp) => {
+export const useNavigateToCardPage = (
+  navigation: AppNavigationProp,
+  cardTermsAndConditionsUrl: string = AppConstants.CARD.CARD_TOS_URL,
+) => {
   const { navigateToInternalBrowserPage } =
     useNavigateToInternalBrowserPage(navigation);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const navigateToTravelPage = useCallback(() => {
     navigateToInternalBrowserPage(CardInternalBrowserPage.TRAVEL);
   }, [navigateToInternalBrowserPage]);
 
   const navigateToCardTosPage = useCallback(() => {
-    navigateToInternalBrowserPage(CardInternalBrowserPage.TOS);
-  }, [navigateToInternalBrowserPage]);
+    Linking.openURL(cardTermsAndConditionsUrl).catch((error) => {
+      Logger.error(error as Error, {
+        tags: { feature: 'card' },
+        context: {
+          name: 'useNavigateToCardPage',
+          data: { url: cardTermsAndConditionsUrl },
+        },
+      });
+    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+        .addProperties({
+          action: CardActions.NAVIGATE_TO_CARD_TOS_PAGE,
+        })
+        .build(),
+    );
+  }, [cardTermsAndConditionsUrl, trackEvent, createEventBuilder]);
 
   return {
     navigateToTravelPage,

--- a/app/components/UI/Card/hooks/useRegistrationSettings.test.ts
+++ b/app/components/UI/Card/hooks/useRegistrationSettings.test.ts
@@ -44,6 +44,34 @@ describe('useRegistrationSettings', () => {
     optionalFields: ['phoneNumber'],
     termsAndConditionsUrl: 'https://example.com/terms',
     privacyPolicyUrl: 'https://example.com/privacy',
+    links: {
+      us: {
+        termsAndConditions:
+          'https://docs.baanx.us/metamask/terms-of-service.pdf',
+        accountOpeningDisclosure:
+          'https://docs.baanx.us/metamask/account-opening-disclosures.pdf',
+        noticeOfPrivacy: 'https://docs.baanx.us/metamask/privacy-policy.pdf',
+        eSignConsentDisclosure:
+          'https://docs.baanx.us/metamask/e-sign-consent.pdf',
+      },
+      intl: {
+        termsAndConditions:
+          'https://www.baanxuk.com/docs/CL-Platform-Terms-of-Use-2026.pdf',
+        rightToInformation: '',
+      },
+    },
+    config: {
+      us: {
+        emailSpecialCharactersDomainsException: 'baanx.com,consensys.net',
+        consentSmsNumber: '833-998-2466',
+        supportEmail: 'metamask@cl-cards.com',
+      },
+      intl: {
+        emailSpecialCharactersDomainsException: 'consensys.net, baanx.com',
+        consentSmsNumber: '1234567890',
+        supportEmail: 'metamask@cl-cards.com',
+      },
+    },
   };
 
   beforeEach(() => {

--- a/app/components/UI/Card/util/registrationSettings.test.ts
+++ b/app/components/UI/Card/util/registrationSettings.test.ts
@@ -1,0 +1,184 @@
+import AppConstants from '../../../../core/AppConstants';
+import {
+  CARD_SUPPORT_EMAIL,
+  CRB_ACCOUNT_OPENING_URL,
+  CRB_PRIVACY_NOTICE_URL,
+  CRB_TERMS_URL,
+} from '../constants';
+import type { RegistrationSettingsResponse } from '../types';
+import {
+  getCardSupportEmail,
+  getCardTermsAndConditionsUrl,
+  getCardUsDisclosureUrls,
+  toOpenableUrl,
+} from './registrationSettings';
+
+const US_TERMS_URL = 'https://docs.baanx.us/metamask/terms.pdf';
+const INTL_TERMS_URL = 'https://www.baanxuk.com/docs/terms.pdf';
+const US_SUPPORT_EMAIL = 'us-support@cl-cards.com';
+const INTL_SUPPORT_EMAIL = 'intl-support@cl-cards.com';
+
+const createRegistrationSettings = ({
+  usTermsAndConditions = US_TERMS_URL,
+  intlTermsAndConditions = INTL_TERMS_URL,
+  accountOpeningDisclosure = 'https://docs.baanx.us/metamask/account-opening.pdf',
+  noticeOfPrivacy = 'https://docs.baanx.us/metamask/privacy.pdf',
+  eSignConsentDisclosure = 'https://docs.baanx.us/metamask/esign.pdf',
+  usSupportEmail = US_SUPPORT_EMAIL,
+  intlSupportEmail = INTL_SUPPORT_EMAIL,
+}: {
+  usTermsAndConditions?: string;
+  intlTermsAndConditions?: string;
+  accountOpeningDisclosure?: string;
+  noticeOfPrivacy?: string;
+  eSignConsentDisclosure?: string;
+  usSupportEmail?: string;
+  intlSupportEmail?: string;
+} = {}): RegistrationSettingsResponse => ({
+  countries: [],
+  usStates: [],
+  links: {
+    us: {
+      termsAndConditions: usTermsAndConditions,
+      accountOpeningDisclosure,
+      noticeOfPrivacy,
+      eSignConsentDisclosure,
+    },
+    intl: {
+      termsAndConditions: intlTermsAndConditions,
+      rightToInformation: '',
+    },
+  },
+  config: {
+    us: {
+      emailSpecialCharactersDomainsException: '',
+      consentSmsNumber: '',
+      supportEmail: usSupportEmail,
+    },
+    intl: {
+      emailSpecialCharactersDomainsException: '',
+      consentSmsNumber: '',
+      supportEmail: intlSupportEmail,
+    },
+  },
+});
+
+describe('toOpenableUrl', () => {
+  it('returns null for blank values', () => {
+    const result = toOpenableUrl('   ');
+
+    expect(result).toBeNull();
+  });
+
+  it('trims valid http URLs', () => {
+    const result = toOpenableUrl('  https://docs.example.com/terms.pdf  ');
+
+    expect(result).toBe('https://docs.example.com/terms.pdf');
+  });
+
+  it('prefixes https for scheme-less domain URLs', () => {
+    const result = toOpenableUrl('www.baanxuk.com/docs/terms.pdf');
+
+    expect(result).toBe('https://www.baanxuk.com/docs/terms.pdf');
+  });
+
+  it('returns null for placeholder values', () => {
+    const result = toOpenableUrl('Not currently available');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('getCardTermsAndConditionsUrl', () => {
+  it('returns the US terms URL for US users', () => {
+    const settings = createRegistrationSettings();
+
+    const result = getCardTermsAndConditionsUrl(settings, 'us');
+
+    expect(result).toBe(US_TERMS_URL);
+  });
+
+  it('returns the international terms URL for international users', () => {
+    const settings = createRegistrationSettings();
+
+    const result = getCardTermsAndConditionsUrl(settings, 'international');
+
+    expect(result).toBe(INTL_TERMS_URL);
+  });
+
+  it('falls back to the static TOS URL when the selected URL is blank', () => {
+    const settings = createRegistrationSettings({
+      intlTermsAndConditions: '   ',
+    });
+
+    const result = getCardTermsAndConditionsUrl(settings, 'international');
+
+    expect(result).toBe(AppConstants.CARD.CARD_TOS_URL);
+  });
+
+  it('falls back to the static TOS URL when settings are missing', () => {
+    const result = getCardTermsAndConditionsUrl(null, 'us');
+
+    expect(result).toBe(AppConstants.CARD.CARD_TOS_URL);
+  });
+});
+
+describe('getCardSupportEmail', () => {
+  it('returns the US support email for US users', () => {
+    const settings = createRegistrationSettings();
+
+    const result = getCardSupportEmail(settings, 'us');
+
+    expect(result).toBe(US_SUPPORT_EMAIL);
+  });
+
+  it('returns the international support email for international users', () => {
+    const settings = createRegistrationSettings();
+
+    const result = getCardSupportEmail(settings, 'international');
+
+    expect(result).toBe(INTL_SUPPORT_EMAIL);
+  });
+
+  it('falls back to the static support email when the selected email is blank', () => {
+    const settings = createRegistrationSettings({ usSupportEmail: '   ' });
+
+    const result = getCardSupportEmail(settings, 'us');
+
+    expect(result).toBe(CARD_SUPPORT_EMAIL);
+  });
+});
+
+describe('getCardUsDisclosureUrls', () => {
+  it('returns dynamic US disclosure URLs when settings include openable URLs', () => {
+    const settings = createRegistrationSettings();
+
+    const result = getCardUsDisclosureUrls(settings);
+
+    expect(result).toStrictEqual({
+      eSignConsentDisclosureUSUrl: 'https://docs.baanx.us/metamask/esign.pdf',
+      crbTermsUrl: US_TERMS_URL,
+      crbAccountOpeningUrl:
+        'https://docs.baanx.us/metamask/account-opening.pdf',
+      crbNoticeOfPrivacyUrl: 'https://docs.baanx.us/metamask/privacy.pdf',
+    });
+  });
+
+  it('falls back to static CRB URLs when dynamic disclosure URLs are not openable', () => {
+    const settings = createRegistrationSettings({
+      usTermsAndConditions: 'pending URL update',
+      accountOpeningDisclosure: '',
+      noticeOfPrivacy: 'N/A',
+      eSignConsentDisclosure: '',
+    });
+
+    const result = getCardUsDisclosureUrls(settings);
+
+    expect(result).toStrictEqual({
+      eSignConsentDisclosureUSUrl: '',
+      crbTermsUrl: CRB_TERMS_URL,
+      crbAccountOpeningUrl: CRB_ACCOUNT_OPENING_URL,
+      crbNoticeOfPrivacyUrl: CRB_PRIVACY_NOTICE_URL,
+    });
+  });
+});

--- a/app/components/UI/Card/util/registrationSettings.ts
+++ b/app/components/UI/Card/util/registrationSettings.ts
@@ -1,0 +1,62 @@
+import AppConstants from '../../../../core/AppConstants';
+import {
+  CARD_SUPPORT_EMAIL,
+  CRB_ACCOUNT_OPENING_URL,
+  CRB_PRIVACY_NOTICE_URL,
+  CRB_TERMS_URL,
+} from '../constants';
+import type { CardLocation, RegistrationSettingsResponse } from '../types';
+
+type RegistrationSettings = RegistrationSettingsResponse | null | undefined;
+
+export const toOpenableUrl = (value?: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (/^[\w-]+(\.[\w-]+)+(\/|\?|#|$)/.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  return null;
+};
+
+export const getCardTermsAndConditionsUrl = (
+  registrationSettings: RegistrationSettings,
+  location: CardLocation | null | undefined,
+): string => {
+  const dynamicUrl =
+    location === 'us'
+      ? registrationSettings?.links?.us?.termsAndConditions
+      : registrationSettings?.links?.intl?.termsAndConditions;
+
+  return toOpenableUrl(dynamicUrl) ?? AppConstants.CARD.CARD_TOS_URL;
+};
+
+export const getCardSupportEmail = (
+  registrationSettings: RegistrationSettings,
+  location: CardLocation | null | undefined,
+): string => {
+  const dynamicEmail =
+    location === 'us'
+      ? registrationSettings?.config?.us?.supportEmail
+      : registrationSettings?.config?.intl?.supportEmail;
+
+  return dynamicEmail?.trim() || CARD_SUPPORT_EMAIL;
+};
+
+export const getCardUsDisclosureUrls = (
+  registrationSettings: RegistrationSettings,
+) => ({
+  eSignConsentDisclosureUSUrl:
+    toOpenableUrl(registrationSettings?.links?.us?.eSignConsentDisclosure) ??
+    '',
+  crbTermsUrl:
+    toOpenableUrl(registrationSettings?.links?.us?.termsAndConditions) ??
+    CRB_TERMS_URL,
+  crbAccountOpeningUrl:
+    toOpenableUrl(registrationSettings?.links?.us?.accountOpeningDisclosure) ??
+    CRB_ACCOUNT_OPENING_URL,
+  crbNoticeOfPrivacyUrl:
+    toOpenableUrl(registrationSettings?.links?.us?.noticeOfPrivacy) ??
+    CRB_PRIVACY_NOTICE_URL,
+});

--- a/tests/component-view/renderers/cardViewRenderer.tsx
+++ b/tests/component-view/renderers/cardViewRenderer.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { renderComponentViewScreen, renderScreenWithRoutes } from '../render';
 import { initialStateCard } from '../presets/cardStatePreset';
 import CardHome from '../../../app/components/UI/Card/Views/CardHome/CardHome';
+import {
+  CardSDKProvider,
+  type ICardSDK,
+} from '../../../app/components/UI/Card/sdk';
 import Routes from '../../../app/constants/navigation/Routes';
 import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
 import type { RootState } from '../../../app/reducers';
@@ -11,6 +15,28 @@ interface RenderCardViewOptions {
   overrides?: DeepPartial<RootState>;
   initialParams?: Record<string, unknown>;
   extraRoutes?: { name: string; Component?: React.ComponentType<object> }[];
+}
+
+const defaultCardSdkContext: ICardSDK = {
+  sdk: null,
+  isLoading: false,
+  user: null,
+  setUser: () => undefined,
+  logoutFromProvider: async () => undefined,
+  fetchUserData: async () => undefined,
+  isReturningSession: false,
+};
+
+function withCardSdkProvider<T extends object>(
+  Component: React.ComponentType<T>,
+): React.ComponentType<T> {
+  return function WrappedWithCardSdkProvider(props: T) {
+    return (
+      <CardSDKProvider value={defaultCardSdkContext}>
+        <Component {...props} />
+      </CardSDKProvider>
+    );
+  };
 }
 
 /**
@@ -28,18 +54,23 @@ export function renderCardHomeView(options: RenderCardViewOptions = {}) {
   }
   const state = builder.build();
 
+  const CardHomeWithSdk = withCardSdkProvider(CardHome);
+
   if (extraRoutes?.length) {
     return renderScreenWithRoutes(
-      CardHome,
+      CardHomeWithSdk,
       { name: Routes.CARD.HOME },
-      extraRoutes,
+      extraRoutes.map(({ name, Component }) => ({
+        name,
+        Component: Component ? withCardSdkProvider(Component) : undefined,
+      })),
       { state },
       initialParams,
     );
   }
 
   return renderComponentViewScreen(
-    CardHome,
+    CardHomeWithSdk,
     { name: Routes.CARD.HOME },
     { state },
     initialParams,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

This PR updates MetaMask Card legal and support links to use the latest registration settings returned by the Card SDK instead of relying only on static constants.

It adds a small registration-settings utility for URL normalization and fallback behavior, derives the Card Home TOS URL and support email directly from React Query data, and keeps TOS as an external `Linking.openURL` flow while Travel remains an internal browser flow.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated MetaMask Card legal and support links to use provider registration settings when available

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: CARD-451

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: MetaMask Card dynamic registration links

  Scenario: user opens Card legal and support links
    Given the Card SDK returns registration settings with legal document URLs and support email
    When the user opens Card Home and taps Card Terms or Contact Support
    Then the app opens the dynamic terms URL or dynamic support email when available
    And the app falls back to the static Card URLs when registration settings are missing or unusable
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Card UI link resolution and external `Linking`/`mailto` behavior with static fallbacks; no auth, payments, or core wallet logic.
> 
> **Overview**
> Card **legal document URLs** and **support email** now come from Card SDK **registration settings** (US vs international), with shared helpers in `registrationSettings.ts` for URL normalization (`toOpenableUrl`) and **fallbacks** to existing static constants when settings are missing or invalid.
> 
> **Card Home** loads registration settings, passes the resolved TOS URL into `useNavigateToCardPage` / `useCardHomeActions`, and passes `supportEmail` into the footer so Contact Support uses `mailto:` with the dynamic address. **Onboarding** (`PhysicalAddress`) uses `getCardUsDisclosureUrls` for CRB terms, account opening, and privacy notice instead of hard-coded CRB URLs.
> 
> **TOS navigation** is simplified: TOS is no longer an internal-browser page type; `navigateToCardTosPage` always opens the resolved URL via `Linking.openURL` (with error logging), defaulting to `AppConstants.CARD.CARD_TOS_URL` when no dynamic URL is passed.
> 
> Tests cover dynamic vs fallback behavior; component-view **Card Home** rendering wraps screens in `CardSDKProvider` for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42cbcb3a6f381fda6c6eed98253cd4308d45217d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->