### PR TITLE
chore: add missing Component View Tests on Price Alerts

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.view.test.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.view.test.tsx
@@ -1,0 +1,87 @@
+import '../../../../../../../tests/component-view/mocks';
+import { renderManagePriceAlertsViewWithRoutes } from '../../../../../../../tests/component-view/renderers/priceAlerts';
+import {
+  setupPriceAlertsApiMock,
+  clearPriceAlertsApiMocks,
+  mockPriceAlertsData,
+} from '../../../../../../../tests/component-view/api-mocking/priceAlerts';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
+import { fireEvent, waitFor, within } from '@testing-library/react-native';
+import {
+  ManagePriceAlertsTestIds,
+  CreatePriceAlertTestIds,
+} from '../../constants';
+
+beforeEach(() => {
+  setupPriceAlertsApiMock();
+});
+
+afterEach(() => {
+  clearPriceAlertsApiMocks();
+});
+
+describeForPlatforms('ManagePriceAlertsView', () => {
+  it('loads and displays all alert fields for each row after async fetch', async () => {
+    const { findByTestId, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    const row1 = await findByTestId(
+      `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${mockPriceAlertsData[0].id}`,
+    );
+    const scope1 = within(row1);
+    expect(scope1.getByText('Reaches $3,000.00')).toBeOnTheScreen();
+    expect(scope1.getByText('Recurring')).toBeOnTheScreen();
+
+    const row2 = await findByTestId(
+      `${ManagePriceAlertsTestIds.ALERT_ITEM_PREFIX}-${mockPriceAlertsData[1].id}`,
+    );
+    const scope2 = within(row2);
+    expect(scope2.getByText('Reaches $1,500.00')).toBeOnTheScreen();
+    expect(scope2.getByText('Once')).toBeOnTheScreen();
+  });
+
+  it('navigates to CreatePriceAlertView when "Add alert" is pressed', async () => {
+    const { findByTestId, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    fireEvent.press(
+      await findByTestId(ManagePriceAlertsTestIds.ADD_ALERT_BUTTON),
+    );
+
+    await findByTestId(CreatePriceAlertTestIds.CONTAINER);
+  });
+
+  it('navigates to CreatePriceAlertView with the alert pre-populated when a row is tapped', async () => {
+    const { findByTestId, getByText, queryByTestId } =
+      renderManagePriceAlertsViewWithRoutes();
+
+    await waitFor(() => {
+      expect(
+        queryByTestId(ManagePriceAlertsTestIds.LOADING),
+      ).not.toBeOnTheScreen();
+    });
+
+    fireEvent.press(
+      await findByTestId(
+        `${ManagePriceAlertsTestIds.ALERT_EDIT_PREFIX}-${mockPriceAlertsData[0].id}`,
+      ),
+    );
+
+    await findByTestId(CreatePriceAlertTestIds.CONTAINER);
+
+    expect(getByText('Edit ETH price alert')).toBeOnTheScreen();
+    expect(getByText('$3000')).toBeOnTheScreen();
+  });
+});

--- a/tests/component-view/api-mocking/priceAlerts.ts
+++ b/tests/component-view/api-mocking/priceAlerts.ts
@@ -1,0 +1,65 @@
+/**
+ * Price Alerts API mock for component view tests.
+ * Intercepts GET https://price-alerts.dev-api.cx.metamask.io/v1/alerts?asset=*
+ *
+ * Note: api.ts uses Engine.context.AuthenticationController.getBearerToken()
+ * for the Authorization header — that is already stubbed in mocks.ts.
+ *
+ * Use in beforeEach/afterEach of ManagePriceAlertsView.view.test.tsx.
+ */
+
+// eslint-disable-next-line import-x/no-extraneous-dependencies
+import nock from 'nock';
+import { clearAllNockMocks, disableNetConnect } from './nockHelpers';
+import type { PriceAlert } from '../../../app/components/UI/Assets/PriceAlerts/constants';
+
+const PRICE_ALERTS_ORIGIN = 'https://price-alerts.dev-api.cx.metamask.io';
+const ALERTS_PATH = '/v1/alerts';
+
+export const mockPriceAlertsData: PriceAlert[] = [
+  {
+    id: 'alert-1',
+    userId: 'user-1',
+    asset: 'eip155:1/slip44:60',
+    threshold: 3000,
+    recurring: true,
+    active: true,
+    createdAt: '2025-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'alert-2',
+    userId: 'user-1',
+    asset: 'eip155:1/slip44:60',
+    threshold: 1500,
+    recurring: false,
+    active: false,
+    createdAt: '2025-01-02T00:00:00.000Z',
+  },
+];
+
+/**
+ * Sets up nock interceptors for the Price Alerts API.
+ * Call in beforeEach of price-alerts view tests.
+ *
+ * @param alerts - The alerts to return from GET /v1/alerts. Defaults to mockPriceAlertsData.
+ */
+export function setupPriceAlertsApiMock(
+  alerts: PriceAlert[] = mockPriceAlertsData,
+): void {
+  clearAllNockMocks();
+  disableNetConnect();
+
+  nock(PRICE_ALERTS_ORIGIN)
+    .get(ALERTS_PATH)
+    .query(true)
+    .reply(200, alerts)
+    .persist();
+}
+
+/**
+ * Clears all nock interceptors after each price-alerts test.
+ */
+export function clearPriceAlertsApiMocks(): void {
+  jest.clearAllMocks();
+  clearAllNockMocks();
+}

--- a/tests/component-view/presets/priceAlerts.ts
+++ b/tests/component-view/presets/priceAlerts.ts
@@ -1,0 +1,15 @@
+import { createStateFixture } from '../stateFixture';
+
+/**
+ * Minimal preset for PriceAlerts screens.
+ *
+ * Neither CreatePriceAlertView nor ManagePriceAlertsView reads from Redux state —
+ * they rely on route params, React Query, and the theme hook. This preset provides
+ * only the baseline required for the framework to mount (accounts, network, keyring).
+ */
+export const initialStatePriceAlerts = () =>
+  createStateFixture()
+    .withMinimalAccounts()
+    .withMinimalMainnetNetwork()
+    .withMinimalKeyringController()
+    .withRemoteFeatureFlags({});

--- a/tests/component-view/renderers/priceAlerts.tsx
+++ b/tests/component-view/renderers/priceAlerts.tsx
@@ -1,0 +1,54 @@
+import '../mocks';
+import React from 'react';
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
+import { renderScreenWithRoutes } from '../render';
+import Routes from '../../../app/constants/navigation/Routes';
+import ManagePriceAlertsView from '../../../app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView';
+import CreatePriceAlertView from '../../../app/components/UI/Assets/PriceAlerts/Views/CreatePriceAlertView/CreatePriceAlertView';
+import { initialStatePriceAlerts } from '../presets/priceAlerts';
+import type { PriceAlertRouteParams } from '../../../app/components/UI/Assets/PriceAlerts/constants';
+
+interface RenderManagePriceAlertsOptions {
+  overrides?: DeepPartial<RootState>;
+  routeParams?: Partial<PriceAlertRouteParams>;
+}
+
+const DEFAULT_ROUTE_PARAMS: PriceAlertRouteParams = {
+  symbol: 'ETH',
+  ticker: 'ETH',
+  currentPrice: 2500,
+  currentCurrency: 'USD',
+  assetId: 'eip155:1/slip44:60',
+};
+
+/**
+ * Renders ManagePriceAlertsView with a real navigation stack that includes
+ * CreatePriceAlertView as a reachable destination. Use this to test cross-screen
+ * navigation journeys that jest.mock('useNavigation') cannot cover.
+ */
+export function renderManagePriceAlertsViewWithRoutes(
+  options: RenderManagePriceAlertsOptions = {},
+): ReturnType<typeof renderScreenWithRoutes> {
+  const { overrides, routeParams } = options;
+
+  const builder = initialStatePriceAlerts();
+  if (overrides) {
+    builder.withOverrides(overrides);
+  }
+  const state = builder.build();
+
+  return renderScreenWithRoutes(
+    ManagePriceAlertsView as unknown as React.ComponentType,
+    { name: Routes.MANAGE_PRICE_ALERTS },
+    [
+      {
+        name: Routes.CREATE_PRICE_ALERT,
+        Component:
+          CreatePriceAlertView as unknown as React.ComponentType<object>,
+      },
+    ],
+    { state },
+    { ...DEFAULT_ROUTE_PARAMS, ...routeParams },
+  );
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Add missing Component View Tests on Price Alerts

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add missing Component View Tests on Price Alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3423

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions following established component-view patterns; no runtime or user-facing behavior changes.
> 
> **Overview**
> Adds **component view tests** for **Manage Price Alerts** using the existing `tests/component-view` harness (no production app changes).
> 
> New **nock** helpers in `tests/component-view/api-mocking/priceAlerts.ts` stub `GET /v1/alerts` on the dev price-alerts API, with shared fixture data and setup/teardown for each test.
> 
> A minimal Redux **preset** (`initialStatePriceAlerts`) and **`renderManagePriceAlertsViewWithRoutes`** mount **ManagePriceAlertsView** on a real stack that includes **CreatePriceAlertView**, so navigation can be asserted without mocking `useNavigation`.
> 
> **ManagePriceAlertsView.view.test.tsx** covers (via `describeForPlatforms`): list rows after fetch (threshold copy and Recurring/Once), **Add alert** → create screen, and row edit → create screen with edit title and pre-filled threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d6b7164f9c988a0b0702358dd6246fefde769a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->