### PR TITLE
fix(money-account): align Money Account withdrawals and deposits with designs cp-8.0.0

### DIFF
--- a/app/components/UI/Money/utils/moneyTransactionGuards.test.ts
+++ b/app/components/UI/Money/utils/moneyTransactionGuards.test.ts
@@ -10,6 +10,7 @@ import {
   isMoneyAccountTx,
   isMoneyDepositTx,
   isMoneyWithdrawTx,
+  isSingleRowMusdMoneyWithdraw,
   isPerpsPredictMoneyActivity,
   isPerpsPredictMoneyDeposit,
   isPerpsPredictMoneyWithdraw,
@@ -112,6 +113,56 @@ describe('isMoneyWithdrawTx', () => {
     expect(isMoneyWithdrawTx(makeTx(TransactionType.contractInteraction))).toBe(
       false,
     );
+  });
+});
+
+describe('isSingleRowMusdMoneyWithdraw', () => {
+  it('returns true when destination is mUSD on Monad', () => {
+    expect(
+      isSingleRowMusdMoneyWithdraw({
+        ...makeTx(TransactionType.moneyAccountWithdraw),
+        metamaskPay: {
+          tokenAddress: MUSD_TOKEN_ADDRESS,
+          chainId: CHAIN_IDS.MONAD,
+        },
+      } as TransactionMeta),
+    ).toBe(true);
+  });
+
+  it('returns true when destination is mUSD on another chain (cross-chain)', () => {
+    expect(
+      isSingleRowMusdMoneyWithdraw({
+        ...makeTx(TransactionType.moneyAccountWithdraw),
+        metamaskPay: {
+          tokenAddress: MUSD_TOKEN_ADDRESS,
+          chainId: CHAIN_IDS.LINEA_MAINNET,
+        },
+      } as TransactionMeta),
+    ).toBe(true);
+  });
+
+  it('returns false when destination is a non-mUSD token', () => {
+    expect(
+      isSingleRowMusdMoneyWithdraw({
+        ...makeTx(TransactionType.moneyAccountWithdraw),
+        metamaskPay: {
+          tokenAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+          chainId: CHAIN_IDS.LINEA_MAINNET,
+        },
+      } as TransactionMeta),
+    ).toBe(false);
+  });
+
+  it('returns false for deposit txs', () => {
+    expect(
+      isSingleRowMusdMoneyWithdraw({
+        ...makeTx(TransactionType.moneyAccountDeposit),
+        metamaskPay: {
+          tokenAddress: MUSD_TOKEN_ADDRESS,
+          chainId: CHAIN_IDS.MONAD,
+        },
+      } as TransactionMeta),
+    ).toBe(false);
   });
 });
 

--- a/app/components/UI/Money/utils/moneyTransactionGuards.ts
+++ b/app/components/UI/Money/utils/moneyTransactionGuards.ts
@@ -3,7 +3,10 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
-import { isMusdOnMoneyAccountChain } from '../../Earn/constants/musd';
+import {
+  isMusdOnMoneyAccountChain,
+  isMusdToken,
+} from '../../Earn/constants/musd';
 
 /**
  * Returns the first nested transaction matching a given TransactionType,
@@ -28,6 +31,20 @@ export const isMoneyWithdrawTx = (transactionMeta: TransactionMeta) =>
   Boolean(
     nestedTxWithType(transactionMeta, TransactionType.moneyAccountWithdraw),
   );
+
+/**
+ * True when a Money Account withdrawal lands as mUSD (single-row hero and
+ * "Sent mUSD" title). Cross-token destinations (e.g. USDC) return false.
+ * Chain is irrelevant — only the destination token matters.
+ */
+export const isSingleRowMusdMoneyWithdraw = (
+  transactionMeta: TransactionMeta,
+): boolean => {
+  if (!isMoneyWithdrawTx(transactionMeta)) {
+    return false;
+  }
+  return isMusdToken(transactionMeta.metamaskPay?.tokenAddress);
+};
 
 export const isMoneyAccountTx = (transactionMeta: TransactionMeta) =>
   isMoneyDepositTx(transactionMeta) || isMoneyWithdrawTx(transactionMeta);

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -4,7 +4,7 @@ import { useTransactionDetails } from '../../../hooks/activity/useTransactionDet
 import {
   TransactionMeta,
   TransactionType,
-} from '@metamask/transaction-controller';
+ CHAIN_IDS } from '@metamask/transaction-controller';
 import { TransactionDetailsHero } from './transaction-details-hero';
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
@@ -365,7 +365,7 @@ describe('TransactionDetailsHero', () => {
       ).toBeDefined();
     });
 
-    it('renders two-asset hero for moneyAccountWithdraw with swapped sent/received', () => {
+    it('renders single-row hero with Money Account icon for cross-chain moneyAccountWithdraw', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -378,12 +378,34 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, getByTestId, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
       expect(getByText(/-200\.00 mUSD/)).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+123\.46 TST/)).toBeDefined();
+      expect(getByTestId('money-account-icon')).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
+    });
+
+    it('renders single-row hero with Money Account icon for mUSD-to-mUSD moneyAccountWithdraw', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountWithdraw,
+          chainId: CHAIN_IDS.MONAD,
+          metamaskPay: {
+            tokenAddress: MUSD_TOKEN_ADDRESS,
+            chainId: CHAIN_IDS.MONAD,
+            targetFiat: '200.00',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText, getByTestId, queryByText } = render();
+
+      expect(getByText(/-200\.00 mUSD/)).toBeDefined();
+      expect(getByTestId('money-account-icon')).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
     it('renders two-asset hero for perpsWithdraw with USDC as sent and mUSD as received', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -398,9 +398,53 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
       expect(getByText(/\+100\.00 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
+    });
+
+    it('renders single-row mUSD deposit hero with Money Account icon', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountDeposit,
+          metamaskPay: {
+            tokenAddress: MUSD_TOKEN_ADDRESS,
+            chainId: CHAIN_ID_MOCK,
+            targetFiat: '50.12',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText, getByTestId, queryByText } = render();
+
+      expect(getByTestId('money-account-icon')).toBeDefined();
+      expect(getByText(/\+50\.12 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
+    });
+
+    it('renders two-asset hero for crypto moneyAccountDeposit conversion', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountDeposit,
+          metamaskPay: {
+            tokenAddress: TOKEN_ADDRESS_MOCK,
+            chainId: CHAIN_ID_MOCK,
+            targetFiat: '123.46',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText('You sent')).toBeDefined();
+      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText('You received')).toBeDefined();
+      expect(getByText(/\+123\.46 mUSD/)).toBeDefined();
     });
 
     it('renders null for unsupported type in money context', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -366,7 +366,7 @@ describe('TransactionDetailsHero', () => {
       ).toBeDefined();
     });
 
-    it('renders single-row hero with Money Account icon for cross-chain moneyAccountWithdraw', () => {
+    it('renders two-asset hero for cross-chain moneyAccountWithdraw', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -379,12 +379,12 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText, getByTestId, queryByText } = render();
+      const { getByText } = render();
 
+      expect(getByText('You sent')).toBeDefined();
       expect(getByText(/-200\.00 mUSD/)).toBeDefined();
-      expect(getByTestId('money-account-icon')).toBeDefined();
-      expect(queryByText('You sent')).toBeNull();
-      expect(queryByText('You received')).toBeNull();
+      expect(getByText('You received')).toBeDefined();
+      expect(getByText(/\+123\.46 TST/)).toBeDefined();
     });
 
     it('renders single-row hero with Money Account icon for mUSD-to-mUSD moneyAccountWithdraw', () => {
@@ -404,6 +404,28 @@ describe('TransactionDetailsHero', () => {
       const { getByText, getByTestId, queryByText } = render();
 
       expect(getByText(/-200\.00 mUSD/)).toBeDefined();
+      expect(getByTestId('money-account-icon')).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
+    });
+
+    it('renders single-row hero for cross-chain mUSD moneyAccountWithdraw', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountWithdraw,
+          chainId: CHAIN_IDS.LINEA_MAINNET,
+          metamaskPay: {
+            tokenAddress: MUSD_TOKEN_ADDRESS,
+            chainId: CHAIN_IDS.LINEA_MAINNET,
+            targetFiat: '0.10',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText, getByTestId, queryByText } = render();
+
+      expect(getByText(/-0\.10 mUSD/)).toBeDefined();
       expect(getByTestId('money-account-icon')).toBeDefined();
       expect(queryByText('You sent')).toBeNull();
       expect(queryByText('You received')).toBeNull();

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -272,6 +272,28 @@ describe('TransactionDetailsHero', () => {
     expect(getByText('$123.46')).toBeDefined();
   });
 
+  it('renders single-row token hero for cross-token moneyAccountWithdraw outside money context', () => {
+    jest.mocked(selectTransactionsByIds).mockReturnValue([]);
+
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.moneyAccountWithdraw,
+        metamaskPay: {
+          tokenAddress: TOKEN_ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          targetFiat: '200.00',
+        },
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText, queryByText } = render();
+
+    expect(getByText(/200\.00 mUSD/)).toBeDefined();
+    expect(queryByText('You sent')).toBeNull();
+    expect(queryByText('You received')).toBeNull();
+  });
+
   describe('money context (isMoneyContext = true)', () => {
     const useIsMoneyAccountContextMock = jest.mocked(useIsMoneyAccountContext);
     const selectTransactionsByIdsMock = jest.mocked(selectTransactionsByIds);

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -77,7 +77,6 @@ const TOKEN_ICON_TYPES = [
 
 const TWO_ASSET_HERO_TYPES = [
   TransactionType.moneyAccountDeposit,
-  TransactionType.moneyAccountWithdraw,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsWithdraw,
@@ -214,6 +213,12 @@ export function TransactionDetailsHero() {
       ]) &&
       Boolean(transactionMeta.metamaskPay?.fiat?.orderId);
 
+    const isMusdWithdraw =
+      isMoneyContext &&
+      hasTransactionType(transactionMeta, [
+        TransactionType.moneyAccountWithdraw,
+      ]);
+
     const icon = isMusdToken(tokenMeta.contractAddress) ? (
       <Image
         source={MoneyIcon}
@@ -242,7 +247,7 @@ export function TransactionDetailsHero() {
           variant={TextVariant.DisplayMD}
           color={isFiatDeposit ? TextColor.Success : undefined}
         >
-          {isFiatDeposit ? '+' : ''}
+          {isFiatDeposit ? '+' : isMusdWithdraw ? '-' : ''}
           {tokenMeta.amount} {tokenMeta.symbol}
         </Text>
       </Box>

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -191,6 +191,7 @@ export function TransactionDetailsHero() {
   const showTwoAssetHero =
     isMoneyContext &&
     hasTransactionType(transactionMeta, TWO_ASSET_HERO_TYPES) &&
+    !isSingleRowMoneyDeposit(transactionMeta) &&
     sentData &&
     receivedData;
 
@@ -207,12 +208,12 @@ export function TransactionDetailsHero() {
     hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) && tokenMeta;
 
   if (showTokenIcon) {
-    const isFiatDeposit =
+    const showDepositPrefix =
       isMoneyContext &&
       hasTransactionType(transactionMeta, [
         TransactionType.moneyAccountDeposit,
       ]) &&
-      Boolean(transactionMeta.metamaskPay?.fiat?.orderId);
+      isSingleRowMoneyDeposit(transactionMeta);
 
     const icon = isMusdToken(tokenMeta.contractAddress) ? (
       <Image
@@ -240,9 +241,9 @@ export function TransactionDetailsHero() {
         {icon}
         <Text
           variant={TextVariant.DisplayMD}
-          color={isFiatDeposit ? TextColor.Success : undefined}
+          color={showDepositPrefix ? TextColor.Success : undefined}
         >
-          {isFiatDeposit ? '+' : ''}
+          {showDepositPrefix ? '+' : ''}
           {tokenMeta.amount} {tokenMeta.symbol}
         </Text>
       </Box>
@@ -289,6 +290,17 @@ const RECEIVED_OVERRIDE: Partial<
     chainId: CHAIN_IDS.POLYGON as Hex,
   },
 };
+
+function isSingleRowMoneyDeposit(transactionMeta: TransactionMeta): boolean {
+  if (
+    !hasTransactionType(transactionMeta, [TransactionType.moneyAccountDeposit])
+  ) {
+    return false;
+  }
+
+  const { fiat, tokenAddress } = transactionMeta.metamaskPay ?? {};
+  return Boolean(fiat?.orderId) || isMusdToken(tokenAddress);
+}
 
 function resolveTwoAssetData(
   transactionMeta: TransactionMeta,

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -41,6 +41,7 @@ import { RootState } from '../../../../../../reducers';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import { TokenIcon } from '../../token-icon';
 import { resolveMusdTransferMeta } from '../../../../../UI/Money/constants/activityStyles';
+import { isSingleRowMusdMoneyWithdraw } from '../../../../../UI/Money/utils/moneyTransactionGuards';
 import { fromTokenMinimalUnit } from '../../../../../../util/number/bigint';
 import {
   isMusdToken,
@@ -77,6 +78,7 @@ const TOKEN_ICON_TYPES = [
 
 const TWO_ASSET_HERO_TYPES = [
   TransactionType.moneyAccountDeposit,
+  TransactionType.moneyAccountWithdraw,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsWithdraw,
@@ -191,6 +193,7 @@ export function TransactionDetailsHero() {
     isMoneyContext &&
     hasTransactionType(transactionMeta, TWO_ASSET_HERO_TYPES) &&
     !isSingleRowMoneyDeposit(transactionMeta) &&
+    !isSingleRowMusdMoneyWithdraw(transactionMeta) &&
     sentData &&
     receivedData;
 
@@ -204,7 +207,12 @@ export function TransactionDetailsHero() {
   }
 
   const showTokenIcon =
-    hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) && tokenMeta;
+    hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) &&
+    tokenMeta &&
+    (!hasTransactionType(transactionMeta, [
+      TransactionType.moneyAccountWithdraw,
+    ]) ||
+      isSingleRowMusdMoneyWithdraw(transactionMeta));
 
   if (showTokenIcon) {
     const showDepositPrefix =
@@ -214,11 +222,8 @@ export function TransactionDetailsHero() {
       ]) &&
       isSingleRowMoneyDeposit(transactionMeta);
 
-    const isMusdWithdraw =
-      isMoneyContext &&
-      hasTransactionType(transactionMeta, [
-        TransactionType.moneyAccountWithdraw,
-      ]);
+    const isMusdWithdrawSingleRow =
+      isMoneyContext && isSingleRowMusdMoneyWithdraw(transactionMeta);
 
     const icon = isMusdToken(tokenMeta.contractAddress) ? (
       <Image
@@ -248,7 +253,7 @@ export function TransactionDetailsHero() {
           variant={TextVariant.DisplayMD}
           color={showDepositPrefix ? TextColor.Success : undefined}
         >
-          {showDepositPrefix ? '+' : isMusdWithdraw ? '-' : ''}
+          {showDepositPrefix ? '+' : isMusdWithdrawSingleRow ? '-' : ''}
           {tokenMeta.amount} {tokenMeta.symbol}
         </Text>
       </Box>

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -212,7 +212,8 @@ export function TransactionDetailsHero() {
     (!hasTransactionType(transactionMeta, [
       TransactionType.moneyAccountWithdraw,
     ]) ||
-      isSingleRowMusdMoneyWithdraw(transactionMeta));
+      isSingleRowMusdMoneyWithdraw(transactionMeta) ||
+      !isMoneyContext);
 
   if (showTokenIcon) {
     const showDepositPrefix =

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -15,6 +15,7 @@ import {
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { strings } from '../../../../../../../locales/i18n';
+import { MUSD_TOKEN_ADDRESS } from '../../../../../UI/Earn/constants/musd';
 import { TransactionDetailsHero } from '../transaction-details-hero';
 import { TransactionDetailsStatusRow } from '../transaction-details-status-row';
 import { TransactionDetailsDateRow } from '../transaction-details-date-row';
@@ -367,7 +368,24 @@ describe('TransactionDetails', () => {
       });
     });
 
-    it('moneyAccountDeposit without fiat orderId returns converted_to_musd', () => {
+    it('moneyAccountDeposit funded with mUSD returns deposited_musd', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountDeposit,
+          status: TransactionStatus.confirmed,
+          metamaskPay: { tokenAddress: MUSD_TOKEN_ADDRESS },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(
+        getByText(strings('transaction_details.title.deposited_musd')),
+      ).toBeTruthy();
+    });
+
+    it('moneyAccountDeposit funded with crypto returns converted_to_musd', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -245,7 +245,7 @@ describe('TransactionDetails', () => {
       ).toBeTruthy();
     });
 
-    it('renders money_account_withdraw title for nested moneyAccountWithdraw', () => {
+    it('renders money_account_withdraw title for nested moneyAccountWithdraw outside money context', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -258,6 +258,30 @@ describe('TransactionDetails', () => {
 
       expect(
         getByText(strings('transaction_details.title.money_account_withdraw')),
+      ).toBeTruthy();
+    });
+
+    it('renders Sent mUSD title for moneyAccountWithdraw in money context', () => {
+      useIsMoneyAccountContextMock.mockReturnValue(true);
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountWithdraw,
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            targetFiat: '200.00',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(
+        getByText(
+          strings('transaction_details.title.money_account_sent', {
+            symbol: 'mUSD',
+          }),
+        ),
       ).toBeTruthy();
     });
 
@@ -445,6 +469,34 @@ describe('TransactionDetails', () => {
       expect(
         getByText(strings('transaction_details.title.deposited_musd')),
       ).toBeTruthy();
+    });
+
+    describe('moneyAccountWithdraw', () => {
+      it.each([
+        [
+          TransactionStatus.confirmed,
+          'transaction_details.title.money_account_sent',
+        ],
+        [TransactionStatus.submitted, 'transaction_details.title.sending_musd'],
+        [TransactionStatus.failed, 'transaction_details.title.send_failed'],
+      ])('returns %s title for status', (status, titleKey) => {
+        useTransactionDetailsMock.mockReturnValue({
+          transactionMeta: {
+            ...TRANSACTION_META_MOCK,
+            type: TransactionType.moneyAccountWithdraw,
+            status,
+            metamaskPay: { targetFiat: '200.00' },
+          } as unknown as TransactionMeta,
+        });
+
+        const { getByText } = render();
+
+        if (titleKey === 'transaction_details.title.money_account_sent') {
+          expect(getByText(strings(titleKey, { symbol: 'mUSD' }))).toBeTruthy();
+        } else {
+          expect(getByText(strings(titleKey))).toBeTruthy();
+        }
+      });
     });
   });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -6,6 +6,7 @@ import {
   TransactionMeta,
   TransactionStatus,
   TransactionType,
+  CHAIN_IDS,
 } from '@metamask/transaction-controller';
 import { useIsMoneyAccountContext } from '../../../hooks/activity/useIsMoneyAccountContext';
 import {
@@ -262,7 +263,7 @@ describe('TransactionDetails', () => {
       ).toBeTruthy();
     });
 
-    it('renders Sent mUSD title for moneyAccountWithdraw in money context', () => {
+    it('renders Sent mUSD title for mUSD-to-mUSD moneyAccountWithdraw in money context', () => {
       useIsMoneyAccountContextMock.mockReturnValue(true);
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
@@ -270,6 +271,8 @@ describe('TransactionDetails', () => {
           type: TransactionType.moneyAccountWithdraw,
           status: TransactionStatus.confirmed,
           metamaskPay: {
+            tokenAddress: MUSD_TOKEN_ADDRESS,
+            chainId: CHAIN_IDS.MONAD,
             targetFiat: '200.00',
           },
         } as unknown as TransactionMeta,
@@ -284,6 +287,52 @@ describe('TransactionDetails', () => {
           }),
         ),
       ).toBeTruthy();
+    });
+
+    it('renders Sent mUSD title for cross-chain mUSD moneyAccountWithdraw in money context', () => {
+      useIsMoneyAccountContextMock.mockReturnValue(true);
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountWithdraw,
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            tokenAddress: MUSD_TOKEN_ADDRESS,
+            chainId: CHAIN_IDS.LINEA_MAINNET,
+            targetFiat: '0.10',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(
+        getByText(
+          strings('transaction_details.title.money_account_sent', {
+            symbol: 'mUSD',
+          }),
+        ),
+      ).toBeTruthy();
+    });
+
+    it('renders Sent title for cross-token moneyAccountWithdraw in money context', () => {
+      useIsMoneyAccountContextMock.mockReturnValue(true);
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountWithdraw,
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            tokenAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+            chainId: CHAIN_ID_MOCK,
+            targetFiat: '200.00',
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText(strings('transaction_details.title.sent'))).toBeTruthy();
     });
 
     it('renders default title for other transaction types', () => {
@@ -500,13 +549,17 @@ describe('TransactionDetails', () => {
         ],
         [TransactionStatus.submitted, 'transaction_details.title.sending_musd'],
         [TransactionStatus.failed, 'transaction_details.title.send_failed'],
-      ])('returns %s title for status', (status, titleKey) => {
+      ])('returns %s title for mUSD-to-mUSD status', (status, titleKey) => {
         useTransactionDetailsMock.mockReturnValue({
           transactionMeta: {
             ...TRANSACTION_META_MOCK,
             type: TransactionType.moneyAccountWithdraw,
             status,
-            metamaskPay: { targetFiat: '200.00' },
+            metamaskPay: {
+              tokenAddress: MUSD_TOKEN_ADDRESS,
+              chainId: CHAIN_IDS.MONAD,
+              targetFiat: '200.00',
+            },
           } as unknown as TransactionMeta,
         });
 
@@ -517,6 +570,27 @@ describe('TransactionDetails', () => {
         } else {
           expect(getByText(strings(titleKey))).toBeTruthy();
         }
+      });
+
+      it('returns Sent for confirmed cross-token withdraw', () => {
+        useTransactionDetailsMock.mockReturnValue({
+          transactionMeta: {
+            ...TRANSACTION_META_MOCK,
+            type: TransactionType.moneyAccountWithdraw,
+            status: TransactionStatus.confirmed,
+            metamaskPay: {
+              tokenAddress: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+              chainId: CHAIN_ID_MOCK,
+              targetFiat: '200.00',
+            },
+          } as unknown as TransactionMeta,
+        });
+
+        const { getByText } = render();
+
+        expect(
+          getByText(strings('transaction_details.title.sent')),
+        ).toBeTruthy();
       });
     });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -26,6 +26,8 @@ import { TransactionDetailsRetry } from '../transaction-details-retry';
 import { TransactionDetailsAccountRow } from '../transaction-details-account-row';
 import { TransactionDetailsToRow } from '../transaction-details-to-row';
 import { TransactionDetailsFiatOrderIdRow } from '../transaction-details-fiat-order-id-row';
+import { resolveMusdTransferMeta } from '../../../../../UI/Money/constants/activityStyles';
+import { MUSD_TOKEN } from '../../../../../UI/Earn/constants/musd';
 
 export const SUMMARY_SECTION_TYPES = [
   TransactionType.musdClaim,
@@ -121,6 +123,22 @@ function getTitle(
   if (
     hasTransactionType(transactionMeta, [TransactionType.moneyAccountWithdraw])
   ) {
+    if (isMoneyContext) {
+      if (transactionMeta.status === TransactionStatus.confirmed) {
+        return strings('transaction_details.title.money_account_sent', {
+          symbol:
+            resolveMusdTransferMeta(transactionMeta)?.symbol ??
+            MUSD_TOKEN.symbol,
+        });
+      }
+      if (
+        transactionMeta.status === TransactionStatus.failed ||
+        transactionMeta.status === TransactionStatus.dropped
+      ) {
+        return strings('transaction_details.title.send_failed');
+      }
+      return strings('transaction_details.title.sending_musd');
+    }
     return strings('transaction_details.title.money_account_withdraw');
   }
 

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -26,6 +26,7 @@ import { TransactionDetailsRetry } from '../transaction-details-retry';
 import { TransactionDetailsAccountRow } from '../transaction-details-account-row';
 import { TransactionDetailsToRow } from '../transaction-details-to-row';
 import { TransactionDetailsFiatOrderIdRow } from '../transaction-details-fiat-order-id-row';
+import { isMusdToken } from '../../../../../UI/Earn/constants/musd';
 
 export const SUMMARY_SECTION_TYPES = [
   TransactionType.musdClaim,
@@ -103,7 +104,10 @@ function getTitle(
   ) {
     if (isMoneyContext) {
       const isFiatDeposit = Boolean(transactionMeta.metamaskPay?.fiat?.orderId);
-      return isFiatDeposit
+      const isMusdDeposit = isMusdToken(
+        transactionMeta.metamaskPay?.tokenAddress,
+      );
+      return isFiatDeposit || isMusdDeposit
         ? statusTitle(transactionMeta.status, {
             confirmed: 'transaction_details.title.deposited_musd',
             failed: 'transaction_details.title.deposit_failed',

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -27,8 +27,11 @@ import { TransactionDetailsAccountRow } from '../transaction-details-account-row
 import { TransactionDetailsToRow } from '../transaction-details-to-row';
 import { TransactionDetailsFiatOrderIdRow } from '../transaction-details-fiat-order-id-row';
 import { resolveMusdTransferMeta } from '../../../../../UI/Money/constants/activityStyles';
+import {
+  isPerpsPredictMoneyDeposit,
+  isSingleRowMusdMoneyWithdraw,
+} from '../../../../../UI/Money/utils/moneyTransactionGuards';
 import { isMusdToken, MUSD_TOKEN } from '../../../../../UI/Earn/constants/musd';
-import { isPerpsPredictMoneyDeposit } from '../../../../../UI/Money/utils/moneyTransactionGuards';
 
 export const SUMMARY_SECTION_TYPES = [
   TransactionType.musdClaim,
@@ -141,9 +144,7 @@ function getTitle(
   }
 
   if (isMoneyContext && isMoneySendTransaction(transactionMeta)) {
-    const symbol = hasTransactionType(transactionMeta, [
-      TransactionType.moneyAccountWithdraw,
-    ])
+    const symbol = isSingleRowMusdMoneyWithdraw(transactionMeta)
       ? (resolveMusdTransferMeta(transactionMeta)?.symbol ?? MUSD_TOKEN.symbol)
       : undefined;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Money Account transaction details in money context now choose the correct hero layout and title based on the destination and source token

**Withdrawals**
- adds `isSingleRowMusdMoneyWithdraw` when `metamaskPay.tokenAddress` is mUSD (regardless of chain)
- cross-token withdrawals (e.g. mUSD  to USDC) keep the two-asset **You sent / You received** hero and the generic **Sent** title.

**Deposits**
- adds `isSingleRowMoneyDeposit` — fiat deposits (`fiat.orderId`) and mUSD-funded deposits use a single-row hero with a green `+` amount and **Deposited mUSD** titles.
- non mUSD crypto conversions keep the two-asset hero and **Converted to mUSD** titles.

**Send-style titles**
- consolidate money-context send titles via `isMoneySendTransaction` and `getMoneySendTitle`


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: fixed Money Account deposit and withdrawal transaction details to match designs 

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1066

Refs: https://consensyssoftware.atlassian.net/browse/MUSD-1065, https://consensyssoftware.atlassian.net/browse/MUSD-1068

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account transaction details hero and titles

  Scenario: mUSD-to-mUSD withdrawal shows single-row hero and Sent mUSD title
    Given the user is viewing a Money Account withdrawal in money context
    And the destination token is mUSD (same-chain or cross-chain)

    When the user opens the transaction details screen
    Then the hero shows a single row with the Money Account icon
    And the amount is prefixed with "-"
    And the title is status-aware (e.g. "Sent mUSD" when confirmed)
    And the two-asset "You sent / You received" layout is not shown

  Scenario: Cross-token withdrawal shows two-asset hero and Sent title
    Given the user is viewing a Money Account withdrawal in money context
    And the destination token is not mUSD (e.g. USDC)

    When the user opens the transaction details screen
    Then the hero shows "You sent" and "You received" rows
    And the title is "Sent" (not "Sent mUSD")

  Scenario: Fiat or mUSD deposit shows single-row hero and Deposited mUSD title
    Given the user is viewing a Money Account deposit in money context
    And the deposit is funded via fiat (orderId) or mUSD

    When the user opens the transaction details screen
    Then the hero shows a single row with the Money Account icon
    And the amount is prefixed with "+" in green
    And the title is status-aware (e.g. "Deposited mUSD" when confirmed)

  Scenario: Crypto-to-mUSD deposit shows two-asset hero and Converted to mUSD title
    Given the user is viewing a Money Account deposit in money context
    And the source token is not mUSD (e.g. USDC)

    When the user opens the transaction details screen
    Then the hero shows "You sent" and "You received" rows
    And the title is "Converted to mUSD"

  Scenario: Send-style titles use shared resolver
    Given the user is viewing a money-context send transaction
    And the transaction type is simpleSend, perps/predict deposit, or perps/predict money deposit

    When the user opens the transaction details screen
    Then the title uses the shared send title resolver (Sent / Sending mUSD / Send failed)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-24 at 11 36 47" src="https://github.com/user-attachments/assets/d4ba6437-3650-4575-a88c-ac4f5aa5cda9" />

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-24 at 11 49 43" src="https://github.com/user-attachments/assets/2aa9132b-3858-4911-9bda-f2def691e79b" />

<!-- [screenshots/recordings] -->

### **After**

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-24 at 12 09 10" src="https://github.com/user-attachments/assets/6b7903e8-82c2-4c68-b6d3-f0b72e6d80db" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-06-24 at 11 39 29" src="https://github.com/user-attachments/assets/58acf86f-40d4-458d-b2ea-275198670488" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing title and hero branching for Money Account and related send flows; logic is covered by new tests but wrong guards would mislabel activity.
> 
> **Overview**
> Money Account transaction details in **money context** now pick **single-row** vs **two-asset** hero and titles from the **destination/source token**, not only transaction type.
> 
> Adds **`isSingleRowMusdMoneyWithdraw`** so withdrawals whose `metamaskPay.tokenAddress` is mUSD (same-chain or cross-chain) use a single-row hero with the Money Account icon, a **`-`** amount prefix, and **“Sent mUSD”** (status-aware). Cross-token withdrawals still use the two-asset **You sent / You received** hero and the generic **Sent** title.
> 
> Deposits use **`isSingleRowMoneyDeposit`** (fiat `orderId` or mUSD-funded): single-row **+** green amount and **deposited mUSD** titles; crypto-to-mUSD conversions keep the two-asset hero and **converted to mUSD** titles.
> 
> **`transaction-details`** consolidates send-style titles via **`isMoneySendTransaction`** and **`getMoneySendTitle`** (withdraws, `simpleSend`, perps/predict deposits, and perps/predict money deposits), replacing duplicated per-type money-context title branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587e93e3b78dade666618ec132d78d486c602b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->