### PR TITLE
feat: add transaction details redesign feature flag selector

### DIFF
--- a/app/components/Views/ActivityView/selectors/featureFlags/index.ts
+++ b/app/components/Views/ActivityView/selectors/featureFlags/index.ts
@@ -1,1 +1,4 @@
-export { selectIsActivityRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';
+export {
+  selectIsActivityRedesignEnabled,
+  selectIsTransactionsRedesignEnabled,
+} from '../../../../../selectors/featureFlagController/activityRedesign';

--- a/app/selectors/featureFlagController/activityRedesign/index.ts
+++ b/app/selectors/featureFlagController/activityRedesign/index.ts
@@ -6,3 +6,11 @@ export const selectIsActivityRedesignEnabled = createSelector(
   (remoteFeatureFlags): boolean =>
     remoteFeatureFlags.tmcuActivityRedesignEnabled === true,
 );
+
+export const selectIsTransactionsRedesignEnabled = createSelector(
+  selectIsActivityRedesignEnabled,
+  selectRemoteFeatureFlags,
+  (isActivityRedesignEnabled, remoteFeatureFlags): boolean =>
+    isActivityRedesignEnabled &&
+    remoteFeatureFlags.tmcuTransactionsRedesignEnabled === true,
+);

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5517,6 +5517,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
+
+  tmcuTransactionsRedesignEnabled: {
+    name: 'tmcuTransactionsRedesignEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: false,
+    status: FeatureFlagStatus.Active,
+  },
 };
 
 // ============================================================================


### PR DESCRIPTION
## **Description**

Adds the feature-flag selector for the new transaction details pages, part of the overall Activity Redesign.

`selectIsTransactionsRedesignEnabled` reads the `tmcuTransactionsRedesignEnabled` remote flag and is **gated behind** `selectIsActivityRedesignEnabled`, so the transaction details redesign only activates when the activity redesign is also enabled. Both selectors live in the existing `activityRedesign` selector file since they're tightly coupled, and are re-exported from the ActivityView feature-flags barrel.

This is plumbing only 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-864](https://consensyssoftware.atlassian.net/browse/TMCU-864)

## **Manual testing steps**

```gherkin
Feature: Transaction details redesign feature flag

  Scenario: flag is gated behind the activity redesign
    Given the tmcuActivityRedesignEnabled remote flag is off
    Then selectIsTransactionsRedesignEnabled returns false regardless of tmcuTransactionsRedesignEnabled

  Scenario: flag is enabled
    Given the tmcuActivityRedesignEnabled remote flag is on
    And the tmcuTransactionsRedesignEnabled remote flag is on
    Then selectIsTransactionsRedesignEnabled returns true
```

## **Screenshots/Recordings**

### **Before**

N/A — no user-facing change (feature-flag selector only).

### **After**

N/A — no user-facing change (feature-flag selector only).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-864]: https://consensyssoftware.atlassian.net/browse/TMCU-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Selector and registry-only changes with no runtime UI wiring; defaults keep both flags off in production.
> 
> **Overview**
> Adds **plumbing** for the transaction details redesign under Activity Redesign: a new remote flag **`tmcuTransactionsRedesignEnabled`** (registered in the E2E feature-flag registry with production default `false`) and a **`selectIsTransactionsRedesignEnabled`** reselect that returns true only when **`selectIsActivityRedesignEnabled`** is on **and** the new remote flag is true.
> 
> The new selector is defined alongside the existing activity redesign selectors and **re-exported** from the ActivityView feature-flags barrel so upcoming transaction-details UI can read a single gated flag. No user-facing behavior changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a209de3618503a102683fff5fc00ec6f2504c871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->