### PR TITLE
chore: show QuickBuy rate pill initially, for tokens the user does not hold

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -472,6 +472,9 @@ const TraderPositionView = () => {
                 marketCap={
                   typeof marketCap === 'number' ? marketCap : undefined
                 }
+                tokenPriceFiat={
+                  typeof currentPrice === 'number' ? currentPrice : undefined
+                }
                 source={quickBuySource}
                 isTraderPositionClosed={isClosed}
               />

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.test.tsx
@@ -87,6 +87,8 @@ jest.mock('../../../../../../component-library/components/Icons/Icon', () => ({
 const buildContext = (overrides = {}) => ({
   sourceToken: undefined,
   destToken: undefined,
+  activeQuote: { quote: {} },
+  hasValidAmount: true,
   formattedNetworkFee: '$1.23',
   formattedSlippage: '0.5%',
   formattedMinimumReceived: '0.99 ETH',
@@ -195,5 +197,31 @@ describe('QuickBuyQuoteDetailsScreen', () => {
       screen.getByText('bridge.price_impact_info_title'),
     ).toBeOnTheScreen();
     expect(screen.getByText('25.00%')).toBeOnTheScreen();
+  });
+
+  it('shows the "enter an amount" empty state when there is no quote and no committed amount', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({ activeQuote: undefined, hasValidAmount: false }),
+    );
+    render(<QuickBuyQuoteDetailsScreen />);
+    expect(
+      screen.getByText(
+        'social_leaderboard.quick_buy.quote_details_empty_no_amount',
+      ),
+    ).toBeOnTheScreen();
+    expect(screen.queryByTestId('quick-buy-rate-row')).not.toBeOnTheScreen();
+  });
+
+  it('shows the "no quote" empty state when an amount is entered but no quote resolves', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue(
+      buildContext({ activeQuote: undefined, hasValidAmount: true }),
+    );
+    render(<QuickBuyQuoteDetailsScreen />);
+    expect(
+      screen.getByText(
+        'social_leaderboard.quick_buy.quote_details_empty_no_quote',
+      ),
+    ).toBeOnTheScreen();
+    expect(screen.queryByTestId('quick-buy-rate-row')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyQuoteDetailsScreen.tsx
@@ -34,6 +34,8 @@ const QuickBuyQuoteDetailsScreen: React.FC = () => {
   const {
     sourceToken,
     destToken,
+    activeQuote,
+    hasValidAmount,
     formattedNetworkFee,
     formattedSlippage,
     formattedMinimumReceived,
@@ -46,6 +48,11 @@ const QuickBuyQuoteDetailsScreen: React.FC = () => {
     onClose,
     setActiveScreen,
   } = useQuickBuyContext();
+
+  // No quote to detail yet: show an actionable empty state instead of a table
+  // of dashes. The rate pill is reachable pre-quote (it shows an estimate), so
+  // tapping it must not land the user on an empty details screen.
+  const hasQuoteDetails = Boolean(activeQuote);
 
   const handleEditSlippage = () => {
     navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
@@ -69,101 +76,115 @@ const QuickBuyQuoteDetailsScreen: React.FC = () => {
         onClose={onClose}
       />
 
-      <Box twClassName="px-4 pt-3" gap={3}>
-        <KeyValueRowStubs.Root>
-          <KeyValueRowStubs.Section>
-            <KeyValueRowStubs.Label
-              label={
+      {!hasQuoteDetails ? (
+        <Box twClassName="px-4 py-8" alignItems={BoxAlignItems.Center}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {strings(
+              hasValidAmount
+                ? 'social_leaderboard.quick_buy.quote_details_empty_no_quote'
+                : 'social_leaderboard.quick_buy.quote_details_empty_no_amount',
+            )}
+          </Text>
+        </Box>
+      ) : (
+        <Box twClassName="px-4 pt-3" gap={3}>
+          <KeyValueRowStubs.Root>
+            <KeyValueRowStubs.Section>
+              <KeyValueRowStubs.Label
+                label={
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    gap={1}
+                  >
+                    <Text
+                      variant={TextVariant.BodyMd}
+                      color={TextColor.TextAlternative}
+                    >
+                      {strings('social_leaderboard.quick_buy.rate')}
+                    </Text>
+                    <QuickBuyQuoteCountdown
+                      quotesLastFetchedAt={quotesLastFetchedAt}
+                      quoteRefreshRateMs={quoteRefreshRateMs}
+                    />
+                  </Box>
+                }
+                tooltip={{
+                  title: strings('bridge.quote_info_title'),
+                  content: strings('bridge.quote_info_content'),
+                  size: TooltipSizes.Sm,
+                  iconName: IconNameLegacy.Info,
+                }}
+              />
+            </KeyValueRowStubs.Section>
+            <KeyValueRowStubs.Section
+              align={KeyValueRowSectionAlignments.RIGHT}
+            >
+              <QuickBuyQuoteDetailPressableValue
+                onPress={() => setActiveScreen('selectQuote')}
+                testID="quick-buy-rate-row"
+                text={formattedRate ?? '-'}
+                iconName={IconName.ArrowRight}
+              />
+            </KeyValueRowStubs.Section>
+          </KeyValueRowStubs.Root>
+
+          <QuickBuyQuoteDetailRow
+            label={strings('social_leaderboard.quick_buy.network_fee')}
+            tooltipTitle={strings('bridge.network_fee_info_title')}
+            tooltipContent={strings('bridge.network_fee_info_content')}
+            value={<QuickBuyQuoteDetailTextValue text={formattedNetworkFee} />}
+          />
+
+          <QuickBuyQuoteDetailRow
+            label={strings('social_leaderboard.quick_buy.slippage')}
+            tooltipTitle={strings('bridge.slippage_info_title')}
+            tooltipContent={strings('bridge.slippage_info_description')}
+            value={
+              <QuickBuyQuoteDetailPressableValue
+                onPress={handleEditSlippage}
+                testID="quick-buy-edit-slippage"
+                text={formattedSlippage}
+                iconName={IconName.Edit}
+              />
+            }
+          />
+
+          {isPriceImpactError && (
+            <QuickBuyQuoteDetailRow
+              label={strings('bridge.price_impact_info_title')}
+              tooltipTitle={strings('bridge.price_impact_info_title')}
+              tooltipContent={strings('bridge.price_impact_info_description')}
+              value={
                 <Box
                   flexDirection={BoxFlexDirection.Row}
                   alignItems={BoxAlignItems.Center}
                   gap={1}
                 >
+                  <Icon
+                    name={IconName.Warning}
+                    size={IconSize.Sm}
+                    color={IconColor.ErrorDefault}
+                  />
                   <Text
                     variant={TextVariant.BodyMd}
-                    color={TextColor.TextAlternative}
+                    color={TextColor.ErrorDefault}
                   >
-                    {strings('social_leaderboard.quick_buy.rate')}
+                    {formattedPriceImpact}
                   </Text>
-                  <QuickBuyQuoteCountdown
-                    quotesLastFetchedAt={quotesLastFetchedAt}
-                    quoteRefreshRateMs={quoteRefreshRateMs}
-                  />
                 </Box>
               }
-              tooltip={{
-                title: strings('bridge.quote_info_title'),
-                content: strings('bridge.quote_info_content'),
-                size: TooltipSizes.Sm,
-                iconName: IconNameLegacy.Info,
-              }}
             />
-          </KeyValueRowStubs.Section>
-          <KeyValueRowStubs.Section align={KeyValueRowSectionAlignments.RIGHT}>
-            <QuickBuyQuoteDetailPressableValue
-              onPress={() => setActiveScreen('selectQuote')}
-              testID="quick-buy-rate-row"
-              text={formattedRate ?? '-'}
-              iconName={IconName.ArrowRight}
-            />
-          </KeyValueRowStubs.Section>
-        </KeyValueRowStubs.Root>
+          )}
 
-        <QuickBuyQuoteDetailRow
-          label={strings('social_leaderboard.quick_buy.network_fee')}
-          tooltipTitle={strings('bridge.network_fee_info_title')}
-          tooltipContent={strings('bridge.network_fee_info_content')}
-          value={<QuickBuyQuoteDetailTextValue text={formattedNetworkFee} />}
-        />
-
-        <QuickBuyQuoteDetailRow
-          label={strings('social_leaderboard.quick_buy.slippage')}
-          tooltipTitle={strings('bridge.slippage_info_title')}
-          tooltipContent={strings('bridge.slippage_info_description')}
-          value={
-            <QuickBuyQuoteDetailPressableValue
-              onPress={handleEditSlippage}
-              testID="quick-buy-edit-slippage"
-              text={formattedSlippage}
-              iconName={IconName.Edit}
-            />
-          }
-        />
-
-        {isPriceImpactError && (
           <QuickBuyQuoteDetailRow
-            label={strings('bridge.price_impact_info_title')}
-            tooltipTitle={strings('bridge.price_impact_info_title')}
-            tooltipContent={strings('bridge.price_impact_info_description')}
-            value={
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                gap={1}
-              >
-                <Icon
-                  name={IconName.Warning}
-                  size={IconSize.Sm}
-                  color={IconColor.ErrorDefault}
-                />
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.ErrorDefault}
-                >
-                  {formattedPriceImpact}
-                </Text>
-              </Box>
-            }
+            label={strings('social_leaderboard.quick_buy.minimum_received')}
+            tooltipTitle={strings('bridge.minimum_received_tooltip_title')}
+            tooltipContent={strings('bridge.minimum_received_tooltip_content')}
+            value={<QuickBuyQuoteDetailTextValue text={minReceivedLabel} />}
           />
-        )}
-
-        <QuickBuyQuoteDetailRow
-          label={strings('social_leaderboard.quick_buy.minimum_received')}
-          tooltipTitle={strings('bridge.minimum_received_tooltip_title')}
-          tooltipContent={strings('bridge.minimum_received_tooltip_content')}
-          value={<QuickBuyQuoteDetailTextValue text={minReceivedLabel} />}
-        />
-      </Box>
+        </Box>
+      )}
     </>
   );
 };

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/TraderPositionQuickBuy.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/TraderPositionQuickBuy.tsx
@@ -14,6 +14,8 @@ export interface TraderPositionQuickBuyProps {
   onClose: () => void;
   traderAddress?: string;
   marketCap?: number;
+  /** Latest buy-token price in the user's display currency (chart feed). */
+  tokenPriceFiat?: number;
   source?: QuickBuySheetSource;
   /** `true` when the trader has closed the position (sell); `false` when still open (buy). */
   isTraderPositionClosed?: boolean;
@@ -29,6 +31,7 @@ const TraderPositionQuickBuy: React.FC<TraderPositionQuickBuyProps> = ({
   onClose,
   traderAddress,
   marketCap,
+  tokenPriceFiat,
   source,
   isTraderPositionClosed,
 }) => {
@@ -55,12 +58,19 @@ const TraderPositionQuickBuy: React.FC<TraderPositionQuickBuyProps> = ({
     const hasAny =
       traderAddress !== undefined ||
       marketCap !== undefined ||
+      tokenPriceFiat !== undefined ||
       source !== undefined ||
       traderTradeType !== undefined;
     return hasAny
-      ? { traderAddress, marketCap, source, traderTradeType }
+      ? { traderAddress, marketCap, tokenPriceFiat, source, traderTradeType }
       : undefined;
-  }, [traderAddress, marketCap, source, isTraderPositionClosed]);
+  }, [
+    traderAddress,
+    marketCap,
+    tokenPriceFiat,
+    source,
+    isTraderPositionClosed,
+  ]);
 
   return (
     <QuickBuy.Root

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.test.ts
@@ -1,0 +1,104 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+import { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
+import { selectCurrencyRates } from '../../../../../../../selectors/currencyRateController';
+import { selectMultichainAssetsRates } from '../../../../../../../selectors/multichain/multichain';
+import { calcTokenFiatRate } from '../../../../../../UI/Bridge/utils/exchange-rates';
+import { useDestTokenExchangeRate } from './useDestTokenExchangeRate';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/tokenRatesController', () => ({
+  selectTokenMarketData: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/currencyRateController', () => ({
+  selectCurrencyRates: jest.fn(),
+}));
+
+jest.mock('../../../../../../../selectors/multichain/multichain', () => ({
+  selectMultichainAssetsRates: jest.fn(),
+}));
+
+jest.mock('../../../../../../UI/Bridge/utils/exchange-rates', () => ({
+  calcTokenFiatRate: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.Mock;
+const mockCalcTokenFiatRate = calcTokenFiatRate as jest.Mock;
+
+const STATE = {
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        networkConfigurationsByChainId: { '0x1': { nativeCurrency: 'ETH' } },
+      },
+    },
+  },
+} as never;
+
+const evmToken = (
+  address = '0x6b175474e89094c44da98b954eedeac495271d0f',
+): BridgeToken =>
+  ({
+    address,
+    chainId: '0x1',
+    symbol: 'DAI',
+    name: 'Dai',
+    decimals: 18,
+  }) as BridgeToken;
+
+describe('useDestTokenExchangeRate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector(STATE),
+    );
+    (selectTokenMarketData as unknown as jest.Mock).mockReturnValue({});
+    (selectCurrencyRates as unknown as jest.Mock).mockReturnValue({});
+    (selectMultichainAssetsRates as unknown as jest.Mock).mockReturnValue({});
+  });
+
+  it('returns undefined when the token is missing', () => {
+    const { result } = renderHook(() => useDestTokenExchangeRate(undefined));
+    expect(result.current).toBeUndefined();
+    expect(mockCalcTokenFiatRate).not.toHaveBeenCalled();
+  });
+
+  it('returns the resolved rate when a positive price is available', () => {
+    mockCalcTokenFiatRate.mockReturnValue(1.23);
+    const { result } = renderHook(() => useDestTokenExchangeRate(evmToken()));
+    expect(result.current).toBe(1.23);
+  });
+
+  it('checksums the EVM address before pricing (matches market-data keys)', () => {
+    mockCalcTokenFiatRate.mockReturnValue(1);
+    renderHook(() =>
+      useDestTokenExchangeRate(
+        evmToken('0x6b175474e89094c44da98b954eedeac495271d0f'),
+      ),
+    );
+    expect(mockCalcTokenFiatRate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.objectContaining({
+          address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        }),
+      }),
+    );
+  });
+
+  it('returns undefined when no price resolves', () => {
+    mockCalcTokenFiatRate.mockReturnValue(undefined);
+    const { result } = renderHook(() => useDestTokenExchangeRate(evmToken()));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined for a non-positive rate', () => {
+    mockCalcTokenFiatRate.mockReturnValue(0);
+    const { result } = renderHook(() => useDestTokenExchangeRate(evmToken()));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useDestTokenExchangeRate.ts
@@ -1,0 +1,74 @@
+import { isNativeAddress, isNonEvmChainId } from '@metamask/bridge-controller';
+import type { Hex } from '@metamask/utils';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../../../../../../reducers';
+import { selectCurrencyRates } from '../../../../../../../selectors/currencyRateController';
+import { selectMultichainAssetsRates } from '../../../../../../../selectors/multichain/multichain';
+import { selectTokenMarketData } from '../../../../../../../selectors/tokenRatesController';
+import { safeToChecksumAddress } from '../../../../../../../util/address';
+import { calcTokenFiatRate } from '../../../../../../UI/Bridge/utils/exchange-rates';
+import type { BridgeToken } from '../../../../../../UI/Bridge/types';
+
+/**
+ * Resolves a *display-only* user-currency-per-token exchange rate for a token,
+ * independent of whether the user holds a balance of it.
+ *
+ * This is the same canonical `calcTokenFiatRate` calculation that
+ * `usePositionTokenBalance` runs internally — but without the balance gate, so
+ * the pre-quote rate pill can render for a token the user is buying for the
+ * first time (and therefore holds no balance of). Returns `undefined` when no
+ * price can be resolved or the token is missing.
+ *
+ * The returned rate is for display only. It must never be merged into the `BridgeToken`
+ * reference passed to quote fetching / redux. Doing so would churn quote requests
+ * on every market-data tick (see `destTokenForRate` in `useQuickBuyController`).
+ */
+export const useDestTokenExchangeRate = (
+  token: BridgeToken | undefined,
+): number | undefined => {
+  const tokenMarketData = useSelector(selectTokenMarketData);
+  const currencyRates = useSelector(selectCurrencyRates);
+  const multichainRates = useSelector(selectMultichainAssetsRates);
+  const networkConfigurations = useSelector(
+    (state: RootState) =>
+      state.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId,
+  );
+
+  return useMemo(() => {
+    if (!token) return undefined;
+
+    // `calcTokenFiatRate` looks up EVM `tokenMarketData` by the checksummed
+    // `token.address`, mirroring `usePositionTokenBalance`. Native and non-EVM
+    // addresses are passed through unchanged (non-EVM is keyed by CAIP-19).
+    const pricedToken =
+      isNonEvmChainId(token.chainId) || isNativeAddress(token.address)
+        ? token
+        : {
+            ...token,
+            address: safeToChecksumAddress(token.address) ?? token.address,
+          };
+
+    const rate = calcTokenFiatRate({
+      token: pricedToken,
+      evmMultiChainMarketData: tokenMarketData,
+      networkConfigurationsByChainId: (networkConfigurations ?? {}) as Record<
+        Hex,
+        { nativeCurrency: string }
+      >,
+      evmMultiChainCurrencyRates: currencyRates,
+      nonEvmMultichainAssetRates: multichainRates as Parameters<
+        typeof calcTokenFiatRate
+      >[0]['nonEvmMultichainAssetRates'],
+    });
+
+    return rate !== undefined && rate > 0 ? rate : undefined;
+  }, [
+    token,
+    tokenMarketData,
+    currencyRates,
+    multichainRates,
+    networkConfigurations,
+  ]);
+};

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -49,6 +49,7 @@ import { formatExchangeRate } from '../utils/formatExchangeRate';
 import { formatQuickBuyRateValue } from '../utils/formatQuickBuyRateValue';
 import { getMetamaskFeePercent } from '../utils/getMetamaskFeePercent';
 import { selectDefaultReceiveToken } from '../utils/selectDefaultReceiveToken';
+import { useDestTokenExchangeRate } from './useDestTokenExchangeRate';
 import { usePayWithTokens } from './usePayWithTokens';
 import { usePositionTokenBalance } from './usePositionTokenBalance';
 import { useQuickBuyAnalytics } from './useQuickBuyAnalytics';
@@ -891,18 +892,37 @@ export function useQuickBuyController(
     ? maxSpendFiat <= 0
     : maxSpendTokens <= 0;
 
-  // For the toolbar rate pill in buy mode the dest token from `useQuickBuySetup`
-  // carries no price data, so we enrich a local copy with the rate already
-  // resolved by `usePositionTokenBalance`. We deliberately do NOT propagate this
-  // into `destToken` itself — the BridgeToken passed to quote fetching and
-  // redux must stay reference-stable, otherwise EVM→non-EVM (e.g. USDC/Base →
-  // SOL/Solana) flows lose their quote requests when market data ticks.
+  // Display-only copy of the dest token enriched with a balance-independent
+  // rate (`useDestTokenExchangeRate`) so the pre-quote pill renders even when
+  // the user holds no balance of the token being bought. Never propagated into
+  // `destToken` — the quote/redux reference must stay stable so market-data
+  // ticks don't churn quote requests.
+  const destTokenLookupRate = useDestTokenExchangeRate(
+    tradeMode === 'buy' ? destToken : undefined,
+  );
+  // Price source priority for the buy token: the host-supplied chart price
+  // (display currency, present even for un-held tokens) → the cached market-data
+  // lookup → the held-balance rate. The first two cover the common case of
+  // buying a token the user doesn't hold, where the lookup alone resolves
+  // nothing (TokenRatesController only tracks held tokens).
+  const hostTokenPriceFiat = analyticsContext?.tokenPriceFiat;
   const destTokenForRate = useMemo<BridgeToken | undefined>(() => {
     if (tradeMode !== 'buy' || !destToken) return destToken;
-    const rate = positionToken?.currencyExchangeRate;
+    const rate =
+      (hostTokenPriceFiat !== undefined && hostTokenPriceFiat > 0
+        ? hostTokenPriceFiat
+        : undefined) ??
+      destTokenLookupRate ??
+      positionToken?.currencyExchangeRate;
     if (rate === undefined) return destToken;
     return { ...destToken, currencyExchangeRate: rate };
-  }, [tradeMode, destToken, positionToken?.currencyExchangeRate]);
+  }, [
+    tradeMode,
+    destToken,
+    hostTokenPriceFiat,
+    destTokenLookupRate,
+    positionToken?.currencyExchangeRate,
+  ]);
 
   const formattedExchangeRate = useMemo(
     () =>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/types.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/types.ts
@@ -40,6 +40,14 @@ export interface QuickBuyAnalyticsContext {
   marketCap?: number;
   source?: QuickBuySheetSource;
   traderTradeType?: 'buy' | 'sell';
+  /**
+   * Latest price of the buy token in the user's display currency, supplied by
+   * the host (e.g. the trader position chart feed). Used as the pre-quote
+   * exchange-rate source for tokens the user does not hold — for which the
+   * cached market-data lookup resolves nothing — so the rate pill renders
+   * immediately on open. Display-only; never fed into quote fetching.
+   */
+  tokenPriceFiat?: number;
 }
 
 export interface QuickBuySheetProps {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -37,6 +37,7 @@ import {
   isSameAsset,
   selectDefaultSourceToken,
 } from '../../../utils/tokenSelection';
+import { useDestTokenExchangeRate } from './hooks/useDestTokenExchangeRate';
 import { usePayWithTokens } from './hooks/usePayWithTokens';
 import { usePositionTokenBalance } from './hooks/usePositionTokenBalance';
 import { useQuickBuyController } from './hooks/useQuickBuyController';
@@ -115,6 +116,10 @@ jest.mock('./hooks/useReceiveTokens', () => ({
 
 jest.mock('./hooks/usePositionTokenBalance', () => ({
   usePositionTokenBalance: jest.fn().mockReturnValue(undefined),
+}));
+
+jest.mock('./hooks/useDestTokenExchangeRate', () => ({
+  useDestTokenExchangeRate: jest.fn().mockReturnValue(undefined),
 }));
 
 jest.mock('./hooks/useQuickBuyQuotes', () => ({
@@ -408,6 +413,7 @@ const setupDefaultMocks = () => {
 
   (useReceiveTokens as jest.Mock).mockReturnValue([]);
   (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
+  (useDestTokenExchangeRate as jest.Mock).mockReturnValue(undefined);
   (usePayWithTokens as jest.Mock).mockReturnValue({
     options: [createSourceToken()],
     isLoading: false,
@@ -1536,6 +1542,97 @@ describe('useQuickBuyController', () => {
 
       expect(result.current.formattedExchangeRate).toMatch(/^1 SOL = /);
       expect(result.current.formattedExchangeRate).not.toMatch(/^1 GIGA = /);
+    });
+
+    it('shows the pre-quote rate from the balance-independent lookup when the user holds no balance of the buy token', () => {
+      const solToken = createSourceToken({
+        symbol: 'SOL',
+        currencyExchangeRate: 150,
+      });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [solToken],
+        isLoading: false,
+      });
+      (useQuickBuySetup as jest.Mock).mockReturnValue({
+        chainId: '0x1',
+        destToken: {
+          address: '0xDEST',
+          chainId: '0x1',
+          decimals: 18,
+          symbol: 'GIGA',
+          name: 'Gigachad',
+        },
+        isLoading: false,
+        isUnsupportedChain: false,
+      });
+      // User holds no balance of GIGA, so the position-token rate is undefined…
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
+      // …but the display-only lookup still resolves a price for it.
+      (useDestTokenExchangeRate as jest.Mock).mockReturnValue(0.006375);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget({ tokenSymbol: 'GIGA' }), jest.fn()),
+      );
+
+      expect(result.current.formattedExchangeRate).toMatch(/^1 SOL = /);
+    });
+
+    it('shows the pre-quote rate from the host-supplied token price when the user holds no balance and no market data exists', () => {
+      const solToken = createSourceToken({
+        symbol: 'SOL',
+        currencyExchangeRate: 150,
+      });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [solToken],
+        isLoading: false,
+      });
+      (useQuickBuySetup as jest.Mock).mockReturnValue({
+        chainId: '0x1',
+        destToken: {
+          address: '0xDEST',
+          chainId: '0x1',
+          decimals: 18,
+          symbol: 'GIGA',
+          name: 'Gigachad',
+        },
+        isLoading: false,
+        isUnsupportedChain: false,
+      });
+      // No balance and no cached market-data rate…
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
+      (useDestTokenExchangeRate as jest.Mock).mockReturnValue(undefined);
+
+      // …but the host passes the chart price for the buy token.
+      const { result } = renderHook(() =>
+        useQuickBuyController(
+          createTarget({ tokenSymbol: 'GIGA' }),
+          jest.fn(),
+          {
+            tokenPriceFiat: 0.95625,
+          },
+        ),
+      );
+
+      expect(result.current.formattedExchangeRate).toMatch(/^1 SOL = /);
+    });
+
+    it('does not render a pre-quote rate when neither the lookup nor the held balance resolves a price', () => {
+      const solToken = createSourceToken({
+        symbol: 'SOL',
+        currencyExchangeRate: 150,
+      });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [solToken],
+        isLoading: false,
+      });
+      (usePositionTokenBalance as jest.Mock).mockReturnValue(undefined);
+      (useDestTokenExchangeRate as jest.Mock).mockReturnValue(undefined);
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget({ tokenSymbol: 'GIGA' }), jest.fn()),
+      );
+
+      expect(result.current.formattedExchangeRate).toBeUndefined();
     });
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1134,6 +1134,8 @@
       "price_impact": "Price impact",
       "est_points": "Est. points",
       "no_quotes": "No quotes available for this token",
+      "quote_details_empty_no_amount": "Enter an amount to see quote details.",
+      "quote_details_empty_no_quote": "No quote available right now. Try a different amount.",
       "loading": "Loading...",
       "unavailable": "Swap unavailable",
       "unsupported_chain": "This chain is not supported for Quick Buy yet",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The QuickBuy pre-quote rate pill was initially blank when buying a token the user didn't already hold. The rate was sourced only from `positionToken`, which is undefined without a token balance, so first-time buys showed no rate until a quote returned.

This adds a balance-independent price source for the buy token: a display-only `useDestTokenExchangeRate` lookup plus the host's existing chart price. The rate feeds only the display-only `destTokenForRate`; the `destToken` passed to quote fetching stays reference-stable, so quoting and performance are unchanged (no new network requests).

**Before:**
<img height="810" alt="IMG_0051" src="https://github.com/user-attachments/assets/4c59249d-cb42-4775-b017-b402597e386c" />

**After:**
<img height="810" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 10 40 26" src="https://github.com/user-attachments/assets/bc280148-ec50-4f5e-87ea-56c9449ede3f" />

<img height="810" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-25 at 14 15 43" src="https://github.com/user-attachments/assets/92f8b83a-0913-4c6f-9816-a3b5bc346c31" />

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: NA

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA

### **After**

NA

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are display-layer only with explicit guards against mutating quote `destToken`; mistaken wiring could affect rate display accuracy but not swap execution.
> 
> **Overview**
> **Quick Buy** now shows an estimated rate on open when buying a token the user does not hold, instead of leaving the rate pill blank until a quote returns.
> 
> Pricing for that pill uses a **display-only** priority chain: the trader position chart price (`tokenPriceFiat` from `TraderPositionView`), then a new **`useDestTokenExchangeRate`** hook (market data via `calcTokenFiatRate`, without requiring a balance), then the existing held-position rate. Only **`destTokenForRate`** is enriched; **`destToken`** for quoting stays reference-stable so quote fetching is unchanged.
> 
> **Quote details** no longer renders a table of dashes when there is no active quote. It shows guided copy for “enter an amount” vs “no quote available,” with new `en.json` strings and unit tests.
> 
> Controller and hook tests cover lookup, host price, and missing-price cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd24faa63b024f26b4a411ab0a138fb9d23755e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->