### PR TITLE
refactor: updated perps gainers and losers to use segmented control

### DIFF
--- a/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.test.tsx
@@ -171,14 +171,9 @@ describe('PerpsTopMoversSection', () => {
   it('selects the gainers (desc) toggle by default', () => {
     renderSection();
 
-    expect(
-      screen.getByTestId(PerpsHomeViewSelectorsIDs.TOP_MOVERS_GAINERS_PILL)
-        .props.accessibilityState.selected,
-    ).toBe(true);
-    expect(
-      screen.getByTestId(PerpsHomeViewSelectorsIDs.TOP_MOVERS_LOSERS_PILL).props
-        .accessibilityState.selected,
-    ).toBe(false);
+    expect(mockUsePerpsTopMovers).toHaveBeenCalledWith({
+      direction: 'desc',
+    });
   });
 
   it('selects the losers toggle after pressing it', () => {
@@ -188,14 +183,17 @@ describe('PerpsTopMoversSection', () => {
       screen.getByTestId(PerpsHomeViewSelectorsIDs.TOP_MOVERS_LOSERS_PILL),
     );
 
-    expect(
-      screen.getByTestId(PerpsHomeViewSelectorsIDs.TOP_MOVERS_LOSERS_PILL).props
-        .accessibilityState.selected,
-    ).toBe(true);
-    expect(
-      screen.getByTestId(PerpsHomeViewSelectorsIDs.TOP_MOVERS_GAINERS_PILL)
-        .props.accessibilityState.selected,
-    ).toBe(false);
+    expect(mockUsePerpsTopMovers).toHaveBeenLastCalledWith({
+      direction: 'asc',
+    });
+
+    fireEvent.press(
+      screen.getByTestId(PerpsHomeViewSelectorsIDs.TOP_MOVERS_GAINERS_PILL),
+    );
+
+    expect(mockUsePerpsTopMovers).toHaveBeenLastCalledWith({
+      direction: 'desc',
+    });
   });
 
   it('requests the losers (asc) direction from the data hook after selecting losers', () => {

--- a/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.tsx
+++ b/app/components/UI/Perps/components/PerpsTopMoversSection/PerpsTopMoversSection.tsx
@@ -1,18 +1,12 @@
 import React, { useState, useCallback } from 'react';
-import { Pressable } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   Box,
-  BoxFlexDirection,
-  BoxAlignItems,
-  Text,
-  TextVariant,
-  TextColor,
-  FontWeight,
+  FilterButton,
   SectionDivider,
   SectionHeader,
+  SegmentedControl,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   type PerpsMarketData,
   type SortDirection,
@@ -34,42 +28,6 @@ import type { TransactionActiveAbTestEntry } from '../../../../../util/transacti
 
 const TOP_MOVERS_ROW_COUNT = 2;
 const TOP_MOVERS_MAX_PILLS = 8;
-
-interface TogglePillProps {
-  label: string;
-  isSelected: boolean;
-  onPress: () => void;
-  testID: string;
-}
-
-const TogglePill: React.FC<TogglePillProps> = ({
-  label,
-  isSelected,
-  onPress,
-  testID,
-}) => {
-  const tw = useTailwind();
-  return (
-    <Pressable
-      onPress={onPress}
-      testID={testID}
-      accessibilityRole="button"
-      accessibilityState={{ selected: isSelected }}
-      style={tw.style(
-        'flex-1 rounded-lg items-center justify-center py-1',
-        isSelected ? 'bg-icon-default' : 'bg-muted',
-      )}
-    >
-      <Text
-        variant={TextVariant.BodySm}
-        fontWeight={FontWeight.Medium}
-        color={isSelected ? TextColor.InfoInverse : TextColor.TextDefault}
-      >
-        {label}
-      </Text>
-    </Pressable>
-  );
-};
 
 type PerpsTopMoversSource =
   (typeof PERPS_EVENT_VALUE.SOURCE)[keyof typeof PERPS_EVENT_VALUE.SOURCE];
@@ -142,23 +100,27 @@ const PerpsTopMoversSectionInner: React.FC<PerpsTopMoversSectionProps> = ({
         onPress={handleViewAll}
         testID={PerpsHomeViewSelectorsIDs.TOP_MOVERS_HEADER}
       />
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        twClassName="px-4 gap-2 mb-3"
-      >
-        <TogglePill
-          label={strings('perps.home.gainers')}
-          isSelected={direction === 'desc'}
-          onPress={() => setDirection('desc')}
-          testID={PerpsHomeViewSelectorsIDs.TOP_MOVERS_GAINERS_PILL}
-        />
-        <TogglePill
-          label={strings('perps.home.losers')}
-          isSelected={direction === 'asc'}
-          onPress={() => setDirection('asc')}
-          testID={PerpsHomeViewSelectorsIDs.TOP_MOVERS_LOSERS_PILL}
-        />
+      <Box twClassName="px-4 mb-3">
+        <SegmentedControl
+          value={direction === 'desc' ? 'gainers' : 'losers'}
+          onChange={(value) =>
+            setDirection(value === 'gainers' ? 'desc' : 'asc')
+          }
+          isFullWidth
+        >
+          <FilterButton
+            value="gainers"
+            testID={PerpsHomeViewSelectorsIDs.TOP_MOVERS_GAINERS_PILL}
+          >
+            {strings('perps.home.gainers')}
+          </FilterButton>
+          <FilterButton
+            value="losers"
+            testID={PerpsHomeViewSelectorsIDs.TOP_MOVERS_LOSERS_PILL}
+          >
+            {strings('perps.home.losers')}
+          </FilterButton>
+        </SegmentedControl>
       </Box>
       <PillScrollList<PerpsMarketData>
         data={data}

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
+import {
+  Box,
+  FilterButton,
+  SegmentedControl,
+} from '@metamask/design-system-react-native';
 import type { ListRenderItem } from '@shopify/flash-list';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
@@ -48,7 +53,6 @@ import ExploreSectionList, {
 } from '../components/ExploreSectionList';
 import SectionHeader from '../components/SectionHeader';
 import PillScrollList from '../components/PillScrollList';
-import PillRow, { type PillOption } from '../components/PillRow';
 import type { TabProps } from '../hooks/useExploreRefresh';
 import { trackExploreInteracted } from '../search/analytics';
 import WhatsHappeningSection from '../../../UI/WhatsHappening';
@@ -81,17 +85,6 @@ const PerpsBlock: React.FC<PerpsBlockProps> = ({ refresh, navigation }) => {
     [perps.data],
   );
   const livePrices = usePerpsLivePrices({ symbols, throttleMs: 3000 });
-
-  const moverPills: PillOption[] = [
-    {
-      key: 'gainers',
-      name: strings('trending.perps_movers_pill_gainers'),
-    },
-    {
-      key: 'losers',
-      name: strings('trending.perps_movers_pill_losers'),
-    },
-  ];
 
   const handleMoverPillSelect = (key: string) => {
     if (key === 'gainers' || key === 'losers') {
@@ -160,12 +153,21 @@ const PerpsBlock: React.FC<PerpsBlockProps> = ({ refresh, navigation }) => {
         tabName="Now"
         sectionName="perps_movers"
       />
-      <PillRow
-        pills={moverPills}
-        activeKey={activeMoverDirection}
-        onSelect={handleMoverPillSelect}
-        testIdPrefix="perps-movers"
-      />
+      <Box twClassName="mb-3">
+        <SegmentedControl
+          value={activeMoverDirection}
+          onChange={handleMoverPillSelect}
+          isFullWidth
+          testID="perps-movers-pills"
+        >
+          <FilterButton value="gainers" testID="perps-movers-pill-gainers">
+            {strings('trending.perps_movers_pill_gainers')}
+          </FilterButton>
+          <FilterButton value="losers" testID="perps-movers-pill-losers">
+            {strings('trending.perps_movers_pill_losers')}
+          </FilterButton>
+        </SegmentedControl>
+      </Box>
       <PillScrollList<PerpsFeedItem>
         data={pillData}
         isLoading={perps.isLoading}


### PR DESCRIPTION
## **Description**

Replaces custom Gainers/Losers pill toggles with MMDS `SegmentedControl` + `FilterButton` in two places:

1. **Perps home → Top movers** — removed the local `TogglePill` in `PerpsTopMoversSection.tsx`
2. **Explore → Now tab → Perps movers** — replaced `PillRow` in `NowTab.tsx` `PerpsBlock`

**Why:** Align Perps Gainers/Losers UI with the MetaMask Design System instead of one-off pill styling.

**What changed:** Both controls use full-width `SegmentedControl` with `FilterButton` segments. Behavior is unchanged — toggling still switches between gainers (desc) and losers (asc) and updates the asset list. Existing testIDs are preserved. Unit tests were updated to assert sort direction via the data hook instead of `accessibilityState.selected`.

## **Changelog**

CHANGELOG entry: Updated Gainers/Losers toggles on Explore and Perps home to use the standard segmented control design

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3428

*(Add your ticket ID before marking ready for review — the CI validator requires a non-empty issue link.)*

## **Manual testing steps**

```gherkin
Feature: Perps Gainers/Losers segmented control

  Scenario: Explore Now tab Perps movers toggle
    Given Perps is enabled and the user is on Explore → Now tab
    And the Perps movers section is visible

    When the user taps "Losers"
    Then the segmented control shows Losers selected
    And the horizontal pill list updates to show negative movers only

    When the user taps "Gainers"
    Then the segmented control shows Gainers selected
    And the pill list updates to show positive movers only

  Scenario: Perps home Top movers toggle
    Given Perps is enabled and the user is on the Perps home screen
    And the Top movers section is visible

    When the user taps "Losers"
    Then the segmented control shows Losers selected
    And the Top movers pill list updates to show losers

    When the user taps the Top movers section header
    Then navigation opens the market list sorted by price change in the active direction
```

## **Screenshots/Recordings**

### **Before**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-23 at 18 14 23" src="https://github.com/user-attachments/assets/88a70de3-e7e0-441d-9a59-c6a72ebddf88" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-23 at 18 14 32" src="https://github.com/user-attachments/assets/43940b9f-d7a5-4ab2-9ea8-323b229623f7" />


### **After**
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-23 at 18 08 06" src="https://github.com/user-attachments/assets/a4ebbbf7-3ba6-4f55-b21c-a9c9f2711834" />

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-06-23 at 18 08 17" src="https://github.com/user-attachments/assets/4b749198-5e51-41d9-afb2-519e347f67d1" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only design-system swap with preserved testIDs and sort behavior; no auth, data, or trading logic changes.
> 
> **Overview**
> **Perps home Top movers** and **Explore → Now → Perps movers** swap bespoke pill toggles for full-width MMDS **`SegmentedControl`** with **`FilterButton`** segments (gainers / losers). The local **`TogglePill`** in `PerpsTopMoversSection` is removed; Explore’s **`PillRow`** usage in `PerpsBlock` is removed in favor of the same control.
> 
> **Behavior is unchanged:** gainers still map to `desc` sort and losers to `asc`, lists and “view all” navigation still follow the active direction, and existing segment **testIDs** are kept. **`PerpsTopMoversSection` tests** now assert **`usePerpsTopMovers`** is called with the right `direction` after taps (including toggling back to gainers) instead of checking pill `accessibilityState.selected`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6918fc761ee769a076700eaa30e654f3a20d40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->