### PR TITLE
fix(money): deactivate two hero token display in transaction details for deposits/withdraws cp-8.0.0

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -627,7 +627,7 @@ describe('TransactionDetailsHero', () => {
       expect(getByText(/-1\.00/)).toBeDefined();
     });
 
-    it('falls back to tokenMeta amount when parent data is not decodable', () => {
+    it('shows fiat display when parent data is not decodable (no two-asset hero)', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -641,10 +641,10 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { queryByText, getByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-77\.00 TST/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(getByText(/\$77/)).toBeDefined();
     });
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -303,7 +303,7 @@ describe('TransactionDetailsHero', () => {
       selectTransactionsByIdsMock.mockReturnValue([]);
     });
 
-    it('renders two-asset hero for musdConversion', () => {
+    it('renders single-line hero for musdConversion with + prefix and green', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -316,15 +316,14 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
       expect(getByText(/\+123\.46 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders Money Account icon instead of token icon for mUSD in two-asset hero', () => {
+    it('renders Money Account icon for musdConversion single-line hero', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -337,9 +336,9 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getAllByTestId } = render();
+      const { getByTestId } = render();
 
-      expect(getAllByTestId('money-account-icon').length).toBeGreaterThan(0);
+      expect(getByTestId('money-account-icon')).toBeDefined();
     });
 
     it('renders two-asset hero for perpsDeposit with USDC symbol', () => {
@@ -388,7 +387,7 @@ describe('TransactionDetailsHero', () => {
       ).toBeDefined();
     });
 
-    it('renders two-asset hero for cross-chain moneyAccountWithdraw', () => {
+    it('renders single-line hero for moneyAccountWithdraw with - prefix', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -401,12 +400,11 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
       expect(getByText(/-200\.00 mUSD/)).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+123\.46 TST/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
     it('renders single-row hero with Money Account icon for mUSD-to-mUSD moneyAccountWithdraw', () => {
@@ -539,7 +537,7 @@ describe('TransactionDetailsHero', () => {
       expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders two-asset hero for crypto moneyAccountDeposit conversion', () => {
+    it('renders single-line hero for crypto moneyAccountDeposit with + prefix', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -552,12 +550,11 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
       expect(getByText(/\+123\.46 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
     it('renders null for unsupported type in money context', () => {
@@ -572,7 +569,7 @@ describe('TransactionDetailsHero', () => {
       expect(queryByTestId('transaction-details-hero')).toBeNull();
     });
 
-    it('extracts sent amount from relay deposit child transaction', () => {
+    it('renders single-line hero for musdConversion even with relay deposit child', () => {
       selectTransactionsByIdsMock.mockReturnValue([
         {
           type: TransactionType.relayDeposit,
@@ -593,41 +590,14 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText(/\+123\.46 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
-    it('extracts sent amount from relay deposit native value', () => {
-      const nativeAddress = '0x0000000000000000000000000000000000000000';
-      selectTransactionsByIdsMock.mockReturnValue([
-        {
-          type: TransactionType.relayDeposit,
-          txParams: { value: '1000000000000000000' },
-        } as unknown as TransactionMeta,
-      ]);
-
-      useTransactionDetailsMock.mockReturnValue({
-        transactionMeta: {
-          ...TRANSACTION_META_MOCK,
-          type: TransactionType.musdConversion,
-          requiredTransactionIds: ['child-tx-1'],
-          metamaskPay: {
-            tokenAddress: nativeAddress,
-            chainId: '0x1',
-            targetFiat: '123.46',
-          },
-        } as unknown as TransactionMeta,
-      });
-
-      const { getByText } = render();
-
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-1\.00/)).toBeDefined();
-    });
-
-    it('shows fiat display when parent data is not decodable (no two-asset hero)', () => {
+    it('falls back to tokenMeta amount when parent data is not decodable', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -641,10 +611,10 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { queryByText, getByText } = render();
+      const { getByText } = render();
 
-      expect(queryByText('You sent')).toBeNull();
-      expect(getByText(/\$77/)).toBeDefined();
+      expect(getByText('You sent')).toBeDefined();
+      expect(getByText(/-77\.00 TST/)).toBeDefined();
     });
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -341,7 +341,7 @@ describe('TransactionDetailsHero', () => {
       expect(getByTestId('money-account-icon')).toBeDefined();
     });
 
-    it('renders two-asset hero for perpsDeposit with USDC symbol', () => {
+    it('renders single-line hero for perpsDeposit with - prefix', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -354,17 +354,14 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
-      expect(
-        getByText(new RegExp(`\\+123\\.46 ${ARBITRUM_USDC.symbol}`)),
-      ).toBeDefined();
+      expect(getByText(/-123\.46 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders two-asset hero for predictDeposit with pUSD symbol', () => {
+    it('renders single-line hero for predictDeposit with - prefix', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -377,14 +374,11 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
-      expect(
-        getByText(new RegExp(`\\+123\\.46 ${POLYGON_PUSD.symbol}`)),
-      ).toBeDefined();
+      expect(getByText(/-123\.46 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
     it('renders single-line hero for moneyAccountWithdraw with - prefix', () => {
@@ -451,7 +445,7 @@ describe('TransactionDetailsHero', () => {
       expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders two-asset hero for perpsWithdraw with USDC as sent and mUSD as received', () => {
+    it('renders single-line hero for perpsWithdraw with + prefix and green', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -464,17 +458,14 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(
-        getByText(new RegExp(`-123\\.46 ${ARBITRUM_USDC.symbol}`)),
-      ).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
       expect(getByText(/\+50\.00 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders two-asset hero for predictWithdraw with pUSD as sent and mUSD as received', () => {
+    it('renders single-line hero for predictWithdraw with + prefix and green', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -487,14 +478,11 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(
-        getByText(new RegExp(`-123\\.46 ${POLYGON_PUSD.symbol}`)),
-      ).toBeDefined();
-      expect(getByText('You received')).toBeDefined();
       expect(getByText(/\+10\.00 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
 
     it('renders fiat deposit hero with green + prefix for moneyAccountDeposit with fiat orderId', () => {
@@ -611,10 +599,11 @@ describe('TransactionDetailsHero', () => {
         } as unknown as TransactionMeta,
       });
 
-      const { getByText } = render();
+      const { getByText, queryByText } = render();
 
-      expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-77\.00 TST/)).toBeDefined();
+      expect(getByText(/-77\.00 mUSD/)).toBeDefined();
+      expect(queryByText('You sent')).toBeNull();
+      expect(queryByText('You received')).toBeNull();
     });
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -37,6 +37,7 @@ import {
   selectConversionRateByChainId,
   selectCurrencyRates,
 } from '../../../../../../selectors/currencyRateController';
+import { selectContractExchangeRatesByChainId } from '../../../../../../selectors/tokenRatesController';
 import { RootState } from '../../../../../../reducers';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import { TokenIcon } from '../../token-icon';
@@ -388,7 +389,6 @@ function useReceivedTokenData(
 
 function useSourceSentData(): TokenDisplayData | null {
   const { transactionMeta } = useTransactionDetails();
-  const tokenMeta = useTokenMeta(transactionMeta);
   const { metamaskPay, requiredTransactionIds } = transactionMeta;
   const { tokenAddress, chainId: sourceChainId } = metamaskPay ?? {};
 
@@ -399,6 +399,17 @@ function useSourceSentData(): TokenDisplayData | null {
 
   const childTransactions = useSelector((state: RootState) =>
     selectTransactionsByIds(state, requiredTransactionIds ?? []),
+  );
+
+  const sourceChainConversionRate = useSelector((state: RootState) =>
+    selectConversionRateByChainId(state, (sourceChainId ?? '0x0') as Hex),
+  );
+
+  const contractExchangeRates = useSelector((state: RootState) =>
+    selectContractExchangeRatesByChainId(
+      state,
+      (sourceChainId ?? '0x0') as Hex,
+    ),
   );
 
   if (!tokenAddress || !sourceChainId) {
@@ -436,11 +447,15 @@ function useSourceSentData(): TokenDisplayData | null {
     return { ...base, amount: parentAmount };
   }
 
-  // Fallback: use the received mUSD amount as an approximation when
-  // we have source token info but can't extract the exact sent amount
-  // (e.g. complex bridge calldata that isn't a simple ERC-20 transfer).
-  if (tokenMeta) {
-    return { ...base, amount: tokenMeta.amount };
+  const fiatDerivedAmount = extractSentAmountFromFiat(
+    metamaskPay,
+    sourceChainConversionRate,
+    tokenAddress as Hex,
+    sourceChainId as Hex,
+    contractExchangeRates,
+  );
+  if (fiatDerivedAmount) {
+    return { ...base, amount: fiatDerivedAmount };
   }
 
   return null;
@@ -475,6 +490,36 @@ function extractSentAmountFromParent(
   }
 
   return null;
+}
+
+function extractSentAmountFromFiat(
+  metamaskPay: TransactionMeta['metamaskPay'],
+  nativeConversionRate: number | null | undefined,
+  tokenAddress: Hex,
+  chainId: Hex,
+  contractExchangeRates: Record<string, { price: number }> | undefined,
+): string | null {
+  const totalFiat = metamaskPay?.totalFiat;
+  if (!totalFiat || !nativeConversionRate || nativeConversionRate === 0) {
+    return null;
+  }
+
+  const nativeTokenAddr = getNativeTokenAddress(chainId);
+  const isNative = tokenAddress.toLowerCase() === nativeTokenAddr.toLowerCase();
+
+  let tokenFiatRate: number;
+  if (isNative) {
+    tokenFiatRate = nativeConversionRate;
+  } else {
+    const contractRate = contractExchangeRates?.[tokenAddress]?.price ?? 0;
+    if (contractRate === 0) return null;
+    tokenFiatRate = nativeConversionRate * contractRate;
+  }
+
+  const tokenAmount = new BigNumber(totalFiat).dividedBy(tokenFiatRate);
+  if (tokenAmount.isNaN() || tokenAmount.isZero()) return null;
+
+  return tokenAmount.toFixed(tokenAmount.lt(0.01) ? 6 : 2);
 }
 
 function extractSentAmount(

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -75,12 +75,9 @@ const TOKEN_ICON_TYPES = [
   TransactionType.musdConversion,
 ];
 
-const TWO_ASSET_HERO_TYPES = [
-  TransactionType.perpsDeposit,
-  TransactionType.perpsWithdraw,
-  TransactionType.predictDeposit,
-  TransactionType.predictWithdraw,
-];
+// Temporarily empty — all money account flows use single-line hero until
+// metamaskPay stores source token amounts (see https://github.com/MetaMask/metamask-mobile/pull/32391).
+const TWO_ASSET_HERO_TYPES: TransactionType[] = [];
 
 interface TokenDisplayData {
   amount: string;
@@ -201,7 +198,15 @@ export function TransactionDetailsHero() {
   }
 
   const showTokenIcon =
-    hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) && tokenMeta;
+    tokenMeta &&
+    (hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) ||
+      (isMoneyContext &&
+        hasTransactionType(transactionMeta, [
+          TransactionType.perpsDeposit,
+          TransactionType.perpsWithdraw,
+          TransactionType.predictDeposit,
+          TransactionType.predictWithdraw,
+        ])));
 
   if (showTokenIcon) {
     const isDeposit =
@@ -209,12 +214,16 @@ export function TransactionDetailsHero() {
       hasTransactionType(transactionMeta, [
         TransactionType.moneyAccountDeposit,
         TransactionType.musdConversion,
+        TransactionType.perpsWithdraw,
+        TransactionType.predictWithdraw,
       ]);
 
     const isWithdraw =
       isMoneyContext &&
       hasTransactionType(transactionMeta, [
         TransactionType.moneyAccountWithdraw,
+        TransactionType.perpsDeposit,
+        TransactionType.predictDeposit,
       ]);
 
     const icon = isMusdToken(tokenMeta.contractAddress) ? (

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -37,12 +37,10 @@ import {
   selectConversionRateByChainId,
   selectCurrencyRates,
 } from '../../../../../../selectors/currencyRateController';
-import { selectContractExchangeRatesByChainId } from '../../../../../../selectors/tokenRatesController';
 import { RootState } from '../../../../../../reducers';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import { TokenIcon } from '../../token-icon';
 import { resolveMusdTransferMeta } from '../../../../../UI/Money/constants/activityStyles';
-import { isSingleRowMusdMoneyWithdraw } from '../../../../../UI/Money/utils/moneyTransactionGuards';
 import { fromTokenMinimalUnit } from '../../../../../../util/number/bigint';
 import {
   isMusdToken,
@@ -78,9 +76,6 @@ const TOKEN_ICON_TYPES = [
 ];
 
 const TWO_ASSET_HERO_TYPES = [
-  TransactionType.moneyAccountDeposit,
-  TransactionType.moneyAccountWithdraw,
-  TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
@@ -193,8 +188,6 @@ export function TransactionDetailsHero() {
   const showTwoAssetHero =
     isMoneyContext &&
     hasTransactionType(transactionMeta, TWO_ASSET_HERO_TYPES) &&
-    !isSingleRowMoneyDeposit(transactionMeta) &&
-    !isSingleRowMusdMoneyWithdraw(transactionMeta) &&
     sentData &&
     receivedData;
 
@@ -208,24 +201,21 @@ export function TransactionDetailsHero() {
   }
 
   const showTokenIcon =
-    hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) &&
-    tokenMeta &&
-    (!hasTransactionType(transactionMeta, [
-      TransactionType.moneyAccountWithdraw,
-    ]) ||
-      isSingleRowMusdMoneyWithdraw(transactionMeta) ||
-      !isMoneyContext);
+    hasTransactionType(transactionMeta, TOKEN_ICON_TYPES) && tokenMeta;
 
   if (showTokenIcon) {
-    const showDepositPrefix =
+    const isDeposit =
       isMoneyContext &&
       hasTransactionType(transactionMeta, [
         TransactionType.moneyAccountDeposit,
-      ]) &&
-      isSingleRowMoneyDeposit(transactionMeta);
+        TransactionType.musdConversion,
+      ]);
 
-    const isMusdWithdrawSingleRow =
-      isMoneyContext && isSingleRowMusdMoneyWithdraw(transactionMeta);
+    const isWithdraw =
+      isMoneyContext &&
+      hasTransactionType(transactionMeta, [
+        TransactionType.moneyAccountWithdraw,
+      ]);
 
     const icon = isMusdToken(tokenMeta.contractAddress) ? (
       <Image
@@ -253,9 +243,9 @@ export function TransactionDetailsHero() {
         {icon}
         <Text
           variant={TextVariant.DisplayMD}
-          color={showDepositPrefix ? TextColor.Success : undefined}
+          color={isDeposit ? TextColor.Success : undefined}
         >
-          {showDepositPrefix ? '+' : isMusdWithdrawSingleRow ? '-' : ''}
+          {isDeposit ? '+' : isWithdraw ? '-' : ''}
           {tokenMeta.amount} {tokenMeta.symbol}
         </Text>
       </Box>
@@ -323,17 +313,6 @@ const SENT_OVERRIDE: Partial<
   },
 };
 
-function isSingleRowMoneyDeposit(transactionMeta: TransactionMeta): boolean {
-  if (
-    !hasTransactionType(transactionMeta, [TransactionType.moneyAccountDeposit])
-  ) {
-    return false;
-  }
-
-  const { fiat, tokenAddress } = transactionMeta.metamaskPay ?? {};
-  return Boolean(fiat?.orderId) || isMusdToken(tokenAddress);
-}
-
 function resolveTwoAssetData(
   transactionMeta: TransactionMeta,
   sentData: TokenDisplayData,
@@ -389,6 +368,7 @@ function useReceivedTokenData(
 
 function useSourceSentData(): TokenDisplayData | null {
   const { transactionMeta } = useTransactionDetails();
+  const tokenMeta = useTokenMeta(transactionMeta);
   const { metamaskPay, requiredTransactionIds } = transactionMeta;
   const { tokenAddress, chainId: sourceChainId } = metamaskPay ?? {};
 
@@ -399,17 +379,6 @@ function useSourceSentData(): TokenDisplayData | null {
 
   const childTransactions = useSelector((state: RootState) =>
     selectTransactionsByIds(state, requiredTransactionIds ?? []),
-  );
-
-  const sourceChainConversionRate = useSelector((state: RootState) =>
-    selectConversionRateByChainId(state, (sourceChainId ?? '0x0') as Hex),
-  );
-
-  const contractExchangeRates = useSelector((state: RootState) =>
-    selectContractExchangeRatesByChainId(
-      state,
-      (sourceChainId ?? '0x0') as Hex,
-    ),
   );
 
   if (!tokenAddress || !sourceChainId) {
@@ -447,15 +416,11 @@ function useSourceSentData(): TokenDisplayData | null {
     return { ...base, amount: parentAmount };
   }
 
-  const fiatDerivedAmount = extractSentAmountFromFiat(
-    metamaskPay,
-    sourceChainConversionRate,
-    tokenAddress as Hex,
-    sourceChainId as Hex,
-    contractExchangeRates,
-  );
-  if (fiatDerivedAmount) {
-    return { ...base, amount: fiatDerivedAmount };
+  // Fallback: use the received mUSD amount as an approximation when
+  // we have source token info but can't extract the exact sent amount
+  // (e.g. complex bridge calldata that isn't a simple ERC-20 transfer).
+  if (tokenMeta) {
+    return { ...base, amount: tokenMeta.amount };
   }
 
   return null;
@@ -490,36 +455,6 @@ function extractSentAmountFromParent(
   }
 
   return null;
-}
-
-function extractSentAmountFromFiat(
-  metamaskPay: TransactionMeta['metamaskPay'],
-  nativeConversionRate: number | null | undefined,
-  tokenAddress: Hex,
-  chainId: Hex,
-  contractExchangeRates: Record<string, { price: number }> | undefined,
-): string | null {
-  const totalFiat = metamaskPay?.totalFiat;
-  if (!totalFiat || !nativeConversionRate || nativeConversionRate === 0) {
-    return null;
-  }
-
-  const nativeTokenAddr = getNativeTokenAddress(chainId);
-  const isNative = tokenAddress.toLowerCase() === nativeTokenAddr.toLowerCase();
-
-  let tokenFiatRate: number;
-  if (isNative) {
-    tokenFiatRate = nativeConversionRate;
-  } else {
-    const contractRate = contractExchangeRates?.[tokenAddress]?.price ?? 0;
-    if (contractRate === 0) return null;
-    tokenFiatRate = nativeConversionRate * contractRate;
-  }
-
-  const tokenAmount = new BigNumber(totalFiat).dividedBy(tokenFiatRate);
-  if (tokenAmount.isNaN() || tokenAmount.isZero()) return null;
-
-  return tokenAmount.toFixed(tokenAmount.lt(0.01) ? 6 : 2);
 }
 
 function extractSentAmount(

--- a/app/lib/Money/feature-flags.ts
+++ b/app/lib/Money/feature-flags.ts
@@ -16,5 +16,5 @@ export function isMoneyAccountEnabled(
   const remoteFlag =
     remoteFeatureFlags?.moneyEnableMoneyAccount as VersionGatedFeatureFlag;
 
-  return validatedVersionGatedFeatureFlag(remoteFlag) ?? true;
+  return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
 }

--- a/app/lib/Money/feature-flags.ts
+++ b/app/lib/Money/feature-flags.ts
@@ -16,5 +16,5 @@ export function isMoneyAccountEnabled(
   const remoteFlag =
     remoteFeatureFlags?.moneyEnableMoneyAccount as VersionGatedFeatureFlag;
 
-  return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  return validatedVersionGatedFeatureFlag(remoteFlag) ?? true;
 }


### PR DESCRIPTION
## **Description**

Money Account transaction detail pages (`moneyAccountDeposit`, `moneyAccountWithdraw`, `musdConversion`, `predictionsDeposit`, `predictionsWithdraw`, `perpsDeposit`, `perpsWithdraw`) were attempting to render a two-asset hero ("You sent" / "You received"), but could not accurately determine the source token amount due to limitations in the `metamaskPay` metadata.

This PR simplifies the display to a single-line hero for all Money Account flows:
- **Deposits & Conversions**: `+X.XX mUSD` in green with the Money Account icon
- **Withdrawals**: `-X.XX mUSD` with the Money Account icon

### Changes

- Removed `moneyAccountDeposit`, `moneyAccountWithdraw`, `musdConversion`, `predictionsDeposit`, `predictionsWithdraw`, `perpsDeposit`, `perpsWithdraw` from `TWO_ASSET_HERO_TYPES`
- Simplified `showTokenIcon` condition — all money account types now render single-line regardless of deposit source
- All deposits/conversions display with `+` prefix and green (`TextColor.Success`)
- All withdrawals display with `-` prefix
- Removed dead code: `isSingleRowMoneyDeposit` function, `isSingleRowMusdMoneyWithdraw` import, and related condition guards from `showTwoAssetHero`
- Updated tests to validate new single-line behavior

## **Changelog**

CHANGELOG entry: Fixed Money Account transaction detail hero to show a single-line token amount display instead of an inaccurate two-asset layout

## **Related issues**

Fixes: [MUSD-1073](https://consensyssoftware.atlassian.net/browse/MUSD-1073)

## **Manual testing steps**

```gherkin
Feature: Money Account transaction detail hero

  Scenario: User views a crypto deposit into Money Account
    Given the user has completed a crypto-to-mUSD deposit (e.g. ETH → mUSD)

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "+X.XX mUSD" in green text with the Money Account icon
    And no "You sent" / "You received" labels are shown

  Scenario: User views a withdrawal from Money Account
    Given the user has completed a withdrawal from Money Account

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "-X.XX mUSD" with the Money Account icon
    And no "You sent" / "You received" labels are shown

  Scenario: User views a mUSD conversion
    Given the user has completed a mUSD conversion

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "+X.XX mUSD" in green text with the Money Account icon
    And no "You sent" / "You received" labels are shown

  Scenario: Perps/Predict flows still show two-asset hero
    Given the user has completed a perpsDeposit or predictDeposit

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "You sent" and "You received" with respective token amounts
```

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="436" height="964" alt="Screenshot 2026-06-25 at 12 04 04" src="https://github.com/user-attachments/assets/3aba3490-fea8-4fd9-a7ec-0bf5afd0ea92" />

<img width="451" height="957" alt="Screenshot 2026-06-25 at 12 03 25" src="https://github.com/user-attachments/assets/caad957b-3f15-48a0-9bbd-7130c3ec1dbe" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1073]: https://consensyssoftware.atlassian.net/browse/MUSD-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in transaction detail hero rendering with updated unit tests; no auth, data, or payment logic touched.
> 
> **Overview**
> Money Account transaction detail heroes no longer use the **"You sent" / "You received"** two-asset layout for `moneyAccountDeposit`, `moneyAccountWithdraw`, or `musdConversion`. In Money context those types always render a **single line** with the Money Account icon: **green `+X.XX mUSD`** for deposits and conversions, **`-X.XX mUSD`** for withdrawals.
> 
> **`TWO_ASSET_HERO_TYPES`** now only includes perps and predict deposit/withdraw types, which still have reliable source/received token data. The hero drops **`isSingleRowMoneyDeposit`**, the **`isSingleRowMusdMoneyWithdraw`** guard, and the extra **`showTokenIcon`** branching that picked between layouts.
> 
> Tests were updated to assert single-line behavior (including when a relay deposit child exists) and removed cases that expected two-asset sent amounts from relay metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4367f9c89060bc6c8ed4bbebb77b0be742e583fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->