### PR TITLE
feat: support predict the pitch rewards deeplink

### DIFF
--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
@@ -154,6 +154,16 @@ describe('handleRewardsUrl', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });
 
+    it('dispatches pending deeplink and navigates to rewards view with campaign=predict-the-pitch param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=predict-the-pitch' });
+
+      expect(setPendingDeeplink).toHaveBeenCalledWith({
+        page: undefined,
+        campaign: 'predict-the-pitch',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
     it('dispatches pending deeplink and navigates to rewards view with page=musd param', async () => {
       await handleRewardsUrl({ rewardsPath: '?page=musd' });
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -20,7 +20,7 @@ interface HandleRewardsUrlParams {
 interface RewardsNavigationParams {
   referral?: string;
   page?: 'campaigns' | 'musd' | 'benefits';
-  campaign?: 'ondo' | 'season1' | 'perps-comp';
+  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch';
 }
 
 /**
@@ -45,7 +45,9 @@ const parseRewardsNavigationParams = (
     page: (['campaigns', 'musd', 'benefits'].includes(pageParam ?? '')
       ? pageParam
       : undefined) as RewardsNavigationParams['page'],
-    campaign: (['ondo', 'season1', 'perps-comp'].includes(campaignParam ?? '')
+    campaign: (['ondo', 'season1', 'perps-comp', 'predict-the-pitch'].includes(
+      campaignParam ?? '',
+    )
       ? campaignParam
       : undefined) as RewardsNavigationParams['campaign'],
   };
@@ -64,6 +66,7 @@ const parseRewardsNavigationParams = (
  * - https://link.metamask.io/rewards?page=benefits
  * - https://link.metamask.io/rewards?campaign=ondo
  * - https://link.metamask.io/rewards?campaign=season1
+ * - https://link.metamask.io/rewards?campaign=predict-the-pitch
  */
 const prepareRewardsDeeplink = (rewardsPath: string) => {
   // Parse navigation parameters from URL


### PR DESCRIPTION
## **Description**

Adds the missing value in the supported values for the "campaign" parameter in the Rewards deeplink to support predict competition. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: n/a

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive deeplink allowlist change with a test; no auth or data-handling impact.
> 
> **Overview**
> Rewards deeplinks can now use **`campaign=predict-the-pitch`**, matching the existing pattern for campaigns like `season1` and `perps-comp`.
> 
> `handleRewardsUrl` extends the allowed `campaign` value in its types and URL parsing so the param is stored in **`setPendingDeeplink`** and the app navigates to Rewards instead of treating it as unknown. JSDoc documents the new URL format, and a unit test covers the deeplink flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eee52de9ac6de462b84b6d1a1ccb767af98d0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->