### PR TITLE
fix(rewards): navigation after native stack migration

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -347,23 +347,26 @@ const RewardsHome = () => {
 
   return (
     <NativeStack.Navigator
+      initialRouteName={
+        subscriptionId
+          ? Routes.REWARDS_DASHBOARD
+          : Routes.REWARDS_ONBOARDING_FLOW
+      }
       screenOptions={{
         headerShown: false,
         animation: 'none',
         contentStyle: { backgroundColor: colors.background.default },
       }}
     >
-      {subscriptionId ? (
-        <NativeStack.Screen
-          name={Routes.REWARDS_DASHBOARD}
-          component={RewardsDashboard}
-        />
-      ) : (
-        <NativeStack.Screen
-          name={Routes.REWARDS_ONBOARDING_FLOW}
-          component={RewardsOnboardingNavigator}
-        />
-      )}
+      <NativeStack.Screen
+        name={Routes.REWARDS_ONBOARDING_FLOW}
+        component={RewardsOnboardingNavigator}
+      />
+      <NativeStack.Screen
+        name={Routes.REWARDS_DASHBOARD}
+        component={RewardsDashboard}
+        options={slideFromRightNativeOptions}
+      />
     </NativeStack.Navigator>
   );
 };

--- a/app/components/Nav/Main/MainNavigator.test.tsx
+++ b/app/components/Nav/Main/MainNavigator.test.tsx
@@ -1540,22 +1540,20 @@ describe('MainNavigator', () => {
           .map((node) => node.props.name as string);
       };
 
-      it('renders the dashboard route when the user has a subscription', () => {
-        // Opted-in users land on the dashboard inside the Rewards tab; the
-        // onboarding flow is not registered for them.
+      it('registers onboarding and dashboard in the Rewards tab stack', () => {
+        // Both routes stay registered so opt-in can push the dashboard with a
+        // native slide transition; initialRouteName picks the entry screen.
         const screenNames = findRewardsHomeScreenNames('test-subscription-id');
 
         expect(screenNames).toContain(Routes.REWARDS_DASHBOARD);
-        expect(screenNames).not.toContain(Routes.REWARDS_ONBOARDING_FLOW);
+        expect(screenNames).toContain(Routes.REWARDS_ONBOARDING_FLOW);
       });
 
-      it('renders the onboarding flow route when the user has no subscription', () => {
-        // Non-subscribed users see RewardsOnboardingNavigator directly in the
-        // tab (the dashboard route is not registered for them).
+      it('registers onboarding and dashboard when the user has no subscription', () => {
         const screenNames = findRewardsHomeScreenNames(null);
 
         expect(screenNames).toContain(Routes.REWARDS_ONBOARDING_FLOW);
-        expect(screenNames).not.toContain(Routes.REWARDS_DASHBOARD);
+        expect(screenNames).toContain(Routes.REWARDS_DASHBOARD);
       });
 
       it('does not register rewards modal screens in the Rewards tab stack', () => {

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeSplashView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeSplashView.test.tsx
@@ -11,6 +11,7 @@ import RewardsVipRefereeSplashView from './RewardsVipRefereeSplashView';
 const mockNavigateDispatch = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockExitRewardsFlow = jest.fn();
 // Obviously-synthetic fixtures — never real VIP codes/subscriptions.
 const mockSubscriptionId = 'test-subscription-id';
 const mockReferredByVipCode = 'TESTCODE';
@@ -21,6 +22,10 @@ let mockVipRefereeSplashAccepted: Record<string, boolean> = {};
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  exitRewardsFlow: (...args: unknown[]) => mockExitRewardsFlow(...args),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -215,17 +220,17 @@ describe('RewardsVipRefereeSplashView', () => {
     );
   });
 
-  it('goes back when not now is pressed', () => {
+  it('exits the rewards flow when not now is pressed', () => {
     const { getByTestId } = render(<RewardsVipRefereeSplashView />);
 
     fireEvent.press(
       getByTestId(VIP_REFEREE_SPLASH_SCREEN_TEST_IDS.NOT_NOW_BUTTON),
     );
 
-    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 
-  it('replaces with dashboard on not now when there is no back route', () => {
+  it('exits the rewards flow on not now even when there is no back route', () => {
     mockCanGoBack = false;
 
     const { getByTestId } = render(<RewardsVipRefereeSplashView />);
@@ -234,10 +239,7 @@ describe('RewardsVipRefereeSplashView', () => {
       getByTestId(VIP_REFEREE_SPLASH_SCREEN_TEST_IDS.NOT_NOW_BUTTON),
     );
 
-    expect(mockGoBack).not.toHaveBeenCalled();
-    expect(mockNavigateDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 
   it('replaces with the referee view when already accepted', () => {
@@ -253,7 +255,7 @@ describe('RewardsVipRefereeSplashView', () => {
     );
   });
 
-  it('replaces with dashboard when the user is not a VIP referee', () => {
+  it('exits the rewards flow when the user is not a VIP referee', () => {
     mockIsVipReferee = false;
 
     const { queryByTestId } = render(<RewardsVipRefereeSplashView />);
@@ -261,12 +263,10 @@ describe('RewardsVipRefereeSplashView', () => {
     expect(
       queryByTestId(VIP_REFEREE_SPLASH_SCREEN_TEST_IDS.CONTAINER),
     ).toBeNull();
-    expect(mockNavigateDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 
-  it('replaces with dashboard when the VIP program flag is off', () => {
+  it('exits the rewards flow when the VIP program flag is off', () => {
     mockIsVipProgramEnabled = false;
 
     const { queryByTestId } = render(<RewardsVipRefereeSplashView />);
@@ -274,8 +274,6 @@ describe('RewardsVipRefereeSplashView', () => {
     expect(
       queryByTestId(VIP_REFEREE_SPLASH_SCREEN_TEST_IDS.CONTAINER),
     ).toBeNull();
-    expect(mockNavigateDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeSplashView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeSplashView.tsx
@@ -8,6 +8,7 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Routes from '../../../../constants/navigation/Routes';
+import { exitRewardsFlow } from '../utils';
 import {
   selectHasAcceptedVipRefereeInvite,
   selectIsVipReferee,
@@ -38,7 +39,7 @@ const RewardsVipRefereeSplashViewContent: React.FC = () => {
 
   useEffect(() => {
     if (!canViewReferee) {
-      navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+      exitRewardsFlow(navigation);
       return;
     }
 
@@ -60,12 +61,7 @@ const RewardsVipRefereeSplashViewContent: React.FC = () => {
   }, [navigation, subscriptionId]);
 
   const handleNotNow = useCallback(() => {
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-      return;
-    }
-
-    navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+    exitRewardsFlow(navigation);
   }, [navigation]);
 
   if (!canViewReferee || hasAcceptedVipRefereeInvite) {

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.test.tsx
@@ -24,6 +24,7 @@ const mockNavDispatch = jest.fn();
 const mockReduxDispatch = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockExitRewardsFlow = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn(() => createMockEventBuilder());
 // Obviously-synthetic fixtures — never real VIP codes/figures.
@@ -36,6 +37,10 @@ let mockVipRefereeSplashAccepted: Record<string, boolean> = {};
 jest.mock('react-redux', () => ({
   useDispatch: jest.fn(() => mockReduxDispatch),
   useSelector: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  exitRewardsFlow: (...args: unknown[]) => mockExitRewardsFlow(...args),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -493,25 +498,21 @@ describe('RewardsVipRefereeView', () => {
     ).toBeOnTheScreen();
   });
 
-  it('replaces with the dashboard when the user is not a VIP referee', () => {
+  it('exits the rewards flow when the user is not a VIP referee', () => {
     mockIsVipReferee = false;
 
     const { queryByTestId } = render(<RewardsVipRefereeView />);
 
     expect(queryByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.VIEW)).toBeNull();
-    expect(mockNavDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 
-  it('replaces with the dashboard when the VIP program flag is off', () => {
+  it('exits the rewards flow when the VIP program flag is off', () => {
     mockIsVipProgramEnabled = false;
 
     const { queryByTestId } = render(<RewardsVipRefereeView />);
 
     expect(queryByTestId(REWARDS_VIP_REFEREE_VIEW_TEST_IDS.VIEW)).toBeNull();
-    expect(mockNavDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipRefereeView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { ScrollView } from 'react-native';
-import { StackActions, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import {
   Box,
   BoxFlexDirection,
@@ -19,6 +19,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
+import { exitRewardsFlow } from '../utils';
 import {
   buildVipPrioritySupportUrl,
   METAMASK_SUPPORT_URL,
@@ -102,7 +103,7 @@ const RewardsVipRefereeViewContent: React.FC = () => {
 
   useEffect(() => {
     if (!canViewReferee) {
-      navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+      exitRewardsFlow(navigation);
     }
   }, [canViewReferee, navigation]);
 

--- a/app/components/UI/Rewards/Views/RewardsVipSplashView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipSplashView.test.tsx
@@ -15,6 +15,7 @@ import RewardsVipSplashView from './RewardsVipSplashView';
 const mockNavigateDispatch = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockExitRewardsFlow = jest.fn();
 const mockSubscriptionId = 'test-subscription-id';
 let mockIsVipEnabled = true;
 let mockIsVipProgramEnabled = true;
@@ -23,6 +24,10 @@ let mockVipSplashAccepted: Record<string, boolean> = {};
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  exitRewardsFlow: (...args: unknown[]) => mockExitRewardsFlow(...args),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -199,28 +204,28 @@ describe('RewardsVipSplashView', () => {
     );
   });
 
-  it('goes back when not now is pressed without accepting', () => {
+  it('exits the rewards flow when not now is pressed', () => {
     const { getByTestId } = render(<RewardsVipSplashView />);
 
     fireEvent.press(getByTestId(VIP_SPLASH_SCREEN_TEST_IDS.NOT_NOW_BUTTON));
 
-    expect(mockGoBack).toHaveBeenCalled();
-    expect(mockNavigateDispatch).not.toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
+    expect(mockExitRewardsFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canGoBack: expect.any(Function),
+        goBack: mockGoBack,
+        navigate: mockNavigate,
+      }),
     );
   });
 
-  it('replaces with dashboard on not now when there is no back route', () => {
+  it('exits the rewards flow on not now even when there is no back route', () => {
     mockCanGoBack = false;
 
     const { getByTestId } = render(<RewardsVipSplashView />);
 
     fireEvent.press(getByTestId(VIP_SPLASH_SCREEN_TEST_IDS.NOT_NOW_BUTTON));
 
-    expect(mockGoBack).not.toHaveBeenCalled();
-    expect(mockNavigateDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 
   it('replaces with VIP view when the invite is already accepted', () => {
@@ -234,25 +239,21 @@ describe('RewardsVipSplashView', () => {
     );
   });
 
-  it('replaces with dashboard when the user cannot view VIP', () => {
+  it('exits the rewards flow when the user cannot view VIP', () => {
     mockIsVipEnabled = false;
 
     const { queryByTestId } = render(<RewardsVipSplashView />);
 
     expect(queryByTestId(VIP_SPLASH_SCREEN_TEST_IDS.CONTAINER)).toBeNull();
-    expect(mockNavigateDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 
-  it('replaces with dashboard when the VIP program flag is off, even if the subscription is VIP', () => {
+  it('exits the rewards flow when the VIP program flag is off, even if the subscription is VIP', () => {
     mockIsVipProgramEnabled = false;
 
     const { queryByTestId } = render(<RewardsVipSplashView />);
 
     expect(queryByTestId(VIP_SPLASH_SCREEN_TEST_IDS.CONTAINER)).toBeNull();
-    expect(mockNavigateDispatch).toHaveBeenCalledWith(
-      StackActions.replace(Routes.REWARDS_DASHBOARD),
-    );
+    expect(mockExitRewardsFlow).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipSplashView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipSplashView.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
+import { exitRewardsFlow } from '../utils';
 import { selectHasAcceptedVipInvite } from '../../../../reducers/rewards/selectors';
 import {
   selectIsCurrentSubscriptionVipEnabled,
@@ -31,7 +32,7 @@ const RewardsVipSplashViewContent: React.FC = () => {
 
   useEffect(() => {
     if (!canViewVip) {
-      navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+      exitRewardsFlow(navigation);
       return;
     }
 
@@ -49,12 +50,7 @@ const RewardsVipSplashViewContent: React.FC = () => {
   }, [navigation, subscriptionId]);
 
   const handleNotNow = useCallback(() => {
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-      return;
-    }
-
-    navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+    exitRewardsFlow(navigation);
   }, [navigation]);
 
   if (!canViewVip || hasAcceptedVipInvite) {

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
@@ -17,9 +17,15 @@ import RewardsVipTiersView, {
 
 const mockDispatch = jest.fn();
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+const mockExitRewardsFlow = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  exitRewardsFlow: (...args: unknown[]) => mockExitRewardsFlow(...args),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -29,6 +35,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       dispatch: mockDispatch,
       goBack: mockGoBack,
+      navigate: mockNavigate,
     }),
   };
 });
@@ -368,13 +375,11 @@ describe('RewardsVipTiersView', () => {
     const { queryByTestId } = render(<RewardsVipTiersView />);
     expect(queryByTestId(REWARDS_VIP_TIERS_VIEW_TEST_IDS.ROOT)).toBeNull();
     await waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace(Routes.REWARDS_DASHBOARD),
-      );
+      expect(mockExitRewardsFlow).toHaveBeenCalled();
     });
   });
 
-  it('redirects to the rewards dashboard when the VIP program flag is off, even for a VIP subscription', async () => {
+  it('exits the rewards flow when the VIP program flag is off, even for a VIP subscription', async () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId)
         return 'test-subscription-id';
@@ -386,9 +391,7 @@ describe('RewardsVipTiersView', () => {
     const { queryByTestId } = render(<RewardsVipTiersView />);
     expect(queryByTestId(REWARDS_VIP_TIERS_VIEW_TEST_IDS.ROOT)).toBeNull();
     await waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace(Routes.REWARDS_DASHBOARD),
-      );
+      expect(mockExitRewardsFlow).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { ScrollView } from 'react-native';
-import { StackActions, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import {
   Box,
   HeaderStandard,
@@ -10,11 +10,11 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
-import Routes from '../../../../constants/navigation/Routes';
 import {
   selectIsCurrentSubscriptionVipEnabled,
   selectRewardsSubscriptionId,
 } from '../../../../selectors/rewards';
+import { exitRewardsFlow } from '../utils';
 import { selectVipProgramEnabled } from '../../../../selectors/featureFlagController/vipProgram';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
@@ -55,7 +55,7 @@ const RewardsVipTiersViewContent: React.FC = () => {
 
   useEffect(() => {
     if (!canViewVip) {
-      navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+      exitRewardsFlow(navigation);
     }
   }, [canViewVip, navigation]);
 

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -23,11 +23,16 @@ const mockDispatch = jest.fn();
 const mockReduxDispatch = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockExitRewardsFlow = jest.fn();
 let mockVipSplashAccepted: Record<string, boolean> = {};
 
 jest.mock('react-redux', () => ({
   useDispatch: jest.fn(() => mockReduxDispatch),
   useSelector: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  exitRewardsFlow: (...args: unknown[]) => mockExitRewardsFlow(...args),
 }));
 
 jest.mock('@react-navigation/native', () => {
@@ -718,13 +723,11 @@ describe('RewardsVipView', () => {
       enabled: false,
     });
     await waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace(Routes.REWARDS_DASHBOARD),
-      );
+      expect(mockExitRewardsFlow).toHaveBeenCalled();
     });
   });
 
-  it('redirects to the rewards dashboard when the VIP program flag is off, even for a VIP subscription', async () => {
+  it('exits the rewards flow when the VIP program flag is off, even for a VIP subscription', async () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectRewardsSubscriptionId) {
         return 'test-subscription-id';
@@ -746,9 +749,7 @@ describe('RewardsVipView', () => {
       enabled: false,
     });
     await waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace(Routes.REWARDS_DASHBOARD),
-      );
+      expect(mockExitRewardsFlow).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { Pressable, ScrollView } from 'react-native';
-import { StackActions, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import {
   Box,
   BoxFlexDirection,
@@ -20,6 +20,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
+import { exitRewardsFlow } from '../utils';
 import { acceptVipInvite } from '../../../../reducers/rewards';
 import {
   selectIsCurrentSubscriptionVipEnabled,
@@ -106,7 +107,7 @@ const RewardsVipViewContent: React.FC = () => {
 
   useEffect(() => {
     if (!canViewVip) {
-      navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
+      exitRewardsFlow(navigation);
     }
   }, [canViewVip, navigation]);
 

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
@@ -231,12 +231,16 @@ const OnboardingMainStep: React.FC = () => {
     });
   }, [optin, canContinue, referralCode, isPrefilledReferral]);
 
-  // Auto-redirect + analytics tracking
+  // Post-opt-in: push the dashboard with a native slide transition. RewardsHome
+  // registers both onboarding and dashboard in the same stack; the parent
+  // conditional remount alone would swap instantly with no animation.
   useFocusEffect(
     useCallback(() => {
       if (subscriptionId) {
         navigation.navigate(Routes.REWARDS_DASHBOARD);
-      } else if (!hasTrackedOnboardingStart.current) {
+        return;
+      }
+      if (!hasTrackedOnboardingStart.current) {
         trackEvent(
           createEventBuilder(
             MetaMetricsEvents.REWARDS_ONBOARDING_STARTED,

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingMainStep.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Image, ActivityIndicator } from 'react-native';
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import {
+  StackActions,
+  useNavigation,
+  useFocusEffect,
+} from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
@@ -231,13 +235,13 @@ const OnboardingMainStep: React.FC = () => {
     });
   }, [optin, canContinue, referralCode, isPrefilledReferral]);
 
-  // Post-opt-in: push the dashboard with a native slide transition. RewardsHome
-  // registers both onboarding and dashboard in the same stack; the parent
-  // conditional remount alone would swap instantly with no animation.
+  // Post-opt-in: replace onboarding with dashboard so back does not return here.
+  // RewardsHome registers both screens in the same stack; dashboard screen options
+  // provide the slide transition.
   useFocusEffect(
     useCallback(() => {
       if (subscriptionId) {
-        navigation.navigate(Routes.REWARDS_DASHBOARD);
+        navigation.dispatch(StackActions.replace(Routes.REWARDS_DASHBOARD));
         return;
       }
       if (!hasTrackedOnboardingStart.current) {

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
@@ -778,8 +778,8 @@ describe('OnboardingMainStep', () => {
     });
   });
 
-  describe('auto-redirect to dashboard', () => {
-    it('navigates to dashboard when subscriptionId exists on focus', () => {
+  describe('post-opt-in transition', () => {
+    it('navigates to dashboard with a stack push when subscriptionId exists on focus', () => {
       setupSelectors(new Map([[selectRewardsSubscriptionId, 'sub-123']]));
 
       renderWithProviders(<OnboardingMainStep />);

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingMainStep.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent } from '@testing-library/react-native';
 import { Linking } from 'react-native';
 import { renderWithProviders, createMockDispatch } from '../testUtils';
 import OnboardingMainStep from '../OnboardingMainStep';
+import { StackActions } from '@react-navigation/native';
 import Routes from '../../../../../../constants/navigation/Routes';
 import {
   REWARDS_ONBOARD_TERMS_URL,
@@ -21,6 +22,7 @@ import { selectVipProgramEnabled } from '../../../../../../selectors/featureFlag
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
+const mockNavigationDispatch = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -30,6 +32,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: mockNavigate,
       goBack: mockGoBack,
+      dispatch: mockNavigationDispatch,
     }),
     useFocusEffect: (effect: () => void | (() => void)) => {
       ReactActual.useEffect(() => {
@@ -779,17 +782,21 @@ describe('OnboardingMainStep', () => {
   });
 
   describe('post-opt-in transition', () => {
-    it('navigates to dashboard with a stack push when subscriptionId exists on focus', () => {
+    it('replaces onboarding with dashboard when subscriptionId exists on focus', () => {
       setupSelectors(new Map([[selectRewardsSubscriptionId, 'sub-123']]));
 
       renderWithProviders(<OnboardingMainStep />);
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+      expect(mockNavigationDispatch).toHaveBeenCalledWith(
+        StackActions.replace(Routes.REWARDS_DASHBOARD),
+      );
+      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
     });
 
     it('does not navigate when subscriptionId does not exist', () => {
       renderWithProviders(<OnboardingMainStep />);
 
+      expect(mockNavigationDispatch).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
     });
   });

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import { useCampaignOutcomeToast } from './useCampaignOutcomeToast';
+import { navigateToRewardsRoute } from '../utils';
 import { dismissCampaignOutcomeToast } from '../../../../reducers/rewards';
 import {
   selectCampaigns,
@@ -89,6 +90,10 @@ jest.mock('../components/Campaigns/CampaignTile.utils', () => ({
   getCampaignStatus: jest.fn(() => 'complete'),
 }));
 
+jest.mock('../utils', () => ({
+  navigateToRewardsRoute: jest.fn(),
+}));
+
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
 const mockShowToast = jest.fn();
@@ -109,6 +114,8 @@ const mockDismissCampaignOutcomeToast =
   dismissCampaignOutcomeToast as jest.MockedFunction<
     typeof dismissCampaignOutcomeToast
   >;
+const mockNavigateToRewardsRoute =
+  navigateToRewardsRoute as jest.MockedFunction<typeof navigateToRewardsRoute>;
 
 const SUBSCRIPTION_ID = 'sub-123';
 const CAMPAIGN_ID = 'campaign-456';
@@ -422,9 +429,10 @@ describe('useCampaignOutcomeToast', () => {
       const { onPress } = mockShowToast.mock.calls[0][0].linkButtonOptions;
       onPress();
 
-      expect(mockNavigate).toHaveBeenCalledWith(
-        WINNER_NAV.route as never,
-        WINNER_NAV.params as never,
+      expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
+        { navigate: mockNavigate },
+        WINNER_NAV.route,
+        WINNER_NAV.params,
       );
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: 'winner' }),
@@ -444,9 +452,10 @@ describe('useCampaignOutcomeToast', () => {
       const { onPress } = mockShowToast.mock.calls[0][0].linkButtonOptions;
       onPress();
 
-      expect(mockNavigate).toHaveBeenCalledWith(
-        NON_WINNER_NAV.route as never,
-        NON_WINNER_NAV.params as never,
+      expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
+        { navigate: mockNavigate },
+        NON_WINNER_NAV.route,
+        NON_WINNER_NAV.params,
       );
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: 'non_winner' }),

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
@@ -20,6 +20,7 @@ import {
   selectDismissedCampaignOutcomeToasts,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import { navigateToRewardsRoute } from '../utils';
 import useRewardsToast from './useRewardsToast';
 
 export interface CampaignOutcomeToastConfig {
@@ -112,7 +113,11 @@ export function useCampaignOutcomeToast(
       variant === 'winner'
         ? getWinnerNavigation(targetCampaign)
         : getNonWinnerNavigation(targetCampaign);
-    navigation.navigate(nav.route, nav.params);
+    navigateToRewardsRoute(
+      navigation,
+      nav.route,
+      nav.params as Record<string, unknown>,
+    );
   }, [
     variant,
     targetCampaign,

--- a/app/components/UI/Rewards/hooks/useRewardDashboardModals.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardDashboardModals.test.tsx
@@ -276,7 +276,7 @@ describe('useRewardDashboardModals', () => {
         type: 'SET_HIDE_UNLINKED_ACCOUNTS_BANNER',
         payload: true,
       });
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
     it('does not show modal when bulk link is running', () => {
@@ -445,7 +445,7 @@ describe('useRewardDashboardModals', () => {
       expect(mockLinkAccountGroup).toHaveBeenCalledWith(
         mockSelectedAccountGroup.id,
       );
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
+      expect(mockNavigate).not.toHaveBeenCalledWith(Routes.REWARDS_DASHBOARD);
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'SET_HIDE_CURRENT_ACCOUNT_NOT_OPTED_IN_BANNER',
         payload: { accountGroupId: mockSelectedAccountGroup.id, hide: true },

--- a/app/components/UI/Rewards/hooks/useRewardDashboardModals.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardDashboardModals.tsx
@@ -139,7 +139,6 @@ export const useRewardDashboardModals = () => {
 
       onCancel: () => {
         dispatch(setHideUnlinkedAccountsBanner(true));
-        navigation.navigate(Routes.REWARDS_DASHBOARD);
       },
       type: ModalType.Confirmation,
       showCancelButton: true,
@@ -193,7 +192,6 @@ export const useRewardDashboardModals = () => {
         onPress: async () => {
           if (!isLinking) {
             const linkSuccess = await linkAccountGroup(selectedAccountGroup.id);
-            navigation.navigate(Routes.REWARDS_DASHBOARD);
             if (linkSuccess) {
               handleDismissCurrentAccountBanner();
             }

--- a/app/components/UI/Rewards/utils.test.ts
+++ b/app/components/UI/Rewards/utils.test.ts
@@ -4,7 +4,10 @@ import {
   convertInternalAccountToCaipAccountId,
   deriveAccountMetricProps,
   getActiveRouteNameFromNavigationState,
+  exitRewardsFlow,
+  navigateToRewardsRoute,
 } from './utils';
+import Routes from '../../../constants/navigation/Routes';
 import { parseCaipChainId, toCaipAccountId } from '@metamask/utils';
 import Logger from '../../../util/Logger';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -243,6 +246,59 @@ describe('Rewards Utils', () => {
       });
 
       expect(routeName).toBeUndefined();
+    });
+  });
+
+  describe('navigateToRewardsRoute', () => {
+    it('navigates into the rewards flow with the target screen and params', () => {
+      const mockNavigate = jest.fn();
+
+      navigateToRewardsRoute(
+        { navigate: mockNavigate },
+        'RewardsSettingsView',
+        {
+          foo: 'bar',
+        },
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
+        screen: 'RewardsSettingsView',
+        params: { foo: 'bar' },
+      });
+    });
+  });
+
+  describe('exitRewardsFlow', () => {
+    it('goes back when the flow can be popped from the root stack', () => {
+      const mockGoBack = jest.fn();
+      const mockNavigate = jest.fn();
+      const navigation = {
+        canGoBack: () => true,
+        goBack: mockGoBack,
+        navigate: mockNavigate,
+      };
+
+      exitRewardsFlow(navigation as never);
+
+      expect(mockGoBack).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to the rewards tab when there is no back route', () => {
+      const mockGoBack = jest.fn();
+      const mockNavigate = jest.fn();
+      const navigation = {
+        canGoBack: () => false,
+        goBack: mockGoBack,
+        navigate: mockNavigate,
+      };
+
+      exitRewardsFlow(navigation as never);
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS, {
+        screen: Routes.REWARDS_VIEW,
+      });
     });
   });
 

--- a/app/components/UI/Rewards/utils.ts
+++ b/app/components/UI/Rewards/utils.ts
@@ -186,6 +186,35 @@ export const navigateToRewardsRoute = (
   navigation.navigate(Routes.REWARDS_FLOW, { screen, params });
 };
 
+type RewardsFlowExitNavigation = Pick<
+  NavigationProp<ReactNavigation.RootParamList>,
+  'navigate' | 'goBack' | 'canGoBack'
+>;
+
+/**
+ * Leaves the pushed `REWARDS_FLOW` stack and returns the user to the Rewards
+ * dashboard in the tab.
+ *
+ * VIP screens previously used `StackActions.replace(Routes.REWARDS_DASHBOARD)`,
+ * but the dashboard lives in the Rewards tab — not inside `RewardsNavigator` —
+ * so that replace could not be handled. Popping the flow (or falling back to the
+ * Rewards tab) keeps navigation consistent with the native-stack migration.
+ *
+ * @param navigation - The navigation object from `useNavigation()`.
+ */
+export const exitRewardsFlow = (
+  navigation: RewardsFlowExitNavigation,
+): void => {
+  if (navigation.canGoBack()) {
+    navigation.goBack();
+    return;
+  }
+
+  navigation.navigate(Routes.HOME_TABS, {
+    screen: Routes.REWARDS_VIEW,
+  });
+};
+
 // Referral URL builder
 export const REFERRAL_LINK_PATH = 'link.metamask.io/rewards?referral=';
 export const REFERRAL_BASE_URL = `https://${REFERRAL_LINK_PATH}`;

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
@@ -154,26 +154,6 @@ describe('handleRewardsUrl', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });
 
-    it('dispatches pending deeplink and navigates to rewards view with campaign=perps-comp param', async () => {
-      await handleRewardsUrl({ rewardsPath: '?campaign=perps-comp' });
-
-      expect(setPendingDeeplink).toHaveBeenCalledWith({
-        page: undefined,
-        campaign: 'perps-comp',
-      });
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
-    });
-
-    it('dispatches pending deeplink and navigates to rewards view with campaign=predict-the-pitch param', async () => {
-      await handleRewardsUrl({ rewardsPath: '?campaign=predict-the-pitch' });
-
-      expect(setPendingDeeplink).toHaveBeenCalledWith({
-        page: undefined,
-        campaign: 'predict-the-pitch',
-      });
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
-    });
-
     it('dispatches pending deeplink and navigates to rewards view with page=musd param', async () => {
       await handleRewardsUrl({ rewardsPath: '?page=musd' });
 

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
@@ -154,6 +154,26 @@ describe('handleRewardsUrl', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });
 
+    it('dispatches pending deeplink and navigates to rewards view with campaign=perps-comp param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=perps-comp' });
+
+      expect(setPendingDeeplink).toHaveBeenCalledWith({
+        page: undefined,
+        campaign: 'perps-comp',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
+    it('dispatches pending deeplink and navigates to rewards view with campaign=predict-the-pitch param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=predict-the-pitch' });
+
+      expect(setPendingDeeplink).toHaveBeenCalledWith({
+        page: undefined,
+        campaign: 'predict-the-pitch',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
     it('dispatches pending deeplink and navigates to rewards view with page=musd param', async () => {
       await handleRewardsUrl({ rewardsPath: '?page=musd' });
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -20,7 +20,7 @@ interface HandleRewardsUrlParams {
 interface RewardsNavigationParams {
   referral?: string;
   page?: 'campaigns' | 'musd' | 'benefits';
-  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch';
+  campaign?: 'ondo' | 'season1' | 'perps-comp';
 }
 
 /**
@@ -45,9 +45,7 @@ const parseRewardsNavigationParams = (
     page: (['campaigns', 'musd', 'benefits'].includes(pageParam ?? '')
       ? pageParam
       : undefined) as RewardsNavigationParams['page'],
-    campaign: (['ondo', 'season1', 'perps-comp', 'predict-the-pitch'].includes(
-      campaignParam ?? '',
-    )
+    campaign: (['ondo', 'season1', 'perps-comp'].includes(campaignParam ?? '')
       ? campaignParam
       : undefined) as RewardsNavigationParams['campaign'],
   };
@@ -66,8 +64,6 @@ const parseRewardsNavigationParams = (
  * - https://link.metamask.io/rewards?page=benefits
  * - https://link.metamask.io/rewards?campaign=ondo
  * - https://link.metamask.io/rewards?campaign=season1
- * - https://link.metamask.io/rewards?campaign=perps-comp
- * - https://link.metamask.io/rewards?campaign=predict-the-pitch
  */
 const prepareRewardsDeeplink = (rewardsPath: string) => {
   // Parse navigation parameters from URL

--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -20,7 +20,7 @@ interface HandleRewardsUrlParams {
 interface RewardsNavigationParams {
   referral?: string;
   page?: 'campaigns' | 'musd' | 'benefits';
-  campaign?: 'ondo' | 'season1' | 'perps-comp';
+  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch';
 }
 
 /**
@@ -45,7 +45,9 @@ const parseRewardsNavigationParams = (
     page: (['campaigns', 'musd', 'benefits'].includes(pageParam ?? '')
       ? pageParam
       : undefined) as RewardsNavigationParams['page'],
-    campaign: (['ondo', 'season1', 'perps-comp'].includes(campaignParam ?? '')
+    campaign: (['ondo', 'season1', 'perps-comp', 'predict-the-pitch'].includes(
+      campaignParam ?? '',
+    )
       ? campaignParam
       : undefined) as RewardsNavigationParams['campaign'],
   };
@@ -64,6 +66,8 @@ const parseRewardsNavigationParams = (
  * - https://link.metamask.io/rewards?page=benefits
  * - https://link.metamask.io/rewards?campaign=ondo
  * - https://link.metamask.io/rewards?campaign=season1
+ * - https://link.metamask.io/rewards?campaign=perps-comp
+ * - https://link.metamask.io/rewards?campaign=predict-the-pitch
  */
 const prepareRewardsDeeplink = (rewardsPath: string) => {
   // Parse navigation parameters from URL


### PR DESCRIPTION
## **Description**

After the Rewards native-stack migration (PR #31227 / #32121), several navigation paths still targeted `REWARDS_FLOW` screens with a plain `navigation.navigate()` from the Rewards tab (dashboard/onboarding). Those routes live on the root `REWARDS_FLOW` stack, not inside `RewardsHome`, so React Navigation could not handle them and users saw errors such as *The action 'NAVIGATE' … was not handled by any navigator*.

This PR fixes those broken paths and hardens related Rewards navigation:

- **Campaign outcome toasts** — "View Details" now uses `navigateToRewardsRoute()` so winning/details screens open inside `REWARDS_FLOW`.
- **VIP exit** — VIP screens use `exitRewardsFlow()` instead of `StackActions.replace(Routes.REWARDS_DASHBOARD)`, which could not resolve from `RewardsNavigator`.
- **Post–opt-in transition** — `OnboardingMainStep` uses `StackActions.replace(REWARDS_DASHBOARD)` so back from the dashboard does not return to onboarding; `RewardsHome` registers both onboarding and dashboard in the same native stack.
- **Dashboard modals** — removed redundant `navigate(REWARDS_DASHBOARD)` calls; the bottom sheet already dismisses via `goBack()`.

Fixes [RWDS-1415](https://consensyssoftware.atlassian.net/browse/RWDS-1415).

## **Changelog**

CHANGELOG entry: Fixed Rewards navigation errors when opening campaign outcome details, exiting VIP flows, and transitioning to the dashboard after opt-in.

## **Related issues**

Fixes: [RWDS-1415](https://consensyssoftware.atlassian.net/browse/RWDS-1415)

## **Manual testing steps**

```gherkin
Feature: Rewards navigation after native stack migration

  Scenario: campaign outcome toast opens winning view from dashboard
    Given the user is opted into Rewards on the dashboard
    And a completed campaign outcome toast is visible
    When the user taps View Details on the toast
    Then the campaign winning or details screen opens without a navigation error

  Scenario: VIP splash exit returns to Rewards dashboard
    Given the user opens the VIP splash from the dashboard
    When the user dismisses or completes the splash
    Then the user returns to the Rewards dashboard without an unhandled navigate error

  Scenario: opt-in replaces onboarding with dashboard
    Given the user completes Rewards onboarding opt-in
    When the dashboard appears
    And the user presses the hardware back button
    Then the user does not return to the onboarding flow
```

## **Screenshots/Recordings**

N/A — navigation-only changes; verified via unit tests and manual navigation flows above.

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/3bb06d25-3c52-4ec2-902b-19942e1e46dd

https://github.com/user-attachments/assets/ab64018e-146f-4049-b4ee-2950e5ab6bbb

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[RWDS-1415]: https://consensyssoftware.atlassian.net/browse/RWDS-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ