### PR TITLE
feat: add RampsServiceDisruptionModal for handling service disruption cp-8.0.0

### DIFF
--- a/app/components/Nav/App/App.test.tsx
+++ b/app/components/Nav/App/App.test.tsx
@@ -76,6 +76,9 @@ jest.mock(
 );
 
 jest.mock('../../UI/Ramp/RampsBootstrap', () => () => null);
+jest.mock('../../UI/Ramp/components/RampsServiceDisruptionModal', () => () => (
+  <MockView testID="mock-ramps-service-disruption-modal" />
+));
 
 jest.mock('../../Views/Onboarding', () => () => (
   <MockView testID="mock-onboarding" />
@@ -2245,11 +2248,23 @@ describe('App', () => {
       });
     });
 
+    it('renders RampsServiceDisruptionModal sheet', async () => {
+      const { getByTestId } = renderAppWithModal(
+        Routes.SHEET.RAMPS_SERVICE_DISRUPTION_MODAL,
+      );
+
+      await waitFor(() => {
+        expect(
+          getByTestId('mock-ramps-service-disruption-modal'),
+        ).toBeOnTheScreen();
+      });
+    });
+
     it('renders WalletActions modal', async () => {
       const { getByTestId } = renderAppWithModal(Routes.MODAL.WALLET_ACTIONS);
 
       await waitFor(() => {
-        expect(getByTestId('mock-wallet-actions')).toBeTruthy();
+        expect(getByTestId('mock-wallet-actions')).toBeOnTheScreen();
       });
     });
 

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -132,6 +132,7 @@ import SuccessErrorSheet from '../../Views/SuccessErrorSheet';
 import ConfirmTurnOnBackupAndSyncModal from '../../UI/Identity/ConfirmTurnOnBackupAndSyncModal/ConfirmTurnOnBackupAndSyncModal';
 import EligibilityFailedModal from '../../UI/Ramp/components/EligibilityFailedModal';
 import RampUnsupportedModal from '../../UI/Ramp/components/RampUnsupportedModal';
+import RampsServiceDisruptionModal from '../../UI/Ramp/components/RampsServiceDisruptionModal';
 import RampsBootstrap from '../../UI/Ramp/RampsBootstrap';
 import SwitchAccountTypeModal from '../../Views/confirmations/components/modals/switch-account-type-modal';
 import { AccountDetails } from '../../Views/MultichainAccounts/AccountDetails/AccountDetails';
@@ -514,6 +515,10 @@ const RootModalFlow = (props: RootModalFlowProps) => (
     <NativeStack.Screen
       name={Routes.SHEET.UNSUPPORTED_REGION_MODAL}
       component={RampUnsupportedModal}
+    />
+    <NativeStack.Screen
+      name={Routes.SHEET.RAMPS_SERVICE_DISRUPTION_MODAL}
+      component={RampsServiceDisruptionModal}
     />
     <NativeStack.Screen
       name={Routes.SHEET.ACCOUNT_SELECTOR}

--- a/app/components/UI/Ramp/components/RampInfoBottomSheet/RampInfoBottomSheet.test.tsx
+++ b/app/components/UI/Ramp/components/RampInfoBottomSheet/RampInfoBottomSheet.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react-native';
+import { ButtonVariant } from '@metamask/design-system-react-native';
+import { renderScreen } from '../../../../../util/test/renderWithProvider';
+import Routes from '../../../../../constants/navigation/Routes';
+import initialRootState from '../../../../../util/test/initial-root-state';
+import RampInfoBottomSheet, {
+  type RampInfoBottomSheetProps,
+} from './RampInfoBottomSheet';
+
+const mockOnCloseBottomSheet = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
+      (
+        { children, testID }: { children: React.ReactNode; testID?: string },
+        ref: React.Ref<{ onCloseBottomSheet: () => void }>,
+      ) => {
+        ReactActual.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: mockOnCloseBottomSheet,
+        }));
+        return <View testID={testID}>{children}</View>;
+      },
+    ),
+  };
+});
+
+const TEST_IDS = {
+  MODAL: 'ramp-info-bottom-sheet',
+  CLOSE_BUTTON: 'bottomsheetheader-close-button',
+} as const;
+
+function renderSheet(props: Partial<RampInfoBottomSheetProps> = {}) {
+  const Component = () => (
+    <RampInfoBottomSheet
+      testIDs={TEST_IDS}
+      title="Title copy"
+      description="Description copy"
+      actions={[{ label: 'Got it', variant: ButtonVariant.Primary }]}
+      {...props}
+    />
+  );
+
+  return renderScreen(
+    Component,
+    { name: Routes.SHEET.RAMPS_SERVICE_DISRUPTION_MODAL },
+    { state: initialRootState },
+  );
+}
+
+describe('RampInfoBottomSheet', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the title, description and sheet testID', () => {
+    renderSheet();
+
+    expect(screen.getByTestId(TEST_IDS.MODAL)).toBeOnTheScreen();
+    expect(screen.getByText('Title copy')).toBeOnTheScreen();
+    expect(screen.getByText('Description copy')).toBeOnTheScreen();
+  });
+
+  it('renders every provided action button', () => {
+    renderSheet({
+      actions: [
+        { label: 'Contact support', variant: ButtonVariant.Secondary },
+        { label: 'Got it', variant: ButtonVariant.Primary },
+      ],
+    });
+
+    expect(screen.getByText('Contact support')).toBeOnTheScreen();
+    expect(screen.getByText('Got it')).toBeOnTheScreen();
+  });
+
+  it('closes the sheet when the header close button is pressed', () => {
+    renderSheet();
+
+    fireEvent.press(screen.getByTestId(TEST_IDS.CLOSE_BUTTON));
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the sheet when an action without a custom handler is pressed', () => {
+    renderSheet();
+
+    fireEvent.press(screen.getByText('Got it'));
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes a custom action handler instead of closing the sheet', () => {
+    const onPress = jest.fn();
+    renderSheet({
+      actions: [
+        { label: 'Contact support', variant: ButtonVariant.Secondary, onPress },
+      ],
+    });
+
+    fireEvent.press(screen.getByText('Contact support'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Ramp/components/RampInfoBottomSheet/RampInfoBottomSheet.tsx
+++ b/app/components/UI/Ramp/components/RampInfoBottomSheet/RampInfoBottomSheet.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
+
+export interface RampInfoBottomSheetAction {
+  /** Button label */
+  label: string;
+  /** Button visual variant (Primary, Secondary, ...) */
+  variant: ButtonVariant;
+  /** Press handler. Defaults to closing the sheet when omitted. */
+  onPress?: () => void;
+  /** Optional testID for the button */
+  testID?: string;
+}
+
+export interface RampInfoBottomSheetProps {
+  /** testIDs for the sheet container and header close button */
+  testIDs: {
+    MODAL: string;
+    CLOSE_BUTTON: string;
+  };
+  /** Heading shown in the sheet header */
+  title: string;
+  /** Heading variant (defaults to HeadingMd) */
+  titleVariant?: TextVariant;
+  /** Body copy shown under the header */
+  description: string;
+  /** Footer actions rendered as full-width buttons, in order */
+  actions: RampInfoBottomSheetAction[];
+}
+
+/**
+ * Shared bottom sheet for simple Ramp informational modals: a header title, a
+ * body description, and one or more full-width dismiss/action buttons. Actions
+ * default to closing the sheet unless they provide their own `onPress`.
+ */
+function RampInfoBottomSheet({
+  testIDs,
+  title,
+  titleVariant = TextVariant.HeadingMd,
+  description,
+  actions,
+}: RampInfoBottomSheetProps) {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
+  const surfaceClass = useElevatedSurface();
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      goBack={navigation.goBack}
+      isInteractable={false}
+      testID={testIDs.MODAL}
+      twClassName={surfaceClass}
+    >
+      <BottomSheetHeader
+        onClose={handleClose}
+        closeButtonProps={{
+          testID: testIDs.CLOSE_BUTTON,
+        }}
+      >
+        <Text variant={titleVariant}>{title}</Text>
+      </BottomSheetHeader>
+
+      <Box twClassName="px-6 pb-6">
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+          {description}
+        </Text>
+      </Box>
+
+      <Box twClassName="gap-4 px-6 pb-6">
+        {actions.map((action) => (
+          <Button
+            key={action.label}
+            size={ButtonSize.Lg}
+            onPress={action.onPress ?? handleClose}
+            variant={action.variant}
+            isFullWidth
+            testID={action.testID}
+          >
+            {action.label}
+          </Button>
+        ))}
+      </Box>
+    </BottomSheet>
+  );
+}
+
+export default RampInfoBottomSheet;

--- a/app/components/UI/Ramp/components/RampInfoBottomSheet/index.ts
+++ b/app/components/UI/Ramp/components/RampInfoBottomSheet/index.ts
@@ -1,0 +1,5 @@
+export { default } from './RampInfoBottomSheet';
+export type {
+  RampInfoBottomSheetAction,
+  RampInfoBottomSheetProps,
+} from './RampInfoBottomSheet';

--- a/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.tsx
+++ b/app/components/UI/Ramp/components/RampUnsupportedModal/RampUnsupportedModal.tsx
@@ -1,22 +1,10 @@
-import React, { useCallback, useRef } from 'react';
-import { useNavigation } from '@react-navigation/native';
-import {
-  BottomSheet,
-  BottomSheetHeader,
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextColor,
-  TextVariant,
-  type BottomSheetRef,
-} from '@metamask/design-system-react-native';
+import React from 'react';
+import { ButtonVariant } from '@metamask/design-system-react-native';
 import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
+import RampInfoBottomSheet from '../RampInfoBottomSheet';
 import { RAMP_UNSUPPORTED_MODAL_TEST_IDS } from './RampUnsupportedModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const createRampUnsupportedModalNavigationDetails =
   createNavigationDetails(
@@ -25,52 +13,22 @@ export const createRampUnsupportedModalNavigationDetails =
   );
 
 function RampUnsupportedModal() {
-  const sheetRef = useRef<BottomSheetRef>(null);
-  const navigation = useNavigation();
-  const surfaceClass = useElevatedSurface();
-
-  const handleClose = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet();
-  }, []);
-
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-      isInteractable={false}
-      testID={RAMP_UNSUPPORTED_MODAL_TEST_IDS.MODAL}
-      twClassName={surfaceClass}
-    >
-      <BottomSheetHeader
-        onClose={handleClose}
-        closeButtonProps={{
-          testID: RAMP_UNSUPPORTED_MODAL_TEST_IDS.CLOSE_BUTTON,
-        }}
-      >
-        <Text variant={TextVariant.HeadingMd}>
-          {strings('fiat_on_ramp_aggregator.unsupported_region_modal.title')}
-        </Text>
-      </BottomSheetHeader>
-
-      <Box twClassName="px-6 pb-6">
-        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-          {strings(
-            'fiat_on_ramp_aggregator.unsupported_region_modal.description',
-          )}
-        </Text>
-      </Box>
-
-      <Box twClassName="gap-4 px-6 pb-6">
-        <Button
-          size={ButtonSize.Lg}
-          onPress={handleClose}
-          variant={ButtonVariant.Primary}
-          isFullWidth
-        >
-          {strings('fiat_on_ramp_aggregator.unsupported_region_modal.got_it')}
-        </Button>
-      </Box>
-    </BottomSheet>
+    <RampInfoBottomSheet
+      testIDs={RAMP_UNSUPPORTED_MODAL_TEST_IDS}
+      title={strings('fiat_on_ramp_aggregator.unsupported_region_modal.title')}
+      description={strings(
+        'fiat_on_ramp_aggregator.unsupported_region_modal.description',
+      )}
+      actions={[
+        {
+          label: strings(
+            'fiat_on_ramp_aggregator.unsupported_region_modal.got_it',
+          ),
+          variant: ButtonVariant.Primary,
+        },
+      ]}
+    />
   );
 }
 

--- a/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.test.tsx
+++ b/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { renderScreen } from '../../../../../util/test/renderWithProvider';
+import RampsServiceDisruptionModal, {
+  createRampsServiceDisruptionModalNavigationDetails,
+} from './RampsServiceDisruptionModal';
+import Routes from '../../../../../constants/navigation/Routes';
+import initialRootState from '../../../../../util/test/initial-root-state';
+import { fireEvent, screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS } from './RampsServiceDisruptionModal.testIds';
+
+const mockOnCloseBottomSheet = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    BottomSheet: ReactActual.forwardRef(
+      (
+        { children, testID }: { children: React.ReactNode; testID?: string },
+        ref: React.Ref<{ onCloseBottomSheet: () => void }>,
+      ) => {
+        ReactActual.useImperativeHandle(ref, () => ({
+          onCloseBottomSheet: mockOnCloseBottomSheet,
+        }));
+        return <View testID={testID}>{children}</View>;
+      },
+    ),
+  };
+});
+
+function render(component: React.ComponentType) {
+  return renderScreen(
+    component,
+    { name: Routes.SHEET.RAMPS_SERVICE_DISRUPTION_MODAL },
+    { state: initialRootState },
+  );
+}
+
+describe('createRampsServiceDisruptionModalNavigationDetails', () => {
+  it('targets root modal flow and the ramp service disruption sheet', () => {
+    const details = createRampsServiceDisruptionModalNavigationDetails();
+    expect(details[0]).toBe(Routes.MODAL.ROOT_MODAL_FLOW);
+    expect(details[1]).toEqual(
+      expect.objectContaining({
+        screen: Routes.SHEET.RAMPS_SERVICE_DISRUPTION_MODAL,
+      }),
+    );
+  });
+});
+
+describe('RampsServiceDisruptionModal', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders title, description and sheet testID', () => {
+    render(RampsServiceDisruptionModal);
+    expect(
+      screen.getByTestId(RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS.MODAL),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        strings('fiat_on_ramp_aggregator.service_disruption_modal.title'),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        strings('fiat_on_ramp_aggregator.service_disruption_modal.description'),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('closes when the header close button is pressed', () => {
+    render(RampsServiceDisruptionModal);
+    fireEvent.press(
+      screen.getByTestId(RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS.CLOSE_BUTTON),
+    );
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the got it button is pressed', () => {
+    render(RampsServiceDisruptionModal);
+    fireEvent.press(
+      screen.getByText(
+        strings('fiat_on_ramp_aggregator.service_disruption_modal.got_it'),
+      ),
+    );
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.testIds.ts
+++ b/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.testIds.ts
@@ -1,0 +1,4 @@
+export const RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS = {
+  MODAL: 'ramps-service-disruption-modal',
+  CLOSE_BUTTON: 'bottomsheetheader-close-button',
+} as const;

--- a/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.tsx
+++ b/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS } from './RampsServiceDisruptionModal.testIds';
+import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
+
+export const createRampsServiceDisruptionModalNavigationDetails =
+  createNavigationDetails(
+    Routes.MODAL.ROOT_MODAL_FLOW,
+    Routes.SHEET.RAMPS_SERVICE_DISRUPTION_MODAL,
+  );
+
+function RampsServiceDisruptionModal() {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
+  const surfaceClass = useElevatedSurface();
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      goBack={navigation.goBack}
+      isInteractable={false}
+      testID={RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS.MODAL}
+      twClassName={surfaceClass}
+    >
+      <BottomSheetHeader
+        onClose={handleClose}
+        closeButtonProps={{
+          testID: RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS.CLOSE_BUTTON,
+        }}
+      >
+        <Text variant={TextVariant.HeadingSm}>
+          {strings('fiat_on_ramp_aggregator.service_disruption_modal.title')}
+        </Text>
+      </BottomSheetHeader>
+
+      <Box twClassName="px-6 pb-6">
+        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+          {strings(
+            'fiat_on_ramp_aggregator.service_disruption_modal.description',
+          )}
+        </Text>
+      </Box>
+
+      <Box twClassName="gap-4 px-6 pb-6">
+        <Button
+          size={ButtonSize.Lg}
+          onPress={handleClose}
+          variant={ButtonVariant.Primary}
+          isFullWidth
+        >
+          {strings('fiat_on_ramp_aggregator.service_disruption_modal.got_it')}
+        </Button>
+      </Box>
+    </BottomSheet>
+  );
+}
+
+export default RampsServiceDisruptionModal;

--- a/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.tsx
+++ b/app/components/UI/Ramp/components/RampsServiceDisruptionModal/RampsServiceDisruptionModal.tsx
@@ -1,22 +1,13 @@
-import React, { useCallback, useRef } from 'react';
-import { useNavigation } from '@react-navigation/native';
+import React from 'react';
 import {
-  BottomSheet,
-  BottomSheetHeader,
-  Box,
-  Button,
-  ButtonSize,
   ButtonVariant,
-  Text,
-  TextColor,
   TextVariant,
-  type BottomSheetRef,
 } from '@metamask/design-system-react-native';
 import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
+import RampInfoBottomSheet from '../RampInfoBottomSheet';
 import { RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS } from './RampsServiceDisruptionModal.testIds';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 
 export const createRampsServiceDisruptionModalNavigationDetails =
   createNavigationDetails(
@@ -25,52 +16,23 @@ export const createRampsServiceDisruptionModalNavigationDetails =
   );
 
 function RampsServiceDisruptionModal() {
-  const sheetRef = useRef<BottomSheetRef>(null);
-  const navigation = useNavigation();
-  const surfaceClass = useElevatedSurface();
-
-  const handleClose = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet();
-  }, []);
-
   return (
-    <BottomSheet
-      ref={sheetRef}
-      goBack={navigation.goBack}
-      isInteractable={false}
-      testID={RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS.MODAL}
-      twClassName={surfaceClass}
-    >
-      <BottomSheetHeader
-        onClose={handleClose}
-        closeButtonProps={{
-          testID: RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS.CLOSE_BUTTON,
-        }}
-      >
-        <Text variant={TextVariant.HeadingSm}>
-          {strings('fiat_on_ramp_aggregator.service_disruption_modal.title')}
-        </Text>
-      </BottomSheetHeader>
-
-      <Box twClassName="px-6 pb-6">
-        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-          {strings(
-            'fiat_on_ramp_aggregator.service_disruption_modal.description',
-          )}
-        </Text>
-      </Box>
-
-      <Box twClassName="gap-4 px-6 pb-6">
-        <Button
-          size={ButtonSize.Lg}
-          onPress={handleClose}
-          variant={ButtonVariant.Primary}
-          isFullWidth
-        >
-          {strings('fiat_on_ramp_aggregator.service_disruption_modal.got_it')}
-        </Button>
-      </Box>
-    </BottomSheet>
+    <RampInfoBottomSheet
+      testIDs={RAMPS_SERVICE_DISRUPTION_MODAL_TEST_IDS}
+      title={strings('fiat_on_ramp_aggregator.service_disruption_modal.title')}
+      titleVariant={TextVariant.HeadingSm}
+      description={strings(
+        'fiat_on_ramp_aggregator.service_disruption_modal.description',
+      )}
+      actions={[
+        {
+          label: strings(
+            'fiat_on_ramp_aggregator.service_disruption_modal.got_it',
+          ),
+          variant: ButtonVariant.Primary,
+        },
+      ]}
+    />
   );
 }
 

--- a/app/components/UI/Ramp/components/RampsServiceDisruptionModal/index.ts
+++ b/app/components/UI/Ramp/components/RampsServiceDisruptionModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RampsServiceDisruptionModal';

--- a/app/components/UI/Ramp/deeplink/handleRampUrl.test.ts
+++ b/app/components/UI/Ramp/deeplink/handleRampUrl.test.ts
@@ -58,6 +58,28 @@ jest.mock('../components/RampUnsupportedModal/RampUnsupportedModal', () => ({
     mockCreateRampUnsupportedModalNavigationDetails(),
 }));
 
+const mockCreateRampsServiceDisruptionModalNavigationDetails = jest.fn(() => [
+  'RAMPS_SERVICE_DISRUPTION_MODAL_ROUTE',
+]);
+jest.mock(
+  '../components/RampsServiceDisruptionModal/RampsServiceDisruptionModal',
+  () => ({
+    createRampsServiceDisruptionModalNavigationDetails: () =>
+      mockCreateRampsServiceDisruptionModalNavigationDetails(),
+  }),
+);
+
+const mockSelectRampsServiceDisruptionRegions = jest.fn<string[], [unknown]>(
+  () => [],
+);
+jest.mock(
+  '../../../../selectors/featureFlagController/rampsServiceDisruption',
+  () => ({
+    selectRampsServiceDisruptionRegions: (state: unknown) =>
+      mockSelectRampsServiceDisruptionRegions(state),
+  }),
+);
+
 const mockCreateBuildQuoteNavDetails = jest.fn(
   (params: { assetId: string }) => ['BUILD_QUOTE_ROUTE', params],
 );
@@ -120,6 +142,7 @@ describe('handleRampUrl', () => {
     mockSelectGeolocationLocation.mockReturnValue('us-ca');
     mockSelectUserRegion.mockReturnValue(null);
     mockSelectCountries.mockReturnValue({ data: [] });
+    mockSelectRampsServiceDisruptionRegions.mockReturnValue([]);
   });
 
   it('handles redirection with the paths', () => {
@@ -208,6 +231,51 @@ describe('handleRampUrl', () => {
       });
       expect(mockRefreshGeolocation).not.toHaveBeenCalled();
       expect(mockCreateTokenSelectionNavDetails).toHaveBeenCalled();
+    });
+
+    it('navigates to the service disruption modal when the resolved region is in an active service disruption', async () => {
+      mockSelectRampsServiceDisruptionRegions.mockReturnValue(['us-ca']);
+      mockSelectUserRegion.mockReturnValue({
+        regionCode: 'us-ca',
+        country: { isoCode: 'US' },
+        state: null,
+      } as unknown as UserRegion);
+      await handleRampUrl({
+        rampPath: '?as=example',
+        rampType: RampType.BUY,
+      });
+      expect(handleRedirection).not.toHaveBeenCalled();
+      expect(
+        mockCreateRampsServiceDisruptionModalNavigationDetails,
+      ).toHaveBeenCalled();
+      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+        'RAMPS_SERVICE_DISRUPTION_MODAL_ROUTE',
+      );
+      expect(mockCreateTokenSelectionNavDetails).not.toHaveBeenCalled();
+    });
+
+    it('shows the service disruption modal over the eligibility modal when geolocation is unknown but the region is in service disruption', async () => {
+      mockSelectGeolocationLocation.mockReturnValue(UNKNOWN_LOCATION);
+      mockRefreshGeolocation.mockResolvedValue(UNKNOWN_LOCATION);
+      mockSelectRampsServiceDisruptionRegions.mockReturnValue(['in']);
+      mockSelectUserRegion.mockReturnValue({
+        regionCode: 'in',
+        country: { isoCode: 'IN' },
+        state: null,
+      } as unknown as UserRegion);
+      await handleRampUrl({
+        rampPath: '?as=example',
+        rampType: RampType.BUY,
+      });
+      expect(
+        mockCreateRampsServiceDisruptionModalNavigationDetails,
+      ).toHaveBeenCalled();
+      expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
+        'RAMPS_SERVICE_DISRUPTION_MODAL_ROUTE',
+      );
+      expect(
+        mockCreateEligibilityFailedModalNavigationDetails,
+      ).not.toHaveBeenCalled();
     });
 
     it('navigates to unsupported modal when the resolved region is definitively unsupported', async () => {

--- a/app/components/UI/Ramp/deeplink/handleRampUrl.ts
+++ b/app/components/UI/Ramp/deeplink/handleRampUrl.ts
@@ -18,6 +18,9 @@ import {
 import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 import { isRampRegionDefinitivelyUnsupported } from '../utils/rampRegionEligibility';
+import { isRampsServiceDisruptionActive } from '../utils/rampsServiceDisruption';
+import { createRampsServiceDisruptionModalNavigationDetails } from '../components/RampsServiceDisruptionModal/RampsServiceDisruptionModal';
+import { selectRampsServiceDisruptionRegions } from '../../../../selectors/featureFlagController/rampsServiceDisruption';
 import { resolveRampControllerAssetId } from '../utils/resolveRampControllerAssetId';
 import Engine from '../../../../core/Engine';
 
@@ -40,6 +43,21 @@ async function navigateUnifiedV2Buy(
     ).catch(() => undefined);
     // Geo refresh may hydrate RampsController; re-read store before eligibility.
     state = ReduxService.store.getState();
+  }
+
+  // Region service disruption kill-switch — takes precedence over the eligibility/unsupported
+  // gating below so a service disruption region is surfaced even when geolocation is unknown.
+  if (
+    isRampsServiceDisruptionActive(
+      selectRampsServiceDisruptionRegions(state),
+      selectUserRegion(state),
+      location,
+    )
+  ) {
+    NavigationService.navigation.navigate(
+      ...createRampsServiceDisruptionModalNavigationDetails(),
+    );
+    return;
   }
 
   if (!location || location === UNKNOWN_LOCATION) {

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -10,6 +10,7 @@ import { createBuildQuoteNavDetails } from '../Views/BuildQuote';
 import { RampType as AggregatorRampType } from '../Aggregator/types';
 import { createEligibilityFailedModalNavigationDetails } from '../components/EligibilityFailedModal/EligibilityFailedModal';
 import { createRampUnsupportedModalNavigationDetails } from '../components/RampUnsupportedModal/RampUnsupportedModal';
+import { createRampsServiceDisruptionModalNavigationDetails } from '../components/RampsServiceDisruptionModal/RampsServiceDisruptionModal';
 
 const mockSetSelectedToken = jest.fn();
 let mockTokens: { allTokens: unknown[]; topTokens: unknown[] } | undefined;
@@ -307,6 +308,98 @@ describe('useRampNavigation', () => {
           buyFlowOrigin: undefined,
         });
         expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+      });
+    });
+
+    describe('service disruption routing', () => {
+      it('navigates to RampsServiceDisruptionModal when a service disruption covers the user region', async () => {
+        mockUserRegion = supportedUserRegion; // regionCode 'us-ca'
+        const { result } = renderUseRampNavigation({
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: { rampsServiceDisruptionModal: ['us-ca'] },
+              },
+            },
+          },
+        });
+
+        await result.current.goToBuy();
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          ...createRampsServiceDisruptionModalNavigationDetails(),
+        );
+      });
+
+      it('does not block when the service disruption list does not cover the region', async () => {
+        mockUserRegion = supportedUserRegion; // 'us-ca'
+        const { result } = renderUseRampNavigation({
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: { rampsServiceDisruptionModal: ['fr'] },
+              },
+            },
+          },
+        });
+
+        await result.current.goToBuy();
+
+        expect(mockNavigate).not.toHaveBeenCalledWith(
+          ...createRampsServiceDisruptionModalNavigationDetails(),
+        );
+        // falls through to TokenSelection (no assetId intent)
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.TOKEN_SELECTION);
+      });
+
+      it('blocks the deprecated override/aggregator path during a service disruption', async () => {
+        mockUserRegion = supportedUserRegion; // 'us-ca'
+        const { result } = renderUseRampNavigation({
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: { rampsServiceDisruptionModal: ['us-ca'] },
+              },
+            },
+          },
+        });
+
+        await result.current.goToBuy(undefined, {
+          overrideUnifiedRouting: true,
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          ...createRampsServiceDisruptionModalNavigationDetails(),
+        );
+        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+      });
+
+      it('shows the service disruption modal over the eligibility modal when geolocation is unknown but the region is in service disruption', async () => {
+        mockUserRegion = {
+          regionCode: 'in',
+          country: { isoCode: 'IN', supported: { buy: true, sell: true } },
+          state: null,
+        } as unknown as UserRegion;
+        mockRefreshGeolocation.mockResolvedValue('UNKNOWN');
+        const { result } = renderUseRampNavigation({
+          engine: {
+            backgroundState: {
+              GeolocationController: { location: 'UNKNOWN' },
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: { rampsServiceDisruptionModal: ['in'] },
+              },
+            },
+          },
+        });
+
+        await result.current.goToBuy();
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+          ...createRampsServiceDisruptionModalNavigationDetails(),
+        );
+        expect(mockNavigate).not.toHaveBeenCalledWith(
+          ...createEligibilityFailedModalNavigationDetails(),
+        );
       });
     });
 

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -15,6 +15,9 @@ import { useRampsTokens } from './useRampsTokens';
 import { useRampsUserRegion } from './useRampsUserRegion';
 import { useRampsCountries } from './useRampsCountries';
 import { isRampRegionDefinitivelyUnsupported } from '../utils/rampRegionEligibility';
+import { isRampsServiceDisruptionActive } from '../utils/rampsServiceDisruption';
+import { createRampsServiceDisruptionModalNavigationDetails } from '../components/RampsServiceDisruptionModal/RampsServiceDisruptionModal';
+import { selectRampsServiceDisruptionRegions } from '../../../../selectors/featureFlagController/rampsServiceDisruption';
 import { resolveRampControllerAssetId } from '../utils/resolveRampControllerAssetId';
 import Engine from '../../../../core/Engine';
 import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
@@ -31,6 +34,9 @@ import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 export const useRampNavigation = () => {
   const navigation = useNavigation();
   const geolocationLocation = useSelector(selectGeolocationLocation);
+  const rampsServiceDisruptionRegions = useSelector(
+    selectRampsServiceDisruptionRegions,
+  );
   const { userRegion } = useRampsUserRegion();
   const { countries } = useRampsCountries();
   const { setSelectedToken, tokens: rampsTokens } = useRampsTokens();
@@ -47,15 +53,34 @@ export const useRampNavigation = () => {
 
       const isUnifiedRoutingEnabled = !overrideUnifiedRouting;
 
+      // Resolve the best available geolocation; only the unified path refreshes.
+      let location: string | undefined = geolocationLocation;
+      if (
+        isUnifiedRoutingEnabled &&
+        (!location || location === UNKNOWN_LOCATION)
+      ) {
+        location = await Promise.resolve(
+          Engine.context.GeolocationController?.refreshGeolocation?.(),
+        ).catch(() => undefined);
+      }
+
+      // Region service disruption kill-switch — applies to every buy entry point (including
+      // the deprecated aggregator/reorder path) and takes precedence over the
+      // eligibility/unsupported gating below.
+      if (
+        isRampsServiceDisruptionActive(
+          rampsServiceDisruptionRegions,
+          userRegion,
+          location,
+        )
+      ) {
+        navigation.navigate(
+          ...createRampsServiceDisruptionModalNavigationDetails(),
+        );
+        return;
+      }
+
       if (isUnifiedRoutingEnabled) {
-        let location: string | undefined = geolocationLocation;
-
-        if (!location || location === UNKNOWN_LOCATION) {
-          location = await Promise.resolve(
-            Engine.context.GeolocationController?.refreshGeolocation?.(),
-          ).catch(() => undefined);
-        }
-
         if (!location || location === UNKNOWN_LOCATION) {
           navigation.navigate(
             ...createEligibilityFailedModalNavigationDetails(),
@@ -117,6 +142,7 @@ export const useRampNavigation = () => {
       countries,
       rampsTokens,
       geolocationLocation,
+      rampsServiceDisruptionRegions,
     ],
   );
 

--- a/app/components/UI/Ramp/utils/rampsServiceDisruption.test.ts
+++ b/app/components/UI/Ramp/utils/rampsServiceDisruption.test.ts
@@ -1,0 +1,50 @@
+import type { UserRegion } from '@metamask/ramps-controller';
+import { isRampsServiceDisruptionActive } from './rampsServiceDisruption';
+
+const region = (regionCode: string) =>
+  ({
+    regionCode,
+    country: { isoCode: regionCode.split('-')[0].toUpperCase() },
+    state: null,
+  }) as unknown as UserRegion;
+
+describe('isRampsServiceDisruptionActive', () => {
+  it('returns false when the service disruption list is empty', () => {
+    expect(isRampsServiceDisruptionActive([], region('in'))).toBe(false);
+  });
+
+  it('matches a country-level region exactly', () => {
+    expect(isRampsServiceDisruptionActive(['in'], region('in'))).toBe(true);
+  });
+
+  it('matches all states under a country entry (hierarchical)', () => {
+    expect(isRampsServiceDisruptionActive(['us'], region('us-ca'))).toBe(true);
+  });
+
+  it('matches a specific state entry only', () => {
+    expect(isRampsServiceDisruptionActive(['us-ca'], region('us-ca'))).toBe(
+      true,
+    );
+    expect(isRampsServiceDisruptionActive(['us-ca'], region('us-ny'))).toBe(
+      false,
+    );
+  });
+
+  it('does not match an unrelated region', () => {
+    expect(isRampsServiceDisruptionActive(['fr'], region('us-ca'))).toBe(false);
+  });
+
+  it('is case-insensitive on both sides', () => {
+    expect(isRampsServiceDisruptionActive(['IN'], region('in'))).toBe(true);
+  });
+
+  it('falls back to geolocation when region is unresolved', () => {
+    expect(isRampsServiceDisruptionActive(['in'], null, 'IN')).toBe(true);
+    expect(isRampsServiceDisruptionActive(['us-ca'], null, 'US-CA')).toBe(true);
+  });
+
+  it('does not block when nothing resolves (region null, geo UNKNOWN)', () => {
+    expect(isRampsServiceDisruptionActive(['in'], null, 'UNKNOWN')).toBe(false);
+    expect(isRampsServiceDisruptionActive(['in'], null, undefined)).toBe(false);
+  });
+});

--- a/app/components/UI/Ramp/utils/rampsServiceDisruption.ts
+++ b/app/components/UI/Ramp/utils/rampsServiceDisruption.ts
@@ -1,0 +1,45 @@
+import type { UserRegion } from '@metamask/ramps-controller';
+import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
+
+/**
+ * Determines whether the Buy flow is in a service disruption for the user's region.
+ *
+ * Matches the user's resolved `regionCode` (e.g. "in", "us-ca"), falling back
+ * to IP geolocation, against the configured service disruption region list. Matching is
+ * hierarchical: a country entry ("us") matches all of its states ("us-ca").
+ *
+ * Only blocks on a definitive region signal — if no region resolves, returns
+ * false (mirrors `isRampRegionDefinitivelyUnsupported`).
+ *
+ * @param disruptionRegions - Lowercase regionCodes from the `rampsServiceDisruptionModal` flag.
+ * @param userRegion - The resolved RampsController user region, or null.
+ * @param geolocationLocation - ISO 3166-2 geolocation (e.g. "US-CA"), optional.
+ * @returns `true` when Buy should be blocked for this user.
+ */
+export function isRampsServiceDisruptionActive(
+  disruptionRegions: string[],
+  userRegion: UserRegion | null,
+  geolocationLocation?: string,
+): boolean {
+  if (disruptionRegions.length === 0) {
+    return false;
+  }
+
+  const regionCode =
+    userRegion?.regionCode?.toLowerCase() ??
+    (geolocationLocation && geolocationLocation !== UNKNOWN_LOCATION
+      ? geolocationLocation.toLowerCase()
+      : undefined);
+
+  if (!regionCode) {
+    return false;
+  }
+
+  return disruptionRegions.some((region) => {
+    const entry = region.trim().toLowerCase();
+    if (!entry) {
+      return false;
+    }
+    return regionCode === entry || regionCode.startsWith(`${entry}-`);
+  });
+}

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -274,6 +274,7 @@ const Routes = {
     SUCCESS_ERROR_SHEET: 'SuccessErrorSheet',
     ELIGIBILITY_FAILED_MODAL: 'EligibilityFailedModal',
     UNSUPPORTED_REGION_MODAL: 'UnsupportedRegionModal',
+    RAMPS_SERVICE_DISRUPTION_MODAL: 'RampsServiceDisruptionModal',
     MULTICHAIN_TRANSACTION_DETAILS: 'MultichainTransactionDetails',
     TRANSACTION_DETAILS: 'TransactionDetailsSheet',
     IMPORT_WALLET_TIP: 'ImportWalletTipSheet',

--- a/app/selectors/featureFlagController/rampsServiceDisruption/index.test.ts
+++ b/app/selectors/featureFlagController/rampsServiceDisruption/index.test.ts
@@ -1,0 +1,76 @@
+import { getVersion } from 'react-native-device-info';
+import { selectRampsServiceDisruptionRegions } from '.';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(() => '8.0.0'),
+}));
+
+const buildState = (rampsServiceDisruptionModal: unknown) =>
+  ({
+    engine: {
+      backgroundState: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: { rampsServiceDisruptionModal },
+          cacheTimestamp: 0,
+        },
+      },
+    },
+  }) as never;
+
+describe('selectRampsServiceDisruptionRegions', () => {
+  beforeEach(() => {
+    (getVersion as jest.Mock).mockReturnValue('8.0.0');
+  });
+
+  it('returns the configured region codes (object shape, no version floor)', () => {
+    expect(
+      selectRampsServiceDisruptionRegions(
+        buildState({ regions: ['in', 'us-ca'] }),
+      ),
+    ).toEqual(['in', 'us-ca']);
+  });
+
+  it('returns regions when the build meets minimumVersion', () => {
+    (getVersion as jest.Mock).mockReturnValue('8.2.0');
+    expect(
+      selectRampsServiceDisruptionRegions(
+        buildState({ regions: ['in'], minimumVersion: '8.1.0' }),
+      ),
+    ).toEqual(['in']);
+  });
+
+  it('returns [] when the build is older than minimumVersion', () => {
+    (getVersion as jest.Mock).mockReturnValue('8.0.0');
+    expect(
+      selectRampsServiceDisruptionRegions(
+        buildState({ regions: ['in'], minimumVersion: '9.0.0' }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('accepts a bare array (no version gate) for back-compat', () => {
+    expect(
+      selectRampsServiceDisruptionRegions(buildState(['in', 'us-ca'])),
+    ).toEqual(['in', 'us-ca']);
+  });
+
+  it('returns [] when the flag is missing', () => {
+    expect(selectRampsServiceDisruptionRegions(buildState(undefined))).toEqual(
+      [],
+    );
+  });
+
+  it('returns [] when regions is empty', () => {
+    expect(
+      selectRampsServiceDisruptionRegions(buildState({ regions: [] })),
+    ).toEqual([]);
+  });
+
+  it('filters out non-string region entries', () => {
+    expect(
+      selectRampsServiceDisruptionRegions(
+        buildState({ regions: ['in', 5, null, 'fr'] }),
+      ),
+    ).toEqual(['in', 'fr']);
+  });
+});

--- a/app/selectors/featureFlagController/rampsServiceDisruption/index.ts
+++ b/app/selectors/featureFlagController/rampsServiceDisruption/index.ts
@@ -1,0 +1,56 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import { hasMinimumRequiredVersion } from '../../../util/remoteFeatureFlag';
+
+/**
+ * Shape of the `rampsServiceDisruptionModal` remote feature flag.
+ *
+ * - `regions`: lowercase `regionCode`s currently in a service disruption. A country entry (`"in"`) blocks all of its states; a country-state entry (`"us-ca"`) blocks only that state. Missing/empty means the service disruption is off.
+ * - `minimumVersion`: optional semver floor — the service disruption is only honored on native builds `>= minimumVersion`. Absent means it applies to every build that has the feature.
+ */
+export interface RampsServiceDisruptionConfig {
+  regions?: string[];
+  minimumVersion?: string;
+}
+
+/**
+ * Region codes for which the Buy flow is currently in a service disruption, after applying
+ * the optional minimum-version gate. Returns `[]` (service disruption off) when the flag is
+ * missing, has no regions, or the current build is older than `minimumVersion`.
+ *
+ * Accepts either the object shape `{ regions, minimumVersion }` or a bare
+ * `string[]` of regionCodes (back-compat; no version gate). Toggled remotely by
+ * incident teams with no deploy.
+ */
+export const selectRampsServiceDisruptionRegions = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): string[] => {
+    // The flag is either the object shape `{ regions, minimumVersion }` or a
+    // bare `string[]` of regionCodes (back-compat; no version gate).
+    const value = remoteFeatureFlags?.rampsServiceDisruptionModal as
+      | string[]
+      | RampsServiceDisruptionConfig
+      | undefined;
+    const rawRegions = Array.isArray(value) ? value : value?.regions;
+    const regions = Array.isArray(rawRegions)
+      ? rawRegions
+          .filter((region): region is string => typeof region === 'string')
+          .map((region) => region.toLowerCase().trim())
+      : [];
+
+    if (regions.length === 0) {
+      return [];
+    }
+
+    // Version gate: ignore the service disruption on builds older than `minimumVersion`.
+    // Absent minimumVersion => applies to every build that has the feature.
+    const minimumVersion = Array.isArray(value)
+      ? undefined
+      : value?.minimumVersion;
+    if (minimumVersion && !hasMinimumRequiredVersion(minimumVersion)) {
+      return [];
+    }
+
+    return regions;
+  },
+);

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6022,6 +6022,11 @@
       "description": "Buying crypto isn't available in your region due to limitations with local payment providers or regulatory restrictions.",
       "got_it": "Got it"
     },
+    "service_disruption_modal": {
+      "title": "Temporary service disruption",
+      "description": "There's a service disruption in your region. We're working to restore service, but some transactions may not go through until then.",
+      "got_it": "Got it"
+    },
     "region": {
       "buy_crypto_tokens": "Buy crypto tokens",
       "sell_crypto_tokens": "Sell crypto tokens",

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4184,6 +4184,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  rampsServiceDisruptionModal: {
+    name: 'rampsServiceDisruptionModal',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      regions: [],
+      minimumVersion: '8.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   rewardsAnnouncementModalEnabled: {
     name: 'rewardsAnnouncementModalEnabled',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

On-Ramp.Money is MetaMask's only Buy provider in India, and during an outage every Buy purchase there fails silently. With no explanation, users misread the failure as "MetaMask doesn't support my region" — the same perception that drew negative press during a previous India outage. This PR adds a remotely-controlled "Temporary service disruption" bottom sheet that disables the Buy flow and tells affected users the outage is temporary, so an incident team can communicate a provider/region disruption without shipping a build.

The behavior is driven by a new LaunchDarkly flag, `rampsServiceDisruptionModal`, whose value is region-targeted rather than hardcoded to India or On-Ramp.Money — so it is reusable for any region and can be turned on or off with no deploy. The flag value is an object, `{ "regions": ["in"], "minimumVersion": "8.1.0" }`: `regions` is a list of lowercase `regionCode`s matched hierarchically — a country entry like `"us"` blocks the entire United States, while a country-state entry like `"us-ca"` blocks only California (likewise `"in"` blocks all of India). The optional `minimumVersion` is a semver floor so the disruption is only honored on native builds at or above that version. A bare array (`["in"]`) is also accepted for back-compat. Missing, empty, or below-floor values mean the disruption is off.

When the flag covers the user's resolved region, the Buy chokepoint navigates to the new blocking sheet and returns, so the Buy flow is disabled across every entry point at once. Sell and deposit are untouched.

Implementation:

- `selectRampsServiceDisruptionRegions` selector reads the `rampsServiceDisruptionModal` flag, normalizes region codes, and applies the optional `minimumVersion` gate via `hasMinimumRequiredVersion` (returning `[]` when the disruption is off).
- `isRampsServiceDisruptionActive` pure util matches the user's resolved `regionCode` against the configured list (lowercased, hierarchical country/state match), falling back to IP geolocation, and only blocks on a definitive region signal.
- `RampsServiceDisruptionModal` bottom sheet presents the "Temporary service disruption" copy with a close button and a "Got it" action.
- The check is wired into the single Buy chokepoint `useRampNavigation.goToBuy` (covering all entry points, including the deprecated override/aggregator path) and the unified Buy deeplink handler `handleRampUrl`, ahead of the eligibility/unsupported-region gating so a disruption is surfaced even when geolocation is unknown.
- Route registration in `App.tsx` / `Routes.ts` and English copy in `en.json`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a temporary service disruption notice that explains a provider outage and disables the Buy flow for users in affected regions, controllable remotely via feature flag.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3667

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Ramp service disruption sheet

  Scenario: Buy is blocked for a region under service disruption
    Given the rampsServiceDisruptionModal flag is set to { "regions": ["in"] } (or the user's resolved region) on a build that meets minimumVersion
    And the user's resolved region is India
    When the user taps Buy from any entry point (wallet actions, token, or a Buy deeplink)
    Then the "Temporary service disruption" bottom sheet appears
    And the Buy flow does not open
    And dismissing the sheet returns the user out of Buy

  Scenario: Buy is unaffected when the region is not listed
    Given the rampsServiceDisruptionModal flag is empty (or lists a different region)
    When the user taps Buy
    Then the normal Buy flow opens and no sheet appears

  Scenario: Version gate suppresses the disruption on older builds
    Given the flag is set to { "regions": ["in"], "minimumVersion": "8.1.0" }
    And the installed build reports a version below 8.1.0
    When the user taps Buy
    Then the normal Buy flow opens and no sheet appears

  Scenario: Sell is never blocked
    Given the rampsServiceDisruptionModal flag covers the user's region
    When the user taps Sell
    Then the Sell flow opens normally
```

<!-- Tip: with no LaunchDarkly access you can drive this locally via the feature-flag dev override, setting `rampsServiceDisruptionModal` to `{ "regions": ["<your resolved regionCode>"] }`. -->

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- TODO: attach a recording of tapping Buy in an affected region BEFORE this change (grayed-out token list / no explanation). -->

### **After**

<!-- TODO: attach a recording of the "Temporary service disruption" sheet appearing on Buy and Buy being blocked. -->

https://github.com/user-attachments/assets/561935c8-24b0-46c5-9a3a-89a9e1b267ba




## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central Buy routing and deeplink handling for ramps; misconfigured flags could block Buy in wrong regions, but scope is gated UI navigation with no payment or auth changes.
> 
> **Overview**
> Adds a **remotely toggled** Buy kill-switch: when `rampsServiceDisruptionModal` lists the user’s resolved region (with optional `minimumVersion`), **Buy navigation stops** and shows a **“Temporary service disruption”** bottom sheet instead of token selection or eligibility/unsupported flows.
> 
> Introduces **`RampInfoBottomSheet`** as a shared title/description/actions sheet, refactors **`RampUnsupportedModal`** onto it, and registers **`RampsServiceDisruptionModal`** on a new sheet route. **`selectRampsServiceDisruptionRegions`** normalizes flag config; **`isRampsServiceDisruptionActive`** matches region codes hierarchically (country vs state) with geolocation fallback.
> 
> The check runs **ahead of** eligibility and unsupported-region gating in **`useRampNavigation.goToBuy`** (including deprecated aggregator override) and **`handleRampUrl`**, so disruption can surface even when geolocation is unknown. English copy and feature-flag registry entry included; tests cover selector, util, navigation, and deeplink behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6395d07a02a6b81173c2cc119b7a2ddc7ea5ae2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->