### PR TITLE
fix: issue with money account selection on perps page for a new account with no funds cp-8.0.0

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -44,7 +44,8 @@ import { useTokenFiatRates } from '../../../hooks/tokens/useTokenFiatRates';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionAccountOverride } from '../../../hooks/transactions/useTransactionAccountOverride';
 import { useMoneyNoFeeTokens } from '../../../hooks/pay/useMoneyNoFeeTokens';
-
+import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
+import Logger from '../../../../../../util/Logger';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
@@ -77,6 +78,7 @@ jest.mock('../../../hooks/pay/useTransactionPayWithdraw', () => ({
 }));
 jest.mock('../../../hooks/transactions/useTransactionAccountOverride');
 jest.mock('../../../hooks/pay/useMoneyNoFeeTokens');
+jest.mock('../../../hooks/pay/sections/usePayWithMoneyAccountSection');
 jest.mock('../../../../../../util/transaction-controller', () => ({}));
 
 jest.mock('../../../../../../core/Engine', () => ({
@@ -266,6 +268,9 @@ describe('CustomAmountInfo', () => {
     useClearConfirmationOnBackSwipe,
   );
   const useMoneyNoFeeTokensMock = jest.mocked(useMoneyNoFeeTokens);
+  const usePayWithMoneyAccountSectionMock = jest.mocked(
+    usePayWithMoneyAccountSection,
+  );
   const setIsConfirmationSubmittingMock = jest.fn();
 
   const useRouteMock = jest.mocked(useRoute);
@@ -366,6 +371,7 @@ describe('CustomAmountInfo', () => {
     } as never);
 
     useMoneyNoFeeTokensMock.mockReturnValue({ isMoneyNoFeeToken: false });
+    usePayWithMoneyAccountSectionMock.mockReturnValue(null);
   });
 
   it('renders amount', () => {
@@ -469,6 +475,24 @@ describe('CustomAmountInfo', () => {
     expect(
       getByText(strings('confirm.custom_amount.buy_button')),
     ).toBeDefined();
+  });
+
+  it('does not render buy button when money account is available', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [],
+      hasTokens: false,
+    });
+
+    usePayWithMoneyAccountSectionMock.mockReturnValue({
+      id: 'money-account',
+      title: '',
+      testID: 'pay-with-section-money-account',
+      rows: [],
+    });
+
+    const { queryByText } = render();
+
+    expect(queryByText(strings('confirm.custom_amount.buy_button'))).toBeNull();
   });
 
   it('navigates to ramps if buy button pressed', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -45,6 +45,7 @@ import {
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayHasSourceAmount } from '../../../hooks/pay/useTransactionPayHasSourceAmount';
+import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import Text, {
@@ -161,7 +162,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const fiatPayment = useTransactionPayFiatPayment();
     const selectedFiatPaymentMethodId = fiatPayment?.selectedPaymentMethodId;
     const isFiatAvailable = useIsFiatPaymentAvailable();
-    const hasPaymentOption = hasAvailableTokens || isFiatAvailable;
+    const moneyAccountSection = usePayWithMoneyAccountSection();
+    const hasPaymentOption =
+      hasAvailableTokens || isFiatAvailable || moneyAccountSection !== null;
     const fiatEverSelectedRef = useRef(false);
     if (selectedFiatPaymentMethodId) {
       fiatEverSelectedRef.current = true;

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -14,6 +14,7 @@ import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayW
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import Routes from '../../../../../../constants/navigation/Routes';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
@@ -62,6 +63,9 @@ jest.mock(
     useTransactionPaySelectedFiatPaymentMethod: jest.fn(),
   }),
 );
+jest.mock('../../../hooks/pay/useTransactionPayAvailableTokens', () => ({
+  useTransactionPayAvailableTokens: jest.fn(),
+}));
 jest.mock('../../../../../../util/address');
 jest.mock('../../../hooks/metrics/useConfirmationMetricEvents', () => ({
   useConfirmationMetricEvents: jest.fn(),
@@ -150,6 +154,9 @@ describe('PayWithRow', () => {
 
     jest.mocked(useAccountNoFundsAlert).mockReturnValue([]);
     jest.mocked(useIsMoneyAccountFlagDefault).mockReturnValue(false);
+    jest
+      .mocked(useTransactionPayAvailableTokens)
+      .mockReturnValue({ availableTokens: [], hasTokens: true });
   });
 
   it('renders selected pay token', async () => {
@@ -170,7 +177,7 @@ describe('PayWithRow', () => {
     );
   });
 
-  it('renders skeleton when no pay token selected', () => {
+  it('renders skeleton when no pay token selected but tokens are available', () => {
     jest.mocked(useTransactionPayToken).mockReturnValue({
       payToken: undefined,
       setPayToken: jest.fn(),
@@ -179,6 +186,21 @@ describe('PayWithRow', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('pay-with-row-skeleton')).toBeDefined();
+  });
+
+  it('renders empty state when no pay token and no available tokens', () => {
+    jest.mocked(useTransactionPayToken).mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+    });
+    jest
+      .mocked(useTransactionPayAvailableTokens)
+      .mockReturnValue({ availableTokens: [], hasTokens: false });
+
+    const { getByTestId, queryByTestId } = render();
+
+    expect(queryByTestId('pay-with-row-skeleton')).toBeNull();
+    expect(getByTestId('pay-with-symbol')).toHaveTextContent('Select token');
   });
 
   it('disables edit if hardware wallet', async () => {
@@ -342,7 +364,7 @@ describe('PayWithRow', () => {
       expect(queryByTestId('pay-with-balance')).toBeNull();
     });
 
-    it('renders skeleton when no pay token in money account mode', () => {
+    it('renders money account row even when no pay token', () => {
       jest.mocked(useTransactionPayToken).mockReturnValue({
         payToken: undefined,
         setPayToken: jest.fn(),
@@ -350,7 +372,7 @@ describe('PayWithRow', () => {
 
       const { getByTestId } = renderMoneyAccount();
 
-      expect(getByTestId('pay-with-row-skeleton')).toBeDefined();
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent('Money account');
     });
 
     it('navigates to pay-with modal on press', async () => {

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -9,6 +9,7 @@ import { TokenIcon, TokenIconVariant } from '../../token-icon';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
 import { Image, TouchableOpacity } from 'react-native';
@@ -156,6 +157,7 @@ function PayWithRowInteractive() {
   const requiredTokens = useTransactionPayRequiredTokens();
   const accountNoFundsAlert = useAccountNoFundsAlert();
   const hasAccountNoFunds = accountNoFundsAlert.length > 0;
+  const { hasTokens: hasAvailableTokens } = useTransactionPayAvailableTokens();
   const selectedFiatPaymentMethod =
     useTransactionPaySelectedFiatPaymentMethod();
   const formatFiat = useFiatFormatter({ currency: 'usd' });
@@ -223,7 +225,10 @@ function PayWithRowInteractive() {
   }
 
   if (!displayToken) {
-    if (!hasAccountNoFunds) {
+    // Show skeleton only while tokens exist to auto-select from.
+    // Without available tokens the skeleton never resolves (e.g. perps
+    // deposit with zero balance and no fiat payment method selected).
+    if (!hasAccountNoFunds && hasAvailableTokens) {
       return <PayWithRowSkeleton />;
     }
 
@@ -341,7 +346,6 @@ function PayWithRowEmpty({
 
 function PayWithRowMoneyAccount() {
   const navigation = useNavigation();
-  const { payToken } = useTransactionPayToken();
   const { isWithdraw } = useTransactionPayWithdraw();
   const { styles } = useStyles(styleSheet, {});
   const { setConfirmationMetric } = useConfirmationMetricEvents();
@@ -355,10 +359,6 @@ function PayWithRowMoneyAccount() {
       preferredPaymentToken,
     });
   }, [navigation, preferredPaymentToken, setConfirmationMetric]);
-
-  if (!payToken) {
-    return <PayWithRowSkeleton />;
-  }
 
   return (
     <PayWithRowLayout

--- a/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useFiatBuyLimitAlert.test.ts
@@ -180,4 +180,20 @@ describe('useFiatBuyLimitAlert', () => {
 
     expect(result.current).toStrictEqual([]);
   });
+
+  it('returns empty array when selectedPaymentMethodId is cleared for money account', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: undefined,
+      amountFiat: '0.05',
+    });
+
+    useRampsBuyLimitsMock.mockReturnValue({
+      amountLimitError: 'Minimum purchase is $5.00',
+      currency: 'USD',
+    });
+
+    const { result } = runHook({ pendingAmount: '0.05' });
+
+    expect(result.current).toStrictEqual([]);
+  });
 });

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.test.tsx
@@ -39,6 +39,7 @@ jest.mock('../../../../../../core/Engine', () => ({
   context: {
     TransactionPayController: {
       setTransactionConfig: jest.fn(),
+      updateFiatPayment: jest.fn(),
     },
   },
 }));
@@ -316,6 +317,31 @@ describe('usePayWithMoneyAccountSection', () => {
       });
 
       expect(goBackMock).toHaveBeenCalled();
+    });
+
+    it('clears selectedPaymentMethodId via updateFiatPayment on press', () => {
+      const updateFiatPaymentMock = jest.mocked(
+        Engine.context.TransactionPayController.updateFiatPayment,
+      );
+
+      const { result } = renderHook(() => usePayWithMoneyAccountSection());
+
+      act(() => {
+        result.current?.rows[0].onPress?.();
+      });
+
+      expect(updateFiatPaymentMock).toHaveBeenCalledWith({
+        transactionId: 'tx-1',
+        callback: expect.any(Function),
+      });
+
+      const fiatPayment = { selectedPaymentMethodId: 'some-method' } as Record<
+        string,
+        unknown
+      >;
+      updateFiatPaymentMock.mock.calls[0][0].callback(fiatPayment as never);
+
+      expect(fiatPayment.selectedPaymentMethodId).toBeUndefined();
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithMoneyAccountSection.tsx
@@ -3,9 +3,7 @@ import { Image, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { PaymentOverride } from '@metamask/transaction-pay-controller';
-import type { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../../locales/i18n';
-import Engine from '../../../../../../core/Engine';
 import MoneyIcon from '../../../../../../images/money.png';
 import { RootState } from '../../../../../../reducers';
 import { selectPrimaryMoneyAccount } from '../../../../../../selectors/moneyAccountController';
@@ -17,6 +15,7 @@ import {
   getTransactionType,
   isTransactionPayWithdraw,
 } from '../../../utils/transaction';
+import { applyMoneyAccountOverride } from '../../../utils/transaction-pay';
 import {
   PayWithRowConfig,
   PayWithSectionConfig,
@@ -55,15 +54,10 @@ export function usePayWithMoneyAccountSection(): PayWithSectionConfig | null {
 
   const handlePress = useCallback(() => {
     if (transactionId) {
-      Engine.context.TransactionPayController.setTransactionConfig(
+      applyMoneyAccountOverride(
         transactionId,
-        (config) => {
-          (config as Record<string, unknown>).paymentOverride =
-            PaymentOverride.MoneyAccount;
-          if (moneyAccount?.address && !isWithdraw) {
-            config.refundTo = moneyAccount.address as Hex;
-          }
-        },
+        moneyAccount?.address,
+        isWithdraw,
       );
     }
     navigation.goBack();

--- a/app/components/Views/confirmations/hooks/pay/useDefaultPaySelectedSection.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useDefaultPaySelectedSection.test.ts
@@ -18,6 +18,7 @@ jest.mock('../../../../../core/Engine', () => ({
     context: {
       TransactionPayController: {
         setTransactionConfig: jest.fn(),
+        updateFiatPayment: jest.fn(),
       },
     },
   },
@@ -42,6 +43,9 @@ jest.mock('./useIsMoneyAccountFlagDefault', () => ({
 
 const setTransactionConfigMock = jest.mocked(
   Engine.context.TransactionPayController.setTransactionConfig,
+);
+const updateFiatPaymentMock = jest.mocked(
+  Engine.context.TransactionPayController.updateFiatPayment,
 );
 
 const render = () =>
@@ -100,6 +104,31 @@ describe('useDefaultPaySelectedSection', () => {
 
     expect(config.paymentOverride).toBe(PaymentOverride.MoneyAccount);
     expect(config.refundTo).toBe(MONEY_ACCOUNT_ADDRESS);
+  });
+
+  it('clears selectedPaymentMethodId via updateFiatPayment for deposit transactions', () => {
+    (useParams as jest.Mock).mockReturnValue({
+      payWithOption: PayWithOption.MoneyAccount,
+    });
+    (useTransactionMetadataRequest as jest.Mock).mockReturnValue({
+      id: TRANSACTION_ID,
+      type: TransactionType.perpsDeposit,
+    });
+
+    render();
+
+    expect(updateFiatPaymentMock).toHaveBeenCalledWith({
+      transactionId: TRANSACTION_ID,
+      callback: expect.any(Function),
+    });
+
+    const fiatPayment = { selectedPaymentMethodId: 'some-method' } as Record<
+      string,
+      unknown
+    >;
+    updateFiatPaymentMock.mock.calls[0][0].callback(fiatPayment as never);
+
+    expect(fiatPayment.selectedPaymentMethodId).toBeUndefined();
   });
 
   it('sets PaymentOverride.MoneyAccount but omits refundTo for withdraw transactions', () => {
@@ -196,6 +225,28 @@ describe('useDefaultPaySelectedSection', () => {
       expect(config.refundTo).toBeUndefined();
     });
 
+    it('clears selectedPaymentMethodId via updateFiatPayment when flag is active', () => {
+      (useIsMoneyAccountFlagDefault as jest.Mock).mockReturnValue(true);
+      (useTransactionMetadataRequest as jest.Mock).mockReturnValue({
+        id: TRANSACTION_ID,
+        type: TransactionType.predictWithdraw,
+      });
+
+      render();
+
+      expect(updateFiatPaymentMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID,
+        callback: expect.any(Function),
+      });
+
+      const fiatPayment = {
+        selectedPaymentMethodId: 'existing-method',
+      } as Record<string, unknown>;
+      updateFiatPaymentMock.mock.calls[0][0].callback(fiatPayment as never);
+
+      expect(fiatPayment.selectedPaymentMethodId).toBeUndefined();
+    });
+
     it('does not set override when useIsMoneyAccountFlagDefault returns false', () => {
       (useIsMoneyAccountFlagDefault as jest.Mock).mockReturnValue(false);
       (useTransactionMetadataRequest as jest.Mock).mockReturnValue({
@@ -205,6 +256,7 @@ describe('useDefaultPaySelectedSection', () => {
       render();
 
       expect(setTransactionConfigMock).not.toHaveBeenCalled();
+      expect(updateFiatPaymentMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useDefaultPaySelectedSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/useDefaultPaySelectedSection.ts
@@ -1,8 +1,5 @@
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { PaymentOverride } from '@metamask/transaction-pay-controller';
-import type { Hex } from '@metamask/utils';
-import Engine from '../../../../../core/Engine';
 import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useParams } from '../../../../../util/navigation/navUtils';
@@ -12,6 +9,7 @@ import {
 } from '../../components/confirm/confirm-component';
 import { useIsMoneyAccountFlagDefault } from './useIsMoneyAccountFlagDefault';
 import { isTransactionPayWithdraw } from '../../utils/transaction';
+import { applyMoneyAccountOverride } from '../../utils/transaction-pay';
 
 export function useDefaultPaySelectedSection() {
   const { payWithOption } = useParams<ConfirmationParams>({});
@@ -36,15 +34,6 @@ export function useDefaultPaySelectedSection() {
 
     appliedRef.current = transactionId;
 
-    Engine.context.TransactionPayController.setTransactionConfig(
-      transactionId,
-      (config) => {
-        (config as Record<string, unknown>).paymentOverride =
-          PaymentOverride.MoneyAccount;
-        if (moneyAccount?.address && !isWithdraw) {
-          config.refundTo = moneyAccount.address as Hex;
-        }
-      },
-    );
+    applyMoneyAccountOverride(transactionId, moneyAccount?.address, isWithdraw);
   }, [isMoneyAccount, isWithdraw, transactionId, moneyAccount?.address]);
 }

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -26,7 +26,8 @@ import { AssetType, TokenStandard } from '../types/token';
 import {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
- PaymentOverride } from '@metamask/transaction-pay-controller';
+  PaymentOverride,
+} from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 import type {
   BlockedTokensListConfig,

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import {
+  applyMoneyAccountOverride,
   getAvailableTokens,
   getBlockedTokensForTransactionType,
   getRequiredBalance,
@@ -25,13 +26,14 @@ import { AssetType, TokenStandard } from '../types/token';
 import {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
-} from '@metamask/transaction-pay-controller';
+ PaymentOverride } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 import type {
   BlockedTokensListConfig,
   BlockedTokensConfig,
 } from '../../../../selectors/featureFlagController/confirmations';
 import { strings } from '../../../../../locales/i18n';
+import Engine from '../../../../core/Engine';
 
 jest.mock('../../../../util/transaction-controller', () => ({
   updateAtomicBatchData: jest.fn(),
@@ -40,6 +42,18 @@ jest.mock('../../../../util/transaction-controller', () => ({
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
   default: { error: jest.fn() },
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      TransactionPayController: {
+        setTransactionConfig: jest.fn(),
+        updateFiatPayment: jest.fn(),
+      },
+    },
+  },
 }));
 
 const CHAIN_ID_MOCK = '0x1';
@@ -857,6 +871,70 @@ describe('Transaction Pay Utils', () => {
 
       expect(result).toBe(OVERRIDE);
       expect(result?.address).not.toBe(MUSD_TOKEN_ADDRESS);
+    });
+  });
+
+  describe('applyMoneyAccountOverride', () => {
+    const TRANSACTION_ID = 'tx-override-1';
+    const MONEY_ADDRESS = '0xabc1111111111111111111111111111111111111';
+
+    const setTransactionConfigMock = jest.mocked(
+      Engine.context.TransactionPayController.setTransactionConfig,
+    );
+    const updateFiatPaymentMock = jest.mocked(
+      Engine.context.TransactionPayController.updateFiatPayment,
+    );
+
+    it('sets PaymentOverride.MoneyAccount with refundTo for deposit', () => {
+      applyMoneyAccountOverride(TRANSACTION_ID, MONEY_ADDRESS, false);
+
+      expect(setTransactionConfigMock).toHaveBeenCalledWith(
+        TRANSACTION_ID,
+        expect.any(Function),
+      );
+
+      const config: Record<string, unknown> = {};
+      setTransactionConfigMock.mock.calls[0][1](config as never);
+
+      expect(config.paymentOverride).toBe(PaymentOverride.MoneyAccount);
+      expect(config.refundTo).toBe(MONEY_ADDRESS);
+    });
+
+    it('sets PaymentOverride.MoneyAccount without refundTo for withdraw', () => {
+      applyMoneyAccountOverride(TRANSACTION_ID, MONEY_ADDRESS, true);
+
+      const config: Record<string, unknown> = {};
+      setTransactionConfigMock.mock.calls[0][1](config as never);
+
+      expect(config.paymentOverride).toBe(PaymentOverride.MoneyAccount);
+      expect(config.refundTo).toBeUndefined();
+    });
+
+    it('omits refundTo when moneyAccountAddress is undefined', () => {
+      applyMoneyAccountOverride(TRANSACTION_ID, undefined, false);
+
+      const config: Record<string, unknown> = {};
+      setTransactionConfigMock.mock.calls[0][1](config as never);
+
+      expect(config.paymentOverride).toBe(PaymentOverride.MoneyAccount);
+      expect(config.refundTo).toBeUndefined();
+    });
+
+    it('clears selectedPaymentMethodId via updateFiatPayment', () => {
+      applyMoneyAccountOverride(TRANSACTION_ID, MONEY_ADDRESS, false);
+
+      expect(updateFiatPaymentMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID,
+        callback: expect.any(Function),
+      });
+
+      const fp = { selectedPaymentMethodId: 'some-method' } as Record<
+        string,
+        unknown
+      >;
+      updateFiatPaymentMock.mock.calls[0][0].callback(fp as never);
+
+      expect(fp.selectedPaymentMethodId).toBeUndefined();
     });
   });
 });

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -4,16 +4,16 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { PaymentOverride ,
+  TransactionFiatPayment,
+  TransactionPayRequiredToken,
+  TransactionPaymentToken,
+} from '@metamask/transaction-pay-controller';
 import { PREDICT_MINIMUM_DEPOSIT } from '../constants/predict';
 import { hasTransactionType } from './transaction';
 import { Hex } from '@metamask/utils';
 import { PERPS_MINIMUM_DEPOSIT } from '../constants/perps';
 import { AssetType, TokenStandard } from '../types/token';
-import {
-  TransactionFiatPayment,
-  TransactionPayRequiredToken,
-  TransactionPaymentToken,
-} from '@metamask/transaction-pay-controller';
 import { BigNumber } from 'bignumber.js';
 import { isTestNet } from '../../../../util/networks';
 import {
@@ -22,6 +22,7 @@ import {
 } from '../../../../selectors/featureFlagController/confirmations';
 import { strings } from '../../../../../locales/i18n';
 import Logger from '../../../../util/Logger';
+import Engine from '../../../../core/Engine';
 import { updateAtomicBatchData } from '../../../../util/transaction-controller';
 import { MUSD_TOKEN_ADDRESS } from '../../../UI/Earn/constants/musd';
 
@@ -306,4 +307,33 @@ export function resolvePreferredPayToken({
   }
 
   return undefined;
+}
+
+/**
+ * Sets the money account payment override on a transaction and clears any
+ * previously selected fiat payment method. For deposit flows the money
+ * account address is stored as the refund destination.
+ */
+export function applyMoneyAccountOverride(
+  transactionId: string,
+  moneyAccountAddress: string | undefined,
+  isWithdraw: boolean,
+): void {
+  Engine.context.TransactionPayController.setTransactionConfig(
+    transactionId,
+    (config) => {
+      (config as Record<string, unknown>).paymentOverride =
+        PaymentOverride.MoneyAccount;
+      if (moneyAccountAddress && !isWithdraw) {
+        config.refundTo = moneyAccountAddress as Hex;
+      }
+    },
+  );
+
+  Engine.context.TransactionPayController.updateFiatPayment({
+    transactionId,
+    callback: (fp) => {
+      fp.selectedPaymentMethodId = undefined;
+    },
+  });
 }

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -4,7 +4,8 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { PaymentOverride ,
+import {
+  PaymentOverride,
   TransactionFiatPayment,
   TransactionPayRequiredToken,
   TransactionPaymentToken,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Fix issues on perps page when depositing using money account for a new account with no crypto balance.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/32218
Fixes: https://github.com/MetaMask/metamask-mobile/issues/32215

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [X] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [X] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction pay controller state (payment override, fiat method clearing) and confirmation pay UI paths used for perps/money deposits; scope is focused with solid test coverage.
> 
> **Overview**
> Fixes **perps (and similar) deposits** when users pay with a **Money account** but have **no crypto** and no usable fiat method—UI could stick on a loading skeleton, show a misleading **Buy** CTA, or surface **fiat buy-limit** errors after switching to Money.
> 
> **`applyMoneyAccountOverride`** centralizes setting `PaymentOverride.MoneyAccount`, optional `refundTo` on deposits, and **clearing `selectedPaymentMethodId`** via `updateFiatPayment`. Default money-account selection and the pay-with bottom sheet now call this helper instead of duplicating controller logic.
> 
> **Pay-with row:** skeleton only shows when tokens exist to auto-select; with **no available tokens**, users see **Select token** instead of an endless skeleton. **Money account** row always shows the Money label (no skeleton when `payToken` is missing).
> 
> **Custom amount:** treats an available money-account section as a payment option (hides buy button when Money is available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c663f6e814b1b8e23de0b1eeecbd8cde5a4edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->