### PR TITLE
fix(money): transaction detail hero  displays fiat amounts with "$" signs instead of token symbols, and show total cost including fees cp-8.0.0

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -152,7 +152,7 @@ describe('TransactionDetailsHero', () => {
     expect(queryByTestId('transaction-details-hero')).toBeNull();
   });
 
-  it('renders token amount with symbol for Money types with targetFiat', () => {
+  it('renders token amount for Money types with targetFiat', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {
         ...TRANSACTION_META_MOCK,
@@ -165,8 +165,7 @@ describe('TransactionDetailsHero', () => {
 
     const { getByText } = render();
 
-    expect(getByText(/456\.78/)).toBeDefined();
-    expect(getByText(/mUSD/)).toBeDefined();
+    expect(getByText(/\$456\.78/)).toBeDefined();
   });
 
   it.each([TransactionType.perpsDeposit, TransactionType.predictDeposit])(
@@ -202,8 +201,7 @@ describe('TransactionDetailsHero', () => {
 
     const { getByText } = render();
 
-    expect(getByText(/100\.00/)).toBeDefined();
-    expect(getByText(/mUSD/)).toBeDefined();
+    expect(getByText(/\$100/)).toBeDefined();
   });
 
   it('renders claim amount for musdClaim with valid claim data', () => {
@@ -289,7 +287,7 @@ describe('TransactionDetailsHero', () => {
 
     const { getByText, queryByText } = render();
 
-    expect(getByText(/200\.00 mUSD/)).toBeDefined();
+    expect(getByText(/\$200/)).toBeDefined();
     expect(queryByText('You sent')).toBeNull();
     expect(queryByText('You received')).toBeNull();
   });

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -303,7 +303,7 @@ describe('TransactionDetailsHero', () => {
       selectTransactionsByIdsMock.mockReturnValue([]);
     });
 
-    it('renders two-asset hero for musdConversion', () => {
+    it('renders two-asset hero for musdConversion with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -312,6 +312,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '123.46',
+            totalFiat: '125.80',
           },
         } as unknown as TransactionMeta,
       });
@@ -319,9 +320,9 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText(/-\$125\.80/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+123\.46 mUSD/)).toBeDefined();
+      expect(getByText(/\+\$123\.46/)).toBeDefined();
     });
 
     it('renders Money Account icon instead of token icon for mUSD in two-asset hero', () => {
@@ -342,7 +343,7 @@ describe('TransactionDetailsHero', () => {
       expect(getAllByTestId('money-account-icon').length).toBeGreaterThan(0);
     });
 
-    it('renders two-asset hero for perpsDeposit with USDC symbol', () => {
+    it('renders two-asset hero for perpsDeposit with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -351,6 +352,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '123.46',
+            totalFiat: '125.80',
           },
         } as unknown as TransactionMeta,
       });
@@ -358,14 +360,12 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText(/-\$125\.80/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(
-        getByText(new RegExp(`\\+123\\.46 ${ARBITRUM_USDC.symbol}`)),
-      ).toBeDefined();
+      expect(getByText(/\+\$123\.46/)).toBeDefined();
     });
 
-    it('renders two-asset hero for predictDeposit with pUSD symbol', () => {
+    it('renders two-asset hero for predictDeposit with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -374,6 +374,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '123.46',
+            totalFiat: '125.80',
           },
         } as unknown as TransactionMeta,
       });
@@ -381,14 +382,12 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText(/-\$125\.80/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(
-        getByText(new RegExp(`\\+123\\.46 ${POLYGON_PUSD.symbol}`)),
-      ).toBeDefined();
+      expect(getByText(/\+\$123\.46/)).toBeDefined();
     });
 
-    it('renders two-asset hero for cross-chain moneyAccountWithdraw', () => {
+    it('renders two-asset hero for cross-chain moneyAccountWithdraw with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -397,6 +396,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '200.00',
+            totalFiat: '202.34',
           },
         } as unknown as TransactionMeta,
       });
@@ -404,9 +404,9 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-200\.00 mUSD/)).toBeDefined();
+      expect(getByText(/-\$202\.34/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+123\.46 TST/)).toBeDefined();
+      expect(getByText(/\+\$200/)).toBeDefined();
     });
 
     it('renders single-row hero with Money Account icon for mUSD-to-mUSD moneyAccountWithdraw', () => {
@@ -425,7 +425,7 @@ describe('TransactionDetailsHero', () => {
 
       const { getByText, getByTestId, queryByText } = render();
 
-      expect(getByText(/-200\.00 mUSD/)).toBeDefined();
+      expect(getByText(/-\$200/)).toBeDefined();
       expect(getByTestId('money-account-icon')).toBeDefined();
       expect(queryByText('You sent')).toBeNull();
       expect(queryByText('You received')).toBeNull();
@@ -447,13 +447,13 @@ describe('TransactionDetailsHero', () => {
 
       const { getByText, getByTestId, queryByText } = render();
 
-      expect(getByText(/-0\.10 mUSD/)).toBeDefined();
+      expect(getByText(/-\$0\.10/)).toBeDefined();
       expect(getByTestId('money-account-icon')).toBeDefined();
       expect(queryByText('You sent')).toBeNull();
       expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders two-asset hero for perpsWithdraw with USDC as sent and mUSD as received', () => {
+    it('renders two-asset hero for perpsWithdraw with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -462,6 +462,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '50.00',
+            totalFiat: '52.34',
           },
         } as unknown as TransactionMeta,
       });
@@ -469,14 +470,12 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(
-        getByText(new RegExp(`-123\\.46 ${ARBITRUM_USDC.symbol}`)),
-      ).toBeDefined();
+      expect(getByText(/-\$52\.34/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+50\.00 mUSD/)).toBeDefined();
+      expect(getByText(/\+\$50/)).toBeDefined();
     });
 
-    it('renders two-asset hero for predictWithdraw with pUSD as sent and mUSD as received', () => {
+    it('renders two-asset hero for predictWithdraw with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -485,6 +484,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '10.00',
+            totalFiat: '12.34',
           },
         } as unknown as TransactionMeta,
       });
@@ -492,11 +492,9 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(
-        getByText(new RegExp(`-123\\.46 ${POLYGON_PUSD.symbol}`)),
-      ).toBeDefined();
+      expect(getByText(/-\$12\.34/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+10\.00 mUSD/)).toBeDefined();
+      expect(getByText(/\+\$10/)).toBeDefined();
     });
 
     it('renders fiat deposit hero with green + prefix for moneyAccountDeposit with fiat orderId', () => {
@@ -513,7 +511,7 @@ describe('TransactionDetailsHero', () => {
 
       const { getByText, queryByText } = render();
 
-      expect(getByText(/\+100\.00 mUSD/)).toBeDefined();
+      expect(getByText(/\+\$100/)).toBeDefined();
       expect(queryByText('You sent')).toBeNull();
       expect(queryByText('You received')).toBeNull();
     });
@@ -534,12 +532,12 @@ describe('TransactionDetailsHero', () => {
       const { getByText, getByTestId, queryByText } = render();
 
       expect(getByTestId('money-account-icon')).toBeDefined();
-      expect(getByText(/\+50\.12 mUSD/)).toBeDefined();
+      expect(getByText(/\+\$50\.12/)).toBeDefined();
       expect(queryByText('You sent')).toBeNull();
       expect(queryByText('You received')).toBeNull();
     });
 
-    it('renders two-asset hero for crypto moneyAccountDeposit conversion', () => {
+    it('renders two-asset hero for crypto moneyAccountDeposit with fiat amounts', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -548,6 +546,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '123.46',
+            totalFiat: '125.80',
           },
         } as unknown as TransactionMeta,
       });
@@ -555,9 +554,9 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText(/-\$125\.80/)).toBeDefined();
       expect(getByText('You received')).toBeDefined();
-      expect(getByText(/\+123\.46 mUSD/)).toBeDefined();
+      expect(getByText(/\+\$123\.46/)).toBeDefined();
     });
 
     it('renders null for unsupported type in money context', () => {
@@ -572,7 +571,7 @@ describe('TransactionDetailsHero', () => {
       expect(queryByTestId('transaction-details-hero')).toBeNull();
     });
 
-    it('extracts sent amount from relay deposit child transaction', () => {
+    it('extracts sent amount from relay deposit child transaction and shows fiat', () => {
       selectTransactionsByIdsMock.mockReturnValue([
         {
           type: TransactionType.relayDeposit,
@@ -589,6 +588,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: TOKEN_ADDRESS_MOCK,
             chainId: CHAIN_ID_MOCK,
             targetFiat: '123.46',
+            totalFiat: '125.80',
           },
         } as unknown as TransactionMeta,
       });
@@ -596,10 +596,10 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-123\.46 TST/)).toBeDefined();
+      expect(getByText(/-\$125\.80/)).toBeDefined();
     });
 
-    it('extracts sent amount from relay deposit native value', () => {
+    it('extracts sent amount from relay deposit native value and shows fiat', () => {
       const nativeAddress = '0x0000000000000000000000000000000000000000';
       selectTransactionsByIdsMock.mockReturnValue([
         {
@@ -617,6 +617,7 @@ describe('TransactionDetailsHero', () => {
             tokenAddress: nativeAddress,
             chainId: '0x1',
             targetFiat: '123.46',
+            totalFiat: '125.80',
           },
         } as unknown as TransactionMeta,
       });
@@ -624,10 +625,10 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-1\.00/)).toBeDefined();
+      expect(getByText(/-\$125\.80/)).toBeDefined();
     });
 
-    it('falls back to tokenMeta amount when parent data is not decodable', () => {
+    it('falls back to tokenMeta amount as fiat when parent data is not decodable', () => {
       useTransactionDetailsMock.mockReturnValue({
         transactionMeta: {
           ...TRANSACTION_META_MOCK,
@@ -644,7 +645,7 @@ describe('TransactionDetailsHero', () => {
       const { getByText } = render();
 
       expect(getByText('You sent')).toBeDefined();
-      expect(getByText(/-77\.00 TST/)).toBeDefined();
+      expect(getByText(/-\$77/)).toBeDefined();
     });
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -262,12 +262,11 @@ export function TransactionDetailsHero() {
           color={showDepositPrefix ? TextColor.Success : undefined}
         >
           {showDepositPrefix ? '+' : isMusdWithdrawSingleRow ? '-' : ''}
-          {(showDepositPrefix || isMusdWithdrawSingleRow) &&
-          transactionMeta.metamaskPay?.targetFiat
-            ? formatFiatPay(
-                new BigNumber(transactionMeta.metamaskPay.targetFiat),
-              )
-            : `${tokenMeta.amount} ${tokenMeta.symbol}`}
+          {formatFiatPay(
+            new BigNumber(
+              transactionMeta.metamaskPay?.targetFiat ?? tokenMeta.amount,
+            ),
+          )}
         </Text>
       </Box>
     );
@@ -352,10 +351,6 @@ function resolveTwoAssetData(
   formatFiat: (value: BigNumber) => string,
 ): { sent: TokenDisplayData; received: TokenDisplayData } {
   const { totalFiat, targetFiat } = transactionMeta.metamaskPay ?? {};
-  const fiatSent = formatFiat(new BigNumber(totalFiat ?? sentData.amount));
-  const fiatReceived = formatFiat(
-    new BigNumber(targetFiat ?? receivedData.amount),
-  );
 
   const isOutbound = hasTransactionType(transactionMeta, [
     TransactionType.moneyAccountWithdraw,
@@ -363,10 +358,21 @@ function resolveTwoAssetData(
 
   if (isOutbound) {
     return {
-      sent: { ...receivedData, fiatAmount: fiatSent },
-      received: { ...sentData, fiatAmount: fiatReceived },
+      sent: {
+        ...receivedData,
+        fiatAmount: formatFiat(new BigNumber(totalFiat ?? receivedData.amount)),
+      },
+      received: {
+        ...sentData,
+        fiatAmount: formatFiat(new BigNumber(targetFiat ?? sentData.amount)),
+      },
     };
   }
+
+  const fiatSent = formatFiat(new BigNumber(totalFiat ?? sentData.amount));
+  const fiatReceived = formatFiat(
+    new BigNumber(targetFiat ?? receivedData.amount),
+  );
 
   for (const [type, override] of Object.entries(SENT_OVERRIDE)) {
     if (hasTransactionType(transactionMeta, [type as TransactionType])) {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -25,6 +25,7 @@ import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './transaction-details-hero.styles';
 import { getTokenTransferData } from '../../../utils/transaction-pay';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import { usePayFiatFormatter } from '../../../hooks/pay/usePayFiatFormatter';
 import { PERPS_CURRENCY, ARBITRUM_USDC } from '../../../constants/perps';
 import { POLYGON_PUSD } from '../../../constants/predict';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
@@ -86,11 +87,15 @@ const TWO_ASSET_HERO_TYPES = [
   TransactionType.predictWithdraw,
 ];
 
-interface TokenDisplayData {
+interface TokenData {
   amount: string;
   symbol: string;
   address: string;
   chainId: Hex;
+}
+
+interface TokenDisplayData extends TokenData {
+  fiatAmount: string;
 }
 
 function TwoAssetHero({
@@ -164,7 +169,7 @@ function AssetLine({
         )}
         <Text variant={TextVariant.DisplayMD} color={amountColor}>
           {sign}
-          {data.amount} {data.symbol}
+          {data.fiatAmount}
         </Text>
       </Box>
     </>
@@ -174,6 +179,7 @@ function AssetLine({
 export function TransactionDetailsHero() {
   const formatFiatPerps = useFiatFormatter({ currency: PERPS_CURRENCY });
   const formatFiatUser = useFiatFormatter();
+  const formatFiatPay = usePayFiatFormatter();
   const { styles } = useStyles(styleSheet, {});
   const decodedAmount = useDecodedAmount();
   const { amount: claimAmount, isConverted: isClaimConverted } =
@@ -202,6 +208,7 @@ export function TransactionDetailsHero() {
       transactionMeta,
       sentData,
       receivedData,
+      formatFiatPay,
     );
     return <TwoAssetHero sentData={sent} receivedData={received} />;
   }
@@ -255,7 +262,12 @@ export function TransactionDetailsHero() {
           color={showDepositPrefix ? TextColor.Success : undefined}
         >
           {showDepositPrefix ? '+' : isMusdWithdrawSingleRow ? '-' : ''}
-          {tokenMeta.amount} {tokenMeta.symbol}
+          {(showDepositPrefix || isMusdWithdrawSingleRow) &&
+          transactionMeta.metamaskPay?.targetFiat
+            ? formatFiatPay(
+                new BigNumber(transactionMeta.metamaskPay.targetFiat),
+              )
+            : `${tokenMeta.amount} ${tokenMeta.symbol}`}
         </Text>
       </Box>
     );
@@ -288,7 +300,7 @@ export function TransactionDetailsHero() {
  * For everything else, falls back to the standard tokenMeta (mUSD).
  */
 const RECEIVED_OVERRIDE: Partial<
-  Record<TransactionType, Omit<TokenDisplayData, 'amount'>>
+  Record<TransactionType, Omit<TokenData, 'amount'>>
 > = {
   [TransactionType.perpsDeposit]: {
     symbol: ARBITRUM_USDC.symbol,
@@ -308,7 +320,7 @@ const RECEIVED_OVERRIDE: Partial<
  * Override the sent data so the hero correctly shows the actual source asset.
  */
 const SENT_OVERRIDE: Partial<
-  Record<TransactionType, Omit<TokenDisplayData, 'amount'>>
+  Record<TransactionType, Omit<TokenData, 'amount'>>
 > = {
   [TransactionType.perpsWithdraw]: {
     symbol: ARBITRUM_USDC.symbol,
@@ -335,32 +347,45 @@ function isSingleRowMoneyDeposit(transactionMeta: TransactionMeta): boolean {
 
 function resolveTwoAssetData(
   transactionMeta: TransactionMeta,
-  sentData: TokenDisplayData,
-  receivedData: TokenDisplayData,
+  sentData: TokenData,
+  receivedData: TokenData,
+  formatFiat: (value: BigNumber) => string,
 ): { sent: TokenDisplayData; received: TokenDisplayData } {
+  const { totalFiat, targetFiat } = transactionMeta.metamaskPay ?? {};
+  const fiatSent = formatFiat(new BigNumber(totalFiat ?? sentData.amount));
+  const fiatReceived = formatFiat(
+    new BigNumber(targetFiat ?? receivedData.amount),
+  );
+
   const isOutbound = hasTransactionType(transactionMeta, [
     TransactionType.moneyAccountWithdraw,
   ]);
 
   if (isOutbound) {
-    return { sent: receivedData, received: sentData };
+    return {
+      sent: { ...receivedData, fiatAmount: fiatSent },
+      received: { ...sentData, fiatAmount: fiatReceived },
+    };
   }
 
   for (const [type, override] of Object.entries(SENT_OVERRIDE)) {
     if (hasTransactionType(transactionMeta, [type as TransactionType])) {
       return {
-        sent: { amount: sentData.amount, ...override },
-        received: receivedData,
+        sent: { amount: sentData.amount, ...override, fiatAmount: fiatSent },
+        received: { ...receivedData, fiatAmount: fiatReceived },
       };
     }
   }
 
-  return { sent: sentData, received: receivedData };
+  return {
+    sent: { ...sentData, fiatAmount: fiatSent },
+    received: { ...receivedData, fiatAmount: fiatReceived },
+  };
 }
 
 function toDisplay(
   tokenMeta: NonNullable<ReturnType<typeof useTokenMeta>>,
-): TokenDisplayData {
+): TokenData {
   return {
     amount: tokenMeta.amount,
     symbol: tokenMeta.symbol,
@@ -371,7 +396,7 @@ function toDisplay(
 
 function useReceivedTokenData(
   tokenMeta: ReturnType<typeof useTokenMeta>,
-): TokenDisplayData | null {
+): TokenData | null {
   const { transactionMeta } = useTransactionDetails();
   const isMoneyContext = useIsMoneyAccountContext();
 
@@ -386,7 +411,7 @@ function useReceivedTokenData(
   return tokenMeta ? toDisplay(tokenMeta) : null;
 }
 
-function useSourceSentData(): TokenDisplayData | null {
+function useSourceSentData(): TokenData | null {
   const { transactionMeta } = useTransactionDetails();
   const tokenMeta = useTokenMeta(transactionMeta);
   const { metamaskPay, requiredTransactionIds } = transactionMeta;
@@ -408,7 +433,7 @@ function useSourceSentData(): TokenDisplayData | null {
   const symbol = sourceToken?.symbol ?? MUSD_TOKEN.symbol;
   const decimals = sourceToken?.decimals ?? MUSD_DECIMALS;
 
-  const base: Omit<TokenDisplayData, 'amount'> = {
+  const base: Omit<TokenData, 'amount'> = {
     symbol,
     address: tokenAddress,
     chainId: sourceChainId as Hex,


### PR DESCRIPTION
## **Description**

The Money Account transaction detail hero was displaying fiat amounts mislabeled with token symbols (e.g., `202.34 ETH` instead of `$202.34`). This PR fixes the hero to show proper fiat-formatted amounts with `$` signs and no token symbols, and updates the "You sent" line to reflect the total cost including fees (`totalFiat`) rather than just the target amount.

### Changes

- Split `TokenDisplayData` into `TokenData` (raw hook data) and `TokenDisplayData` (display-ready with mandatory `fiatAmount`)
- Moved fiat formatting logic into `resolveTwoAssetData`, which now accepts a fiat formatter and sets `fiatAmount` on all returned data using `totalFiat` for sent and `targetFiat` for received
- "You sent" now shows total including fees (e.g., `-$202.34`), "You received" shows net amount (e.g., `+$200.00`)
- Single-row deposits/withdrawals also display fiat-formatted amounts (e.g., `+$100.00` instead of `+100.00 mUSD`)
- Applied uniformly to all `TWO_ASSET_HERO_TYPES` (moneyAccountDeposit, moneyAccountWithdraw, musdConversion, perpsDeposit, perpsWithdraw, predictDeposit, predictWithdraw)
- Updated all affected tests to validate fiat display

## **Changelog**

CHANGELOG entry: Fixed Money Account transaction detail hero to display fiat amounts with $ signs instead of token symbols, and show total cost including fees

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1073

## **Manual testing steps**

```gherkin
Feature: Money Account transaction detail hero fiat display

  Scenario: User views a crypto deposit into Money Account
    Given the user has completed a crypto-to-mUSD deposit (e.g. ETH → mUSD)

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "You sent" with "-$X.XX" (total including fees)
    And "You received" with "+$X.XX" (net deposited amount) in green text
    And no token symbols (mUSD, ETH, etc.) are shown next to amounts

  Scenario: User views a withdrawal from Money Account
    Given the user has completed a cross-chain withdrawal from Money Account

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "You sent" with "-$X.XX" (total including fees)
    And "You received" with "+$X.XX" (net received amount) in green text
    And no token symbols are shown next to amounts

  Scenario: User views a fiat-funded deposit (single-row)
    Given the user has completed a fiat-funded deposit with an order ID

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "+$X.XX" in green text with the Money Account icon
    And no token symbol is shown

  Scenario: User views a mUSD-to-mUSD withdrawal (single-row)
    Given the user has completed a mUSD-to-mUSD withdrawal

    When user navigates to the transaction detail page from Money Account activity
    Then the hero displays "-$X.XX" with the Money Account icon
    And no token symbol is shown
```

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="442" height="956" alt="Screenshot 2026-06-25 at 13 09 13" src="https://github.com/user-attachments/assets/c814b613-3a49-4d72-813b-89da714bfe61" />

<img width="414" height="890" alt="Screenshot 2026-06-25 at 13 09 28" src="https://github.com/user-attachments/assets/06d5a58e-00d7-4394-a6e9-92f0eb533663" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display change in confirmations activity hero with broad test updates; no auth, persistence, or transaction execution logic changed.
> 
> **Overview**
> Fixes the **Money Account transaction detail hero** so amounts read as **fiat** (e.g. `-$125.80`, `+$123.46`) via `usePayFiatFormatter`, instead of pairing numbers with token symbols like mUSD, TST, or USDC.
> 
> For **two-asset** flows in money context, `resolveTwoAssetData` now attaches formatted `fiatAmount` on each row: **You sent** uses `metamaskPay.totalFiat` when present (total including fees), **You received** uses `targetFiat`. Token icons/overrides are unchanged; only the displayed amount text switches to fiat. **Single-row** deposits and mUSD withdrawals use the same formatter on `targetFiat` (with `+`/`-` prefixes where applicable).
> 
> Tests in `transaction-details-hero.test.tsx` were updated to assert `$`-prefixed strings and the new sent/received fiat split, including `totalFiat` on relevant mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3dbeba754b671e5dc061e97405ba69bb43c4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->