### PR TITLE
fix: cp-8.0.0 revert legacy ButtonIcon Sm to IconSize.Sm

### DIFF
--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts
@@ -13,7 +13,7 @@ import {
 
 // Mappings
 export const ICONSIZE_BY_BUTTONICONSIZE: IconSizeByButtonIconSize = {
-  [ButtonIconSizes.Sm]: IconSize.Md,
+  [ButtonIconSizes.Sm]: IconSize.Sm,
   [ButtonIconSizes.Md]: IconSize.Lg,
   [ButtonIconSizes.Lg]: IconSize.Xl,
 };

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -303,15 +303,15 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
         <SvgMock
           color="#4459ff"
           fill="currentColor"
-          height={20}
+          height={16}
           name="Close"
           style={
             {
-              "height": 20,
-              "width": 20,
+              "height": 16,
+              "width": 16,
             }
           }
-          width={20}
+          width={16}
         />
       </View>
     </View>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Reverts the legacy `ButtonIcon` small size icon mapping so that `ButtonIconSizes.Sm` renders an `IconSize.Sm` (16) icon instead of `IconSize.Md` (20). This restores expected tooltip/info icon sizing on Swaps, Bridge quote details, and confirmations without affecting other sizes.

One-line change in `app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts`.

## **Changelog**

CHANGELOG entry: Fixed oversized info icons by restoring small ButtonIcon size on mobile.

## **Related issues**

Fixes:

Refs: Slack thread in `#metamask-design-system` (2026-06-24) discussing larger-than-expected tooltip icons on 8.0.0.

## **Manual testing steps**

```gherkin
Feature: Tooltip/info icon sizing on Swaps and Bridge

  Scenario: Info icons render at small size
    Given I open the app on a device or simulator
    And I navigate to Swap > set any pair and amount
    Then the “i” info icons next to Rate, Network fee, and Slippage are small and aligned with text

  Scenario: Bridge quote details card info icon sizing
    Given I start a Bridge flow until the Quote details card is visible
    Then the info icon(s) in the rows render at the smaller size and align with the row text

  Scenario: Send confirmation network fee info icon
    Given I proceed to Send > Confirm screen
    Then the info icon next to Network fee renders small and aligns with the label
```

## **Screenshots/Recordings**

### Before / After

<img width="190" height="183" alt="Screenshot 2026-06-24 at 2 13 04 PM" src="https://github.com/user-attachments/assets/08bb17a3-1341-4c5d-8bf1-c36f35043673" /><img width="175" height="182" alt="Screenshot 2026-06-24 at 2 13 49 PM" src="https://github.com/user-attachments/assets/f7ad1eb5-4bb7-4086-b93f-8f881cb8a63a" />

### Before

https://github.com/user-attachments/assets/d1bea1e5-78c0-40d4-8197-d7502bd05c40

### After



https://github.com/user-attachments/assets/0668a6fd-8399-44ae-9c6e-b3dc73a23686

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR. Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use the power-user SRPs to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1782289572366889?thread_ts=1782289572.366889&cid=C0354T27M5M)

<div><a href="https://cursor.com/agents/bc-75812c56-c63c-59d7-a6a7-adc6c8a7a697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75812c56-c63c-59d7-a6a7-adc6c8a7a697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

