### PR TITLE
fix(money): update Money account copy and UI polish (MUSD-1074)

### DIFF
--- a/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
+++ b/app/components/UI/Money/Views/MoneyActivityView/MoneyActivityView.tsx
@@ -83,7 +83,7 @@ function groupByDate(
   }
   return Array.from(groups.entries()).map(([dateKey, data]) => ({
     title: new Date(`${dateKey}T00:00:00.000Z`).toLocaleDateString(locale, {
-      month: 'long',
+      month: 'short',
       day: 'numeric',
       year: 'numeric',
     }),

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.test.tsx
@@ -107,6 +107,7 @@ interface SetupOptions {
   isAggregatedBalanceLoading?: boolean;
   isBalanceLoading?: boolean;
   tokenTotal?: BigNumber;
+  apyPercent?: number;
 }
 
 const setupDefaultMocks = ({
@@ -119,6 +120,7 @@ const setupDefaultMocks = ({
   isAggregatedBalanceLoading = false,
   isBalanceLoading = false,
   tokenTotal = new BigNumber(0),
+  apyPercent,
 }: SetupOptions = {}) => {
   mockUseOnboardingStep.mockReturnValue({
     currentStep,
@@ -131,6 +133,7 @@ const setupDefaultMocks = ({
   mockUseMoneyAccountBalance.mockReturnValue({
     tokenTotal,
     isBalanceLoading,
+    apyPercent,
   } as ReturnType<typeof useMoneyAccountBalance>);
   (mockUseMoneyAccountCardLinkage as jest.Mock).mockReturnValue({
     startLinkFlow: mockStartLinkFlow,
@@ -201,24 +204,34 @@ describe('MoneyOnboardingCard', () => {
       expect(mockIncrementStep).not.toHaveBeenCalled();
     });
 
-    it('renders the step 1 title', () => {
+    it('renders the APY step 1 title and description when APY is available', () => {
+      setupDefaultMocks({ currentStep: 0, apyPercent: 4 });
+
+      const { getByTestId } = render(<MoneyOnboardingCard />);
+
+      expect(getByTestId('money-onboarding-card-title')).toHaveTextContent(
+        strings('money.onboarding.step_1.title', { apy: 4 }),
+      );
+      expect(
+        getByTestId('money-onboarding-card-description'),
+      ).toHaveTextContent(
+        strings('money.onboarding.step_1.description', { apy: 4 }),
+      );
+    });
+
+    it('falls back to the no-APY step 1 copy when APY is unavailable', () => {
       setupDefaultMocks({ currentStep: 0 });
 
       const { getByTestId } = render(<MoneyOnboardingCard />);
 
       expect(getByTestId('money-onboarding-card-title')).toHaveTextContent(
-        strings('money.onboarding.step_1.title'),
+        strings('money.onboarding.step_1.title_no_apy'),
       );
-    });
-
-    it('renders the step 1 description', () => {
-      setupDefaultMocks({ currentStep: 0 });
-
-      const { getByTestId } = render(<MoneyOnboardingCard />);
-
       expect(
         getByTestId('money-onboarding-card-description'),
-      ).toHaveTextContent(strings('money.onboarding.step_1.description'));
+      ).toHaveTextContent(
+        strings('money.onboarding.step_1.description_no_apy'),
+      );
     });
 
     it('renders the Add funds primary CTA', () => {

--- a/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
+++ b/app/components/UI/Money/components/MoneyOnboardingCard/MoneyOnboardingCard.tsx
@@ -6,6 +6,7 @@ import { strings } from '../../../../../../locales/i18n';
 import { useMoneyAccountCardLinkage } from '../../../Card/hooks/useMoneyAccountCardLinkage';
 import { MONEY_HOME_CARD_ORIGIN } from '../../../Card/hooks/useCardPostAuthRedirect';
 import { useOnboardingStep, STEPPER_IDS } from '../../hooks/useOnboardingStep';
+import { isPositiveNumber } from '../../utils/number';
 import StepperCard, {
   type StepperCardStep,
 } from '../../../../../component-library/components-temp/StepperCard';
@@ -48,7 +49,8 @@ const MoneyOnboardingCard = () => {
   });
 
   const { initiateDeposit } = useMoneyAccountDeposit();
-  const { tokenTotal, isBalanceLoading } = useMoneyAccountBalance();
+  const { tokenTotal, isBalanceLoading, apyPercent } = useMoneyAccountBalance();
+  const showApy = isPositiveNumber(apyPercent);
   const { trackOnboardingEvent } = useMoneyAnalytics({
     screen_name: SCREEN_NAMES.MONEY_HOME,
     component_name: COMPONENT_NAMES.MONEY_ONBOARDING_CARD,
@@ -240,7 +242,9 @@ const MoneyOnboardingCard = () => {
   const handleStep1CtaPressed = useCallback(() => {
     trackOnboardingEvent({
       step: currentStep + 1, // Use 1-based index for event tracking to match total_steps count.
-      step_title: strings('money.onboarding.step_1.title', { locale: 'en' }),
+      step_title: strings('money.onboarding.step_1.title_no_apy', {
+        locale: 'en',
+      }),
       total_steps: MONEY_ONBOARDING_TOTAL_STEPS,
       step_action: MONEY_ONBOARDING_STEP_ACTIONS.DEPOSIT_INITIATED,
       redirect_target: SCREEN_NAMES.MONEY_DEPOSIT,
@@ -253,8 +257,12 @@ const MoneyOnboardingCard = () => {
     if (!isOnboardingCardVisible || !isVisibleAfterAutoSkip) return [];
 
     const step1: StepperCardStep = {
-      title: strings('money.onboarding.step_1.title'),
-      description: strings('money.onboarding.step_1.description'),
+      title: showApy
+        ? strings('money.onboarding.step_1.title', { apy: apyPercent })
+        : strings('money.onboarding.step_1.title_no_apy'),
+      description: showApy
+        ? strings('money.onboarding.step_1.description', { apy: apyPercent })
+        : strings('money.onboarding.step_1.description_no_apy'),
       primaryCta: {
         text: strings('money.onboarding.step_1.cta'),
         onPress: handleStep1CtaPressed,
@@ -330,6 +338,8 @@ const MoneyOnboardingCard = () => {
   }, [
     isOnboardingCardVisible,
     isVisibleAfterAutoSkip,
+    showApy,
+    apyPercent,
     handleStep1CtaPressed,
     shouldShowLinkCardAction,
     isLinking,

--- a/app/components/Views/confirmations/components/activity/transaction-details-fee-section/transaction-details-fee-section.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-fee-section/transaction-details-fee-section.tsx
@@ -52,7 +52,7 @@ export function TransactionDetailsFeeSection() {
           testID="paid-by-metamask"
         >
           <Icon
-            name={IconName.Check}
+            name={IconName.CheckBold}
             color={IconColor.Success}
             size={IconSize.Sm}
           />

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.styles.ts
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.styles.ts
@@ -1,6 +1,9 @@
 import { Platform, StyleSheet } from 'react-native';
 import { Theme } from '../../../../../../util/theme/models';
 
+const ACCOUNT_SELECTOR_VERTICAL_PADDING = 12;
+const BOTTOM_BLOCK_GAP = 16;
+
 const styleSheet = (params: { theme: Theme }) => {
   const { theme } = params;
   return StyleSheet.create({
@@ -32,6 +35,7 @@ const styleSheet = (params: { theme: Theme }) => {
     separator: {
       borderBottomWidth: 1,
       borderBottomColor: theme.colors.border.muted,
+      marginBottom: ACCOUNT_SELECTOR_VERTICAL_PADDING - BOTTOM_BLOCK_GAP,
     },
   });
 };

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -131,7 +131,7 @@ function TransactionFeeRow({
     <AlertRow
       testID="bridge-fee-row"
       alertField={RowAlertKey.PayWithFee}
-      label={strings('confirm.label.transaction_fee')}
+      label={strings('confirm.label.transaction_fees')}
       tooltip={
         !paidByMetaMask && hasQuotes && totals ? (
           <Tooltip transactionMeta={transactionMeta} totals={totals} />
@@ -167,7 +167,7 @@ function PaidByLabel() {
       testID={ConfirmationRowComponentIDs.PAID_BY_METAMASK}
     >
       <Icon
-        name={IconName.Check}
+        name={IconName.CheckBold}
         color={IconColor.Success}
         size={IconSize.Sm}
       />

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7275,7 +7275,7 @@
       "how_it_works_subtitle": "See how your money works for you",
       "musd_title": "MetaMask USD",
       "musd_subtitle": "Learn more about mUSD",
-      "what_you_get_title": "Money account benefits",
+      "what_you_get_title": "What you get",
       "what_you_get_subtitle": "Explore your benefits"
     },
     "transaction": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7063,8 +7063,10 @@
     "balance_no_account": "Money account not found",
     "onboarding": {
       "step_1": {
-        "title": "Fund your account",
-        "description": "Drop in some funds. Your Money account will handle the rest.",
+        "title": "Earn up to {{apy}}% APY",
+        "title_no_apy": "Fund your Money account",
+        "description": "Fund your Money account and watch your balance grow with up to {{apy}}% APY (variable).",
+        "description_no_apy": "Fund your Money account and watch your balance grow.",
         "cta": "Add funds"
       },
       "step_2": {
@@ -7170,7 +7172,7 @@
       "verification_pending": "Your identity verification is being reviewed. This typically takes less than 12 hours."
     },
     "what_you_get": {
-      "title": "What you get",
+      "title": "Money account benefits",
       "benefit_auto_earn": "Auto-earn up to",
       "benefit_auto_earn_variable": "(variable)",
       "benefit_dollar_backed": "Keep your money secure in mUSD, a 1:1 dollar-backed stablecoin",
@@ -7197,7 +7199,7 @@
     "more_sheet": {
       "title": "More",
       "how_it_works": "How it works",
-      "what_you_get": "What you get",
+      "what_you_get": "Money account benefits",
       "contact_support": "Contact support"
     },
     "transfer_sheet": {
@@ -7270,10 +7272,10 @@
     },
     "condensed_cards": {
       "how_it_works_title": "How it works",
-      "how_it_works_subtitle": "See how your money can grow",
+      "how_it_works_subtitle": "See how your money works for you",
       "musd_title": "MetaMask USD",
       "musd_subtitle": "Learn more about mUSD",
-      "what_you_get_title": "What you get",
+      "what_you_get_title": "Money account benefits",
       "what_you_get_subtitle": "Explore your benefits"
     },
     "transaction": {
@@ -7717,7 +7719,7 @@
         "transaction_fee": "Conversion fees include network costs and may include provider fees."
       },
       "title": {
-        "transaction_fee": "Fees"
+        "transaction_fee": "Transaction fees"
       },
       "network_fee": "Network fees depend on how busy the network is and how complex your transaction is."
     },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Copy and UI polish across the Money account / MMPay surfaces, per the MUSD-1074 design review:

1. **Next Best Action card** — step-1 headline/description now read "Earn up to {{apy}}% APY" / "Fund your Money account and watch your balance grow with up to {{apy}}% APY (variable).", interpolating the live APY with a no-APY fallback.
2. **"What you get" → "Money account benefits"** — updated across the section title, condensed card and the More sheet for consistency.
3. **How it works banner** — description updated to "See how your money works for you".
4. **From/Pay with & To/Receive divider** — centered with equal spacing above and below the line.
5. **Transaction fee tooltip** — header renamed to "Transaction fees" (sheet content already matched the design).
6. **Activity list dates** — months abbreviated (e.g. `Sep 1, 2026`).
7. **Transaction fees label** — pluralized in the MMPay fee rows.
8. **"Paid by MetaMask" check** — switched to the bolder `CheckBold` icon.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Money account copy and UI polish (Next Best Action APY copy, "Money account benefits" section, abbreviated activity dates, "Transaction fees" labels, and a bolder "Paid by MetaMask" check).

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1074

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money account copy and UI polish

  Scenario: Next Best Action card shows APY copy
    Given the user is on the Money home screen with a 0 balance
    Then the onboarding card reads "Earn up to 4% APY" with the matching description

  Scenario: Section and banner copy
    Given the user is on the Money home screen
    Then the benefits section title reads "Money account benefits"
    And the How it works banner description reads "See how your money works for you"

  Scenario: Add funds / Send funds divider
    When the user opens the Add funds or Send funds flow
    Then the divider between the From/Pay with (and To/Receive) rows is centered with equal spacing

  Scenario: Transaction fees
    When the user opens the transaction fee tooltip in an MMPay flow
    Then the sheet header reads "Transaction fees"
    And the fee row label reads "Transaction fees"
    And the "Paid by MetaMask" check icon appears bolder

  Scenario: Activity list dates
    When the user views the Activity list
    Then dates are shown with abbreviated months (e.g. "Sep 1, 2026")
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c97b27b2-d090-4aa0-974e-10f78ca9bd97" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/66ad29ad-8953-4bae-a452-fe73282f77b0" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/0e5517c5-eb52-4ff1-8f17-4c93c10987ea" />
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ece93a72-9304-4248-b4c3-fe2e840f6359" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing strings and minor styling/icon tweaks only; no auth, payments logic, or data-layer changes.
> 
> **Overview**
> **Money onboarding step 1** now shows APY-driven headline and body copy when `apyPercent` from `useMoneyAccountBalance` is a positive number, with separate `title_no_apy` / `description_no_apy` strings when APY is missing. Tests were updated to cover both paths.
> 
> **English copy** renames **"What you get"** to **"Money account benefits"** (section, More sheet), tweaks How it works banner and onboarding fallbacks, and pluralizes **"Transaction fees"** in confirm tooltip titles and MMPay fee row labels.
> 
> **UI polish:** activity section dates use **short** month names; **Paid by MetaMask** uses `IconName.CheckBold` instead of `Check`; custom amount **separator** spacing is adjusted via `marginBottom` so the From/To divider sits with balanced vertical padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be1fa2c6f88976a44f56aec40133f1151de0dd70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->