### PR TITLE
fix: cp-8.0.0 Fix transaction fee regression for fiat transaction fees

### DIFF
--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -15,6 +15,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import {
   useIsTransactionPayLoading,
+  useTransactionPayFiatPayment,
   useTransactionPayQuotes,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
@@ -67,6 +68,9 @@ describe('BridgeFeeRow', () => {
     useIsTransactionPayLoading,
   );
   const useIsPaidByMetaMaskMock = jest.mocked(useIsPaidByMetaMask);
+  const useTransactionPayFiatPaymentMock = jest.mocked(
+    useTransactionPayFiatPayment,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -89,6 +93,8 @@ describe('BridgeFeeRow', () => {
     useTransactionPaySourceAmountsMock.mockReturnValue([]);
 
     useIsPaidByMetaMaskMock.mockReturnValue(false);
+
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
   });
 
   it('renders transaction fee', async () => {
@@ -209,6 +215,16 @@ describe('BridgeFeeRow', () => {
   it('renders $0 fee when transaction is gas fee sponsored', () => {
     const { getByText } = render({ isGasFeeSponsored: true });
     expect(getByText('$0')).toBeOnTheScreen();
+  });
+
+  it('renders fee from totals when gas fee sponsored and fiat payment selected', () => {
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'pm-123',
+    } as never);
+
+    const { getByText } = render({ isGasFeeSponsored: true });
+
+    expect(getByText('$1.23')).toBeOnTheScreen();
   });
 
   describe('paid by MetaMask', () => {

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -21,6 +21,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import {
   useIsTransactionPayLoading,
+  useTransactionPayFiatPayment,
   useTransactionPayQuotes,
   useTransactionPaySourceAmounts,
   useTransactionPayTotals,
@@ -52,6 +53,8 @@ export function BridgeFeeRow() {
   const { fieldAlerts } = useAlerts();
   const hasAlert = fieldAlerts.some((a) => a.field === RowAlertKey.PayWithFee);
   const { isHeadlessBuyInProgress } = useConfirmationContext();
+  const fiatPayment = useTransactionPayFiatPayment();
+  const isFiatPayment = Boolean(fiatPayment?.selectedPaymentMethodId);
 
   return (
     <TransactionFeeRow
@@ -61,6 +64,7 @@ export function BridgeFeeRow() {
       hasSourceAmounts={Boolean(sourceAmounts?.length)}
       hasAlert={hasAlert}
       isLoading={isLoading}
+      isFiatPayment={isFiatPayment}
       paidByMetaMask={paidByMetaMask}
       tooltipDisabled={isHeadlessBuyInProgress}
       isDisabled={isHeadlessBuyInProgress}
@@ -75,6 +79,7 @@ function TransactionFeeRow({
   quotes,
   totals,
   isLoading,
+  isFiatPayment,
   paidByMetaMask,
   tooltipDisabled,
   isDisabled,
@@ -85,6 +90,7 @@ function TransactionFeeRow({
   quotes?: TransactionPayQuote<Json>[];
   totals?: TransactionPayTotals;
   isLoading: boolean;
+  isFiatPayment: boolean;
   paidByMetaMask: boolean;
   tooltipDisabled?: boolean;
   isDisabled?: boolean;
@@ -94,7 +100,11 @@ function TransactionFeeRow({
   const hasQuotes = Boolean(quotes?.length);
 
   const feeTotalUsd = useMemo(() => {
-    if (transactionMeta?.isGasFeeSponsored && !hasSourceAmounts) {
+    if (
+      transactionMeta?.isGasFeeSponsored &&
+      !hasSourceAmounts &&
+      !isFiatPayment
+    ) {
       return formatFiat(new BigNumber(0));
     }
 
@@ -116,6 +126,7 @@ function TransactionFeeRow({
     formatFiat,
     transactionMeta?.isGasFeeSponsored,
     hasSourceAmounts,
+    isFiatPayment,
   ]);
 
   if (isLoading) return <InfoRowSkeleton testId="bridge-fee-row-skeleton" />;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes a transaction fee display regression on the bridge confirmation fee row. When gas is sponsored (`isGasFeeSponsored: true`) but the user has a fiat payment method selected, the fee total was incorrectly forced to `$0` because `hasSourceAmounts` was `false` and the fiat payment path was not accounted for.

The fix reads `useTransactionPayFiatPayment()` and derives `isFiatPayment` from whether a `selectedPaymentMethodId` is present. This flag is passed into `TransactionFeeRow` and added to the early-return guard, so sponsored-gas flows only show `$0` when there are no source amounts **and** no fiat payment is active. When fiat is selected, the fee is correctly computed from totals (provider + network + MetaMask fees).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug where the bridge fee row showed $0 for fiat-funded transactions when gas was sponsored

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/32395

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Open the app and navigate to the Bridge flow.
2. Select a token pair that triggers a bridge transaction with sponsored gas (`isGasFeeSponsored: true`).
3. Select a fiat payment method (credit/debit card) as the funding source.
4. Proceed to the confirmation screen.
5. Verify the **Fee** row shows the correct total (provider + network + MetaMask fees) instead of `$0`.

**Before fix:** Fee row displayed `$0` when gas was sponsored and fiat payment was selected.
**After fix:** Fee row displays the correct total fee amount.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="606" height="1158" alt="Screenshot 2026-06-25 at 12 48 14" src="https://github.com/user-attachments/assets/5b7293c8-5c2b-46d4-b00c-7ea7d325fc85" />

<img width="606" height="1158" alt="Screenshot 2026-06-25 at 12 48 09" src="https://github.com/user-attachments/assets/39d2c639-9473-4212-b49d-e4c339b9e2f3" />

### **After**

<img width="562" height="1114" alt="Screenshot 2026-06-25 at 12 36 53" src="https://github.com/user-attachments/assets/809409b1-ccb8-4152-a4af-1085ee67a924" />

<img width="606" height="1158" alt="Screenshot 2026-06-25 at 12 37 18" src="https://github.com/user-attachments/assets/7693744e-ff6a-4fa1-92d3-7a2221b112a9" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only fee display logic in confirmations with a focused unit test; no auth, payment processing, or transaction submission changes.
> 
> **Overview**
> Fixes a **transaction fee display regression** on the confirmation **bridge fee row** when gas is sponsored but the user pays with **fiat**.
> 
> Previously, `isGasFeeSponsored` with no source amounts forced the fee total to **$0**. That incorrectly hid real fees for fiat-funded transaction pay flows. The row now reads `useTransactionPayFiatPayment` and treats a selected payment method as **fiat payment**, passing `isFiatPayment` into the fee calculation so sponsored gas still shows **totals-based** fees (provider, network, MetaMask) when fiat is selected.
> 
> Adds a unit test asserting **$1.23** is shown when gas is sponsored and a fiat payment method is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acec7a69d4a18738f11082cae29a18e7f75d6082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
