### PR TITLE
chore: fix titles of money account card transactions cp-8.0.0

### DIFF
--- a/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.test.tsx
@@ -187,17 +187,12 @@ describe('MoneyApiActivityDetailsView', () => {
     });
 
     it('renders the From row with the Money account label', () => {
-      const { getByText } = render(<MoneyApiActivityDetailsView />);
-      expect(getByText('transaction_details.label.from')).toBeTruthy();
-      expect(getByText('transaction_details.label.money_account')).toBeTruthy();
-    });
-
-    it('renders the To row with the merchant address', () => {
-      const { getByText, getByTestId } = render(
+      const { getByText, queryByText } = render(
         <MoneyApiActivityDetailsView />,
       );
-      expect(getByText('transaction_details.label.to')).toBeTruthy();
-      expect(getByTestId('counterparty-name')).toHaveTextContent(card.paidTo);
+      expect(getByText('transaction_details.label.from')).toBeTruthy();
+      expect(getByText('transaction_details.label.money_account')).toBeTruthy();
+      expect(queryByText('transaction_details.label.to')).toBeNull();
     });
   });
 
@@ -221,6 +216,11 @@ describe('MoneyApiActivityDetailsView', () => {
     it('renders the "You earned" label', () => {
       const { getByText } = render(<MoneyApiActivityDetailsView />);
       expect(getByText('money.api_activity_details.you_earned')).toBeTruthy();
+    });
+
+    it('renders the Money account hero icon', () => {
+      const { getByTestId } = render(<MoneyApiActivityDetailsView />);
+      expect(getByTestId('money-account-hero-icon')).toBeTruthy();
     });
 
     it('renders the "Received from" row with the sender', () => {

--- a/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.test.tsx
@@ -164,10 +164,10 @@ describe('MoneyApiActivityDetailsView', () => {
   });
 
   describe('card spend', () => {
-    it('renders the card title', () => {
+    it('renders the Purchase title', () => {
       const { getByTestId } = render(<MoneyApiActivityDetailsView />);
       expect(getByTestId('header-title')).toHaveTextContent(
-        'money.api_activity_details.card_title',
+        'money.transaction.purchase',
       );
     });
 
@@ -181,10 +181,23 @@ describe('MoneyApiActivityDetailsView', () => {
       expect(getByText('money.api_activity_details.you_spent')).toBeTruthy();
     });
 
-    it('renders the "To" row with the "Money account" label', () => {
+    it('renders the Money account hero icon', () => {
+      const { getByTestId } = render(<MoneyApiActivityDetailsView />);
+      expect(getByTestId('money-account-hero-icon')).toBeTruthy();
+    });
+
+    it('renders the From row with the Money account label', () => {
       const { getByText } = render(<MoneyApiActivityDetailsView />);
-      expect(getByText('transaction_details.label.to')).toBeTruthy();
+      expect(getByText('transaction_details.label.from')).toBeTruthy();
       expect(getByText('transaction_details.label.money_account')).toBeTruthy();
+    });
+
+    it('renders the To row with the merchant address', () => {
+      const { getByText, getByTestId } = render(
+        <MoneyApiActivityDetailsView />,
+      );
+      expect(getByText('transaction_details.label.to')).toBeTruthy();
+      expect(getByTestId('counterparty-name')).toHaveTextContent(card.paidTo);
     });
   });
 
@@ -193,10 +206,10 @@ describe('MoneyApiActivityDetailsView', () => {
       mockRouteParams = { activity: cashback };
     });
 
-    it('renders the cashback title', () => {
+    it('renders the mUSD back title', () => {
       const { getByTestId } = render(<MoneyApiActivityDetailsView />);
       expect(getByTestId('header-title')).toHaveTextContent(
-        'money.api_activity_details.cashback_title',
+        'money.transaction.musd_back',
       );
     });
 

--- a/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.tsx
+++ b/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.tsx
@@ -63,6 +63,7 @@ const iconStyles = StyleSheet.create({
     justifyContent: 'center' as const,
   },
   moneyIcon: { width: 32, height: 32 },
+  heroMoneyIcon: { width: 32, height: 32, borderRadius: 16 },
 });
 
 /**
@@ -159,11 +160,7 @@ function MoneyApiActivityDetailsContent({
   return (
     <View style={styles.wrapper}>
       <HeaderStandard
-        title={strings(
-          isCard
-            ? 'money.api_activity_details.card_title'
-            : 'money.api_activity_details.cashback_title',
-        )}
+        title={display.label}
         onBack={handleBack}
         backButtonProps={{ testID: 'card-transaction-details-back-button' }}
         includesTopInset
@@ -184,12 +181,20 @@ function MoneyApiActivityDetailsContent({
               alignItems={AlignItems.center}
               gap={12}
             >
-              <TokenIcon
-                chainId={activity.chainId}
-                address={activity.token.address}
-                symbol={activity.token.symbol}
-                variant={TokenIconVariant.Hero}
-              />
+              {isCard ? (
+                <Image
+                  source={MoneyIcon}
+                  style={iconStyles.heroMoneyIcon}
+                  testID="money-account-hero-icon"
+                />
+              ) : (
+                <TokenIcon
+                  chainId={activity.chainId}
+                  address={activity.token.address}
+                  symbol={activity.token.symbol}
+                  variant={TokenIconVariant.Hero}
+                />
+              )}
               <Text
                 variant={TextVariant.DisplayMD}
                 color={
@@ -238,29 +243,42 @@ function MoneyApiActivityDetailsContent({
             </TransactionDetailsRow>
           ) : null}
 
-          {/* Counterparty. Card spends are framed as leaving the money account
-              ("To: Money account"); musdback shows the actual sender. */}
+          {/* Card spends mirror send details: From Money account → merchant. */}
           {isCard ? (
-            <TransactionDetailsRow
-              label={strings('transaction_details.label.to')}
-            >
-              <Box
-                flexDirection={FlexDirection.Row}
-                alignItems={AlignItems.center}
-                gap={6}
+            <>
+              <TransactionDetailsRow
+                label={strings('transaction_details.label.from')}
               >
-                <View style={iconStyles.moneyIconWrapper}>
-                  <Image
-                    source={MoneyIcon}
-                    style={iconStyles.moneyIcon}
-                    testID="money-account-icon"
-                  />
-                </View>
-                <Text>
-                  {strings('transaction_details.label.money_account')}
-                </Text>
-              </Box>
-            </TransactionDetailsRow>
+                <Box
+                  flexDirection={FlexDirection.Row}
+                  alignItems={AlignItems.center}
+                  gap={6}
+                >
+                  <View style={iconStyles.moneyIconWrapper}>
+                    <Image
+                      source={MoneyIcon}
+                      style={iconStyles.moneyIcon}
+                      testID="money-account-icon"
+                    />
+                  </View>
+                  <Text>
+                    {strings('transaction_details.label.money_account')}
+                  </Text>
+                </Box>
+              </TransactionDetailsRow>
+
+              <TransactionDetailDivider />
+
+              <TransactionDetailsRow
+                label={strings('transaction_details.label.to')}
+              >
+                <Name
+                  type={NameType.EthereumAddress}
+                  value={activity.paidTo}
+                  variation={activity.chainId}
+                />
+              </TransactionDetailsRow>
+            </>
           ) : (
             <TransactionDetailsRow
               label={strings('money.api_activity_details.received_from')}

--- a/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.tsx
+++ b/app/components/UI/Money/Views/MoneyApiActivityDetailsView/MoneyApiActivityDetailsView.tsx
@@ -33,10 +33,6 @@ import Routes from '../../../../../constants/navigation/Routes';
 import I18n, { strings } from '../../../../../../locales/i18n';
 import { TransactionDetailDivider } from '../../../../Views/confirmations/components/activity/transaction-detail-divider/transaction-detail-divider';
 import { TransactionDetailsRow } from '../../../../Views/confirmations/components/activity/transaction-details-row/transaction-details-row';
-import {
-  TokenIcon,
-  TokenIconVariant,
-} from '../../../../Views/confirmations/components/token-icon';
 import useNetworkInfo from '../../../../Views/confirmations/hooks/useNetworkInfo';
 import Name from '../../../Name/Name';
 import { NameType } from '../../../Name/Name.types';
@@ -181,20 +177,11 @@ function MoneyApiActivityDetailsContent({
               alignItems={AlignItems.center}
               gap={12}
             >
-              {isCard ? (
-                <Image
-                  source={MoneyIcon}
-                  style={iconStyles.heroMoneyIcon}
-                  testID="money-account-hero-icon"
-                />
-              ) : (
-                <TokenIcon
-                  chainId={activity.chainId}
-                  address={activity.token.address}
-                  symbol={activity.token.symbol}
-                  variant={TokenIconVariant.Hero}
-                />
-              )}
+              <Image
+                source={MoneyIcon}
+                style={iconStyles.heroMoneyIcon}
+                testID="money-account-hero-icon"
+              />
               <Text
                 variant={TextVariant.DisplayMD}
                 color={
@@ -243,42 +230,28 @@ function MoneyApiActivityDetailsContent({
             </TransactionDetailsRow>
           ) : null}
 
-          {/* Card spends mirror send details: From Money account → merchant. */}
+          {/* Card spends show the source account only; merchant is not surfaced yet. */}
           {isCard ? (
-            <>
-              <TransactionDetailsRow
-                label={strings('transaction_details.label.from')}
+            <TransactionDetailsRow
+              label={strings('transaction_details.label.from')}
+            >
+              <Box
+                flexDirection={FlexDirection.Row}
+                alignItems={AlignItems.center}
+                gap={6}
               >
-                <Box
-                  flexDirection={FlexDirection.Row}
-                  alignItems={AlignItems.center}
-                  gap={6}
-                >
-                  <View style={iconStyles.moneyIconWrapper}>
-                    <Image
-                      source={MoneyIcon}
-                      style={iconStyles.moneyIcon}
-                      testID="money-account-icon"
-                    />
-                  </View>
-                  <Text>
-                    {strings('transaction_details.label.money_account')}
-                  </Text>
-                </Box>
-              </TransactionDetailsRow>
-
-              <TransactionDetailDivider />
-
-              <TransactionDetailsRow
-                label={strings('transaction_details.label.to')}
-              >
-                <Name
-                  type={NameType.EthereumAddress}
-                  value={activity.paidTo}
-                  variation={activity.chainId}
-                />
-              </TransactionDetailsRow>
-            </>
+                <View style={iconStyles.moneyIconWrapper}>
+                  <Image
+                    source={MoneyIcon}
+                    style={iconStyles.moneyIcon}
+                    testID="money-account-icon"
+                  />
+                </View>
+                <Text>
+                  {strings('transaction_details.label.money_account')}
+                </Text>
+              </Box>
+            </TransactionDetailsRow>
           ) : (
             <TransactionDetailsRow
               label={strings('money.api_activity_details.received_from')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes several card spend and cashback detail-screen issues in `MoneyApiActivityDetailsView`:

- **Title (MUSD-1069):** Use the activity list label (`Purchase` / `mUSD back`) via `display.label` instead of the generic `Card transaction` header.
- **Hero icon (MUSD-1070):** Show the Money account icon for card spends and cashback instead of a broken/missing token icon.
- **Account row (MUSD-1071):** For card spends, show a **From: Money account** row (matching send-style details) instead of the incorrect **To: Money account** row. Merchant/recipient is intentionally omitted until that data is available.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed card spend and cashback activity detail titles, icons, and account rows on the Money account activity screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1069](https://consensyssoftware.atlassian.net/browse/MUSD-1069), [MUSD-1070](https://consensyssoftware.atlassian.net/browse/MUSD-1070), [MUSD-1071](https://consensyssoftware.atlassian.net/browse/MUSD-1071)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account card activity details

  Scenario: Card spend detail screen shows corrected layout
    Given a wallet with Money account card spend activity
    And the moneyEnableActivityDetails feature flag is enabled

    When the user opens a card spend from the activity list
    Then the header reads "Purchase"
    And the hero shows the Money account icon and spent amount
    And a "From: Money account" row is shown
    And no "To" row is shown

  Scenario: Cashback detail screen shows corrected layout
    Given a wallet with Money account cashback activity
    And the moneyEnableActivityDetails feature flag is enabled

    When the user opens a cashback entry from the activity list
    Then the header reads "mUSD back"
    And the hero shows the Money account icon and earned amount
    And a "Received from" row shows the sender address
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="735" height="1600" alt="image" src="https://github.com/user-attachments/assets/f753673c-2d0e-4f12-b6af-c9bb56e4545a" />


<!-- [screenshots/recordings] -->


### **After**
<img width="1170" height="2532" alt="simulator_screenshot_C20B17B8-F0FD-4C53-A08B-603049143899" src="https://github.com/user-attachments/assets/c1f8513b-92d9-4ae1-a810-e0838561aced" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUSD-1069]: https://consensyssoftware.atlassian.net/browse/MUSD-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ