### PR TITLE
chore: migrate METAMASK_MOBILE_ORG_READ_TOKEN to OIDC token exchange

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -391,13 +391,23 @@ jobs:
       - validate-pr
     if: ${{ needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - name: Get token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            members: read
+            metadata: read
       - name: Await approval from mobile release team
         uses: op5dev/require-team-approval@dfd7b8b9a88bf82a955c103f7e19642b0411aecd
         with:
           team: release-team
           pr-number: ${{ needs.validate-pr.outputs.pr_number }}
-          token: ${{ secrets.METAMASK_MOBILE_ORG_READ_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
 
   push-update-ios:
     name: Push EAS Update (iOS)


### PR DESCRIPTION
## Summary

Replaces `secrets.METAMASK_MOBILE_ORG_READ_TOKEN` in `.github/workflows/push-eas-update.yml` with the OIDC `get-token` action pattern, removing the PAT dependency.

### Changes

- `push-eas-update.yml` `approval` job: adds `permissions: id-token: write` and a `Get token` step using `MetaMask/github-tools/.github/actions/get-token@v1`, then passes `${{ steps.get-token.outputs.token }}` to `op5dev/require-team-approval` instead of the PAT.

### Permissions (from patroll)

```json
{
  "members": "read",
  "metadata": "read"
}
```

---

## Token-exchange service repo — Rego policy to add

Add the following block to the token-exchange policy file for this token:

```rego
metamask_policies["mm-metamask-mobile-push-eas-update-org-read-token-exchange"] := {
    "description": "Allow MetaMask/metamask-mobile push-eas-update.yml to exchange for a same-repo installation token to check release-team membership during OTA approval.",
    "source": {
        "repository": "MetaMask/metamask-mobile",
        "workflow_ref_match": {"type": "glob", "pattern": "MetaMask/metamask-mobile/.github/workflows/push-eas-update.yml@*"},
    },
    "target": {"repository": "MetaMask/metamask-mobile"},
    "grant_permissions": {
        "members": "read",
        "metadata": "read",
    },
}
```

## Testing

- [ ] Verify `push-eas-update.yml` OTA approval step succeeds with the exchanged token
- [ ] Confirm `METAMASK_MOBILE_ORG_READ_TOKEN` secret is no longer referenced in any workflow


Made with [Cursor](https://cursor.com)