### PR TITLE
fix(confirmations): cp-8.0.0 harden sentinel relay and bump transaction pay controller

### DIFF
--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -40,6 +40,7 @@ import {
   KeyringControllerGetStateAction,
   KeyringControllerSignEip7702AuthorizationAction,
   KeyringControllerSignTypedMessageAction,
+  KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
 import type { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
 import {
@@ -136,6 +137,7 @@ type InitMessengerActions =
 
 type InitMessengerEvents =
   | BridgeStatusControllerEvents
+  | KeyringControllerUnlockEvent
   | TransactionControllerStateChangeEvent
   | TransactionControllerTransactionApprovedEvent
   | TransactionControllerTransactionConfirmedEvent
@@ -230,6 +232,7 @@ export function getTransactionControllerInitMessenger(
     ],
     events: [
       'BridgeStatusController:stateChange',
+      'KeyringController:unlock',
       'TransactionController:stateChange',
       'TransactionController:transactionApproved',
       'TransactionController:transactionConfirmed',

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -22,9 +22,8 @@ import {
 import { getDeleGatorEnvironment } from '../../../core/Delegation';
 import { TransactionControllerInitMessenger } from '../../../core/Engine/messengers/transaction-controller-messenger';
 import {
-  RelayStatus,
   submitRelayTransaction,
-  waitForRelayResult,
+  waitForRelaySuccess,
 } from '../transaction-relay';
 import { Delegation7702PublishHook } from './delegation-7702-publish';
 import { NetworkClientId } from '@metamask/network-controller';
@@ -89,7 +88,7 @@ const getRootMessenger = (): RootMessenger =>
 
 describe('Delegation 7702 Publish Hook', () => {
   const submitRelayTransactionMock = jest.mocked(submitRelayTransaction);
-  const waitForRelayResultMock = jest.mocked(waitForRelayResult);
+  const waitForRelaySuccessMock = jest.mocked(waitForRelaySuccess);
   let messenger: TransactionControllerInitMessenger;
   let hookClass: Delegation7702PublishHook;
 
@@ -184,8 +183,8 @@ describe('Delegation 7702 Publish Hook', () => {
     signEip7702AuthorizationMock.mockResolvedValue(
       AUTHORIZATION_SIGNATURE_MOCK,
     );
-    waitForRelayResultMock.mockResolvedValue({
-      status: RelayStatus.Success,
+    waitForRelaySuccessMock.mockResolvedValue({
+      status: 'VALIDATED',
       transactionHash: TRANSACTION_HASH_MOCK,
     });
     getStateMock.mockReturnValue({
@@ -683,10 +682,12 @@ describe('Delegation 7702 Publish Hook', () => {
     );
   });
 
-  it('throws if relay status is not success', async () => {
-    waitForRelayResultMock.mockResolvedValueOnce({
-      status: 'TEST_STATUS',
-    });
+  it('throws if relay result is not success', async () => {
+    waitForRelaySuccessMock.mockRejectedValueOnce(
+      new Error(
+        'Sentinel: Relay: Transaction failed - TEST_STATUS - Unknown error',
+      ),
+    );
     isAtomicBatchSupportedMock.mockResolvedValueOnce([
       {
         chainId: TRANSACTION_META_MOCK.chainId,
@@ -706,7 +707,7 @@ describe('Delegation 7702 Publish Hook', () => {
         SIGNED_TX_MOCK,
       ),
     ).rejects.toThrow(
-      'Gas Station 7702: Transaction relay error - TEST_STATUS',
+      'Gas Station 7702: Sentinel: Relay: Transaction failed - TEST_STATUS - Unknown error',
     );
   });
 

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -34,10 +34,9 @@ import {
 } from '../../../core/Delegation/delegation';
 import { TransactionControllerInitMessenger } from '../../../core/Engine/messengers/transaction-controller-messenger';
 import {
-  RelayStatus,
   RelaySubmitRequest,
   submitRelayTransaction,
-  waitForRelayResult,
+  waitForRelaySuccess,
 } from '../transaction-relay';
 import { NetworkClientId } from '@metamask/network-controller';
 import { isE2ETest } from '../util';
@@ -247,15 +246,11 @@ export class Delegation7702PublishHook {
 
     const { uuid } = await submitRelayTransaction(relayRequest);
 
-    const { transactionHash, status } = await waitForRelayResult({
+    const { transactionHash } = await waitForRelaySuccess({
       chainId,
       uuid,
       interval: POLLING_INTERVAL_MS,
     });
-
-    if (status !== RelayStatus.Success) {
-      throw new Error(`Transaction relay error - ${status}`);
-    }
 
     // Mark 7702 relay transaction as intent complete so PendingTransactionTracker
     // skips dropped checks

--- a/app/util/transactions/transaction-relay.test.ts
+++ b/app/util/transactions/transaction-relay.test.ts
@@ -8,7 +8,7 @@ import {
   RelayWaitResponse,
   isRelaySupported,
   submitRelayTransaction,
-  waitForRelayResult,
+  waitForRelaySuccess,
 } from './transaction-relay';
 
 import jsonRpcRequest from '../../util/jsonRpcRequest';
@@ -142,15 +142,15 @@ describe('Transaction Relay (mobile)', () => {
     });
   });
 
-  describe('waitForRelayResult', () => {
+  describe('waitForRelaySuccess', () => {
     it('throws when chain is not supported by relay', async () => {
       mockRelayUnsupported();
-      await expect(waitForRelayResult(WAIT_REQUEST_MOCK)).rejects.toThrow(
+      await expect(waitForRelaySuccess(WAIT_REQUEST_MOCK)).rejects.toThrow(
         `Sentinel: Relay: Chain not supported - ${WAIT_REQUEST_MOCK.chainId}`,
       );
     });
 
-    it('resolves with transactionHash when status is Success', async () => {
+    it('resolves with transactionHash and errorReason when status is Success', async () => {
       mockRelaySupported('mainnet');
       mockFetchSuccess({
         transactions: [
@@ -158,12 +158,13 @@ describe('Transaction Relay (mobile)', () => {
         ],
       });
 
-      const resultPromise = waitForRelayResult(WAIT_REQUEST_MOCK);
+      const resultPromise = waitForRelaySuccess(WAIT_REQUEST_MOCK);
 
       await jest.advanceTimersByTimeAsync(INTERVAL_MS);
 
       const result = await resultPromise;
       expect(result).toEqual<RelayWaitResponse>({
+        errorReason: 'Unknown error',
         status: RelayStatus.Success,
         transactionHash: TRANSACTION_HASH_MOCK,
       });
@@ -174,26 +175,27 @@ describe('Transaction Relay (mobile)', () => {
       );
     });
 
-    it('resolves with status only (no hash) when transaction hash is missing', async () => {
+    it('throws when relay status is not Success', async () => {
       mockFetchSuccess({
         transactions: [{ status: 'TEST_STATUS' }],
       });
 
-      const resultPromise = waitForRelayResult(WAIT_REQUEST_MOCK);
+      const errorPromise = waitForRelaySuccess(WAIT_REQUEST_MOCK).catch(
+        (error) => error,
+      );
 
       await jest.advanceTimersByTimeAsync(INTERVAL_MS);
 
-      const result = await resultPromise;
-      expect(result).toEqual<RelayWaitResponse>({
-        status: 'TEST_STATUS',
-        transactionHash: undefined,
+      await expect(errorPromise).resolves.toMatchObject({
+        message:
+          'Sentinel: Relay: Transaction failed - TEST_STATUS - Unknown error',
       });
     });
 
     it('rejects when polling responds with non-ok status', async () => {
       mockFetchError(ERROR_BODY_MOCK, 502);
 
-      const errorPromise = waitForRelayResult(WAIT_REQUEST_MOCK).catch(
+      const errorPromise = waitForRelaySuccess(WAIT_REQUEST_MOCK).catch(
         (error) => error,
       );
 
@@ -210,7 +212,7 @@ describe('Transaction Relay (mobile)', () => {
         new Error('poll failed'),
       );
 
-      const errorPromise = waitForRelayResult(WAIT_REQUEST_MOCK).catch(
+      const errorPromise = waitForRelaySuccess(WAIT_REQUEST_MOCK).catch(
         (error) => error,
       );
 
@@ -230,7 +232,7 @@ describe('Transaction Relay (mobile)', () => {
         ],
       });
 
-      const resultPromise = waitForRelayResult(WAIT_REQUEST_MOCK);
+      const resultPromise = waitForRelaySuccess(WAIT_REQUEST_MOCK);
 
       await jest.advanceTimersByTimeAsync(INTERVAL_MS);
       await jest.advanceTimersByTimeAsync(INTERVAL_MS);
@@ -238,6 +240,7 @@ describe('Transaction Relay (mobile)', () => {
 
       const result = await resultPromise;
       expect(result).toEqual<RelayWaitResponse>({
+        errorReason: 'Unknown error',
         status: RelayStatus.Success,
         transactionHash: TRANSACTION_HASH_MOCK,
       });

--- a/app/util/transactions/transaction-relay.ts
+++ b/app/util/transactions/transaction-relay.ts
@@ -34,7 +34,6 @@ export interface RelayWaitResponse {
   errorReason?: string;
   status: string;
   transactionHash?: Hex;
-  uuid?: string;
 }
 
 export enum RelayStatus {

--- a/app/util/transactions/transaction-relay.ts
+++ b/app/util/transactions/transaction-relay.ts
@@ -31,8 +31,10 @@ export interface RelaySubmitResponse {
 }
 
 export interface RelayWaitResponse {
-  transactionHash?: Hex;
+  errorReason?: string;
   status: string;
+  transactionHash?: Hex;
+  uuid?: string;
 }
 
 export enum RelayStatus {
@@ -72,7 +74,7 @@ export async function submitRelayTransaction(
   }
 }
 
-export async function waitForRelayResult(
+export async function waitForRelaySuccess(
   request: RelayWaitRequest,
 ): Promise<RelayWaitResponse> {
   const { chainId, interval, uuid } = request;
@@ -91,6 +93,7 @@ export async function waitForRelayResult(
           try {
             const headers = await getSentinelApiHeadersAsync();
             const relayResult = await pollResult(url, headers);
+
             if (relayResult.status !== RelayStatus.Pending) {
               clearInterval(intervalId);
               resolve(relayResult);
@@ -102,6 +105,12 @@ export async function waitForRelayResult(
         }, interval);
       },
     );
+
+    const { status, errorReason } = waitResult;
+
+    if (status !== RelayStatus.Success) {
+      throw new Error(`Transaction failed - ${status} - ${errorReason}`);
+    }
 
     return waitResult;
   } catch (error) {
@@ -131,11 +140,20 @@ async function pollResult(
     );
   }
 
-  const data = await response.json();
-  const transaction = data?.transactions[0];
-  const { hash: transactionHash, status } = transaction || {};
+  const data = (await response.json()) ?? {};
+  const { transactions } = data || {};
+  const transaction = transactions?.[0] ?? {};
+
+  const {
+    hash: transactionHash,
+    status,
+    errorReason: rawErrorReason,
+  } = transaction;
+
+  const errorReason = rawErrorReason ?? 'Unknown error';
 
   return {
+    errorReason,
     status,
     transactionHash,
   };

--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^68.2.0",
-    "@metamask/transaction-pay-controller": "^23.16.1",
+    "@metamask/transaction-pay-controller": "^23.17.0",
     "@metamask/tron-wallet-snap": "^1.28.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^68.2.0",
-    "@metamask/transaction-pay-controller": "^23.17.0",
+    "@metamask/transaction-pay-controller": "^23.17.1",
     "@metamask/tron-wallet-snap": "^1.28.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10400,9 +10400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^23.16.1":
-  version: 23.16.1
-  resolution: "@metamask/transaction-pay-controller@npm:23.16.1"
+"@metamask/transaction-pay-controller@npm:^23.17.0":
+  version: 23.17.0
+  resolution: "@metamask/transaction-pay-controller@npm:23.17.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10426,7 +10426,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/708ede9b28b037dae9895f05abfadabc2ce315b751836fa4a2ea6b1803223c6e039e0d794aa9406cc4b25ff9680f561b5643ae43a69bc359791502a6d602a1fa
+  checksum: 10/aa46a719af51026805fe62cf84e4c1064530268bfda12aab8c281ae6b53e11e4cf235cc644e957f7e7378e49d7ac5f601cc23a691e7403c744a4c67a33fccd48
   languageName: node
   linkType: hard
 
@@ -35555,7 +35555,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^68.2.0"
-    "@metamask/transaction-pay-controller": "npm:^23.16.1"
+    "@metamask/transaction-pay-controller": "npm:^23.17.0"
     "@metamask/tron-wallet-snap": "npm:^1.28.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10400,9 +10400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^23.17.0":
-  version: 23.17.0
-  resolution: "@metamask/transaction-pay-controller@npm:23.17.0"
+"@metamask/transaction-pay-controller@npm:^23.17.1":
+  version: 23.17.1
+  resolution: "@metamask/transaction-pay-controller@npm:23.17.1"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10426,7 +10426,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/aa46a719af51026805fe62cf84e4c1064530268bfda12aab8c281ae6b53e11e4cf235cc644e957f7e7378e49d7ac5f601cc23a691e7403c744a4c67a33fccd48
+  checksum: 10/636fe1ff705294be71afd2913449943defac71027b5a42f4c3190d4c78eed7116e1a8466114a6973bb247873de407ab25a28629867654abdfa1ba0c970f14205
   languageName: node
   linkType: hard
 
@@ -35555,7 +35555,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/transaction-controller": "npm:^68.2.0"
-    "@metamask/transaction-pay-controller": "npm:^23.17.0"
+    "@metamask/transaction-pay-controller": "npm:^23.17.1"
     "@metamask/tron-wallet-snap": "npm:^1.28.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^4.0.0"


### PR DESCRIPTION
## **Description**

Two related hardening changes for the MetaMask Pay post-ramp flow.

**1. Wire `KeyringController:unlock` to the TransactionController init messenger**

`KeyringController:unlock` is added to the TC init messenger's allowed events and its subscription list. This is a prerequisite for the companion Core fix ([MetaMask/core#9267](https://github.com/MetaMask/core/pull/9267)) which uses that event to wait for wallet unlock before executing the fiat post-ramp second leg.

**2. Harden sentinel relay result handling (`waitForRelaySuccess`)**

`waitForRelayResult` is renamed to `waitForRelaySuccess` and now throws immediately on any non-success relay status instead of returning the status to callers and requiring them to check. The error message includes both the status and the `errorReason` field returned by the sentinel API (previously ignored). `pollResult` is hardened with nullish coalescing so a missing `transactions` array or empty transaction object does not produce uncaught property access errors. The sentinel consumer in `delegation-7702-publish.ts` is updated to use the renamed function and the now-redundant status check is removed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect transaction relay failure paths and unlock signaling for pay/post-ramp flows; behavior is stricter (fail-fast) rather than silently returning failed relay status.
> 
> **Overview**
> Hardens MetaMask Pay / sentinel relay handling and exposes wallet unlock to the TransactionController init messenger for the fiat post-ramp second leg (companion Core work).
> 
> **TransactionController messenger:** Subscribes to **`KeyringController:unlock`** on the TC init messenger so downstream logic can wait for unlock before signing the post-ramp leg.
> 
> **Sentinel relay:** Renames **`waitForRelayResult`** to **`waitForRelaySuccess`**, which **throws** on any non-success status with **`status`** and sentinel **`errorReason`** (defaulting to `Unknown error`). **`pollResult`** uses nullish coalescing so missing `transactions` or empty entries do not cause property access crashes. **`delegation-7702-publish`** switches to the new helper and drops its redundant success check.
> 
> **Dependency:** Bumps **`@metamask/transaction-pay-controller`** from `^23.16.1` to **`^23.17.1`** (lockfile updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae56408651d1e766c0dc67fced722cc7e0b0b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->