### PR TITLE
feat(card): gate forgot password link behind cardForgotPasswordFeature flag

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.test.tsx
@@ -60,6 +60,12 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('../../hooks/useCardAuth');
 
+let mockIsForgotPasswordEnabled = true;
+jest.mock('../../../../../selectors/featureFlagController/card', () => ({
+  ...jest.requireActual('../../../../../selectors/featureFlagController/card'),
+  selectCardForgotPasswordFeatureEnabled: () => mockIsForgotPasswordEnabled,
+}));
+
 const mockUseCardAuth = useCardAuth as jest.MockedFunction<typeof useCardAuth>;
 
 const mockInitiateMutateAsync = jest.fn();
@@ -194,6 +200,7 @@ jest.useFakeTimers({ advanceTimers: true });
 describe('CardAuthentication Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsForgotPasswordEnabled = true;
     mockRouteParams = {};
 
     mockInitiateMutateAsync.mockResolvedValue(undefined);
@@ -1014,6 +1021,18 @@ describe('CardAuthentication Component', () => {
       expect(
         screen.getByTestId(CardAuthenticationSelectors.FORGOT_PASSWORD_BUTTON),
       ).toBeOnTheScreen();
+    });
+
+    it('does not render the forgot password link when the feature flag is disabled', () => {
+      mockIsForgotPasswordEnabled = false;
+
+      render();
+
+      expect(
+        screen.queryByTestId(
+          CardAuthenticationSelectors.FORGOT_PASSWORD_BUTTON,
+        ),
+      ).not.toBeOnTheScreen();
     });
 
     it('does not render the forgot password link on the OTP step', () => {

--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -32,6 +32,7 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useDispatch, useSelector } from 'react-redux';
 import { setOnboardingId } from '../../../../../core/redux/slices/card';
 import { selectCardUserLocation } from '../../../../../selectors/cardController';
+import { selectCardForgotPasswordFeatureEnabled } from '../../../../../selectors/featureFlagController/card';
 import { CardMessageBoxType, type CardLocation } from '../../types';
 import { CardActions, CardScreens } from '../../util/metrics';
 import OnboardingStep from '../../components/Onboarding/OnboardingStep';
@@ -67,6 +68,9 @@ const CardAuthentication = () => {
   const [password, setPassword] = useState('');
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const persistedLocation = useSelector(selectCardUserLocation);
+  const isForgotPasswordEnabled = useSelector(
+    selectCardForgotPasswordFeatureEnabled,
+  );
   const [selectedLocation, setSelectedLocation] = useState<CardLocation>(
     persistedLocation ?? 'international',
   );
@@ -500,19 +504,21 @@ const CardAuthentication = () => {
                 testID: CardAuthenticationSelectors.PASSWORD_FIELD,
               }}
             />
-            <TouchableOpacity
-              onPress={handleForgotPassword}
-              testID={CardAuthenticationSelectors.FORGOT_PASSWORD_BUTTON}
-              style={tw.style('self-end mt-2')}
-            >
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                twClassName="text-default"
+            {isForgotPasswordEnabled && (
+              <TouchableOpacity
+                onPress={handleForgotPassword}
+                testID={CardAuthenticationSelectors.FORGOT_PASSWORD_BUTTON}
+                style={tw.style('self-end mt-2')}
               >
-                {strings('card.card_authentication.forgot_password_button')}
-              </Text>
-            </TouchableOpacity>
+                <Text
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                  twClassName="text-default"
+                >
+                  {strings('card.card_authentication.forgot_password_button')}
+                </Text>
+              </TouchableOpacity>
+            )}
           </Box>
         </>
       ),
@@ -525,6 +531,7 @@ const CardAuthentication = () => {
       handleOtpValueChange,
       handlePasswordChange,
       handleResendOtp,
+      isForgotPasswordEnabled,
       isPasswordVisible,
       isOtpStep,
       otpError,

--- a/app/selectors/featureFlagController/card/index.test.ts
+++ b/app/selectors/featureFlagController/card/index.test.ts
@@ -6,6 +6,7 @@ import {
   selectMetalCardCheckoutFeatureFlag,
   selectGalileoAppleWalletProvisioningEnabled,
   selectGalileoGoogleWalletProvisioningEnabled,
+  selectCardForgotPasswordFeatureEnabled,
 } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
@@ -727,6 +728,146 @@ describe('selectGalileoGoogleWalletProvisioningEnabled', () => {
     } as any;
 
     const result = selectGalileoGoogleWalletProvisioningEnabled(
+      stateWithMalformedFlag,
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('selectCardForgotPasswordFeatureEnabled', () => {
+  const mockedValidatedVersionGatedFeatureFlag =
+    validatedVersionGatedFeatureFlag as jest.MockedFunction<
+      typeof validatedVersionGatedFeatureFlag
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns false when feature flag state is empty', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const result = selectCardForgotPasswordFeatureEnabled(
+      mockedEmptyFlagsState,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when RemoteFeatureFlagController state is undefined', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const result = selectCardForgotPasswordFeatureEnabled(
+      mockedUndefinedFlagsState,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when feature flag is enabled and version requirement is met', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(true);
+
+    const stateWithForgotPassword = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardForgotPasswordFeature: {
+                enabled: true,
+                minimumVersion: '7.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardForgotPasswordFeatureEnabled(
+      stateWithForgotPassword,
+    );
+
+    expect(result).toBe(true);
+    expect(mockedValidatedVersionGatedFeatureFlag).toHaveBeenCalledWith({
+      enabled: true,
+      minimumVersion: '7.0.0',
+    });
+  });
+
+  it('returns false when feature flag is disabled', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(false);
+
+    const stateWithDisabledFlag = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardForgotPasswordFeature: {
+                enabled: false,
+                minimumVersion: '7.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardForgotPasswordFeatureEnabled(
+      stateWithDisabledFlag,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when version requirement is not met', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(false);
+
+    const stateWithVersionGate = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardForgotPasswordFeature: {
+                enabled: true,
+                minimumVersion: '99.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardForgotPasswordFeatureEnabled(stateWithVersionGate);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when validatedVersionGatedFeatureFlag returns undefined', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const stateWithMalformedFlag = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardForgotPasswordFeature: {
+                enabled: 'true', // Invalid type
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardForgotPasswordFeatureEnabled(
       stateWithMalformedFlag,
     );
 

--- a/app/selectors/featureFlagController/card/index.ts
+++ b/app/selectors/featureFlagController/card/index.ts
@@ -224,3 +224,13 @@ export const selectGalileoGoogleWalletProvisioningEnabled = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );
+
+export const selectCardForgotPasswordFeatureEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.cardForgotPasswordFeature as unknown as GateVersionedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -685,6 +685,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  cardForgotPasswordFeature: {
+    name: 'cardForgotPasswordFeature',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: {
+      enabled: true,
+      minimumVersion: '8.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   cardSupportedCountries: {
     name: 'cardSupportedCountries',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
## **Description**

Gates the "Forgot password" link on the Card authentication screen behind a new version-gated remote feature flag (`cardForgotPasswordFeature`).

1. **What is the reason for the change?** The "Forgot password" entry point needs to be remotely controllable so it can be rolled out (and version-gated) independently of the app release.
2. **What is the improvement/solution?** Added a new `selectCardForgotPasswordFeatureEnabled` selector that follows the canonical version-gated feature flag pattern (`validatedVersionGatedFeatureFlag`, defaults to `false`). `CardAuthentication` consumes it and only renders the "Forgot password" `TouchableOpacity` when the flag is enabled and the minimum version requirement is met.

## **Changelog**

CHANGELOG entry: Gated the Card "Forgot password" option behind the cardForgotPasswordFeature remote feature flag.

## **Related issues**

Fixes: CARD-542

## **Manual testing steps**

```gherkin
Feature: Card forgot password feature flag

  Scenario: Forgot password link is visible when the flag is enabled
    Given the cardForgotPasswordFeature remote flag is enabled and the app meets the minimum version
    When the user opens the Card authentication (login) screen
    Then the "Forgot password" link is displayed below the password field

  Scenario: Forgot password link is hidden when the flag is disabled
    Given the cardForgotPasswordFeature remote flag is disabled or absent
    When the user opens the Card authentication (login) screen
    Then the "Forgot password" link is not displayed
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)