### PR TITLE
chore: remove rc environment from showDevErrorAlert helper cp-8.0.0

### DIFF
--- a/app/components/UI/Money/utils/devErrorAlert.test.ts
+++ b/app/components/UI/Money/utils/devErrorAlert.test.ts
@@ -16,7 +16,7 @@ describe('showDevErrorAlert', () => {
     alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
   });
 
-  it.each(['rc', 'exp', 'dev', 'test'])(
+  it.each(['exp', 'dev', 'test'])(
     'shows an alert with the stack trace in %s environment',
     (env) => {
       const error = new Error('something went wrong');

--- a/app/components/UI/Money/utils/devErrorAlert.ts
+++ b/app/components/UI/Money/utils/devErrorAlert.ts
@@ -1,14 +1,14 @@
 import { Alert } from 'react-native';
 import ClipboardManager from '../../../../core/ClipboardManager';
 
-const DEV_ENVIRONMENTS = new Set(['rc', 'exp', 'dev', 'test']);
+const DEV_ENVIRONMENTS = new Set(['exp', 'dev', 'test']);
 
 const SUPPRESSED_ERRORS = [
   'MetaMask Tx Signature: User denied transaction signature.',
 ];
 
 /**
- * In non-production builds (rc / exp / dev / test) shows a native Alert
+ * In non-production builds (exp / dev / test) shows a native Alert
  * containing the full error stack trace, with a one-tap "Copy" button.
  *
  * Certain expected user-cancellation errors are suppressed so testers are


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->
Remove RC environment from `showDevErrorAlert`
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: removed RC environment from `showDevErrorAlert`

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1052: Remove RC environment from showDevErrorAlert helper](https://consensyssoftware.atlassian.net/browse/MUSD-1052)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A 

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
N/A
### **After**

<!-- [screenshots/recordings] -->
N/A
## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small gating change in a dev-only error UI helper; RC users simply stop seeing debug alerts, with no auth or transaction logic touched.
> 
> **Overview**
> **`showDevErrorAlert` no longer treats `rc` as a dev-like environment**, so RC builds will not pop native alerts with full stack traces and a Copy button when Money flows hit errors.
> 
> The change updates `DEV_ENVIRONMENTS` in `devErrorAlert.ts`, the JSDoc wording, and the parameterized unit test cases so only **`exp`**, **`dev`**, and **`test`** still trigger the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7c6ee08d5117c600f3d0b94779316998f2c0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->