### PR TITLE
chore: top traders follow button sm

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -172,7 +172,7 @@ describe('TraderRow', () => {
     expect(screen.getByTestId('custom-test-id')).toBeOnTheScreen();
   });
 
-  describe('layout stability (prevents Follow/Following toggle shift)', () => {
+  describe('layout stability', () => {
     const findAncestor = (
       start: ReactTestInstance | null,
       predicate: (node: ReactTestInstance) => boolean,
@@ -185,18 +185,31 @@ describe('TraderRow', () => {
       return null;
     };
 
-    const resolveMinWidth = (node: ReactTestInstance): number | undefined => {
-      const flat = StyleSheet.flatten(node.props.style) as
-        | { minWidth?: number }
-        | undefined;
-      return flat?.minWidth;
-    };
-
     const resolveAlignSelf = (node: ReactTestInstance): string | undefined => {
       const flat = StyleSheet.flatten(node.props.style) as
         | { alignSelf?: string }
         | undefined;
       return flat?.alignSelf;
+    };
+
+    const resolveHeight = (node: ReactTestInstance): number | undefined => {
+      const flat = StyleSheet.flatten(node.props.style);
+      if (Array.isArray(flat)) {
+        for (const entry of flat) {
+          if (entry && typeof entry === 'object' && 'height' in entry) {
+            return (entry as { height?: number }).height;
+          }
+        }
+        return undefined;
+      }
+      return (flat as { height?: number } | undefined)?.height;
+    };
+
+    const resolveMinWidth = (node: ReactTestInstance): number | undefined => {
+      const flat = StyleSheet.flatten(node.props.style) as
+        | { minWidth?: number }
+        | undefined;
+      return flat?.minWidth;
     };
 
     it('renders the stats line with numberOfLines=1 so it does not wrap when the button grows', () => {
@@ -217,7 +230,37 @@ describe('TraderRow', () => {
       expect(statsText).not.toBeNull();
     });
 
-    it('renders the Follow button with a minimum width', () => {
+    it('uses ButtonSize.Sm (32px height from the design system)', () => {
+      renderWithProvider(
+        <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+      );
+
+      const followLabel = screen.getByText('Follow');
+      const buttonWithHeight = findAncestor(
+        followLabel,
+        (node) => resolveHeight(node) === 32,
+      );
+
+      expect(buttonWithHeight).not.toBeNull();
+    });
+
+    it('applies 8px horizontal padding to match the Following state visually', () => {
+      renderWithProvider(
+        <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
+      );
+
+      const followLabel = screen.getByText('Follow');
+      const buttonWithPadding = findAncestor(followLabel, (node) => {
+        const flat = StyleSheet.flatten(node.props.style) as
+          | { paddingLeft?: number; paddingRight?: number }
+          | undefined;
+        return flat?.paddingLeft === 8 && flat?.paddingRight === 8;
+      });
+
+      expect(buttonWithPadding).not.toBeNull();
+    });
+
+    it('sets min-width 60px on the Follow button so the label is not clipped', () => {
       renderWithProvider(
         <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
       );
@@ -225,11 +268,28 @@ describe('TraderRow', () => {
       const followLabel = screen.getByText('Follow');
       const buttonWithMinWidth = findAncestor(
         followLabel,
-        (node) => resolveMinWidth(node) !== undefined,
+        (node) => resolveMinWidth(node) === 60,
       );
 
       expect(buttonWithMinWidth).not.toBeNull();
-      expect(resolveMinWidth(buttonWithMinWidth as ReactTestInstance)).toBe(96);
+    });
+
+    it('sets min-width 80px on the Following button so the longer label fits without clipping', () => {
+      const followingTrader: TopTrader = { ...baseTrader, isFollowing: true };
+      renderWithProvider(
+        <TraderRow
+          trader={followingTrader}
+          onFollowPress={mockOnFollowPress}
+        />,
+      );
+
+      const followingLabel = screen.getByText('Following');
+      const buttonWithMinWidth = findAncestor(
+        followingLabel,
+        (node) => resolveMinWidth(node) === 80,
+      );
+
+      expect(buttonWithMinWidth).not.toBeNull();
     });
 
     it('vertically centers the Follow button so it sits in the middle of the row (overrides ButtonBase self-start default)', () => {
@@ -244,38 +304,6 @@ describe('TraderRow', () => {
       );
 
       expect(buttonWithAlignSelf).not.toBeNull();
-    });
-
-    it('keeps the same minimum width when toggling between Follow and Following', () => {
-      const { rerender } = renderWithProvider(
-        <TraderRow trader={baseTrader} onFollowPress={mockOnFollowPress} />,
-      );
-
-      const followLabel = screen.getByText('Follow');
-      const followButton = findAncestor(
-        followLabel,
-        (node) => resolveMinWidth(node) !== undefined,
-      );
-      const followMinWidth = resolveMinWidth(followButton as ReactTestInstance);
-
-      rerender(
-        <TraderRow
-          trader={{ ...baseTrader, isFollowing: true }}
-          onFollowPress={mockOnFollowPress}
-        />,
-      );
-
-      const followingLabel = screen.getByText('Following');
-      const followingButton = findAncestor(
-        followingLabel,
-        (node) => resolveMinWidth(node) !== undefined,
-      );
-      const followingMinWidth = resolveMinWidth(
-        followingButton as ReactTestInstance,
-      );
-
-      expect(followMinWidth).toBeDefined();
-      expect(followingMinWidth).toBe(followMinWidth);
     });
   });
 });

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.test.tsx
@@ -274,7 +274,7 @@ describe('TraderRow', () => {
       expect(buttonWithMinWidth).not.toBeNull();
     });
 
-    it('sets min-width 80px on the Following button so the longer label fits without clipping', () => {
+    it('uses the same min-width on the Following button so the longer label can grow naturally', () => {
       const followingTrader: TopTrader = { ...baseTrader, isFollowing: true };
       renderWithProvider(
         <TraderRow
@@ -286,7 +286,7 @@ describe('TraderRow', () => {
       const followingLabel = screen.getByText('Following');
       const buttonWithMinWidth = findAncestor(
         followingLabel,
-        (node) => resolveMinWidth(node) === 80,
+        (node) => resolveMinWidth(node) === 60,
       );
 
       expect(buttonWithMinWidth).not.toBeNull();

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRow.tsx
@@ -24,7 +24,7 @@ import TraderAvatar from './TraderAvatar';
 const AVATAR_SIZE = 40;
 // Fixed row height so the skeleton placeholder can match it exactly without
 // drifting due to font-scale or button-size differences.
-export const TRADER_ROW_HEIGHT = 64;
+export const TRADER_ROW_HEIGHT = 71;
 
 export interface TraderRowProps {
   trader: TopTrader;
@@ -120,14 +120,13 @@ const TraderRow: React.FC<TraderRowProps> = ({
         </Box>
       </TouchableOpacity>
 
-      {/* Follow / Following button */}
       <Button
         variant={
           trader.isFollowing ? ButtonVariant.Secondary : ButtonVariant.Primary
         }
-        size={ButtonSize.Md}
+        size={ButtonSize.Sm}
         onPress={() => onFollowPress(trader.id)}
-        twClassName="min-w-[96px] self-center"
+        twClassName="self-center min-w-[60px] px-2"
       >
         {trader.isFollowing
           ? strings('social_leaderboard.following')

--- a/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/components/TraderRowSkeleton.tsx
@@ -38,9 +38,9 @@ const TraderRowSkeleton: React.FC = () => {
             <View style={tw.style('w-40 h-4 rounded')} />
           </View>
 
-          {/* Button placeholder — `min-w-[96px]` matches the rendered Follow
-              button so the right edge of the row aligns between states. */}
-          <View style={tw.style('w-24 h-8 rounded-xl ml-3')} />
+          {/* Button placeholder — 80×32 matches the wider Following state so
+              the row's right edge stays stable when the button toggles. */}
+          <View style={tw.style('w-20 h-8 rounded-lg ml-3')} />
         </View>
       </SkeletonPlaceholder>
     </View>


### PR DESCRIPTION
<!--
  Please submit this PR as a draft initially.

  Do not mark it as "Ready for review" until this PR meets the canonical
  Definition of Ready For Review in `docs/readme/ready-for-review.md`.

  In short: the template must be materially complete (not just section titles
  present), all status checks must be currently passing, and the only expected
  follow-up commits must be reviewer-driven.
  -->
  <!--
  mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
  at module load to build the validation plan. Directives are invisible in rendered
  markdown and must NOT be removed or edited without updating the validator registry.

    type=text           Section must contain non-placeholder prose.
    type=changelog      Section must have a valid CHANGELOG entry: line.
    type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
    type=manual-testing Section must have real testing steps or an explicit N/A.
    type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
    type=checklist      Section must have all checkboxes consciously checked.
    required=true|false Whether a missing/invalid section runs the validator at all.
    blocking=true|false Whether a failure of this check fails the CI workflow.
                        Default: false — failures are shown as warnings in the sticky
                        comment but do not block the PR.

  Sections without a directive are checked for structural presence only.
  -->

  ## **Description**

  <!-- mms-check: type=text required=true -->

  Updates the Top Traders leaderboard Follow / Following button styling and row spacing to match the latest Figma redesign (`Social` file, node `2849:13724`).

  - Switches the button to the smaller compact treatment: 32px height, 8px corner radius, `BodySm` (14px) label — previously the `ButtonSize.Md`-style pill with `BodyMd` (16px) text.
  - Aligns horizontal padding (`px-2` = 8px each side) and the `min-w-[60px]` baseline so "Follow" sits tight while "Following" can grow to fit the longer label.
  - Tightens the row height to 71px (down from 72px on this branch / 64px on main earlier) so vertical rhythm between rows matches the redesign without the previously-excessive gap.
  - Skeleton placeholder mirrors the new row height + button shape automatically via the shared `TRADER_ROW_HEIGHT` constant.

Figma: https://www.figma.com/design/HzPB0InxHBY5hPkOukPCqv/Social?node-id=2849-13724&t=twlWQEpVxjxZ16R0-4

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  CHANGELOG entry: Updated the Follow / Following button and row spacing on the Top Traders leaderboard to match the latest design.

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Fixes: [TSA-811](https://consensyssoftware.atlassian.net/browse/TSA-811)

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  ```gherkin
  Feature: Top Traders leaderboard Follow button styling

    Scenario: Follow button renders in the compact style
      Given I am on the Top Traders view with at least one unfollowed trader
      Then each unfollowed row shows a white "Follow" button that is 32px tall with 8px corner radius
      And the "Follow" label renders at the smaller (BodySm / 14px) text size

    Scenario: Following button accommodates the longer label
      Given I am on the Top Traders view with at least one followed trader
      Then each followed row shows a muted "Following" button at the same 32px / 8px-radius style
      And the button widens enough that "Following" is not clipped

    Scenario: Row rhythm matches the redesign
      Given the Top Traders list is rendered
      Then each row is 71px tall and rows are stacked directly without an additional gap

    Scenario: Loading state matches the rendered state
      Given the Top Traders list is loading
      Then each skeleton row occupies the same 71px height as a rendered row
      And the button-shaped placeholder mirrors the new compact dimensions
  ```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  <!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

  ### **Before**
<img width="568" height="928" alt="Screenshot 2026-06-24 at 6 55 23 PM" src="https://github.com/user-attachments/assets/ca5fdab0-76d1-483d-9240-335137c02750" />


  <!-- [screenshots/recordings] -->

  ### **After**
<img width="568" height="928" alt="Screenshot 2026-06-24 at 6 53 06 PM" src="https://github.com/user-attachments/assets/1d177106-cb4d-4325-8cdb-884213c8a91d" />

  <!-- [screenshots/recordings] -->

  ## **Pre-merge author checklist**

  <!-- mms-check: type=checklist required=true -->

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  - [x] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [x] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - [x] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  <!--
  Reviewer checklist items follow the same semantics as the author checklist: an
  unchecked box is ambiguous, a checked box means the reviewer consciously
  assessed that responsibility. See `docs/readme/ready-for-review.md`.
  -->

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots

[TSA-811]: https://consensyssoftware.atlassian.net/browse/TSA-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only leaderboard row and skeleton styling with no auth, data, or API changes.
> 
> **Overview**
> Aligns **Top Traders** row layout with the Figma redesign by shrinking the Follow/Following control and adjusting row metrics.
> 
> The action button moves from **`ButtonSize.Md`** to **`ButtonSize.Sm`** (32px height), with **`min-w-[60px]`** and **`px-2`** instead of a fixed **96px** minimum width so **Follow** stays tight while **Following** can widen. **`TRADER_ROW_HEIGHT`** increases from **64** to **71** so vertical rhythm matches the new control.
> 
> **`TraderRowSkeleton`** updates the button placeholder (**`w-20`**, **`rounded-lg`**, 32px height) so loading rows match the rendered compact button. **Layout stability** tests now assert Sm sizing, 8px padding, 60px min-width on both states, and vertical centering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf434f97dd17bee40acc884d42c7681a06143b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->