### PR TITLE
fix: cp-8.0.0 require EIP-7702 for sponsored gas transactions

### DIFF
--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -223,6 +223,34 @@ describe('Delegation 7702 Publish Hook', () => {
       });
     });
 
+    it('throws when atomic batch is not supported for a gas-sponsored transaction', async () => {
+      await expect(
+        hookClass.getHook()(
+          {
+            ...TRANSACTION_META_MOCK,
+            isGasFeeSponsored: true,
+          },
+          SIGNED_TX_MOCK,
+        ),
+      ).rejects.toThrow(
+        'Gas Station 7702: Chain must support EIP-7702 for sponsored or gas included transaction',
+      );
+    });
+
+    it('throws when atomic batch is not supported for a gas-included transaction', async () => {
+      await expect(
+        hookClass.getHook()(
+          {
+            ...TRANSACTION_META_MOCK,
+            isGasFeeIncluded: true,
+          },
+          SIGNED_TX_MOCK,
+        ),
+      ).rejects.toThrow(
+        'Gas Station 7702: Chain must support EIP-7702 for sponsored or gas included transaction',
+      );
+    });
+
     it('no selected gas fee token', async () => {
       isAtomicBatchSupportedMock.mockResolvedValueOnce([
         {

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -120,6 +120,8 @@ export class Delegation7702PublishHook {
       transactionMeta;
 
     const { from } = txParams;
+    const isGaslessBridge = Boolean(transactionMeta.isGasFeeIncluded);
+    const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
 
     const atomicBatchSupport = await this.#isAtomicBatchSupported({
       address: from as Hex,
@@ -137,15 +139,18 @@ export class Delegation7702PublishHook {
 
     if (!isChainSupported) {
       log('Skipping as EIP-7702 is not supported', { from, chainId });
+
+      if (isGaslessBridge || isSponsored) {
+        throw new Error(
+          'Chain must support EIP-7702 for sponsored or gas included transaction',
+        );
+      }
+
       return EMPTY_RESULT;
     }
 
     const { delegationAddress, upgradeContractAddress } =
       atomicBatchChainSupport;
-
-    const isGaslessBridge = transactionMeta.isGasFeeIncluded;
-
-    const isSponsored = Boolean(transactionMeta.isGasFeeSponsored);
 
     if (
       (!selectedGasFeeToken || !gasFeeTokens?.length) &&
@@ -173,8 +178,7 @@ export class Delegation7702PublishHook {
       parseInt(isE2ETest(chainId) ? SEPOLIA_CHAIN_ID : chainId, 16),
     );
     const delegationManagerAddress = delegationEnvironment.DelegationManager;
-    const includeTransfer =
-      !isGaslessBridge && !transactionMeta.isGasFeeSponsored;
+    const includeTransfer = !isGaslessBridge && !isSponsored;
 
     if (includeTransfer && (!gasFeeToken || gasFeeToken === undefined)) {
       throw new Error('Gas fee token not found');


### PR DESCRIPTION
## **Description**

Sponsored and gas-included transaction publishing depends on the EIP-7702 delegation relay path. Previously, when atomic EIP-7702 support was unavailable for the selected chain, the delegation publish hook returned an empty result, which allowed the publish pipeline to continue to later publication paths.

This PR makes that path fail closed for sponsored and gas-included transactions by throwing a clear error when the chain does not support EIP-7702 atomic batching. Non-sponsored transactions keep the existing empty-result behavior when EIP-7702 is unavailable.

## **Changelog**

CHANGELOG entry: Fixed sponsored and gas-included transactions falling back when EIP-7702 support is unavailable

## **Related issues**

Refs: https://github.com/MetaMask/core/pull/9240

## **Manual testing steps**

N/A - covered by unit tests for the transaction publish hook.

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction publish behavior for gas-sponsored and gas-included flows on chains without EIP-7702, blocking unsafe fallbacks instead of silently continuing.
> 
> **Overview**
> **Sponsored** and **gas-included** publishes must use the EIP-7702 delegation relay. When atomic batch support is missing for the chain, `Delegation7702PublishHook` used to return an empty result so later publish hooks could run.
> 
> This change **throws** for `isGasFeeSponsored` or `isGasFeeIncluded` when the chain is not EIP-7702-capable, with a clear error (prefixed as `Gas Station 7702:`). Regular transactions still get the empty result and can fall through.
> 
> Gas flags are normalized earlier (`Boolean` on `isGasFeeIncluded` / `isGasFeeSponsored`) and `includeTransfer` now keys off the same `isSponsored` flag. Unit tests cover sponsored and gas-included cases when atomic batch is unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5dfa7408d5778425db9369941157fc5ebeec9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->