### PR TITLE
fix: add Update Amount Data outer prefix to money account deposit amount callback

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
@@ -188,7 +188,7 @@ describe('useUpdateTransactionPayAmount', () => {
 
     await expect(
       result.current.updateTransactionPayAmount('1.23'),
-    ).rejects.toThrow('boom');
+    ).rejects.toThrow('Update Amount Data: Money Account Deposit: boom');
   });
 
   it('rejects and logs when updateMoneyAccountDepositTokenAmount rejects', async () => {
@@ -199,7 +199,7 @@ describe('useUpdateTransactionPayAmount', () => {
 
     await expect(
       result.current.updateTransactionPayAmount('1.23'),
-    ).rejects.toThrow('rpc failure');
+    ).rejects.toThrow('Update Amount Data: Money Account Deposit: rpc failure');
 
     expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
   });
@@ -403,7 +403,9 @@ describe('useUpdateTransactionPayAmount', () => {
 
       await expect(
         result.current.updateTransactionPayAmount('1'),
-      ).rejects.toThrow('updateTransaction failed');
+      ).rejects.toThrow(
+        'Update Amount Data: Money Account Deposit: updateTransaction failed',
+      );
     });
 
     it('still applies money account deposit updates after syncing requiredAssets', async () => {

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
@@ -22,6 +22,7 @@ import { hasTransactionType } from '../../utils/transaction';
 import { prefixError } from '../../../../../util/transactions/error-prefix';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 
+const UPDATE_AMOUNT_DATA_ERROR_PREFIX = 'Update Amount Data: ';
 const DEPOSIT_ERROR_PREFIX = 'Money Account Deposit: ';
 const WITHDRAW_ERROR_PREFIX = 'Money Account Withdrawal: ';
 
@@ -87,16 +88,20 @@ export function useUpdateTransactionPayAmount() {
           TransactionType.moneyAccountDeposit,
         ])
       ) {
-        syncMoneyAccountDepositRequiredAssets(
-          transactionMeta,
-          amountHuman,
-          requiredTokens?.[0]?.decimals,
-        );
-        await applyMoneyAccountAmountUpdates(
-          amountHuman,
-          updateMoneyAccountDepositTokenAmount,
-          DEPOSIT_ERROR_PREFIX,
-        );
+        try {
+          syncMoneyAccountDepositRequiredAssets(
+            transactionMeta,
+            amountHuman,
+            requiredTokens?.[0]?.decimals,
+          );
+          await applyMoneyAccountAmountUpdates(
+            amountHuman,
+            updateMoneyAccountDepositTokenAmount,
+            DEPOSIT_ERROR_PREFIX,
+          );
+        } catch (error) {
+          throw prefixError(error, UPDATE_AMOUNT_DATA_ERROR_PREFIX);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Adds a two-level error prefix to the money account deposit amount-update callback in `useUpdateTransactionPayAmount`:

- **Outer** (`updateTransactionPayAmount` deposit block): `Update Amount Data: `
- **Inner** (`applyMoneyAccountAmountUpdates` / `syncMoneyAccountDepositRequiredAssets`): `Money Account Deposit: ` (pre-existing)

A failure during amount data update now surfaces as:
```
Update Amount Data: Money Account Deposit: <original error>
```

This mirrors the naming convention introduced on the core side (MetaMask/core#9250) and makes it immediately clear from the error message that the failure occurred in the deposit amount-update step.

## Changes

- `useUpdateTransactionPayAmount.ts`: Add `UPDATE_AMOUNT_DATA_ERROR_PREFIX` constant; wrap the `moneyAccountDeposit` branch in a try-catch that applies the outer prefix
- `useUpdateTransactionPayAmount.test.ts`: Update three error-propagation assertions to assert the full prefix-chained message