### PR TITLE
feat(tabs): enhance HomepageDiscoveryTabs tests and context stability

### DIFF
--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.test.tsx
@@ -8,8 +8,13 @@ import type {
 import HomepageDiscoveryTabs from './HomepageDiscoveryTabs';
 import { PredictEventValues } from '../../../../UI/Predict/constants/eventNames';
 import { HomeTabNames } from '../../hooks/useTabViewedEvent';
+import {
+  TabIconAnimationContext,
+  type TabIconAnimationContextValue,
+} from '../../../../../component-library/components-temp/Tabs/TabsIconTab/TabsIconAnimationContext';
 
 const mockTrackTabViewed = jest.fn();
+const mockIconCollapseProgress = { value: 0 };
 jest.mock('../../hooks/useTabViewedEvent', () => ({
   __esModule: true,
   HomeTabNames: {
@@ -23,6 +28,7 @@ jest.mock('../../hooks/useTabViewedEvent', () => ({
 jest.mock('react-native-reanimated', () => {
   const Reanimated = jest.requireActual('react-native-reanimated/mock');
   Reanimated.default.ScrollView = jest.requireActual('react-native').ScrollView;
+  Reanimated.useSharedValue = jest.fn(() => mockIconCollapseProgress);
   return Reanimated;
 });
 
@@ -139,6 +145,16 @@ const pressTab = async (label: string) => {
 const renderComponent = (props = {}) =>
   render(<HomepageDiscoveryTabs {...props} />);
 
+const ContextValueObserver = ({
+  onValue,
+}: {
+  onValue: (value: TabIconAnimationContextValue) => void;
+}) => {
+  const value = React.useContext(TabIconAnimationContext);
+  onValue(value);
+  return null;
+};
+
 describe('HomepageDiscoveryTabs', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -163,6 +179,34 @@ describe('HomepageDiscoveryTabs', () => {
     it('shows Portfolio content on initial mount', () => {
       renderComponent();
       expect(screen.getByTestId('homepage')).toBeOnTheScreen();
+    });
+
+    it('keeps TabIconAnimationContext value stable across unrelated rerenders', () => {
+      const observedValues: TabIconAnimationContextValue[] = [];
+      const portfolioHeader = (
+        <ContextValueObserver
+          onValue={(value) => {
+            observedValues.push(value);
+          }}
+        />
+      );
+      const { rerender } = render(
+        <HomepageDiscoveryTabs
+          portfolioHeader={portfolioHeader}
+          walletHeaderOffset={0}
+        />,
+      );
+      const initialValue = observedValues[observedValues.length - 1];
+
+      rerender(
+        <HomepageDiscoveryTabs
+          portfolioHeader={portfolioHeader}
+          walletHeaderOffset={100}
+        />,
+      );
+      const rerenderedValue = observedValues[observedValues.length - 1];
+
+      expect(rerenderedValue).toBe(initialValue);
     });
   });
 

--- a/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryTabs/HomepageDiscoveryTabs.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react';
 import {
@@ -195,13 +196,13 @@ const HomepageDiscoveryTabs = forwardRef<
 
     // Triggered directly from the scroll worklet via onHeaderHiddenChange —
     // fires in the same frame as the hide/show decision, not based on position.
-    // eslint-disable-next-line react-compiler/react-compiler -- mutating a Reanimated SharedValue is the documented pattern; it does not affect React render
     const animateIcons = useCallback(
       (hidden: boolean) => {
         const toValue = hidden ? 1 : 0;
         const duration = hidden ? 300 : 250;
 
         // UI-thread layout animation via Reanimated.
+        // eslint-disable-next-line react-compiler/react-compiler -- mutating a Reanimated SharedValue is the documented pattern; it does not affect React render
         iconCollapseProgress.value = withTiming(toValue, {
           duration,
           easing: Easing.out(Easing.cubic),
@@ -343,10 +344,17 @@ const HomepageDiscoveryTabs = forwardRef<
       ],
     );
 
+    const tabIconAnimationContextValue = useMemo(
+      () => ({ iconCollapseProgress }),
+      [iconCollapseProgress],
+    );
+
     return (
       <PerpsConnectionProvider suppressErrorView>
         <PerpsStreamProvider>
-          <TabIconAnimationContext.Provider value={{ iconCollapseProgress }}>
+          <TabIconAnimationContext.Provider
+            value={tabIconAnimationContextValue}
+          >
             <View style={styles.flex}>
               <TabsIconList
                 ref={tabsRef}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Memoizes the `TabIconAnimationContext` provider value in `HomepageDiscoveryTabs` so tab icon consumers do not receive a new context object on unrelated parent rerenders. This keeps the Reanimated `SharedValue` plumbing intact while reducing unnecessary context invalidation for the homepage discovery tab bar.

This also moves the existing React compiler suppression onto the exact Reanimated shared-value mutation it documents, and adds a focused regression test that verifies the provider value remains referentially stable across unrelated rerenders.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-882

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small React performance/context fix with no auth, data, or API changes; behavior is unchanged aside from fewer context updates.
> 
> **Overview**
> **`HomepageDiscoveryTabs`** now memoizes the **`TabIconAnimationContext`** provider value with **`useMemo`**, so tab icon consumers keep the same context object reference when the parent rerenders for unrelated props (e.g. **`walletHeaderOffset`**) instead of getting a fresh inline object every time.
> 
> The React compiler **`eslint-disable`** for Reanimated **`SharedValue`** mutation is relocated to sit on the **`iconCollapseProgress.value = withTiming(...)`** line it documents.
> 
> Tests mock **`useSharedValue`** for a stable shared value and add a regression case that asserts the context value is **referentially stable** across such rerenders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b32cbf9630094d53d0f1d3ac393514a0373f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->