### PR TITLE
fix(money): use translated debit card label on Android (MUSD-1051) cp-8.0.0

### DIFF
--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -211,7 +211,7 @@ const MoneyAddMoneySheet: React.FC = () => {
           {
             label: strings(
               Platform.OS === 'android'
-                ? 'money.add_money_sheet.deposit_funds_android'
+                ? 'fiat_on_ramp.debit_card'
                 : 'money.add_money_sheet.deposit_funds',
             ),
             icon: IconName.Card,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7169,7 +7169,6 @@
       "title": "Add funds",
       "convert_crypto": "Convert crypto",
       "deposit_funds": "Debit card or Apple Pay",
-      "deposit_funds_android": "Debit card",
       "bank_account": "Bank account",
       "move_musd": "{{amount}} mUSD",
       "add_musd": "Add mUSD",


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Money "Add funds" sheet renders a "Debit card" option on Android via `money.add_money_sheet.deposit_funds_android`, which is English-only and has no translations yet — so non-English users see English text.

The Ramps team already ships a fully translated "Debit card" string at `fiat_on_ramp.debit_card` (present in all locales). This change piggybacks on it for the Android label until the Money strings get their own translations.

- Android: `money.add_money_sheet.deposit_funds_android` → `fiat_on_ramp.debit_card` (translated everywhere; English value is identical, "Debit card").
- Removed the now-unused, English-only `money.add_money_sheet.deposit_funds_android` key.
- iOS is unchanged: it shows "Debit card or Apple Pay" (`money.add_money_sheet.deposit_funds`), which has no single translated equivalent — left as-is until own translations land.

Marked `cp-8.0.0` for cherry-pick into `release/8.0.0`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Add funds "Debit card" option showing untranslated on Android for non-English locales.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1051

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Translated Add funds debit card label

  Scenario: Android user in a non-English locale opens Add funds
    Given the device language is set to a non-English locale (e.g. German)
    And the user is on Android
    When the user opens the Money "Add funds" sheet
    Then the deposit option label is shown translated (e.g. "Debitkarte")

  Scenario: iOS Add funds label is unchanged
    Given the user is on iOS
    When the user opens the Money "Add funds" sheet
    Then the deposit option label reads "Debit card or Apple Pay"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only i18n key swap for one Android label in the Add funds sheet; no deposit flow or payment logic changes.
> 
> **Overview**
> On **Android**, the Money **Add funds** sheet deposit option no longer uses the English-only `money.add_money_sheet.deposit_funds_android` key. It now resolves **`fiat_on_ramp.debit_card`**, which is already translated across locales (same English copy: “Debit card”).
> 
> The unused **`deposit_funds_android`** entry was removed from **`en.json`**. **iOS** is unchanged and still shows **`money.add_money_sheet.deposit_funds`** (“Debit card or Apple Pay”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7320191e7d5155030ee25e5049f0ee1895d7c20e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->