### PR TITLE
fix(ci): repack iOS E2E app on Bitrise fingerprint cache hit

### DIFF
--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -486,7 +486,7 @@ jobs:
           key: bitrise-ios-app-${{ inputs.build_type }}-main-v${{ env.IOS_APP_CACHE_VERSION }}-${{ steps.generate-fingerprint.outputs.fingerprint }}
 
       - name: Build iOS E2E App (Bitrise RN cache)
-        if: ${{ inputs.runner_provider == 'bitrise' && steps.gate.outputs.needs-native-build == 'true' }}
+        if: ${{ inputs.runner_provider == 'bitrise' && steps.gate.outputs.needs-native-build == 'true' && steps.cache-restore.outputs.cache-hit != 'true' && steps.cache-restore-main.outputs.cache-hit != 'true' }}
         run: |
           echo "Building iOS E2E App on Bitrise runner..."
           bitrise-build-cache react-native run yarn build:ios:${{ inputs.build_type }}:e2e
@@ -542,7 +542,7 @@ jobs:
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
 
       - name: Repack iOS app with JS updates using @expo/repack-app
-        if: ${{ steps.gate.outputs.needs-native-build != 'true' }}
+        if: ${{ steps.gate.outputs.needs-native-build != 'true' || (inputs.runner_provider == 'bitrise' && (steps.cache-restore.outputs.cache-hit == 'true' || steps.cache-restore-main.outputs.cache-hit == 'true')) }}
         run: |
           echo "📦 Repacking iOS app with updated JavaScript bundle using @expo/repack-app..."
           # Use the optimized repack script which uses @expo/repack-app


### PR DESCRIPTION
## TL;DR
On Bitrise runners, skip the full iOS native build when the fingerprint-matched app cache hits and repack the cached `.app` with the current JS bundle instead.

## Why
Bitrise skips GitHub artifact reuse, so `needs-native-build` stays true even when `actions/cache` restores a matching native app. Without this, every Build iOS Apps run does a full Xcode build instead of repack, making Bitrise slower than cirrus/namespace on JS-only PRs.

## Changes Made
- Skip "Build iOS E2E App (Bitrise RN cache)" when branch or main fingerprint cache hits
- Run repack when Bitrise fingerprint cache hits (in addition to the existing artifact-reuse repack path)

## Dependencies (if applicable)

## Testing (if applicable)
- Trigger CI on a Bitrise shadow PR with a JS-only change after a prior run populated the fingerprint cache
- Confirm cache hit → repack runs, native build step skipped
- Confirm cache miss → full native build still runs

## Related Issues
[Jira: INFRA-3679](https://consensyssoftware.atlassian.net/browse/INFRA-3679)

Made with [Cursor](https://cursor.com)