### PR TITLE
fix: cp-8.0.0 musd fiat deposit amount data error prefixes

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -216,6 +216,7 @@ describe('useMoneyAccountDeposit', () => {
         origin: ORIGIN_METAMASK,
         disableHook: true,
         disableSequential: true,
+        disableUpgrade: true,
       }),
     );
   });
@@ -454,6 +455,7 @@ describe('useMoneyAccountWithdrawal', () => {
         origin: ORIGIN_METAMASK,
         disableHook: true,
         disableSequential: true,
+        disableUpgrade: true,
         transactions: [
           expect.objectContaining({ type: 'moneyAccountWithdraw' }),
           expect.objectContaining({ type: 'tokenMethodTransfer' }),

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -123,6 +123,7 @@ export function useMoneyAccountDeposit() {
           batchId,
           disableHook: true,
           disableSequential: true,
+          disableUpgrade: true,
           from: primaryMoneyAccount.address as Hex,
           isGasFeeSponsored,
           isInternal: true,
@@ -205,6 +206,7 @@ export function useMoneyAccountWithdrawal() {
       await addTransactionBatch({
         disableHook: true,
         disableSequential: true,
+        disableUpgrade: true,
         from: primaryMoneyAccount.address as Hex,
         isGasFeeSponsored,
         isInternal: true,

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
@@ -146,7 +146,9 @@ describe('getAmountData', () => {
   });
 
   it('throws a prefixed error when buildMoneyAccountDepositBatch fails', async () => {
-    buildDepositBatchMock.mockRejectedValueOnce(new Error('previewDeposit reverted'));
+    buildDepositBatchMock.mockRejectedValueOnce(
+      new Error('previewDeposit reverted'),
+    );
 
     await expect(
       getAmountData({ amount: '5000000', transaction: buildTransaction() }),

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
@@ -145,6 +145,36 @@ describe('getAmountData', () => {
     expect(buildDepositBatchMock).not.toHaveBeenCalled();
   });
 
+  it('throws a prefixed error when buildMoneyAccountDepositBatch fails', async () => {
+    buildDepositBatchMock.mockRejectedValueOnce(new Error('previewDeposit reverted'));
+
+    await expect(
+      getAmountData({ amount: '5000000', transaction: buildTransaction() }),
+    ).rejects.toThrow(
+      'Update Amount Data: Money Account Deposit: previewDeposit reverted',
+    );
+  });
+
+  it('parses a CALL_EXCEPTION into a short message', async () => {
+    const callError = Object.assign(
+      new Error(
+        'call revert exception (method="previewDeposit(address,uint256,address,address)", reason="Deposit not allowed", code=CALL_EXCEPTION)',
+      ),
+      {
+        code: 'CALL_EXCEPTION',
+        method: 'previewDeposit(address,uint256,address,address)',
+        reason: 'Deposit not allowed',
+      },
+    );
+    buildDepositBatchMock.mockRejectedValueOnce(callError);
+
+    await expect(
+      getAmountData({ amount: '5000000', transaction: buildTransaction() }),
+    ).rejects.toThrow(
+      'Update Amount Data: Money Account Deposit: eth_call failed - previewDeposit - Deposit not allowed',
+    );
+  });
+
   it('handles direct moneyAccountDeposit type (non-batch)', async () => {
     const result = await getAmountData({
       amount: '5000000',

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
@@ -8,6 +8,10 @@ import ReduxService from '../../../../core/redux/ReduxService';
 import { RootState } from '../../../../reducers';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
+import { prefixError } from '../../../../util/transactions/error-prefix';
+
+const UPDATE_AMOUNT_DATA_ERROR_PREFIX = 'Update Amount Data: ';
+const MONEY_ACCOUNT_DEPOSIT_ERROR_PREFIX = 'Money Account Deposit: ';
 
 interface GetAmountDataRequest {
   amount: string;
@@ -53,20 +57,30 @@ export async function getAmountData(
 
   const rawAmount = BigInt(amount);
 
-  const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
-    amount: rawAmount,
-    chainId: chainIdHex,
-    boringVault: vaultConfig.boringVault,
-    tellerAddress: vaultConfig.tellerAddress,
-    accountantAddress: vaultConfig.accountantAddress,
-    lensAddress: vaultConfig.lensAddress,
-    provider,
-  });
+  try {
+    let buildResult;
 
-  return {
-    updates: [
-      { nestedTransactionIndex: 0, data: approveTx.params.data },
-      { nestedTransactionIndex: 1, data: depositTx.params.data },
-    ],
-  };
+    try {
+      buildResult = await buildMoneyAccountDepositBatch({
+        amount: rawAmount,
+        chainId: chainIdHex,
+        boringVault: vaultConfig.boringVault,
+        tellerAddress: vaultConfig.tellerAddress,
+        accountantAddress: vaultConfig.accountantAddress,
+        lensAddress: vaultConfig.lensAddress,
+        provider,
+      });
+    } catch (error) {
+      throw prefixError(error, MONEY_ACCOUNT_DEPOSIT_ERROR_PREFIX);
+    }
+
+    return {
+      updates: [
+        { nestedTransactionIndex: 0, data: buildResult.approveTx.params.data },
+        { nestedTransactionIndex: 1, data: buildResult.depositTx.params.data },
+      ],
+    };
+  } catch (error) {
+    throw prefixError(error, UPDATE_AMOUNT_DATA_ERROR_PREFIX);
+  }
 }

--- a/app/util/transactions/error-prefix.test.ts
+++ b/app/util/transactions/error-prefix.test.ts
@@ -106,19 +106,27 @@ describe('prefixError', () => {
       );
     });
 
-    it('falls through to plain-Error handling when reason is missing', () => {
+    it('formats as "eth_call failed - method" when reason is absent but method is present', () => {
       const error = Object.assign(new Error(VERBOSE_ETHERS_MESSAGE), {
         code: 'CALL_EXCEPTION',
+        method: 'previewDeposit(address,uint256,address,address)',
       });
       expect(prefixError(error, PREFIX).message).toBe(
-        `MyModule: ${VERBOSE_ETHERS_MESSAGE}`,
+        'MyModule: eth_call failed - previewDeposit',
       );
     });
 
-    it('falls through to plain-Error handling when reason is not a string', () => {
+    it('returns "eth_call failed" when reason is absent and neither method nor transaction.data is present', () => {
+      const error = Object.assign(new Error(VERBOSE_ETHERS_MESSAGE), {
+        code: 'CALL_EXCEPTION',
+      });
+      expect(prefixError(error, PREFIX).message).toBe('MyModule: eth_call failed');
+    });
+
+    it('formats as "eth_call failed - method" when reason is not a string', () => {
       expect(
         prefixError(makeCallException({ reason: 42 }), PREFIX).message,
-      ).toBe(`MyModule: ${VERBOSE_ETHERS_MESSAGE}`);
+      ).toBe('MyModule: eth_call failed - previewDeposit');
     });
   });
 });

--- a/app/util/transactions/error-prefix.test.ts
+++ b/app/util/transactions/error-prefix.test.ts
@@ -120,7 +120,9 @@ describe('prefixError', () => {
       const error = Object.assign(new Error(VERBOSE_ETHERS_MESSAGE), {
         code: 'CALL_EXCEPTION',
       });
-      expect(prefixError(error, PREFIX).message).toBe('MyModule: eth_call failed');
+      expect(prefixError(error, PREFIX).message).toBe(
+        'MyModule: eth_call failed',
+      );
     });
 
     it('formats as "eth_call failed - method" when reason is not a string', () => {

--- a/app/util/transactions/error-prefix.ts
+++ b/app/util/transactions/error-prefix.ts
@@ -26,7 +26,6 @@ function getCallErrorMessage(error: unknown): string | undefined {
 
   if (
     !(error instanceof Error) ||
-    typeof errorRecord.reason !== 'string' ||
     errorRecord.code !== 'CALL_EXCEPTION' ||
     !error.message.includes('code=CALL_EXCEPTION')
   ) {
@@ -35,12 +34,14 @@ function getCallErrorMessage(error: unknown): string | undefined {
 
   const { method, reason, transaction } = errorRecord as {
     method?: string;
-    reason: string;
+    reason?: string | null;
     transaction?: { data?: string };
   };
 
+  const reasonStr = typeof reason === 'string' ? ` - ${reason}` : '';
+
   if (method) {
-    return `eth_call failed - ${method.split('(')[0]} - ${reason}`;
+    return `eth_call failed - ${method.split('(')[0]}${reasonStr}`;
   }
 
   const selector = transaction?.data?.slice(0, 10);


### PR DESCRIPTION
## Summary

Applies the two-level error prefix pattern to `getAmountData` in `amount-data-callback.ts`:

- **Outer** (entire `getAmountData` function): `Update Amount Data: `
- **Inner** (around `buildMoneyAccountDepositBatch`): `Money Account Deposit: `

A failure during deposit calldata building now surfaces as:
```
Update Amount Data: Money Account Deposit: <original error>
```

This matches the naming convention on the core side (MetaMask/core#9250) and in the `useUpdateTransactionPayAmount` hook, making it immediately clear from the error message that the failure occurred in the amount data callback and specifically in the money account deposit build step.

## Also included

- `disableUpgrade: true` added to `useMoneyAccount` deposit and withdrawal `addTransactionBatch` calls (the Money Account is always already upgraded on Monad)
- `error-prefix.ts`: `reason` in CALL_EXCEPTION handling made optional to handle ethers errors where `reason` may be `null`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error-handling and transaction-batch flags for money account flows; no auth or broad architectural changes.
> 
> **Overview**
> Improves **mUSD / money account deposit** failures during MM Pay amount updates by wrapping `getAmountData` in a **two-level** `prefixError` pattern (`Update Amount Data:` → `Money Account Deposit:`), so users and support can tell the failure is in the amount-data callback and specifically in deposit calldata building.
> 
> **`prefixError`** now treats ethers **`CALL_EXCEPTION`** `reason` as optional: when `reason` is missing or non-string, messages use `eth_call failed - <method>` instead of falling back to the full verbose ethers string.
> 
> Money account **deposit and withdrawal** `addTransactionBatch` calls set **`disableUpgrade: true`** because the money account is already upgraded on Monad, avoiding unnecessary upgrade logic in the batch pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128eb6989ab7137b438b2ba44a28efe6ecbb1997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->