### PR TITLE
fix(card): cp-8.0.0 keep Money Account branding when DelegationSettings omits VEDA

### DIFF
--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -448,6 +448,14 @@ describe('useMoneyAccountCardLinkage', () => {
       expect(result.current.canLink).toBe(false);
     });
 
+    it('reports hasMoneyAccountRequirements=false when VEDA is allowlisted in cardFeature but missing from DelegationSettings', () => {
+      mockResolveMoneyAccountCardToken.mockReturnValue(null);
+      const { result } = renderLinkageHook();
+      expect(result.current.moneyAccountCardToken).toBeNull();
+      expect(result.current.hasMoneyAccountRequirements).toBe(false);
+      expect(result.current.canLink).toBe(false);
+    });
+
     it('reports canLink=false when the Money Account is already delegated for card (re-link suppressed)', () => {
       applySelectorMocks(buildSelectors({ isAlreadyDelegated: true }));
       const { result } = renderLinkageHook();

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -173,7 +173,7 @@ export const useMoneyAccountCardLinkage =
     });
 
     const hasRequirements =
-      hasMoneyAccountBaseRequirements && isMoneyAccountCardSupported;
+      hasMoneyAccountBaseRequirements && Boolean(moneyAccountCardToken);
 
     const canSubmitDelegation = Boolean(
       hasRequirements &&

--- a/app/components/UI/Card/util/vedaToken.test.ts
+++ b/app/components/UI/Card/util/vedaToken.test.ts
@@ -2,6 +2,7 @@ import type { CaipChainId } from '@metamask/utils';
 import type { DelegationSettingsResponse } from '../types';
 import {
   getVedaTokenConfig,
+  getVedaTokenConfigFromFeatureFlag,
   isVedaToken,
   isMoneyAccountCardTokenAllowlisted,
   MONEY_ACCOUNT_DELEGATION_NETWORK,
@@ -103,6 +104,94 @@ describe('getVedaTokenConfig', () => {
   it('matches network case-insensitively', () => {
     const config = getVedaTokenConfig(makeSettings({ network: 'Monad' }));
     expect(config?.address).toBe(VEDA_ADDRESS);
+  });
+});
+
+describe('getVedaTokenConfigFromFeatureFlag', () => {
+  it('returns null when chains is null/undefined', () => {
+    expect(getVedaTokenConfigFromFeatureFlag(null)).toBeNull();
+    expect(getVedaTokenConfigFromFeatureFlag(undefined)).toBeNull();
+  });
+
+  it('returns null when no veda token is allowlisted', () => {
+    expect(
+      getVedaTokenConfigFromFeatureFlag({
+        'eip155:143': {
+          tokens: [{ symbol: 'USDC', address: USDC_ADDRESS, decimals: 6 }],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when the veda token is disabled', () => {
+    expect(
+      getVedaTokenConfigFromFeatureFlag({
+        'eip155:143': {
+          tokens: [
+            {
+              symbol: 'veda',
+              address: VEDA_ADDRESS,
+              decimals: 6,
+              enabled: false,
+            },
+          ],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when the veda token has no address', () => {
+    expect(
+      getVedaTokenConfigFromFeatureFlag({
+        'eip155:143': {
+          tokens: [{ symbol: 'veda', address: '', decimals: 6 }],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('builds a config (without delegationContract) from the veda token', () => {
+    expect(
+      getVedaTokenConfigFromFeatureFlag({
+        'eip155:143': {
+          tokens: [
+            { symbol: 'USDC', address: USDC_ADDRESS, decimals: 6 },
+            { symbol: 'VEDA', address: VEDA_ADDRESS, decimals: 6 },
+          ],
+        },
+      }),
+    ).toEqual({
+      caipChainId: 'eip155:143',
+      address: VEDA_ADDRESS,
+      decimals: 6,
+    });
+  });
+
+  it('treats a token with enabled omitted as enabled', () => {
+    const config = getVedaTokenConfigFromFeatureFlag({
+      'eip155:143': {
+        tokens: [{ symbol: 'veda', address: VEDA_ADDRESS, decimals: 6 }],
+      },
+    });
+    expect(config?.address).toBe(VEDA_ADDRESS);
+  });
+
+  it('defaults decimals to 6 when missing', () => {
+    const config = getVedaTokenConfigFromFeatureFlag({
+      'eip155:143': {
+        tokens: [{ symbol: 'veda', address: VEDA_ADDRESS }],
+      },
+    });
+    expect(config?.decimals).toBe(6);
+  });
+
+  it('uses the chain key as the CAIP chain id', () => {
+    const config = getVedaTokenConfigFromFeatureFlag({
+      'eip155:59144': {
+        tokens: [{ symbol: 'veda', address: VEDA_ADDRESS, decimals: 6 }],
+      },
+    });
+    expect(config?.caipChainId).toBe('eip155:59144');
   });
 });
 

--- a/app/components/UI/Card/util/vedaToken.test.ts
+++ b/app/components/UI/Card/util/vedaToken.test.ts
@@ -185,13 +185,30 @@ describe('getVedaTokenConfigFromFeatureFlag', () => {
     expect(config?.decimals).toBe(6);
   });
 
-  it('uses the chain key as the CAIP chain id', () => {
+  it('ignores veda tokens on non-Monad chains', () => {
+    expect(
+      getVedaTokenConfigFromFeatureFlag({
+        'eip155:59144': {
+          tokens: [{ symbol: 'veda', address: VEDA_ADDRESS, decimals: 6 }],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('resolves the Monad veda row when veda is listed on multiple chains', () => {
     const config = getVedaTokenConfigFromFeatureFlag({
       'eip155:59144': {
+        tokens: [{ symbol: 'veda', address: USDC_ADDRESS, decimals: 6 }],
+      },
+      'eip155:143': {
         tokens: [{ symbol: 'veda', address: VEDA_ADDRESS, decimals: 6 }],
       },
     });
-    expect(config?.caipChainId).toBe('eip155:59144');
+    expect(config).toEqual({
+      caipChainId: 'eip155:143',
+      address: VEDA_ADDRESS,
+      decimals: 6,
+    });
   });
 });
 

--- a/app/components/UI/Card/util/vedaToken.ts
+++ b/app/components/UI/Card/util/vedaToken.ts
@@ -11,7 +11,7 @@ export interface VedaTokenConfig {
   caipChainId: CaipChainId;
   address: string;
   decimals: number;
-  delegationContract: string;
+  delegationContract?: string;
 }
 
 const parseEvmCaipChainId = (chainId: string): CaipChainId => {
@@ -49,6 +49,49 @@ export const getVedaTokenConfig = (
     decimals: vedaToken.decimals,
     delegationContract: monadNetwork.delegationContract,
   };
+};
+
+export const getVedaTokenConfigFromFeatureFlag = (
+  chains:
+    | Record<
+        string,
+        | {
+            tokens?:
+              | {
+                  address?: string | null;
+                  symbol?: string | null;
+                  decimals?: number | null;
+                  enabled?: boolean | null;
+                }[]
+              | null;
+          }
+        | undefined
+      >
+    | null
+    | undefined,
+): VedaTokenConfig | null => {
+  if (!chains) {
+    return null;
+  }
+
+  for (const [chainId, chain] of Object.entries(chains)) {
+    const vedaToken = (chain?.tokens ?? []).find(
+      (token) =>
+        token?.enabled !== false &&
+        !!token?.address &&
+        token.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+    );
+
+    if (vedaToken?.address) {
+      return {
+        caipChainId: chainId as CaipChainId,
+        address: vedaToken.address,
+        decimals: vedaToken.decimals ?? 6,
+      };
+    }
+  }
+
+  return null;
 };
 
 export const isVedaToken = (

--- a/app/components/UI/Card/util/vedaToken.ts
+++ b/app/components/UI/Card/util/vedaToken.ts
@@ -3,6 +3,9 @@ import type { DelegationSettingsResponse } from '../types';
 
 export const MONEY_ACCOUNT_DELEGATION_NETWORK = 'monad';
 
+export const MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID =
+  'eip155:143' as CaipChainId;
+
 export const MONEY_ACCOUNT_DELEGATION_TOKEN_KEY = 'veda';
 
 export const MONEY_ACCOUNT_DISPLAY_SYMBOL = 'mUSD';
@@ -70,28 +73,24 @@ export const getVedaTokenConfigFromFeatureFlag = (
     | null
     | undefined,
 ): VedaTokenConfig | null => {
-  if (!chains) {
+  const vedaToken = (
+    chains?.[MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID]?.tokens ?? []
+  ).find(
+    (token) =>
+      token?.enabled !== false &&
+      !!token?.address &&
+      token.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+  );
+
+  if (!vedaToken?.address) {
     return null;
   }
 
-  for (const [chainId, chain] of Object.entries(chains)) {
-    const vedaToken = (chain?.tokens ?? []).find(
-      (token) =>
-        token?.enabled !== false &&
-        !!token?.address &&
-        token.symbol?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
-    );
-
-    if (vedaToken?.address) {
-      return {
-        caipChainId: chainId as CaipChainId,
-        address: vedaToken.address,
-        decimals: vedaToken.decimals ?? 6,
-      };
-    }
-  }
-
-  return null;
+  return {
+    caipChainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+    address: vedaToken.address,
+    decimals: vedaToken.decimals ?? 6,
+  };
 };
 
 export const isVedaToken = (

--- a/app/components/UI/Money/utils/moneyMetaMaskCardMode.test.ts
+++ b/app/components/UI/Money/utils/moneyMetaMaskCardMode.test.ts
@@ -90,6 +90,17 @@ describe('deriveMoneyMetaMaskCardMode', () => {
     ).toBe('link');
   });
 
+  it('returns null for a verified authenticated non-cardholder when full requirements are not met', () => {
+    expect(
+      deriveMoneyMetaMaskCardMode({
+        ...baseInput,
+        isCardAuthenticated: true,
+        isCardVerified: true,
+        hasMoneyAccountRequirements: false,
+      }),
+    ).toBeNull();
+  });
+
   it('returns verifying for an authenticated but unverified non-cardholder', () => {
     expect(
       deriveMoneyMetaMaskCardMode({

--- a/app/components/UI/Money/utils/moneyMetaMaskCardMode.test.ts
+++ b/app/components/UI/Money/utils/moneyMetaMaskCardMode.test.ts
@@ -90,17 +90,6 @@ describe('deriveMoneyMetaMaskCardMode', () => {
     ).toBe('link');
   });
 
-  it('returns null for a verified authenticated non-cardholder when full requirements are not met', () => {
-    expect(
-      deriveMoneyMetaMaskCardMode({
-        ...baseInput,
-        isCardAuthenticated: true,
-        isCardVerified: true,
-        hasMoneyAccountRequirements: false,
-      }),
-    ).toBeNull();
-  });
-
   it('returns verifying for an authenticated but unverified non-cardholder', () => {
     expect(
       deriveMoneyMetaMaskCardMode({

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -2324,33 +2324,6 @@ describe('CardController — data pass-throughs', () => {
     });
   });
 
-  describe('getFundingConfig', () => {
-    it('delegates to provider.getFundingConfig', async () => {
-      const mockConfig = {
-        maxLimit: 1000,
-        fundingOptions: [],
-        supportedChains: [],
-      };
-      const mockGetFundingConfig = jest.fn().mockResolvedValue(mockConfig);
-      const provider = buildMockProvider({
-        getFundingConfig: mockGetFundingConfig,
-      });
-      const { controller } = buildAuthenticatedController(provider);
-
-      const result = await controller.getFundingConfig();
-      expect(result).toStrictEqual(mockConfig);
-    });
-
-    it('throws when provider does not support getFundingConfig', async () => {
-      const provider = buildMockProvider({ getFundingConfig: undefined });
-      const { controller } = buildAuthenticatedController(provider);
-
-      await expect(controller.getFundingConfig()).rejects.toThrow(
-        'Funding config not supported',
-      );
-    });
-  });
-
   describe('fetchDelegationChallenge', () => {
     it('delegates to provider.fetchDelegationChallenge', async () => {
       const mockFetch = jest.fn().mockResolvedValue({

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -982,18 +982,6 @@ export class CardController extends BaseController<
     return this.#withAuthRetry((tokens) => getCardPinView(tokens, params));
   }
 
-  async getFundingConfig(): Promise<CardFundingConfig> {
-    const provider = this.getActiveProvider();
-    const getFundingConfig = provider.getFundingConfig?.bind(provider);
-    if (!getFundingConfig) {
-      throw new CardProviderError(
-        CardProviderErrorCode.Unknown,
-        'Funding config not supported',
-      );
-    }
-    return this.#withAuthRetry((tokens) => getFundingConfig(tokens));
-  }
-
   async updateAssetPriority(
     asset: CardFundingAsset,
     allAssets: CardFundingAsset[],

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -28,7 +28,6 @@ import {
   type CardCredentials,
   type CardDetails,
   type CardFundingAsset,
-  type CardFundingConfig,
   type CardHomeData,
   type CardProviderCapabilities,
   type CardSecureView,

--- a/app/core/Engine/controllers/card-controller/provider-types.ts
+++ b/app/core/Engine/controllers/card-controller/provider-types.ts
@@ -376,7 +376,6 @@ export interface ICardProvider {
     allAssets: CardFundingAsset[],
     tokens: CardAuthTokens,
   ): Promise<void>;
-  getFundingConfig?(tokens: CardAuthTokens): Promise<CardFundingConfig>;
   fetchDelegationChallenge?(
     params: { network: string; address: string; faucet?: boolean },
     tokens: CardAuthTokens,

--- a/app/core/Engine/controllers/card-controller/provider-types.ts
+++ b/app/core/Engine/controllers/card-controller/provider-types.ts
@@ -258,17 +258,6 @@ export interface DelegationChallengeResponse {
   expiresAt: string;
 }
 
-export interface CardFundingOption {
-  symbol: string;
-  asset: CardFundingAsset | null;
-}
-
-export interface CardFundingConfig {
-  maxLimit: string;
-  fundingOptions: CardFundingOption[];
-  supportedChains: CaipChainId[];
-}
-
 // -- Cashback --
 
 export interface CashbackWalletResponse {

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -578,31 +578,6 @@ export class BaanxProvider implements ICardProvider {
     await this.service.put('/v1/wallet/external/priority', { wallets }, tokens);
   }
 
-  async getFundingConfig(tokens: CardAuthTokens): Promise<CardFundingConfig> {
-    const settings = await this.service.get<DelegationSettingsResponse>(
-      '/v1/delegation/chain/config',
-      tokens,
-    );
-
-    const supportedChains = settings.networks
-      .filter((n: DelegationSettingsNetwork) =>
-        SUPPORTED_ASSET_NETWORKS.includes(
-          n.network?.toLowerCase() as CardNetwork,
-        ),
-      )
-      .map((n: DelegationSettingsNetwork) => {
-        const info =
-          cardNetworkInfos[n.network as keyof typeof cardNetworkInfos];
-        return info?.caipChainId ?? `eip155:${n.chainId}`;
-      });
-
-    return {
-      maxLimit: BAANX_MAX_LIMIT,
-      fundingOptions: this.buildFundingOptions(settings),
-      supportedChains,
-    };
-  }
-
   async fetchDelegationChallenge(
     params: { network: string; address: string; faucet?: boolean },
     tokens: CardAuthTokens,

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -9,7 +9,6 @@ import {
   CardLoginResponse,
   CardAuthorizeResponse,
   DelegationSettingsResponse,
-  DelegationSettingsNetwork,
   UserResponse,
   RegistrationSettingsResponse,
   CardLocation,
@@ -23,7 +22,6 @@ import type {
 import {
   ARBITRARY_ALLOWANCE,
   BALANCE_SCANNER_ABI,
-  BAANX_MAX_LIMIT,
   SUPPORTED_ASSET_NETWORKS,
   cardNetworkInfos,
   caipChainIdToNetwork,
@@ -46,7 +44,6 @@ import {
   CardCredentials,
   CardDetails,
   CardFundingAsset,
-  CardFundingConfig,
   CardHomeData,
   CardProviderCapabilities,
   CardSecureView,

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -595,7 +595,30 @@ describe('selectCardPrimaryToken', () => {
     expect(selectCardPrimaryToken(state)?.displaySymbol).toBeUndefined();
   });
 
-  it('sets isMoneyAccountEntry and displaySymbol=mUSD when the primary funding asset is the Veda token', () => {
+  it('sets isMoneyAccountEntry and displaySymbol=mUSD when the primary funding asset is the Veda token allowlisted in cardFeature', () => {
+    const homeData: CardHomeData = {
+      ...mockCardHomeData,
+      primaryFundingAsset: {
+        ...mockPrimaryAsset,
+        symbol: 'veda',
+        address: VEDA_ADDRESS,
+        chainId: VEDA_CAIP,
+      },
+      delegationSettings: makeVedaDelegationSettings(),
+    } as unknown as CardHomeData;
+    const state = createMockRootState(
+      {
+        cardHomeData:
+          homeData as unknown as CardControllerState['cardHomeData'],
+      },
+      MONAD_VEDA_FEATURE_FLAG,
+    );
+    const token = selectCardPrimaryToken(state);
+    expect(token?.isMoneyAccountEntry).toBe(true);
+    expect(token?.displaySymbol).toBe('mUSD');
+  });
+
+  it('does not flag the Veda primary funding asset when veda is not allowlisted in cardFeature', () => {
     const homeData: CardHomeData = {
       ...mockCardHomeData,
       primaryFundingAsset: {
@@ -610,8 +633,8 @@ describe('selectCardPrimaryToken', () => {
       cardHomeData: homeData as unknown as CardControllerState['cardHomeData'],
     });
     const token = selectCardPrimaryToken(state);
-    expect(token?.isMoneyAccountEntry).toBe(true);
-    expect(token?.displaySymbol).toBe('mUSD');
+    expect(token?.isMoneyAccountEntry).toBe(false);
+    expect(token?.displaySymbol).toBeUndefined();
   });
 });
 
@@ -1002,7 +1025,7 @@ describe('selectCardAvailableTokens', () => {
   });
 
   describe('isMoneyAccountEntry flag', () => {
-    it('flags real entries that match the Veda token from delegation settings', () => {
+    it('flags real entries that match the Veda token allowlisted in cardFeature', () => {
       const assets = [
         makeAsset({
           walletAddress: WALLET_A,
@@ -1017,13 +1040,16 @@ describe('selectCardAvailableTokens', () => {
           status: FundingAssetStatus.Active,
         }),
       ];
-      const state = createMockRootState({
-        cardHomeData: {
-          ...mockCardHomeData,
-          fundingAssets: assets,
-          delegationSettings: makeVedaDelegationSettings(),
-        } as unknown as CardControllerState['cardHomeData'],
-      });
+      const state = createMockRootState(
+        {
+          cardHomeData: {
+            ...mockCardHomeData,
+            fundingAssets: assets,
+            delegationSettings: makeVedaDelegationSettings(),
+          } as unknown as CardControllerState['cardHomeData'],
+        },
+        MONAD_VEDA_FEATURE_FLAG,
+      );
       const tokens = selectCardAvailableTokens(state);
       const vedaToken = tokens.find((t) => t.address === VEDA_ADDRESS);
       const otherToken = tokens.find((t) => t.address !== VEDA_ADDRESS);
@@ -1031,6 +1057,59 @@ describe('selectCardAvailableTokens', () => {
       expect(vedaToken?.displaySymbol).toBe('mUSD');
       expect(otherToken?.isMoneyAccountEntry).toBe(false);
       expect(otherToken?.displaySymbol).toBeUndefined();
+    });
+
+    it('still flags real Veda entries when delegationSettings omits Veda but cardFeature allowlists it', () => {
+      const assets = [
+        makeAsset({
+          walletAddress: WALLET_A,
+          address: VEDA_ADDRESS,
+          chainId: VEDA_CAIP,
+          status: FundingAssetStatus.Active,
+        }),
+      ];
+      const state = createMockRootState(
+        {
+          cardHomeData: {
+            ...mockCardHomeData,
+            fundingAssets: assets,
+            delegationSettings: {
+              networks: [],
+              count: 0,
+              _links: { self: '' },
+            },
+          } as unknown as CardControllerState['cardHomeData'],
+        },
+        MONAD_VEDA_FEATURE_FLAG,
+      );
+      const vedaToken = selectCardAvailableTokens(state).find(
+        (t) => t.address === VEDA_ADDRESS,
+      );
+      expect(vedaToken?.isMoneyAccountEntry).toBe(true);
+      expect(vedaToken?.displaySymbol).toBe('mUSD');
+    });
+
+    it('does not flag real Veda entries when cardFeature does not allowlist Veda', () => {
+      const assets = [
+        makeAsset({
+          walletAddress: WALLET_A,
+          address: VEDA_ADDRESS,
+          chainId: VEDA_CAIP,
+          status: FundingAssetStatus.Active,
+        }),
+      ];
+      const state = createMockRootState({
+        cardHomeData: {
+          ...mockCardHomeData,
+          fundingAssets: assets,
+          delegationSettings: makeVedaDelegationSettings(),
+        } as unknown as CardControllerState['cardHomeData'],
+      });
+      const vedaToken = selectCardAvailableTokens(state).find(
+        (t) => t.address === VEDA_ADDRESS,
+      );
+      expect(vedaToken?.isMoneyAccountEntry).toBe(false);
+      expect(vedaToken?.displaySymbol).toBeUndefined();
     });
 
     it('flags the synthesized Veda placeholder for the current wallet', () => {
@@ -1116,7 +1195,7 @@ describe('selectCardFundingTokens', () => {
     expect(tokens[1]?.symbol).toBe('USDT');
   });
 
-  it('flags only the funding row matching the Veda token', () => {
+  it('flags only the funding row matching the Veda token allowlisted in cardFeature', () => {
     const cardHomeData: CardHomeData = {
       ...mockCardHomeData,
       fundingAssets: [
@@ -1134,10 +1213,13 @@ describe('selectCardFundingTokens', () => {
       ],
       delegationSettings: makeVedaDelegationSettings(),
     } as unknown as CardHomeData;
-    const state = createMockRootState({
-      cardHomeData:
-        cardHomeData as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = createMockRootState(
+      {
+        cardHomeData:
+          cardHomeData as unknown as CardControllerState['cardHomeData'],
+      },
+      MONAD_VEDA_FEATURE_FLAG,
+    );
     const tokens = selectCardFundingTokens(state);
     expect(tokens).toHaveLength(2);
     const vedaRow = tokens.find((t) => t.address === VEDA_ADDRESS);
@@ -1346,16 +1428,19 @@ describe('selectIsMoneyAccountDelegatedForCard', () => {
     delegationSettings: makeVedaDelegationSettings(),
   });
 
+  const stateWithVeda = (home: CardHomeData) =>
+    createMockRootState(
+      { cardHomeData: home as unknown as CardControllerState['cardHomeData'] },
+      MONAD_VEDA_FEATURE_FLAG,
+    );
+
   beforeEach(() => {
     mockSelectPrimaryMoneyAccount.mockReset();
   });
 
   it('returns false when there is no primary Money Account', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue(undefined);
-    const state = createMockRootState({
-      cardHomeData:
-        homeDataWithVeda() as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = stateWithVeda(homeDataWithVeda());
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(false);
   });
@@ -1367,12 +1452,13 @@ describe('selectIsMoneyAccountDelegatedForCard', () => {
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(false);
   });
 
-  it('returns false when delegation settings have no Veda entry', () => {
+  it('returns false when cardFeature does not allowlist Veda', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
     const state = createMockRootState({
       cardHomeData: {
         ...mockCardHomeData,
         fundingAssets: [vedaFundingAsset],
+        delegationSettings: makeVedaDelegationSettings(),
       } as unknown as CardControllerState['cardHomeData'],
     });
 
@@ -1381,54 +1467,54 @@ describe('selectIsMoneyAccountDelegatedForCard', () => {
 
   it('returns true when the primary Money Account has an active Veda funding row', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
-    const state = createMockRootState({
-      cardHomeData:
-        homeDataWithVeda() as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = stateWithVeda(homeDataWithVeda());
+
+    expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(true);
+  });
+
+  it('returns true even when delegationSettings omit Veda but cardFeature allowlists it', () => {
+    mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
+    const state = stateWithVeda({
+      ...mockCardHomeData,
+      fundingAssets: [vedaFundingAsset],
+      delegationSettings: { networks: [], count: 0, _links: { self: '' } },
+    } as unknown as CardHomeData);
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(true);
   });
 
   it('returns true when the matching row has Limited (partial allowance) status', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
-    const state = createMockRootState({
-      cardHomeData: homeDataWithVeda({
-        status: FundingAssetStatus.Limited,
-      }) as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = stateWithVeda(
+      homeDataWithVeda({ status: FundingAssetStatus.Limited }),
+    );
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(true);
   });
 
   it('returns false when the matching row is Inactive (NotEnabled)', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
-    const state = createMockRootState({
-      cardHomeData: homeDataWithVeda({
-        status: FundingAssetStatus.Inactive,
-      }) as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = stateWithVeda(
+      homeDataWithVeda({ status: FundingAssetStatus.Inactive }),
+    );
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(false);
   });
 
   it('returns false when the wallet address on the funding row does not match the Money Account', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
-    const state = createMockRootState({
-      cardHomeData: homeDataWithVeda({
+    const state = stateWithVeda(
+      homeDataWithVeda({
         walletAddress: '0xother000000000000000000000000000000000099',
-      }) as unknown as CardControllerState['cardHomeData'],
-    });
+      }),
+    );
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(false);
   });
 
   it('returns false when the Money Account row is on a different chain than Monad', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({ address: MA_ADDRESS });
-    const state = createMockRootState({
-      cardHomeData: homeDataWithVeda({
-        chainId: 'eip155:59144',
-      }) as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = stateWithVeda(homeDataWithVeda({ chainId: 'eip155:59144' }));
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(false);
   });
@@ -1437,10 +1523,7 @@ describe('selectIsMoneyAccountDelegatedForCard', () => {
     mockSelectPrimaryMoneyAccount.mockReturnValue({
       address: MA_ADDRESS.toUpperCase(),
     });
-    const state = createMockRootState({
-      cardHomeData:
-        homeDataWithVeda() as unknown as CardControllerState['cardHomeData'],
-    });
+    const state = stateWithVeda(homeDataWithVeda());
 
     expect(selectIsMoneyAccountDelegatedForCard(state)).toBe(true);
   });

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -21,7 +21,7 @@ import { toCardFundingToken } from '../components/UI/Card/util/toCardTokenAllowa
 import { buildDelegationTokenList } from '../components/UI/Card/util/buildTokenList';
 import { isMoneyAccountEntry } from '../components/UI/Card/util/isMoneyAccountEntry';
 import {
-  getVedaTokenConfig,
+  getVedaTokenConfigFromFeatureFlag,
   MONEY_ACCOUNT_DISPLAY_SYMBOL,
   type VedaTokenConfig,
 } from '../components/UI/Card/util/vedaToken';
@@ -159,9 +159,9 @@ export const selectCardHomeDataStatus = createSelector(
 );
 
 export const selectMoneyAccountVedaTokenConfig = createSelector(
-  selectCardHomeData,
-  (data): VedaTokenConfig | null =>
-    getVedaTokenConfig(data?.delegationSettings),
+  selectCardFeatureFlag,
+  (cardFeatureFlag): VedaTokenConfig | null =>
+    getVedaTokenConfigFromFeatureFlag(cardFeatureFlag?.chains),
 );
 
 export const selectCardCountryOfResidence = createSelector(


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Money Account (mUSD/VEDA) branding and linkage on MetaMask Card were derived from the `delegationSettings` payload returned by the provider. When that payload omitted the VEDA entry (which happens transiently or for certain backend states), the app lost the Money Account branding entirely — the VEDA funding row stopped being flagged as a Money Account entry, the `mUSD` display symbol disappeared, and the link/delegation flow was incorrectly suppressed.

This PR moves the source of truth for the VEDA token config from `delegationSettings` to the card feature flag allowlist (`cardFeatureFlag.chains`):

- Adds `getVedaTokenConfigFromFeatureFlag`, which builds a `VedaTokenConfig` from the feature-flag chain/token allowlist (matching the VEDA symbol, honoring `enabled`, defaulting `decimals` to 6). `VedaTokenConfig.delegationContract` is now optional since the feature-flag source does not carry it.
- Points `selectMoneyAccountVedaTokenConfig` at `selectCardFeatureFlag` instead of `selectCardHomeData`, so Money Account branding/visibility is gated consistently by the remote feature flag regardless of what `delegationSettings` returns.
- Updates `useMoneyAccountCardLinkage` to base `hasRequirements` on the presence of a resolved `moneyAccountCardToken` rather than the `isMoneyAccountCardSupported` flag.

It also removes the now-unused `getFundingConfig` path (`CardController.getFundingConfig`, the `ICardProvider.getFundingConfig` member, `BaanxProvider.getFundingConfig`, and the `CardFundingConfig`/`CardFundingOption` types) that was dead code.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed MetaMask Card Money Account (mUSD) branding and linking disappearing when the provider's delegation settings omitted the Money Account token.

## **Related issues**

Fixes: null

## **Manual testing steps**

```gherkin
Feature: MetaMask Card Money Account visibility

  Scenario: Money Account branding persists when delegation settings omit VEDA
    Given the card feature flag allowlists the VEDA token for the network
    And the user has an active VEDA funding asset on their Money Account
    And the provider's delegation settings response does NOT include the VEDA entry
    When the user opens the MetaMask Card screen
    Then the VEDA funding row is flagged as a Money Account entry
    And the row displays the "mUSD" symbol
    And the Money Account link/delegation flow remains available

  Scenario: Money Account branding is hidden when the feature flag does not allowlist VEDA
    Given the card feature flag does NOT allowlist the VEDA token
    When the user opens the MetaMask Card screen
    Then the VEDA funding row is not flagged as a Money Account entry
    And no "mUSD" branding is shown
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gating for Money Account card UX and delegation eligibility; misconfigured feature flags could hide or show mUSD incorrectly, but scope is card UI/selectors rather than core auth or payments.
> 
> **Overview**
> **Money Account (mUSD) branding and linkage** no longer depend on the provider’s `delegationSettings` including VEDA. `selectMoneyAccountVedaTokenConfig` now reads the **card feature flag** chain allowlist via new `getVedaTokenConfigFromFeatureFlag` (Monad `eip155:143`, symbol `veda`, `enabled`, default decimals 6). `VedaTokenConfig.delegationContract` is optional for that path.
> 
> Card selectors and tests were updated so `isMoneyAccountEntry`, `mUSD` display, and “already delegated for card” stay correct when delegation settings omit VEDA but the flag allowlists VEDA—and hide branding when the flag does not.
> 
> `useMoneyAccountCardLinkage` ties `hasMoneyAccountRequirements` to a resolved `moneyAccountCardToken` instead of a separate support flag.
> 
> Removes unused **card funding config** API: `CardController.getFundingConfig`, provider `getFundingConfig`, `BaanxProvider` implementation, and `CardFundingConfig` / `CardFundingOption` types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b46c5e4685267eeff334722fdbee0ffe5f08564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->