### PR TITLE
fix(ramps): resolve ramp order details by cached order id cp-8.0.0

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampsOrders.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsOrders.test.ts
@@ -122,72 +122,76 @@ describe('useRampsOrders', () => {
     jest.clearAllMocks();
   });
 
-  it('returns empty orders when none exist', () => {
-    const store = createMockStore();
-    const { result } = renderHook(() => useRampsOrders(), {
-      wrapper: wrapper(store),
+  describe('orders (group-scoped for ramp order lists)', () => {
+    it('returns empty orders when none exist', () => {
+      const store = createMockStore();
+      const { result } = renderHook(() => useRampsOrders(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.orders).toEqual([]);
     });
 
-    expect(result.current.orders).toEqual([]);
+    it('returns orders from the store when walletAddress matches the selected account group', () => {
+      const order = createMockOrder();
+      const store = createMockStore([order]);
+      const { result } = renderHook(() => useRampsOrders(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.orders).toEqual([order]);
+    });
+
+    it('excludes orders whose walletAddress is not in the selected account group', () => {
+      const foreignOrder = createMockOrder({
+        providerOrderId: 'foreign-order',
+        walletAddress: '0x0000000000000000000000000000000000000001',
+      });
+      const store = createMockStore([foreignOrder]);
+      const { result } = renderHook(() => useRampsOrders(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.orders).toEqual([]);
+    });
   });
 
-  it('returns orders from the store when walletAddress matches the selected account group', () => {
-    const order = createMockOrder();
-    const store = createMockStore([order]);
-    const { result } = renderHook(() => useRampsOrders(), {
-      wrapper: wrapper(store),
+  describe('getOrderById (all cached orders for point lookups)', () => {
+    it('finds a cached order by id even when its wallet is outside the selected account group', () => {
+      const moneyAccountOrder = createMockOrder({
+        providerOrderId: 'money-account-order',
+        walletAddress: '0x0000000000000000000000000000000000000002',
+      });
+      const store = createMockStore([moneyAccountOrder]);
+      const { result } = renderHook(() => useRampsOrders(), {
+        wrapper: wrapper(store),
+      });
+
+      expect(result.current.orders).toEqual([]);
+      expect(result.current.getOrderById('money-account-order')).toEqual(
+        moneyAccountOrder,
+      );
     });
 
-    expect(result.current.orders).toEqual([order]);
-  });
+    it('finds an order by providerOrderId', () => {
+      const order1 = createMockOrder({ providerOrderId: 'order-1' });
+      const order2 = createMockOrder({ providerOrderId: 'order-2' });
+      const store = createMockStore([order1, order2]);
+      const { result } = renderHook(() => useRampsOrders(), {
+        wrapper: wrapper(store),
+      });
 
-  it('excludes orders whose walletAddress is not in the selected account group', () => {
-    const foreignOrder = createMockOrder({
-      providerOrderId: 'foreign-order',
-      walletAddress: '0x0000000000000000000000000000000000000001',
-    });
-    const store = createMockStore([foreignOrder]);
-    const { result } = renderHook(() => useRampsOrders(), {
-      wrapper: wrapper(store),
+      expect(result.current.getOrderById('order-2')).toEqual(order2);
     });
 
-    expect(result.current.orders).toEqual([]);
-  });
+    it('returns undefined for non-existent order id', () => {
+      const store = createMockStore([createMockOrder()]);
+      const { result } = renderHook(() => useRampsOrders(), {
+        wrapper: wrapper(store),
+      });
 
-  it('finds a cached order by id even when its wallet is outside the selected account group', () => {
-    const moneyAccountOrder = createMockOrder({
-      providerOrderId: 'money-account-order',
-      walletAddress: '0x0000000000000000000000000000000000000002',
+      expect(result.current.getOrderById('non-existent')).toBeUndefined();
     });
-    const store = createMockStore([moneyAccountOrder]);
-    const { result } = renderHook(() => useRampsOrders(), {
-      wrapper: wrapper(store),
-    });
-
-    expect(result.current.orders).toEqual([]);
-    expect(result.current.getOrderById('money-account-order')).toEqual(
-      moneyAccountOrder,
-    );
-  });
-
-  it('finds an order by providerOrderId', () => {
-    const order1 = createMockOrder({ providerOrderId: 'order-1' });
-    const order2 = createMockOrder({ providerOrderId: 'order-2' });
-    const store = createMockStore([order1, order2]);
-    const { result } = renderHook(() => useRampsOrders(), {
-      wrapper: wrapper(store),
-    });
-
-    expect(result.current.getOrderById('order-2')).toEqual(order2);
-  });
-
-  it('returns undefined for non-existent order id', () => {
-    const store = createMockStore([createMockOrder()]);
-    const { result } = renderHook(() => useRampsOrders(), {
-      wrapper: wrapper(store),
-    });
-
-    expect(result.current.getOrderById('non-existent')).toBeUndefined();
   });
 
   it('calls Engine.context.RampsController.addOrder', () => {

--- a/app/components/UI/Ramp/hooks/useRampsOrders.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsOrders.test.ts
@@ -154,6 +154,22 @@ describe('useRampsOrders', () => {
     expect(result.current.orders).toEqual([]);
   });
 
+  it('finds a cached order by id even when its wallet is outside the selected account group', () => {
+    const moneyAccountOrder = createMockOrder({
+      providerOrderId: 'money-account-order',
+      walletAddress: '0x0000000000000000000000000000000000000002',
+    });
+    const store = createMockStore([moneyAccountOrder]);
+    const { result } = renderHook(() => useRampsOrders(), {
+      wrapper: wrapper(store),
+    });
+
+    expect(result.current.orders).toEqual([]);
+    expect(result.current.getOrderById('money-account-order')).toEqual(
+      moneyAccountOrder,
+    );
+  });
+
   it('finds an order by providerOrderId', () => {
     const order1 = createMockOrder({ providerOrderId: 'order-1' });
     const order2 = createMockOrder({ providerOrderId: 'order-2' });

--- a/app/components/UI/Ramp/hooks/useRampsOrders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsOrders.ts
@@ -16,7 +16,13 @@ export interface AddPrecreatedOrderParams {
 }
 
 export interface UseRampsOrdersResult {
+  /** Ramp order lists (e.g. OrdersList). Scoped to the selected account group. */
   orders: RampsOrder[];
+  /**
+   * Resolves a single cached order by id. Searches all `RampsController`
+   * orders — not scoped to the selected group. Money Home activity rows are
+   * built from `TransactionController`, not this hook.
+   */
   getOrderById: (providerOrderId: string) => RampsOrder | undefined;
   addOrder: (order: RampsOrder) => void;
   addPrecreatedOrder: (params: AddPrecreatedOrderParams) => void;

--- a/app/components/UI/Ramp/hooks/useRampsOrders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsOrders.ts
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux';
 import type { RampsOrder } from '@metamask/ramps-controller';
 import { extractOrderCode } from '../utils/extractOrderCode';
 import Engine from '../../../../core/Engine';
-import { selectRampsOrdersForSelectedAccountGroup } from '../../../../selectors/rampsController';
+import {
+  selectRampsOrders,
+  selectRampsOrdersForSelectedAccountGroup,
+} from '../../../../selectors/rampsController';
 
 export interface AddPrecreatedOrderParams {
   orderId: string;
@@ -32,13 +35,17 @@ export interface UseRampsOrdersResult {
 
 export function useRampsOrders(): UseRampsOrdersResult {
   const orders = useSelector(selectRampsOrdersForSelectedAccountGroup);
+  const allOrders = useSelector(selectRampsOrders);
 
   const getOrderById = useCallback(
     (providerOrderId: string) => {
       const orderCode = extractOrderCode(providerOrderId);
-      return orders.find((o) => o.providerOrderId === orderCode);
+      // Point lookups use all cached controller orders. List views stay scoped
+      // to the selected account group; Money account deposits use a separate
+      // wallet address that is not in that group.
+      return allOrders.find((o) => o.providerOrderId === orderCode);
     },
-    [orders],
+    [allOrders],
   );
 
   const addOrder = useCallback(


### PR DESCRIPTION
## **Description**

Fixes blank **Order details** when opening a Money account fiat ramp order from activity (e.g. export on the "Buy MUSD with Apple Pay" step in transaction details).

**Root cause:** Orders are cached in `RampsController.orders` under the **Money account wallet**, which is not in the selected account group's internal addresses. `useRampsOrders().getOrderById` searched only the group-scoped `orders` list, so lookup returned `undefined` and `RampsOrderDetails` rendered header-only.

**Solution:** `getOrderById` searches all cached controller orders (`selectRampsOrders`). The `orders` property returned for ramp **lists** stays scoped to `selectRampsOrdersForSelectedAccountGroup`.

**Not affected:**
- Money Home activity rows — built from `TransactionController` via `useMoneyAccountTransactions`, not `useRampsOrders`
- Activity subtitles ("Apple Pay") — `useFiatPaymentMethodName` already uses unfiltered `selectRampsOrders`
- Ramp order lists (`OrdersList`, etc.) — still use group-scoped `orders`


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3681

## **Manual testing steps**

```gherkin
Feature: Money account ramp order details

  Scenario: user opens ramp order details from Money activity without blank screen
    Given a completed Money account fiat deposit (e.g. Apple Pay) exists in activity
    And the order is cached in RampsController orders under the Money account wallet

    When user taps the deposit in Money Home activity
    And opens transaction details
    And taps the export action on the fiat purchase step
    Then the Order details screen shows order content (not a blank body)

  Scenario: Money Home activity list is unchanged
    Given the same Money account with fiat deposit activity

    When user views Money Home activity
    Then deposit rows still show correct labels, amounts, and payment method subtitles
    And tapping a row still opens transaction details (not ramp order details directly)

  Scenario: ramp order list remains group-scoped
    Given ramp orders exist for wallets outside the selected account group

    When user opens the ramp orders list
    Then only orders for the selected account group are shown
```

**Unit tests run:**
- `yarn jest app/components/UI/Ramp/hooks/useRampsOrders.test.ts`
- `yarn jest app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx`
- `yarn jest app/components/UI/Money/hooks/useMoneyActivityItems.test.ts`
- `yarn jest app/components/UI/Money/hooks/useMoneyTransactionDisplayInfo.test.ts`
- `yarn jest app/components/UI/Money/hooks/useFiatPaymentMethodName.test.ts`

## **Screenshots/Recordings**

### **Before**


https://github.com/user-attachments/assets/2dc725c0-9d00-490a-bb36-7690d6627940

### **After**

https://github.com/user-attachments/assets/2fedd99a-675c-4b5c-a77b-5ac073530e6f


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.