### PR TITLE
test: add unit tests for TransactionDetailsSheet component

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetailsSheet/TransactionDetailsSheet.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetailsSheet/TransactionDetailsSheet.test.tsx
@@ -116,20 +116,30 @@ describe('TransactionDetailsSheet', () => {
 
   it('uses live transaction from Redux when transaction id matches', () => {
     const routeTransaction = createTransaction({
+      id: 'route-tx-id',
       time: 1111,
       status: TransactionStatus.submitted,
       txParams: { nonce: '0x1' },
     });
+    const otherLiveTransaction = createTransaction({
+      id: 'other-tx-id',
+      time: 9999,
+      status: TransactionStatus.confirmed,
+      hash: '0xotherlivehash',
+      txParams: { nonce: '0x3' },
+    });
     const liveTransaction = createTransaction({
+      id: routeTransaction.id,
       time: 2222,
       status: TransactionStatus.confirmed,
       hash: '0xlivehash',
       txParams: { nonce: '0x2' },
     });
 
-    renderSheet([liveTransaction], routeTransaction);
+    renderSheet([otherLiveTransaction, liveTransaction], routeTransaction);
 
     expect(screen.getAllByText('formatted-2222')).toHaveLength(2);
+    expect(screen.queryByText('formatted-9999')).not.toBeOnTheScreen();
     expect(screen.queryByText('formatted-1111')).not.toBeOnTheScreen();
   });
 

--- a/app/components/UI/TransactionElement/TransactionDetailsSheet/TransactionDetailsSheet.test.tsx
+++ b/app/components/UI/TransactionElement/TransactionDetailsSheet/TransactionDetailsSheet.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+
+import {
+  DeepPartial,
+  renderScreen,
+} from '../../../../util/test/renderWithProvider';
+import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+import type { RootState } from '../../../../reducers';
+import TransactionDetailsSheet from './TransactionDetailsSheet';
+
+interface TransactionOverrides
+  extends Omit<Partial<TransactionMeta>, 'txParams'> {
+  txParams?: Partial<TransactionMeta['txParams']>;
+}
+
+const mockUseRoute = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: () => mockUseRoute(),
+}));
+
+jest.mock('../../../../util/date', () => ({
+  toDateFormat: (time: number) => `formatted-${time}`,
+}));
+
+const createTransaction = (
+  overrides: TransactionOverrides = {},
+): TransactionMeta => {
+  const baseTransaction: TransactionMeta = {
+    id: 'tx-id',
+    time: 1000,
+    chainId: '0x1',
+    networkClientId: 'mainnet',
+    status: TransactionStatus.submitted,
+    txParams: {
+      from: '0x0000000000000000000000000000000000000001',
+      to: '0x0000000000000000000000000000000000000002',
+      nonce: '0x1',
+    },
+  };
+
+  return {
+    ...baseTransaction,
+    ...overrides,
+    txParams: {
+      ...baseTransaction.txParams,
+      ...overrides.txParams,
+    },
+  };
+};
+
+const createRouteParams = (tx: TransactionMeta) => ({
+  tx,
+  transactionElement: {
+    actionKey: 'Send ETH',
+  },
+  transactionDetails: {
+    hash: tx.hash,
+    renderFrom: tx.txParams.from,
+    renderTo: tx.txParams.to,
+    summaryAmount: '1 ETH',
+    summaryFee: '0.001 ETH',
+    summaryTotalAmount: '1.001 ETH',
+    summarySecondaryTotalAmount: '$100',
+    txChainId: tx.chainId,
+  },
+  showSpeedUpModal: jest.fn(),
+  showCancelModal: jest.fn(),
+});
+
+const createState = (
+  transactions: TransactionMeta[],
+): DeepPartial<RootState> => ({
+  settings: {
+    avatarAccountType: AvatarAccountType.Blockies,
+  },
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      TransactionController: {
+        transactions,
+        transactionBatches: [],
+      },
+    },
+  },
+});
+
+const renderSheet = (
+  transactions: TransactionMeta[],
+  routeTransaction: TransactionMeta,
+) => {
+  mockUseRoute.mockReturnValue({
+    params: createRouteParams(routeTransaction),
+  });
+
+  return renderScreen(
+    TransactionDetailsSheet,
+    { name: 'TransactionDetailsSheet' },
+    {
+      state: createState(transactions),
+    },
+  );
+};
+
+describe('TransactionDetailsSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses live transaction from Redux when transaction id matches', () => {
+    const routeTransaction = createTransaction({
+      time: 1111,
+      status: TransactionStatus.submitted,
+      txParams: { nonce: '0x1' },
+    });
+    const liveTransaction = createTransaction({
+      time: 2222,
+      status: TransactionStatus.confirmed,
+      hash: '0xlivehash',
+      txParams: { nonce: '0x2' },
+    });
+
+    renderSheet([liveTransaction], routeTransaction);
+
+    expect(screen.getAllByText('formatted-2222')).toHaveLength(2);
+    expect(screen.queryByText('formatted-1111')).not.toBeOnTheScreen();
+  });
+
+  it('uses route transaction when Redux does not have a matching transaction', () => {
+    const routeTransaction = createTransaction({
+      time: 3333,
+      status: TransactionStatus.submitted,
+    });
+
+    renderSheet([], routeTransaction);
+
+    expect(screen.getAllByText('formatted-3333')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a co-located unit test for `TransactionDetailsSheet` to cover the live transaction selector path. The sheet now has regression coverage proving it uses the latest transaction metadata from Redux when `selectTransactionMetadataById` finds a matching transaction, and falls back to the route transaction when Redux does not have a match.

The test renders the real sheet/header/details component tree and asserts the displayed transaction date follows the selected transaction source.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-881

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no runtime or user-facing behavior changes.
> 
> **Overview**
> Adds a new co-located test file for **`TransactionDetailsSheet`** with no production code changes.
> 
> The tests render the real sheet via **`renderScreen`**, stub navigation route params and **`toDateFormat`**, and seed **`TransactionController`** transactions in Redux. They lock in two behaviors: when **`selectTransactionMetadataById`** finds a matching id, the UI shows the **live** transaction timestamp (not stale route data or unrelated txs); when Redux has no match, it **falls back** to the route **`tx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973203a734db07e1c8323cac04bd64e570da98a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->