### PR TITLE
fix(ramp): handle Transak callback and Money activity

### DIFF
--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import { RampsOrderStatus } from '@metamask/ramps-controller';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { useMoneyAccountTransactions } from '../../hooks/useMoneyAccountTransactions';
 import { useMoneyAccountApiActivity } from '../../hooks/useMoneyAccountApiActivity';
@@ -87,6 +88,21 @@ jest.mock(
       default: ({ activity }: { activity: { hash: string } }) => (
         <RNPressable testID={`activity-mock-api-${activity.hash}`}>
           <Text>{activity.hash}</Text>
+        </RNPressable>
+      ),
+    };
+  },
+);
+
+jest.mock(
+  '../../components/RampOrderActivityItem/RampOrderActivityItem',
+  () => {
+    const { Text, Pressable: RNPressable } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({ order }: { order: { providerOrderId: string } }) => (
+        <RNPressable testID={`activity-mock-ramp-${order.providerOrderId}`}>
+          <Text>{order.providerOrderId}</Text>
         </RNPressable>
       ),
     };
@@ -300,6 +316,48 @@ describe('MoneyActivityView', () => {
     expect(
       getByTestId(MoneyActivityViewTestIds.EMPTY_LIST_MESSAGE),
     ).toBeOnTheScreen();
+  });
+
+  it('renders a Money-address ramp order when transaction sources are empty', () => {
+    const moneyAddress = '0x0000000000000000000000000000000000000001';
+    mockUseMoneyAccountTransactions.mockReturnValue({
+      allTransactions: [],
+      deposits: [],
+      transfers: [],
+      submittedTransactions: [],
+      moneyAddress,
+      mockDataEnabled: false,
+    });
+
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <MoneyActivityView />,
+      {
+        state: {
+          engine: {
+            backgroundState: {
+              RampsController: {
+                orders: [
+                  {
+                    providerOrderId: 'transak-order-1',
+                    walletAddress: moneyAddress,
+                    status: RampsOrderStatus.Completed,
+                    createdAt: 1782241698969,
+                    cryptoAmount: '4.96',
+                    fiatAmount: 6.14,
+                    fiatCurrency: { symbol: 'USD' },
+                    cryptoCurrency: { symbol: 'MUSD' },
+                    orderType: 'BUY',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(getByTestId('activity-mock-ramp-transak-order-1')).toBeOnTheScreen();
+    expect(queryByTestId(MoneyActivityViewTestIds.EMPTY_LIST)).toBeNull();
   });
 
   it('pressing a row navigates to the transaction details sheet when mockDataEnabled is false', () => {

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx
@@ -259,6 +259,49 @@ describe('MoneyActivityView', () => {
     ).toBeOnTheScreen();
   });
 
+  it('renders pending ramp orders in the Pending section', () => {
+    const moneyAddress = '0x0000000000000000000000000000000000000001';
+    mockUseMoneyAccountTransactions.mockReturnValue({
+      allTransactions: [],
+      deposits: [],
+      transfers: [],
+      submittedTransactions: [],
+      moneyAddress,
+      mockDataEnabled: false,
+    });
+
+    const { getByTestId } = renderWithProvider(<MoneyActivityView />, {
+      state: {
+        engine: {
+          backgroundState: {
+            RampsController: {
+              orders: [
+                {
+                  providerOrderId: 'transak-pending-order-1',
+                  walletAddress: moneyAddress,
+                  status: RampsOrderStatus.Pending,
+                  createdAt: 1782241698969,
+                  cryptoAmount: '4.96',
+                  fiatAmount: 6.14,
+                  fiatCurrency: { symbol: 'USD' },
+                  cryptoCurrency: { symbol: 'MUSD' },
+                  orderType: 'BUY',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      getByTestId(MoneyActivityViewTestIds.PENDING_HEADER),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId('activity-mock-ramp-transak-pending-order-1'),
+    ).toBeOnTheScreen();
+  });
+
   it('omits the Pending section when nothing is in flight', () => {
     mockUseMoneyAccountTransactions.mockReturnValue({
       allTransactions: MOCK_DEPOSITS.filter(

--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { SectionList, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import { RampsOrderStatus } from '@metamask/ramps-controller';
 import { type TransactionMeta } from '@metamask/transaction-controller';
 import {
   Box,
@@ -56,8 +57,18 @@ interface ActivitySection {
   isPending?: boolean;
 }
 
-/** True for an in-flight on-chain row. Card spends are never pending. */
+const SETTLED_RAMP_ORDER_STATUSES = new Set<RampsOrderStatus>([
+  RampsOrderStatus.Completed,
+  RampsOrderStatus.Failed,
+  RampsOrderStatus.Cancelled,
+  RampsOrderStatus.IdExpired,
+]);
+
+/** True for an in-flight row. Card spends are never pending. */
 function isPendingItem(item: MoneyActivityItem): boolean {
+  if (item.kind === 'rampOrder') {
+    return !SETTLED_RAMP_ORDER_STATUSES.has(item.order.status);
+  }
   return (
     item.kind === 'onchain' && getMoneyActivityStatus(item.tx) === 'pending'
   );

--- a/app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.test.tsx
+++ b/app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.test.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
+import { RampsOrderStatus, type RampsOrder } from '@metamask/ramps-controller';
 import MoneyActivityRow from './MoneyActivityRow';
 import {
   accountsApiItem,
   onchainItem,
+  rampOrderItem,
   type AccountsApiActivity,
 } from '../../types/moneyActivity';
 
@@ -29,6 +31,16 @@ jest.mock('../AccountsApiActivityItem/AccountsApiActivityItem', () => {
   };
 });
 
+jest.mock('../RampOrderActivityItem/RampOrderActivityItem', () => {
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({ order }: { order: { providerOrderId: string } }) => (
+      <Text testID="ramp-order-row">{order.providerOrderId}</Text>
+    ),
+  };
+});
+
 const tx = { id: 'tx-1', time: 100 } as TransactionMeta;
 const card: AccountsApiActivity = {
   kind: 'card',
@@ -39,6 +51,12 @@ const card: AccountsApiActivity = {
   amount: '1000000',
   paidTo: '0xbaanx' as Hex,
 };
+const rampOrder = {
+  providerOrderId: 'ramp-order-1',
+  createdAt: 300,
+  walletAddress: '0x1',
+  status: RampsOrderStatus.Completed,
+} as RampsOrder;
 
 describe('MoneyActivityRow', () => {
   it('renders the on-chain row for an onchain item', () => {
@@ -57,5 +75,15 @@ describe('MoneyActivityRow', () => {
 
     expect(getByTestId('api-row')).toHaveTextContent('0xfeed');
     expect(queryByTestId('onchain-row')).toBeNull();
+  });
+
+  it('renders the ramp order row for a rampOrder item', () => {
+    const { getByTestId, queryByTestId } = render(
+      <MoneyActivityRow item={rampOrderItem(rampOrder)} moneyAddress="0x1" />,
+    );
+
+    expect(getByTestId('ramp-order-row')).toHaveTextContent('ramp-order-1');
+    expect(queryByTestId('onchain-row')).toBeNull();
+    expect(queryByTestId('api-row')).toBeNull();
   });
 });

--- a/app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.tsx
+++ b/app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.tsx
@@ -3,6 +3,7 @@ import type { MoneyActivityItem } from '../../types/moneyActivity';
 import MoneyActivityItemView from '../MoneyActivityItem/MoneyActivityItem';
 import AccountsApiActivityItem from '../AccountsApiActivityItem/AccountsApiActivityItem';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import RampOrderActivityItem from '../RampOrderActivityItem/RampOrderActivityItem';
 
 export interface MoneyActivityRowProps {
   item: MoneyActivityItem;
@@ -25,6 +26,9 @@ const MoneyActivityRow = ({
         showNetworkBadge={showNetworkBadge}
       />
     );
+  }
+  if (item.kind === 'rampOrder') {
+    return <RampOrderActivityItem order={item.order} />;
   }
   return (
     <MoneyActivityItemView

--- a/app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.test.tsx
+++ b/app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
+import RampOrderActivityItem from './RampOrderActivityItem';
+
+jest.mock('../MoneyActivityItem/ActivityRowView', () => {
+  const { Text } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ({
+      id,
+      display,
+      showNetworkBadge,
+    }: {
+      id: string;
+      display: { label: string };
+      showNetworkBadge: boolean;
+    }) => (
+      <Text testID="activity-row">
+        {id}:{display.label}:{String(showNetworkBadge)}
+      </Text>
+    ),
+  };
+});
+
+describe('RampOrderActivityItem', () => {
+  it('renders a ramp order through the shared activity row view', () => {
+    const order = {
+      providerOrderId: 'order-1',
+      status: RampsOrderStatus.Completed,
+      cryptoAmount: '4.96',
+      cryptoCurrency: { symbol: 'MUSD' },
+      fiatAmount: 6.14,
+      fiatCurrency: { symbol: 'USD' },
+    } as RampsOrder;
+
+    const { getByTestId } = render(<RampOrderActivityItem order={order} />);
+
+    expect(getByTestId('activity-row')).toHaveTextContent(
+      'order-1:Deposited:false',
+    );
+  });
+});

--- a/app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.tsx
+++ b/app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.tsx
@@ -1,0 +1,22 @@
+import React, { useMemo } from 'react';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { rampOrderActivityDisplayInfo } from '../../utils/rampOrderActivityDisplayInfo';
+import ActivityRowView from '../MoneyActivityItem/ActivityRowView';
+
+export interface RampOrderActivityItemProps {
+  order: RampsOrder;
+}
+
+const RampOrderActivityItem = ({ order }: RampOrderActivityItemProps) => {
+  const display = useMemo(() => rampOrderActivityDisplayInfo(order), [order]);
+
+  return (
+    <ActivityRowView
+      id={order.providerOrderId}
+      display={display}
+      showNetworkBadge={false}
+    />
+  );
+};
+
+export default RampOrderActivityItem;

--- a/app/components/UI/Money/hooks/useMoneyActivityItems.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyActivityItems.test.ts
@@ -1,5 +1,6 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
+import { RampsOrderStatus, type RampsOrder } from '@metamask/ramps-controller';
 import {
   mergeMoneyActivity,
   buildMoneyActivityBuckets,
@@ -30,14 +31,34 @@ const cashbackTx = (hash: Hex, time: number): AccountsApiActivity => ({
   receivedFrom: '0xrewarder' as Hex,
 });
 
+const rampOrder = (
+  providerOrderId: string,
+  time: number,
+  txHash?: Hex,
+): RampsOrder =>
+  ({
+    providerOrderId,
+    createdAt: time,
+    txHash,
+    walletAddress: '0x0000000000000000000000000000000000000001',
+    status: RampsOrderStatus.Completed,
+    cryptoAmount: '4.96',
+    fiatAmount: 6.14,
+    fiatCurrency: { symbol: 'USD' },
+    cryptoCurrency: { symbol: 'MUSD' },
+    orderType: 'BUY',
+  }) as RampsOrder;
+
 describe('mergeMoneyActivity', () => {
   it('merges both sources, tags by source, and sorts time-descending', () => {
     const onchain = [onchainTx('a', 100), onchainTx('b', 300)];
     const api = [cardTx('0xcard' as Hex, 200)];
+    const ramps = [rampOrder('ramp-order', 400)];
 
-    const items = mergeMoneyActivity(onchain, api);
+    const items = mergeMoneyActivity(onchain, api, ramps);
 
     expect(items.map((i) => [i.kind, i.id, i.time])).toEqual([
+      ['rampOrder', 'ramp-order', 400],
       ['onchain', 'b', 300],
       ['accountsApi', '0xcard', 200],
       ['onchain', 'a', 100],
@@ -53,6 +74,16 @@ describe('mergeMoneyActivity', () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]).toMatchObject({ kind: 'accountsApi', id: '0xabc123' });
+  });
+
+  it('drops a ramp order whose tx hash already exists on-chain', () => {
+    const shared = '0xAbC123' as Hex;
+    const onchain = [onchainTx('dup', 100, shared)];
+    const ramps = [rampOrder('ramp-dup', 200, '0xabc123' as Hex)];
+
+    const items = mergeMoneyActivity(onchain, [], ramps);
+
+    expect(items.map((i) => i.id)).toEqual(['dup']);
   });
 
   it('returns an empty list when both sources are empty', () => {
@@ -83,23 +114,30 @@ describe('buildMoneyActivityBuckets', () => {
   };
   const card = cardTx('0xcard' as Hex, 200);
   const cashback = cashbackTx('0xback' as Hex, 300);
+  const ramp = rampOrder('ramp-order', 400);
 
   it('routes card spends to Transfers and cashback to Deposits; both into All', () => {
-    const buckets = buildMoneyActivityBuckets(onchain, [card, cashback]);
+    const buckets = buildMoneyActivityBuckets(
+      onchain,
+      [card, cashback],
+      [ramp],
+    );
 
     const ids = (filter: MoneyActivityFilter) =>
       buckets[filter].map((i) => i.id);
 
     // All contains both API rows.
     expect(ids(MoneyActivityFilter.All)).toEqual(
-      expect.arrayContaining(['0xback', '0xcard', 'all']),
+      expect.arrayContaining(['0xback', '0xcard', 'ramp-order', 'all']),
     );
     // Deposits: cashback inflow, not the card spend.
     expect(ids(MoneyActivityFilter.Deposits)).toContain('0xback');
+    expect(ids(MoneyActivityFilter.Deposits)).toContain('ramp-order');
     expect(ids(MoneyActivityFilter.Deposits)).not.toContain('0xcard');
     // Transfers: card outflow, not the cashback.
     expect(ids(MoneyActivityFilter.Transfers)).toContain('0xcard');
     expect(ids(MoneyActivityFilter.Transfers)).not.toContain('0xback');
+    expect(ids(MoneyActivityFilter.Transfers)).not.toContain('ramp-order');
   });
 
   it('keeps each bucket time-descending', () => {

--- a/app/components/UI/Money/hooks/useMoneyActivityItems.ts
+++ b/app/components/UI/Money/hooks/useMoneyActivityItems.ts
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
 import {
   accountsApiItem,
   onchainItem,
+  rampOrderItem,
   type AccountsApiActivity,
   type MoneyActivityItem,
 } from '../types/moneyActivity';
@@ -12,6 +15,8 @@ import {
 } from '../constants/mockActivityData';
 import { useMoneyAccountTransactions } from './useMoneyAccountTransactions';
 import { useMoneyAccountApiActivity } from './useMoneyAccountApiActivity';
+import { selectRampsOrdersForAddress } from '../../../../selectors/rampsController';
+import type { RootState } from '../../../../reducers';
 
 /** The list shown for each activity filter tab. */
 export type MoneyActivityBuckets = Record<
@@ -27,6 +32,28 @@ export interface UseMoneyActivityItemsResult {
   mockDataEnabled: boolean;
 }
 
+const HIDDEN_RAMP_ORDER_STATUSES = new Set<RampsOrderStatus>([
+  RampsOrderStatus.Precreated,
+  RampsOrderStatus.Unknown,
+]);
+
+function normalizeHash(hash: string | undefined): string | undefined {
+  return hash?.toLowerCase();
+}
+
+function visibleRampOrders(
+  rampOrders: RampsOrder[],
+  excludedHashes: Set<string>,
+): RampsOrder[] {
+  return rampOrders.filter((order) => {
+    if (HIDDEN_RAMP_ORDER_STATUSES.has(order.status)) {
+      return false;
+    }
+    const txHash = normalizeHash(order.txHash);
+    return !txHash || !excludedHashes.has(txHash);
+  });
+}
+
 /**
  * Merge local on-chain Money transactions with Accounts-API activity (card
  * spends and cashback) into a single source-tagged, time-descending list.
@@ -34,16 +61,24 @@ export interface UseMoneyActivityItemsResult {
 export function mergeMoneyActivity(
   onchainTransactions: TransactionMeta[],
   apiActivity: AccountsApiActivity[],
+  rampOrders: RampsOrder[] = [],
 ): MoneyActivityItem[] {
   const apiHashes = new Set(apiActivity.map((a) => a.hash.toLowerCase()));
+  const onchainHashes = new Set(
+    onchainTransactions
+      .map((tx) => normalizeHash(tx.hash))
+      .filter((hash): hash is string => Boolean(hash)),
+  );
+  const excludedHashes = new Set([...apiHashes, ...onchainHashes]);
   const onchain = onchainTransactions
     // we ignore any on chain data that exists in the accounts API response.
     .filter((tx) => !(tx.hash && apiHashes.has(tx.hash.toLowerCase())))
     .map(onchainItem);
+  const ramp = visibleRampOrders(rampOrders, excludedHashes).map(rampOrderItem);
   // Time-descending, with `id` as a stable tiebreak so rows sharing a timestamp
   // (e.g. a spend and its cashback in the same second) keep a deterministic
   // order across renders/refetches and across the two merged sources.
-  return [...onchain, ...apiActivity.map(accountsApiItem)].sort(
+  return [...onchain, ...apiActivity.map(accountsApiItem), ...ramp].sort(
     (a, b) => b.time - a.time || a.id.localeCompare(b.id),
   );
 }
@@ -55,14 +90,20 @@ export function buildMoneyActivityBuckets(
     transfers: TransactionMeta[];
   },
   apiActivity: AccountsApiActivity[],
+  rampOrders: RampsOrder[] = [],
 ): MoneyActivityBuckets {
   const cards = apiActivity.filter((a) => a.kind === 'card');
   const cashback = apiActivity.filter((a) => a.kind === 'cashback');
   return {
-    [MoneyActivityFilter.All]: mergeMoneyActivity(onchain.all, apiActivity),
+    [MoneyActivityFilter.All]: mergeMoneyActivity(
+      onchain.all,
+      apiActivity,
+      rampOrders,
+    ),
     [MoneyActivityFilter.Deposits]: mergeMoneyActivity(
       onchain.deposits,
       cashback,
+      rampOrders,
     ),
     [MoneyActivityFilter.Transfers]: mergeMoneyActivity(
       onchain.transfers,
@@ -85,16 +126,24 @@ export function useMoneyActivityItems(): UseMoneyActivityItemsResult {
     mockDataEnabled,
   } = useMoneyAccountTransactions();
   const { activity, isLoading } = useMoneyAccountApiActivity();
+  const moneyRampOrders = useSelector((state: RootState) =>
+    selectRampsOrdersForAddress(state, moneyAddress),
+  );
 
   const apiActivity = mockDataEnabled ? MOCK_API_ACTIVITY : activity;
+  const rampOrders = useMemo(
+    () => (mockDataEnabled ? [] : moneyRampOrders),
+    [mockDataEnabled, moneyRampOrders],
+  );
 
   const buckets = useMemo(
     () =>
       buildMoneyActivityBuckets(
         { all: allTransactions, deposits, transfers },
         apiActivity,
+        rampOrders,
       ),
-    [allTransactions, deposits, transfers, apiActivity],
+    [allTransactions, deposits, transfers, apiActivity, rampOrders],
   );
 
   return {

--- a/app/components/UI/Money/types/moneyActivity.test.ts
+++ b/app/components/UI/Money/types/moneyActivity.test.ts
@@ -1,0 +1,35 @@
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { rampOrderItem } from './moneyActivity';
+
+describe('rampOrderItem', () => {
+  it('uses a numeric createdAt value as the item time', () => {
+    const item = rampOrderItem({
+      providerOrderId: 'order-1',
+      createdAt: 123,
+    } as RampsOrder);
+
+    expect(item).toMatchObject({
+      kind: 'rampOrder',
+      id: 'order-1',
+      time: 123,
+    });
+  });
+
+  it('parses ISO createdAt values as epoch milliseconds', () => {
+    const item = rampOrderItem({
+      providerOrderId: 'order-1',
+      createdAt: '2026-06-23T18:00:00.000Z',
+    } as unknown as RampsOrder);
+
+    expect(item.time).toBe(Date.parse('2026-06-23T18:00:00.000Z'));
+  });
+
+  it('falls back to zero for invalid createdAt values', () => {
+    const item = rampOrderItem({
+      providerOrderId: 'order-1',
+      createdAt: 'invalid-date',
+    } as unknown as RampsOrder);
+
+    expect(item.time).toBe(0);
+  });
+});

--- a/app/components/UI/Money/types/moneyActivity.ts
+++ b/app/components/UI/Money/types/moneyActivity.ts
@@ -1,4 +1,5 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { RampsOrder } from '@metamask/ramps-controller';
 import type { Hex } from '@metamask/utils';
 
 /**
@@ -37,7 +38,8 @@ export type AccountsApiActivity =
  **/
 export type MoneyActivityItem =
   | { kind: 'onchain'; id: string; time: number; tx: TransactionMeta }
-  | { kind: 'accountsApi'; id: string; time: number; tx: AccountsApiActivity };
+  | { kind: 'accountsApi'; id: string; time: number; tx: AccountsApiActivity }
+  | { kind: 'rampOrder'; id: string; time: number; order: RampsOrder };
 
 export const onchainItem = (tx: TransactionMeta): MoneyActivityItem => ({
   kind: 'onchain',
@@ -53,4 +55,24 @@ export const accountsApiItem = (
   id: tx.hash,
   time: tx.time,
   tx,
+});
+
+function toEpochMs(value: unknown): number {
+  if (typeof value === 'number' && value > 0) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const ms = new Date(value).getTime();
+    if (!Number.isNaN(ms)) {
+      return ms;
+    }
+  }
+  return 0;
+}
+
+export const rampOrderItem = (order: RampsOrder): MoneyActivityItem => ({
+  kind: 'rampOrder',
+  id: order.providerOrderId,
+  time: toEpochMs(order.createdAt),
+  order,
 });

--- a/app/components/UI/Money/utils/rampOrderActivityDisplayInfo.test.ts
+++ b/app/components/UI/Money/utils/rampOrderActivityDisplayInfo.test.ts
@@ -1,0 +1,46 @@
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
+import { IconName } from '@metamask/design-system-react-native';
+import { rampOrderActivityDisplayInfo } from './rampOrderActivityDisplayInfo';
+
+describe('rampOrderActivityDisplayInfo', () => {
+  it('formats a completed Money funding order as a confirmed deposit', () => {
+    const order = {
+      providerOrderId: 'order-1',
+      status: RampsOrderStatus.Completed,
+      provider: { name: 'Transak' },
+      paymentMethod: { name: 'Apple Pay' },
+      cryptoAmount: '4.96',
+      cryptoCurrency: { symbol: 'MUSD' },
+      fiatAmount: 6.14,
+      fiatCurrency: { symbol: 'USD' },
+    } as RampsOrder;
+
+    expect(rampOrderActivityDisplayInfo(order)).toEqual({
+      label: 'Deposited',
+      description: 'Apple Pay',
+      primaryAmount: '+4.96 mUSD',
+      fiatAmount: '+$6.14',
+      isIncoming: true,
+      icon: IconName.Add,
+      status: 'confirmed',
+    });
+  });
+
+  it('formats pending orders with the pending label and status', () => {
+    const order = {
+      providerOrderId: 'order-1',
+      status: RampsOrderStatus.Pending,
+      provider: { name: 'Transak' },
+      cryptoAmount: '4.96',
+      cryptoCurrency: { symbol: 'MUSD' },
+      fiatAmount: 6.14,
+      fiatCurrency: { symbol: 'USD' },
+    } as RampsOrder;
+
+    expect(rampOrderActivityDisplayInfo(order)).toMatchObject({
+      label: 'Depositing',
+      description: 'Transak',
+      status: 'pending',
+    });
+  });
+});

--- a/app/components/UI/Money/utils/rampOrderActivityDisplayInfo.test.ts
+++ b/app/components/UI/Money/utils/rampOrderActivityDisplayInfo.test.ts
@@ -43,4 +43,24 @@ describe('rampOrderActivityDisplayInfo', () => {
       status: 'pending',
     });
   });
+
+  it('formats failed orders with string payment methods and invalid amounts', () => {
+    const order = {
+      providerOrderId: 'order-1',
+      status: RampsOrderStatus.Failed,
+      provider: { name: 'Transak' },
+      paymentMethod: 'Wire transfer',
+      cryptoAmount: 'invalid',
+      fiatAmount: 'invalid',
+      fiatCurrency: { symbol: 'USD' },
+    } as unknown as RampsOrder;
+
+    expect(rampOrderActivityDisplayInfo(order)).toMatchObject({
+      label: 'Deposit failed',
+      description: 'Wire transfer',
+      primaryAmount: '',
+      fiatAmount: '',
+      status: 'failed',
+    });
+  });
 });

--- a/app/components/UI/Money/utils/rampOrderActivityDisplayInfo.ts
+++ b/app/components/UI/Money/utils/rampOrderActivityDisplayInfo.ts
@@ -1,0 +1,75 @@
+import BigNumber from 'bignumber.js';
+import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
+import { moneyFormatFiat } from './moneyFormatFiat';
+import type { MoneyTransactionDisplayInfo } from '../hooks/useMoneyTransactionDisplayInfo';
+import {
+  moneyActivityKindToIcon,
+  moneyActivityLabel,
+  type MoneyActivityStatus,
+} from './classifyMoneyActivity';
+import { MUSD_TOKEN } from '../../Earn/constants/musd';
+
+function getRampOrderActivityStatus(
+  status: RampsOrderStatus,
+): MoneyActivityStatus {
+  switch (status) {
+    case RampsOrderStatus.Completed:
+      return 'confirmed';
+    case RampsOrderStatus.Failed:
+    case RampsOrderStatus.Cancelled:
+    case RampsOrderStatus.IdExpired:
+      return 'failed';
+    default:
+      return 'pending';
+  }
+}
+
+function formatCryptoAmount(amount: string | number | undefined): string {
+  const value = new BigNumber(amount ?? 0);
+  if (!value.isFinite()) {
+    return '';
+  }
+  return `+${value.toFormat(2)}`;
+}
+
+function getCryptoSymbol(order: RampsOrder): string {
+  const symbol = order.cryptoCurrency?.symbol ?? '';
+  return symbol.toUpperCase() === 'MUSD' ? MUSD_TOKEN.symbol : symbol;
+}
+
+function getPaymentMethodName(order: RampsOrder): string | undefined {
+  const orderWithPayment = order as RampsOrder & {
+    paymentMethod?: string | { name?: string };
+  };
+  const { paymentMethod } = orderWithPayment;
+  if (typeof paymentMethod === 'string') {
+    return paymentMethod;
+  }
+  return paymentMethod?.name;
+}
+
+export function rampOrderActivityDisplayInfo(
+  order: RampsOrder,
+): MoneyTransactionDisplayInfo {
+  const status = getRampOrderActivityStatus(order.status);
+  const cryptoSymbol = getCryptoSymbol(order);
+  const primaryAmount = cryptoSymbol
+    ? `${formatCryptoAmount(order.cryptoAmount)} ${cryptoSymbol}`
+    : formatCryptoAmount(order.cryptoAmount);
+  const fiatCurrency = order.fiatCurrency?.symbol;
+  const fiatValue = new BigNumber(order.fiatAmount ?? 0);
+  const fiatAmount =
+    fiatCurrency && fiatValue.isFinite()
+      ? `+${moneyFormatFiat(fiatValue, fiatCurrency)}`
+      : '';
+
+  return {
+    label: moneyActivityLabel('deposited', status),
+    description: getPaymentMethodName(order) ?? order.provider?.name,
+    primaryAmount,
+    fiatAmount,
+    isIncoming: true,
+    icon: moneyActivityKindToIcon('deposited'),
+    status,
+  };
+}

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -689,6 +689,39 @@ describe('Checkout', () => {
       expect(shouldStartLoadWithRequest).not.toHaveBeenCalled();
     });
 
+    it('does not replace the WebView for custom callback URLs without an orderId', () => {
+      const { shouldStartLoadWithRequest } = jest.requireMock(
+        '../../../../../util/browser',
+      ) as { shouldStartLoadWithRequest: jest.Mock };
+      const callbackUrl = `${callbackBaseUrl}?status=cancelled`;
+      const mockCallback = jest.fn();
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Transak',
+        onNavigationStateChange: mockCallback,
+      });
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <Checkout />,
+        {},
+        true,
+        false,
+      );
+
+      let result: boolean | undefined;
+      act(() => {
+        result = capturedOnShouldStartLoadWithRequest?.({
+          url: callbackUrl,
+        });
+      });
+
+      expect(result).toBe(false);
+      expect(mockCallback).toHaveBeenCalledWith({ url: callbackUrl });
+      expect(getByTestId('checkout-webview')).toBeOnTheScreen();
+      expect(queryByTestId('checkout-callback-loading')).toBeNull();
+      expect(shouldStartLoadWithRequest).not.toHaveBeenCalled();
+    });
+
     it('blocks callback URL loads and handles callback flow params directly', async () => {
       const { shouldStartLoadWithRequest } = jest.requireMock(
         '../../../../../util/browser',

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -668,14 +668,24 @@ describe('Checkout', () => {
         onNavigationStateChange: mockCallback,
       });
 
-      renderWithProvider(<Checkout />, {}, true, false);
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <Checkout />,
+        {},
+        true,
+        false,
+      );
 
-      const result = capturedOnShouldStartLoadWithRequest?.({
-        url: callbackUrl,
+      let result: boolean | undefined;
+      act(() => {
+        result = capturedOnShouldStartLoadWithRequest?.({
+          url: callbackUrl,
+        });
       });
 
       expect(result).toBe(false);
       expect(mockCallback).toHaveBeenCalledWith({ url: callbackUrl });
+      expect(getByTestId('checkout-callback-loading')).toBeOnTheScreen();
+      expect(queryByTestId('checkout-webview')).toBeNull();
       expect(shouldStartLoadWithRequest).not.toHaveBeenCalled();
     });
 
@@ -692,13 +702,23 @@ describe('Checkout', () => {
         cryptocurrency: 'ETH',
       });
 
-      renderWithProvider(<Checkout />, {}, true, false);
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <Checkout />,
+        {},
+        true,
+        false,
+      );
 
-      const result = capturedOnShouldStartLoadWithRequest?.({
-        url: callbackUrl,
+      let result: boolean | undefined;
+      act(() => {
+        result = capturedOnShouldStartLoadWithRequest?.({
+          url: callbackUrl,
+        });
       });
 
       expect(result).toBe(false);
+      expect(getByTestId('checkout-callback-loading')).toBeOnTheScreen();
+      expect(queryByTestId('checkout-webview')).toBeNull();
       await waitFor(() => {
         expect(mockNavigation.reset).toHaveBeenCalledWith({
           index: 0,

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -75,6 +75,9 @@ jest.mock('uuid', () => ({
 let capturedOnNavigationStateChange:
   | ((state: { url: string; loading?: boolean }) => void)
   | undefined;
+let capturedOnShouldStartLoadWithRequest:
+  | ((req: { url: string }) => boolean)
+  | undefined;
 
 jest.mock('@metamask/react-native-webview', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- jest mock factory
@@ -104,6 +107,7 @@ jest.mock('@metamask/react-native-webview', () => {
       testID?: string;
     }) => {
       capturedOnNavigationStateChange = onNavigationStateChange;
+      capturedOnShouldStartLoadWithRequest = onShouldStartLoadWithRequest;
       return (
         <View testID={testID ?? 'checkout-webview'}>
           <Button
@@ -275,6 +279,8 @@ describe('Checkout', () => {
         setOptions: mockHeadlessEntrySetOptions,
       }),
     }));
+    capturedOnNavigationStateChange = undefined;
+    capturedOnShouldStartLoadWithRequest = undefined;
   });
 
   describe('handleNavigationStateChange (callback flow)', () => {
@@ -639,11 +645,78 @@ describe('Checkout', () => {
       const { getByTestId } = renderWithProvider(<Checkout />, {}, true, false);
 
       fireEvent.press(getByTestId('trigger-should-start-load'));
+      const result = capturedOnShouldStartLoadWithRequest?.({
+        url: 'https://provider.example.com/next-hop',
+      });
 
+      expect(result).toBe(true);
       expect(shouldStartLoadWithRequest).toHaveBeenCalledWith(
         'https://provider.example.com/next-hop',
         Logger,
       );
+    });
+
+    it('blocks callback URL loads and forwards them to the custom navigation handler', () => {
+      const { shouldStartLoadWithRequest } = jest.requireMock(
+        '../../../../../util/browser',
+      ) as { shouldStartLoadWithRequest: jest.Mock };
+      const callbackUrl = `${callbackBaseUrl}?orderId=123`;
+      const mockCallback = jest.fn();
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Transak',
+        onNavigationStateChange: mockCallback,
+      });
+
+      renderWithProvider(<Checkout />, {}, true, false);
+
+      const result = capturedOnShouldStartLoadWithRequest?.({
+        url: callbackUrl,
+      });
+
+      expect(result).toBe(false);
+      expect(mockCallback).toHaveBeenCalledWith({ url: callbackUrl });
+      expect(shouldStartLoadWithRequest).not.toHaveBeenCalled();
+    });
+
+    it('blocks callback URL loads and handles callback flow params directly', async () => {
+      const { shouldStartLoadWithRequest } = jest.requireMock(
+        '../../../../../util/browser',
+      ) as { shouldStartLoadWithRequest: jest.Mock };
+      const callbackUrl = `${callbackBaseUrl}?orderId=123`;
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'Test',
+        providerCode: 'moonpay',
+        walletAddress: '0xabc',
+        cryptocurrency: 'ETH',
+      });
+
+      renderWithProvider(<Checkout />, {}, true, false);
+
+      const result = capturedOnShouldStartLoadWithRequest?.({
+        url: callbackUrl,
+      });
+
+      expect(result).toBe(false);
+      await waitFor(() => {
+        expect(mockNavigation.reset).toHaveBeenCalledWith({
+          index: 0,
+          routes: [
+            {
+              name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+              params: {
+                callbackUrl,
+                providerCode: 'moonpay',
+                walletAddress: '0xabc',
+                showCloseButton: true,
+                cryptocurrency: 'ETH',
+              },
+            },
+          ],
+        });
+      });
+      expect(shouldStartLoadWithRequest).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.testIds.ts
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.testIds.ts
@@ -1,4 +1,5 @@
 export const CHECKOUT_TEST_IDS = {
   CLOSE_BUTTON: 'checkout-close-button',
+  CALLBACK_LOADING: 'checkout-callback-loading',
   WEBVIEW: 'checkout-webview',
 } as const;

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -8,6 +8,7 @@ import React, {
 import { useDispatch } from 'react-redux';
 import { parseUrl } from 'query-string';
 import { v4 as uuidv4 } from 'uuid';
+import { ActivityIndicator } from 'react-native';
 import { WebView, WebViewNavigation } from '@metamask/react-native-webview';
 import { useNavigation } from '@react-navigation/native';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
@@ -94,6 +95,7 @@ const Checkout = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const dispatch = useDispatch();
   const [error, setError] = useState('');
+  const [isHandlingCallback, setIsHandlingCallback] = useState(false);
   const isRedirectionHandledRef = useRef(false);
   const [key, setKey] = useState(0);
   const navigation = useNavigation();
@@ -354,14 +356,17 @@ const Checkout = () => {
     async (navState: WebViewNavigation) => {
       recordUrlChange(navState.url);
 
+      const isCallbackNavigation = navState.url.startsWith(callbackBaseUrl);
       if (
         !hasCallbackFlow ||
         isRedirectionHandledRef.current ||
-        !navState.url.startsWith(callbackBaseUrl) ||
+        !isCallbackNavigation ||
         navState.loading !== false
       ) {
         return;
       }
+
+      setIsHandlingCallback(true);
 
       trackEvent(
         createEventBuilder(MetaMetricsEvents.RAMPS_CHECKOUT_CALLBACK_DETECTED)
@@ -454,6 +459,7 @@ const Checkout = () => {
         });
       } catch (navError) {
         closeSourceRef.current = 'callback_error';
+        setIsHandlingCallback(false);
         Logger.error(navError as Error, {
           message: 'UnifiedCheckout: error handling callback',
         });
@@ -572,11 +578,18 @@ const Checkout = () => {
   const handleShouldStartLoadWithRequest = useCallback(
     ({ url }: { url: string }) => {
       if (url.startsWith(callbackBaseUrl)) {
+        if (hasCallbackFlow || onNavigationStateChange) {
+          setIsHandlingCallback(true);
+        }
         if (hasCallbackFlow) {
-          void handleNavigationStateChange({
+          handleNavigationStateChange({
             url,
             loading: false,
-          } as WebViewNavigation);
+          } as WebViewNavigation).catch((callbackError) => {
+            Logger.error(callbackError as Error, {
+              message: 'UnifiedCheckout: error forwarding callback URL',
+            });
+          });
         } else if (onNavigationStateChange) {
           handleNavigationStateChangeWithDedup({ url });
         }
@@ -673,6 +686,7 @@ const Checkout = () => {
               ctaOnPress={() => {
                 setKey((prevKey) => prevKey + 1);
                 setError('');
+                setIsHandlingCallback(false);
                 isRedirectionHandledRef.current = false;
                 lastLoadCompleteUrlRef.current = null;
                 loadUrlErrorsRef.current.clear();
@@ -701,70 +715,78 @@ const Checkout = () => {
         twClassName={surfaceClass}
       >
         {sharedHeader}
-        <WebView
-          key={key}
-          style={styles.webview}
-          source={{ uri }}
-          userAgent={userAgent ?? undefined}
-          onHttpError={(syntheticEvent) => {
-            const { nativeEvent } = syntheticEvent;
-            const errorUrl = nativeEvent.url;
-            const isInitialUrl = errorUrl === initialUriRef.current;
-            const isTerminal =
-              isInitialUrl || errorUrl.startsWith(callbackBaseUrl);
+        {isHandlingCallback ? (
+          <ScreenLayout>
+            <ScreenLayout.Body>
+              <ActivityIndicator testID={CHECKOUT_TEST_IDS.CALLBACK_LOADING} />
+            </ScreenLayout.Body>
+          </ScreenLayout>
+        ) : (
+          <WebView
+            key={key}
+            style={styles.webview}
+            source={{ uri }}
+            userAgent={userAgent ?? undefined}
+            onHttpError={(syntheticEvent) => {
+              const { nativeEvent } = syntheticEvent;
+              const errorUrl = nativeEvent.url;
+              const isInitialUrl = errorUrl === initialUriRef.current;
+              const isTerminal =
+                isInitialUrl || errorUrl.startsWith(callbackBaseUrl);
 
-            loadUrlErrorsRef.current.add(errorUrl);
-            trackEvent(
-              createEventBuilder(
-                MetaMetricsEvents.RAMPS_CHECKOUT_HTTP_ERROR_RECEIVED,
-              )
-                .addProperties({
-                  ...buildBaseProps({
-                    checkoutSessionId,
-                    providerName,
-                    ...headlessBaseOverrides,
-                  }),
-                  url_path: redactUrlForAnalytics(errorUrl),
-                  status_code: nativeEvent.statusCode,
-                  is_initial_url: isInitialUrl,
-                  error_message: strings(
-                    'fiat_on_ramp_aggregator.webview_received_error',
-                    { code: nativeEvent.statusCode },
-                  ),
-                })
-                .build(),
-            );
-
-            if (isTerminal) {
-              closeSourceRef.current = 'http_error';
-              const webviewHttpError = strings(
-                'fiat_on_ramp_aggregator.webview_received_error',
-                { code: nativeEvent.statusCode },
+              loadUrlErrorsRef.current.add(errorUrl);
+              trackEvent(
+                createEventBuilder(
+                  MetaMetricsEvents.RAMPS_CHECKOUT_HTTP_ERROR_RECEIVED,
+                )
+                  .addProperties({
+                    ...buildBaseProps({
+                      checkoutSessionId,
+                      providerName,
+                      ...headlessBaseOverrides,
+                    }),
+                    url_path: redactUrlForAnalytics(errorUrl),
+                    status_code: nativeEvent.statusCode,
+                    is_initial_url: isInitialUrl,
+                    error_message: strings(
+                      'fiat_on_ramp_aggregator.webview_received_error',
+                      { code: nativeEvent.statusCode },
+                    ),
+                  })
+                  .build(),
               );
-              if (failHeadlessCheckout(new Error(webviewHttpError))) {
-                return;
+
+              if (isTerminal) {
+                closeSourceRef.current = 'http_error';
+                const webviewHttpError = strings(
+                  'fiat_on_ramp_aggregator.webview_received_error',
+                  { code: nativeEvent.statusCode },
+                );
+                if (failHeadlessCheckout(new Error(webviewHttpError))) {
+                  return;
+                }
+                setError(webviewHttpError);
+              } else {
+                Logger.log(
+                  `Checkout: HTTP error ${nativeEvent.statusCode} for auxiliary resource: ${errorUrl}`,
+                );
               }
-              setError(webviewHttpError);
-            } else {
-              Logger.log(
-                `Checkout: HTTP error ${nativeEvent.statusCode} for auxiliary resource: ${errorUrl}`,
-              );
+            }}
+            allowsInlineMediaPlayback
+            enableApplePay
+            paymentRequestEnabled
+            mediaPlaybackRequiresUserAction={false}
+            onLoadStart={handleLoadStart}
+            onLoadEnd={handleLoadEnd}
+            onNavigationStateChange={
+              hasCallbackFlow
+                ? handleNavigationStateChange
+                : handleNavigationStateChangeWithDedup
             }
-          }}
-          allowsInlineMediaPlayback
-          enableApplePay
-          paymentRequestEnabled
-          mediaPlaybackRequiresUserAction={false}
-          onLoadStart={handleLoadStart}
-          onLoadEnd={handleLoadEnd}
-          onNavigationStateChange={
-            hasCallbackFlow
-              ? handleNavigationStateChange
-              : handleNavigationStateChangeWithDedup
-          }
-          onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
-          testID={CHECKOUT_TEST_IDS.WEBVIEW}
-        />
+            onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+            testID={CHECKOUT_TEST_IDS.WEBVIEW}
+          />
+        )}
       </BottomSheet>
     );
   }

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -570,8 +570,28 @@ const Checkout = () => {
   );
 
   const handleShouldStartLoadWithRequest = useCallback(
-    ({ url }: { url: string }) => shouldStartLoadWithRequest(url, Logger),
-    [],
+    ({ url }: { url: string }) => {
+      if (url.startsWith(callbackBaseUrl)) {
+        if (hasCallbackFlow) {
+          void handleNavigationStateChange({
+            url,
+            loading: false,
+          } as WebViewNavigation);
+        } else if (onNavigationStateChange) {
+          handleNavigationStateChangeWithDedup({ url });
+        }
+
+        return false;
+      }
+
+      return shouldStartLoadWithRequest(url, Logger);
+    },
+    [
+      hasCallbackFlow,
+      handleNavigationStateChange,
+      handleNavigationStateChangeWithDedup,
+      onNavigationStateChange,
+    ],
   );
 
   const fireClosedRef = useRef<() => void>(() => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -578,7 +578,8 @@ const Checkout = () => {
   const handleShouldStartLoadWithRequest = useCallback(
     ({ url }: { url: string }) => {
       if (url.startsWith(callbackBaseUrl)) {
-        if (hasCallbackFlow || onNavigationStateChange) {
+        const hasOrderId = parseUrl(url).query.orderId != null;
+        if (hasCallbackFlow || (onNavigationStateChange && hasOrderId)) {
           setIsHandlingCallback(true);
         }
         if (hasCallbackFlow) {

--- a/app/selectors/rampsController/index.test.ts
+++ b/app/selectors/rampsController/index.test.ts
@@ -17,6 +17,7 @@ import {
   selectPaymentMethods,
   selectRampsControllerState,
   selectRampsOrders,
+  selectRampsOrdersForAddress,
   selectRampsOrdersForSelectedAccountGroup,
   selectTransak,
 } from './index';
@@ -438,6 +439,49 @@ describe('RampsController Selectors', () => {
       );
 
       expect(selectRampsOrdersForSelectedAccountGroup(state)).toEqual([]);
+    });
+  });
+
+  describe('selectRampsOrdersForAddress', () => {
+    const walletAddrLower = '0x2990079bcdee240329a520d2444386fc119da21a';
+
+    it('keeps orders whose walletAddress matches the explicit address', () => {
+      const mockOrders = [
+        {
+          providerOrderId: 'order-match',
+          walletAddress: '0x2990079BCDEE240329A520D2444386FC119DA21A',
+          status: 'COMPLETED',
+          createdAt: 1000,
+        },
+        {
+          providerOrderId: 'order-other',
+          walletAddress: '0x0000000000000000000000000000000000000001',
+          status: 'COMPLETED',
+          createdAt: 2000,
+        },
+      ];
+      const state = createMockState({
+        orders: mockOrders,
+      } as never);
+
+      expect(selectRampsOrdersForAddress(state, walletAddrLower)).toEqual([
+        mockOrders[0],
+      ]);
+    });
+
+    it('returns empty array when the explicit address is missing', () => {
+      const state = createMockState({
+        orders: [
+          {
+            providerOrderId: 'order-match',
+            walletAddress: walletAddrLower,
+            status: 'COMPLETED',
+            createdAt: 1000,
+          },
+        ],
+      } as never);
+
+      expect(selectRampsOrdersForAddress(state, undefined)).toEqual([]);
     });
   });
 

--- a/app/selectors/rampsController/index.ts
+++ b/app/selectors/rampsController/index.ts
@@ -130,6 +130,35 @@ export const selectRampsOrdersForSelectedAccountGroup = createDeepEqualSelector(
 );
 
 /**
+ * V2 on-ramp orders whose `walletAddress` matches an explicit address.
+ * Use this for UI scoped to a non-selected account, such as the primary Money
+ * account when the selected wallet group is an HD account group.
+ */
+export const selectRampsOrdersForAddress = createDeepEqualSelector(
+  [
+    selectRampsOrders,
+    (_state: RootState, walletAddress?: string) => walletAddress,
+  ],
+  (orders, walletAddress): RampsOrder[] => {
+    if (!walletAddress) {
+      return [];
+    }
+    return orders.filter((order) => {
+      const orderWalletAddress = order.walletAddress;
+      if (!orderWalletAddress) {
+        return false;
+      }
+      return areAddressesEqual(orderWalletAddress, walletAddress);
+    });
+  },
+  {
+    devModeChecks: {
+      identityFunctionCheck: 'never',
+    },
+  },
+);
+
+/**
  * Selects whether the current provider was auto-selected by the system
  * (soft selection) rather than chosen by the user or derived from order history.
  */


### PR DESCRIPTION
## **Description**

This PR fixes the Transak Money account completion path as one combined change.

First, Checkout now prevents handled Ramp callback URLs from loading inside the provider WebView. When a callback URL is detected, Checkout switches to a neutral loading surface, blocks the WebView request, and forwards the URL into the existing callback handler. This prevents Transak from painting its generic `Oops something went wrong` screen while the app-side handler waits for order fetch and session cleanup.

Second, Money activity now includes Ramp orders scoped to the primary Money account address. The new RC log shows the Transak order completed successfully and was persisted in `RampsController.orders`, while `TransactionController` did not contain a matching June 23 transaction and the selected account group was not the Money account. Money activity now reads completed and in-flight Ramp orders for the Money address, renders them as deposit rows, and dedupes by transaction hash when a local transaction or Accounts API row already exists.

Validation:

- `git diff --check`
- `NODE_OPTIONS='--max-old-space-size=12288' yarn eslint app/components/UI/Ramp/Views/Checkout/Checkout.tsx app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx app/components/UI/Ramp/Views/Checkout/Checkout.testIds.ts app/selectors/rampsController/index.ts app/selectors/rampsController/index.test.ts app/components/UI/Money/types/moneyActivity.ts app/components/UI/Money/types/moneyActivity.test.ts app/components/UI/Money/hooks/useMoneyActivityItems.ts app/components/UI/Money/hooks/useMoneyActivityItems.test.ts app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.tsx app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.test.tsx app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.tsx app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.test.tsx app/components/UI/Money/utils/rampOrderActivityDisplayInfo.ts app/components/UI/Money/utils/rampOrderActivityDisplayInfo.test.ts app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx`
- `yarn lint:tsc`
- `NODE_OPTIONS='--max-old-space-size=12288' yarn jest --runInBand --runTestsByPath app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx app/selectors/rampsController/index.test.ts app/components/UI/Money/hooks/useMoneyActivityItems.test.ts app/components/UI/Money/components/MoneyActivityRow/MoneyActivityRow.test.tsx app/components/UI/Money/components/RampOrderActivityItem/RampOrderActivityItem.test.tsx app/components/UI/Money/types/moneyActivity.test.ts app/components/UI/Money/utils/rampOrderActivityDisplayInfo.test.ts app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.test.tsx` (8 suites, 115 tests passed)

## **Changelog**

CHANGELOG entry: Fixed a bug that could briefly show Transak's generic error screen and miss completed Money account funding activity after a successful ramp order.

## **Related issues**

Refs: Internal RC bug report and Slack thread. No public GitHub or Jira issue was filed for this repro.

## **Manual testing steps**

```gherkin
Feature: Transak Money account ramp completion

  Scenario: Successful Transak checkout reaches the fake callback URL
    Given the app is running a build with Ramp and MetaMask Pay enabled
    And a user starts a Transak Money account funding checkout
    And Transak successfully creates the order
    When Transak redirects the Checkout WebView to the configured fake callback URL
    Then the Checkout WebView does not load the callback URL
    And the Checkout WebView does not paint Transak's generic error screen
    And the existing callback handler persists the order and closes the headless session

  Scenario: Completed Transak Money funding appears in Money activity
    Given a completed Transak ramp order exists for the primary Money account address
    And no matching transaction exists in TransactionController yet
    When the user opens Money activity
    Then the completed ramp order appears as a deposit row
    And the row is not duplicated if a matching on-chain transaction later appears
```

## **Screenshots/Recordings**

### **Before**

N/A - the repro was captured in internal RC state logs and Slack context, not as a local recording in this worktree.

### **After**

N/A - no live Transak checkout recording is available from this local worktree. Regression coverage verifies callback URL blocking, WebView replacement during callback handling, and Money activity rendering for completed and pending Ramp orders.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Considered, not applicable for this targeted callback handling and activity data-source fix in this local worktree.
- [x] I've tested with a power user scenario
  - Considered, not applicable for this targeted callback handling and activity data-source fix.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Considered, not applicable. This change does not add a new measured operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
